### PR TITLE
feat: add configurable accessibility presets

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -119,14 +119,15 @@ If both exist, `react-doctor.config.json` takes precedence.
 
 ### Config options
 
-| Key            | Type                | Default | Description                                                                                                                         |
-| -------------- | ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `ignore.rules` | `string[]`          | `[]`    | Rules to suppress, using the `plugin/rule` format shown in diagnostic output (e.g. `react/no-danger`, `knip/exports`, `knip/types`) |
-| `ignore.files` | `string[]`          | `[]`    | File paths to exclude, supports glob patterns (`src/generated/**`, `**/*.test.tsx`)                                                 |
-| `lint`         | `boolean`           | `true`  | Enable/disable lint checks (same as `--no-lint`)                                                                                    |
-| `deadCode`     | `boolean`           | `true`  | Enable/disable dead code detection (same as `--no-dead-code`)                                                                       |
-| `verbose`      | `boolean`           | `false` | Show file details per rule (same as `--verbose`)                                                                                    |
-| `diff`         | `boolean \| string` | —       | Force diff mode (`true`) or pin a base branch (`"main"`). Set to `false` to disable auto-detection.                                 |
+| Key             | Type                                              | Default     | Description                                                                                                                                                             |
+| --------------- | ------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ignore.rules`  | `string[]`                                        | `[]`        | Rules to suppress, using the `plugin/rule` format shown in diagnostic output (e.g. `react/no-danger`, `knip/exports`, `knip/types`)                                     |
+| `ignore.files`  | `string[]`                                        | `[]`        | File paths to exclude, supports glob patterns (`src/generated/**`, `**/*.test.tsx`)                                                                                     |
+| `lint`          | `boolean`                                         | `true`      | Enable/disable lint checks (same as `--no-lint`)                                                                                                                        |
+| `deadCode`      | `boolean`                                         | `true`      | Enable/disable dead code detection (same as `--no-dead-code`)                                                                                                           |
+| `verbose`       | `boolean`                                         | `false`     | Show file details per rule (same as `--verbose`)                                                                                                                        |
+| `diff`          | `boolean \| string`                               | —           | Force diff mode (`true`) or pin a base branch (`"main"`). Set to `false` to disable auto-detection.                                                                     |
+| `accessibility` | `"minimal" \| "recommended" \| "strict" \| false` | `"minimal"` | Accessibility checking level. `minimal`: 15 high-impact rules, `recommended`: 31 rules (jsx-a11y/recommended), `strict`: 33 rules as errors. Set to `false` to disable. |
 
 CLI flags always override config values.
 
@@ -150,6 +151,7 @@ The `diagnose` function accepts an optional second argument:
 const result = await diagnose(".", {
   lint: true, // run lint checks (default: true)
   deadCode: true, // run dead code detection (default: true)
+  accessibility: "recommended", // "minimal" | "recommended" | "strict" | false (default: "minimal")
 });
 ```
 

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -1,6 +1,13 @@
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import type { Diagnostic, DiffInfo, ProjectInfo, ReactDoctorConfig, ScoreResult } from "./types.js";
+import type {
+  AccessibilityPreset,
+  Diagnostic,
+  DiffInfo,
+  ProjectInfo,
+  ReactDoctorConfig,
+  ScoreResult,
+} from "./types.js";
 import { calculateScore } from "./utils/calculate-score.js";
 import { combineDiagnostics, computeJsxIncludePaths } from "./utils/combine-diagnostics.js";
 import { discoverProject } from "./utils/discover-project.js";
@@ -8,13 +15,21 @@ import { loadConfig } from "./utils/load-config.js";
 import { runKnip } from "./utils/run-knip.js";
 import { runOxlint } from "./utils/run-oxlint.js";
 
