### PR TITLE
feat: add no-inline-object-props performance rule

### DIFF
--- a/packages/react-doctor/src/oxlint-config.ts
+++ b/packages/react-doctor/src/oxlint-config.ts
@@ -119,6 +119,7 @@ export const createOxlintConfig = ({
     "react-doctor/rerender-memo-with-default-value": "warn",
     "react-doctor/rendering-animate-svg-wrapper": "warn",
     "react-doctor/no-inline-prop-on-memo-component": "warn",
+    "react-doctor/no-inline-object-props": "warn",
     "react-doctor/rendering-hydration-no-flicker": "warn",
 
     "react-doctor/no-transition-all": "warn",

--- a/packages/react-doctor/src/plugin/index.ts
+++ b/packages/react-doctor/src/plugin/index.ts
@@ -49,6 +49,7 @@ import {
 } from "./rules/nextjs.js";
 import {
   noGlobalCssVariableAnimation,
+  noInlineObjectProps,
   noLargeAnimatedBlur,
   noLayoutPropertyAnimation,
   noPermanentWillChange,
@@ -107,6 +108,7 @@ const plugin: RulePlugin = {
     "rerender-memo-with-default-value": rerenderMemoWithDefaultValue,
     "rendering-animate-svg-wrapper": renderingAnimateSvgWrapper,
     "no-inline-prop-on-memo-component": noInlinePropOnMemoComponent,
+    "no-inline-object-props": noInlineObjectProps,
     "rendering-hydration-no-flicker": renderingHydrationNoFlicker,
 
     "no-transition-all": noTransitionAll,

--- a/packages/react-doctor/src/utils/run-oxlint.ts
+++ b/packages/react-doctor/src/utils/run-oxlint.ts
@@ -40,6 +40,7 @@ const RULE_CATEGORY_MAP: Record<string, string> = {
   "react-doctor/rerender-memo-with-default-value": "Performance",
   "react-doctor/rendering-animate-svg-wrapper": "Performance",
   "react-doctor/rendering-usetransition-loading": "Performance",
+  "react-doctor/no-inline-object-props": "Performance",
   "react-doctor/rendering-hydration-no-flicker": "Performance",
 
   "react-doctor/no-transition-all": "Performance",
@@ -124,6 +125,8 @@ const RULE_HELP_MAP: Record<string, string> = {
     "Wrap the SVG: `<motion.div animate={...}><svg>...</svg></motion.div>`",
   "rendering-usetransition-loading":
     "Replace with `const [isPending, startTransition] = useTransition()` — avoids a re-render for the loading state",
+  "no-inline-object-props":
+    "Extract object/array literals to stable references with `useMemo` or module-level constants, then pass those variables as props",
   "rendering-hydration-no-flicker":
     "Use `useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)` or add `suppressHydrationWarning` to the element",
 

--- a/packages/react-doctor/tests/run-oxlint.test.ts
+++ b/packages/react-doctor/tests/run-oxlint.test.ts
@@ -149,6 +149,12 @@ describe("runOxlint", () => {
         fixture: "performance-issues.tsx",
         ruleSource: "rules/performance.ts",
       },
+      "no-inline-object-props": {
+        fixture: "performance-issues.tsx",
+        ruleSource: "rules/performance.ts",
+        severity: "warning",
+        category: "Performance",
+      },
       "no-usememo-simple-expression": {
         fixture: "performance-issues.tsx",
         ruleSource: "rules/performance.ts",


### PR DESCRIPTION
## Summary
Adds a new performance rule `no-inline-object-props` that detects inline object and array literals passed directly as JSX props.

## Problem
When objects or arrays are created inline as JSX props, a new reference is created on every render. This causes unnecessary re-renders of child components even when the actual data hasn't changed — a common and silent React performance issue.

## Example

❌ Bad — new reference created on every render
```jsx
<Component style={{ color: 'red' }} />
<Component data={[1, 2, 3]} />
<Component config={{ theme: 'dark', size: 'lg' }} />
```

✅ Good — stable reference, no unnecessary re-renders
```jsx
const style = { color: 'red' };
<Component style={style} />
```

## Changes
- Added rule visitor in `performance.ts`
- Registered rule in `index.ts`
- Added severity (`warn`) in `oxlint-config.ts`
- Added category mapping and help text in `run-oxlint.ts`
- Added test coverage in `run-oxlint.test.ts`

## Validation
- All 81 tests pass (`pnpm --filter react-doctor test`)
- Typecheck passes
- Build passes
- Rule emits 7 diagnostics on fixture with correct severity/category