### PR TITLE
Pass ignore.files patterns to scanning tools

### DIFF
--- a/packages/react-doctor/src/scan.ts
+++ b/packages/react-doctor/src/scan.ts
@@ -361,6 +361,7 @@ export const scan = async (directory: string, inputOptions: ScanOptions = {}): P
     includePaths: inputOptions.includePaths,
   };
 
+  const ignoreFilePatterns = userConfig?.ignore?.files ?? [];
   const includePaths = options.includePaths ?? [];
   const isDiffMode = includePaths.length > 0;
 
@@ -412,6 +413,7 @@ export const scan = async (directory: string, inputOptions: ScanOptions = {}): P
             projectInfo.framework,
             projectInfo.hasReactCompiler,
             jsxIncludePaths,
+            ignoreFilePatterns,
           );
           lintSpinner?.succeed("Running lint checks.");
           return lintDiagnostics;
@@ -437,7 +439,7 @@ export const scan = async (directory: string, inputOptions: ScanOptions = {}): P
             ? null
             : spinner("Detecting dead code...").start();
           try {
-            const knipDiagnostics = await runKnip(directory);
+            const knipDiagnostics = await runKnip(directory, ignoreFilePatterns);
             deadCodeSpinner?.succeed("Detecting dead code.");
             return knipDiagnostics;
           } catch (error) {

--- a/packages/react-doctor/src/utils/run-oxlint.ts
+++ b/packages/react-doctor/src/utils/run-oxlint.ts
@@ -258,6 +258,7 @@ export const runOxlint = async (
   framework: Framework,
   hasReactCompiler: boolean,
   includePaths?: string[],
+  ignorePatterns?: string[],
 ): Promise<Diagnostic[]> => {
   if (includePaths !== undefined && includePaths.length === 0) {
     return [];
@@ -276,6 +277,12 @@ export const runOxlint = async (
 
     if (hasTypeScript) {
       args.push("--tsconfig", "./tsconfig.json");
+    }
+
+    if (ignorePatterns) {
+      for (const pattern of ignorePatterns) {
+        args.push("--ignore-pattern", pattern);
+      }
     }
 
     if (includePaths !== undefined) {


### PR DESCRIPTION
## Summary

Pass `ignore.files` config patterns down to `runOxlint` and `runKnip` so excluded files are skipped during scanning, not just filtered from results after the fact.

## Motivation

The `ignore.files` config option is documented and accepted, but it only post-filters diagnostics in `filterIgnoredDiagnostics`. The scanning tools (oxlint and knip) still process every file regardless. This means projects with large build artifact directories still get hundreds of false positive "unused file" warnings from generated output, even when those paths are configured to be ignored.

## Usage

```json
{
  "ignore": {
    "files": ["build/**", ".cache/**"]
  }
}
```

With this change, the patterns above are now forwarded to:
- **oxlint** via `--ignore-pattern` CLI flags
- **knip** via post-filter using the existing `compileGlobPattern` utility