### PR TITLE
fix(website): prevent hydration mismatch in terminal demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ dist
 .DS_Store
 .agents
 .cursor
+
+
+# MARK: You have ignore this
+package-lock.json 

--- a/packages/website/.gitignore
+++ b/packages/website/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# MARK: You have ignore this
+package-lock.json 

--- a/packages/website/src/components/terminal.tsx
+++ b/packages/website/src/components/terminal.tsx
@@ -301,12 +301,16 @@ const markAnimationCompleted = () => {
 };
 
 const Terminal = () => {
-  const [state, setState] = useState<AnimationState>(
-    didAnimationComplete() ? COMPLETED_STATE : INITIAL_STATE,
-  );
+  // #MARK: Before this fix, we read localStorage during render and could start from COMPLETED_STATE on the client.
+  // #MARK: That produced different first HTML on server vs client and triggered hydration mismatch.
+  const [state, setState] = useState<AnimationState>(INITIAL_STATE);
 
   useEffect(() => {
-    if (didAnimationComplete()) return;
+    // #MARK: Read persisted completion only after mount so the first client render matches SSR output.
+    if (didAnimationComplete()) {
+      setState(COMPLETED_STATE);
+      return;
+    }
 
     let cancelled = false;
 


### PR DESCRIPTION
## Summary

Fix hydration mismatch on the website terminal demo.

The issue was caused by reading `localStorage` during initial render, which could produce different first render output between SSR and client (empty command on server vs completed command on client).

## What changed

- `Terminal` now always starts from `INITIAL_STATE` on first render.
- Moved persisted state check (`didAnimationComplete`) into `useEffect` (client-only after mount).
- If animation was already completed, state is set to `COMPLETED_STATE` after mount.

## Why this fixes it

SSR and first client render are now deterministic and identical, so React hydration no longer sees text/content mismatch.

## Files

- `packages/website/src/components/terminal.tsx`

## Validation

- Reproduced mismatch before fix.
- Verified render flow after fix: no server/client initial state divergence.

## Additional changes

- Ignore `package-lock.json` in repo/website gitignore files.
