### PR TITLE
fix: clarify passive listener warning

### DIFF
--- a/packages/react-doctor/src/plugin/rules/client.ts
+++ b/packages/react-doctor/src/plugin/rules/client.ts
@@ -2,6 +2,9 @@ import { PASSIVE_EVENT_NAMES } from "../constants.js";
 import { isMemberProperty } from "../helpers.js";
 import type { EsTreeNode, Rule, RuleContext } from "../types.js";
 
+const PASSIVE_EVENT_LISTENER_MESSAGE =
+  "Listener without { passive: true } — improves scrolling performance, but only use it when the handler does not call event.preventDefault()";
+
 export const clientPassiveEventListeners: Rule = {
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
@@ -17,7 +20,7 @@ export const clientPassiveEventListeners: Rule = {
       if (!optionsArgument) {
         context.report({
           node,
-          message: `"${eventName}" listener without { passive: true } — blocks scrolling performance`,
+          message: `"${eventName}" ${PASSIVE_EVENT_LISTENER_MESSAGE}`,
         });
         return;
       }
@@ -36,7 +39,7 @@ export const clientPassiveEventListeners: Rule = {
       if (!hasPassiveTrue) {
         context.report({
           node,
-          message: `"${eventName}" listener without { passive: true } — blocks scrolling performance`,
+          message: `"${eventName}" ${PASSIVE_EVENT_LISTENER_MESSAGE}`,
         });
       }
     },

--- a/packages/react-doctor/src/utils/run-oxlint.ts
+++ b/packages/react-doctor/src/utils/run-oxlint.ts
@@ -288,7 +288,7 @@ const RULE_HELP_MAP: Record<string, string> = {
     "`import { after } from 'next/server'` then wrap: `after(() => analytics.track(...))` — response isn't blocked",
 
   "client-passive-event-listeners":
-    "Add `{ passive: true }` as the third argument: `addEventListener('scroll', handler, { passive: true })`",
+    "Add `{ passive: true }` as the third argument: `addEventListener('scroll', handler, { passive: true })`. Only do this if the handler does not call `event.preventDefault()`.",
 
   "query-stable-query-client":
     "Move `new QueryClient()` to module scope or wrap in `useState(() => new QueryClient())` — recreating it on every render resets the entire cache",


### PR DESCRIPTION
## Summary
Fixes #138

Clarifies the passive event listener guidance so developers are warned not to apply `{ passive: true }` when the handler calls `event.preventDefault()`.

## Changes
- Update the CLI help text for `client-passive-event-listeners`.
- Update the plugin diagnostic message to include the same `preventDefault()` caveat.

## Test Plan
- `git diff --check`
- `npx -y -p node@22.18.0 -p pnpm@10.29.1 pnpm typecheck`
- `npx -y -p node@22.18.0 -p pnpm@10.29.1 pnpm lint` (passes with pre-existing warnings)
- `npx -y -p node@22.18.0 -p pnpm@10.29.1 pnpm format`
- `npx -y -p node@22.18.0 -p pnpm@10.29.1 pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only changes to lint diagnostics/help output; no behavior or rule matching logic is altered.
> 
> **Overview**
> Clarifies the `client-passive-event-listeners` diagnostic/help text to warn that `{ passive: true }` should only be added when the handler does *not* call `event.preventDefault()`.
> 
> Refactors the rule’s reported message to reuse a shared constant so the updated wording is consistent across reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17ff3cbd10ca3a4314cd45ec2d38fad022330d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->