### PR TITLE
fix(react-doctor): handle knip 6.x IssueRecords shape for files

### DIFF
--- a/.changeset/fix-knip-files-iteration.md
+++ b/.changeset/fix-knip-files-iteration.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix `TypeError: issues.files is not iterable` crash during dead code detection. Knip 6.x returns `issues.files` as an `IssueRecords` object instead of a `Set<string>`. The dead code pass now handles both shapes (and arrays) defensively.

--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -141,7 +141,7 @@ export interface PromptMultiselectContext {
 
 export interface KnipResults {
   issues: {
-    files: Set<string>;
+    files: KnipIssueRecords | Set<string> | string[];
     dependencies: KnipIssueRecords;
     devDependencies: KnipIssueRecords;
     unlisted: KnipIssueRecords;

--- a/packages/react-doctor/src/utils/collect-unused-file-paths.ts
+++ b/packages/react-doctor/src/utils/collect-unused-file-paths.ts
@@ -1,0 +1,32 @@
+import type { KnipIssueRecords } from "../types.js";
+import { isPlainObject } from "./is-plain-object.js";
+
+export const collectUnusedFilePaths = (
+  filesIssues: KnipIssueRecords | Set<string> | string[] | unknown,
+): string[] => {
+  if (filesIssues instanceof Set) {
+    return [...filesIssues];
+  }
+
+  if (Array.isArray(filesIssues)) {
+    return filesIssues.filter((entry): entry is string => typeof entry === "string");
+  }
+
+  if (!isPlainObject(filesIssues)) {
+    return [];
+  }
+
+  const unusedFilePaths: string[] = [];
+
+  for (const innerValue of Object.values(filesIssues)) {
+    if (!isPlainObject(innerValue)) continue;
+
+    for (const issue of Object.values(innerValue)) {
+      if (isPlainObject(issue) && typeof issue.filePath === "string") {
+        unusedFilePaths.push(issue.filePath);
+      }
+    }
+  }
+
+  return unusedFilePaths;
+};

--- a/packages/react-doctor/src/utils/run-knip.ts
+++ b/packages/react-doctor/src/utils/run-knip.ts
@@ -4,6 +4,7 @@ import { main } from "knip";
 import { createOptions } from "knip/session";
 import { MAX_KNIP_RETRIES } from "../constants.js";
 import type { Diagnostic, KnipIssueRecords, KnipResults } from "../types.js";
+import { collectUnusedFilePaths } from "./collect-unused-file-paths.js";
 import { findMonorepoRoot } from "./find-monorepo-root.js";
 import { isFile } from "./is-file.js";
 
@@ -153,9 +154,9 @@ export const runKnip = async (rootDirectory: string): Promise<Diagnostic[]> => {
   const { issues } = knipResult;
   const diagnostics: Diagnostic[] = [];
 
-  for (const unusedFile of issues.files) {
+  for (const unusedFilePath of collectUnusedFilePaths(issues.files)) {
     diagnostics.push({
-      filePath: path.relative(rootDirectory, unusedFile),
+      filePath: path.relative(rootDirectory, unusedFilePath),
       plugin: "knip",
       rule: "files",
       severity: KNIP_SEVERITY_MAP["files"],

--- a/packages/react-doctor/tests/collect-unused-file-paths.test.ts
+++ b/packages/react-doctor/tests/collect-unused-file-paths.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { collectUnusedFilePaths } from "../src/utils/collect-unused-file-paths.js";
+
+describe("collectUnusedFilePaths", () => {
+  it("extracts file paths from a knip 6.x IssueRecords object", () => {
+    const knipFilesIssues = {
+      "src/unused-a.ts": {
+        "src/unused-a.ts": {
+          type: "files",
+          filePath: "/repo/src/unused-a.ts",
+          symbol: "src/unused-a.ts",
+          workspace: "",
+          severity: "warn",
+          fixes: [],
+        },
+      },
+      "src/unused-b.ts": {
+        "src/unused-b.ts": {
+          type: "files",
+          filePath: "/repo/src/unused-b.ts",
+          symbol: "src/unused-b.ts",
+          workspace: "",
+          severity: "warn",
+          fixes: [],
+        },
+      },
+    };
+
+    expect(collectUnusedFilePaths(knipFilesIssues)).toEqual([
+      "/repo/src/unused-a.ts",
+      "/repo/src/unused-b.ts",
+    ]);
+  });
+
+  it("handles legacy Set<string> output", () => {
+    const filesSet = new Set(["/repo/src/a.ts", "/repo/src/b.ts"]);
+    expect(collectUnusedFilePaths(filesSet)).toEqual(["/repo/src/a.ts", "/repo/src/b.ts"]);
+  });
+
+  it("handles array output", () => {
+    expect(collectUnusedFilePaths(["/repo/src/a.ts", "/repo/src/b.ts"])).toEqual([
+      "/repo/src/a.ts",
+      "/repo/src/b.ts",
+    ]);
+  });
+
+  it("returns an empty array when input is undefined", () => {
+    expect(collectUnusedFilePaths(undefined)).toEqual([]);
+  });
+
+  it("returns an empty array when input is an empty object", () => {
+    expect(collectUnusedFilePaths({})).toEqual([]);
+  });
+
+  it("skips entries without a string filePath", () => {
+    const malformed = {
+      "src/a.ts": {
+        "src/a.ts": { type: "files", symbol: "src/a.ts" },
+      },
+    };
+    expect(collectUnusedFilePaths(malformed)).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #132.

`react-doctor` crashed during dead-code detection with:

```
✖ Dead code detection failed (non-fatal, skipping).
TypeError: issues.files is not iterable
```

### Root cause

In `knip@^6.3.1` (pinned in this repo), `issues.files` is an `IssueRecords` object of shape:

```ts
{
  [symbolKey: string]: {
    [symbolKey: string]: { type: 'files'; filePath: string; symbol: string; /* ... */ }
  }
}
```

However, `runKnip()` was still iterating it as if it were a `Set<string>` (the old shape):

```ts
for (const unusedFile of issues.files) { /* ... */ }
```

which throws `TypeError: issues.files is not iterable` and causes the dead-code pass to skip entirely.

### Fix

- New utility `collectUnusedFilePaths` in `packages/react-doctor/src/utils/collect-unused-file-paths.ts` that:
  - Walks the Knip 6.x `IssueRecords` shape and extracts each issue's `filePath`.
  - Still handles the legacy `Set<string>` form (and a plain `string[]`) defensively to avoid future breakage.
  - Returns `[]` for any unexpected shape so dead-code detection degrades gracefully.
- `runKnip()` now uses that utility instead of `for (const unusedFile of issues.files)`.
- Widen `KnipResults['issues']['files']` in `types.ts` to reflect the real shape.

### Tests

New `collect-unused-file-paths.test.ts` covers:
- Knip 6.x `IssueRecords` object shape
- Legacy `Set<string>` shape
- `string[]` shape
- `undefined`, `{}`, and malformed entries (no `filePath`)

Full suite: `pnpm test` — 224 passed (20 files), incl. 6 new tests.
Also verified: `pnpm lint`, `pnpm typecheck`, `pnpm format:check`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68388899-bb06-4615-9b35-d2bdad0fe256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68388899-bb06-4615-9b35-d2bdad0fe256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

