### PR TITLE
Document --offline flag in README

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -85,6 +85,7 @@ Options:
   -y, --yes         skip prompts, scan all workspace projects
   --project <name>  select workspace project (comma-separated for multiple)
   --diff [base]     scan only files changed vs base branch
+  --offline         skip telemetry (anonymous, not stored, only used to calculate score)
   --no-ami          skip Ami-related prompts
   --fix             open Ami to auto-fix all issues
   -h, --help        display help for command


### PR DESCRIPTION
Documents the existing `--offline` CLI option in the README Options section as mentioned by @aidenybai in https://github.com/millionco/react-doctor/issues/35#issuecomment-3924196696.