### PR TITLE
Fix multiselect 'a' key select-all behavior

### DIFF
--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -93,6 +93,19 @@ export interface WorkspacePackage {
   directory: string;
 }
 
+export interface PromptMultiselectChoiceState {
+  selected?: boolean;
+  disabled?: boolean;
+}
+
+export interface PromptMultiselectContext {
+  maxChoices?: number;
+  cursor: number;
+  value: PromptMultiselectChoiceState[];
+  bell: () => void;
+  render: () => void;
+}
+
 export interface KnipResults {
   issues: {
     files: Set<string>;

--- a/packages/react-doctor/src/utils/should-select-all-choices.ts
+++ b/packages/react-doctor/src/utils/should-select-all-choices.ts
@@ -1,0 +1,6 @@
+import type { PromptMultiselectChoiceState } from "../types.js";
+
+export const shouldSelectAllChoices = (choiceStates: PromptMultiselectChoiceState[]): boolean => {
+  const enabledChoiceStates = choiceStates.filter((choiceState) => !choiceState.disabled);
+  return enabledChoiceStates.some((choiceState) => choiceState.selected !== true);
+};

--- a/packages/react-doctor/tests/should-select-all-choices.test.ts
+++ b/packages/react-doctor/tests/should-select-all-choices.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { shouldSelectAllChoices } from "../src/utils/should-select-all-choices.js";
+
+describe("shouldSelectAllChoices", () => {
+  it("returns true when no enabled choice is selected", () => {
+    const shouldSelectAllEnabledChoices = shouldSelectAllChoices([
+      { selected: false },
+      { selected: false },
+    ]);
+
+    expect(shouldSelectAllEnabledChoices).toBe(true);
+  });
+
+  it("returns true when some enabled choices are selected", () => {
+    const shouldSelectAllEnabledChoices = shouldSelectAllChoices([
+      { selected: true },
+      { selected: false },
+      { selected: false },
+    ]);
+
+    expect(shouldSelectAllEnabledChoices).toBe(true);
+  });
+
+  it("returns false when all enabled choices are selected", () => {
+    const shouldSelectAllEnabledChoices = shouldSelectAllChoices([
+      { selected: true },
+      { selected: true },
+      { selected: true },
+    ]);
+
+    expect(shouldSelectAllEnabledChoices).toBe(false);
+  });
+
+  it("ignores disabled choices when checking if all are selected", () => {
+    const shouldSelectAllEnabledChoices = shouldSelectAllChoices([
+      { selected: true },
+      { selected: false, disabled: true },
+      { selected: true },
+    ]);
+
+    expect(shouldSelectAllEnabledChoices).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- patch multiselect 'a' key behavior to use overall selection state
- pressing 'a' now selects all when only some items are selected
- pressing 'a' only clears when all selectable items are already selected
- add focused unit tests for the select-all decision logic

## Validation
- nr test
- nr typecheck
- nr format
- nr lint (existing fixture warnings only)