### PR TITLE
Add @fragments-sdk/ui to leaderboard (100/100)

### DIFF
--- a/packages/website/src/app/leaderboard/leaderboard-entries.ts
+++ b/packages/website/src/app/leaderboard/leaderboard-entries.ts
@@ -21,6 +21,15 @@ const buildShareUrl = (entry: LeaderboardEntry): string => {
 
 const RAW_ENTRIES: LeaderboardEntry[] = [
   {
+    name: "fragments",
+    githubUrl: "https://github.com/ConanMcN/fragments",
+    packageName: "@fragments-sdk/ui",
+    score: 100,
+    errorCount: 0,
+    warningCount: 0,
+    fileCount: 0,
+  },
+  {
     name: "tldraw",
     githubUrl: "https://github.com/tldraw/tldraw",
     packageName: "tldraw",


### PR DESCRIPTION
## Summary

Adding [@fragments-sdk/ui](https://github.com/ConanMcN/fragments) to the react-doctor leaderboard.

**Score: 100/100** — 0 errors, 0 warnings across 243 source files.

Fragments is an AI-native React component library with 67 components, design tokens, and MCP integration.

```
npx -y react-doctor@latest --project '@fragments-sdk/ui' -y
```

Share URL: https://www.react.doctor/share?p=%40fragments-sdk%2Fui&s=100&e=0&w=0&f=0