### PR TITLE
Add gitdiagram leaderboard entry

### DIFF
--- a/packages/website/src/app/leaderboard/leaderboard-entries.ts
+++ b/packages/website/src/app/leaderboard/leaderboard-entries.ts
@@ -21,6 +21,15 @@ const buildShareUrl = (entry: LeaderboardEntry): string => {
 
 const RAW_ENTRIES: LeaderboardEntry[] = [
   {
+    name: "gitdiagram",
+    githubUrl: "https://github.com/ahmedkhaleel2004/gitdiagram",
+    packageName: "gitdiagram",
+    score: 100,
+    errorCount: 0,
+    warningCount: 0,
+    fileCount: 67,
+  },
+  {
     name: "tldraw",
     githubUrl: "https://github.com/tldraw/tldraw",
     packageName: "tldraw",


### PR DESCRIPTION
Adds gitdiagram to the leaderboard entries using the latest scan results:

- Score: 100
- Errors: 0
- Warnings: 0
- Files: 67

Repository: https://github.com/ahmedkhaleel2004/gitdiagram