### PR TITLE
remove space from line label so they are clickable

### DIFF
--- a/packages/react-doctor/src/scan.ts
+++ b/packages/react-doctor/src/scan.ts
@@ -102,8 +102,13 @@ const printDiagnostics = (diagnostics: Diagnostic[], isVerbose: boolean): void =
       const fileLines = buildFileLineMap(ruleDiagnostics);
 
       for (const [filePath, lines] of fileLines) {
-        const lineLabel = lines.length > 0 ? `: ${lines.join(", ")}` : "";
-        logger.dim(`    ${filePath}${lineLabel}`);
+        if (lines.length > 0) {
+          for (const line of lines) {
+            logger.dim(`  ${filePath}:${line}`);
+          }
+        } else {
+          logger.dim(`  ${filePath}`);
+        }
       }
     }
 
@@ -137,8 +142,13 @@ const formatRuleSummary = (ruleKey: string, ruleDiagnostics: Diagnostic[]): stri
 
   sections.push("", "Files:");
   for (const [filePath, lines] of fileLines) {
-    const lineLabel = lines.length > 0 ? `: ${lines.join(", ")}` : "";
-    sections.push(`  ${filePath}${lineLabel}`);
+    if (lines.length > 0) {
+      for (const line of lines) {
+        sections.push(`  ${filePath}:${line}`);
+      }
+    } else {
+      sections.push(`  ${filePath}`);
+    }
   }
 
   return sections.join("\n") + "\n";


### PR DESCRIPTION
The current formatting for file + lines isn't picked up by the vscode file regex, meaning you can't click it to navigate directly to the location.

This PR changes the formatting from 

```
path/to/file: 42, 44, 46
```

to

```
path/to/file:42
path/to/file:44
path/to/file:46
```