### PR TITLE
feat: HTML diagnostic report and --open-report flag

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -22,7 +22,7 @@ React Doctor detects your framework (Next.js, Vite, Remix, etc.), React version,
 1. **Lint**: Checks 60+ rules across state & effects, performance, architecture, bundle size, security, correctness, accessibility, and framework-specific categories (Next.js, React Native). Rules are toggled automatically based on your project setup.
 2. **Dead code**: Detects unused files, exports, types, and duplicates.
 
-Diagnostics are filtered through your config, then scored by severity (errors weigh more than warnings) to produce a **0–100 health score** (75+ Great, 50–74 Needs work, <50 Critical).
+Diagnostics are filtered through your config, then scored by severity (errors weigh more than warnings) to produce a **0–100 health score** (75+ Great, 50–74 Needs work, <50 Critical). When issues are found, a **diagnostics.json** and an **HTML report** (report.html) are written to a temporary directory; use `--open-report` to open the report in your browser after the scan.
 
 ## Install
 
@@ -62,6 +62,8 @@ Options:
   -y, --yes         skip prompts, scan all workspace projects
   --project <name>  select workspace project (comma-separated for multiple)
   --diff [base]     scan only files changed vs base branch
+  --offline         skip telemetry (score not calculated)
+  --open-report     open the HTML report in the default browser after scan
   --no-ami          skip Ami-related prompts
   --fix             open Ami to auto-fix all issues
   -h, --help        display help for command

--- a/packages/react-doctor/src/cli.ts
+++ b/packages/react-doctor/src/cli.ts
@@ -34,6 +34,7 @@ interface CliFlags {
   fix: boolean;
   yes: boolean;
   offline: boolean;
+  openReport?: boolean;
   ami: boolean;
   project?: string;
   diff?: boolean | string;
@@ -77,6 +78,7 @@ const resolveCliScanOptions = (
     verbose: isCliOverride("verbose") ? Boolean(flags.verbose) : (userConfig?.verbose ?? false),
     scoreOnly: flags.score,
     offline: flags.offline,
+    openReport: flags.openReport ?? false,
   };
 };
 
@@ -128,6 +130,7 @@ const program = new Command()
   .option("--project <name>", "select workspace project (comma-separated for multiple)")
   .option("--diff [base]", "scan only files changed vs base branch")
   .option("--offline", "skip telemetry (anonymous, not stored, only used to calculate score)")
