### PR TITLE
feat(action): add offline input to skip remote API calls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   fail-on:
     description: "Exit with error code on diagnostics: error, warning, none"
     default: "error"
+  offline:
+    description: "Skip sending diagnostics to the react.doctor API and calculate score locally"
+    default: "false"
   node-version:
     description: "Node.js version to use"
     default: "20"
@@ -47,11 +50,13 @@ runs:
         INPUT_DIFF: ${{ inputs.diff }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_OFFLINE: ${{ inputs.offline }}
       run: |
         FLAGS="--fail-on $INPUT_FAIL_ON"
         if [ "$INPUT_VERBOSE" = "true" ]; then FLAGS="$FLAGS --verbose"; fi
         if [ -n "$INPUT_PROJECT" ]; then FLAGS="$FLAGS --project $INPUT_PROJECT"; fi
         if [ -n "$INPUT_DIFF" ]; then FLAGS="$FLAGS --diff $INPUT_DIFF"; fi
+        if [ "$INPUT_OFFLINE" = "true" ]; then FLAGS="$FLAGS --offline"; fi
 
         if [ -n "$INPUT_GITHUB_TOKEN" ]; then
           npx -y react-doctor@latest "$INPUT_DIRECTORY" $FLAGS | tee /tmp/react-doctor-output.txt
@@ -64,8 +69,11 @@ runs:
       shell: bash
       env:
         INPUT_DIRECTORY: ${{ inputs.directory }}
+        INPUT_OFFLINE: ${{ inputs.offline }}
       run: |
-        SCORE=$(npx -y react-doctor@latest "$INPUT_DIRECTORY" --score 2>/dev/null | tail -1 | tr -d '[:space:]')
+        OFFLINE_FLAG=""
+        if [ "$INPUT_OFFLINE" = "true" ]; then OFFLINE_FLAG="--offline"; fi
+        SCORE=$(npx -y react-doctor@latest "$INPUT_DIRECTORY" --score $OFFLINE_FLAG 2>/dev/null | tail -1 | tr -d '[:space:]')
         if [[ -n "$SCORE" && "$SCORE" =~ ^[0-9]+$ ]]; then
           echo "score=$SCORE" >> "$GITHUB_OUTPUT"
         fi

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -67,6 +67,8 @@ Supports Cursor, Claude Code, Amp Code, Codex, Gemini CLI, OpenCode, Windsurf, a
 | `project`      |         | Workspace project(s) to scan (comma-separated)                    |
 | `diff`         |         | Base branch for diff mode. Only changed files are scanned         |
 | `github-token` |         | When set on `pull_request` events, posts findings as a PR comment |
+| `fail-on`      | `error` | Exit with error code on diagnostics: `error`, `warning`, `none`   |
+| `offline`      | `false` | Skip sending diagnostics to the react.doctor API                  |
 | `node-version` | `20`    | Node.js version to use                                            |
 
 The action outputs a `score` (0–100) you can use in subsequent steps.


### PR DESCRIPTION
When running React Doctor in GitHub Actions, there's no way to disable publishing diagnostics to the react.doctor API. This is a problem for orgs where `react.doctor` is blocked by network security policies, self-hosted runners without external internet access, or teams that simply want local-only scoring.

## Changes

- Add `offline` input to `action.yml` (default `"false"`) — passes the existing `--offline` CLI flag when set to `"true"`
- Wire `--offline` into both the main scan step and the score extraction step
- Add `offline` and `fail-on` (previously missing) to the README inputs table

## Usage

```yaml
- uses: millionco/react-doctor@main
  with:
    offline: "true"
    diff: main
```

When `offline` is enabled, scores are calculated locally instead of via the remote API. All scanning behavior remains identical — only the score API calls are skipped.
