### PR TITLE
Move video overlay text to bottom with darker gradient

### DIFF
--- a/packages/video/src/constants.ts
+++ b/packages/video/src/constants.ts
@@ -8,6 +8,13 @@ export const MUTED_COLOR = "#737373";
 export const RED_COLOR = "#f87171";
 export const GREEN_COLOR = "#4ade80";
 export const YELLOW_COLOR = "#eab308";
+export const OVERLAY_GRADIENT_RGB = "10, 10, 10";
+export const OVERLAY_GRADIENT_HEIGHT_PX = 420;
+export const OVERLAY_GRADIENT_HORIZONTAL_PADDING_PX = 120;
+export const OVERLAY_GRADIENT_BOTTOM_PADDING_PX = 80;
+export const OVERLAY_GRADIENT_BOTTOM_ALPHA = 0.96;
+export const OVERLAY_GRADIENT_MIDDLE_ALPHA = 0.55;
+export const OVERLAY_GRADIENT_MIDDLE_STOP_PERCENT = 50;
 
 export const COMMAND = "npx -y react-doctor@latest";
 export const CONTENT_WIDTH_PX = 1400;

--- a/packages/video/src/scenes/diagnostics.tsx
+++ b/packages/video/src/scenes/diagnostics.tsx
@@ -1,9 +1,4 @@
-import {
-  AbsoluteFill,
-  Easing,
-  interpolate,
-  useCurrentFrame,
-} from "remotion";
+import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from "remotion";
 import {
   AFFECTED_FILE_COUNT,
   BACKGROUND_COLOR,
@@ -13,6 +8,9 @@ import {
   ELAPSED_TIME,
   FRAMES_PER_DIAGNOSTIC,
   MUTED_COLOR,
+  OVERLAY_GRADIENT_BOTTOM_PADDING_PX,
+  OVERLAY_GRADIENT_HEIGHT_PX,
+  OVERLAY_GRADIENT_HORIZONTAL_PADDING_PX,
   PERFECT_SCORE,
   RED_COLOR,
   SCORE_ANIMATION_FRAMES,
@@ -22,6 +20,7 @@ import {
   TEXT_COLOR,
   TOTAL_ERROR_COUNT,
 } from "../constants";
+import { getBottomOverlayGradient } from "../utils/get-bottom-overlay-gradient";
 import { fontFamily } from "../utils/font";
 
 const HERO_FACE_FONT_SIZE_PX = 80;
@@ -44,17 +43,12 @@ const SHRINK_END_FRAME = SHRINK_START_FRAME + SHRINK_DURATION_FRAMES;
 const DIAGNOSTIC_FADE_IN_FRAMES = 6;
 const ERRORS_START_DELAY_FRAMES = 58;
 
-const OVERLAY_START_FRAME = Math.floor(
-  SCENE_DIAGNOSTICS_DURATION_FRAMES * 0.5,
-);
+const OVERLAY_START_FRAME = Math.floor(SCENE_DIAGNOSTICS_DURATION_FRAMES * 0.5);
 const OVERLAY_FADE_IN_FRAMES = 15;
 const OVERLAY_HOLD_FRAMES = 35;
 const OVERLAY_FADE_OUT_FRAMES = 15;
 const OVERLAY_END_FRAME =
-  OVERLAY_START_FRAME +
-  OVERLAY_FADE_IN_FRAMES +
-  OVERLAY_HOLD_FRAMES +
-  OVERLAY_FADE_OUT_FRAMES;
+  OVERLAY_START_FRAME + OVERLAY_FADE_IN_FRAMES + OVERLAY_HOLD_FRAMES + OVERLAY_FADE_OUT_FRAMES;
 const OVERLAY_TITLE_FONT_SIZE_PX = 88;
 
 const getScoreColor = (score: number) => {
@@ -81,77 +75,43 @@ const lerpSize = (heroSize: number, smallSize: number, progress: number) =>
 export const Diagnostics = () => {
   const frame = useCurrentFrame();
 
-  const scoreBlockOpacity = interpolate(
-    frame,
-    [0, SCORE_FADE_IN_FRAMES],
-    [0, 1],
-    {
-      extrapolateLeft: "clamp",
-      extrapolateRight: "clamp",
-      easing: Easing.out(Easing.cubic),
-    },
-  );
+  const scoreBlockOpacity = interpolate(frame, [0, SCORE_FADE_IN_FRAMES], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.out(Easing.cubic),
+  });
 
-  const scoreProgress = interpolate(
-    frame,
-    [0, SCORE_ANIMATION_FRAMES],
-    [0, 1],
-    {
-      extrapolateLeft: "clamp",
-      extrapolateRight: "clamp",
-      easing: Easing.out(Easing.cubic),
-    },
-  );
+  const scoreProgress = interpolate(frame, [0, SCORE_ANIMATION_FRAMES], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.out(Easing.cubic),
+  });
   const currentScore = Math.round(scoreProgress * TARGET_SCORE);
   const scoreColor = getScoreColor(currentScore);
   const [eyes, mouth] = getDoctorFace(currentScore);
-  const filledBarCount = Math.round(
-    (currentScore / PERFECT_SCORE) * SCORE_BAR_WIDTH,
-  );
+  const filledBarCount = Math.round((currentScore / PERFECT_SCORE) * SCORE_BAR_WIDTH);
   const emptyBarCount = SCORE_BAR_WIDTH - filledBarCount;
 
-  const shrinkProgress = interpolate(
-    frame,
-    [SHRINK_START_FRAME, SHRINK_END_FRAME],
-    [0, 1],
-    {
-      extrapolateLeft: "clamp",
-      extrapolateRight: "clamp",
-      easing: Easing.inOut(Easing.quad),
-    },
-  );
+  const shrinkProgress = interpolate(frame, [SHRINK_START_FRAME, SHRINK_END_FRAME], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.inOut(Easing.quad),
+  });
 
-  const faceFontSize = lerpSize(
-    HERO_FACE_FONT_SIZE_PX,
-    SMALL_FACE_FONT_SIZE_PX,
-    shrinkProgress,
-  );
+  const faceFontSize = lerpSize(HERO_FACE_FONT_SIZE_PX, SMALL_FACE_FONT_SIZE_PX, shrinkProgress);
   const numberFontSize = lerpSize(
     HERO_NUMBER_FONT_SIZE_PX,
     SMALL_NUMBER_FONT_SIZE_PX,
     shrinkProgress,
   );
-  const labelFontSize = lerpSize(
-    HERO_LABEL_FONT_SIZE_PX,
-    SMALL_LABEL_FONT_SIZE_PX,
-    shrinkProgress,
-  );
-  const barFontSize = lerpSize(
-    HERO_BAR_FONT_SIZE_PX,
-    SMALL_BAR_FONT_SIZE_PX,
-    shrinkProgress,
-  );
+  const labelFontSize = lerpSize(HERO_LABEL_FONT_SIZE_PX, SMALL_LABEL_FONT_SIZE_PX, shrinkProgress);
+  const barFontSize = lerpSize(HERO_BAR_FONT_SIZE_PX, SMALL_BAR_FONT_SIZE_PX, shrinkProgress);
 
-  const summaryOpacity = interpolate(
-    frame,
-    [SHRINK_END_FRAME, SHRINK_END_FRAME + 10],
-    [0, 1],
-    {
-      extrapolateLeft: "clamp",
-      extrapolateRight: "clamp",
-      easing: Easing.out(Easing.cubic),
-    },
-  );
+  const summaryOpacity = interpolate(frame, [SHRINK_END_FRAME, SHRINK_END_FRAME + 10], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.out(Easing.cubic),
+  });
 
   const diagnosticsStartFrame = ERRORS_START_DELAY_FRAMES;
 
