### PR TITLE
feat(website): add Vary: Accept header on / for llms.txt content negotiation

### DIFF
--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -1,6 +1,19 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  headers: async () => {
+    return [
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Vary",
+            value: "Accept",
+          },
+        ],
+      },
+    ];
+  },
   rewrites: async () => {
     return {
       beforeFiles: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mirrors the content-negotiation pattern from [`aidenybai/react-grab`](https://github.com/aidenybai/react-grab/blob/main/apps/website/next.config.ts) on the React Doctor website.

The website already serves `public/llms.txt` at `/` when the request `Accept` header contains `text/markdown` (via the existing `rewrites` rule). What was missing is the matching response header that tells caches/CDNs the response varies by `Accept`.

Without `Vary: Accept`, an upstream cache (Vercel edge, browsers, intermediaries) can serve a cached HTML response to a client requesting `text/markdown` (or vice versa), defeating the rewrite.

## Change

`packages/website/next.config.ts` — add a `headers()` block that sets `Vary: Accept` on the `/` route, exactly matching the react-grab setup.

```ts
headers: async () => {
  return [
    {
      source: "/",
      headers: [{ key: "Vary", value: "Accept" }],
    },
  ];
},
```

## Reference: react-grab

```ts
// apps/website/next.config.ts in aidenybai/react-grab
headers: async () => {
  return [
    {
      source: "/",
      headers: [{ key: "Vary", value: "Accept" }],
    },
  ];
},
rewrites: async () => ({
  beforeFiles: [
    {
      source: "/",
      destination: "/llms.txt",
      has: [{ type: "header", key: "accept", value: "(.*)text/markdown(.*)" }],
    },
    { source: "/llm.txt", destination: "/llms.txt" },
  ],
}),
```

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm format` — no changes

After deploy, the response for `GET /` should include `Vary: Accept`, and `curl -H 'Accept: text/markdown' https://…/` should return the contents of `/llms.txt`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f73f7897-37b7-48d1-8ef9-af75eab6ad49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f73f7897-37b7-48d1-8ef9-af75eab6ad49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