+  .option("--open-report", "open the HTML report in the default browser after scan")
   .option("--no-ami", "skip Ami-related prompts")
   .option("--fix", "open Ami to auto-fix all issues")
   .action(async (directory: string, flags: CliFlags) => {

--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -83,6 +83,13 @@ export interface ScoreResult {
   label: string;
 }
 
+export interface ReportPayload {
+  diagnostics: Diagnostic[];
+  score: number | null;
+  label: string | null;
+  projectName: string;
+}
+
 export interface ScanResult {
   diagnostics: Diagnostic[];
   scoreResult: ScoreResult | null;
@@ -102,6 +109,7 @@ export interface ScanOptions {
   verbose?: boolean;
   scoreOnly?: boolean;
   offline?: boolean;
+  openReport?: boolean;
   includePaths?: string[];
 }
 

--- a/packages/react-doctor/src/utils/open-file.ts
+++ b/packages/react-doctor/src/utils/open-file.ts
@@ -1,0 +1,18 @@
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const openFile = (filePath: string): void => {
+  const absolutePath = path.resolve(filePath);
+  const url = pathToFileURL(absolutePath).toString();
+
+  if (process.platform === "win32") {
+    const cmdEscapedUrl = url.replace(/%/g, "%%");
+    execSync(`start "" "${cmdEscapedUrl}"`, { stdio: "ignore" });
+    return;
+  }
+
+  const openCommand =
+    process.platform === "darwin" ? `open "${url}"` : `xdg-open "${url}"`;
+  execSync(openCommand, { stdio: "ignore" });
+};

--- a/packages/react-doctor/src/utils/report-template.ts
+++ b/packages/react-doctor/src/utils/report-template.ts
@@ -1,0 +1,199 @@
+import type { Diagnostic, ReportPayload } from "../types.js";
+
+const PERFECT_SCORE = 100;
+const SCORE_GOOD_THRESHOLD = 75;
+const SCORE_OK_THRESHOLD = 50;
+
+const escapeHtml = (raw: string): string =>
+  raw
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const getScoreLabel = (score: number): string => {
+  if (score >= SCORE_GOOD_THRESHOLD) return "Great";
+  if (score >= SCORE_OK_THRESHOLD) return "Needs work";
+  return "Critical";
+};
+
+const getScoreColor = (score: number): string => {
+  if (score >= SCORE_GOOD_THRESHOLD) return "#22c55e";
+  if (score >= SCORE_OK_THRESHOLD) return "#eab308";
+  return "#ef4444";
+};
+
+const getDoctorFace = (score: number): [string, string] => {
+  if (score >= SCORE_GOOD_THRESHOLD) return ["\u25E0 \u25E0", " \u25BD "];
+  if (score >= SCORE_OK_THRESHOLD) return ["\u2022 \u2022", " \u2500 "];
+  return ["x x", " \u25BD "];
+};
+
+const groupByRule = (diagnostics: Diagnostic[]): Map<string, Diagnostic[]> => {
+  const groups = new Map<string, Diagnostic[]>();
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.plugin}/${diagnostic.rule}`;
+    const existing = groups.get(key) ?? [];
+    existing.push(diagnostic);
+    groups.set(key, existing);
+  }
+  return groups;
+};
+
+const sortBySeverity = (entries: [string, Diagnostic[]][]): [string, Diagnostic[]][] => {
+  const order = { error: 0, warning: 1 };
+  return entries.toSorted(
+    ([, diagnosticsA], [, diagnosticsB]) =>
+      order[diagnosticsA[0].severity] - order[diagnosticsB[0].severity],
+  );
+};
+
+const buildFileLineMap = (diagnostics: Diagnostic[]): Map<string, number[]> => {
+  const fileLines = new Map<string, number[]>();
+  for (const diagnostic of diagnostics) {
+    const lines = fileLines.get(diagnostic.filePath) ?? [];
+    if (diagnostic.line > 0) {
+      lines.push(diagnostic.line);
+    }
+    fileLines.set(diagnostic.filePath, lines);
+  }
+  return fileLines;
+};
+
+export const buildReportHtml = (payload: ReportPayload): string => {
+  const { diagnostics, score, label, projectName } = payload;
+  const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
+  const warningCount = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
+  const affectedFileCount = new Set(diagnostics.map((diagnostic) => diagnostic.filePath)).size;
+
+  const ruleGroups = groupByRule(diagnostics);
+  const sortedRuleGroups = sortBySeverity([...ruleGroups.entries()]);
+
+  const scoreBarPercent = score !== null ? Math.round((score / PERFECT_SCORE) * 100) : 0;
+  const scoreColor = score !== null ? getScoreColor(score) : "#6b7280";
+  const displayLabel = label ?? (score !== null ? getScoreLabel(score) : null);
+  const [eyes, mouth] = score !== null ? getDoctorFace(score) : ["? ?", " ? "];
+
+  const summaryParts: string[] = [];
+  if (errorCount > 0) {
+    summaryParts.push(
+      `<span class="summary-error">\u2717 ${errorCount} error${errorCount === 1 ? "" : "s"}</span>`,
+    );
+  }
+  if (warningCount > 0) {
+    summaryParts.push(
+      `<span class="summary-warning">\u26A0 ${warningCount} warning${warningCount === 1 ? "" : "s"}</span>`,
+    );
+  }
+  summaryParts.push(
+    `<span class="summary-muted">across ${affectedFileCount} file${affectedFileCount === 1 ? "" : "s"}</span>`,
+  );
+
+  let diagnosticsSections = "";
+  for (const [ruleKey, ruleDiagnostics] of sortedRuleGroups) {
+    const firstDiagnostic = ruleDiagnostics[0];
+    const severityClass =
+      firstDiagnostic.severity === "error" ? "severity-error" : "severity-warning";
+    const severitySymbol = firstDiagnostic.severity === "error" ? "\u2717" : "\u26A0";
+    const countLabel = ruleDiagnostics.length > 1 ? ` (${ruleDiagnostics.length})` : "";
+    const fileLines = buildFileLineMap(ruleDiagnostics);
+
+    let locationsHtml = "";
+    for (const [filePath, lines] of fileLines) {
+      const lineLabel = lines.length > 0 ? `:${lines.join(", ")}` : "";
+      locationsHtml += `<li><code>${escapeHtml(filePath)}${escapeHtml(lineLabel)}</code></li>`;
+    }
+
+    const helpHtml = firstDiagnostic.help
+      ? `<p class="diagnostic-help">${escapeHtml(firstDiagnostic.help)}</p>`
+      : "";
+
+    diagnosticsSections += `
+<section class="diagnostic-group" aria-labelledby="rule-${escapeHtml(ruleKey.replace(/\//g, "--"))}">
+  <h2 id="rule-${escapeHtml(ruleKey.replace(/\//g, "--"))}" class="diagnostic-heading ${severityClass}">
+    <span class="severity-icon" aria-hidden="true">${severitySymbol}</span>
+    ${escapeHtml(firstDiagnostic.message)}${escapeHtml(countLabel)}
+  </h2>
+  <p class="diagnostic-rule"><code>${escapeHtml(ruleKey)}</code></p>
+  ${helpHtml}
+  <ul class="diagnostic-locations">${locationsHtml}</ul>
+</section>`;
+  }
+
+  const scoreSection =
+    score !== null
+      ? `
+  <div class="score-section">
+    <pre class="doctor-face" aria-hidden="true">  \u250C\u2500\u2500\u2500\u2500\u2500\u2510
+  \u2502 ${eyes} \u2502
+  \u2502 ${mouth} \u2502
+  \u2514\u2500\u2500\u2500\u2500\u2500\u2518</pre>
+    <div class="score-gauge">
+      <span class="score-value">${score}</span> / ${PERFECT_SCORE}
+      <span class="score-label">${escapeHtml(displayLabel ?? "")}</span>
+    </div>
+    <div class="score-bar-track">
+      <div class="score-bar-fill" style="width: ${scoreBarPercent}%; background-color: ${scoreColor};"></div>
+    </div>
+  </div>`
+      : `
+  <div class="score-section score-unavailable">
+    <p>Score unavailable (offline or error).</p>
+  </div>`;
+
+  const projectTitle = projectName
+    ? `${escapeHtml(projectName)} \u2014 React Doctor`
+    : "React Doctor";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${projectTitle}</title>
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #e5e7eb; background: #111827; margin: 0; padding: 1.5rem; max-width: 56rem; margin-left: auto; margin-right: auto; }
+    header { margin-bottom: 2rem; }
+    h1 { font-size: 1.5rem; font-weight: 600; margin: 0 0 0.5rem 0; }
+    .subtitle { font-size: 0.875rem; color: #9ca3af; margin-bottom: 1.5rem; }
+    .summary { font-size: 0.875rem; margin-bottom: 1.5rem; }
+    .summary-error { color: #f87171; }
+    .summary-warning { color: #fbbf24; }
+    .summary-muted { color: #9ca3af; }
+    .score-section { margin-bottom: 2rem; }
+    .score-unavailable p { color: #9ca3af; margin: 0; }
+    .doctor-face { font-size: 1rem; margin: 0 0 0.5rem 0; line-height: 1.2; }
+    .score-gauge { font-size: 1.25rem; margin-bottom: 0.5rem; }
+    .score-value { font-weight: 700; }
+    .score-label { margin-left: 0.5rem; }
+    .score-bar-track { height: 0.5rem; background: #374151; border-radius: 0.25rem; overflow: hidden; }
+    .score-bar-fill { height: 100%; border-radius: 0.25rem; }
+    main h2 { font-size: 1rem; margin: 0 0 0.25rem 0; }
+    .diagnostic-group { margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid #374151; }
+    .diagnostic-group:last-child { border-bottom: none; }
+    .diagnostic-heading { display: flex; align-items: baseline; gap: 0.5rem; }
+    .severity-error { color: #f87171; }
+    .severity-warning { color: #fbbf24; }
+    .severity-icon { flex-shrink: 0; }
+    .diagnostic-rule { font-size: 0.8125rem; color: #9ca3af; margin: 0 0 0.25rem 0; }
+    .diagnostic-help { font-size: 0.875rem; color: #d1d5db; margin: 0.25rem 0; }
+    .diagnostic-locations { font-size: 0.8125rem; color: #9ca3af; margin: 0.25rem 0; padding-left: 1.25rem; }
+    .diagnostic-locations code { word-break: break-all; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>React Doctor</h1>
+    <p class="subtitle">www.react.doctor</p>
+    ${scoreSection}
+    <p class="summary">${summaryParts.join("  ")}</p>
+  </header>
+  <main>
+    <h2 id="diagnostics-heading">Diagnostics</h2>
+    ${diagnosticsSections}
+  </main>
+</body>
+</html>`;
+};

--- a/packages/react-doctor/tests/report-template.test.ts
+++ b/packages/react-doctor/tests/report-template.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { Diagnostic, ReportPayload } from "../src/types.js";
+import { buildReportHtml } from "../src/utils/report-template.js";
+
+const createDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: "src/App.tsx",
+  plugin: "basic-react",
+  rule: "no-danger",
+  severity: "error",
+  message: "Avoid using dangerouslySetInnerHTML.",
+  help: "Use a sanitization library or render text instead.",
+  line: 10,
+  column: 5,
+  category: "Security",
+  ...overrides,
+});
+
+describe("buildReportHtml", () => {
+  it("includes document structure and React Doctor header", () => {
+    const payload: ReportPayload = {
+      diagnostics: [],
+      score: null,
+      label: null,
+      projectName: "test-project",
+    };
+    const html = buildReportHtml(payload);
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("<title>test-project \u2014 React Doctor</title>");
+    expect(html).toContain("<h1>React Doctor</h1>");
+    expect(html).toContain("www.react.doctor");
+  });
+
+  it("includes score section when score is present", () => {
+    const payload: ReportPayload = {
+      diagnostics: [],
+      score: 85,
+      label: "Great",
+      projectName: "my-app",
+    };
+    const html = buildReportHtml(payload);
+    expect(html).toContain("85");
+    expect(html).toContain("/ 100");
+    expect(html).toContain("Great");
+    expect(html).toContain("score-bar-fill");
+  });
+
+  it("shows score unavailable when score is null", () => {
+    const payload: ReportPayload = {
+      diagnostics: [createDiagnostic()],
+      score: null,
+      label: null,
+      projectName: "offline-run",
+    };
+    const html = buildReportHtml(payload);
+    expect(html).toContain("Score unavailable");
+    expect(html).toContain("score-unavailable");
+  });
+
+  it("includes summary counts for errors and warnings", () => {
+    const payload: ReportPayload = {
+      diagnostics: [
+        createDiagnostic({ severity: "error" }),
+        createDiagnostic({ severity: "error" }),
+        createDiagnostic({ severity: "warning" }),
+      ],
+      score: 70,
+      label: "Needs work",
+      projectName: "counts-test",
+    };
+    const html = buildReportHtml(payload);
+    expect(html).toContain("2 errors");
+    expect(html).toContain("1 warning");
+  });
+
+  it("includes diagnostic groups with rule key, message, help, and locations", () => {
+    const payload: ReportPayload = {
+      diagnostics: [
+        createDiagnostic({
+          message: "Avoid using dangerouslySetInnerHTML.",
+          help: "Use a sanitization library.",
+          filePath: "src/App.tsx",
+          line: 10,
+        }),
+      ],
+      score: null,
+      label: null,
+      projectName: "diagnostics-test",
+    };
+    const html = buildReportHtml(payload);
+    expect(html).toContain("Avoid using dangerouslySetInnerHTML.");
+    expect(html).toContain("Use a sanitization library.");
+    expect(html).toContain("basic-react/no-danger");
+    expect(html).toContain("src/App.tsx");
+    expect(html).toContain(":10");
+  });
+
+  it("escapes HTML in diagnostic message and help", () => {
+    const payload: ReportPayload = {
+      diagnostics: [
+        createDiagnostic({
+          message: "Message with <script>alert(1)</script> tags",
+          help: 'Help with "quotes" and <b>HTML</b>',
+        }),
+      ],
+      score: null,
+      label: null,
+      projectName: "escape-test",
+    };
+    const html = buildReportHtml(payload);
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&quot;quotes&quot;");
+    expect(html).toContain("&lt;b&gt;HTML&lt;/b&gt;");
+  });
+
+  it("groups multiple diagnostics by plugin/rule and shows count", () => {
+    const payload: ReportPayload = {
+      diagnostics: [
+        createDiagnostic({ filePath: "src/A.tsx", line: 1 }),
+        createDiagnostic({ filePath: "src/B.tsx", line: 2 }),
+      ],
+      score: 50,
+      label: "Needs work",
+      projectName: "group-test",
+    };
+    const html = buildReportHtml(payload);
+    expect(html).toContain("(2)");
+    expect(html).toContain("src/A.tsx");
+    expect(html).toContain("src/B.tsx");
+  });
+});