@@ -198,151 +158,151 @@ export const Diagnostics = () => {
           padding: "60px 80px",
         }}
       >
-      <div
-        style={{
-          opacity: scoreBlockOpacity,
-          display: "flex",
-          gap: interpolate(shrinkProgress, [0, 1], [48, 32]),
-          alignItems: "flex-start",
-          marginBottom: 32,
-        }}
-      >
-        <pre
+        <div
           style={{
-            color: scoreColor,
-            lineHeight: 1.2,
-            fontSize: faceFontSize,
-            fontFamily,
-            margin: 0,
+            opacity: scoreBlockOpacity,
+            display: "flex",
+            gap: interpolate(shrinkProgress, [0, 1], [48, 32]),
+            alignItems: "flex-start",
+            marginBottom: 32,
           }}
         >
-          {`${BOX_TOP}\n│ ${eyes} │\n│ ${mouth} │\n${BOX_BOTTOM}`}
-        </pre>
-
-        <div>
-          <div>
-            <span
-              style={{
-                color: scoreColor,
-                fontWeight: 500,
-                fontSize: numberFontSize,
-                fontFamily,
-              }}
-            >
-              {currentScore}
-            </span>
-            <span
-              style={{
-                color: MUTED_COLOR,
-                fontSize: labelFontSize,
-                fontFamily,
-              }}
-            >
-              {` / ${PERFECT_SCORE}  `}
-            </span>
-            <span
-              style={{
-                color: scoreColor,
-                fontSize: labelFontSize,
-                fontFamily,
-              }}
-            >
-              {getScoreLabel(currentScore)}
-            </span>
-          </div>
-          <div
+          <pre
             style={{
-              marginTop: 8,
-              letterSpacing: 2,
-              fontSize: barFontSize,
+              color: scoreColor,
+              lineHeight: 1.2,
+              fontSize: faceFontSize,
               fontFamily,
+              margin: 0,
             }}
           >
