### PR TITLE
Support block comment inline suppressions

### DIFF
--- a/packages/react-doctor/src/utils/filter-diagnostics.ts
+++ b/packages/react-doctor/src/utils/filter-diagnostics.ts
@@ -15,8 +15,8 @@ const resolveCandidateReadPath = (rootDirectory: string, filePath: string): stri
 };
 
 const OPENING_TAG_PATTERN = /<([A-Z][\w.]*)/;
-const DISABLE_NEXT_LINE_PATTERN = /(?:\/\/|\{?\/\*)\s*react-doctor-disable-next-line\b(?:\s+(.+?))?(?:\s*\*\/\}?)?\s*$/;
-const DISABLE_LINE_PATTERN = /(?:\/\/|\{?\/\*)\s*react-doctor-disable-line\b(?:\s+(.+?))?(?:\s*\*\/\}?)?\s*$/;
+const DISABLE_NEXT_LINE_PATTERN = /(?:\/\/|\{?\/\*)\s*react-doctor-disable-next-line\b(?:\s+((?!\*\/).+?))?\s*(?:\*\/\}?)?\s*$/;
+const DISABLE_LINE_PATTERN = /(?:\/\/|\{?\/\*)\s*react-doctor-disable-line\b(?:\s+((?!\*\/).+?))?\s*(?:\*\/\}?)?\s*$/;
 
 const createFileLinesCache = (
   rootDirectory: string,

--- a/packages/react-doctor/src/utils/filter-diagnostics.ts
+++ b/packages/react-doctor/src/utils/filter-diagnostics.ts
@@ -15,8 +15,8 @@ const resolveCandidateReadPath = (rootDirectory: string, filePath: string): stri
 };
 
 const OPENING_TAG_PATTERN = /<([A-Z][\w.]*)/;