--- a/packages/react-doctor/tests/scan.test.ts
+++ b/packages/react-doctor/tests/scan.test.ts
@@ -81,4 +81,23 @@ describe("scan", () => {
       consoleSpy.mockRestore();
     }
   });
+
+  it("writes report.html and logs report path when diagnostics exist", async () => {
+    const logCalls: string[] = [];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation((message: string) => {
+      logCalls.push(message);
+    });
+    try {
+      await scan(path.join(FIXTURES_DIRECTORY, "basic-react"), {
+        lint: true,
+        deadCode: false,
+      });
+      const hasReportWrittenMessage = logCalls.some((call) => call.includes("report written to"));
+      const hasReportOpenMessage = logCalls.some((call) => call.includes("report.html"));
+      expect(hasReportWrittenMessage).toBe(true);
+      expect(hasReportOpenMessage).toBe(true);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
 });

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -34,6 +34,12 @@ Use `-y` to skip prompts (required for non-interactive environments like CI or c
 npx -y react-doctor@latest . -y
 ```
 
+When issues are found, diagnostics and an HTML report are written to a temp directory. Use `--open-report` to open the report in the browser after the scan:
+
+```bash
+npx -y react-doctor@latest . --open-report
+```
+
 ## Options
 
 ```
@@ -48,6 +54,8 @@ Options:
   -y, --yes         skip prompts, scan all workspace projects
   --project <name>  select workspace project (comma-separated for multiple)
   --diff [base]     scan only files changed vs base branch or uncommitted changes
+  --offline         skip telemetry (score not calculated)
+  --open-report     open the HTML report in the default browser after scan
   --fix             open Ami to auto-fix all issues
   -h, --help        display help for command
 ```

--- a/skills/react-doctor/SKILL.md
+++ b/skills/react-doctor/SKILL.md
@@ -6,12 +6,18 @@ version: 1.0.0
 
 # React Doctor
 
-Scans your React codebase for security, performance, correctness, and architecture issues. Outputs a 0-100 score with actionable diagnostics.
+Scans your React codebase for security, performance, correctness, and architecture issues. Outputs a 0-100 score with actionable diagnostics. Writes diagnostics.json and an HTML report (report.html) when issues are found; use `--open-report` to open the report in the browser.
 
 ## Usage
 
 ```bash
 npx -y react-doctor@latest . --verbose --diff
+```
+
+Open the HTML report after the scan:
+
+```bash
+npx -y react-doctor@latest . --open-report
 ```
 
 ## Workflow


### PR DESCRIPTION
Hi there, great tool. It would be very useful to be able to share a static HTML report with colleagues after running the tool (or alternatively enhance the `/share` endpoint to include all identified issues).

## Summary
- **HTML report**: When issues are found, a self-contained `report.html` is written next to `diagnostics.json` in the output directory. The report shows score (when available), summary counts, and diagnostics grouped by rule.
- **`--open-report`**: New CLI flag to open the HTML report in the default browser after the scan.
- **Docs**: README, `packages/website/public/llms.txt`, and react-doctor skill updated with the new options and report behavior.

## Changes
- `packages/react-doctor`: `ReportPayload` type, `buildReportHtml()` in `report-template.ts`, `writeReportDirectory()` writes `report.html`, `openFile()` util, `--open-report` flag and `openReport` in `ScanOptions`.
- Tests for report HTML generation and scan logging.
- README / llms.txt / skill: `--open-report`, `--offline`, and description of the HTML report.

## How it looks
<img width="1512" height="825" alt="Screenshot 2026-02-20 at 11 49 57" src="https://github.com/user-attachments/assets/98a6f819-8a0a-4818-80f5-d364e43faf95" />


Made with [Cursor](https://cursor.com)