-            <span style={{ color: scoreColor }}>
-              {"█".repeat(filledBarCount)}
-            </span>
-            <span style={{ color: "#525252" }}>
-              {"░".repeat(emptyBarCount)}
-            </span>
+            {`${BOX_TOP}\n│ ${eyes} │\n│ ${mouth} │\n${BOX_BOTTOM}`}
+          </pre>
+
+          <div>
+            <div>
+              <span
+                style={{
+                  color: scoreColor,
+                  fontWeight: 500,
+                  fontSize: numberFontSize,
+                  fontFamily,
+                }}
+              >
+                {currentScore}
+              </span>
+              <span
+                style={{
+                  color: MUTED_COLOR,
+                  fontSize: labelFontSize,
+                  fontFamily,
+                }}
+              >
+                {` / ${PERFECT_SCORE}  `}
+              </span>
+              <span
+                style={{
+                  color: scoreColor,
+                  fontSize: labelFontSize,
+                  fontFamily,
+                }}
+              >
+                {getScoreLabel(currentScore)}
+              </span>
+            </div>
+            <div
+              style={{
+                marginTop: 8,
+                letterSpacing: 2,
+                fontSize: barFontSize,
+                fontFamily,
+              }}
+            >
+              <span style={{ color: scoreColor }}>{"█".repeat(filledBarCount)}</span>
+              <span style={{ color: "#525252" }}>{"░".repeat(emptyBarCount)}</span>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div
-        style={{
-          fontFamily,
-          fontSize: SUMMARY_FONT_SIZE_PX,
-          lineHeight: 1.7,
-          color: TEXT_COLOR,
-          opacity: summaryOpacity,
-          marginBottom: 24,
-        }}
-      >
-        <span style={{ color: RED_COLOR }}>
-          {TOTAL_ERROR_COUNT} errors
-        </span>
-        <span style={{ color: MUTED_COLOR }}>
-          {`  across ${AFFECTED_FILE_COUNT} files  in ${ELAPSED_TIME}`}
-        </span>
-      </div>
+        <div
+          style={{
+            fontFamily,
+            fontSize: SUMMARY_FONT_SIZE_PX,
+            lineHeight: 1.7,
+            color: TEXT_COLOR,
+            opacity: summaryOpacity,
+            marginBottom: 24,
+          }}
+        >
+          <span style={{ color: RED_COLOR }}>{TOTAL_ERROR_COUNT} errors</span>
+          <span style={{ color: MUTED_COLOR }}>
+            {`  across ${AFFECTED_FILE_COUNT} files  in ${ELAPSED_TIME}`}
+          </span>
+        </div>
 
