### PR TITLE
fix: strip ANSI escape codes from PR comment output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,8 @@ runs:
         if [ -n "$INPUT_DIFF" ]; then FLAGS="$FLAGS --diff $INPUT_DIFF"; fi
 
         if [ -n "$INPUT_GITHUB_TOKEN" ]; then
-          npx -y react-doctor@latest "$INPUT_DIRECTORY" $FLAGS | tee /tmp/react-doctor-output.txt
+          npx -y react-doctor@latest "$INPUT_DIRECTORY" $FLAGS | tee /tmp/react-doctor-output-raw.txt
+          sed 's/\x1b\[[0-9;]*[mGKHFJABCDsuh]//g' /tmp/react-doctor-output-raw.txt > /tmp/react-doctor-output.txt
         else
           npx -y react-doctor@latest "$INPUT_DIRECTORY" $FLAGS
         fi


### PR DESCRIPTION
## Problem

When react-doctor output is posted as a GitHub PR comment, ANSI color codes (e.g. `\x1b[32m`) appear as garbled text because GitHub Markdown does not render ANSI escape sequences.

## Solution

Pipe the raw output through `sed` to strip all ANSI escape sequences before writing to the file used for the PR comment. The terminal output in the Actions log remains unaffected (colors are preserved via the raw file).

## Changes

- `action.yml`: Save raw output to a temporary file, then produce a clean copy with ANSI codes stripped for use in the PR comment body.

・before
<img width="894" height="530" alt="スクリーンショット 2026-02-23 14 02 29" src="https://github.com/user-attachments/assets/cf4d17be-5e62-48b5-9749-7780ac0a146f" />

・after
<img width="888" height="527" alt="スクリーンショット 2026-02-23 14 03 33" src="https://github.com/user-attachments/assets/dcaa226c-037b-4301-89b9-d92825ac94f9" />
