### PR TITLE
fix(react-doctor): honor empty-frame barriers in `no-prop-callback-in-effect` / `no-derived-useState` prop-stack lookups

### DIFF
--- a/packages/react-doctor/src/plugin/rules/state-and-effects.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects.ts
@@ -170,9 +170,17 @@ export const noDerivedUseState: Rule = {
     // are not modeled here (a known limitation — pre-existing).
     const componentPropStack: Array<Set<string>> = [];
 
+    // HACK: empty stack frames are barriers — pushed when entering a
+    // non-component FunctionDeclaration / ArrowFunctionExpression so
+    // identifiers inside the helper don't resolve against an outer
+    // component's props (a closed-over `value` is NOT a prop of the
+    // helper). Stop the walk at the first empty frame so the lookup
+    // honors the barrier the visitor pushed.
     const isPropName = (name: string): boolean => {
       for (let stackIndex = componentPropStack.length - 1; stackIndex >= 0; stackIndex--) {
-        if (componentPropStack[stackIndex].has(name)) return true;
+        const frame = componentPropStack[stackIndex];
+        if (frame.size === 0) return false;
+        if (frame.has(name)) return true;
       }
       return false;
     };
@@ -405,9 +413,16 @@ export const noPropCallbackInEffect: Rule = {
       componentPropParamStack.push(propNames);
     };
 
+    // HACK: empty stack frames are barriers — pushed when entering a
+    // non-component FunctionDeclaration / ArrowFunctionExpression so
+    // identifiers inside the helper don't resolve against an outer
+    // component's props. Stop the walk at the first empty frame so
+    // the lookup honors the barrier the visitor pushed.
     const isPropName = (name: string): boolean => {
       for (let stackIndex = componentPropParamStack.length - 1; stackIndex >= 0; stackIndex--) {
-        if (componentPropParamStack[stackIndex].has(name)) return true;
+        const frame = componentPropParamStack[stackIndex];
+        if (frame.size === 0) return false;
+        if (frame.has(name)) return true;
       }
       return false;
     };

--- a/packages/react-doctor/tests/regressions/prop-stack-barrier.test.ts
+++ b/packages/react-doctor/tests/regressions/prop-stack-barrier.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression tests for the "empty-frame-as-barrier" semantic in the
+ * shared prop-stack scaffolding used by `no-prop-callback-in-effect`
+ * and `no-derived-useState`. The visitor pushes an empty `Set` when
+ * entering a non-component FunctionDeclaration / ArrowFunctionExpression
+ * so identifiers inside the helper don't resolve against an outer
+ * component's props (a closed-over `value` is NOT a prop of the
+ * helper).
+ *
+ * The original `isPropName` walked the entire stack without honoring
+ * the barrier, so a useState / useEffect inside a nested helper would
+ * pick up the outer component's prop names and produce false positives.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import { runOxlint } from "../../src/utils/run-oxlint.js";
+import { setupReactProject } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-prop-stack-barrier-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const collectRuleHits = async (
+  projectDir: string,
+  ruleId: string,
+): Promise<Array<{ filePath: string; message: string }>> => {
+  const diagnostics = await runOxlint({
+    rootDirectory: projectDir,
+    hasTypeScript: true,
+    framework: "unknown",
+    hasReactCompiler: false,
+    hasTanStackQuery: false,
+  });
+  return diagnostics
+    .filter((diagnostic) => diagnostic.rule === ruleId)
+    .map((diagnostic) => ({
+      filePath: diagnostic.filePath,
+      message: diagnostic.message,
+    }));
+};
+
+describe("no-derived-useState — empty-frame barrier", () => {
+  it("flags `useState(value)` when `value` is a real prop of the current component", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-derived-usestate-real-prop", {
+      files: {
+        "src/Field.tsx": `import { useState } from "react";
+
+export const Field = ({ value }: { value: string }) => {
+  const [draft, setDraft] = useState(value);
+  return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-derived-useState");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("value");
+  });
+
+  it("does NOT flag `useState(value)` when `value` is closed over from an outer component", async () => {
+    // The inner FunctionDeclaration pushes an empty barrier frame; the
+    // barrier-aware isPropName must stop the walk there and not see
+    // Outer's prop set.
+    const projectDir = setupReactProject(tempRoot, "no-derived-usestate-nested-helper", {
+      files: {
+        "src/Outer.tsx": `import { useState } from "react";
+
+export const Outer = ({ value }: { value: string }) => {
+  function inner() {
+    const [draft, setDraft] = useState(value);
+    void draft;
+    void setDraft;
+  }
+  inner();
+  return <span>{value}</span>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-derived-useState");
+    expect(hits).toHaveLength(0);
+  });
+});
+
+describe("no-prop-callback-in-effect — empty-frame barrier", () => {
+  it("flags the canonical `useEffect(() => onChange(state), [state, onChange])` shape", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-callback-real-prop", {
+      files: {
+        "src/Toggle.tsx": `import { useEffect, useState } from "react";
+
+export const Toggle = ({ onChange }: { onChange: (next: boolean) => void }) => {
+  const [isOn, setIsOn] = useState(false);
+  useEffect(() => {
+    onChange(isOn);
+  }, [isOn, onChange]);
+  return <button onClick={() => setIsOn(!isOn)}>{isOn ? "on" : "off"}</button>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-callback-in-effect");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("onChange");
+  });
+
+  it("does NOT flag `useEffect(() => onChange(state), [state, onChange])` inside a nested helper", async () => {
+    // Same nested-helper shape — the outer component's `onChange` prop
+    // must not leak into the helper's effect-callback check.
+    const projectDir = setupReactProject(tempRoot, "no-prop-callback-nested-helper", {
+      files: {
+        "src/Outer.tsx": `import { useEffect, useState } from "react";
+
+export const Outer = ({ onChange }: { onChange: (next: boolean) => void }) => {
+  function inner() {
+    const [isOn, setIsOn] = useState(false);
+    useEffect(() => {
+      onChange(isOn);
+    }, [isOn, onChange]);
+    void setIsOn;
+  }
+  inner();
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-callback-in-effect");
+    expect(hits).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Surfaced during a self-review of the in-flight useEffect rule PRs (#153, #154, #155, #156, #157, #162). The bug is on `main` and predates that work, but the same shape needed fixing on the new branches too — fixing here keeps `main` honest and avoids forking the convention.

## The bug

The visitor scaffolding shared by `no-prop-callback-in-effect` and `no-derived-useState` pushes an empty `Set` when entering a non-component `FunctionDeclaration` / `ArrowFunctionExpression`. The intent (per the existing comment) is to act as a **barrier**: identifiers inside a helper shouldn't resolve against an outer component's props because a closed-over `value` is **not a prop** of the helper.

The implementation walked the entire stack anyway:

```ts
const isPropName = (name: string): boolean => {
  for (let stackIndex = componentPropParamStack.length - 1; stackIndex >= 0; stackIndex--) {
    if (componentPropParamStack[stackIndex].has(name)) return true;
  }
  return false;
};
```

Top frame is empty → keep walking → next frame matches → return `true`. Barrier intent broken.

## False positives this produced

Both rules incorrectly fired on this shape:

```tsx
function Outer({ value, onChange }) {
  function inner() {
    const [draft, setDraft] = useState(value);          // FP: no-derived-useState
    useEffect(() => {
      onChange(isOn);
    }, [isOn, onChange]);                               // FP: no-prop-callback-in-effect
  }
  inner();
}
```

`value` and `onChange` are lexically captured from `Outer`, not props of `inner`.

## Fix

Single-line change in each rule's `isPropName`: stop the walk at the first empty frame.

```ts
const isPropName = (name: string): boolean => {
  for (let stackIndex = componentPropParamStack.length - 1; stackIndex >= 0; stackIndex--) {
    const frame = componentPropParamStack[stackIndex];
    if (frame.size === 0) return false;   // ← barrier
    if (frame.has(name)) return true;
  }
  return false;
};
```

The empty frame the visitor pushes when entering a non-component function now acts as the barrier the comment claims it does.

## Tests

New file `tests/regressions/prop-stack-barrier.test.ts` with 4 cases:

- `no-derived-useState` real prop → still flags ✅
- `no-derived-useState` nested helper closing over outer prop → no longer flags ❌
- `no-prop-callback-in-effect` real prop → still flags ✅
- `no-prop-callback-in-effect` nested helper closing over outer prop → no longer flags ❌

484/484 tests passing. Lint, typecheck, format clean. No changeset.

## Related

The same fix has been applied to the equivalent helpers introduced by the in-flight rule PRs:
- #157 `no-mirror-prop-effect` (commit 6954c64 on `cursor/comprehensive-useeffect-analyzer-7144`)
- #162 `prefer-use-effect-event` (commit 77be9a8 on `cursor/prefer-use-effect-event-7144`)

Both of those branches additionally switched from `walkAst` to a direct `for (statement of componentBody.body)` iteration so they only visit useEffects that are direct top-level statements — that's a separate fix for a related FP path that only affected the new rules.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e19bc65c-90d1-44e2-bdf0-57dcb1b77144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e19bc65c-90d1-44e2-bdf0-57dcb1b77144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

