### PR TITLE
fix: Migrate domain from `react.doctor` to `react-doctor.com`

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -11,7 +11,7 @@ Let coding agents diagnose and fix your React code.
 
 One command scans your codebase for security, performance, correctness, and architecture issues, then outputs a **0–100 score** with actionable diagnostics.
 
-### [See it in action →](https://react.doctor)
+### [See it in action →](https://react-doctor.com)
 
 https://github.com/user-attachments/assets/07cc88d9-9589-44c3-aa73-5d603cb1c570
 
@@ -43,7 +43,7 @@ npx -y react-doctor@latest . --verbose
 Teach your coding agent all 47+ React best practice rules:
 
 ```bash
-curl -fsSL https://react.doctor/install-skill.sh | bash
+curl -fsSL https://react-doctor.com/install-skill.sh | bash
 ```
 
 Supports Cursor, Claude Code, Amp Code, Codex, Gemini CLI, OpenCode, Windsurf, and Antigravity.
@@ -146,22 +146,22 @@ interface Diagnostic {
 }
 ```
 
-## [Scores for popular open-source projects](https://react.doctor/leaderboard)
+## [Scores for popular open-source projects](https://react-doctor.com/leaderboard)
 
 | Project                                                | Score  | Share                                                                                   |
 | ------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------- |
-| [tldraw](https://github.com/tldraw/tldraw)             | **84** | [view](https://www.react.doctor/share?p=tldraw&s=84&e=98&w=139&f=40)                    |
-| [excalidraw](https://github.com/excalidraw/excalidraw) | **84** | [view](https://www.react.doctor/share?p=%40excalidraw%2Fexcalidraw&s=84&e=2&w=196&f=80) |
-| [twenty](https://github.com/twentyhq/twenty)           | **78** | [view](https://www.react.doctor/share?p=twenty-front&s=78&e=99&w=293&f=268)             |
-| [plane](https://github.com/makeplane/plane)            | **78** | [view](https://www.react.doctor/share?p=web&s=78&e=7&w=525&f=292)                       |
-| [formbricks](https://github.com/formbricks/formbricks) | **75** | [view](https://www.react.doctor/share?p=%40formbricks%2Fweb&s=75&e=15&w=389&f=242)      |
-| [posthog](https://github.com/PostHog/posthog)          | **72** | [view](https://www.react.doctor/share?p=%40posthog%2Ffrontend&s=72&e=82&w=1177&f=585)   |
-| [supabase](https://github.com/supabase/supabase)       | **69** | [view](https://www.react.doctor/share?p=studio&s=69&e=74&w=1087&f=566)                  |
-| [onlook](https://github.com/onlook-dev/onlook)         | **69** | [view](https://www.react.doctor/share?p=%40onlook%2Fweb-client&s=69&e=64&w=418&f=178)   |
-| [payload](https://github.com/payloadcms/payload)       | **68** | [view](https://www.react.doctor/share?p=%40payloadcms%2Fui&s=68&e=139&w=408&f=298)      |
-| [sentry](https://github.com/getsentry/sentry)          | **64** | [view](https://www.react.doctor/share?p=sentry&s=64&e=94&w=1345&f=818)                  |
-| [cal.com](https://github.com/calcom/cal.com)           | **63** | [view](https://www.react.doctor/share?p=%40calcom%2Fweb&s=63&e=31&w=558&f=311)          |
-| [dub](https://github.com/dubinc/dub)                   | **62** | [view](https://www.react.doctor/share?p=web&s=62&e=52&w=966&f=457)                      |
+| [tldraw](https://github.com/tldraw/tldraw)             | **84** | [view](https://www.react-doctor.com/share?p=tldraw&s=84&e=98&w=139&f=40)                    |
+| [excalidraw](https://github.com/excalidraw/excalidraw) | **84** | [view](https://www.react-doctor.com/share?p=%40excalidraw%2Fexcalidraw&s=84&e=2&w=196&f=80) |
+| [twenty](https://github.com/twentyhq/twenty)           | **78** | [view](https://www.react-doctor.com/share?p=twenty-front&s=78&e=99&w=293&f=268)             |
+| [plane](https://github.com/makeplane/plane)            | **78** | [view](https://www.react-doctor.com/share?p=web&s=78&e=7&w=525&f=292)                       |
+| [formbricks](https://github.com/formbricks/formbricks) | **75** | [view](https://www.react-doctor.com/share?p=%40formbricks%2Fweb&s=75&e=15&w=389&f=242)      |
+| [posthog](https://github.com/PostHog/posthog)          | **72** | [view](https://www.react-doctor.com/share?p=%40posthog%2Ffrontend&s=72&e=82&w=1177&f=585)   |
+| [supabase](https://github.com/supabase/supabase)       | **69** | [view](https://www.react-doctor.com/share?p=studio&s=69&e=74&w=1087&f=566)                  |
+| [onlook](https://github.com/onlook-dev/onlook)         | **69** | [view](https://www.react-doctor.com/share?p=%40onlook%2Fweb-client&s=69&e=64&w=418&f=178)   |
+| [payload](https://github.com/payloadcms/payload)       | **68** | [view](https://www.react-doctor.com/share?p=%40payloadcms%2Fui&s=68&e=139&w=408&f=298)      |
+| [sentry](https://github.com/getsentry/sentry)          | **64** | [view](https://www.react-doctor.com/share?p=sentry&s=64&e=94&w=1345&f=818)                  |
+| [cal.com](https://github.com/calcom/cal.com)           | **63** | [view](https://www.react-doctor.com/share?p=%40calcom%2Fweb&s=63&e=31&w=558&f=311)          |
+| [dub](https://github.com/dubinc/dub)                   | **62** | [view](https://www.react-doctor.com/share?p=web&s=62&e=52&w=966&f=457)                      |
 
 ## Contributing
 

--- a/packages/react-doctor/src/constants.ts
+++ b/packages/react-doctor/src/constants.ts
@@ -18,13 +18,13 @@ export const SUMMARY_BOX_HORIZONTAL_PADDING_CHARS = 1;
 
 export const SUMMARY_BOX_OUTER_INDENT_CHARS = 2;
 
-export const SCORE_API_URL = "https://www.react.doctor/api/score";
+export const SCORE_API_URL = "https://www.react-doctor.com/api/score";
 
-export const ESTIMATE_SCORE_API_URL = "https://www.react.doctor/api/estimate-score";
+export const ESTIMATE_SCORE_API_URL = "https://www.react-doctor.com/api/estimate-score";
 
-export const SHARE_BASE_URL = "https://www.react.doctor/share";
+export const SHARE_BASE_URL = "https://www.react-doctor.com/share";
 
-export const OPEN_BASE_URL = "https://www.react.doctor/open";
+export const OPEN_BASE_URL = "https://www.react-doctor.com/open";
 
 export const FETCH_TIMEOUT_MS = 10_000;
 

--- a/packages/react-doctor/src/scan.ts
+++ b/packages/react-doctor/src/scan.ts
@@ -208,7 +208,7 @@ const printBranding = (score?: number): void => {
     logger.log(colorize(`  │ ${mouth} │`));
     logger.log(colorize("  └─────┘"));
   }
-  logger.log(`  React Doctor ${highlighter.dim("(www.react.doctor)")}`);
+  logger.log(`  React Doctor ${highlighter.dim("(www.react-doctor.com)")}`);
   logger.break();
 };
 
@@ -247,8 +247,8 @@ const buildBrandingLines = (
     lines.push(createFramedLine("└─────┘", scoreColorizer("└─────┘")));
     lines.push(
       createFramedLine(
-        "React Doctor (www.react.doctor)",
-        `React Doctor ${highlighter.dim("(www.react.doctor)")}`,
+        "React Doctor (www.react-doctor.com)",
+        `React Doctor ${highlighter.dim("(www.react-doctor.com)")}`,
       ),
     );
     lines.push(createFramedLine(""));
@@ -264,8 +264,8 @@ const buildBrandingLines = (
   } else {
     lines.push(
       createFramedLine(
-        "React Doctor (www.react.doctor)",
-        `React Doctor ${highlighter.dim("(www.react.doctor)")}`,
+        "React Doctor (www.react-doctor.com)",
+        `React Doctor ${highlighter.dim("(www.react-doctor.com)")}`,
       ),
     );
     lines.push(createFramedLine(""));

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -9,7 +9,7 @@ const ibmPlexMono = IBM_Plex_Mono({
   weight: ["400", "500"],
 });
 
-const SITE_URL = "https://www.react.doctor";
+const SITE_URL = "https://www.react-doctor.com";
 const TWITTER_IMAGE_PATH = "/react-doctor-og-banner.svg";
 
 export const metadata: Metadata = {

--- a/packages/website/src/app/share/badge-snippet.tsx
+++ b/packages/website/src/app/share/badge-snippet.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 
 const COPY_FEEDBACK_DURATION_MS = 2000;
-const BADGE_BASE_URL = "https://www.react.doctor/share/badge";
-const SHARE_BASE_URL = "https://www.react.doctor/share";
+const BADGE_BASE_URL = "https://www.react-doctor.com/share/badge";
+const SHARE_BASE_URL = "https://www.react-doctor.com/share";
 
 interface BadgeSnippetProps {
   searchParamsString: string;

--- a/packages/website/src/app/share/page.tsx
+++ b/packages/website/src/app/share/page.tsx
@@ -7,7 +7,7 @@ const SCORE_GOOD_THRESHOLD = 75;
 const SCORE_OK_THRESHOLD = 50;
 const COMMAND = "npx -y react-doctor@latest .";
 const FIX_COMMAND = "npx -y react-doctor@latest . --fix";
-const SHARE_BASE_URL = "https://www.react.doctor/share";
+const SHARE_BASE_URL = "https://www.react-doctor.com/share";
 const X_ICON_PATH =
   "M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z";
 const LINKEDIN_ICON_PATH =
@@ -119,7 +119,7 @@ const SharePage = async ({ searchParams }: { searchParams: Promise<ShareSearchPa
         {projectName && <div className="mb-4 text-xl text-white">{projectName}</div>}
         <DoctorFace score={score} />
         <div className="mt-2 text-neutral-500">
-          React Doctor <span className="text-neutral-600">(www.react.doctor)</span>
+          React Doctor <span className="text-neutral-600">(www.react-doctor.com)</span>
         </div>
       </div>
 


### PR DESCRIPTION
 ## Summary
- Replace all `react.doctor` URLs with `react-doctor.com` across the codebase
- Updates API endpoints, share/badge URLs, display text, and README links

Fixes #56 