-      {DIAGNOSTICS.map((diagnostic, index) => {
-        const diagnosticStartFrame =
-          diagnosticsStartFrame + index * FRAMES_PER_DIAGNOSTIC;
-        const localFrame = frame - diagnosticStartFrame;
-        const diagnosticOpacity = interpolate(
-          localFrame,
-          [0, DIAGNOSTIC_FADE_IN_FRAMES],
-          [0, 1],
-          {
-            extrapolateLeft: "clamp",
-            extrapolateRight: "clamp",
-            easing: Easing.out(Easing.cubic),
-          },
-        );
+        {DIAGNOSTICS.map((diagnostic, index) => {
+          const diagnosticStartFrame = diagnosticsStartFrame + index * FRAMES_PER_DIAGNOSTIC;
+          const localFrame = frame - diagnosticStartFrame;
+          const diagnosticOpacity = interpolate(
+            localFrame,
+            [0, DIAGNOSTIC_FADE_IN_FRAMES],
+            [0, 1],
+            {
+              extrapolateLeft: "clamp",
+              extrapolateRight: "clamp",
+              easing: Easing.out(Easing.cubic),
+            },
+          );
 
-        return (
-          <div
-            key={diagnostic.message}
-            style={{
-              fontFamily,
-              fontSize: DIAGNOSTIC_FONT_SIZE_PX,
-              lineHeight: 1.7,
-              color: TEXT_COLOR,
-              whiteSpace: "pre-wrap",
-              opacity: diagnosticOpacity,
-              marginBottom: 2,
-            }}
-          >
-            <span style={{ color: RED_COLOR }}> ✗</span>
-            {` ${diagnostic.message} `}
-            <span style={{ color: MUTED_COLOR }}>
-              ({diagnostic.count})
-            </span>
-          </div>
-        );
-      })}
+          return (
+            <div
+              key={diagnostic.message}
+              style={{
+                fontFamily,
+                fontSize: DIAGNOSTIC_FONT_SIZE_PX,
+                lineHeight: 1.7,
+                color: TEXT_COLOR,
+                whiteSpace: "pre-wrap",
+                opacity: diagnosticOpacity,
+                marginBottom: 2,
+              }}
+            >
+              <span style={{ color: RED_COLOR }}> ✗</span>
+              {` ${diagnostic.message} `}
+              <span style={{ color: MUTED_COLOR }}>({diagnostic.count})</span>
+            </div>
+          );
+        })}
       </div>
 
       <AbsoluteFill
         style={{
-          backgroundColor: `rgba(10, 10, 10, ${overlayOpacity * 0.85})`,
-          justifyContent: "center",
-          alignItems: "center",
+          justifyContent: "flex-end",
         }}
       >
         <div
           style={{
-            fontFamily,
-            fontSize: OVERLAY_TITLE_FONT_SIZE_PX,
-            color: "white",
-            opacity: overlayTitleOpacity,
-            textAlign: "center",
-            padding: "0 120px",
-            lineHeight: 1.4,
+            width: "100%",
+            height: OVERLAY_GRADIENT_HEIGHT_PX,
+            background: getBottomOverlayGradient(overlayOpacity),
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "flex-end",
+            padding: `0 ${OVERLAY_GRADIENT_HORIZONTAL_PADDING_PX}px ${OVERLAY_GRADIENT_BOTTOM_PADDING_PX}px`,
           }}
         >
-          Send to coding agent
+          <div
+            style={{
+              fontFamily,
+              fontSize: OVERLAY_TITLE_FONT_SIZE_PX,
+              color: "white",
+              opacity: overlayTitleOpacity,
+              textAlign: "center",
+              lineHeight: 1.4,
+            }}
+          >
+            Send to coding agent
+          </div>
         </div>
       </AbsoluteFill>
     </AbsoluteFill>

--- a/packages/video/src/scenes/file-scan.tsx
+++ b/packages/video/src/scenes/file-scan.tsx
@@ -1,21 +1,20 @@
-import {
-  AbsoluteFill,
-  Easing,
-  interpolate,
-  useCurrentFrame,
-} from "remotion";
+import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from "remotion";
 import {
   BACKGROUND_COLOR,
   FILE_SCAN_FONT_SIZE_PX,
   FILE_SCAN_INITIAL_DELAY_FRAMES,
   FRAMES_PER_FILE,
   MUTED_COLOR,
+  OVERLAY_GRADIENT_BOTTOM_PADDING_PX,
+  OVERLAY_GRADIENT_HEIGHT_PX,
+  OVERLAY_GRADIENT_HORIZONTAL_PADDING_PX,
   RED_COLOR,
   SCANNED_FILES,
   SCENE_FILE_SCAN_DURATION_FRAMES,
   TEXT_COLOR,
   YELLOW_COLOR,
 } from "../constants";