-const DISABLE_NEXT_LINE_PATTERN = /\/\/\s*react-doctor-disable-next-line\b(?:\s+(.+))?/;
-const DISABLE_LINE_PATTERN = /\/\/\s*react-doctor-disable-line\b(?:\s+(.+))?/;
+const DISABLE_NEXT_LINE_PATTERN = /(?:\/\/|\{?\/\*)\s*react-doctor-disable-next-line\b(?:\s+(.+?))?(?:\s*\*\/\}?)?\s*$/;
+const DISABLE_LINE_PATTERN = /(?:\/\/|\{?\/\*)\s*react-doctor-disable-line\b(?:\s+(.+?))?(?:\s*\*\/\}?)?\s*$/;
 
 const createFileLinesCache = (
   rootDirectory: string,

--- a/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
+++ b/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
@@ -55,10 +55,46 @@ describe("issue #72: inline suppressions — variants", () => {
     expect(filtered).toHaveLength(0);
   });
 
+  it("block comment disable-line suppresses a diagnostic on the SAME line", () => {
+    const filtered = runFilter(
+      "block-disable-line-same",
+      `const x = 1; /* react-doctor-disable-line react-doctor/no-derived-state-effect */\n`,
+      [baseDiagnostic({ line: 1 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("jsx block comment disable-line suppresses a diagnostic on the SAME line", () => {
+    const filtered = runFilter(
+      "jsx-block-disable-line-same",
+      `<div>{x}</div> {/* react-doctor-disable-line react-doctor/no-derived-state-effect */}\n`,
+      [baseDiagnostic({ line: 1 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
   it("disable-next-line suppresses a diagnostic on the line BELOW", () => {
     const filtered = runFilter(
       "disable-next-line",
       `// react-doctor-disable-next-line react-doctor/no-derived-state-effect\nconst x = 1;\n`,
+      [baseDiagnostic({ line: 2 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("block comment disable-next-line suppresses a diagnostic on the line BELOW", () => {
+    const filtered = runFilter(
+      "block-disable-next-line",
+      `/* react-doctor-disable-next-line react-doctor/no-derived-state-effect */\nconst x = 1;\n`,
+      [baseDiagnostic({ line: 2 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("jsx block comment disable-next-line suppresses a diagnostic on the line BELOW", () => {
+    const filtered = runFilter(
+      "jsx-block-disable-next-line",
+      `{/* react-doctor-disable-next-line react-doctor/no-derived-state-effect */}\nconst x = 1;\n`,
       [baseDiagnostic({ line: 2 })],
     );
     expect(filtered).toHaveLength(0);

--- a/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
+++ b/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
@@ -133,6 +133,30 @@ describe("issue #72: inline suppressions — variants", () => {
     ]);
     expect(filtered).toHaveLength(0);
   });
+
+  it("a bare block disable-line comment suppresses EVERY diagnostic on that line", () => {
+    const filtered = runFilter(
+      "bare-block-disable-line",
+      `const x = 1; /* react-doctor-disable-line */\n`,
+      [
+        baseDiagnostic({ rule: "no-derived-state-effect", line: 1 }),
+        baseDiagnostic({ rule: "no-fetch-in-effect", line: 1 }),
+      ],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("a bare block disable-next-line comment suppresses EVERY diagnostic on the line BELOW", () => {
+    const filtered = runFilter(
+      "bare-block-disable-next-line",
+      `/* react-doctor-disable-next-line */\nconst x = 1;\n`,
+      [
+        baseDiagnostic({ rule: "no-derived-state-effect", line: 2 }),
+        baseDiagnostic({ rule: "no-fetch-in-effect", line: 2 }),
+      ],
+    );
+    expect(filtered).toHaveLength(0);
+  });
 });
 
 describe("issue #72: inline suppressions — boundary safety", () => {

--- a/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
+++ b/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
@@ -64,15 +64,6 @@ describe("issue #72: inline suppressions — variants", () => {
     expect(filtered).toHaveLength(0);
   });
 
-  it("jsx block comment disable-line suppresses a diagnostic on the SAME line", () => {
-    const filtered = runFilter(
-      "jsx-block-disable-line-same",
-      `<div>{x}</div> {/* react-doctor-disable-line react-doctor/no-derived-state-effect */}\n`,
-      [baseDiagnostic({ line: 1 })],
-    );
-    expect(filtered).toHaveLength(0);
-  });
-
   it("disable-next-line suppresses a diagnostic on the line BELOW", () => {
     const filtered = runFilter(
       "disable-next-line",
@@ -86,15 +77,6 @@ describe("issue #72: inline suppressions — variants", () => {
     const filtered = runFilter(
       "block-disable-next-line",
       `/* react-doctor-disable-next-line react-doctor/no-derived-state-effect */\nconst x = 1;\n`,
-      [baseDiagnostic({ line: 2 })],
-    );
-    expect(filtered).toHaveLength(0);
-  });
-
-  it("jsx block comment disable-next-line suppresses a diagnostic on the line BELOW", () => {
-    const filtered = runFilter(
-      "jsx-block-disable-next-line",
-      `{/* react-doctor-disable-next-line react-doctor/no-derived-state-effect */}\nconst x = 1;\n`,
       [baseDiagnostic({ line: 2 })],
     );
     expect(filtered).toHaveLength(0);


### PR DESCRIPTION
resolves #144 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands inline suppression matching to include block-comment forms, which could unintentionally suppress (or fail to suppress) diagnostics if the new regexes are overly permissive or miss edge cases.
> 
> **Overview**
> **Inline suppression comments now work in block-comment form.** `filterInlineSuppressions` expands its `react-doctor-disable-line`/`react-doctor-disable-next-line` parsing from `// ...` to also match `/* ... */` (including JSX-style `{/\* ... \*/}`) while still supporting optional rule lists and bare suppressions.
> 
> Regression tests are extended to cover block-comment variants for both directives and for bare (no rule id) suppressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 461e9cf723f607350dcc0926c595aa659d2e3f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->