### PR TITLE
[merged into main as 8745c34] suppression follow-ups — audit-mode, overrides validation, --explain monorepo, JSX generics, line-comment skip, single-pass evaluator

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -103,15 +103,19 @@ Options:
 
 ### `--explain <file:line>`
 
-When a rule keeps firing despite a `react-doctor-disable-next-line` you wrote, pass `--explain <file:line>` (mirroring `rustc --explain <error-code>`) to ask the scanner what it sees:
+When a rule keeps firing despite a `react-doctor-disable-next-line` you wrote, pass `--explain <file:line>` (mirroring `rustc --explain <error-code>`) to ask the scanner what it sees at one specific site:
 
 ```bash
 npx -y react-doctor@latest --explain components/projects/Snapshot.tsx:254
 ```
 
-`--why` is a hidden alias of `--explain` for users coming from the issue's vocabulary.
+Output names the rule, severity, and category, then prints any nearby suppression comment that didn't apply with an explanation — wrong rule list (suggesting the comma form), or a code-line gap (suggesting moving the comment or extracting the surrounding code into a helper).
 
-Output names the rule, prints any nearby suppression comment that didn't apply, and explains why — wrong rule list (suggesting the comma form), or a code-line gap (suggesting moving the comment or extracting the surrounding code into a helper). The same hint is also attached to each diagnostic inline when running with `--verbose` and is included in `--json` output as `diagnostic.suppressionHint`.
+In a monorepo, the path is auto-resolved to the workspace package that owns the file; `--project <name>` overrides that and forces a specific project.
+
+The same hint is also attached to every diagnostic inline when running with `--verbose` and is included in `--json` output as `diagnostic.suppressionHint`. If you're debugging more than one site at once, prefer `--verbose` over running `--explain` repeatedly.
+
+`--why` is a hidden alias of `--explain` for users coming from the issue's vocabulary.
 
 ## JSON output
 
@@ -302,7 +306,7 @@ If you want React Doctor to ignore those inline suppressions and audit your code
 { "respectInlineDisables": false }
 ```
 
-This only neutralizes the inline `// eslint-disable*` / `// oxlint-disable*` comments — the file-level ignore lists above are always honored, even in audit mode, because they typically point at vendored or generated code that genuinely shouldn't be linted.
+This neutralizes the inline `// eslint-disable*`, `// oxlint-disable*`, and `// react-doctor-disable*` comments — the file-level ignore lists above are always honored, even in audit mode, because they typically point at vendored or generated code that genuinely shouldn't be linted.
 
 ### Adopting your existing oxlint / eslint rules
 
@@ -351,7 +355,7 @@ To opt out completely, set:
 | `customRulesOnly`         | `boolean`                        | `false`  | Disable built-in react/jsx-a11y/compiler rules, keeping only `react-doctor/*` plugin rules                                                                                                                                                                                                                                                 |
 | `share`                   | `boolean`                        | `true`   | Show the share-your-results URL after scanning                                                                                                                                                                                                                                                                                             |
 | `textComponents`          | `string[]`                       | `[]`     | React Native only. Component names whose children should not trigger `rn-no-raw-text` (e.g. `["MyText", "Label.Bold"]`)                                                                                                                                                                                                                    |
-| `respectInlineDisables`   | `boolean`                        | `true`   | Respect inline `// eslint-disable*` / `// oxlint-disable*` comments. Set `false` for audit mode. File-level ignores (`.gitignore`, `.eslintignore`, `.oxlintignore`, `.prettierignore`, `.gitattributes` linguist annotations) are always respected.                                                                                       |
+| `respectInlineDisables`   | `boolean`                        | `true`   | Respect inline `// eslint-disable*`, `// oxlint-disable*`, and `// react-doctor-disable*` comments. Set `false` for audit mode. File-level ignores (`.gitignore`, `.eslintignore`, `.oxlintignore`, `.prettierignore`, `.gitattributes` linguist annotations) are always respected.                                                        |
 | `adoptExistingLintConfig` | `boolean`                        | `true`   | Merge the project's existing JSON oxlint / eslint config (`.oxlintrc.json` or `.eslintrc.json`, walking up to the nearest project boundary) into the scan via oxlint's `extends`. Diagnostics from those rules count toward the score. Flat / JS / TS configs are skipped; category-level enables don't apply (use rule-level severities). |
 
 CLI flags always override config values.

--- a/packages/react-doctor/src/cli.ts
+++ b/packages/react-doctor/src/cli.ts
@@ -25,6 +25,7 @@ import { highlighter } from "./utils/highlighter.js";
 import { loadConfig } from "./utils/load-config.js";
 import { logger, setLoggerSilent } from "./utils/logger.js";
 import { encodeAnnotationProperty, encodeAnnotationMessage } from "./utils/annotation-encoding.js";
+import { findOwningProjectDirectory } from "./utils/find-owning-project.js";
 import { parseFileLineArgument } from "./utils/parse-file-line-argument.js";
 import { prompts } from "./utils/prompts.js";
 import { selectProjects } from "./utils/select-projects.js";
@@ -259,23 +260,32 @@ const resolveDiffMode = async (
   return Boolean(shouldScanChangedOnly);
 };
 
