### PR TITLE
fix(cli): add severity icons to summary counts

### DIFF
--- a/packages/react-doctor/src/scan.ts
+++ b/packages/react-doctor/src/scan.ts
@@ -217,10 +217,10 @@ const printSummary = (
 
   const parts: string[] = [];
   if (errorCount > 0) {
-    parts.push(highlighter.error(`${errorCount} error${errorCount === 1 ? "" : "s"}`));
+    parts.push(highlighter.error(`✗ ${errorCount} error${errorCount === 1 ? "" : "s"}`));
   }
   if (warningCount > 0) {
-    parts.push(highlighter.warn(`${warningCount} warning${warningCount === 1 ? "" : "s"}`));
+    parts.push(highlighter.warn(`⚠ ${warningCount} warning${warningCount === 1 ? "" : "s"}`));
   }
   parts.push(
     highlighter.dim(`across ${affectedFileCount} file${affectedFileCount === 1 ? "" : "s"}`),


### PR DESCRIPTION
## Summary
- prepend ✗ to the error count in the summary line
- prepend ⚠ to the warning count in the summary line

## Example
- before: 9 errors  61 warnings  across 24 files  in 983ms
- after: ✗ 9 errors  ⚠ 61 warnings  across 24 files  in 983ms

## Testing
- nr test