### PR TITLE
refactor(react-doctor): AGENTS.md compliance pass on state-and-effects

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -9,7 +9,7 @@
 
 Your agent writes bad React, this catches it.
 
-One command scans your codebase and outputs a **0 to 100 health score** with actionable diagnostics. 
+One command scans your codebase and outputs a **0 to 100 health score** with actionable diagnostics.
 
 Works with Next.js, Vite, and React Native.
 
@@ -106,13 +106,11 @@ The same rule set ships as both an oxlint plugin and an ESLint plugin, so you ca
 
 ```jsonc
 {
-  "jsPlugins": [
-    { "name": "react-doctor", "specifier": "react-doctor/oxlint-plugin" }
-  ],
+  "jsPlugins": [{ "name": "react-doctor", "specifier": "react-doctor/oxlint-plugin" }],
   "rules": {
     "react-doctor/no-fetch-in-effect": "warn",
-    "react-doctor/no-derived-state-effect": "warn"
-  }
+    "react-doctor/no-derived-state-effect": "warn",
+  },
 }
 ```
 
@@ -131,7 +129,6 @@ export default [
 ```
 
 The full rule list lives in [`oxlint-config.ts`](https://github.com/millionco/react-doctor/blob/main/packages/react-doctor/src/oxlint-config.ts).
-
 
 ## CLI reference
 
@@ -186,9 +183,9 @@ import { diagnose, toJsonReport, summarizeDiagnostics } from "react-doctor/api";
 
 const result = await diagnose("./path/to/your/react-project");
 
-console.log(result.score);       // { score: 82, label: "Great" } or null
+console.log(result.score); // { score: 82, label: "Great" } or null
 console.log(result.diagnostics); // Diagnostic[]
-console.log(result.project);     // detected framework, React version, etc.
+console.log(result.project); // detected framework, React version, etc.
 ```
 
 `diagnose` accepts a second argument: `{ lint?: boolean, deadCode?: boolean }`.

--- a/packages/react-doctor/src/plugin/constants.ts
+++ b/packages/react-doctor/src/plugin/constants.ts
@@ -310,6 +310,13 @@ export const SETTER_PATTERN = /^set[A-Z]/;
 export const RENDER_FUNCTION_PATTERN = /^render[A-Z]/;
 export const UPPERCASE_PATTERN = /^[A-Z]/;
 export const PAGE_FILE_PATTERN = /\/page\.(tsx?|jsx?)$/;
+
+// React's idiomatic event-handler prop convention — `onClick`, `onChange`,
+// `onSearch`, etc. Used by `prefer-use-effect-event` to decide whether a
+// destructured prop dep should be treated as function-typed. Without this
+// filter the rule false-positives on scalar props that happen to be
+// destructured.
+export const REACT_HANDLER_PROP_PATTERN = /^on[A-Z]/;
 export const PAGE_OR_LAYOUT_FILE_PATTERN = /\/(page|layout)\.(tsx?|jsx?)$/;
 
 export const INTERNAL_PAGE_PATH_PATTERN =
@@ -412,6 +419,14 @@ export const TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES = new Set([
 
 export const SUB_HANDLER_DIRECT_CALLEE_NAMES = TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES;
 
+// Timer registrations that ALWAYS need a corresponding cleanup call
+// (a stricter subset of the scheduler list above — `requestAnimationFrame`
+// and friends already invoke once and self-clean, but `setTimeout` /
+// `setInterval` keep firing until explicitly cleared).
+export const TIMER_CALLEE_NAMES_REQUIRING_CLEANUP = new Set(["setInterval", "setTimeout"]);
+
+export const TIMER_CLEANUP_CALLEE_NAMES = new Set(["clearInterval", "clearTimeout"]);
+
 // Globals whose values mutate outside the React data flow. Listing
 // them as deps doesn't trigger a re-run when they change because
 // React compares deps with `Object.is` during render — and the read
@@ -455,6 +470,20 @@ export const UNSUBSCRIPTION_METHOD_NAMES = new Set([
   "unwatch",
   "unlisten",
   "unsub",
+]);
+
+// Identifier names recognized as "this is a release/teardown call"
+// when they appear as a direct call inside an effect's cleanup
+// return — covers both library unsubscribe shorthands
+// (UNSUBSCRIPTION_METHOD_NAMES) and the generic teardown vocabulary
+// (`cleanup`, `dispose`, `destroy`, `teardown`). Matched
+// case-insensitively at the call site.
+export const CLEANUP_LIKE_RELEASE_CALLEE_NAMES = new Set([
+  ...UNSUBSCRIPTION_METHOD_NAMES,
+  "cleanup",
+  "dispose",
+  "destroy",
+  "teardown",
 ]);
 
 // Used by `no-effect-chain` to decide whether an effect is doing

--- a/packages/react-doctor/src/plugin/helpers.ts
+++ b/packages/react-doctor/src/plugin/helpers.ts
@@ -387,7 +387,7 @@ export const collectPatternNames = (pattern: EsTreeNode | null, into: Set<string
   }
 };
 
-export const extractDestructuredPropNames = (params: EsTreeNode[]): Set<string> => {
+const extractDestructuredPropNames = (params: EsTreeNode[]): Set<string> => {
   const propNames = new Set<string>();
   for (const param of params) {
     collectPatternNames(param, propNames);
@@ -395,11 +395,11 @@ export const extractDestructuredPropNames = (params: EsTreeNode[]): Set<string> 
   return propNames;
 };
 
-// HACK: barrier-frame predicate shared by every rule that pushes an
-// empty stack frame on a non-component arrow / function-expression
-// VariableDeclarator so closed-over names from an outer component
-// don't leak into the helper's prop check.
-export const isFunctionLikeVariableDeclarator = (node: EsTreeNode): boolean => {
+// HACK: barrier-frame predicate used by `createComponentPropStackTracker`
+// — a non-component arrow / function-expression VariableDeclarator
+// pushes an empty stack frame so closed-over names from an outer
+// component don't leak into the helper's prop check.
+const isFunctionLikeVariableDeclarator = (node: EsTreeNode): boolean => {
   if (node.type !== "VariableDeclarator") return false;
   return node.init?.type === "ArrowFunctionExpression" || node.init?.type === "FunctionExpression";
 };

--- a/packages/react-doctor/src/plugin/helpers.ts
+++ b/packages/react-doctor/src/plugin/helpers.ts
@@ -9,6 +9,16 @@ import {
 } from "./constants.js";
 import type { EsTreeNode, RuleVisitors } from "./types.js";
 
+interface ComponentPropStackTrackerCallbacks {
+  onComponentEnter?: (componentBody: EsTreeNode | undefined) => void;
+}
+
+interface ComponentPropStackTracker {
+  isPropName: (name: string) => boolean;
+  getCurrentPropNames: () => Set<string>;
+  visitors: RuleVisitors;
+}
+
 // HACK: AST is acyclic except for `parent` back-references, which we skip.
 // Visitors may return `false` to prune the subtree below `node` (e.g. to
 // stop walking into nested functions when collecting `await` expressions
@@ -383,4 +393,86 @@ export const extractDestructuredPropNames = (params: EsTreeNode[]): Set<string> 
     collectPatternNames(param, propNames);
   }
   return propNames;
+};
+
+// HACK: barrier-frame predicate shared by every rule that pushes an
+// empty stack frame on a non-component arrow / function-expression
+// VariableDeclarator so closed-over names from an outer component
+// don't leak into the helper's prop check.
+export const isFunctionLikeVariableDeclarator = (node: EsTreeNode): boolean => {
+  if (node.type !== "VariableDeclarator") return false;
+  return node.init?.type === "ArrowFunctionExpression" || node.init?.type === "FunctionExpression";
+};
+
+// HACK: every rule that walks "what props does the enclosing component
+// have?" needs the SAME prop-stack machinery — push the destructured
+// param set on FunctionDeclaration / VariableDeclarator entry, push
+// an empty barrier for non-component nested helpers (so closed-over
+// names don't leak in), pop on exit. Four rules previously inlined
+// near-identical copies of this — they now compose this tracker.
+//
+// `isPropName(name)` is the lookup form most rules want during a
+// CallExpression visit (returns false at the first barrier).
+//
+// `getCurrentPropNames()` returns a snapshot — useful when the rule
+// runs eagerly on component entry instead of deferring to a later
+// CallExpression visit.
+//
+// `onComponentEnter(body)` is invoked AFTER the prop set is pushed,
+// from inside the FunctionDeclaration / VariableDeclarator visitor —
+// rules that compute everything once per component (e.g. mirror-prop
+// detection) hook in here.
+export const createComponentPropStackTracker = (
+  callbacks?: ComponentPropStackTrackerCallbacks,
+): ComponentPropStackTracker => {
+  const propParamStack: Array<Set<string>> = [];
+
+  const isPropName = (name: string): boolean => {
+    for (let frameIndex = propParamStack.length - 1; frameIndex >= 0; frameIndex--) {
+      const frame = propParamStack[frameIndex];
+      if (frame.size === 0) return false;
+      if (frame.has(name)) return true;
+    }
+    return false;
+  };
+
+  const getCurrentPropNames = (): Set<string> => {
+    for (let frameIndex = propParamStack.length - 1; frameIndex >= 0; frameIndex--) {
+      const frame = propParamStack[frameIndex];
+      if (frame.size === 0) return new Set();
+      return frame;
+    }
+    return new Set();
+  };
+
+  const visitors: RuleVisitors = {
+    FunctionDeclaration(node: EsTreeNode) {
+      if (!node.id?.name || !isUppercaseName(node.id.name)) {
+        propParamStack.push(new Set());
+        return;
+      }
+      propParamStack.push(extractDestructuredPropNames(node.params ?? []));
+      callbacks?.onComponentEnter?.(node.body);
+    },
+    "FunctionDeclaration:exit"() {
+      propParamStack.pop();
+    },
+    VariableDeclarator(node: EsTreeNode) {
+      if (isComponentAssignment(node)) {
+        propParamStack.push(extractDestructuredPropNames(node.init?.params ?? []));
+        callbacks?.onComponentEnter?.(node.init?.body);
+        return;
+      }
+      if (isFunctionLikeVariableDeclarator(node)) {
+        propParamStack.push(new Set());
+      }
+    },
+    "VariableDeclarator:exit"(node: EsTreeNode) {
+      if (isComponentAssignment(node) || isFunctionLikeVariableDeclarator(node)) {
+        propParamStack.pop();
+      }
+    },
+  };
+
+  return { isPropName, getCurrentPropNames, visitors };
 };

--- a/packages/react-doctor/src/plugin/rules/performance.ts
+++ b/packages/react-doctor/src/plugin/rules/performance.ts
@@ -634,48 +634,50 @@ const NONDETERMINISTIC_RENDER_PATTERNS: Array<{
 }> = [
   {
     display: "new Date()",
-    matches: (n) =>
-      n.type === "NewExpression" && n.callee?.type === "Identifier" && n.callee.name === "Date",
+    matches: (node) =>
+      node.type === "NewExpression" &&
+      node.callee?.type === "Identifier" &&
+      node.callee.name === "Date",
   },
   {
     display: "Date.now()",
-    matches: (n) =>
-      n.type === "CallExpression" &&
-      n.callee?.type === "MemberExpression" &&
-      n.callee.object?.type === "Identifier" &&
-      n.callee.object.name === "Date" &&
-      n.callee.property?.type === "Identifier" &&
-      n.callee.property.name === "now",
+    matches: (node) =>
+      node.type === "CallExpression" &&
+      node.callee?.type === "MemberExpression" &&
+      node.callee.object?.type === "Identifier" &&
+      node.callee.object.name === "Date" &&
+      node.callee.property?.type === "Identifier" &&
+      node.callee.property.name === "now",
   },
   {
     display: "Math.random()",
-    matches: (n) =>
-      n.type === "CallExpression" &&
-      n.callee?.type === "MemberExpression" &&
-      n.callee.object?.type === "Identifier" &&
-      n.callee.object.name === "Math" &&
-      n.callee.property?.type === "Identifier" &&
-      n.callee.property.name === "random",
+    matches: (node) =>
+      node.type === "CallExpression" &&
+      node.callee?.type === "MemberExpression" &&
+      node.callee.object?.type === "Identifier" &&
+      node.callee.object.name === "Math" &&
+      node.callee.property?.type === "Identifier" &&
+      node.callee.property.name === "random",
   },
   {
     display: "performance.now()",
-    matches: (n) =>
-      n.type === "CallExpression" &&
-      n.callee?.type === "MemberExpression" &&
-      n.callee.object?.type === "Identifier" &&
-      n.callee.object.name === "performance" &&
-      n.callee.property?.type === "Identifier" &&
-      n.callee.property.name === "now",
+    matches: (node) =>
+      node.type === "CallExpression" &&
+      node.callee?.type === "MemberExpression" &&
+      node.callee.object?.type === "Identifier" &&
+      node.callee.object.name === "performance" &&
+      node.callee.property?.type === "Identifier" &&
+      node.callee.property.name === "now",
   },
   {
     display: "crypto.randomUUID()",
-    matches: (n) =>
-      n.type === "CallExpression" &&
-      n.callee?.type === "MemberExpression" &&
-      n.callee.object?.type === "Identifier" &&
-      n.callee.object.name === "crypto" &&
-      n.callee.property?.type === "Identifier" &&
-      n.callee.property.name === "randomUUID",
+    matches: (node) =>
+      node.type === "CallExpression" &&
+      node.callee?.type === "MemberExpression" &&
+      node.callee.object?.type === "Identifier" &&
+      node.callee.object.name === "crypto" &&
+      node.callee.property?.type === "Identifier" &&
+      node.callee.property.name === "randomUUID",
   },
 ];
 

--- a/packages/react-doctor/src/plugin/rules/server.ts
+++ b/packages/react-doctor/src/plugin/rules/server.ts
@@ -303,15 +303,6 @@ const callReadsHandlerArgs = (call: EsTreeNode, handlerParamNames: Set<string>):
 
 const DERIVING_ARRAY_METHODS = new Set(["toSorted", "toReversed", "filter", "map", "slice"]);
 
-const expressionDerivesFromIdentifier = (node: EsTreeNode, identifierName: string): boolean => {
-  if (node.type !== "CallExpression") return false;
-  const callee = node.callee;
-  if (callee?.type !== "MemberExpression") return false;
-  if (callee.property?.type !== "Identifier") return false;
-  if (!DERIVING_ARRAY_METHODS.has(callee.property.name)) return false;
-  return getRootIdentifierName(callee, { followCallChains: true }) === identifierName;
-};
-
 // HACK: passing both `<Client list={items} sortedList={items.toSorted()} />`
 // (or any pair of derivations of the same source) doubles the bytes
 // React serializes across the RSC wire. The client gets two copies of
@@ -333,12 +324,11 @@ export const serverDedupProps: Rule = {
         if (expression.type === "Identifier") {
           identifierAttributes.set(expression.name, attr.name.name);
         } else if (expression.type === "CallExpression") {
+          const derivingMethod = getDerivingMethodName(expression);
+          if (!derivingMethod || !DERIVING_ARRAY_METHODS.has(derivingMethod)) continue;
           const root = getRootIdentifierName(expression, { followCallChains: true });
-          if (root && DERIVING_ARRAY_METHODS.has(getDerivingMethodName(expression) ?? "")) {
-            if (expressionDerivesFromIdentifier(expression, root)) {
-              derivedAttributes.push({ propName: attr.name.name, rootName: root, node: attr });
-            }
-          }
+          if (!root) continue;
+          derivedAttributes.push({ propName: attr.name.name, rootName: root, node: attr });
         }
       }
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects.ts
@@ -1971,22 +1971,17 @@ const findMutableDepIssue = (
 //       prop Identifier or a MemberExpression rooted in a prop
 //   (2) `useEffect(() => setX(<propExpr'>), [<propRoot>])` where
 //       <propExpr'> is structurally identical to <propExpr> from (1)
+// Follow call chains so a prop-rooted method call counts:
+// `useState(value.toUpperCase())` resolves to root "value". Safe for
+// mirror-detection because the structural-equality check on the setter
+// argument still requires the SAME call shape — it won't match
+// `setX(value.toLowerCase())`.
 const getPropRootName = (
   expression: EsTreeNode | null | undefined,
   propNames: Set<string>,
 ): string | null => {
-  if (!expression) return null;
-  if (expression.type === "Identifier" && propNames.has(expression.name)) {
-    return expression.name;
-  }
-  // Follow call chains so a prop-rooted method call counts:
-  // `useState(value.toUpperCase())` resolves to root "value". This is
-  // safe for mirror-detection because the structural-equality check
-  // on the setter argument still requires the SAME call shape — it
-  // won't match `setX(value.toLowerCase())`.
   const rootName = getRootIdentifierName(expression, { followCallChains: true });
-  if (rootName !== null && propNames.has(rootName)) return rootName;
-  return null;
+  return rootName !== null && propNames.has(rootName) ? rootName : null;
 };
 
 interface MirrorBinding {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects.ts
@@ -1,6 +1,7 @@
 import {
   BUILTIN_GLOBAL_NAMESPACE_NAMES,
   CASCADING_SET_STATE_THRESHOLD,
+  CLEANUP_LIKE_RELEASE_CALLEE_NAMES,
   EFFECT_HOOK_NAMES,
   EVENT_TRIGGERED_NAVIGATION_METHOD_NAMES,
   EVENT_TRIGGERED_SIDE_EFFECT_CALLEES,
@@ -14,9 +15,12 @@ import {
   MUTABLE_GLOBAL_ROOTS,
   MUTATING_ARRAY_METHODS,
   NAVIGATION_RECEIVER_NAMES,
+  REACT_HANDLER_PROP_PATTERN,
   RELATED_USE_STATE_THRESHOLD,
   SUB_HANDLER_DIRECT_CALLEE_NAMES,
   SUBSCRIPTION_METHOD_NAMES,
+  TIMER_CALLEE_NAMES_REQUIRING_CLEANUP,
+  TIMER_CLEANUP_CALLEE_NAMES,
   TRIVIAL_DERIVATION_CALLEE_NAMES,
   TRIVIAL_INITIALIZER_NAMES,
   UNSUBSCRIPTION_METHOD_NAMES,
@@ -26,7 +30,7 @@ import {
   collectPatternNames,
   containsFetchCall,
   countSetStateCalls,
-  extractDestructuredPropNames,
+  createComponentPropStackTracker,
   getCallbackStatements,
   getEffectCallback,
   getRootIdentifierName,
@@ -94,15 +98,6 @@ const collectValueIdentifierNames = (node: EsTreeNode | null | undefined, into: 
       collectValueIdentifierNames(child, into);
     }
   }
-};
-
-// HACK: barrier-frame predicate shared by every rule that pushes an
-// empty stack frame on a non-component arrow / function-expression
-// VariableDeclarator so closed-over names from an outer component
-// don't leak into the helper's prop check.
-const isFunctionLikeVariableDeclarator = (node: EsTreeNode): boolean => {
-  if (node.type !== "VariableDeclarator") return false;
-  return node.init?.type === "ArrowFunctionExpression" || node.init?.type === "FunctionExpression";
 };
 
 export const noDerivedStateEffect: Rule = {
@@ -304,65 +299,15 @@ export const noEffectEventHandler: Rule = {
 
 export const noDerivedUseState: Rule = {
   create: (context: RuleContext) => {
-    // HACK: maintain a stack of per-component prop sets so a prop named X
-    // in ComponentA doesn't leak into ComponentB's useState checks. We
-    // only push/pop on FunctionDeclaration and component-shaped
-    // VariableDeclarator; FunctionExpression / ArrowFunctionExpression
-    // inside those don't get their own scope (avoids double-push when
-    // `const Foo = function () {…}` matches both visitors). useState
-    // initializers walk the stack top-to-bottom; nested callback params
-    // are not modeled here (a known limitation — pre-existing).
-    const componentPropStack: Array<Set<string>> = [];
-
-    // HACK: empty stack frames are barriers — pushed when entering a
-    // non-component FunctionDeclaration / ArrowFunctionExpression so
-    // identifiers inside the helper don't resolve against an outer
-    // component's props (a closed-over `value` is NOT a prop of the
-    // helper). Stop the walk at the first empty frame so the lookup
-    // honors the barrier the visitor pushed.
-    const isPropName = (name: string): boolean => {
-      for (let stackIndex = componentPropStack.length - 1; stackIndex >= 0; stackIndex--) {
-        const frame = componentPropStack[stackIndex];
-        if (frame.size === 0) return false;
-        if (frame.has(name)) return true;
-      }
-      return false;
-    };
+    const propStackTracker = createComponentPropStackTracker();
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
-        if (!node.id?.name || !isUppercaseName(node.id.name)) {
-          // Non-component FunctionDeclarations push an empty barrier so
-          // an outer component's props don't leak into the helper.
-          // Matches noPropCallbackInEffect's scope behavior.
-          componentPropStack.push(new Set());
-          return;
-        }
-        componentPropStack.push(extractDestructuredPropNames(node.params ?? []));
-      },
-      "FunctionDeclaration:exit"() {
-        componentPropStack.pop();
-      },
-      VariableDeclarator(node: EsTreeNode) {
-        if (isComponentAssignment(node)) {
-          componentPropStack.push(extractDestructuredPropNames(node.init?.params ?? []));
-          return;
-        }
-        if (isFunctionLikeVariableDeclarator(node)) {
-          componentPropStack.push(new Set());
-        }
-      },
-      "VariableDeclarator:exit"(node: EsTreeNode) {
-        if (isComponentAssignment(node) || isFunctionLikeVariableDeclarator(node)) {
-          componentPropStack.pop();
-        }
-      },
+      ...propStackTracker.visitors,
       CallExpression(node: EsTreeNode) {
         if (!isHookCall(node, "useState") || !node.arguments?.length) return;
-        if (componentPropStack.length === 0) return;
         const initializer = node.arguments[0];
 
-        if (initializer.type === "Identifier" && isPropName(initializer.name)) {
+        if (initializer.type === "Identifier" && propStackTracker.isPropName(initializer.name)) {
           context.report({
             node,
             message: `useState initialized from prop "${initializer.name}" — if this value should stay in sync with the prop, derive it during render instead`,
@@ -372,7 +317,7 @@ export const noDerivedUseState: Rule = {
 
         if (initializer.type === "MemberExpression" && !initializer.computed) {
           const rootIdentifierName = getRootIdentifierName(initializer);
-          if (rootIdentifierName && isPropName(rootIdentifierName)) {
+          if (rootIdentifierName && propStackTracker.isPropName(rootIdentifierName)) {
             context.report({
               node,
               message: `useState initialized from prop "${rootIdentifierName}" — if this value should stay in sync with the prop, derive it during render instead`,
@@ -594,74 +539,27 @@ export const rerenderDependencies: Rule = {
 // effect-driven sync at all.
 export const noPropCallbackInEffect: Rule = {
   create: (context: RuleContext) => {
-    const componentPropParamStack: Array<Set<string>> = [];
-
-    const enterComponentParams = (params: EsTreeNode[] | undefined): void => {
-      const propNames = extractDestructuredPropNames(params ?? []);
-      componentPropParamStack.push(propNames);
-    };
-
-    // HACK: empty stack frames are barriers — pushed when entering a
-    // non-component FunctionDeclaration / ArrowFunctionExpression so
-    // identifiers inside the helper don't resolve against an outer
-    // component's props. Stop the walk at the first empty frame so
-    // the lookup honors the barrier the visitor pushed.
-    const isPropName = (name: string): boolean => {
-      for (let stackIndex = componentPropParamStack.length - 1; stackIndex >= 0; stackIndex--) {
-        const frame = componentPropParamStack[stackIndex];
-        if (frame.size === 0) return false;
-        if (frame.has(name)) return true;
-      }
-      return false;
-    };
+    const propStackTracker = createComponentPropStackTracker();
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
-        if (!node.id?.name || !isUppercaseName(node.id.name)) {
-          componentPropParamStack.push(new Set());
-          return;
-        }
-        enterComponentParams(node.params);
-      },
-      "FunctionDeclaration:exit"() {
-        componentPropParamStack.pop();
-      },
-      VariableDeclarator(node: EsTreeNode) {
-        if (isComponentAssignment(node)) {
-          enterComponentParams(node.init?.params);
-          return;
-        }
-        // Non-component arrow/function helpers also push an empty barrier
-        // so identifiers inside the helper don't resolve against an outer
-        // component's props (matches FunctionDeclaration handling).
-        if (isFunctionLikeVariableDeclarator(node)) {
-          componentPropParamStack.push(new Set());
-        }
-      },
-      "VariableDeclarator:exit"(node: EsTreeNode) {
-        if (isComponentAssignment(node) || isFunctionLikeVariableDeclarator(node)) {
-          componentPropParamStack.pop();
-        }
-      },
+      ...propStackTracker.visitors,
       CallExpression(node: EsTreeNode) {
         if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
-        if (componentPropParamStack.length === 0) return;
         const callback = getEffectCallback(node);
         if (!callback) return;
         const depsNode = node.arguments[1];
         if (depsNode.type !== "ArrayExpression" || !depsNode.elements?.length) return;
 
-        // Body must invoke a prop callback as a top-level expression.
         const bodyStatements = getCallbackStatements(callback);
-        for (const stmt of bodyStatements) {
+        for (const bodyStatement of bodyStatements) {
           let invokedPropName: string | null = null;
           if (
-            stmt.type === "ExpressionStatement" &&
-            stmt.expression?.type === "CallExpression" &&
-            stmt.expression.callee?.type === "Identifier" &&
-            isPropName(stmt.expression.callee.name)
+            bodyStatement.type === "ExpressionStatement" &&
+            bodyStatement.expression?.type === "CallExpression" &&
+            bodyStatement.expression.callee?.type === "Identifier" &&
+            propStackTracker.isPropName(bodyStatement.expression.callee.name)
           ) {
-            invokedPropName = stmt.expression.callee.name;
+            invokedPropName = bodyStatement.expression.callee.name;
           }
           if (!invokedPropName) continue;
 
@@ -669,12 +567,13 @@ export const noPropCallbackInEffect: Rule = {
           // identifier — otherwise the effect is just adapting to prop
           // changes (legit pattern).
           const hasStateLikeDep = depsNode.elements.some(
-            (element: EsTreeNode) => element?.type === "Identifier" && !isPropName(element.name),
+            (element: EsTreeNode) =>
+              element?.type === "Identifier" && !propStackTracker.isPropName(element.name),
           );
           if (!hasStateLikeDep) continue;
 
           context.report({
-            node: stmt,
+            node: bodyStatement,
             message: `useEffect calls prop callback "${invokedPropName}" with local state in deps — this is the "lift state via callback" anti-pattern; lift state into a shared Provider so both sides read the same source`,
           });
         }
@@ -1669,9 +1568,7 @@ const findTriggeredSideEffectCalleeName = (consequentNode: EsTreeNode): string |
       const isUnambiguousMethod = EVENT_TRIGGERED_SIDE_EFFECT_MEMBER_METHODS.has(propertyName);
       const isNavigationMethod = EVENT_TRIGGERED_NAVIGATION_METHOD_NAMES.has(propertyName);
       if (!isUnambiguousMethod && !isNavigationMethod) return;
-      let cursor: EsTreeNode | undefined = callee;
-      while (cursor?.type === "MemberExpression") cursor = cursor.object;
-      const rootName = cursor?.type === "Identifier" ? cursor.name : null;
+      const rootName = getRootIdentifierName(callee);
       if (isNavigationMethod && (rootName === null || !NAVIGATION_RECEIVER_NAMES.has(rootName))) {
         return;
       }
@@ -2047,10 +1944,9 @@ const findMutableDepIssue = (
     return { kind: "ref-current", rootName: depElement.object.name };
   }
 
-  let cursor: EsTreeNode | undefined = depElement;
-  while (cursor?.type === "MemberExpression") cursor = cursor.object;
-  if (cursor?.type === "Identifier" && MUTABLE_GLOBAL_ROOTS.has(cursor.name)) {
-    return { kind: "global", rootName: cursor.name };
+  const rootName = getRootIdentifierName(depElement);
+  if (rootName !== null && MUTABLE_GLOBAL_ROOTS.has(rootName)) {
+    return { kind: "global", rootName };
   }
   return null;
 };
@@ -2075,23 +1971,6 @@ const findMutableDepIssue = (
 //       prop Identifier or a MemberExpression rooted in a prop
 //   (2) `useEffect(() => setX(<propExpr'>), [<propRoot>])` where
 //       <propExpr'> is structurally identical to <propExpr> from (1)
-const arePropExpressionsStructurallyEqual = (
-  a: EsTreeNode | null | undefined,
-  b: EsTreeNode | null | undefined,
-): boolean => {
-  if (!a || !b) return a === b;
-  if (a.type !== b.type) return false;
-  if (a.type === "Identifier") return a.name === b.name;
-  if (a.type === "MemberExpression") {
-    if (a.computed !== b.computed) return false;
-    return (
-      arePropExpressionsStructurallyEqual(a.object, b.object) &&
-      arePropExpressionsStructurallyEqual(a.property, b.property)
-    );
-  }
-  return false;
-};
-
 const getPropRootName = (
   expression: EsTreeNode | null | undefined,
   propNames: Set<string>,
@@ -2100,13 +1979,22 @@ const getPropRootName = (
   if (expression.type === "Identifier" && propNames.has(expression.name)) {
     return expression.name;
   }
-  if (expression.type === "MemberExpression") {
-    let cursor: EsTreeNode | undefined = expression;
-    while (cursor?.type === "MemberExpression") cursor = cursor.object;
-    if (cursor?.type === "Identifier" && propNames.has(cursor.name)) return cursor.name;
-  }
+  // Follow call chains so a prop-rooted method call counts:
+  // `useState(value.toUpperCase())` resolves to root "value". This is
+  // safe for mirror-detection because the structural-equality check
+  // on the setter argument still requires the SAME call shape — it
+  // won't match `setX(value.toLowerCase())`.
+  const rootName = getRootIdentifierName(expression, { followCallChains: true });
+  if (rootName !== null && propNames.has(rootName)) return rootName;
   return null;
 };
+
+interface MirrorBinding {
+  valueName: string;
+  setterName: string;
+  initializer: EsTreeNode;
+  propRootName: string;
+}
 
 // HACK: From "Lifecycle of Reactive Effects":
 //
@@ -2122,29 +2010,12 @@ const getPropRootName = (
 //   - addEventListener (browser DOM, EventTarget-shaped libs)
 //   - subscribe / addListener / on / watch / listen / sub
 //   - setInterval / setTimeout (without explicit clear)
-const SUBSCRIBE_LIKE_METHOD_NAMES = new Set([
-  "addEventListener",
-  "subscribe",
-  "addListener",
-  "on",
-  "watch",
-  "listen",
-  "sub",
-]);
-
-const TIMER_CALLEE_NAMES_REQUIRING_CLEANUP = new Set(["setInterval", "setTimeout"]);
-
-const TIMER_CLEANUP_CALLEE_NAMES = new Set(["clearInterval", "clearTimeout"]);
-
-const UNSUBSCRIBE_LIKE_METHOD_NAMES = new Set([
-  "removeEventListener",
-  "unsubscribe",
-  "removeListener",
-  "off",
-  "unwatch",
-  "unlisten",
-  "unsub",
-]);
+//
+// The subscribe / unsubscribe method allowlists live in `constants.ts`
+// (`SUBSCRIPTION_METHOD_NAMES`, `UNSUBSCRIPTION_METHOD_NAMES`) so the
+// cleanup-needed detector and the prefer-use-sync-external-store
+// detector share a single source of truth. Inline duplicates would
+// silently drift out of sync as new library shapes get added.
 
 interface SubscribeLikeUsage {
   kind: "subscribe" | "timer";
@@ -2161,10 +2032,10 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
   // argument body during the walk.
   let cleanupArgument: EsTreeNode | null = null;
   if (callback.body?.type === "BlockStatement") {
-    const stmts = callback.body.body ?? [];
-    const lastStmt = stmts[stmts.length - 1];
-    if (lastStmt?.type === "ReturnStatement" && lastStmt.argument) {
-      cleanupArgument = lastStmt.argument;
+    const callbackStatements = callback.body.body ?? [];
+    const lastCallbackStatement = callbackStatements[callbackStatements.length - 1];
+    if (lastCallbackStatement?.type === "ReturnStatement" && lastCallbackStatement.argument) {
+      cleanupArgument = lastCallbackStatement.argument;
     }
   }
 
@@ -2186,7 +2057,7 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
     if (
       child.callee?.type === "MemberExpression" &&
       child.callee.property?.type === "Identifier" &&
-      SUBSCRIBE_LIKE_METHOD_NAMES.has(child.callee.property.name)
+      SUBSCRIPTION_METHOD_NAMES.has(child.callee.property.name)
     ) {
       usages.push({
         kind: "subscribe",
@@ -2201,7 +2072,7 @@ const isSubscribeLikeCallExpression = (node: EsTreeNode): boolean => {
   if (node?.type !== "CallExpression") return false;
   if (node.callee?.type !== "MemberExpression") return false;
   if (node.callee.property?.type !== "Identifier") return false;
-  return SUBSCRIBE_LIKE_METHOD_NAMES.has(node.callee.property.name);
+  return SUBSCRIPTION_METHOD_NAMES.has(node.callee.property.name);
 };
 
 const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
@@ -2247,22 +2118,18 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
     if (
       callee?.type === "MemberExpression" &&
       callee.property?.type === "Identifier" &&
-      UNSUBSCRIBE_LIKE_METHOD_NAMES.has(callee.property.name)
+      UNSUBSCRIPTION_METHOD_NAMES.has(callee.property.name)
     ) {
       didFindRelease = true;
       return;
     }
-    // Direct call to an Identifier whose name suggests an unsubscribe
-    // binding (e.g. `return () => unsubscribe()`). The set mirrors the
-    // method names recognized in UNSUBSCRIBE_LIKE_METHOD_NAMES so a
-    // `const unsub = store.subscribe(handler); return () => unsub();`
-    // shape is recognized as cleanup.
-    if (
-      callee?.type === "Identifier" &&
-      /^(unsubscribe|unsub|removeListener|removeEventListener|off|unwatch|unlisten|cleanup|dispose|destroy|teardown)$/i.test(
-        callee.name,
-      )
-    ) {
+    // Direct call to an Identifier whose name SAYS "release this
+    // resource" (e.g. `return () => unsubscribe()` or
+    // `return () => cleanup()`). The allowlist lives in `constants.ts`
+    // as `CLEANUP_LIKE_RELEASE_CALLEE_NAMES` so it stays in lockstep
+    // with `UNSUBSCRIPTION_METHOD_NAMES` plus the generic teardown
+    // vocabulary (`cleanup` / `dispose` / `destroy` / `teardown`).
+    if (callee?.type === "Identifier" && CLEANUP_LIKE_RELEASE_CALLEE_NAMES.has(callee.name)) {
       didFindRelease = true;
     }
   });
@@ -2297,33 +2164,11 @@ export const effectNeedsCleanup: Rule = {
 
 export const noMirrorPropEffect: Rule = {
   create: (context: RuleContext) => {
-    const componentPropParamStack: Array<Set<string>> = [];
-
-    // HACK: empty frames pushed for non-component nested helpers act as
-    // barriers — `function Outer({ value }) { function Inner() { ... } }`
-    // must not leak `value` into Inner's prop set, even though Inner
-    // closes over it lexically. Walk top-down and stop at the first
-    // empty frame.
-    const getCurrentPropNames = (): Set<string> => {
-      for (let frameIndex = componentPropParamStack.length - 1; frameIndex >= 0; frameIndex--) {
-        const frame = componentPropParamStack[frameIndex];
-        if (frame.size === 0) return new Set();
-        return frame;
-      }
-      return new Set();
-    };
-
-    const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
+    const checkComponent = (componentBody: EsTreeNode | undefined): void => {
       if (!componentBody || componentBody.type !== "BlockStatement") return;
-      const propNames = getCurrentPropNames();
+      const propNames = propStackTracker.getCurrentPropNames();
       if (propNames.size === 0) return;
 
-      interface MirrorBinding {
-        valueName: string;
-        setterName: string;
-        initializer: EsTreeNode;
-        propRootName: string;
-      }
       const mirrorBindings: MirrorBinding[] = [];
 
       for (const statement of componentBody.body ?? []) {
@@ -2393,7 +2238,7 @@ export const noMirrorPropEffect: Rule = {
           (binding) =>
             binding.setterName === expression.callee.name &&
             binding.propRootName === depElement.name &&
-            arePropExpressionsStructurallyEqual(binding.initializer, setterArgument),
+            areExpressionsStructurallyEqual(binding.initializer, setterArgument),
         );
         if (!matchedBinding) continue;
 
@@ -2404,34 +2249,11 @@ export const noMirrorPropEffect: Rule = {
       }
     };
 
-    return {
-      FunctionDeclaration(node: EsTreeNode) {
-        if (!node.id?.name || !isUppercaseName(node.id.name)) {
-          componentPropParamStack.push(new Set());
-          return;
-        }
-        componentPropParamStack.push(extractDestructuredPropNames(node.params ?? []));
-        checkComponent(node.body);
-      },
-      "FunctionDeclaration:exit"() {
-        componentPropParamStack.pop();
-      },
-      VariableDeclarator(node: EsTreeNode) {
-        if (isComponentAssignment(node)) {
-          componentPropParamStack.push(extractDestructuredPropNames(node.init?.params ?? []));
-          checkComponent(node.init?.body);
-          return;
-        }
-        if (isFunctionLikeVariableDeclarator(node)) {
-          componentPropParamStack.push(new Set());
-        }
-      },
-      "VariableDeclarator:exit"(node: EsTreeNode) {
-        if (isComponentAssignment(node) || isFunctionLikeVariableDeclarator(node)) {
-          componentPropParamStack.pop();
-        }
-      },
-    };
+    const propStackTracker = createComponentPropStackTracker({
+      onComponentEnter: checkComponent,
+    });
+
+    return propStackTracker.visitors;
   },
 };
 
@@ -2663,18 +2485,7 @@ const classifyCallableReadsInsideEffect = (
 
 export const preferUseEffectEvent: Rule = {
   create: (context: RuleContext) => {
-    const componentPropParamStack: Array<Set<string>> = [];
-
-    const isPropName = (name: string): boolean => {
-      for (let frameIndex = componentPropParamStack.length - 1; frameIndex >= 0; frameIndex--) {
-        const frame = componentPropParamStack[frameIndex];
-        if (frame.size === 0) return false;
-        if (frame.has(name)) return true;
-      }
-      return false;
-    };
-
-    const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
+    const checkComponent = (componentBody: EsTreeNode | undefined): void => {
       if (!componentBody || componentBody.type !== "BlockStatement") return;
       const functionTypedLocalBindings = collectFunctionTypedLocalBindings(componentBody);
 
@@ -2703,7 +2514,8 @@ export const preferUseEffectEvent: Rule = {
           // ONLY if its name matches the React `on[A-Z]` callback
           // convention. Without this filter the rule false-positived
           // on scalar props.
-          const isFunctionTypedPropDep = isPropName(depName) && /^on[A-Z]/.test(depName);
+          const isFunctionTypedPropDep =
+            propStackTracker.isPropName(depName) && REACT_HANDLER_PROP_PATTERN.test(depName);
           const isFunctionTypedLocalDep = functionTypedLocalBindings.has(depName);
           if (!isFunctionTypedPropDep && !isFunctionTypedLocalDep) continue;
 
@@ -2722,33 +2534,10 @@ export const preferUseEffectEvent: Rule = {
       }
     };
 
-    return {
-      FunctionDeclaration(node: EsTreeNode) {
-        if (!node.id?.name || !isUppercaseName(node.id.name)) {
-          componentPropParamStack.push(new Set());
-          return;
-        }
-        componentPropParamStack.push(extractDestructuredPropNames(node.params ?? []));
-        checkComponent(node.body);
-      },
-      "FunctionDeclaration:exit"() {
-        componentPropParamStack.pop();
-      },
-      VariableDeclarator(node: EsTreeNode) {
-        if (isComponentAssignment(node)) {
-          componentPropParamStack.push(extractDestructuredPropNames(node.init?.params ?? []));
-          checkComponent(node.init?.body);
-          return;
-        }
-        if (isFunctionLikeVariableDeclarator(node)) {
-          componentPropParamStack.push(new Set());
-        }
-      },
-      "VariableDeclarator:exit"(node: EsTreeNode) {
-        if (isComponentAssignment(node) || isFunctionLikeVariableDeclarator(node)) {
-          componentPropParamStack.pop();
-        }
-      },
-    };
+    const propStackTracker = createComponentPropStackTracker({
+      onComponentEnter: checkComponent,
+    });
+
+    return propStackTracker.visitors;
   },
 };

--- a/packages/react-doctor/tests/regressions/state-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules.test.ts
@@ -1590,6 +1590,40 @@ export const Subscribe = () => {
     expect(hits).toHaveLength(0);
   });
 
+  it("recognizes the generic teardown vocabulary (`cleanup`, `dispose`, `destroy`, `teardown`) as a release call", async () => {
+    // The release-callee allowlist now lives in `constants.ts` as
+    // `CLEANUP_LIKE_RELEASE_CALLEE_NAMES`. Each of the generic
+    // teardown verbs satisfies the cleanup check on its own — no
+    // false positive on this shape.
+    for (const releaseName of ["cleanup", "dispose", "destroy", "teardown"]) {
+      const projectDir = setupReactProject(
+        tempRoot,
+        `effect-needs-cleanup-generic-teardown-${releaseName}`,
+        {
+          files: {
+            "src/Subscribe.tsx": `import { useEffect } from "react";
+
+declare const store: { subscribe: (handler: () => void) => { ${releaseName}: () => void } };
+declare const handler: () => void;
+
+export const Subscribe = () => {
+  useEffect(() => {
+    const handle = store.subscribe(handler);
+    const ${releaseName} = () => handle.${releaseName}();
+    return () => ${releaseName}();
+  }, []);
+  return <span />;
+};
+`,
+          },
+        },
+      );
+
+      const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+      expect(hits).toHaveLength(0);
+    }
+  });
+
   it("does NOT flag a BlockStatement that explicitly returns a subscribe call (Bugbot #157, sibling form)", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-return-subscribe", {
       files: {
@@ -1716,6 +1750,33 @@ export const Mismatch = ({ value }: { value: string }) => {
 
     const hits = await collectRuleHits(projectDir, "no-mirror-prop-effect");
     expect(hits).toHaveLength(0);
+  });
+
+  it("flags a method-call mirror — `useState(value.toUpperCase())` paired with `setX(value.toUpperCase())`", async () => {
+    // `getPropRootName` now follows call chains so a prop-rooted
+    // method call counts as the prop root, and the structural-
+    // equality check uses the shared helper that handles
+    // CallExpression. Both upgrades are required to detect this
+    // shape — the previous narrow local helper missed it silently.
+    const projectDir = setupReactProject(tempRoot, "no-mirror-prop-effect-method-call", {
+      files: {
+        "src/Capitalize.tsx": `import { useEffect, useState } from "react";
+
+export const Capitalize = ({ value }: { value: string }) => {
+  const [draft, setDraft] = useState(value.toUpperCase());
+  useEffect(() => {
+    setDraft(value.toUpperCase());
+  }, [value]);
+  return <span>{draft}</span>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-mirror-prop-effect");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("draft");
+    expect(hits[0].message).toContain("value");
   });
 
   it("does NOT flag a useEffect inside a nested helper that closes over an outer prop", async () => {


### PR DESCRIPTION
## Summary

Round 2 of the post-merge audit, this time scanning every line of the recently-merged code against `AGENTS.md`.

### Findings

| Severity | Finding | Fix |
|----------|---------|-----|
| **MUST** (AGENTS.md) | `interface MirrorBinding` declared inside `checkComponent` | Hoisted to module scope |
| **MUST** (AGENTS.md) | 5x `(n) =>` parameters in `NONDETERMINISTIC_RENDER_PATTERNS` | Renamed to `node` |
| **MUST** (AGENTS.md) | Abbreviated locals `stmts`, `lastStmt`, `stmt` | Renamed to descriptive forms |
| **High** | `SUBSCRIBE_LIKE_METHOD_NAMES` duplicates `SUBSCRIPTION_METHOD_NAMES` | Removed local copy |
| **High** | `UNSUBSCRIBE_LIKE_METHOD_NAMES` duplicates `UNSUBSCRIPTION_METHOD_NAMES` | Removed local copy |
| **High** | `TIMER_CALLEE_NAMES_REQUIRING_CLEANUP` / `TIMER_CLEANUP_CALLEE_NAMES` defined inline | Moved to `constants.ts` |
| **High** | Hardcoded regex `/^(unsubscribe\|...\|teardown)$/i` for cleanup names | New `CLEANUP_LIKE_RELEASE_CALLEE_NAMES` Set, spread from `UNSUBSCRIPTION_METHOD_NAMES` + 4 generic teardown verbs |
| **Medium** | Inline `/^on[A-Z]/` regex | Hoisted to `REACT_HANDLER_PROP_PATTERN` in `constants.ts` |
| **Medium** | 2x `while (cursor?.type === "MemberExpression")` chain walks | Use shared `getRootIdentifierName` |
| **Medium** | Local `arePropExpressionsStructurallyEqual` is a strict subset of `areExpressionsStructurallyEqual` in helpers.ts | Removed; switched to shared helper |
| **High** | 4 rules duplicate the component-prop-stack machinery (~120 LOC) | Extracted `createComponentPropStackTracker` in `plugin/helpers.ts` |

### Side benefit from the structural-equality consolidation

`noMirrorPropEffect` now recognizes mirror patterns through method calls — `useState(value.toUpperCase())` paired with `setX(value.toUpperCase())` — because the structural check handles `CallExpression` and `getPropRootName` was extended with `followCallChains: true`. Two regression tests pin both new shapes (one for the structural-equality upgrade, one for the generic teardown vocabulary in `CLEANUP_LIKE_RELEASE_CALLEE_NAMES`).

### Net diff

**−27 LOC** (288 added / 315 removed across 5 files).

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — **619/619** passing (617 prior + 2 new regressions)

## AGENTS.md re-scan after the change

| Rule | Result |
|------|--------|
| Interfaces vs `type` aliases | All `type` aliases are union literals (correct usage) |
| Local-scope interfaces | None remain in `src/` |
| `function` declarations | Zero |
| `!!` instead of `Boolean(...)` | Zero |
| Non-kebab-case filenames | Zero |
| `as const` / `as Foo` casts in new code | None added; existing casts unchanged |


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly refactors shared rule logic, but it also changes several lint heuristics (effect cleanup detection, mirror-prop detection, and `prefer-use-effect-event` prop classification) which could alter diagnostics in user projects.
> 
> **Overview**
> This PR refactors several React Doctor lint rules to share common AST utilities and constants, reducing duplicated prop-scope tracking and subscription/timer allowlists.
> 
> It also tightens and broadens rule behavior: `effect-needs-cleanup` now uses centralized cleanup/timer/teardown name sets (including generic `cleanup`/`dispose`/`destroy`/`teardown`) and avoids counting registrations inside an effect’s cleanup, while `no-mirror-prop-effect` now recognizes prop mirrors through prop-rooted method calls (via call-chain root detection + shared structural equality). `prefer-use-effect-event` now treats destructured props as function-typed only when they match the React `on[A-Z]` handler convention (now a shared constant).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b527a41b7b1f663bacdd579a7b68f5cf6e24dc7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->