### PR TITLE
fix: add typescript as dependency to resolve knip peer dep in npx/dlx environments

### DIFF
--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -54,7 +54,8 @@
     "ora": "^9.3.0",
     "oxlint": "^1.47.0",
     "picocolors": "^1.1.1",
-    "prompts": "^2.4.2"
+    "prompts": "^2.4.2",
+    "typescript": ">=5.0.4 <7"
   },
   "devDependencies": {
     "@types/prompts": "^2.4.9",


### PR DESCRIPTION
## Problem

When running `npx -y react-doctor@latest .` or `pnpm dlx react-doctor@latest .`, the following error occurs:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'typescript' imported from
.../knip/dist/plugins/astro/resolveFromAST.js
```

## Root Cause

`knip` declares `typescript >=5.0.4` as a **required peer dependency** for its Astro plugin. When `react-doctor` is executed via `npx` or `pnpm dlx`, it runs in an isolated cache directory that does not have access to the host project's `node_modules`. As a result, `typescript` cannot be resolved at module load time.

## Fix

Add `typescript` as an explicit dependency in `packages/react-doctor/package.json`, matching the range required by knip (`>=5.0.4 <7`). This ensures `typescript` is always installed alongside `react-doctor` in any environment.

## Testing

Before fix:
```bash
npx -y react-doctor@latest .  # ERR_MODULE_NOT_FOUND for typescript
```

After fix: react-doctor runs correctly since typescript is bundled as a direct dependency.