-export type { Diagnostic, DiffInfo, ProjectInfo, ReactDoctorConfig, ScoreResult };
+export type {
+  AccessibilityPreset,
+  Diagnostic,
+  DiffInfo,
+  ProjectInfo,
+  ReactDoctorConfig,
+  ScoreResult,
+};
 export { getDiffInfo, filterSourceFiles } from "./utils/get-diff-files.js";
 
 export interface DiagnoseOptions {
   lint?: boolean;
   deadCode?: boolean;
   includePaths?: string[];
+  accessibility?: AccessibilityPreset | false;
 }
 
 export interface DiagnoseResult {
@@ -38,6 +53,7 @@ export const diagnose = async (
 
   const effectiveLint = options.lint ?? userConfig?.lint ?? true;
   const effectiveDeadCode = options.deadCode ?? userConfig?.deadCode ?? true;
+  const effectiveAccessibility = options.accessibility ?? userConfig?.accessibility ?? "minimal";
 
   if (!projectInfo.reactVersion) {
     throw new Error("No React dependency found in package.json");
@@ -54,6 +70,7 @@ export const diagnose = async (
         projectInfo.framework,
         projectInfo.hasReactCompiler,
         jsxIncludePaths,
+        effectiveAccessibility,
       ).catch((error: unknown) => {
         console.error("Lint failed:", error);
         return emptyDiagnostics;

--- a/packages/react-doctor/src/scan.ts
+++ b/packages/react-doctor/src/scan.ts
@@ -463,6 +463,7 @@ export const scan = async (
   const options = mergeScanOptions(inputOptions, userConfig);
   const { includePaths } = options;
   const isDiffMode = includePaths.length > 0;
+  const effectiveAccessibility = userConfig?.accessibility ?? "minimal";
 
   if (!projectInfo.reactVersion) {
     throw new Error("No React dependency found in package.json");
@@ -490,6 +491,7 @@ export const scan = async (
             projectInfo.framework,
             projectInfo.hasReactCompiler,
             jsxIncludePaths,
+            effectiveAccessibility,
             resolvedNodeBinaryPath,
           );
           lintSpinner?.succeed("Running lint checks.");

--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -167,6 +167,8 @@ export interface ReactDoctorIgnoreConfig {
   files?: string[];
 }
 
+export type AccessibilityPreset = "minimal" | "recommended" | "strict";
+
 export interface ReactDoctorConfig {
   ignore?: ReactDoctorIgnoreConfig;
   lint?: boolean;
@@ -174,4 +176,5 @@ export interface ReactDoctorConfig {
   verbose?: boolean;
   diff?: boolean | string;
   failOn?: FailOnLevel;
+  accessibility?: AccessibilityPreset | false;
 }

--- a/packages/react-doctor/src/utils/run-oxlint.ts
+++ b/packages/react-doctor/src/utils/run-oxlint.ts
@@ -10,7 +10,13 @@ import {
   SPAWN_ARGS_MAX_LENGTH_CHARS,
 } from "../constants.js";
 import { createOxlintConfig } from "../oxlint-config.js";
-import type { CleanedDiagnostic, Diagnostic, Framework, OxlintOutput } from "../types.js";
+import type {
+  AccessibilityPreset,
+  CleanedDiagnostic,
+  Diagnostic,
+  Framework,
+  OxlintOutput,
+} from "../types.js";
 import { neutralizeDisableDirectives } from "./neutralize-disable-directives.js";
 
 const esmRequire = createRequire(import.meta.url);
@@ -251,7 +257,10 @@ const cleanDiagnosticMessage = (
     return { message: REACT_COMPILER_MESSAGE, help: rawMessage || help };
   }
   const cleaned = message.replace(FILEPATH_WITH_LOCATION_PATTERN, "").trim();
-  return { message: cleaned || message, help: help || RULE_HELP_MAP[rule] || "" };
+  return {
+    message: cleaned || message,
+    help: help || RULE_HELP_MAP[rule] || "",
+  };
 };
 
 const parseRuleCode = (code: string): { plugin: string; rule: string } => {
@@ -379,6 +388,7 @@ export const runOxlint = async (
   framework: Framework,
   hasReactCompiler: boolean,
   includePaths?: string[],
+  accessibilityPreset: AccessibilityPreset | false = "minimal",
   nodeBinaryPath: string = process.execPath,
 ): Promise<Diagnostic[]> => {
   if (includePaths !== undefined && includePaths.length === 0) {
@@ -387,7 +397,12 @@ export const runOxlint = async (
 
   const configPath = path.join(os.tmpdir(), `react-doctor-oxlintrc-${process.pid}.json`);
   const pluginPath = resolvePluginPath();
-  const config = createOxlintConfig({ pluginPath, framework, hasReactCompiler });
+  const config = createOxlintConfig({
+    pluginPath,
+    framework,
+    hasReactCompiler,
+    accessibilityPreset,
+  });
   const restoreDisableDirectives = neutralizeDisableDirectives(rootDirectory);
 
   try {

--- a/packages/react-doctor/tests/oxlint-config.test.ts
+++ b/packages/react-doctor/tests/oxlint-config.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { createOxlintConfig } from "../src/oxlint-config.js";
+
+type OxlintConfig = ReturnType<typeof createOxlintConfig>;
+type Rules = Record<string, string | undefined>;
+
+const getRules = (config: OxlintConfig): Rules => config.rules as Rules;
+
+describe("createOxlintConfig", () => {
+  const baseOptions = {
+    pluginPath: "/path/to/plugin.js",
+    framework: "unknown" as const,
+    hasReactCompiler: false,
+  };
+
+  describe("accessibility presets", () => {
+    it("includes jsx-a11y plugin when accessibility is enabled", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "minimal",
+      });
+      expect(config.plugins).toContain("jsx-a11y");
+    });
+
+    it("excludes jsx-a11y plugin when accessibility is false", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: false,
+      });
+      expect(config.plugins).not.toContain("jsx-a11y");
+    });
+
+    it("includes minimal a11y rules for minimal preset", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "minimal",
+      });
+      const rules = getRules(config);
+
+      // Core minimal rules
+      expect(rules["jsx-a11y/alt-text"]).toBe("error");
+      expect(rules["jsx-a11y/click-events-have-key-events"]).toBe("warn");
+      expect(rules["jsx-a11y/no-static-element-interactions"]).toBe("warn");
+      expect(rules["jsx-a11y/role-has-required-aria-props"]).toBe("error");
+
+      // Rules NOT in minimal but in recommended
+      expect(rules["jsx-a11y/mouse-events-have-key-events"]).toBeUndefined();
+      expect(rules["jsx-a11y/aria-props"]).toBeUndefined();
+    });
+
+    it("includes all recommended a11y rules for recommended preset", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "recommended",
+      });
+      const rules = getRules(config);
+
+      // All minimal rules should be present
+      expect(rules["jsx-a11y/alt-text"]).toBe("error");
+      expect(rules["jsx-a11y/click-events-have-key-events"]).toBe("warn");
+
+      // Additional recommended rules
+      expect(rules["jsx-a11y/mouse-events-have-key-events"]).toBe("warn");
+      expect(rules["jsx-a11y/aria-props"]).toBe("warn");
+      expect(rules["jsx-a11y/aria-proptypes"]).toBe("warn");
+      expect(rules["jsx-a11y/interactive-supports-focus"]).toBe("warn");
+
+      // Rules NOT in recommended but in strict
+      expect(rules["jsx-a11y/anchor-ambiguous-text"]).toBeUndefined();
+      expect(rules["jsx-a11y/control-has-associated-label"]).toBeUndefined();
+    });
+
+    it("includes all strict a11y rules with error severity for strict preset", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "strict",
+      });
+      const rules = getRules(config);
+
+      // All rules should be errors in strict mode
+      expect(rules["jsx-a11y/alt-text"]).toBe("error");
+      expect(rules["jsx-a11y/click-events-have-key-events"]).toBe("error");
+      expect(rules["jsx-a11y/mouse-events-have-key-events"]).toBe("error");
+      expect(rules["jsx-a11y/aria-props"]).toBe("error");
+
+      // Strict-only rules
+      expect(rules["jsx-a11y/anchor-ambiguous-text"]).toBe("error");
+      expect(rules["jsx-a11y/control-has-associated-label"]).toBe("error");
+    });
+
+    it("excludes all a11y rules when accessibility is false", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: false,
+      });
+      const rules = getRules(config);
+
+      const a11yRules = Object.keys(rules).filter((rule) => rule.startsWith("jsx-a11y/"));
+      expect(a11yRules).toHaveLength(0);
+    });
+
+    it("counts correct number of rules per preset", () => {
+      const minimalConfig = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "minimal",
+      });
+      const recommendedConfig = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "recommended",
+      });
+      const strictConfig = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "strict",
+      });
+
+      const countA11yRules = (config: OxlintConfig) =>
+        Object.keys(config.rules).filter((rule) => rule.startsWith("jsx-a11y/")).length;
+
+      expect(countA11yRules(minimalConfig)).toBe(15);
+      expect(countA11yRules(recommendedConfig)).toBe(31);
+      expect(countA11yRules(strictConfig)).toBe(33);
+    });
+  });
+
+  describe("framework configuration", () => {
+    it("includes nextjs rules when framework is nextjs", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "minimal",
+        framework: "nextjs",
+      });
+      const rules = getRules(config);
+      expect(rules["react-doctor/nextjs-no-img-element"]).toBe("warn");
+      expect(rules["react-doctor/nextjs-async-client-component"]).toBe("error");
+    });
+
+    it("excludes nextjs rules when framework is not nextjs", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "minimal",
+        framework: "unknown",
+      });
+      const rules = getRules(config);
+      expect(rules["react-doctor/nextjs-no-img-element"]).toBeUndefined();
+      expect(rules["react-doctor/nextjs-async-client-component"]).toBeUndefined();
+    });
+  });
+
+  describe("react compiler configuration", () => {
+    it("includes react-perf plugin when react compiler is disabled", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "minimal",
+        hasReactCompiler: false,
+      });
+      expect(config.plugins).toContain("react-perf");
+    });
+
+    it("excludes react-perf plugin when react compiler is enabled", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "minimal",
+        hasReactCompiler: true,
+      });
+      expect(config.plugins).not.toContain("react-perf");
+    });
+
+    it("includes react compiler rules when react compiler is enabled", () => {
+      const config = createOxlintConfig({
+        ...baseOptions,
+        accessibilityPreset: "minimal",
+        hasReactCompiler: true,
+      });
+      const rules = getRules(config);
+      expect(rules["react-hooks-js/immutability"]).toBe("error");
+      expect(rules["react-hooks-js/purity"]).toBe("error");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds configurable accessibility presets for jsx-a11y rules, allowing users to choose the level of accessibility linting that fits their project.

## Motivation

Previously, react-doctor included a fixed set of 15 accessibility rules. This PR enables users to choose from three presets based on their accessibility requirements:

| Preset | Rules | Description |
|--------|-------|-------------|
| `minimal` (default) | 15 | Curated high-impact rules (original behavior) |
| `recommended` | 31 | Matches `jsx-a11y/recommended` preset |
| `strict` | 33 | Matches `jsx-a11y/strict` preset (all rules as errors) |

Users can also disable accessibility checks entirely by setting `accessibility: false`.

## Usage

### Via config file (`react-doctor.config.json`)

```json
{
  "accessibility": "recommended"
}
```

### Via `package.json`

```json
{
  "reactDoctor": {
    "accessibility": "strict"
  }
}
```

### Programmatically

```ts
import { diagnose } from "react-doctor";

const result = await diagnose("/path/to/project", {
  accessibility: "recommended"
});
```

## Changes

- Added `AccessibilityPreset` type (`"minimal" | "recommended" | "strict"`)
- Added `accessibility` field to `ReactDoctorConfig` and `DiagnoseOptions`
- Created preset rule sets in `oxlint-config.ts`
- Updated `runOxlint`, `diagnose`, and `scan` to pass accessibility preset
- Added 12 unit tests for the new configuration
- Updated README to include the accessibility option

## Testing

All 137 tests pass, including new tests covering:
- Plugin inclusion/exclusion based on preset
- Correct rule counts per preset (15, 31, 33)
- Severity differences between recommended (warn) and strict (error)
- Disabling accessibility with `false`