+import { getBottomOverlayGradient } from "../utils/get-bottom-overlay-gradient";
 import { fontFamily } from "../utils/font";
 
 const LINE_HEIGHT_MULTIPLIER = 1.6;
@@ -27,37 +26,25 @@ const USABLE_HEIGHT_PX = VIEWPORT_HEIGHT_PX - CONTENT_PADDING_PX * 2;
 const VISIBLE_ROW_COUNT = Math.floor(USABLE_HEIGHT_PX / LINE_HEIGHT_PX);
 const TOTAL_LIST_HEIGHT_PX = SCANNED_FILES.length * LINE_HEIGHT_PX;
 const MAX_SCROLL_PX = Math.max(0, TOTAL_LIST_HEIGHT_PX - USABLE_HEIGHT_PX);
-const SCROLL_START_FRAME =
-  FILE_SCAN_INITIAL_DELAY_FRAMES + VISIBLE_ROW_COUNT * FRAMES_PER_FILE;
-const SCROLL_END_FRAME =
-  FILE_SCAN_INITIAL_DELAY_FRAMES + SCANNED_FILES.length * FRAMES_PER_FILE;
+const SCROLL_START_FRAME = FILE_SCAN_INITIAL_DELAY_FRAMES + VISIBLE_ROW_COUNT * FRAMES_PER_FILE;
+const SCROLL_END_FRAME = FILE_SCAN_INITIAL_DELAY_FRAMES + SCANNED_FILES.length * FRAMES_PER_FILE;
 
-const OVERLAY_START_FRAME = Math.floor(
-  SCENE_FILE_SCAN_DURATION_FRAMES * 0.25,
-);
+const OVERLAY_START_FRAME = Math.floor(SCENE_FILE_SCAN_DURATION_FRAMES * 0.25);
 const OVERLAY_FADE_IN_FRAMES = 15;
 const OVERLAY_HOLD_FRAMES = 60;
 const OVERLAY_FADE_OUT_FRAMES = 15;
 const OVERLAY_END_FRAME =
