### PR TITLE
Fix: useMemo detected as cheap - but subjectively still more expensive than dependency comparison

### DIFF
--- a/packages/react-doctor/src/plugin/rules/performance.ts
+++ b/packages/react-doctor/src/plugin/rules/performance.ts
@@ -14,7 +14,6 @@ import {
   isComponentAssignment,
   isHookCall,
   isMemberProperty,
-  isSetterCall,
   isSimpleExpression,
   isUppercaseName,
   walkAst,
@@ -116,6 +115,15 @@ export const noUsememoSimpleExpression: Rule = {
       }
 
       if (returnExpression && isSimpleExpression(returnExpression)) {
+        let isComplex = false;
+        walkAst(returnExpression, (child: EsTreeNode) => {
+          if (child.type === "CallExpression" || child.type === "NewExpression") {
+            isComplex = true;
+          }
+        });
+
+        if (isComplex) return;
+
         context.report({
           node,
           message:


### PR DESCRIPTION
The `noUsememoSimpleExpression` rule was too aggressive because it relied on `isSimpleExpression`, which apparently doesn't account for complex operations like function calls when they are nested (e.g., inside a property access like `.length`). I updated the rule to traverse the return expression using `walkAst` and check for any `CallExpression` or `NewExpression`. If either is found, the expression is no longer considered 'trivially cheap', and the warning is suppressed. This allows memoizing potentially expensive operations like array filtering and mapping even when they appear in simple-looking expressions.

Test: Create a React component using `useMemo` where the return expression is a chain ending in a property access but containing a method call, such as `useMemo(() => list.filter(item => item.valid).length, [list])`. Before the fix, this would trigger a `no-usememo-simple-expression` warning. After the fix, it should no longer trigger the warning. Truly simple expressions like `useMemo(() => a + b, [a, b])` should still be flagged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior of the `noUsememoSimpleExpression` lint rule changes and may affect developer guidance; additionally, `isSetterCall` is removed from imports in `performance.ts` but still referenced, which could break builds/runtime if not resolved.
> 
> **Overview**
> Tightens the `noUsememoSimpleExpression` rule to suppress warnings when the `useMemo` callback’s return expression contains any nested `CallExpression` or `NewExpression` (via `walkAst`), reducing false positives for “simple-looking” expressions that hide expensive work.
> 
> Also removes the `isSetterCall` import from `performance.ts` despite `isSetterCall` still being used later in the file, which appears likely to be an accidental compile/runtime break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 387c48a9cbf459f59b30b8a47cdda7994d10171f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->