### PR TITLE
fix(react-doctor): block-comment suppressions (#144) + stop false-positive useState→useRef hint (#146)

### DIFF
--- a/.changeset/issue-144-block-comment-suppressions.md
+++ b/.changeset/issue-144-block-comment-suppressions.md
@@ -1,0 +1,13 @@
+---
+"react-doctor": patch
+---
+
+fix(react-doctor): support block comment forms of `react-doctor-disable-line` / `react-doctor-disable-next-line`
+
+The inline-suppression matcher previously only recognized line comments
+(`// react-doctor-disable-…`). Block comments — including the JSX form
+`{/* react-doctor-disable-next-line … */}`, which is the only suppression
+form legal directly inside JSX — were silently ignored, forcing users to
+write `{/* // react-doctor-disable-line … */}` as a workaround. Both forms
+now work, and either accepts a comma- or whitespace-separated rule list
+or no rule id (suppress every diagnostic on the targeted line). Closes #144.

--- a/.changeset/issue-146-state-only-in-handlers-false-positives.md
+++ b/.changeset/issue-146-state-only-in-handlers-false-positives.md
@@ -1,0 +1,27 @@
+---
+"react-doctor": patch
+---
+
+fix(react-doctor): stop flagging `useState` as `useRef` when state reaches render through `useMemo`, derived values, or context `value`
+
+`rerender-state-only-in-handlers` (the rule that suggests "use `useRef`
+because this state is never read in render") only checked whether the
+state name appeared by name in the component's `return` JSX. That
+heuristic produced loud false positives for ordinary patterns:
+
+- state filtered/derived through `useMemo` → JSX uses the memo result
+- state passed as the `value` of a React Context Provider
+- state combined with other variables into a rendered constant
+
+Following the bad hint and converting these to `useRef` silently broke
+apps because `ref.current = …` does not trigger a re-render — search
+results stopped updating, dialogs stayed open, and context consumers
+saw stale snapshots.
+
+The rule now performs a transitive "render-reachable" analysis on
+top-level component bindings. A `useState` is only flagged when neither
+the value itself nor anything derived from it (recursively) appears
+anywhere in the rendered JSX, including attribute values like
+`<Context value={…}>`, `style={…}`, `className={…}`, etc. Truly
+transient state (e.g. a scroll position only stored to be ignored)
+still fires. Closes #146.

--- a/packages/react-doctor/CHANGELOG.md
+++ b/packages/react-doctor/CHANGELOG.md
@@ -52,7 +52,6 @@
   previously hand-rolled).
 
   Behavior changes:
-
   - **Detection** is now the union of CLI binaries on `$PATH` (the previous
     signal) and config dirs in `$HOME` (`~/.claude`, `~/.cursor`,
     `~/.codex`, `~/.factory`, `~/.pi`, etc.). This catches agents the user

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -200,6 +200,14 @@ useEffect(() => {
 const value = expensiveComputation(); // react-doctor-disable-line react-doctor/no-usememo-simple-expression
 ```
 
+Block comments work too — useful inside JSX where `//` line comments aren't legal:
+
+<!-- prettier-ignore -->
+```tsx
+{/* react-doctor-disable-next-line react/no-danger */}
+<div dangerouslySetInnerHTML={{ __html }} />
+```
+
 Comma- or space-separate multiple rule ids on the same comment. With no rule id, the comment suppresses every diagnostic on that line.
 
 ### Respecting your existing project ignores

--- a/packages/react-doctor/src/plugin/helpers.ts
+++ b/packages/react-doctor/src/plugin/helpers.ts
@@ -265,7 +265,7 @@ export const findSideEffect = (node: EsTreeNode): string | null => {
 // recursing into nested object/array patterns. We need every binding so
 // `noDerivedUseState` can detect e.g. `function Foo({ user: { name } })` →
 // `useState(name)` (false negative if we only added "user").
-const collectPatternNames = (pattern: EsTreeNode | null, into: Set<string>): void => {
+export const collectPatternNames = (pattern: EsTreeNode | null, into: Set<string>): void => {
   if (!pattern) return;
 
   if (pattern.type === "Identifier") {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects.ts
@@ -6,6 +6,7 @@ import {
   TRIVIAL_INITIALIZER_NAMES,
 } from "../constants.js";
 import {
+  collectPatternNames,
   containsFetchCall,
   countSetStateCalls,
   extractDestructuredPropNames,
@@ -651,43 +652,6 @@ const collectIdentifierNames = (expression: EsTreeNode): Set<string> => {
   return names;
 };
 
-// Collect every identifier name extracted from a binding pattern
-// (`Identifier`, `ObjectPattern`, `ArrayPattern`, `RestElement`, etc.).
-const collectBindingNames = (pattern: EsTreeNode | null | undefined): string[] => {
-  if (!pattern) return [];
-  const names: string[] = [];
-  const visit = (node: EsTreeNode | null | undefined): void => {
-    if (!node) return;
-    switch (node.type) {
-      case "Identifier":
-        names.push(node.name);
-        return;
-      case "ObjectPattern":
-        for (const property of node.properties ?? []) {
-          if (property.type === "RestElement") {
-            visit(property.argument);
-          } else {
-            visit(property.value ?? property.key);
-          }
-        }
-        return;
-      case "ArrayPattern":
-        for (const element of node.elements ?? []) visit(element);
-        return;
-      case "RestElement":
-        visit(node.argument);
-        return;
-      case "AssignmentPattern":
-        visit(node.left);
-        return;
-      default:
-        return;
-    }
-  };
-  visit(pattern);
-  return names;
-};
-
 // Build a "name -> identifiers it transitively depends on" graph for
 // every top-level VariableDeclarator in the component body. Includes
 // names referenced anywhere inside the initializer (deps arrays, nested
@@ -697,12 +661,14 @@ const collectBindingNames = (pattern: EsTreeNode | null | undefined): string[] =
 const buildLocalDependencyGraph = (componentBody: EsTreeNode): Map<string, Set<string>> => {
   const graph = new Map<string, Set<string>>();
   if (componentBody?.type !== "BlockStatement") return graph;
+  const declaredNames = new Set<string>();
   for (const statement of componentBody.body ?? []) {
     if (statement.type !== "VariableDeclaration") continue;
     for (const declarator of statement.declarations ?? []) {
       if (!declarator.init) continue;
       const dependencyNames = collectIdentifierNames(declarator.init);
-      const declaredNames = collectBindingNames(declarator.id);
+      declaredNames.clear();
+      collectPatternNames(declarator.id, declaredNames);
       for (const declaredName of declaredNames) {
         const existing = graph.get(declaredName);
         if (existing === undefined) {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects.ts
@@ -643,13 +643,115 @@ const walkInsideStatementBlocks = (
   }
 };
 
-const expressionReadsName = (expression: EsTreeNode, name: string): boolean => {
-  let didRead = false;
+const collectIdentifierNames = (expression: EsTreeNode): Set<string> => {
+  const names = new Set<string>();
   walkAst(expression, (child: EsTreeNode) => {
-    if (didRead) return;
-    if (child.type === "Identifier" && child.name === name) didRead = true;
+    if (child.type === "Identifier") names.add(child.name);
   });
-  return didRead;
+  return names;
+};
+
+// Collect every identifier name extracted from a binding pattern
+// (`Identifier`, `ObjectPattern`, `ArrayPattern`, `RestElement`, etc.).
+const collectBindingNames = (pattern: EsTreeNode | null | undefined): string[] => {
+  if (!pattern) return [];
+  const names: string[] = [];
+  const visit = (node: EsTreeNode | null | undefined): void => {
+    if (!node) return;
+    switch (node.type) {
+      case "Identifier":
+        names.push(node.name);
+        return;
+      case "ObjectPattern":
+        for (const property of node.properties ?? []) {
+          if (property.type === "RestElement") {
+            visit(property.argument);
+          } else {
+            visit(property.value ?? property.key);
+          }
+        }
+        return;
+      case "ArrayPattern":
+        for (const element of node.elements ?? []) visit(element);
+        return;
+      case "RestElement":
+        visit(node.argument);
+        return;
+      case "AssignmentPattern":
+        visit(node.left);
+        return;
+      default:
+        return;
+    }
+  };
+  visit(pattern);
+  return names;
+};
+
+// Build a "name -> identifiers it transitively depends on" graph for
+// every top-level VariableDeclarator in the component body. Includes
+// names referenced anywhere inside the initializer (deps arrays, nested
+// callbacks, member access — we deliberately over-approximate here so
+// that `useMemo(() => derive(state), [state])` propagates `state` into
+// the dependency set of the resulting variable).
+const buildLocalDependencyGraph = (componentBody: EsTreeNode): Map<string, Set<string>> => {
+  const graph = new Map<string, Set<string>>();
+  if (componentBody?.type !== "BlockStatement") return graph;
+  for (const statement of componentBody.body ?? []) {
+    if (statement.type !== "VariableDeclaration") continue;
+    for (const declarator of statement.declarations ?? []) {
+      if (!declarator.init) continue;
+      const dependencyNames = collectIdentifierNames(declarator.init);
+      const declaredNames = collectBindingNames(declarator.id);
+      for (const declaredName of declaredNames) {
+        const existing = graph.get(declaredName);
+        if (existing === undefined) {
+          graph.set(declaredName, new Set(dependencyNames));
+        } else {
+          for (const dependencyName of dependencyNames) existing.add(dependencyName);
+        }
+      }
+    }
+  }
+  return graph;
+};
+
+// "Read in render" = any identifier (`Identifier`, NOT `JSXIdentifier`)
+// that appears anywhere inside a return expression — JSX text content,
+// `{expression}` containers, attribute values like
+// `<MyContext value={value}>` (the React Context case from #146),
+// `style={…}`, `className={…}`, props passed to children, conditional
+// chains, the lot. JSX element/tag names are `JSXIdentifier`, which we
+// deliberately do not track — referring to a component by name does
+// not "read" any value.
+const collectRenderReachableNames = (returnExpressions: EsTreeNode[]): Set<string> => {
+  const names = new Set<string>();
+  for (const expression of returnExpressions) {
+    walkAst(expression, (child: EsTreeNode) => {
+      if (child.type === "Identifier") names.add(child.name);
+    });
+  }
+  return names;
+};
+
+const expandTransitiveDependencies = (
+  seedNames: Set<string>,
+  dependencyGraph: Map<string, Set<string>>,
+): Set<string> => {
+  const reachable = new Set(seedNames);
+  const queue: string[] = Array.from(seedNames);
+  while (queue.length > 0) {
+    const currentName = queue.pop();
+    if (currentName === undefined) continue;
+    const dependencyNames = dependencyGraph.get(currentName);
+    if (!dependencyNames) continue;
+    for (const dependencyName of dependencyNames) {
+      if (reachable.has(dependencyName)) continue;
+      reachable.add(dependencyName);
+      queue.push(dependencyName);
+    }
+  }
+  return reachable;
 };
 
 export const rerenderStateOnlyInHandlers: Rule = {
@@ -662,11 +764,12 @@ export const rerenderStateOnlyInHandlers: Rule = {
       const returnExpressions = collectReturnExpressions(componentBody);
       if (returnExpressions.length === 0) return;
 
+      const dependencyGraph = buildLocalDependencyGraph(componentBody);
+      const directRenderNames = collectRenderReachableNames(returnExpressions);
+      const renderReachableNames = expandTransitiveDependencies(directRenderNames, dependencyGraph);
+
       for (const binding of bindings) {
-        const isReadInReturn = returnExpressions.some((expression) =>
-          expressionReadsName(expression, binding.valueName),
-        );
-        if (isReadInReturn) continue;
+        if (renderReachableNames.has(binding.valueName)) continue;
 
         let setterCalled = false;
         walkAst(componentBody, (child: EsTreeNode) => {

--- a/packages/react-doctor/src/utils/filter-diagnostics.ts
+++ b/packages/react-doctor/src/utils/filter-diagnostics.ts
@@ -15,8 +15,16 @@ const resolveCandidateReadPath = (rootDirectory: string, filePath: string): stri
 };
 
 const OPENING_TAG_PATTERN = /<([A-Z][\w.]*)/;
-const DISABLE_NEXT_LINE_PATTERN = /\/\/\s*react-doctor-disable-next-line\b(?:\s+(.+))?/;
-const DISABLE_LINE_PATTERN = /\/\/\s*react-doctor-disable-line\b(?:\s+(.+))?/;
+// Matches either line comments (`// react-doctor-disable-…`) or block
+// comments (`/* react-doctor-disable-… */`, including the JSX form
+// `{/* … */}`). Capture group 1 is the optional rule list, restricted
+// to characters that legally appear in plugin/rule identifiers and
+// their separators (`,`, whitespace) so it can never absorb the
+// block-comment terminator `*/` or the JSX `}`.
+const DISABLE_NEXT_LINE_PATTERN =
+  /(?:\/\/|\/\*)\s*react-doctor-disable-next-line\b(?:\s+([\w/\-.,\s]+?))?\s*(?:\*\/)?\s*\}?\s*$/;
+const DISABLE_LINE_PATTERN =
+  /(?:\/\/|\/\*)\s*react-doctor-disable-line\b(?:\s+([\w/\-.,\s]+?))?\s*(?:\*\/)?\s*\}?\s*$/;
 
 const createFileLinesCache = (
   rootDirectory: string,

--- a/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
+++ b/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
@@ -99,6 +99,70 @@ describe("issue #72: inline suppressions — variants", () => {
   });
 });
 
+describe("issue #144: inline suppressions — block comment forms", () => {
+  it("plain block disable-next-line suppresses the line BELOW", () => {
+    const filtered = runFilter(
+      "block-disable-next-line",
+      `/* react-doctor-disable-next-line react-doctor/no-derived-state-effect */\nconst x = 1;\n`,
+      [baseDiagnostic({ line: 2 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("plain block disable-line suppresses the SAME line", () => {
+    const filtered = runFilter(
+      "block-disable-line",
+      `const x = 1; /* react-doctor-disable-line react-doctor/no-derived-state-effect */\n`,
+      [baseDiagnostic({ line: 1 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("JSX-style block disable-next-line `{/* … */}` works for tsx files", () => {
+    const filtered = runFilter(
+      "jsx-block-disable-next-line",
+      `{/* react-doctor-disable-next-line react/no-danger */}\n<div dangerouslySetInnerHTML={{ __html }} />\n`,
+      [baseDiagnostic({ plugin: "react", rule: "no-danger", line: 2 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("JSX-style block disable-line `{/* … */}` works for tsx files", () => {
+    const filtered = runFilter(
+      "jsx-block-disable-line",
+      `<div dangerouslySetInnerHTML={{ __html }} /> {/* react-doctor-disable-line react/no-danger */}\n`,
+      [baseDiagnostic({ plugin: "react", rule: "no-danger", line: 1 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("block bare disable-next-line `{/* … */}` (no rule id) suppresses EVERY diagnostic on the next line", () => {
+    const filtered = runFilter(
+      "jsx-block-bare",
+      `{/* react-doctor-disable-next-line */}\n<div dangerouslySetInnerHTML={{ __html }} />\n`,
+      [
+        baseDiagnostic({ plugin: "react", rule: "no-danger", line: 2 }),
+        baseDiagnostic({ plugin: "react-doctor", rule: "no-derived-state-effect", line: 2 }),
+      ],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("block comma-separated rule list inside `{/* … */}` suppresses only listed rules", () => {
+    const filtered = runFilter(
+      "jsx-block-comma",
+      `{/* react-doctor-disable-next-line react-doctor/no-derived-state-effect, react-doctor/no-fetch-in-effect */}\nconst x = 1;\n`,
+      [
+        baseDiagnostic({ rule: "no-derived-state-effect", line: 2 }),
+        baseDiagnostic({ rule: "no-fetch-in-effect", line: 2 }),
+        baseDiagnostic({ rule: "no-cascading-set-state", line: 2 }),
+      ],
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].rule).toBe("no-cascading-set-state");
+  });
+});
+
 describe("issue #72: inline suppressions — boundary safety", () => {
   it("disable-line on line N does NOT suppress diagnostics on line N+1", () => {
     const filtered = runFilter(

--- a/packages/react-doctor/tests/regressions/state-only-in-handlers.test.ts
+++ b/packages/react-doctor/tests/regressions/state-only-in-handlers.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression tests for `react-doctor/rerender-state-only-in-handlers`
+ * — issue #146.
+ *
+ * The rule advised replacing `useState` with `useRef` whenever the
+ * state value did not appear by name inside the JSX `return`. That
+ * heuristic ignored every common shape where state still ends up
+ * affecting render via an indirection:
+ *   - `useMemo` / derived constants computed during render
+ *   - context `value` passed to a Provider
+ *   - props or attributes on JSX that aren't text children
+ *
+ * Following the bad advice and switching to `useRef` would silently
+ * break consumers because `ref.current = …` does not trigger a
+ * re-render. These tests pin down the transitive "render-reaches"
+ * analysis so the false-positive hint never comes back.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import { runOxlint } from "../../src/utils/run-oxlint.js";
+import { setupReactProject } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-state-only-in-handlers-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const RULE_NAME = "rerender-state-only-in-handlers";
+
+const findStateOnlyInHandlersDiagnostics = (
+  diagnostics: Array<{ rule: string; filePath: string }>,
+  fileSuffix: string,
+): Array<{ rule: string; filePath: string }> =>
+  diagnostics.filter(
+    (diagnostic) => diagnostic.rule === RULE_NAME && diagnostic.filePath.endsWith(fileSuffix),
+  );
+
+describe("issue #146: rerenderStateOnlyInHandlers — no false positives via indirection", () => {
+  it("does NOT flag state read through a useMemo whose result is used in JSX", async () => {
+    const projectDir = setupReactProject(tempRoot, "issue-146-usememo", {
+      files: {
+        "src/search.tsx": `import { useMemo, useState } from "react";
+
+declare const mediasWithIndex: { lc: string }[];
+declare const RowVirtualizer: (props: { rows: { lc: string }[] }) => null;
+
+export const Search = () => {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!query) return mediasWithIndex;
+    return mediasWithIndex.filter((media) => media.lc.includes(query));
+  }, [query]);
+
+  return (
+    <div>
+      <input value={query} onChange={(event) => setQuery(event.target.value)} />
+      <RowVirtualizer rows={filtered} />
+    </div>
+  );
+};
+`,
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      hasTypeScript: true,
+      framework: "unknown",
+      hasReactCompiler: false,
+      hasTanStackQuery: false,
+    });
+
+    expect(findStateOnlyInHandlersDiagnostics(diagnostics, "src/search.tsx")).toHaveLength(0);
+  });
+
+  it("does NOT flag state read through a derived constant used in JSX", async () => {
+    const projectDir = setupReactProject(tempRoot, "issue-146-derived", {
+      files: {
+        "src/preview.tsx": `import { useState } from "react";
+declare const FileIconByMime: (props: { mime: string }) => null;
+
+export const Preview = ({ mime, src }: { mime: string; src: string }) => {
+  const [imgError, setImgError] = useState(false);
+  const isImage = mime.startsWith("image/") && Boolean(src) && !imgError;
+  return (
+    <div>
+      {isImage ? <img src={src} onError={() => setImgError(true)} /> : <FileIconByMime mime={mime} />}
+    </div>
+  );
+};
+`,
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      hasTypeScript: true,
+      framework: "unknown",
+      hasReactCompiler: false,
+      hasTanStackQuery: false,
+    });
+
+    expect(findStateOnlyInHandlersDiagnostics(diagnostics, "src/preview.tsx")).toHaveLength(0);
+  });
+
+  it("does NOT flag state passed as the value of a context provider", async () => {
+    const projectDir = setupReactProject(tempRoot, "issue-146-context", {
+      files: {
+        "src/desktop-updater.tsx": `import { createContext, useMemo, useState } from "react";
+
+interface Snapshot { version: string }
+const DEFAULT_SNAPSHOT: Snapshot = { version: "0.0.0" };
+
+const DesktopUpdaterContext = createContext<{ snapshot: Snapshot } | null>(null);
+
+declare const isSupported: boolean;
+declare const DesktopUpdaterDialogs: () => null;
+
+export const DesktopUpdaterProvider = ({
+  children,
+  renderDialogs,
+}: {
+  children: React.ReactNode;
+  renderDialogs: boolean;
+}) => {
+  const [snapshot, setSnapshot] = useState<Snapshot>(DEFAULT_SNAPSHOT);
+  void setSnapshot;
+  const value = useMemo(() => ({ isSupported, snapshot }), [snapshot]);
+  return (
+    <DesktopUpdaterContext value={value}>
+      {children}
+      {renderDialogs ? <DesktopUpdaterDialogs /> : null}
+    </DesktopUpdaterContext>
+  );
+};
+`,
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      hasTypeScript: true,
+      framework: "unknown",
+      hasReactCompiler: false,
+      hasTanStackQuery: false,
+    });
+
+    expect(findStateOnlyInHandlersDiagnostics(diagnostics, "src/desktop-updater.tsx")).toHaveLength(
+      0,
+    );
+  });
+
+  it("DOES still flag truly transient state — only mutated, never reachable from render", async () => {
+    const projectDir = setupReactProject(tempRoot, "issue-146-true-positive", {
+      files: {
+        "src/scroll-tracker.tsx": `import { useEffect, useState } from "react";
+
+export const ScrollTracker = () => {
+  const [scrollY, setScrollY] = useState(0);
+  void scrollY;
+  useEffect(() => {
+    const onScroll = () => setScrollY(window.scrollY);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+  return <div>tracking</div>;
+};
+`,
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      hasTypeScript: true,
+      framework: "unknown",
+      hasReactCompiler: false,
+      hasTanStackQuery: false,
+    });
+
+    expect(
+      findStateOnlyInHandlersDiagnostics(diagnostics, "src/scroll-tracker.tsx").length,
+    ).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes two open issues triaged from the issue tracker.

## #144 — Support block comments with `react-doctor-disable-next-line`

The inline-suppression matcher only recognized `//` line comments, so the
JSX form

```tsx
{/* react-doctor-disable-next-line react/no-danger */}
<div dangerouslySetInnerHTML={{ __html }} />
```

was silently ignored, forcing users to write `{/* // react-doctor-disable-line … */}`
as a workaround.

The patterns now match both `//` and `/* … */` (including the JSX
`{/* … */}` wrapper). The captured rule list is character-class-restricted
so it can never absorb the `*/` terminator or the JSX `}`. Comma- and
whitespace-separated rule lists, the bare "disable everything on this
line" form, and the existing line-boundary safety guarantees are
unchanged.

Six new regression tests in `inline-suppressions.test.ts` cover the
plain block, JSX block, JSX block bare-comment, and JSX block
comma-list shapes.

## #146 — `useState → useRef` false positives via `useMemo` / context / derived values

`rerender-state-only-in-handlers` previously only checked whether the
state name appeared by name in the component's `return` JSX. That
heuristic produced loud false positives for ordinary patterns:

- state filtered/derived through `useMemo` whose result is in JSX
- state passed as the `value` of a React Context Provider
- state combined into a derived constant used in JSX
- state read by an `onError`-style closure that flips a derived flag

Following the bad hint and converting these to `useRef` silently breaks
apps because `ref.current = …` doesn't trigger a re-render — search
results stop updating, dialogs stay open, context consumers see stale
snapshots, etc.

The rule now performs a **transitive render-reachable analysis** on the
component's top-level variable bindings:

1. Build a graph of "name X depends on identifiers {a, b, c, …}" from
   each top-level `VariableDeclarator`'s initializer (over-approximate —
   includes deps arrays, nested callback bodies, member access, etc.).
2. Seed a "render-reachable" set with every `Identifier` referenced
   anywhere inside any `return` expression — JSX text, `{expression}`
   containers, attribute values like `<Context value={value}>`,
   `style={…}`, `className={…}`, props passed to children, ternaries,
   the lot.
3. Iteratively expand the set through the dependency graph.
4. A `useState` is only flagged when its value name is **not** in the
   final reachable set.

Truly transient state (e.g. a scroll offset stored only to be ignored,
covered by the existing `TrackedScroller` fixture) still fires. A new
regression suite `tests/regressions/state-only-in-handlers.test.ts`
covers all four shapes from the issue plus the still-flagged true
positive.

## Also covered (no code change needed)

- **#141** (`react-hooks-js not found`) was already fixed in 0.0.46
  (skip rules when `eslint-plugin-react-hooks` isn't installed) and
  hardened in 0.0.47 (filter to rules the loaded version actually
  exports). Verified the relevant code in `oxlint-config.ts` still
  gates `reactCompilerRules` on `resolveReactHooksJsPlugin` and only
  appends the plugin entry to `jsPlugins` when resolution succeeds.
- **#143** (ESLint plugin) is a feature request, not a bug. Out of
  scope for this batch.

## Verification

- `pnpm test` — 395 tests pass (35 → 36 files, +4 new tests for #146,
  +6 new tests for #144).
- `pnpm typecheck` — clean.
- `pnpm lint` — only pre-existing warnings (unchanged count).
- `pnpm format:check` — README fence wrapped in `<!-- prettier-ignore -->`
  so the JSX example renders verbatim. The pre-existing `CHANGELOG.md`
  format issue is unrelated to this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-147f8a40-b710-4b1b-b40b-60f5539ba5a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-147f8a40-b710-4b1b-b40b-60f5539ba5a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

