### PR TITLE
fix: remove unsupported jsx-a11y/no-noninteractive-element-interactions rule

### DIFF
--- a/packages/react-doctor/src/oxlint-config.ts
+++ b/packages/react-doctor/src/oxlint-config.ts
@@ -97,7 +97,6 @@ export const createOxlintConfig = ({
     "jsx-a11y/anchor-is-valid": "warn",
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/no-static-element-interactions": "warn",
-    "jsx-a11y/no-noninteractive-element-interactions": "warn",
     "jsx-a11y/role-has-required-aria-props": "error",
     "jsx-a11y/no-autofocus": "warn",
     "jsx-a11y/heading-has-content": "warn",


### PR DESCRIPTION
## Summary

Removes `jsx-a11y/no-noninteractive-element-interactions` from the oxlint config. This rule is not implemented in oxlint, causing all lint checks to fail with:

```
Failed to parse oxlint configuration file.
  x Rule 'no-noninteractive-element-interactions' not found in plugin 'jsx_a11y'
```

This has been breaking lint scoring for all users since v0.0.26+.

Closes #113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single linter configuration rule is removed, reducing strictness slightly but avoiding oxlint config parse failures.
> 
> **Overview**
> Stops `oxlint` from failing to load the generated config by removing the unsupported rule `jsx-a11y/no-noninteractive-element-interactions` from `packages/react-doctor/src/oxlint-config.ts`.
> 
> This unblocks lint checks for users while leaving the rest of the `jsx-a11y` ruleset unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1facf3ca0e4c20d96c4a8777adf2cd81c5a7eba3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->