### PR TITLE
feat: add Expo and React Native framework detection and enable RN-specific rules

### DIFF
--- a/packages/react-doctor/src/oxlint-config.ts
+++ b/packages/react-doctor/src/oxlint-config.ts
@@ -22,6 +22,17 @@ const NEXTJS_RULES: Record<string, string> = {
   "react-doctor/nextjs-no-side-effect-in-get-handler": "error",
 };
 
+const REACT_NATIVE_RULES: Record<string, string> = {
+  "react-doctor/rn-no-raw-text": "error",
+  "react-doctor/rn-no-deprecated-modules": "error",
+  "react-doctor/rn-no-legacy-expo-packages": "warn",
+  "react-doctor/rn-no-dimensions-get": "warn",
+  "react-doctor/rn-no-inline-flatlist-renderitem": "warn",
+  "react-doctor/rn-no-legacy-shadow-styles": "warn",
+  "react-doctor/rn-prefer-reanimated": "warn",
+  "react-doctor/rn-no-single-element-style-array": "warn",
+};
+
 const REACT_COMPILER_RULES: Record<string, string> = {
   "react-hooks-js/set-state-in-render": "error",
   "react-hooks-js/immutability": "error",
@@ -147,5 +158,6 @@ export const createOxlintConfig = ({
 
     "react-doctor/async-parallel": "warn",
     ...(framework === "nextjs" ? NEXTJS_RULES : {}),
+    ...(framework === "expo" || framework === "react-native" ? REACT_NATIVE_RULES : {}),
   },
 });

--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -1,4 +1,4 @@
-export type Framework = "nextjs" | "vite" | "cra" | "remix" | "gatsby" | "unknown";
+export type Framework = "nextjs" | "vite" | "cra" | "remix" | "gatsby" | "expo" | "react-native" | "unknown";
 
 export interface ProjectInfo {
   rootDirectory: string;

--- a/packages/react-doctor/src/utils/discover-project.ts
+++ b/packages/react-doctor/src/utils/discover-project.ts
@@ -51,6 +51,8 @@ const FRAMEWORK_PACKAGES: Record<string, Framework> = {
   "react-scripts": "cra",
   "@remix-run/react": "remix",
   gatsby: "gatsby",
+  expo: "expo",
+  "react-native": "react-native",
 };
 
 const FRAMEWORK_DISPLAY_NAMES: Record<Framework, string> = {
@@ -59,6 +61,8 @@ const FRAMEWORK_DISPLAY_NAMES: Record<Framework, string> = {
   cra: "Create React App",
   remix: "Remix",
   gatsby: "Gatsby",
+  expo: "Expo",
+  "react-native": "React Native",
   unknown: "React",
 };
 

--- a/packages/react-doctor/src/utils/run-oxlint.ts
+++ b/packages/react-doctor/src/utils/run-oxlint.ts
@@ -87,6 +87,15 @@ const RULE_CATEGORY_MAP: Record<string, string> = {
   "react-doctor/client-passive-event-listeners": "Performance",
 
   "react-doctor/async-parallel": "Performance",
+
+  "react-doctor/rn-no-raw-text": "React Native",
+  "react-doctor/rn-no-deprecated-modules": "React Native",
+  "react-doctor/rn-no-legacy-expo-packages": "React Native",
+  "react-doctor/rn-no-dimensions-get": "React Native",
+  "react-doctor/rn-no-inline-flatlist-renderitem": "React Native",
+  "react-doctor/rn-no-legacy-shadow-styles": "React Native",
+  "react-doctor/rn-prefer-reanimated": "React Native",
+  "react-doctor/rn-no-single-element-style-array": "React Native",
 };
 
 const RULE_HELP_MAP: Record<string, string> = {
@@ -208,6 +217,23 @@ const RULE_HELP_MAP: Record<string, string> = {
 
   "async-parallel":
     "Use `const [a, b] = await Promise.all([fetchA(), fetchB()])` to run independent operations concurrently",
+
+  "rn-no-raw-text":
+    "Wrap text in a `<Text>` component: `<Text>{value}</Text>` — raw strings outside `<Text>` crash on React Native",
+  "rn-no-deprecated-modules":
+    "Import from the community package instead — deprecated modules were removed from the react-native core",
+  "rn-no-legacy-expo-packages":
+    "Migrate to the recommended replacement package — legacy Expo packages are no longer maintained",
+  "rn-no-dimensions-get":
+    "Use `const { width, height } = useWindowDimensions()` — it updates reactively on rotation and resize",
+  "rn-no-inline-flatlist-renderitem":
+    "Extract renderItem to a named function or wrap in useCallback to avoid re-creating on every render",
+  "rn-no-legacy-shadow-styles":
+    "Use `boxShadow` for cross-platform shadows on the new architecture instead of platform-specific shadow properties",
+  "rn-prefer-reanimated":
+    "Use `import Animated from 'react-native-reanimated'` — animations run on the UI thread instead of the JS thread",
+  "rn-no-single-element-style-array":
+    "Use `style={value}` instead of `style={[value]}` — single-element arrays add unnecessary allocation",
 };
 
 const FILEPATH_WITH_LOCATION_PATTERN = /\S+\.\w+:\d+:\d+[\s\S]*$/;


### PR DESCRIPTION
## Summary

React Native and Expo projects are currently detected as `"unknown"` framework (displayed as just "React"), and the 8 existing `rn-*` lint rules in the plugin are **never enabled** in the oxlint config — they're effectively dead code.

This PR:

- **Adds `"expo"` and `"react-native"` as recognized `Framework` types** in `types.ts`
- **Detects `expo` and `react-native` packages** in `FRAMEWORK_PACKAGES` during project discovery, so the CLI correctly displays "Expo" or "React Native" instead of "React"
- **Conditionally enables all 8 `rn-*` rules** when framework is Expo or React Native (same pattern as `NEXTJS_RULES`):
  - `rn-no-raw-text` (error) — raw text outside `<Text>` crashes on RN
  - `rn-no-deprecated-modules` (error) — removed modules from react-native core
  - `rn-no-legacy-expo-packages` (warn) — deprecated Expo packages
  - `rn-no-dimensions-get` (warn) — non-reactive dimension API
  - `rn-no-inline-flatlist-renderitem` (warn) — perf issue with inline renderItem
  - `rn-no-legacy-shadow-styles` (warn) — legacy shadow props vs boxShadow
  - `rn-prefer-reanimated` (warn) — UI-thread animations over JS-thread
  - `rn-no-single-element-style-array` (warn) — unnecessary array allocation
- **Adds "React Native" category** for all `rn-*` rules in diagnostic output
- **Adds actionable help text** for each `rn-*` rule

### Before
```
✓ Detecting framework. Found React.     ← wrong
  (no RN-specific diagnostics)           ← rules exist but never fire
```

### After (tested on a real Expo project)
```
✓ Detecting framework. Found Expo.
✗ "SafeAreaView" was removed from react-native — use react-native-safe-area-context instead
    Import from the community package instead — deprecated modules were removed from the react-native core
⚠ Dimensions.get() does not update on screen rotation or resize — use useWindowDimensions()
    Use const { width, height } = useWindowDimensions() — it updates reactively on rotation and resize
```

## Test plan

- [x] `pnpm build` succeeds
- [x] All 125 existing tests pass (`pnpm test`)
- [x] No new files created — follows existing patterns exactly (mirrors `NEXTJS_RULES` approach)
- [x] Verified on a real Expo project: framework shows as "Expo" and RN rules fire correctly