### PR TITLE
Set twitter:image to React Doctor banner

### DIFF
--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -8,9 +8,17 @@ const ibmPlexMono = IBM_Plex_Mono({
   weight: ["400", "500"],
 });
 
+const SITE_URL = "https://www.react.doctor";
+const TWITTER_IMAGE_PATH = "/react-doctor-og-banner.svg";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "React Doctor",
   description: "Let coding agents diagnose and fix your React code.",
+  twitter: {
+    card: "summary_large_image",
+    images: [TWITTER_IMAGE_PATH],
+  },
   icons: { icon: "/react-doctor-icon.svg" },
 };
 


### PR DESCRIPTION
## Summary
- set `twitter:image` in website metadata to `/react-doctor-og-banner.svg`
- add `metadataBase` so the image URL resolves correctly for crawlers

## Validation
- `nr build` in `packages/website` passes