### PR TITLE
fix(cli): include React workspace root in project selection

### DIFF
--- a/packages/react-doctor/src/utils/discover-project.ts
+++ b/packages/react-doctor/src/utils/discover-project.ts
@@ -227,6 +227,19 @@ const hasReactDependency = (packageJson: PackageJson): boolean => {
   );
 };
 
+export const discoverRootReactPackage = (rootDirectory: string): WorkspacePackage | null => {
+  const packageJsonPath = path.join(rootDirectory, "package.json");
+  if (!fs.existsSync(packageJsonPath)) return null;
+
+  const packageJson = readPackageJson(packageJsonPath);
+  if (!hasReactDependency(packageJson)) return null;
+
+  return {
+    name: packageJson.name ?? path.basename(rootDirectory),
+    directory: rootDirectory,
+  };
+};
+
 export const discoverReactSubprojects = (rootDirectory: string): WorkspacePackage[] => {
   if (!fs.existsSync(rootDirectory) || !fs.statSync(rootDirectory).isDirectory()) return [];
 

--- a/packages/react-doctor/src/utils/select-projects.ts
+++ b/packages/react-doctor/src/utils/select-projects.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import type { WorkspacePackage } from "../types.js";
-import { discoverReactSubprojects, listWorkspacePackages } from "./discover-project.js";
+import {
+  discoverReactSubprojects,
+  discoverRootReactPackage,
+  listWorkspacePackages,
+} from "./discover-project.js";
 import { highlighter } from "./highlighter.js";
 import { logger } from "./logger.js";
 import { prompts } from "./prompts.js";
@@ -13,6 +17,18 @@ export const selectProjects = async (
   let packages = listWorkspacePackages(rootDirectory);
   if (packages.length === 0) {
     packages = discoverReactSubprojects(rootDirectory);
+  }
+
+  const rootPackage = discoverRootReactPackage(rootDirectory);
+  if (rootPackage) {
+    const hasDuplicateRootPackage = packages.some(
+      (workspacePackage) =>
+        workspacePackage.name === rootPackage.name ||
+        workspacePackage.directory === rootPackage.directory,
+    );
+    if (!hasDuplicateRootPackage) {
+      packages.push(rootPackage);
+    }
   }
 
   if (packages.length === 0) return [rootDirectory];

--- a/packages/react-doctor/tests/select-projects.test.ts
+++ b/packages/react-doctor/tests/select-projects.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { selectProjects } from "../src/utils/select-projects.js";
+
+interface WorkspacePackageDefinition {
+  name: string;
+  reactDependency: boolean;
+}
+
+interface WorkspaceFixtureDefinition {
+  rootName: string;
+  rootReactDependency: boolean;
+  workspacePackages: WorkspacePackageDefinition[];
+}
+
+const temporaryDirectories: string[] = [];
+
+const createWorkspaceFixture = (definition: WorkspaceFixtureDefinition): string => {
+  const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-select-projects-"));
+
+  const rootDependencies = definition.rootReactDependency ? { react: "^19.0.0" } : {};
+  fs.writeFileSync(
+    path.join(rootDirectory, "package.json"),
+    JSON.stringify(
+      {
+        name: definition.rootName,
+        workspaces: ["packages/*"],
+        dependencies: rootDependencies,
+      },
+      null,
+      2,
+    ),
+  );
+
+  for (const workspacePackage of definition.workspacePackages) {
+    const workspaceDirectory = path.join(rootDirectory, "packages", workspacePackage.name);
+    fs.mkdirSync(workspaceDirectory, { recursive: true });
+
+    const workspaceDependencies = workspacePackage.reactDependency ? { react: "^19.0.0" } : {};
+    fs.writeFileSync(
+      path.join(workspaceDirectory, "package.json"),
+      JSON.stringify(
+        {
+          name: workspacePackage.name,
+          dependencies: workspaceDependencies,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  temporaryDirectories.push(rootDirectory);
+  return rootDirectory;
+};
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+  temporaryDirectories.length = 0;
+});
+
+describe("selectProjects", () => {
+  it("includes root package even when workspace candidates exist", async () => {
+    const rootDirectory = createWorkspaceFixture({
+      rootName: "workspace-root",
+      rootReactDependency: true,
+      workspacePackages: [{ name: "workspace-app", reactDependency: true }],
+    });
+    const workspaceDirectory = path.join(rootDirectory, "packages", "workspace-app");
+
+    const selectedDirectories = await selectProjects(rootDirectory, undefined, true);
+
+    expect(selectedDirectories).toContain(workspaceDirectory);
+    expect(selectedDirectories).toContain(rootDirectory);
+  });
+
+  it("resolves root package with --project", async () => {
+    const rootDirectory = createWorkspaceFixture({
+      rootName: "workspace-root",
+      rootReactDependency: true,
+      workspacePackages: [{ name: "workspace-app", reactDependency: true }],
+    });
+
+    const selectedDirectories = await selectProjects(rootDirectory, "workspace-root", true);
+
+    expect(selectedDirectories).toEqual([rootDirectory]);
+  });
+
+  it("does not include root package when root has no React dependency", async () => {
+    const rootDirectory = createWorkspaceFixture({
+      rootName: "workspace-root",
+      rootReactDependency: false,
+      workspacePackages: [{ name: "workspace-app", reactDependency: true }],
+    });
+    const workspaceDirectory = path.join(rootDirectory, "packages", "workspace-app");
+
+    const selectedDirectories = await selectProjects(rootDirectory, undefined, true);
+
+    expect(selectedDirectories).toEqual([workspaceDirectory]);
+  });
+});


### PR DESCRIPTION
## Summary

- Include React workspace root project in the selectable project list
- Add `discoverRootReactPackage` to detect React dependency on workspace root
- Update project selection flow to append root project with duplicate guard (`name`/`directory`)
- Add tests for root inclusion, root resolution via `--project`, and non-React root exclusion

## Why

In monorepo setups, react-doctor listed only workspace sub-packages and did not include the workspace root even when the root package used React. This prevented users from selecting and scanning root-based apps directly.

## Architecture Changes

**TypeScript (CLI):**
- Add `discoverRootReactPackage(rootDirectory)` in `discover-project.ts`
- Keep `hasReactDependency` as an internal helper (non-exported)
- In `select-projects.ts`, append root candidate when eligible and not duplicated
- Preserve existing fallback behavior when no candidates are found

**Tests:**
- Add `tests/select-projects.test.ts`
  - includes root package when workspace candidates exist
  - resolves root package with `--project`
  - excludes root package when root has no React dependency

## Test Plan

- [x] `pnpm --filter react-doctor run test -- select-projects`
- [x] `pnpm --filter react-doctor run typecheck`
- [x] Manual verification: root project appears as selectable option in monorepo (`l-shift-4`)

## Files Changed

**Updated:**
- `packages/react-doctor/src/utils/discover-project.ts`
- `packages/react-doctor/src/utils/select-projects.ts`

**Added:**
- `packages/react-doctor/tests/select-projects.test.ts`