-const runExplain = async (
-  fileLineArgument: string,
-  resolvedDirectory: string,
-  userConfig: ReactDoctorConfig | null,
-): Promise<void> => {
+interface ExplainContext {
+  resolvedDirectory: string;
+  userConfig: ReactDoctorConfig | null;
+  scanOptions: ScanOptions;
+  projectFlag: string | undefined;
+}
+
+const colorizeRuleByDiagnostic = (text: string, severity: Diagnostic["severity"]): string =>
+  severity === "error" ? highlighter.error(text) : highlighter.warn(text);
+
+const runExplain = async (fileLineArgument: string, context: ExplainContext): Promise<void> => {
   const { filePath, line } = parseFileLineArgument(fileLineArgument);
-  const scanResult = await scan(resolvedDirectory, {
+  const targetDirectory = await resolveExplainTargetDirectory(filePath, context);
+
+  const scanResult = await scan(targetDirectory, {
+    ...context.scanOptions,
     silent: true,
     offline: true,
-    configOverride: userConfig,
+    configOverride: context.userConfig,
   });
 
-  const requestedRelativePath = toRelativePath(filePath, resolvedDirectory);
+  const requestedRelativePath = toRelativePath(filePath, targetDirectory);
   const matchingDiagnostics = scanResult.diagnostics.filter(
     (diagnostic) =>
       diagnostic.line === line &&
-      toRelativePath(diagnostic.filePath, resolvedDirectory) === requestedRelativePath,
+      toRelativePath(diagnostic.filePath, targetDirectory) === requestedRelativePath,
   );
 
   if (matchingDiagnostics.length === 0) {
@@ -285,7 +295,13 @@ const runExplain = async (
 
   for (const diagnostic of matchingDiagnostics) {
     const ruleIdentifier = `${diagnostic.plugin}/${diagnostic.rule}`;
-    logger.log(`${highlighter.error(ruleIdentifier)} — ${diagnostic.message}`);
+    const severitySymbol = diagnostic.severity === "error" ? "✗" : "⚠";
+    const colorizedRule = colorizeRuleByDiagnostic(ruleIdentifier, diagnostic.severity);
+    const severityLabel = colorizeRuleByDiagnostic(diagnostic.severity, diagnostic.severity);
+    logger.log(
+      `${severitySymbol} ${colorizedRule} ${highlighter.dim(`(${severityLabel})`)} — ${diagnostic.message}`,
+    );
+    if (diagnostic.category) logger.dim(`  Category: ${diagnostic.category}`);
     if (diagnostic.help) logger.dim(`  ${diagnostic.help}`);
     if (diagnostic.suppressionHint) {
       logger.break();
@@ -297,6 +313,27 @@ const runExplain = async (
     }
     logger.break();
   }
+};
+
+const resolveExplainTargetDirectory = async (
+  filePath: string,
+  context: ExplainContext,
+): Promise<string> => {
+  if (context.projectFlag) {
+    const matchedDirectories = await selectProjects(
+      context.resolvedDirectory,
+      context.projectFlag,
+      true,
+    );
+    if (matchedDirectories.length === 0) return context.resolvedDirectory;
+    if (matchedDirectories.length > 1) {
+      throw new Error(
+        `--explain takes a single project; --project resolved to ${matchedDirectories.length} projects.`,
+      );
+    }
+    return matchedDirectories[0];
+  }
+  return findOwningProjectDirectory(context.resolvedDirectory, filePath);
 };
 
 const validateModeFlags = (flags: CliFlags): void => {
@@ -395,7 +432,12 @@ const program = new Command()
 
       const explainArgument = flags.explain ?? flags.why;
       if (explainArgument !== undefined) {
-        await runExplain(explainArgument, resolvedDirectory, userConfig);
+        await runExplain(explainArgument, {
+          resolvedDirectory,
+          userConfig,
+          scanOptions: resolveCliScanOptions(flags, userConfig, program),
+          projectFlag: flags.project,
+        });
         return;
       }
 

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -120,6 +120,8 @@ export const diagnose = async (
 
   const effectiveLint = options.lint ?? userConfig?.lint ?? true;
   const effectiveDeadCode = options.deadCode ?? userConfig?.deadCode ?? true;
+  const effectiveRespectInlineDisables =
+    options.respectInlineDisables ?? userConfig?.respectInlineDisables ?? true;
 
   const lintPromise = effectiveLint
     ? runOxlint({
@@ -130,8 +132,7 @@ export const diagnose = async (
         hasTanStackQuery: projectInfo.hasTanStackQuery,
         includePaths: lintIncludePaths,
         customRulesOnly: userConfig?.customRulesOnly ?? false,
-        respectInlineDisables:
-          options.respectInlineDisables ?? userConfig?.respectInlineDisables ?? true,
+        respectInlineDisables: effectiveRespectInlineDisables,
         adoptExistingLintConfig: userConfig?.adoptExistingLintConfig ?? true,
       }).catch((error: unknown) => {
         console.error("Lint failed:", error);
@@ -162,6 +163,7 @@ export const diagnose = async (
     resolvedDirectory,
     userConfig,
     readFileLinesSync,
+    { respectInlineDisables: effectiveRespectInlineDisables },
   );
   const elapsedMilliseconds = globalThis.performance.now() - startTime;
   const score = await calculateScore(diagnostics);

--- a/packages/react-doctor/src/scan.ts
+++ b/packages/react-doctor/src/scan.ts
@@ -622,6 +622,7 @@ const runScan = async (
     directory,
     isDiffMode,
     userConfig,
+    respectInlineDisables: options.respectInlineDisables,
   });
 
   const elapsedMilliseconds = performance.now() - startTime;

--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -205,8 +205,8 @@ export interface ReactDoctorConfig {
   share?: boolean;
   textComponents?: string[];
   /**
-   * Whether to respect inline `// eslint-disable*` / `// oxlint-disable*`
-   * comments in source files. Default: `true`.
+   * Whether to respect inline `// eslint-disable*`, `// oxlint-disable*`,
+   * and `// react-doctor-disable*` comments in source files. Default: `true`.
    *
    * File-level ignores (`.gitignore`, `.eslintignore`, `.oxlintignore`,
    * `.prettierignore`, `.gitattributes` `linguist-vendored` /

--- a/packages/react-doctor/src/utils/apply-ignore-overrides.ts
+++ b/packages/react-doctor/src/utils/apply-ignore-overrides.ts
@@ -8,23 +8,56 @@ export interface CompiledIgnoreOverride {
   ruleIds: ReadonlySet<string>;
 }
 
-const isIgnoreOverrideEntry = (value: unknown): value is ReactDoctorIgnoreOverride =>
-  isPlainObject(value) && Array.isArray(value.files);
+const warnConfigField = (message: string): void => {
+  process.stderr.write(`[react-doctor] ${message}\n`);
+};
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string");
 
 const collectStringList = (value: unknown): string[] =>
   Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+
+const validateOverrideEntry = (entry: unknown, index: number): ReactDoctorIgnoreOverride | null => {
+  if (!isPlainObject(entry)) {
+    warnConfigField(
+      `ignore.overrides[${index}] must be an object with { files, rules }; ignoring this entry.`,
+    );
+    return null;
+  }
+  if (!isStringArray(entry.files)) {
+    warnConfigField(
+      `ignore.overrides[${index}].files must be an array of strings; ignoring this entry.`,
+    );
+    return null;
+  }
+  if (entry.rules !== undefined && !isStringArray(entry.rules)) {
+    warnConfigField(
+      `ignore.overrides[${index}].rules must be an array of "plugin/rule" strings or omitted; treating as missing (override would suppress every rule for the matched files).`,
+    );
+    return { files: entry.files };
+  }
+  return entry.rules === undefined
+    ? { files: entry.files }
+    : { files: entry.files, rules: entry.rules };
+};
 
 export const compileIgnoreOverrides = (
   userConfig: ReactDoctorConfig | null,
 ): CompiledIgnoreOverride[] => {
   const overrides = userConfig?.ignore?.overrides;
-  if (!Array.isArray(overrides)) return [];
+  if (overrides === undefined) return [];
+  if (!Array.isArray(overrides)) {
+    warnConfigField(`ignore.overrides must be an array of { files, rules } entries; ignoring.`);
+    return [];
+  }
 
-  return overrides.flatMap((entry) => {
-    if (!isIgnoreOverrideEntry(entry)) return [];
-    const filePatterns = collectStringList(entry.files).map(compileGlobPattern);
+  return overrides.flatMap((entry, index) => {
+    const validated = validateOverrideEntry(entry, index);
+    if (!validated) return [];
+    const filePatterns = collectStringList(validated.files).map(compileGlobPattern);
     if (filePatterns.length === 0) return [];
-    const ruleIds = new Set(collectStringList(entry.rules));
+    const ruleIds = new Set(collectStringList(validated.rules));
     return [{ filePatterns, ruleIds }];
   });
 };

--- a/packages/react-doctor/src/utils/classify-suppression-near-miss.ts
+++ b/packages/react-doctor/src/utils/classify-suppression-near-miss.ts
@@ -1,71 +1,7 @@
-import { findEnclosingMultilineJsxOpenerStart } from "./find-enclosing-jsx-opener.js";
-import {
-  findStackedDisableCommentsAbove,
-  type StackedDisableComment,
-} from "./find-stacked-disable-comments.js";
-import { isRuleListedInComment } from "./is-rule-listed-in-comment.js";
-
-const formatLineGap = (gapLineCount: number): string =>
-  `${gapLineCount} line${gapLineCount === 1 ? "" : "s"}`;
-
-const findAdjacentRuleListMismatch = (
-  comments: StackedDisableComment[],
-  ruleId: string,
-): StackedDisableComment | undefined =>
-  comments.find(
-    (comment) =>
-      comment.isInChain &&
-      Boolean(comment.ruleList?.trim()) &&
-      !isRuleListedInComment(comment.ruleList, ruleId),
-  );
-
-const findOutOfChainMatch = (
-  comments: StackedDisableComment[],
-  ruleId: string,
-): StackedDisableComment | undefined =>
-  comments.find((comment) => !comment.isInChain && isRuleListedInComment(comment.ruleList, ruleId));
-
-const buildAdjacentMismatchHint = (comment: StackedDisableComment, ruleId: string): string => {
-  const ruleListText = comment.ruleList?.trim() ?? "";
-  return (
-    `An adjacent react-doctor-disable-next-line at line ${comment.commentLineIndex + 1} lists "${ruleListText}" — ${ruleId} is not in that list. ` +
-    `Use the comma form: react-doctor-disable-next-line ${ruleListText}, ${ruleId}`
-  );
-};
-
-const buildGapHint = (
-  comment: StackedDisableComment,
-  diagnosticLineIndex: number,
-  ruleId: string,
-): string => {
-  const commentLineNumber = comment.commentLineIndex + 1;
-  const diagnosticLineNumber = diagnosticLineIndex + 1;
-  const gapLineCount = diagnosticLineNumber - commentLineNumber - 1;
-  return (
-    `A react-doctor-disable-next-line for ${ruleId} sits at line ${commentLineNumber}, but ${formatLineGap(gapLineCount)} of code separate it from the diagnostic on line ${diagnosticLineNumber}. ` +
-    `Move the comment immediately above line ${diagnosticLineNumber}, or extract the surrounding code into a helper so the suppression is adjacent.`
-  );
-};
+import { evaluateSuppression } from "./evaluate-suppression.js";
 
 export const classifySuppressionNearMiss = (
   lines: string[],
   diagnosticLineIndex: number,
   ruleId: string,
-): string | null => {
-  const anchorIndices = [diagnosticLineIndex];
-  const openerStartIndex = findEnclosingMultilineJsxOpenerStart(lines, diagnosticLineIndex);
-  if (openerStartIndex !== null && openerStartIndex > 0) {
-    anchorIndices.push(openerStartIndex);
-  }
-
-  for (const anchorIndex of anchorIndices) {
-    const comments = findStackedDisableCommentsAbove(lines, anchorIndex);
-    const adjacentMismatch = findAdjacentRuleListMismatch(comments, ruleId);
-    if (adjacentMismatch) return buildAdjacentMismatchHint(adjacentMismatch, ruleId);
-
-    const outOfChainMatch = findOutOfChainMatch(comments, ruleId);
-    if (outOfChainMatch) return buildGapHint(outOfChainMatch, diagnosticLineIndex, ruleId);
-  }
-
-  return null;
-};
+): string | null => evaluateSuppression(lines, diagnosticLineIndex, ruleId).nearMissHint;

--- a/packages/react-doctor/src/utils/combine-diagnostics.ts
+++ b/packages/react-doctor/src/utils/combine-diagnostics.ts
@@ -11,6 +11,7 @@ interface CombineDiagnosticsInput {
   userConfig: ReactDoctorConfig | null;
   readFileLinesSync?: (filePath: string) => string[] | null;
   includeEnvironmentChecks?: boolean;
+  respectInlineDisables?: boolean;
 }
 
 export const combineDiagnostics = (input: CombineDiagnosticsInput): Diagnostic[] => {
@@ -22,9 +23,12 @@ export const combineDiagnostics = (input: CombineDiagnosticsInput): Diagnostic[]
     userConfig,
     readFileLinesSync = createNodeReadFileLinesSync(directory),
     includeEnvironmentChecks = true,
+    respectInlineDisables,
   } = input;
   const extraDiagnostics =
     isDiffMode || !includeEnvironmentChecks ? [] : checkReducedMotion(directory);
   const merged = [...lintDiagnostics, ...deadCodeDiagnostics, ...extraDiagnostics];
-  return mergeAndFilterDiagnostics(merged, directory, userConfig, readFileLinesSync);
+  return mergeAndFilterDiagnostics(merged, directory, userConfig, readFileLinesSync, {
+    respectInlineDisables,
+  });
 };

--- a/packages/react-doctor/src/utils/evaluate-suppression.ts
+++ b/packages/react-doctor/src/utils/evaluate-suppression.ts
@@ -1,0 +1,108 @@
+import { findEnclosingMultilineJsxOpenerStart } from "./find-enclosing-jsx-opener.js";
+import {
+  findStackedDisableCommentsAbove,
+  type StackedDisableComment,
+} from "./find-stacked-disable-comments.js";
+import { isRuleListedInComment } from "./is-rule-listed-in-comment.js";
+
+const DISABLE_LINE_PATTERN =
+  /(?:\/\/|\/\*)\s*react-doctor-disable-line\b(?:\s+([\w/\-.,\s]+?))?\s*(?:\*\/)?\s*\}?\s*$/;
+
+export interface SuppressionEvaluation {
+  isSuppressed: boolean;
+  nearMissHint: string | null;
+}
+
+const formatLineGap = (gapLineCount: number): string =>
+  `${gapLineCount} line${gapLineCount === 1 ? "" : "s"}`;
+
+const findChainSuppressor = (
+  comments: StackedDisableComment[],
+  ruleId: string,
+): StackedDisableComment | undefined =>
+  comments.find((comment) => comment.isInChain && isRuleListedInComment(comment.ruleList, ruleId));
+
+const findAdjacentRuleListMismatch = (
+  comments: StackedDisableComment[],
+  ruleId: string,
+): StackedDisableComment | undefined =>
+  comments.find(
+    (comment) =>
+      comment.isInChain &&
+      Boolean(comment.ruleList?.trim()) &&
+      !isRuleListedInComment(comment.ruleList, ruleId),
+  );
+
+const findOutOfChainMatch = (
+  comments: StackedDisableComment[],
+  ruleId: string,
+): StackedDisableComment | undefined =>
+  comments.find((comment) => !comment.isInChain && isRuleListedInComment(comment.ruleList, ruleId));
+
+const buildAdjacentMismatchHint = (comment: StackedDisableComment, ruleId: string): string => {
+  const ruleListText = comment.ruleList?.trim() ?? "";
+  return (
+    `An adjacent react-doctor-disable-next-line at line ${comment.commentLineIndex + 1} lists "${ruleListText}" — ${ruleId} is not in that list. ` +
+    `Use the comma form: react-doctor-disable-next-line ${ruleListText}, ${ruleId}`
+  );
+};
+
+const buildGapHint = (
+  comment: StackedDisableComment,
+  diagnosticLineIndex: number,
+  ruleId: string,
+): string => {
+  const commentLineNumber = comment.commentLineIndex + 1;
+  const diagnosticLineNumber = diagnosticLineIndex + 1;
+  const gapLineCount = diagnosticLineNumber - commentLineNumber - 1;
+  return (
+    `A react-doctor-disable-next-line for ${ruleId} sits at line ${commentLineNumber}, but ${formatLineGap(gapLineCount)} of code separate it from the diagnostic on line ${diagnosticLineNumber}. ` +
+    `Move the comment immediately above line ${diagnosticLineNumber}, or extract the surrounding code into a helper so the suppression is adjacent.`
+  );
+};
+
+const classifyFromComments = (
+  commentsByAnchor: StackedDisableComment[][],
+  diagnosticLineIndex: number,
+  ruleId: string,
+): string | null => {
+  for (const comments of commentsByAnchor) {
+    const adjacentMismatch = findAdjacentRuleListMismatch(comments, ruleId);
+    if (adjacentMismatch) return buildAdjacentMismatchHint(adjacentMismatch, ruleId);
+    const outOfChainMatch = findOutOfChainMatch(comments, ruleId);
+    if (outOfChainMatch) return buildGapHint(outOfChainMatch, diagnosticLineIndex, ruleId);
+  }
+  return null;
+};
+
+export const evaluateSuppression = (
+  lines: string[],
+  diagnosticLineIndex: number,
+  ruleId: string,
+): SuppressionEvaluation => {
+  const sameLineMatch = lines[diagnosticLineIndex]?.match(DISABLE_LINE_PATTERN);
+  if (sameLineMatch && isRuleListedInComment(sameLineMatch[1], ruleId)) {
+    return { isSuppressed: true, nearMissHint: null };
+  }
+
+  const directComments = findStackedDisableCommentsAbove(lines, diagnosticLineIndex);
+  if (findChainSuppressor(directComments, ruleId)) {
+    return { isSuppressed: true, nearMissHint: null };
+  }
+
+  const openerStartIndex = findEnclosingMultilineJsxOpenerStart(lines, diagnosticLineIndex);
+  const openerComments =
+    openerStartIndex !== null && openerStartIndex > 0
+      ? findStackedDisableCommentsAbove(lines, openerStartIndex)
+      : [];
+  if (findChainSuppressor(openerComments, ruleId)) {
+    return { isSuppressed: true, nearMissHint: null };
+  }
+
+  const nearMissHint = classifyFromComments(
+    [directComments, openerComments],
+    diagnosticLineIndex,
+    ruleId,
+  );
+  return { isSuppressed: false, nearMissHint };
+};

--- a/packages/react-doctor/src/utils/evaluate-suppression.ts
+++ b/packages/react-doctor/src/utils/evaluate-suppression.ts
@@ -16,11 +16,8 @@ export interface SuppressionEvaluation {
 const formatLineGap = (gapLineCount: number): string =>
   `${gapLineCount} line${gapLineCount === 1 ? "" : "s"}`;
 
-const findChainSuppressor = (
-  comments: StackedDisableComment[],
-  ruleId: string,
-): StackedDisableComment | undefined =>
-  comments.find((comment) => comment.isInChain && isRuleListedInComment(comment.ruleList, ruleId));
+const hasChainSuppressor = (comments: StackedDisableComment[], ruleId: string): boolean =>
+  comments.some((comment) => comment.isInChain && isRuleListedInComment(comment.ruleList, ruleId));
 
 const findAdjacentRuleListMismatch = (
   comments: StackedDisableComment[],
@@ -86,7 +83,7 @@ export const evaluateSuppression = (
   }
 
   const directComments = findStackedDisableCommentsAbove(lines, diagnosticLineIndex);
-  if (findChainSuppressor(directComments, ruleId)) {
+  if (hasChainSuppressor(directComments, ruleId)) {
     return { isSuppressed: true, nearMissHint: null };
   }
 
@@ -95,7 +92,7 @@ export const evaluateSuppression = (
     openerStartIndex !== null && openerStartIndex > 0
       ? findStackedDisableCommentsAbove(lines, openerStartIndex)
       : [];
-  if (findChainSuppressor(openerComments, ruleId)) {
+  if (hasChainSuppressor(openerComments, ruleId)) {
     return { isSuppressed: true, nearMissHint: null };
   }
 

--- a/packages/react-doctor/src/utils/filter-diagnostics.ts
+++ b/packages/react-doctor/src/utils/filter-diagnostics.ts
@@ -3,9 +3,8 @@ import {
   compileIgnoreOverrides,
   isDiagnosticIgnoredByOverrides,
 } from "./apply-ignore-overrides.js";
-import { classifySuppressionNearMiss } from "./classify-suppression-near-miss.js";
+import { evaluateSuppression } from "./evaluate-suppression.js";
 import { compileIgnoredFilePatterns, isFileIgnoredByPatterns } from "./is-ignored-file.js";
-import { isRuleSuppressedAt } from "./is-rule-suppressed-at.js";
 
 const OPENING_TAG_PATTERN = /<([A-Z][\w.]*)/;
 
@@ -111,9 +110,10 @@ export const filterInlineSuppressions = (
     const ruleIdentifier = `${diagnostic.plugin}/${diagnostic.rule}`;
     const diagnosticLineIndex = diagnostic.line - 1;
 
-    if (isRuleSuppressedAt(lines, diagnosticLineIndex, ruleIdentifier)) return [];
-
-    const suppressionHint = classifySuppressionNearMiss(lines, diagnosticLineIndex, ruleIdentifier);
-    return suppressionHint ? [{ ...diagnostic, suppressionHint }] : [diagnostic];
+    const evaluation = evaluateSuppression(lines, diagnosticLineIndex, ruleIdentifier);
+    if (evaluation.isSuppressed) return [];
+    return evaluation.nearMissHint
+      ? [{ ...diagnostic, suppressionHint: evaluation.nearMissHint }]
+      : [diagnostic];
   });
 };

--- a/packages/react-doctor/src/utils/find-jsx-opener-span.ts
+++ b/packages/react-doctor/src/utils/find-jsx-opener-span.ts
@@ -1,21 +1,55 @@
 import { JSX_OPENER_SCAN_MAX_LINES } from "../constants.js";
 
-const JSX_OPENER_TAG_PATTERN = /<[A-Za-z][\w.]*/;
+const JSX_OPENER_TAG_PATTERN = /<[A-Za-z][\w.]*/g;
+const JSX_TAG_NAME_FOLLOW = /[A-Za-z]/;
+
+const isOpenerMatchInsideLineComment = (line: string, openerCharIndex: number): boolean => {
+  let stringDelimiter: '"' | "'" | "`" | null = null;
+  for (let charIndex = 0; charIndex < openerCharIndex; charIndex++) {
+    const character = line[charIndex];
+    if (stringDelimiter !== null) {
+      if (character === "\\") {
+        charIndex++;
+        continue;
+      }
+      if (character === stringDelimiter) stringDelimiter = null;
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      stringDelimiter = character;
+      continue;
+    }
+    if (character === "/" && line[charIndex + 1] === "/") return true;
+  }
+  return false;
+};
+
+const findOpenerTagOnLine = (line: string): { startCharIndex: number } | null => {
+  JSX_OPENER_TAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null = JSX_OPENER_TAG_PATTERN.exec(line);
+  while (match !== null) {
+    if (!isOpenerMatchInsideLineComment(line, match.index)) {
+      return { startCharIndex: match.index + match[0].length };
+    }
+    match = JSX_OPENER_TAG_PATTERN.exec(line);
+  }
+  return null;
+};
 
 export const findJsxOpenerSpan = (lines: string[], openerLineIndex: number): number | null => {
   const openerLine = lines[openerLineIndex];
   if (openerLine === undefined) return null;
-  const tagMatch = openerLine.match(JSX_OPENER_TAG_PATTERN);
-  if (!tagMatch || tagMatch.index === undefined) return null;
+  const opener = findOpenerTagOnLine(openerLine);
+  if (!opener) return null;
 
-  const startCharIndex = tagMatch.index + tagMatch[0].length;
   const lookaheadLimit = Math.min(lines.length, openerLineIndex + JSX_OPENER_SCAN_MAX_LINES);
   let braceDepth = 0;
+  let innerAngleDepth = 0;
   let stringDelimiter: '"' | "'" | "`" | null = null;
 
   for (let lineIndex = openerLineIndex; lineIndex < lookaheadLimit; lineIndex++) {
     const currentLine = lines[lineIndex];
-    const startCharForLine = lineIndex === openerLineIndex ? startCharIndex : 0;
+    const startCharForLine = lineIndex === openerLineIndex ? opener.startCharIndex : 0;
 
     for (let charIndex = startCharForLine; charIndex < currentLine.length; charIndex++) {
       const character = currentLine[charIndex];
@@ -42,11 +76,26 @@ export const findJsxOpenerSpan = (lines: string[], openerLineIndex: number): num
         braceDepth--;
         continue;
       }
-      if (character !== ">" || braceDepth !== 0) continue;
+
+      if (braceDepth !== 0) continue;
+
+      if (character === "<") {
+        const followCharacter = currentLine[charIndex + 1];
+        if (followCharacter !== undefined && JSX_TAG_NAME_FOLLOW.test(followCharacter)) {
+          innerAngleDepth++;
+        }
+        continue;
+      }
+
+      if (character !== ">") continue;
 
       const previousCharacter = currentLine[charIndex - 1];
       const nextCharacter = currentLine[charIndex + 1];
       if (previousCharacter === "=" || nextCharacter === "=") continue;
+      if (innerAngleDepth > 0) {
+        innerAngleDepth--;
+        continue;
+      }
       return lineIndex;
     }
   }

--- a/packages/react-doctor/src/utils/find-jsx-opener-span.ts
+++ b/packages/react-doctor/src/utils/find-jsx-opener-span.ts
@@ -25,13 +25,11 @@ const isOpenerMatchInsideLineComment = (line: string, openerCharIndex: number): 
 };
 
 const findOpenerTagOnLine = (line: string): { startCharIndex: number } | null => {
-  JSX_OPENER_TAG_PATTERN.lastIndex = 0;
-  let match: RegExpExecArray | null = JSX_OPENER_TAG_PATTERN.exec(line);
-  while (match !== null) {
+  for (const match of line.matchAll(JSX_OPENER_TAG_PATTERN)) {
+    if (match.index === undefined) continue;
     if (!isOpenerMatchInsideLineComment(line, match.index)) {
       return { startCharIndex: match.index + match[0].length };
     }
-    match = JSX_OPENER_TAG_PATTERN.exec(line);
   }
   return null;
 };

--- a/packages/react-doctor/src/utils/find-owning-project.ts
+++ b/packages/react-doctor/src/utils/find-owning-project.ts
@@ -1,0 +1,24 @@
+import path from "node:path";
+import { discoverReactSubprojects, listWorkspacePackages } from "./discover-project.js";
+
+export const findOwningProjectDirectory = (rootDirectory: string, filePath: string): string => {
+  const absoluteFile = path.isAbsolute(filePath) ? filePath : path.resolve(rootDirectory, filePath);
+
+  const workspacePackages = listWorkspacePackages(rootDirectory);
+  const candidates =
+    workspacePackages.length > 0 ? workspacePackages : discoverReactSubprojects(rootDirectory);
+  if (candidates.length === 0) return rootDirectory;
+
+  let bestMatch: { directory: string; depth: number } | null = null;
+  for (const candidate of candidates) {
+    const candidateDirectory = path.resolve(candidate.directory);
+    const relativeFromCandidate = path.relative(candidateDirectory, absoluteFile);
+    if (relativeFromCandidate.startsWith("..") || path.isAbsolute(relativeFromCandidate)) continue;
+    const depth = candidateDirectory.length;
+    if (!bestMatch || depth > bestMatch.depth) {
+      bestMatch = { directory: candidate.directory, depth };
+    }
+  }
+
+  return bestMatch ? bestMatch.directory : rootDirectory;
+};

--- a/packages/react-doctor/src/utils/is-rule-suppressed-at.ts
+++ b/packages/react-doctor/src/utils/is-rule-suppressed-at.ts
@@ -1,33 +1,7 @@
-import { findEnclosingMultilineJsxOpenerStart } from "./find-enclosing-jsx-opener.js";
-import { findStackedDisableCommentsAbove } from "./find-stacked-disable-comments.js";
-import { isRuleListedInComment } from "./is-rule-listed-in-comment.js";
-
-const DISABLE_LINE_PATTERN =
-  /(?:\/\/|\/\*)\s*react-doctor-disable-line\b(?:\s+([\w/\-.,\s]+?))?\s*(?:\*\/)?\s*\}?\s*$/;
-
-const isRuleSuppressedByChainAbove = (
-  lines: string[],
-  anchorIndex: number,
-  ruleId: string,
-): boolean =>
-  findStackedDisableCommentsAbove(lines, anchorIndex).some(
-    (comment) => comment.isInChain && isRuleListedInComment(comment.ruleList, ruleId),
-  );
+import { evaluateSuppression } from "./evaluate-suppression.js";
 
 export const isRuleSuppressedAt = (
   lines: string[],
   diagnosticLineIndex: number,
   ruleId: string,
-): boolean => {
-  const sameLineMatch = lines[diagnosticLineIndex]?.match(DISABLE_LINE_PATTERN);
-  if (sameLineMatch && isRuleListedInComment(sameLineMatch[1], ruleId)) return true;
-
-  if (isRuleSuppressedByChainAbove(lines, diagnosticLineIndex, ruleId)) return true;
-
-  const openerStartIndex = findEnclosingMultilineJsxOpenerStart(lines, diagnosticLineIndex);
-  if (openerStartIndex !== null && openerStartIndex > 0) {
-    return isRuleSuppressedByChainAbove(lines, openerStartIndex, ruleId);
-  }
-
-  return false;
-};
+): boolean => evaluateSuppression(lines, diagnosticLineIndex, ruleId).isSuppressed;

--- a/packages/react-doctor/src/utils/merge-and-filter-diagnostics.ts
+++ b/packages/react-doctor/src/utils/merge-and-filter-diagnostics.ts
@@ -1,14 +1,20 @@
 import type { Diagnostic, ReactDoctorConfig } from "../types.js";
 import { filterIgnoredDiagnostics, filterInlineSuppressions } from "./filter-diagnostics.js";
 
+interface MergeAndFilterOptions {
+  respectInlineDisables?: boolean;
+}
+
 export const mergeAndFilterDiagnostics = (
   mergedDiagnostics: Diagnostic[],
   directory: string,
   userConfig: ReactDoctorConfig | null,
   readFileLinesSync: (filePath: string) => string[] | null,
+  options: MergeAndFilterOptions = {},
 ): Diagnostic[] => {
   const filtered = userConfig
     ? filterIgnoredDiagnostics(mergedDiagnostics, userConfig, directory, readFileLinesSync)
     : mergedDiagnostics;
+  if (options.respectInlineDisables === false) return filtered;
   return filterInlineSuppressions(filtered, directory, readFileLinesSync);
 };

--- a/packages/react-doctor/tests/filter-diagnostics.test.ts
+++ b/packages/react-doctor/tests/filter-diagnostics.test.ts
@@ -257,6 +257,57 @@ describe("filterIgnoredDiagnostics", () => {
     expect(filtered[0].filePath).toBe("src/modern/B.tsx");
   });
 
+  it("ignore.overrides emits stderr warnings for malformed entries instead of silently treating rules-as-string as 'ignore everything'", () => {
+    const stderrWrites: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+      stderrWrites.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      const diagnostics = [
+        createDiagnostic({
+          plugin: "react-doctor",
+          rule: "no-array-index-as-key",
+          filePath: "components/diff/A.tsx",
+        }),
+        createDiagnostic({
+          plugin: "react-doctor",
+          rule: "no-cascading-set-state",
+          filePath: "components/diff/A.tsx",
+        }),
+      ];
+      const config: ReactDoctorConfig = {
+        ignore: {
+          overrides: [
+            {
+              files: ["components/diff/**"],
+              // @ts-expect-error: intentionally malformed for the validation test.
+              rules: "react-doctor/no-array-index-as-key",
+            },
+          ],
+        },
+      };
+
+      const filtered = filterIgnoredDiagnostics(
+        diagnostics,
+        config,
+        TEST_ROOT_DIRECTORY,
+        testReadFileLines,
+      );
+
+      const combinedStderr = stderrWrites.join("");
+      expect(combinedStderr).toContain("ignore.overrides[0].rules");
+      // Both diagnostics drop because the malformed entry was treated as
+      // "no rules listed" → suppress every rule for matched files. The
+      // warning above tells the user that's why.
+      expect(filtered).toHaveLength(0);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  });
+
   it("ignore.overrides accepts multiple entries and combines them additively", () => {
     const diagnostics = [
       createDiagnostic({

--- a/packages/react-doctor/tests/find-jsx-opener-span.test.ts
+++ b/packages/react-doctor/tests/find-jsx-opener-span.test.ts
@@ -54,4 +54,20 @@ describe("findJsxOpenerSpan", () => {
   it("returns null for closing tags (no opener match)", () => {
     expect(findJsxOpenerSpan(["</li>"], 0)).toBeNull();
   });
+
+  it("handles `<Foo<T>` followed by self-close `/>` on the same line", () => {
+    expect(findJsxOpenerSpan(["<Foo<Item> />"], 0)).toBe(0);
+  });
+
+  it("handles `<Foo<T>>` (generic + immediate close) on a single line", () => {
+    expect(findJsxOpenerSpan(["<Foo<Item>>"], 0)).toBe(0);
+  });
+
+  it("does NOT mistake `<` inside string attributes for a generic opener", () => {
+    expect(findJsxOpenerSpan(['<Foo title="<not-a-tag>" />'], 0)).toBe(0);
+  });
+
+  it("ignores a `<Tag` match that comes after code + `//` on the same line", () => {
+    expect(findJsxOpenerSpan(['const x = "y"; // <Foo bar={x} />'], 0)).toBeNull();
+  });
 });

--- a/packages/react-doctor/tests/find-jsx-opener-span.test.ts
+++ b/packages/react-doctor/tests/find-jsx-opener-span.test.ts
@@ -9,7 +9,21 @@ describe("findJsxOpenerSpan", () => {
 
   it("returns null when the line has no JSX opener tag", () => {
     expect(findJsxOpenerSpan(["const x = 1;"], 0)).toBeNull();
-    expect(findJsxOpenerSpan(["// comment about <Foo>"], 0)).not.toBeNull();
+  });
+
+  it("ignores `<Tag` matches that sit inside a `//` line comment", () => {
+    expect(findJsxOpenerSpan(["// some note about <Foo>"], 0)).toBeNull();
+    expect(findJsxOpenerSpan(["const x = 1; // see <Foo bar={x} />"], 0)).toBeNull();
+  });
+
+  it("handles TypeScript generic JSX components by tracking inner < / > pairs", () => {
+    const lines = ["<List<Item>", "  data={items}", "/>"];
+    expect(findJsxOpenerSpan(lines, 0)).toBe(2);
+  });
+
+  it("handles nested generic constraints inside the opener", () => {
+    const lines = ["<Form<Schema<Item>>", "  onSubmit={fn}", "/>"];
+    expect(findJsxOpenerSpan(lines, 0)).toBe(2);
   });
 
   it("walks across lines to find the closing > of a multi-line opener", () => {

--- a/packages/react-doctor/tests/find-owning-project.test.ts
+++ b/packages/react-doctor/tests/find-owning-project.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { findOwningProjectDirectory } from "../src/utils/find-owning-project.js";
+import { setupReactProject, writeJson } from "./regressions/_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-find-owning-project-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("findOwningProjectDirectory", () => {
+  it("returns the root when no workspace packages exist", () => {
+    const projectDir = setupReactProject(tempRoot, "single-project", {
+      files: { "src/index.tsx": "export const A = () => null;" },
+    });
+    expect(findOwningProjectDirectory(projectDir, "src/index.tsx")).toBe(projectDir);
+  });
+
+  it("returns the workspace package whose directory contains the file", () => {
+    const monorepoRoot = path.join(tempRoot, "monorepo");
+    fs.mkdirSync(monorepoRoot, { recursive: true });
+    writeJson(path.join(monorepoRoot, "package.json"), {
+      name: "monorepo",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    setupReactProject(monorepoRoot, "packages/web", {
+      files: { "src/App.tsx": "export const App = () => null;" },
+    });
+    setupReactProject(monorepoRoot, "packages/api", {
+      files: { "src/server.ts": "export const start = () => undefined;" },
+    });
+
+    const webFile = path.join(monorepoRoot, "packages/web/src/App.tsx");
+    const apiFile = path.join(monorepoRoot, "packages/api/src/server.ts");
+
+    expect(findOwningProjectDirectory(monorepoRoot, webFile)).toBe(
+      path.join(monorepoRoot, "packages/web"),
+    );
+    expect(findOwningProjectDirectory(monorepoRoot, apiFile)).toBe(
+      path.join(monorepoRoot, "packages/api"),
+    );
+  });
+
+  it("falls back to the root when the file does not belong to any workspace package", () => {
+    const monorepoRoot = path.join(tempRoot, "monorepo-fallback");
+    fs.mkdirSync(monorepoRoot, { recursive: true });
+    writeJson(path.join(monorepoRoot, "package.json"), {
+      name: "monorepo-fallback",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    setupReactProject(monorepoRoot, "packages/web", {
+      files: { "src/App.tsx": "export const App = () => null;" },
+    });
+
+    const orphanFile = path.join(monorepoRoot, "scripts/build.ts");
+    expect(findOwningProjectDirectory(monorepoRoot, orphanFile)).toBe(monorepoRoot);
+  });
+
+  it("accepts relative file paths and resolves them against the root", () => {
+    const monorepoRoot = path.join(tempRoot, "monorepo-relative");
+    fs.mkdirSync(monorepoRoot, { recursive: true });
+    writeJson(path.join(monorepoRoot, "package.json"), {
+      name: "monorepo-relative",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    setupReactProject(monorepoRoot, "packages/web", {
+      files: { "src/App.tsx": "export const App = () => null;" },
+    });
+
+    expect(findOwningProjectDirectory(monorepoRoot, "packages/web/src/App.tsx")).toBe(
+      path.join(monorepoRoot, "packages/web"),
+    );
+  });
+});

--- a/packages/react-doctor/tests/merge-and-filter-diagnostics.test.ts
+++ b/packages/react-doctor/tests/merge-and-filter-diagnostics.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import type { Diagnostic } from "../src/types.js";
+import { createNodeReadFileLinesSync } from "../src/utils/read-file-lines-node.js";
+import { mergeAndFilterDiagnostics } from "../src/utils/merge-and-filter-diagnostics.js";
+import { buildDiagnostic, writeFile } from "./regressions/_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-merge-and-filter-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const setupCase = (caseId: string, fileContents: string): string => {
+  const projectDir = path.join(tempRoot, caseId);
+  writeFile(path.join(projectDir, "src", "app.tsx"), fileContents);
+  return projectDir;
+};
+
+const baseDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic =>
+  buildDiagnostic({ rule: "no-derived-state-effect", line: 2, ...overrides });
+
+describe("mergeAndFilterDiagnostics — respectInlineDisables option", () => {
+  it("filters react-doctor-disable comments by default (respectInlineDisables defaults to true)", () => {
+    const projectDir = setupCase(
+      "default-respects-disables",
+      `// react-doctor-disable-next-line react-doctor/no-derived-state-effect\nconst x = 1;\n`,
+    );
+    const filtered = mergeAndFilterDiagnostics(
+      [baseDiagnostic()],
+      projectDir,
+      null,
+      createNodeReadFileLinesSync(projectDir),
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("audit mode (respectInlineDisables=false) bypasses react-doctor-disable comments too", () => {
+    const projectDir = setupCase(
+      "audit-bypasses-disables",
+      `// react-doctor-disable-next-line react-doctor/no-derived-state-effect\nconst x = 1;\n`,
+    );
+    const filtered = mergeAndFilterDiagnostics(
+      [baseDiagnostic()],
+      projectDir,
+      null,
+      createNodeReadFileLinesSync(projectDir),
+      { respectInlineDisables: false },
+    );
+    expect(filtered).toHaveLength(1);
+  });
+
+  it("audit mode still honors config-level ignore.rules and ignore.files", () => {
+    const projectDir = setupCase("audit-honors-config-ignores", `const x = 1;\n`);
+    const filtered = mergeAndFilterDiagnostics(
+      [baseDiagnostic({ filePath: "src/skip.tsx", line: 1 })],
+      projectDir,
+      { ignore: { files: ["src/skip.tsx"] } },
+      createNodeReadFileLinesSync(projectDir),
+      { respectInlineDisables: false },
+    );
+    expect(filtered).toHaveLength(0);
+  });
+});

--- a/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
+++ b/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
@@ -232,6 +232,29 @@ describe("issue #158: disable-next-line covers multi-line JSX opening tags", () 
     );
     expect(filtered).toHaveLength(0);
   });
+
+  it("does NOT suppress when the `<Tag` lives in a `//` line comment above the diagnostic", () => {
+    const filtered = runFilter(
+      "jsx-fake-opener-line-comment",
+      `// react-doctor-disable-next-line react-doctor/no-derived-state-effect\n` +
+        `// docs example: <Foo bar={x} />\n` +
+        `if (x > 1) doStuff();\n`,
+      [baseDiagnostic({ line: 3 })],
+    );
+    expect(filtered).toHaveLength(1);
+  });
+
+  it("recognizes generic-typed JSX components (`<List<Item>`) so attribute-line diagnostics still suppress", () => {
+    const filtered = runFilter(
+      "jsx-multiline-generic-component",
+      `// react-doctor-disable-next-line react-doctor/no-derived-state-effect\n` +
+        `<List<Item>\n` +
+        `  data={items}\n` +
+        `/>\n`,
+      [baseDiagnostic({ line: 3 })],
+    );
+    expect(filtered).toHaveLength(0);
+  });
 });
 
 describe("issue #159: stacked disable-next-line comments", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**This PR's changes have been squash-committed directly to `main` as [`8745c34`](https://github.com/millionco/react-doctor/commit/8745c34). The branch has been deleted; this PR can be closed.**

---

Follow-up to #165. Addresses everything I'd flagged during the post-merge audit, including the items I'd originally listed as "deliberately not fixed" (the user asked for those too).

## 1. Audit-mode asymmetry

`respectInlineDisables: false` is documented as:

> Set to `false` for "audit mode": every inline suppression is neutralized so react-doctor reports every diagnostic regardless of historical hide-comments.

But `mergeAndFilterDiagnostics` ran `filterInlineSuppressions` unconditionally, so `// react-doctor-disable-next-line` comments still hid diagnostics in audit mode. `// eslint-disable*` and `// oxlint-disable*` were correctly neutralized (oxlint handles those by source-rewriting before linting); `// react-doctor-disable*` was the gap because it's a post-filter on our side.

Thread `respectInlineDisables` through `combineDiagnostics → mergeAndFilterDiagnostics` and skip `filterInlineSuppressions` when false. Config-level `ignore.rules`, `ignore.files`, and `ignore.overrides` stay honored in audit mode (they're file-level / configuration, not "historical hide-comments"), matching the existing `.oxlintignore` carve-out.

## 2. `ignore.overrides` config-shape footgun

`compileIgnoreOverrides` silently dropped malformed entries. `{ files: ["src/foo/**"], rules: "react/no-danger" }` (string instead of array) silently became "ignore everything for these files." Now: validate each entry, emit stderr warnings (mirroring `validate-config-types.ts`), preserve `files` while dropping malformed `rules` so the warning makes the situation explicit.

## 3. `--explain <file:line>` monorepo + ergonomics

`runExplain` previously called `scan(resolvedDirectory, ...)` directly. In a monorepo it crashed with `No React dependency found`. `--project <name>` was silently ignored. `--no-lint` / `--no-dead-code` were ignored.

New `findOwningProjectDirectory` walks the workspace packages and picks the longest-prefix match for the requested file. The CLI now passes `flags.project` and the resolved `ScanOptions` into `runExplain`. Output is severity-aware (warnings yellow, errors red), shows the diagnostic's `category`.

## 4. TypeScript generic JSX components

`<List<Item>` followed by a multi-line attribute list is now correctly recognized via an `innerAngleDepth` counter — each `<` followed by an alpha char at brace depth 0 increments, each matching `>` decrements, the OUTER `>` closes the opener. Nested generic constraints (`<Form<Schema<Item>>>`) work too.

## 5. Line-comment skipping

`<Foo` matches inside `//` line comments are now ignored via `isOpenerMatchInsideLineComment`. Eliminates a false-positive class where a `disable-next-line` above a `// docs example: <Foo>` line could extend coverage to a real diagnostic below. Block-comment edge case remains a documented limitation.

## 6. Single-pass suppression evaluator

`filterInlineSuppressions` used to call both `isRuleSuppressedAt` and `classifySuppressionNearMiss`, each independently looking up `findEnclosingMultilineJsxOpenerStart` and `findStackedDisableCommentsAbove`. New `evaluate-suppression.ts` consolidates both into one pass; the original utility files remain as thin wrappers so external test imports keep working.

## 7. README polish

`--explain` section calls out monorepo auto-resolution, the `--project` override, and steers users to `--verbose` when they want hints across many sites at once. `respectInlineDisables` documentation lists `// react-doctor-disable*` alongside the eslint / oxlint forms (now that audit mode actually neutralizes them).

## Cleanup

- `findOpenerTagOnLine` now uses `String.prototype.matchAll` instead of `exec()` against a stateful module-scope `g`-flag regex.
- `findChainSuppressor` was using `.find()` to retrieve an entry but the caller only checked existence — renamed to `hasChainSuppressor` and switched to `.some()`.

## Tests

17 new (527 total, all passing).

- `find-jsx-opener-span.test.ts` (7 added): line-comment containing fake `<Tag`, single-generic component, nested generic constraints, generic + self-close, generic + immediate close, string-attribute angle, code-after-`//`-on-same-line.
- `inline-suppressions.test.ts` (2 added): line-comment fake-opener doesn't cause a false-positive suppression; generic-typed JSX component attribute-line suppression works end-to-end.
- `merge-and-filter-diagnostics.test.ts` (3): default respects react-doctor-disable; audit mode bypasses it; audit mode still honors config-level `ignore.files`.
- `filter-diagnostics.test.ts` (1 added): malformed `ignore.overrides[0].rules` triggers a stderr warning.
- `find-owning-project.test.ts` (4): single-project, monorepo dispatch, orphan-file fallback, relative-path resolution.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd15a3df-1d14-4416-84af-e35284dd3ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd15a3df-1d14-4416-84af-e35284dd3ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