-  OVERLAY_START_FRAME +
-  OVERLAY_FADE_IN_FRAMES +
-  OVERLAY_HOLD_FRAMES +
-  OVERLAY_FADE_OUT_FRAMES;
+  OVERLAY_START_FRAME + OVERLAY_FADE_IN_FRAMES + OVERLAY_HOLD_FRAMES + OVERLAY_FADE_OUT_FRAMES;
 const TITLE_FONT_SIZE_PX = 88;
 
 export const FileScan = () => {
   const frame = useCurrentFrame();
 
-  const scrollY = interpolate(
-    frame,
-    [SCROLL_START_FRAME, SCROLL_END_FRAME],
-    [0, MAX_SCROLL_PX],
-    {
-      extrapolateLeft: "clamp",
-      extrapolateRight: "clamp",
-      easing: Easing.inOut(Easing.quad),
-    },
-  );
+  const scrollY = interpolate(frame, [SCROLL_START_FRAME, SCROLL_END_FRAME], [0, MAX_SCROLL_PX], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.inOut(Easing.quad),
+  });
 
   const overlayOpacity = interpolate(
     frame,
@@ -106,23 +93,15 @@ export const FileScan = () => {
       >
         <div style={{ transform: `translateY(-${scrollY}px)` }}>
           {SCANNED_FILES.map((file, index) => {
-            const fileStartFrame =
-              FILE_SCAN_INITIAL_DELAY_FRAMES +
-              index * FRAMES_PER_FILE;
+            const fileStartFrame = FILE_SCAN_INITIAL_DELAY_FRAMES + index * FRAMES_PER_FILE;
             const localFrame = frame - fileStartFrame;
-            const fileOpacity = interpolate(
-              localFrame,
-              [0, FADE_IN_FRAMES],
-              [0, 1],
-              {
-                extrapolateLeft: "clamp",
-                extrapolateRight: "clamp",
-                easing: Easing.out(Easing.cubic),
-              },
-            );
+            const fileOpacity = interpolate(localFrame, [0, FADE_IN_FRAMES], [0, 1], {
+              extrapolateLeft: "clamp",
+              extrapolateRight: "clamp",
+              easing: Easing.out(Easing.cubic),
+            });
 
-            const hasIssues =
-              file.errors > 0 || file.warnings > 0;
+            const hasIssues = file.errors > 0 || file.warnings > 0;
 
             return (
               <div
@@ -139,9 +118,7 @@ export const FileScan = () => {
                 }}
               >
                 <span>
-                  <span style={{ color: MUTED_COLOR }}>
-                    {String(index + 1).padStart(2, " ")}{" "}
-                  </span>
+                  <span style={{ color: MUTED_COLOR }}>{String(index + 1).padStart(2, " ")} </span>
                   <span>{file.path}</span>
                 </span>
                 {hasIssues && (
@@ -153,14 +130,10 @@ export const FileScan = () => {
                       </span>
                     )}
                     {file.errors > 0 && file.warnings > 0 && (
-                      <span style={{ color: MUTED_COLOR }}>
-                        {"  "}
-                      </span>
+                      <span style={{ color: MUTED_COLOR }}>{"  "}</span>
                     )}
                     {file.warnings > 0 && (
-                      <span style={{ color: YELLOW_COLOR }}>
-                        {file.warnings} ⚠️
-                      </span>
+                      <span style={{ color: YELLOW_COLOR }}>{file.warnings} ⚠️</span>
                     )}
                   </span>
                 )}
@@ -172,23 +145,32 @@ export const FileScan = () => {
 
       <AbsoluteFill
         style={{
-          backgroundColor: `rgba(10, 10, 10, ${overlayOpacity * 0.85})`,
-          justifyContent: "center",
-          alignItems: "center",
+          justifyContent: "flex-end",
         }}
       >
         <div
           style={{
-            fontFamily,
-            fontSize: TITLE_FONT_SIZE_PX,
-            color: "white",
-            opacity: titleOpacity,
-            textAlign: "center",
-            padding: "0 120px",
-            lineHeight: 1.4,
+            width: "100%",
+            height: OVERLAY_GRADIENT_HEIGHT_PX,
+            background: getBottomOverlayGradient(overlayOpacity),
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "flex-end",
+            padding: `0 ${OVERLAY_GRADIENT_HORIZONTAL_PADDING_PX}px ${OVERLAY_GRADIENT_BOTTOM_PADDING_PX}px`,
           }}
         >
-          Scan for React issues
+          <div
+            style={{
+              fontFamily,
+              fontSize: TITLE_FONT_SIZE_PX,
+              color: "white",
+              opacity: titleOpacity,
+              textAlign: "center",
+              lineHeight: 1.4,
+            }}
+          >
+            Scan for React issues
+          </div>
         </div>
       </AbsoluteFill>
     </AbsoluteFill>

--- a/packages/video/src/utils/get-bottom-overlay-gradient.ts
+++ b/packages/video/src/utils/get-bottom-overlay-gradient.ts
@@ -1,0 +1,9 @@
+import {
+  OVERLAY_GRADIENT_BOTTOM_ALPHA,
+  OVERLAY_GRADIENT_MIDDLE_ALPHA,
+  OVERLAY_GRADIENT_MIDDLE_STOP_PERCENT,
+  OVERLAY_GRADIENT_RGB,
+} from "../constants";
+
+export const getBottomOverlayGradient = (overlayOpacity: number) =>
+  `linear-gradient(to top, rgba(${OVERLAY_GRADIENT_RGB}, ${overlayOpacity * OVERLAY_GRADIENT_BOTTOM_ALPHA}) 0%, rgba(${OVERLAY_GRADIENT_RGB}, ${overlayOpacity * OVERLAY_GRADIENT_MIDDLE_ALPHA}) ${OVERLAY_GRADIENT_MIDDLE_STOP_PERCENT}%, rgba(${OVERLAY_GRADIENT_RGB}, 0) 100%)`;


### PR DESCRIPTION
## Summary
- move overlay text from centered full-screen placement to a bottom-anchored overlay in video scenes
- render only a bottom overlay region that gradients upward and fades out
- extract shared overlay gradient generation into a utility
- darken overlay gradient alpha values for stronger contrast

## Validation
- nr format packages/video/src/constants.ts packages/video/src/scenes/file-scan.tsx packages/video/src/scenes/diagnostics.tsx packages/video/src/utils/get-bottom-overlay-gradient.ts
- nr lint packages/video/src/constants.ts packages/video/src/scenes/file-scan.tsx packages/video/src/scenes/diagnostics.tsx packages/video/src/utils/get-bottom-overlay-gradient.ts
- nr build (in packages/video)