### PR TITLE
Fix/knip files runtime safe

### DIFF
--- a/packages/react-doctor/src/utils/run-knip.ts
+++ b/packages/react-doctor/src/utils/run-knip.ts
@@ -151,9 +151,10 @@ export const runKnip = async (rootDirectory: string): Promise<Diagnostic[]> => {
   }
 
   const { issues } = knipResult;
+  const fileIssues = issues.files ?? new Set();
   const diagnostics: Diagnostic[] = [];
 
-  for (const unusedFile of issues.files) {
+  for (const unusedFile of fileIssues) {
     diagnostics.push({
       filePath: path.relative(rootDirectory, unusedFile),
       plugin: "knip",

--- a/packages/react-doctor/tests/run-knip.test.ts
+++ b/packages/react-doctor/tests/run-knip.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { main } from "knip";
+import { runKnip } from "../src/utils/run-knip.js";
+
+vi.mock("knip", () => ({
+  main: vi.fn(),
+}));
+
+vi.mock("knip/session", () => ({
+  createOptions: vi.fn(async () => ({
+    parsedConfig: {},
+  })),
+}));
+
+const tempProjectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-knip-test-"));
+fs.mkdirSync(path.join(tempProjectDirectory, "node_modules"));
+
+afterAll(() => {
+  fs.rmSync(tempProjectDirectory, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runKnip", () => {
+  it("returns diagnostics without throwing when issues.files is missing", async () => {
+    vi.mocked(main).mockResolvedValue({
+      issues: {
+        files: undefined,
+        dependencies: {},
+        devDependencies: {},
+        unlisted: {},
+        exports: {},
+        types: {},
+        duplicates: {},
+      },
+      counters: {},
+    } as never);
+
+    await expect(runKnip(tempProjectDirectory)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
### This fixes a runtime crash in the Knip integration when issues.files is missing..

Previously, we directly iterated over `issues.files`, which could throw in edge cases when the field was unavailable at runtime.
Now we normalize it first with a runtime-safe fallback:

```tsx 
const fileIssues = issues.files ?? new Set();
```
Then we iterate over `fileIssues` instead of `issues.files`.

This keeps existing behavior unchanged when file issues are present, while preventing failures when Knip returns incomplete or variant output.

### Tests I added
- [x] Added a regression test for missing `issues.files` in `runKnip
- [x] Confirmed normal behavior remains intact for valid `issues.files` values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive change to avoid a runtime crash when Knip omits `issues.files`, plus a focused regression test.
> 
> **Overview**
> Prevents `runKnip` from crashing when Knip returns `issues.files` as missing/undefined by normalizing it to an empty `Set` before iteration.
> 
> Adds a Vitest regression test that mocks Knip output without `issues.files` and asserts `runKnip` resolves to an empty diagnostics array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d028dfd93f8527610492599ed6d6d5088ea4a2f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->