### PR TITLE
Remove private flag from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "react-doctor",
-  "private": true,
   "scripts": {
     "dev": "pnpm --filter react-doctor run dev",
     "build": "pnpm --filter react-doctor run build",


### PR DESCRIPTION
This should allow the repo to be linked from the npm website when viewing this package.