### PR TITLE
fix: restrict setter detection to direct Identifier callees

### DIFF
--- a/packages/react-doctor/src/plugin/helpers.ts
+++ b/packages/react-doctor/src/plugin/helpers.ts
@@ -29,6 +29,11 @@ export const walkAst = (node: EsTreeNode, visitor: (child: EsTreeNode) => void):
 
 export const isSetterIdentifier = (name: string): boolean => SETTER_PATTERN.test(name);
 
+export const isSetterCall = (node: EsTreeNode): boolean =>
+  node.type === "CallExpression" &&
+  node.callee?.type === "Identifier" &&
+  isSetterIdentifier(node.callee.name);
+
 export const isUppercaseName = (name: string): boolean => UPPERCASE_PATTERN.test(name);
 
 export const isMemberProperty = (node: EsTreeNode, propertyName: string): boolean =>
@@ -55,11 +60,7 @@ export const getCallbackStatements = (callback: EsTreeNode): EsTreeNode[] => {
 export const countSetStateCalls = (node: EsTreeNode): number => {
   let setStateCallCount = 0;
   walkAst(node, (child) => {
-    if (child.type !== "CallExpression") return;
-    const calleeName = getCalleeName(child);
-    if (calleeName && isSetterIdentifier(calleeName)) {
-      setStateCallCount++;
-    }
+    if (isSetterCall(child)) setStateCallCount++;
   });
   return setStateCallCount;
 };

--- a/packages/react-doctor/src/plugin/rules/performance.ts
+++ b/packages/react-doctor/src/plugin/rules/performance.ts
@@ -6,14 +6,13 @@ import {
   LAYOUT_PROPERTIES,
   LOADING_STATE_PATTERN,
   MOTION_ANIMATE_PROPS,
-  SETTER_PATTERN,
 } from "../constants.js";
 import {
-  getCalleeName,
   getEffectCallback,
   isComponentAssignment,
   isHookCall,
   isMemberProperty,
+  isSetterCall,
   isSimpleExpression,
   isUppercaseName,
   walkAst,
@@ -413,14 +412,9 @@ export const renderingHydrationNoFlicker: Rule = {
       if (!bodyStatements || bodyStatements.length !== 1) return;
 
       const soleStatement = bodyStatements[0];
-      const soleCalleeName =
-        soleStatement?.expression?.type === "CallExpression"
-          ? getCalleeName(soleStatement.expression)
-          : null;
       if (
         soleStatement?.type === "ExpressionStatement" &&
-        soleCalleeName &&
-        SETTER_PATTERN.test(soleCalleeName)
+        isSetterCall(soleStatement.expression)
       ) {
         context.report({
           node,

--- a/packages/react-doctor/src/plugin/rules/performance.ts
+++ b/packages/react-doctor/src/plugin/rules/performance.ts
@@ -412,10 +412,7 @@ export const renderingHydrationNoFlicker: Rule = {
       if (!bodyStatements || bodyStatements.length !== 1) return;
 
       const soleStatement = bodyStatements[0];
-      if (
-        soleStatement?.type === "ExpressionStatement" &&
-        isSetterCall(soleStatement.expression)
-      ) {
+      if (soleStatement?.type === "ExpressionStatement" && isSetterCall(soleStatement.expression)) {
         context.report({
           node,
           message:

--- a/packages/react-doctor/src/plugin/rules/state-and-effects.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects.ts
@@ -10,10 +10,10 @@ import {
   countSetStateCalls,
   extractDestructuredPropNames,
   getCallbackStatements,
-  getCalleeName,
   getEffectCallback,
   isComponentAssignment,
   isHookCall,
+  isSetterCall,
   isSetterIdentifier,
   isUppercaseName,
   walkAst,
@@ -43,9 +43,7 @@ export const noDerivedStateEffect: Rule = {
 
       const containsOnlySetStateCalls = statements.every((statement: EsTreeNode) => {
         if (statement.type !== "ExpressionStatement") return false;
-        if (statement.expression?.type !== "CallExpression") return false;
-        const name = getCalleeName(statement.expression);
-        return name !== null && isSetterIdentifier(name);
+        return isSetterCall(statement.expression);
       });
       if (!containsOnlySetStateCalls) return;
 
@@ -248,10 +246,10 @@ export const rerenderLazyStateInit: Rule = {
 export const rerenderFunctionalSetstate: Rule = {
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      const calleeName = getCalleeName(node);
-      if (!calleeName || !isSetterIdentifier(calleeName)) return;
+      if (!isSetterCall(node)) return;
       if (!node.arguments?.length) return;
 
+      const calleeName = node.callee.name;
       const argument = node.arguments[0];
       if (
         argument.type === "BinaryExpression" &&

--- a/packages/react-doctor/tests/fixtures/basic-react/src/clean.tsx
+++ b/packages/react-doctor/tests/fixtures/basic-react/src/clean.tsx
@@ -1,8 +1,28 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 const Counter = () => {
   const [count, setCount] = useState(0);
   return <button onClick={() => setCount((previous) => previous + 1)}>{count}</button>;
 };
 
-export { Counter };
+const MemberExpressionSetterCalls = () => {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    localStorage.setItem("count", String(count));
+  }, [count]);
+
+  return (
+    <button
+      onClick={() => {
+        localStorage.setItem("clicked", "true");
+        sessionStorage.setItem("clicked", "true");
+        setCount((previous) => previous + 1);
+      }}
+    >
+      {count}
+    </button>
+  );
+};
+
+export { Counter, MemberExpressionSetterCalls };

--- a/packages/react-doctor/tests/namespace-hooks.test.ts
+++ b/packages/react-doctor/tests/namespace-hooks.test.ts
@@ -104,6 +104,27 @@ describe("namespace hook detection (React.useEffect, React.useState, etc.)", () 
     expect(issues[0].message).toContain("useState calls");
   });
 
+  it("does not flag member expression calls like localStorage.setItem as state setters", () => {
+    const allCleanFileIssues = diagnostics.filter(
+      (diagnostic) => diagnostic.filePath.includes("clean"),
+    );
+
+    const setterRules = new Set([
+      "no-derived-state-effect",
+      "no-cascading-set-state",
+      "rerender-functional-setstate",
+      "rendering-hydration-no-flicker",
+    ]);
+
+    const falsePositives = allCleanFileIssues.filter((diagnostic) =>
+      setterRules.has(diagnostic.rule),
+    );
+    expect(
+      falsePositives,
+      "member expression calls like localStorage.setItem should not be flagged as React state setters",
+    ).toHaveLength(0);
+  });
+
   it("still detects all rules from direct-import fixtures (no regression)", () => {
     const directImportRules = [
       "no-derived-state-effect",

--- a/packages/react-doctor/tests/namespace-hooks.test.ts
+++ b/packages/react-doctor/tests/namespace-hooks.test.ts
@@ -105,8 +105,8 @@ describe("namespace hook detection (React.useEffect, React.useState, etc.)", () 
   });
 
   it("does not flag member expression calls like localStorage.setItem as state setters", () => {
-    const allCleanFileIssues = diagnostics.filter(
-      (diagnostic) => diagnostic.filePath.includes("clean"),
+    const allCleanFileIssues = diagnostics.filter((diagnostic) =>
+      diagnostic.filePath.includes("clean"),
     );
 
     const setterRules = new Set([


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`getCalleeName` returns the property name from `MemberExpression` nodes, which is correct for namespace hook detection (`React.useEffect`), but it also broadens setter-detection logic. Rules like `rerenderFunctionalSetstate`, `countSetStateCalls`, `noDerivedStateEffect`, and `renderingHydrationNoFlicker` use `isSetterIdentifier` (pattern `/^set[A-Z]/`) on the result of `getCalleeName`, so calls like `localStorage.setItem(count + 1)`, `cache.setItem(...)`, or `map.setKey(...)` falsely match as React state setters, producing spurious warnings.

## Solution

Introduce a new `isSetterCall()` helper that checks **both** conditions atomically:
1. The node is a `CallExpression`
2. The callee is a **direct `Identifier`** (not a `MemberExpression` property)
3. The identifier name matches the setter pattern (`/^set[A-Z]/`)

This ensures only bare `setCount(...)` calls are matched, not `localStorage.setItem(...)` or `cache.setKey(...)`.

### Files changed

- **`helpers.ts`** — Added `isSetterCall()`, updated `countSetStateCalls` to use it
- **`rules/state-and-effects.ts`** — `noDerivedStateEffect` and `rerenderFunctionalSetstate` now use `isSetterCall` instead of `getCalleeName` + `isSetterIdentifier`
- **`rules/performance.ts`** — `renderingHydrationNoFlicker` now uses `isSetterCall` instead of `getCalleeName` + `SETTER_PATTERN.test()`
- **`tests/fixtures/basic-react/src/clean.tsx`** — Added `MemberExpressionSetterCalls` component with `localStorage.setItem()` calls that should NOT trigger setter warnings
- **`tests/namespace-hooks.test.ts`** — Added test asserting member expression setter-like calls produce zero false positives
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3561827-799d-4c69-971c-b17ce4bd69b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3561827-799d-4c69-971c-b17ce4bd69b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

