### PR TITLE
fix(action): strip ANSI colors and fix diff mode on PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
     - if: ${{ inputs.diff != '' && github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        git fetch origin "$BASE_REF" --depth=1
+        git fetch origin "$BASE_REF"
         git checkout "$HEAD_REF"
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -42,10 +42,12 @@ runs:
     - if: ${{ inputs.diff != '' && github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        git fetch origin ${{ github.base_ref }} --depth=1
-        git checkout ${{ github.head_ref }}
+        git fetch origin "$BASE_REF" --depth=1
+        git checkout "$HEAD_REF"
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        BASE_REF: ${{ github.base_ref }}
+        HEAD_REF: ${{ github.head_ref }}
 
     - shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -42,8 +42,21 @@ runs:
     - if: ${{ inputs.diff != '' && github.event_name == 'pull_request' }}
       shell: bash
       run: |
+        echo "::group::Debug git state before fix"
+        echo "HEAD before: $(git rev-parse --abbrev-ref HEAD)"
+        echo "Branches: $(git branch -a | head -20)"
+        echo "::endgroup::"
         git fetch origin "$BASE_REF"
         git checkout "$HEAD_REF"
+        echo "::group::Debug git state after fix"
+        echo "HEAD after: $(git rev-parse --abbrev-ref HEAD)"
+        MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>&1) && echo "merge-base: $MERGE_BASE" || echo "merge-base FAILED: $MERGE_BASE"
+        echo "Changed files (from repo root):"
+        git diff --name-only --diff-filter=ACMR "$MERGE_BASE" HEAD 2>&1 | head -20
+        echo "Changed files (--relative from ${{ inputs.directory }}):"
+        cd "${{ inputs.directory }}" && git diff --name-only --diff-filter=ACMR --relative "$MERGE_BASE" HEAD 2>&1 | head -20
+        cd -
+        echo "::endgroup::"
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         BASE_REF: ${{ github.base_ref }}

--- a/action.yml
+++ b/action.yml
@@ -42,11 +42,13 @@ runs:
     - if: ${{ inputs.diff != '' && github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        git fetch origin "$BASE_REF":"$BASE_REF"
-        git checkout "$HEAD_REF"
+        # create local ref for the diff base so git merge-base can resolve it
+        git fetch origin "$DIFF_BASE" && git branch -f "$DIFF_BASE" FETCH_HEAD 2>/dev/null || true
+        # checkout the PR head branch so getCurrentBranch() doesn't return null
+        git checkout "$HEAD_REF" 2>/dev/null || true
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        BASE_REF: ${{ github.base_ref }}
+        DIFF_BASE: ${{ inputs.diff }}
         HEAD_REF: ${{ github.head_ref }}
 
     - shell: bash

--- a/action.yml
+++ b/action.yml
@@ -42,21 +42,8 @@ runs:
     - if: ${{ inputs.diff != '' && github.event_name == 'pull_request' }}
       shell: bash
       run: |
-        echo "::group::Debug git state before fix"
-        echo "HEAD before: $(git rev-parse --abbrev-ref HEAD)"
-        echo "Branches: $(git branch -a | head -20)"
-        echo "::endgroup::"
-        git fetch origin "$BASE_REF"
+        git fetch origin "$BASE_REF":"$BASE_REF"
         git checkout "$HEAD_REF"
-        echo "::group::Debug git state after fix"
-        echo "HEAD after: $(git rev-parse --abbrev-ref HEAD)"
-        MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>&1) && echo "merge-base: $MERGE_BASE" || echo "merge-base FAILED: $MERGE_BASE"
-        echo "Changed files (from repo root):"
-        git diff --name-only --diff-filter=ACMR "$MERGE_BASE" HEAD 2>&1 | head -20
-        echo "Changed files (--relative from ${{ inputs.directory }}):"
-        cd "${{ inputs.directory }}" && git diff --name-only --diff-filter=ACMR --relative "$MERGE_BASE" HEAD 2>&1 | head -20
-        cd -
-        echo "::endgroup::"
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         BASE_REF: ${{ github.base_ref }}

--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,17 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - if: ${{ inputs.diff != '' && github.event_name == 'pull_request' }}
+      shell: bash
+      run: |
+        git fetch origin ${{ github.base_ref }} --depth=1
+        git checkout ${{ github.head_ref }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+
     - shell: bash
       env:
+        NO_COLOR: "1"
         INPUT_DIRECTORY: ${{ inputs.directory }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
         INPUT_PROJECT: ${{ inputs.project }}


### PR DESCRIPTION
fixes two bugs in the github action introduced in #63.

### ANSI escape codes in PR comments

react-doctor uses picocolors for terminal output. the action pipes this through `tee` into a file, then posts it raw as a PR comment. ANSI codes (`^[[32m`, etc.) show up as literal text in the markdown code block.

fix: set `NO_COLOR=1` in the env block. picocolors respects this natively — no stripping needed.

### --diff mode falls back to full scan

`actions/checkout` checks out a detached HEAD merge commit on `pull_request` events. `getCurrentBranch()` in `get-diff-files.ts:13` returns `null` for detached HEAD (`branch === "HEAD" ? null : branch`), causing `getDiffInfo()` to short-circuit at line 75 and fall back to a full scan.

fix: when `diff` input is set on a PR, checkout the actual head ref (`github.head_ref`) and fetch the base branch. this puts git on a real branch so `getCurrentBranch()` succeeds.

### evidence

spotted in [axiomhq/app#7259](https://github.com/axiomhq/app/pull/7259) — the action posted a comment with raw ANSI and ran a full scan instead of diffing.

— igor's agent