### PR TITLE
fix(react-doctor): harden rules against prototype-pollution FPs and adopt-config noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 review-report.md
 review-*.md
 *.review.md
+*.tgz

--- a/packages/react-doctor/src/oxlint-config.ts
+++ b/packages/react-doctor/src/oxlint-config.ts
@@ -383,14 +383,23 @@ export const ALL_REACT_DOCTOR_RULE_KEYS: ReadonlySet<string> = new Set([
 // project's detected React major. Adding a new version-gated rule means
 // touching just this map.
 //
-// `mode` controls behavior when version detection FAILS (null):
+// `mode` controls how the gate interacts with the detected React major:
 //   - "prefer-newer-api": the rule recommends an API that ONLY exists at
-//     or above `minMajor` (e.g. `useEffectEvent`). Suggesting it on a
-//     project where we can't prove the API exists is noise — fail closed.
-//   - "deprecation-warning": the rule flags patterns that BREAK at or
-//     above `minMajor` (e.g. `defaultProps` removal in React 19). Useful
-//     even on projects we can't version-detect, because the user may be
-//     mid-migration. Fail open.
+//     or above `minMajor` (e.g. `useEffectEvent`). Skipped when the
+//     project is on a known version below `minMajor` (recommending an
+//     API that demonstrably doesn't exist there is noise).
+//   - "deprecation-warning": the rule flags patterns that are removed
+//     at or above `minMajor` (e.g. `defaultProps` in React 19). The
+//     audience that benefits most is the version that still allows the
+//     pattern — fires on every detected major.
+//
+// When version detection FAILS (`reactMajorVersion === null`) we
+// optimistically assume the user is on the latest React major and
+// apply EVERY rule, including `prefer-newer-api` ones. Detection
+// failure is rare (custom resolvers, monorepo overrides, mid-clone
+// state); silently dropping rules in that path turned a missing
+// `react` entry into a quietly degraded scan. Better to recommend a
+// modern API and let the user reject it than to hide the suggestion.
 type VersionGateMode = "prefer-newer-api" | "deprecation-warning";
 interface VersionGate {
   minMajor: number;
@@ -423,7 +432,8 @@ const filterRulesByReactMajor = (
     Object.entries(rules).filter(([ruleKey]) => {
       const gate = VERSION_GATED_RULE_IDS.get(ruleKey);
       if (gate === undefined) return true;
-      if (reactMajorVersion === null) return gate.mode === "deprecation-warning";
+      if (gate.mode === "deprecation-warning") return true;
+      if (reactMajorVersion === null) return true;
       return reactMajorVersion >= gate.minMajor;
     }),
   );

--- a/packages/react-doctor/src/plugin/constants.ts
+++ b/packages/react-doctor/src/plugin/constants.ts
@@ -667,31 +667,40 @@ export const REACT_NATIVE_TEXT_COMPONENT_KEYWORDS = new Set([
   "Body",
 ]);
 
-export const DEPRECATED_RN_MODULE_REPLACEMENTS: Record<string, string> = {
-  AsyncStorage: "@react-native-async-storage/async-storage",
-  Picker: "@react-native-picker/picker",
-  PickerIOS: "@react-native-picker/picker",
-  DatePickerIOS: "@react-native-community/datetimepicker",
-  DatePickerAndroid: "@react-native-community/datetimepicker",
-  ProgressBarAndroid: "a community alternative",
-  ProgressViewIOS: "a community alternative",
-  SafeAreaView: "react-native-safe-area-context",
-  Slider: "@react-native-community/slider",
-  ViewPagerAndroid: "react-native-pager-view",
-  WebView: "react-native-webview",
-  NetInfo: "@react-native-community/netinfo",
-  CameraRoll: "@react-native-camera-roll/camera-roll",
-  Clipboard: "@react-native-clipboard/clipboard",
-  ImageEditor: "@react-native-community/image-editor",
-  MaskedViewIOS: "@react-native-masked-view/masked-view",
-};
+// HACK: Maps (not plain objects) so that an unusual `import { constructor }
+// from "react-native"` (or any other Object.prototype name) doesn't fall
+// through to `Object.prototype.constructor` and falsely report. Symmetric
+// with the deprecated-React-API rules in `architecture.ts`.
+export const DEPRECATED_RN_MODULE_REPLACEMENTS = new Map<string, string>([
+  ["AsyncStorage", "@react-native-async-storage/async-storage"],
+  ["Picker", "@react-native-picker/picker"],
+  ["PickerIOS", "@react-native-picker/picker"],
+  ["DatePickerIOS", "@react-native-community/datetimepicker"],
+  ["DatePickerAndroid", "@react-native-community/datetimepicker"],
+  ["ProgressBarAndroid", "a community alternative"],
+  ["ProgressViewIOS", "a community alternative"],
+  ["SafeAreaView", "react-native-safe-area-context"],
+  ["Slider", "@react-native-community/slider"],
+  ["ViewPagerAndroid", "react-native-pager-view"],
+  ["WebView", "react-native-webview"],
+  ["NetInfo", "@react-native-community/netinfo"],
+  ["CameraRoll", "@react-native-camera-roll/camera-roll"],
+  ["Clipboard", "@react-native-clipboard/clipboard"],
+  ["ImageEditor", "@react-native-community/image-editor"],
+  ["MaskedViewIOS", "@react-native-masked-view/masked-view"],
+]);
 
-export const LEGACY_EXPO_PACKAGE_REPLACEMENTS: Record<string, string> = {
-  "expo-av": "expo-audio for audio and expo-video for video",
-  "expo-permissions": "the permissions API in each module (e.g. Camera.requestPermissionsAsync())",
-  "@expo/vector-icons":
+export const LEGACY_EXPO_PACKAGE_REPLACEMENTS = new Map<string, string>([
+  ["expo-av", "expo-audio for audio and expo-video for video"],
+  [
+    "expo-permissions",
+    "the permissions API in each module (e.g. Camera.requestPermissionsAsync())",
+  ],
+  [
+    "@expo/vector-icons",
     "expo-symbols or expo-image (see https://docs.expo.dev/versions/latest/sdk/symbols/)",
-};
+  ],
+]);
 
 export const REACT_NATIVE_LIST_COMPONENTS = new Set([
   "FlatList",
@@ -743,6 +752,26 @@ export const HEAVY_HEADING_TAILWIND_WEIGHTS = new Set([
 ]);
 
 export const TAILWIND_DEFAULT_PALETTE_NAMES = ["indigo", "gray", "slate"];
+
+// HACK: the canonical Tailwind v3/v4 numeric color stops. Anchoring the
+// `design-no-default-tailwind-palette` regex to this exact set (rather
+// than `\d{2,3}`) avoids false-positiving on Radix Colors integrations
+// that map non-Tailwind stops onto Tailwind utilities (`text-gray-11`,
+// `text-gray-12`, `text-gray-10` are Radix scale numbers, not Tailwind
+// defaults — flagging them as "the Tailwind template default" is wrong).
+export const TAILWIND_DEFAULT_PALETTE_STOPS = [
+  "50",
+  "100",
+  "200",
+  "300",
+  "400",
+  "500",
+  "600",
+  "700",
+  "800",
+  "900",
+  "950",
+];
 
 export const TAILWIND_PALETTE_UTILITY_PREFIXES = [
   "text",

--- a/packages/react-doctor/src/plugin/rules/architecture.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture.ts
@@ -213,18 +213,28 @@ export const noManyBooleanProps: Rule = {
 // AND member access on namespace/default imports (`React.forwardRef`,
 // `React.useContext` after `import React from "react"` or
 // `import * as React from "react"`).
-const REACT_19_DEPRECATED_MESSAGES: Record<string, string> = {
-  forwardRef:
+//
+// Stored as a Map (not a plain object) because plain-object lookups inherit
+// from `Object.prototype` — `messages["constructor"]` returns the native
+// `Object` function, which is truthy and would silently false-positive on
+// `import { constructor } from "react"` or `React.toString()`. Maps return
+// `undefined` for missing keys with no prototype fall-through.
+const REACT_19_DEPRECATED_MESSAGES = new Map<string, string>([
+  [
+    "forwardRef",
     "forwardRef is no longer needed on React 19+ — refs are regular props on function components; remove forwardRef and pass ref directly",
-  useContext:
+  ],
+  [
+    "useContext",
     "useContext is superseded by `use()` on React 19+ — `use()` reads context conditionally inside hooks, branches, and loops; switch to `import { use } from 'react'`",
-};
+  ],
+]);
 
 interface DeprecatedReactImportRuleOptions {
   /** The exact `import "..."` source string this rule watches. */
   source: string;
   /** Per-imported-name message dictionary. Exact-match lookup. */
-  messages: Record<string, string>;
+  messages: ReadonlyMap<string, string>;
   /**
    * Optional extra ImportDeclaration handler invoked BEFORE the standard
    * source check — used by the react-dom rule to flag every import from
@@ -262,7 +272,7 @@ const createDeprecatedReactImportRule = ({
           if (specifier.type === "ImportSpecifier") {
             const importedName = specifier.imported?.name;
             if (!importedName) continue;
-            const message = messages[importedName];
+            const message = messages.get(importedName);
             if (message) context.report({ node: specifier, message });
             continue;
           }
@@ -281,7 +291,7 @@ const createDeprecatedReactImportRule = ({
         if (node.object?.type !== "Identifier") return;
         if (!namespaceBindings.has(node.object.name)) return;
         if (node.property?.type !== "Identifier") return;
-        const message = messages[node.property.name];
+        const message = messages.get(node.property.name);
         if (message) context.report({ node, message });
       },
     };
@@ -437,16 +447,34 @@ export const reactCompilerDestructureMethod: Rule = {
 // the work away, and call them again. React 18.3.1 emits a warning;
 // React 19 REMOVES them entirely (the `UNSAFE_` prefix included). We
 // flag both forms so the prefix doesn't get treated as a permanent fix.
-const LEGACY_LIFECYCLE_REPLACEMENTS: Record<string, string> = {
-  componentWillMount:
+//
+// Stored as a Map (not a plain object) because plain-object lookups inherit
+// from `Object.prototype` — `LEGACY_LIFECYCLE_REPLACEMENTS["constructor"]`
+// returns the native `Object` function (truthy), which previously made the
+// rule false-positive on every class with a constructor (Lexical nodes,
+// MobX stores, custom Error subclasses, etc.). Maps return `undefined` for
+// missing keys with no prototype fall-through.
+const LEGACY_LIFECYCLE_REPLACEMENTS = new Map<string, string>([
+  [
+    "componentWillMount",
     "Move side effects to `componentDidMount`; move initial state to `constructor`",
-  componentWillReceiveProps:
+  ],
+  [
+    "componentWillReceiveProps",
     "Move side effects to `componentDidUpdate` (compare prevProps); move pure state derivation to the static `getDerivedStateFromProps`",
-  componentWillUpdate:
+  ],
+  [
+    "componentWillUpdate",
     "Move DOM reads to `getSnapshotBeforeUpdate` (passes the value to `componentDidUpdate`); move other work to `componentDidUpdate`",
-};
+  ],
+]);
 
-const stripUnsafePrefix = (name: string): { baseName: string; hasUnsafePrefix: boolean } => {
+interface UnsafePrefixSplit {
+  baseName: string;
+  hasUnsafePrefix: boolean;
+}
+
+const stripUnsafePrefix = (name: string): UnsafePrefixSplit => {
   if (name.startsWith("UNSAFE_")) {
     return { baseName: name.slice("UNSAFE_".length), hasUnsafePrefix: true };
   }
@@ -455,7 +483,7 @@ const stripUnsafePrefix = (name: string): { baseName: string; hasUnsafePrefix: b
 
 const buildLegacyLifecycleMessage = (originalName: string): string | null => {
   const { baseName, hasUnsafePrefix } = stripUnsafePrefix(originalName);
-  const replacement = LEGACY_LIFECYCLE_REPLACEMENTS[baseName];
+  const replacement = LEGACY_LIFECYCLE_REPLACEMENTS.get(baseName);
   if (!replacement) return null;
   const removalNote = hasUnsafePrefix
     ? `\`${originalName}\` is removed in React 19 (the UNSAFE_ prefix only silences the React 18 warning, it doesn't fix the concurrent-mode hazard).`
@@ -600,28 +628,36 @@ export const noDefaultProps: Rule = {
 // moved to `react` in 19. A whole-rule version gate (`>= 18`) can't
 // distinguish "still on 18" from "should have migrated" inside the
 // rule, so we drop the entry rather than false-positive on 18 code.
-const REACT_DOM_DEPRECATED_MESSAGES: Record<string, string> = {
-  render:
+const REACT_DOM_DEPRECATED_MESSAGES = new Map<string, string>([
+  [
+    "render",
     "ReactDOM.render is the legacy root API — switch to `import { createRoot } from 'react-dom/client'` and call `createRoot(container).render(...)` (REMOVED in React 19)",
-  hydrate:
+  ],
+  [
+    "hydrate",
     "ReactDOM.hydrate is the legacy SSR API — switch to `import { hydrateRoot } from 'react-dom/client'` and call `hydrateRoot(container, <App />)` (REMOVED in React 19)",
-  unmountComponentAtNode:
+  ],
+  [
+    "unmountComponentAtNode",
     "ReactDOM.unmountComponentAtNode no longer works on roots created with `createRoot` — keep a reference to the root and call `root.unmount()` instead (REMOVED in React 19)",
-  findDOMNode:
+  ],
+  [
+    "findDOMNode",
     "ReactDOM.findDOMNode crawls the rendered tree and breaks composition — accept a ref directly and read `ref.current` (REMOVED in React 19)",
-};
+  ],
+]);
 
-const REACT_DOM_TEST_UTILS_REPLACEMENTS: Record<string, string> = {
-  act: "`import { act } from 'react'` instead",
-  Simulate: "`fireEvent` from `@testing-library/react` instead",
-  renderIntoDocument: "`render` from `@testing-library/react` instead",
-  findRenderedDOMComponentWithTag: "`getByRole` / `getByTestId` from `@testing-library/react`",
-  findRenderedDOMComponentWithClass: "`getByRole` or `container.querySelector` from RTL",
-  scryRenderedDOMComponentsWithTag: "`getAllByRole` from `@testing-library/react`",
-};
+const REACT_DOM_TEST_UTILS_REPLACEMENTS = new Map<string, string>([
+  ["act", "`import { act } from 'react'` instead"],
+  ["Simulate", "`fireEvent` from `@testing-library/react` instead"],
+  ["renderIntoDocument", "`render` from `@testing-library/react` instead"],
+  ["findRenderedDOMComponentWithTag", "`getByRole` / `getByTestId` from `@testing-library/react`"],
+  ["findRenderedDOMComponentWithClass", "`getByRole` or `container.querySelector` from RTL"],
+  ["scryRenderedDOMComponentsWithTag", "`getAllByRole` from `@testing-library/react`"],
+]);
 
 const buildTestUtilsMessage = (importedName: string): string => {
-  const replacement = REACT_DOM_TEST_UTILS_REPLACEMENTS[importedName];
+  const replacement = REACT_DOM_TEST_UTILS_REPLACEMENTS.get(importedName);
   const replacementText = replacement
     ? `Use ${replacement}.`
     : "Switch to `act` from `react` or the equivalent in `@testing-library/react`.";

--- a/packages/react-doctor/src/plugin/rules/correctness.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness.ts
@@ -113,10 +113,14 @@ export const noArrayIndexAsKey: Rule = {
 // <button type="button"> would need attribute inspection plus form-scope
 // detection to be reliable; out of scope until we have evidence of real
 // false-negatives.
-const PREVENT_DEFAULT_ELEMENTS: Record<string, string[]> = {
-  form: ["onSubmit"],
-  a: ["onClick"],
-};
+// HACK: Map (not plain object) so a JSX tag named after an
+// Object.prototype property (`<constructor>`, `<toString>`) doesn't
+// fall through to a truthy `Object.prototype.X` value and crash on
+// `targetEventProps.includes(...)` later in the rule body.
+const PREVENT_DEFAULT_ELEMENTS = new Map<string, string[]>([
+  ["form", ["onSubmit"]],
+  ["a", ["onClick"]],
+]);
 
 const containsPreventDefaultCall = (node: EsTreeNode): boolean => {
   let didFindPreventDefault = false;
@@ -147,7 +151,7 @@ export const noPreventDefault: Rule = {
       const elementName = node.name?.type === "JSXIdentifier" ? node.name.name : null;
       if (!elementName) return;
 
-      const targetEventProps = PREVENT_DEFAULT_ELEMENTS[elementName];
+      const targetEventProps = PREVENT_DEFAULT_ELEMENTS.get(elementName);
       if (!targetEventProps) return;
 
       for (const targetEventProp of targetEventProps) {

--- a/packages/react-doctor/src/plugin/rules/design.ts
+++ b/packages/react-doctor/src/plugin/rules/design.ts
@@ -228,12 +228,18 @@ const isBackgroundDark = (bgValue: string): boolean => {
   );
 };
 
-const BORDER_SIDE_KEYS: Record<string, string> = {
-  borderLeft: "left",
-  borderRight: "right",
-  borderInlineStart: "left",
-  borderInlineEnd: "right",
-};
+// HACK: Map (not plain object) so the `key in BORDER_SIDE_KEYS` guard
+// below doesn't accept inherited Object.prototype names. Without this,
+// any inline style object whose key happens to be `constructor` /
+// `toString` / `hasOwnProperty` / `__proto__` would pass the membership
+// check and fall through to a garbage report message that reads off
+// `BORDER_SIDE_KEYS["constructor"]` (= the native Object function).
+const BORDER_SIDE_KEYS = new Map<string, string>([
+  ["borderLeft", "left"],
+  ["borderRight", "right"],
+  ["borderInlineStart", "left"],
+  ["borderInlineEnd", "right"],
+]);
 
 const BORDER_SIDE_WIDTH_KEYS = new Set([
   "borderLeftWidth",
@@ -390,7 +396,8 @@ export const noSideTabBorder: Rule = {
         const key = getStylePropertyKey(property);
         if (!key) continue;
 
-        if (key in BORDER_SIDE_KEYS) {
+        const sideLabel = BORDER_SIDE_KEYS.get(key);
+        if (sideLabel !== undefined) {
           const value = getStylePropertyStringValue(property);
           if (!value) continue;
           const widthMatch = value.match(/^(\d+)px\s+solid/);
@@ -403,7 +410,7 @@ export const noSideTabBorder: Rule = {
           if (width >= threshold) {
             context.report({
               node: property,
-              message: `Thick one-sided border (${BORDER_SIDE_KEYS[key]}: ${width}px) — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it`,
+              message: `Thick one-sided border (${sideLabel}: ${width}px) — the most recognizable tell of AI-generated UIs. Use a subtler accent or remove it`,
             });
           }
         }

--- a/packages/react-doctor/src/plugin/rules/react-native.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native.ts
@@ -96,7 +96,7 @@ export const rnNoDeprecatedModules: Rule = {
         const importedName = specifier.imported?.name;
         if (!importedName) continue;
 
-        const replacement = DEPRECATED_RN_MODULE_REPLACEMENTS[importedName];
+        const replacement = DEPRECATED_RN_MODULE_REPLACEMENTS.get(importedName);
         if (!replacement) continue;
 
         context.report({
@@ -114,7 +114,7 @@ export const rnNoLegacyExpoPackages: Rule = {
       const source = node.source?.value;
       if (typeof source !== "string") return;
 
-      for (const [packageName, replacement] of Object.entries(LEGACY_EXPO_PACKAGE_REPLACEMENTS)) {
+      for (const [packageName, replacement] of LEGACY_EXPO_PACKAGE_REPLACEMENTS) {
         if (source === packageName || source.startsWith(`${packageName}/`)) {
           context.report({
             node,

--- a/packages/react-doctor/src/plugin/rules/react-ui.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui.ts
@@ -11,6 +11,7 @@ import {
   SIZE_WIDTH_AXIS_PATTERN,
   SPACE_AXIS_PATTERN,
   TAILWIND_DEFAULT_PALETTE_NAMES,
+  TAILWIND_DEFAULT_PALETTE_STOPS,
   TAILWIND_PALETTE_UTILITY_PREFIXES,
   TRAILING_THREE_PERIOD_ELLIPSIS_PATTERN,
   VAGUE_BUTTON_LABELS,
@@ -301,12 +302,18 @@ export const noThreePeriodEllipsis: Rule = {
 const buildDefaultPaletteRegex = (): RegExp => {
   const utilityPrefixGroup = TAILWIND_PALETTE_UTILITY_PREFIXES.join("|");
   const paletteNameGroup = TAILWIND_DEFAULT_PALETTE_NAMES.join("|");
+  // HACK: anchor the numeric group to the actual Tailwind palette stops
+  // rather than `\d{2,3}`. Custom Tailwind themes that re-purpose the
+  // utility prefix for a non-Tailwind scale (e.g. Radix Colors uses
+  // `gray.1` … `gray.12`) would otherwise false-positive on `text-gray-11`,
+  // `fill-gray-12`, etc. — those aren't the Tailwind template default.
+  const paletteStopGroup = TAILWIND_DEFAULT_PALETTE_STOPS.join("|");
   // HACK: /g so we can iterate every default-palette token in one
   // className. Without /g the user fixes one token, re-runs, sees the
   // next, fixes that, re-runs… N round-trips for N tokens in a single
   // attribute.
   return new RegExp(
-    `(?:^|\\s|:)(${utilityPrefixGroup})-(${paletteNameGroup})-(\\d{2,3})(?=$|[\\s:/])`,
+    `(?:^|\\s|:)(${utilityPrefixGroup})-(${paletteNameGroup})-(${paletteStopGroup})(?=$|[\\s:/])`,
     "g",
   );
 };

--- a/packages/react-doctor/src/plugin/rules/state-and-effects.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects.ts
@@ -2124,11 +2124,33 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   if (callback.body?.type !== "BlockStatement") {
     return isSubscribeLikeCallExpression(callback.body);
   }
-  const statements = callback.body.body ?? [];
-  const lastStatement = statements[statements.length - 1];
-  if (lastStatement?.type !== "ReturnStatement") return false;
   const knownBoundReleaseNames = collectReleasableBindingNames(callback);
-  return isCleanupReturn(lastStatement.argument, knownBoundReleaseNames);
+  // HACK: scan ALL `return` statements at the effect's own function
+  // scope (skipping nested functions via `walkInsideStatementBlocks`),
+  // not just the top-level last statement. The last-statement check
+  // false-positives on the very common conditional-cleanup shape:
+  //
+  //   useEffect(() => {
+  //     if (!enabled) return;
+  //     const sub = subscribe(...);
+  //     if (someCondition) {
+  //       return () => sub();
+  //     }
+  //   }, [enabled]);
+  //
+  // Either accept the conditional cleanup as intentional, or risk
+  // ~36% FPs on real codebases (measured: react-grab, excalidraw,
+  // textarea/popover patterns). Accepting nested cleanup mirrors how
+  // exhaustive-deps treats branched returns: trust the author.
+  let didFindCleanupReturn = false;
+  walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
+    if (didFindCleanupReturn) return;
+    if (child.type !== "ReturnStatement") return;
+    if (isCleanupReturn(child.argument, knownBoundReleaseNames)) {
+      didFindCleanupReturn = true;
+    }
+  });
+  return didFindCleanupReturn;
 };
 
 export const effectNeedsCleanup: Rule = {

--- a/packages/react-doctor/src/utils/can-oxlint-extend-config.ts
+++ b/packages/react-doctor/src/utils/can-oxlint-extend-config.ts
@@ -80,16 +80,21 @@ const parseJsonOrJsonc = (raw: string): unknown => {
 // adopt it — drop it from the extends list silently. Configs with no
 // `extends`, or with at least one local path, still go through (oxlint
 // can resolve local extends and tolerate unknown rules within them).
+const isPlainObject = (value: unknown): value is PartialEslintConfig =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 export const canOxlintExtendConfig = (configPath: string): boolean => {
   if (!configPath.endsWith(".eslintrc.json")) return true;
 
-  let parsed: PartialEslintConfig;
+  let parsed: unknown;
   try {
     const raw = fs.readFileSync(configPath, "utf-8");
-    parsed = parseJsonOrJsonc(raw) as PartialEslintConfig;
+    parsed = parseJsonOrJsonc(raw);
   } catch {
     return true;
   }
+
+  if (!isPlainObject(parsed)) return true;
 
   const extendsValue = parsed.extends;
   if (extendsValue === undefined || extendsValue === null) return true;

--- a/packages/react-doctor/src/utils/can-oxlint-extend-config.ts
+++ b/packages/react-doctor/src/utils/can-oxlint-extend-config.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+
+interface PartialEslintConfig {
+  extends?: unknown;
+}
+
+const EXTENDS_LOCAL_PATH_PREFIXES = ["./", "../", "/"];
+
+const isLocalPathExtend = (entry: string): boolean => {
+  for (const prefix of EXTENDS_LOCAL_PATH_PREFIXES) {
+    if (entry.startsWith(prefix)) return true;
+  }
+  return false;
+};
+
+// HACK: ESLint's JSON config files in the wild are routinely JSONC —
+// `//` line comments and `/* */` block comments. Strict `JSON.parse`
+// throws on them. Strip both forms (avoiding matches inside string
+// literals) so the extends pre-screen still works on real Next.js /
+// CRA / TypeScript scaffolds.
+const stripJsoncComments = (raw: string): string => {
+  let result = "";
+  let cursor = 0;
+  let inString = false;
+  let stringQuote = "";
+  while (cursor < raw.length) {
+    const character = raw[cursor];
+    const nextCharacter = raw[cursor + 1];
+    if (inString) {
+      result += character;
+      if (character === "\\" && cursor + 1 < raw.length) {
+        result += nextCharacter;
+        cursor += 2;
+        continue;
+      }
+      if (character === stringQuote) inString = false;
+      cursor += 1;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      inString = true;
+      stringQuote = character;
+      result += character;
+      cursor += 1;
+      continue;
+    }
+    if (character === "/" && nextCharacter === "/") {
+      const lineEndIndex = raw.indexOf("\n", cursor);
+      cursor = lineEndIndex === -1 ? raw.length : lineEndIndex;
+      continue;
+    }
+    if (character === "/" && nextCharacter === "*") {
+      const blockEndIndex = raw.indexOf("*/", cursor + 2);
+      cursor = blockEndIndex === -1 ? raw.length : blockEndIndex + 2;
+      continue;
+    }
+    result += character;
+    cursor += 1;
+  }
+  return result;
+};
+
+const parseJsonOrJsonc = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return JSON.parse(stripJsoncComments(raw));
+  }
+};
+
+// HACK: oxlint's `extends` resolver only handles local file paths and
+// other oxlint configs — bare-package extends (`"next"`, `"airbnb"`,
+// `"plugin:@typescript-eslint/recommended"`) crash the parser with
+// "Failed to parse oxlint configuration file". The crash drops every
+// adopted rule AND emits a misleading stderr warning that suggests the
+// user's ESLint config is broken when it's just incompatible-by-design.
+//
+// We pre-screen the file: if it's an `.eslintrc.json` whose `extends`
+// is non-empty and contains ONLY bare-package references, oxlint can't
+// adopt it — drop it from the extends list silently. Configs with no
+// `extends`, or with at least one local path, still go through (oxlint
+// can resolve local extends and tolerate unknown rules within them).
+export const canOxlintExtendConfig = (configPath: string): boolean => {
+  if (!configPath.endsWith(".eslintrc.json")) return true;
+
+  let parsed: PartialEslintConfig;
+  try {
+    const raw = fs.readFileSync(configPath, "utf-8");
+    parsed = parseJsonOrJsonc(raw) as PartialEslintConfig;
+  } catch {
+    return true;
+  }
+
+  const extendsValue = parsed.extends;
+  if (extendsValue === undefined || extendsValue === null) return true;
+
+  const extendsEntries = Array.isArray(extendsValue) ? extendsValue : [extendsValue];
+  if (extendsEntries.length === 0) return true;
+
+  const hasAnyLocalExtend = extendsEntries.some(
+    (entry) => typeof entry === "string" && isLocalPathExtend(entry),
+  );
+  return hasAnyLocalExtend;
+};

--- a/packages/react-doctor/src/utils/can-oxlint-extend-config.ts
+++ b/packages/react-doctor/src/utils/can-oxlint-extend-config.ts
@@ -1,8 +1,5 @@
 import fs from "node:fs";
-
-interface PartialEslintConfig {
-  extends?: unknown;
-}
+import { isPlainObject } from "./is-plain-object.js";
 
 const EXTENDS_LOCAL_PATH_PREFIXES = ["./", "../", "/"];
 
@@ -80,9 +77,6 @@ const parseJsonOrJsonc = (raw: string): unknown => {
 // adopt it — drop it from the extends list silently. Configs with no
 // `extends`, or with at least one local path, still go through (oxlint
 // can resolve local extends and tolerate unknown rules within them).
-const isPlainObject = (value: unknown): value is PartialEslintConfig =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 export const canOxlintExtendConfig = (configPath: string): boolean => {
   if (!configPath.endsWith(".eslintrc.json")) return true;
 

--- a/packages/react-doctor/src/utils/run-knip.ts
+++ b/packages/react-doctor/src/utils/run-knip.ts
@@ -18,12 +18,15 @@ interface KnipIssueDescriptor {
   severity: "error" | "warning";
 }
 
-const KNIP_ISSUE_TYPE_DESCRIPTORS: Record<string, KnipIssueDescriptor> = {
-  files: { category: "Dead Code", message: "Unused file", severity: "warning" },
-  exports: { category: "Dead Code", message: "Unused export", severity: "warning" },
-  types: { category: "Dead Code", message: "Unused type", severity: "warning" },
-  duplicates: { category: "Dead Code", message: "Duplicate export", severity: "warning" },
-};
+// HACK: Map (not plain object) so an unexpected `issueType` of
+// `"constructor"`, `"toString"`, etc. doesn't fall through to a
+// `Object.prototype.X` value and bypass the FALLBACK_KNIP_DESCRIPTOR.
+const KNIP_ISSUE_TYPE_DESCRIPTORS = new Map<string, KnipIssueDescriptor>([
+  ["files", { category: "Dead Code", message: "Unused file", severity: "warning" }],
+  ["exports", { category: "Dead Code", message: "Unused export", severity: "warning" }],
+  ["types", { category: "Dead Code", message: "Unused type", severity: "warning" }],
+  ["duplicates", { category: "Dead Code", message: "Duplicate export", severity: "warning" }],
+]);
 
 const FALLBACK_KNIP_DESCRIPTOR: KnipIssueDescriptor = {
   category: "Dead Code",
@@ -36,7 +39,7 @@ const collectIssueRecords = (
   issueType: string,
   rootDirectory: string,
 ): Diagnostic[] => {
-  const descriptor = KNIP_ISSUE_TYPE_DESCRIPTORS[issueType] ?? FALLBACK_KNIP_DESCRIPTOR;
+  const descriptor = KNIP_ISSUE_TYPE_DESCRIPTORS.get(issueType) ?? FALLBACK_KNIP_DESCRIPTOR;
   const diagnostics: Diagnostic[] = [];
 
   for (const issues of Object.values(records)) {
@@ -177,7 +180,7 @@ export const runKnip = async (rootDirectory: string): Promise<Diagnostic[]> => {
   const { issues } = knipResult;
   const diagnostics: Diagnostic[] = [];
 
-  const filesDescriptor = KNIP_ISSUE_TYPE_DESCRIPTORS.files;
+  const filesDescriptor = KNIP_ISSUE_TYPE_DESCRIPTORS.get("files") ?? FALLBACK_KNIP_DESCRIPTOR;
   for (const unusedFilePath of collectUnusedFilePaths(issues.files)) {
     diagnostics.push({
       filePath: path.relative(rootDirectory, unusedFilePath),

--- a/packages/react-doctor/src/utils/run-knip.ts
+++ b/packages/react-doctor/src/utils/run-knip.ts
@@ -98,7 +98,11 @@ const tryDisableFailedPlugin = (
   disabledPlugins: Set<string>,
 ): boolean => {
   const failedPlugin = extractFailedPluginName(error);
-  if (!failedPlugin || !(failedPlugin in parsedConfig) || disabledPlugins.has(failedPlugin)) {
+  if (
+    !failedPlugin ||
+    !Object.hasOwn(parsedConfig, failedPlugin) ||
+    disabledPlugins.has(failedPlugin)
+  ) {
     return false;
   }
   disabledPlugins.add(failedPlugin);

--- a/packages/react-doctor/src/utils/run-oxlint.ts
+++ b/packages/react-doctor/src/utils/run-oxlint.ts
@@ -10,6 +10,7 @@ import {
   SOURCE_FILE_PATTERN,
 } from "../constants.js";
 import { batchIncludePaths } from "./batch-include-paths.js";
+import { canOxlintExtendConfig } from "./can-oxlint-extend-config.js";
 import { collectIgnorePatterns } from "./collect-ignore-patterns.js";
 import { detectUserLintConfigPaths } from "./detect-user-lint-config.js";
 import { ALL_REACT_DOCTOR_RULE_KEYS, createOxlintConfig } from "../oxlint-config.js";
@@ -622,6 +623,15 @@ const FILEPATH_WITH_LOCATION_PATTERN = /\S+\.\w+:\d+:\d+[\s\S]*$/;
 
 const REACT_COMPILER_MESSAGE = "React Compiler can't optimize this code";
 
+// HACK: `Object.hasOwn` guards against falling through to
+// `Object.prototype` when oxlint emits a rule whose name happens to
+// shadow a base Object property (`constructor`, `toString`, …). Without
+// the guard the rule's help text would render as
+// `function Object() { [native code] }`. Same defense applied to the
+// plugin-/rule-category lookups below.
+const lookupOwnString = (record: Record<string, string>, key: string): string | undefined =>
+  Object.hasOwn(record, key) ? record[key] : undefined;
+
 const cleanDiagnosticMessage = (
   message: string,
   help: string,
@@ -633,7 +643,7 @@ const cleanDiagnosticMessage = (
     return { message: REACT_COMPILER_MESSAGE, help: rawMessage || help };
   }
   const cleaned = message.replace(FILEPATH_WITH_LOCATION_PATTERN, "").trim();
-  return { message: cleaned || message, help: help || RULE_HELP_MAP[rule] || "" };
+  return { message: cleaned || message, help: help || lookupOwnString(RULE_HELP_MAP, rule) || "" };
 };
 
 const parseRuleCode = (code: string): { plugin: string; rule: string } => {
@@ -661,7 +671,11 @@ const resolvePluginPath = (): string => {
 
 const resolveDiagnosticCategory = (plugin: string, rule: string): string => {
   const ruleKey = `${plugin}/${rule}`;
-  return RULE_CATEGORY_MAP[ruleKey] ?? PLUGIN_CATEGORY_MAP[plugin] ?? "Other";
+  return (
+    lookupOwnString(RULE_CATEGORY_MAP, ruleKey) ??
+    lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ??
+    "Other"
+  );
 };
 
 // HACK: Sanitize child env so a developer's NODE_OPTIONS=--inspect (or
@@ -849,12 +863,14 @@ interface RunOxlintOptions {
   /**
    * Major version of React detected for the project. Forwarded to
    * `createOxlintConfig`, which gates rules directionally:
-   *   - `"deprecation-warning"` rules (e.g. `no-default-props`) stay
-   *     enabled when this is `null` so mid-migration projects still
-   *     get the warning even if version detection failed.
+   *   - `"deprecation-warning"` rules (e.g. `no-default-props`) fire on
+   *     every detected major — the audience that still allows the
+   *     pattern is the one planning the upgrade.
    *   - `"prefer-newer-api"` rules (e.g. `prefer-use-effect-event`) are
-   *     skipped when this is `null` to avoid recommending APIs that
-   *     may not exist in the consumer's React version.
+   *     skipped when this is a known major below the rule's minimum.
+   * When this is `null` (version detection failed) we optimistically
+   * apply EVERY rule, treating the project as if it were on the latest
+   * React major.
    */
   reactMajorVersion?: number | null;
   includePaths?: string[];
@@ -943,8 +959,15 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   // accepts them and they're stable across runtimes. We skip extends
   // entirely under `customRulesOnly` because that mode opts out of
   // every rule outside the react-doctor plugin.
-  const extendsPaths =
+  const detectedConfigPaths =
     adoptExistingLintConfig && !customRulesOnly ? detectUserLintConfigPaths(rootDirectory) : [];
+  // HACK: filter out `.eslintrc.json` files whose `extends` lists only
+  // bare-package refs (`"next"`, `"airbnb"`, `"plugin:foo/bar"`). oxlint's
+  // resolver can't follow those — adopting them guarantees the parser
+  // crash + misleading "could not adopt existing lint config" warning.
+  // Drop them up front so the scan starts in the same state the fallback
+  // would land in, with no stderr noise.
+  const extendsPaths = detectedConfigPaths.filter(canOxlintExtendConfig);
   const config = createOxlintConfig({
     pluginPath,
     framework,

--- a/packages/react-doctor/src/utils/run-oxlint.ts
+++ b/packages/react-doctor/src/utils/run-oxlint.ts
@@ -903,10 +903,10 @@ const validateRuleRegistration = (): void => {
   const missingCategory: string[] = [];
   for (const fullKey of ALL_REACT_DOCTOR_RULE_KEYS) {
     const ruleName = fullKey.replace(/^react-doctor\//, "");
-    if (!(fullKey in RULE_CATEGORY_MAP)) {
+    if (!Object.hasOwn(RULE_CATEGORY_MAP, fullKey)) {
       missingCategory.push(fullKey);
     }
-    if (!(ruleName in RULE_HELP_MAP)) {
+    if (!Object.hasOwn(RULE_HELP_MAP, ruleName)) {
       missingHelp.push(fullKey);
     }
   }

--- a/packages/react-doctor/tests/can-oxlint-extend-config.test.ts
+++ b/packages/react-doctor/tests/can-oxlint-extend-config.test.ts
@@ -70,6 +70,17 @@ describe("canOxlintExtendConfig", () => {
     expect(canOxlintExtendConfig(eslintrcPath)).toBe(true);
   });
 
+  // HACK: regression for the null-safety bug — `JSON.parse("null")` returns
+  // a literal null and `parsed.extends` would have thrown a TypeError that
+  // propagates out of the pre-screen entirely.
+  it("returns true on non-object JSON (null, array, primitive)", () => {
+    for (const payload of ["null", "[]", "42", '"a string"']) {
+      const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+      fs.writeFileSync(eslintrcPath, payload);
+      expect(canOxlintExtendConfig(eslintrcPath)).toBe(true);
+    }
+  });
+
   // HACK: real-world ESLint configs are routinely JSONC. Strict
   // `JSON.parse` would throw on `// commented out option` and the
   // pre-screen would fall through to "let oxlint try" — the exact

--- a/packages/react-doctor/tests/can-oxlint-extend-config.test.ts
+++ b/packages/react-doctor/tests/can-oxlint-extend-config.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { canOxlintExtendConfig } from "../src/utils/can-oxlint-extend-config.js";
+
+let temporaryDirectory: string;
+
+const writeJson = (targetPath: string, payload: object): void => {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, JSON.stringify(payload));
+};
+
+beforeEach(() => {
+  temporaryDirectory = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "rd-can-extend-")));
+});
+
+afterEach(() => {
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+describe("canOxlintExtendConfig", () => {
+  it("always returns true for .oxlintrc.json (oxlint-native)", () => {
+    const oxlintrcPath = path.join(temporaryDirectory, ".oxlintrc.json");
+    writeJson(oxlintrcPath, { extends: ["next"] });
+    expect(canOxlintExtendConfig(oxlintrcPath)).toBe(true);
+  });
+
+  it("returns true for an .eslintrc.json without extends", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    writeJson(eslintrcPath, { rules: { "no-debugger": "error" } });
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(true);
+  });
+
+  it("returns true for an .eslintrc.json with empty extends", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    writeJson(eslintrcPath, { extends: [] });
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(true);
+  });
+
+  it("returns false for an .eslintrc.json with only bare-package extends (Next.js style)", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    writeJson(eslintrcPath, { extends: ["next/core-web-vitals", "prettier"] });
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(false);
+  });
+
+  it("returns false for an .eslintrc.json with only plugin: extends", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    writeJson(eslintrcPath, {
+      extends: ["plugin:@typescript-eslint/recommended", "plugin:react/recommended"],
+    });
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(false);
+  });
+
+  it("returns false for a single-string bare-package extends", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    writeJson(eslintrcPath, { extends: "next" });
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(false);
+  });
+
+  it("returns true when at least one extends entry is a local path", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    writeJson(eslintrcPath, { extends: ["next", "./shared/eslint.json"] });
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(true);
+  });
+
+  it("returns true on malformed JSON (let oxlint surface the real error)", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    fs.writeFileSync(eslintrcPath, "{ this is not json");
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(true);
+  });
+
+  // HACK: real-world ESLint configs are routinely JSONC. Strict
+  // `JSON.parse` would throw on `// commented out option` and the
+  // pre-screen would fall through to "let oxlint try" — the exact
+  // misleading-warning path we're trying to avoid.
+  it("handles `//` line comments inside .eslintrc.json (JSONC)", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    fs.writeFileSync(
+      eslintrcPath,
+      `{
+  // pin to next preset for app router
+  "extends": ["next", "plugin:@typescript-eslint/recommended"],
+  "rules": {
+    // "off-for-now": "off"
+  }
+}
+`,
+    );
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(false);
+  });
+
+  it("handles `/* */` block comments inside .eslintrc.json (JSONC)", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    fs.writeFileSync(
+      eslintrcPath,
+      `{
+  /* multi-line
+     comment */
+  "extends": ["next"]
+}
+`,
+    );
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(false);
+  });
+
+  it("does not strip `//` sequences inside string values", () => {
+    const eslintrcPath = path.join(temporaryDirectory, ".eslintrc.json");
+    fs.writeFileSync(
+      eslintrcPath,
+      `{
+  "extends": ["./shared//slashy-but-still-local.json"]
+}
+`,
+    );
+    expect(canOxlintExtendConfig(eslintrcPath)).toBe(true);
+  });
+});

--- a/packages/react-doctor/tests/diagnose.test.ts
+++ b/packages/react-doctor/tests/diagnose.test.ts
@@ -44,14 +44,13 @@ export const Debounced = ({ onChange }: { onChange: (value: string) => void }) =
     expect(preferUseEffectEventHits.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("skips prefer-use-effect-event when the project's React version cannot be resolved (no react dep)", async () => {
-    // Symmetric guard: when the project has no React dependency the
-    // function throws before lint runs, so we synthesize a project
-    // with an unresolvable React version range. Its major can't be
-    // parsed, so `parseReactMajor` returns null and the prefer-newer-
-    // api rule should be skipped pessimistically — confirming the
-    // forward really is honoring the version-gate boundary.
-    const projectDir = setupReactProject(tempRoot, "diagnose-prefer-use-effect-event-skipped", {
+  it("STILL emits prefer-use-effect-event when the React version cannot be resolved (assume latest)", async () => {
+    // When the React major can't be parsed (custom resolver, git URL,
+    // workspace:* without a resolved manifest) we optimistically assume
+    // the latest React major and apply every rule, including the
+    // `prefer-newer-api` ones. Hiding the suggestion would silently
+    // degrade the scan whenever React resolves through an unusual path.
+    const projectDir = setupReactProject(tempRoot, "diagnose-prefer-use-effect-event-fallback", {
       reactVersion: "github:facebook/react",
       files: {
         "src/Debounced.tsx": `import { useEffect, useState } from "react";
@@ -72,6 +71,6 @@ export const Debounced = ({ onChange }: { onChange: (value: string) => void }) =
     const preferUseEffectEventHits = result.diagnostics.filter(
       (diagnostic) => diagnostic.rule === "prefer-use-effect-event",
     );
-    expect(preferUseEffectEventHits).toHaveLength(0);
+    expect(preferUseEffectEventHits.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/react-doctor/tests/regressions/_helpers.ts
+++ b/packages/react-doctor/tests/regressions/_helpers.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { runOxlint } from "../../src/utils/run-oxlint.js";
 import type { Diagnostic } from "../../src/types.js";
 
 export const writeFile = (filePath: string, contents: string): void => {
@@ -81,4 +82,43 @@ export const setupReactProject = (
     writeFile(path.join(projectDir, relativePath), content);
   }
   return projectDir;
+};
+
+export interface CollectRuleHitsOptions {
+  /** React major to forward to runOxlint (default: 19). Pass null to test the unresolvable-version path. */
+  reactMajorVersion?: number | null;
+  /** Project framework hint (default: "unknown"). Set to "react-native" for RN-only rules. */
+  framework?: "unknown" | "react-native";
+  hasReactCompiler?: boolean;
+  hasTanStackQuery?: boolean;
+}
+
+export interface RuleHit {
+  filePath: string;
+  message: string;
+}
+
+// Replaces the five near-identical `collectRuleHits` helpers that each
+// regression suite previously declared at the top of the file. Defaults
+// match the most common shape (React 19, framework="unknown"); pass an
+// options bag to override per-test.
+export const collectRuleHits = async (
+  projectDir: string,
+  ruleId: string,
+  options: CollectRuleHitsOptions = {},
+): Promise<RuleHit[]> => {
+  const diagnostics = await runOxlint({
+    rootDirectory: projectDir,
+    hasTypeScript: true,
+    framework: options.framework ?? "unknown",
+    hasReactCompiler: options.hasReactCompiler ?? false,
+    hasTanStackQuery: options.hasTanStackQuery ?? false,
+    reactMajorVersion: options.reactMajorVersion ?? 19,
+  });
+  return diagnostics
+    .filter((diagnostic) => diagnostic.rule === ruleId)
+    .map((diagnostic) => ({
+      filePath: diagnostic.filePath,
+      message: diagnostic.message,
+    }));
 };

--- a/packages/react-doctor/tests/regressions/_helpers.ts
+++ b/packages/react-doctor/tests/regressions/_helpers.ts
@@ -102,18 +102,27 @@ export interface RuleHit {
 // regression suite previously declared at the top of the file. Defaults
 // match the most common shape (React 19, framework="unknown"); pass an
 // options bag to override per-test.
+//
+// HACK: distinguish "caller didn't pass `reactMajorVersion`" (omit → 19,
+// the synthetic project's actual React version) from "caller explicitly
+// passed `null`" (testing the unresolvable-version code path). A naive
+// `options.reactMajorVersion ?? 19` collapses both into 19 and silently
+// changes what null-version tests are testing.
 export const collectRuleHits = async (
   projectDir: string,
   ruleId: string,
   options: CollectRuleHitsOptions = {},
 ): Promise<RuleHit[]> => {
+  const reactMajorVersion = Object.hasOwn(options, "reactMajorVersion")
+    ? options.reactMajorVersion
+    : 19;
   const diagnostics = await runOxlint({
     rootDirectory: projectDir,
     hasTypeScript: true,
     framework: options.framework ?? "unknown",
     hasReactCompiler: options.hasReactCompiler ?? false,
     hasTanStackQuery: options.hasTanStackQuery ?? false,
-    reactMajorVersion: options.reactMajorVersion ?? 19,
+    reactMajorVersion,
   });
   return diagnostics
     .filter((diagnostic) => diagnostic.rule === ruleId)

--- a/packages/react-doctor/tests/regressions/prop-stack-barrier.test.ts
+++ b/packages/react-doctor/tests/regressions/prop-stack-barrier.test.ts
@@ -18,34 +18,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 
-import { runOxlint } from "../../src/utils/run-oxlint.js";
-import { setupReactProject } from "./_helpers.js";
+import { collectRuleHits, setupReactProject } from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-prop-stack-barrier-"));
 
 afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
-
-const collectRuleHits = async (
-  projectDir: string,
-  ruleId: string,
-): Promise<Array<{ filePath: string; message: string }>> => {
-  const diagnostics = await runOxlint({
-    rootDirectory: projectDir,
-    hasTypeScript: true,
-    framework: "unknown",
-    hasReactCompiler: false,
-    hasTanStackQuery: false,
-    reactMajorVersion: 19,
-  });
-  return diagnostics
-    .filter((diagnostic) => diagnostic.rule === ruleId)
-    .map((diagnostic) => ({
-      filePath: diagnostic.filePath,
-      message: diagnostic.message,
-    }));
-};
 
 describe("no-derived-useState — empty-frame barrier", () => {
   it("flags `useState(value)` when `value` is a real prop of the current component", async () => {

--- a/packages/react-doctor/tests/regressions/proto-pollution-defenses.test.ts
+++ b/packages/react-doctor/tests/regressions/proto-pollution-defenses.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression tests for the prototype-pollution defenses added to every
+ * rule that does `OBJECT[someAstName]` lookups.
+ *
+ * The original blocker hit was `no-legacy-class-lifecycles` flagging
+ * EVERY `class { constructor() {} }` because
+ * `LEGACY_LIFECYCLE_REPLACEMENTS["constructor"]` falls through to
+ * `Object.prototype.constructor` (the native `Object` function — truthy,
+ * bypassing the `if (!replacement)` guard). The same shape exists in:
+ *   - `rn-no-deprecated-modules` (Map of imported names -> replacement)
+ *   - `no-side-tab-border` (Map of border CSS keys -> side label)
+ *   - `no-prevent-default` (Map of JSX tag name -> event prop list)
+ *
+ * Each rule is now backed by a `Map.get()` lookup so the prototype chain
+ * can never leak through. These tests pin the defense.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { runOxlint } from "../../src/utils/run-oxlint.js";
+import { setupReactProject } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-proto-defenses-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const collectRuleHits = async (
+  projectDir: string,
+  ruleId: string,
+  framework: "unknown" | "react-native" = "unknown",
+): Promise<Array<{ filePath: string; message: string }>> => {
+  const diagnostics = await runOxlint({
+    rootDirectory: projectDir,
+    hasTypeScript: true,
+    framework,
+    hasReactCompiler: false,
+    hasTanStackQuery: false,
+    reactMajorVersion: 19,
+  });
+  return diagnostics
+    .filter((diagnostic) => diagnostic.rule === ruleId)
+    .map((diagnostic) => ({
+      filePath: diagnostic.filePath,
+      message: diagnostic.message,
+    }));
+};
+
+describe("rn-no-deprecated-modules — prototype-pollution defense", () => {
+  it("does NOT flag `import { constructor } from 'react-native'` (or other Object.prototype names)", async () => {
+    const projectDir = setupReactProject(tempRoot, "rn-deprecated-proto-import", {
+      files: {
+        "src/index.ts": `import { constructor, toString, hasOwnProperty } from "react-native";
+
+void constructor;
+void toString;
+void hasOwnProperty;
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "rn-no-deprecated-modules", "react-native");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("STILL flags a real removed RN export (`AsyncStorage`)", async () => {
+    const projectDir = setupReactProject(tempRoot, "rn-deprecated-real-hit", {
+      files: {
+        "src/index.ts": `import { AsyncStorage } from "react-native";
+
+void AsyncStorage;
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "rn-no-deprecated-modules", "react-native");
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+    expect(hits[0].message).toContain("AsyncStorage");
+  });
+});
+
+describe("no-prevent-default — prototype-pollution defense", () => {
+  it("does NOT flag a JSX tag whose name shadows an Object.prototype property", async () => {
+    const projectDir = setupReactProject(tempRoot, "prevent-default-proto-tag", {
+      files: {
+        "src/Custom.tsx": `export const Custom = () => (
+  // @ts-expect-error custom intrinsic with a clashing name
+  <constructor onSubmit={(event) => { event.preventDefault(); }} />
+);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prevent-default");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("STILL flags preventDefault on a real `<form>` onSubmit handler", async () => {
+    const projectDir = setupReactProject(tempRoot, "prevent-default-real-form", {
+      files: {
+        "src/SignUp.tsx": `export const SignUp = () => (
+  <form onSubmit={(event) => { event.preventDefault(); }}>
+    <input />
+  </form>
+);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prevent-default");
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("no-side-tab-border — prototype-pollution defense", () => {
+  it("does NOT flag an inline-style key whose name shadows an Object.prototype property", async () => {
+    const projectDir = setupReactProject(tempRoot, "side-tab-border-proto-key", {
+      files: {
+        "src/Card.tsx": `export const Card = () => (
+  <div style={{ constructor: "4px solid red", toString: "blue" } as any} />
+);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-side-tab-border");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("STILL flags a real `borderLeft: 4px solid` style", async () => {
+    const projectDir = setupReactProject(tempRoot, "side-tab-border-real", {
+      files: {
+        "src/Card.tsx": `export const Card = () => (
+  <div style={{ borderLeft: "4px solid #00f" }} />
+);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-side-tab-border");
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/react-doctor/tests/regressions/proto-pollution-defenses.test.ts
+++ b/packages/react-doctor/tests/regressions/proto-pollution-defenses.test.ts
@@ -19,35 +19,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
-import { runOxlint } from "../../src/utils/run-oxlint.js";
-import { setupReactProject } from "./_helpers.js";
+import { collectRuleHits, setupReactProject } from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-proto-defenses-"));
 
 afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
-
-const collectRuleHits = async (
-  projectDir: string,
-  ruleId: string,
-  framework: "unknown" | "react-native" = "unknown",
-): Promise<Array<{ filePath: string; message: string }>> => {
-  const diagnostics = await runOxlint({
-    rootDirectory: projectDir,
-    hasTypeScript: true,
-    framework,
-    hasReactCompiler: false,
-    hasTanStackQuery: false,
-    reactMajorVersion: 19,
-  });
-  return diagnostics
-    .filter((diagnostic) => diagnostic.rule === ruleId)
-    .map((diagnostic) => ({
-      filePath: diagnostic.filePath,
-      message: diagnostic.message,
-    }));
-};
 
 describe("rn-no-deprecated-modules — prototype-pollution defense", () => {
   it("does NOT flag `import { constructor } from 'react-native'` (or other Object.prototype names)", async () => {
@@ -62,7 +40,9 @@ void hasOwnProperty;
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "rn-no-deprecated-modules", "react-native");
+    const hits = await collectRuleHits(projectDir, "rn-no-deprecated-modules", {
+      framework: "react-native",
+    });
     expect(hits).toHaveLength(0);
   });
 
@@ -76,7 +56,9 @@ void AsyncStorage;
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "rn-no-deprecated-modules", "react-native");
+    const hits = await collectRuleHits(projectDir, "rn-no-deprecated-modules", {
+      framework: "react-native",
+    });
     expect(hits.length).toBeGreaterThanOrEqual(1);
     expect(hits[0].message).toContain("AsyncStorage");
   });

--- a/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
@@ -184,6 +184,51 @@ export function componentWillReceiveProps() {}
     const hits = await collectRuleHits(projectDir, "no-legacy-class-lifecycles");
     expect(hits).toHaveLength(0);
   });
+
+  // HACK: regression for the prototype-pollution false positive.
+  // Plain-object lookups (`messages["constructor"]`) inherit from
+  // `Object.prototype`, so `replacement` was the native Object function
+  // (truthy). Every Lexical/MobX/Three.js/etc. class with a `constructor`
+  // fired with a message ending in `function Object() { [native code] }`.
+  it("does not flag a plain `constructor` (Lexical-style class with no React lifecycles)", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-legacy-class-lifecycles-ctor", {
+      files: {
+        "src/lexical-node.ts": `import { TextNode } from "lexical";
+
+export class AutocompleteSuggestionNode extends TextNode {
+  __suggestion: string;
+
+  constructor(suggestion: string, key?: string) {
+    super(suggestion, key);
+    this.__suggestion = suggestion;
+  }
+}
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-legacy-class-lifecycles");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag class members named after Object.prototype properties (toString, hasOwnProperty, etc.)", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-legacy-class-lifecycles-proto-names", {
+      files: {
+        "src/Custom.tsx": `import React from "react";
+
+export class Custom extends React.Component<{}, {}> {
+  toString() { return "Custom"; }
+  hasOwnProperty(key: string) { return key === "x"; }
+  valueOf() { return 0; }
+  render() { return null; }
+}
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-legacy-class-lifecycles");
+    expect(hits).toHaveLength(0);
+  });
 });
 
 describe("no-legacy-context-api", () => {
@@ -324,7 +369,13 @@ export { config };
 });
 
 describe("version gating", () => {
-  it("does NOT flag forwardRef on React 18 projects", async () => {
+  // HACK: deprecation-warning rules fire on every detected React major.
+  // The audience that benefits MOST is the version that still allows
+  // the pattern (R18 users planning the React 19 upgrade) — silencing
+  // the rule on R17/18 lost ~1.1k diagnostics on real projects between
+  // 0.0.47 and HEAD. The rule's message names the breaking version so
+  // users on older Reacts can prioritize the warning appropriately.
+  it("DOES flag forwardRef on React 18 projects (deprecation-warning, fail open)", async () => {
     const projectDir = setupReactProject(tempRoot, "gating-r18-forwardRef", {
       reactVersion: "^18.3.1",
       files: {
@@ -338,7 +389,7 @@ export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
     });
 
     const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", 18);
-    expect(hits).toHaveLength(0);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
   it("DOES flag forwardRef on React 19 projects", async () => {
@@ -357,7 +408,26 @@ export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("does NOT flag Foo.defaultProps on React 18 projects", async () => {
+  // HACK: regression for the prototype-pollution sibling of the
+  // `constructor` FP. `messages[importedName]` previously fell through
+  // to `Object.prototype.toString` etc. when the user imported (or member-
+  // accessed) a name shared with a base Object property.
+  it("does NOT flag React.toString() / React.hasOwnProperty (prototype-name member access)", async () => {
+    const projectDir = setupReactProject(tempRoot, "deprecated-apis-proto-names", {
+      files: {
+        "src/index.tsx": `import React from "react";
+
+export const debug = (): string => React.toString();
+export const has = (key: string): boolean => React.hasOwnProperty(key);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", 19);
+    expect(hits).toHaveLength(0);
+  });
+
+  it("DOES flag Foo.defaultProps on React 18 projects (deprecation-warning, fail open)", async () => {
     const projectDir = setupReactProject(tempRoot, "gating-r18-defaultProps", {
       reactVersion: "^18.3.1",
       files: {
@@ -368,10 +438,10 @@ Button.defaultProps = { size: "md" };
     });
 
     const hits = await collectRuleHits(projectDir, "no-default-props", 18);
-    expect(hits).toHaveLength(0);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("does NOT flag react-dom render on React 17 projects", async () => {
+  it("DOES flag react-dom render on React 17 projects (deprecation-warning, fail open)", async () => {
     const projectDir = setupReactProject(tempRoot, "gating-r17-render", {
       reactVersion: "^17.0.2",
       files: {
@@ -383,7 +453,7 @@ void render;
     });
 
     const hits = await collectRuleHits(projectDir, "no-react-dom-deprecated-apis", 17);
-    expect(hits).toHaveLength(0);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
   it("DOES flag react-dom render on React 18 projects (deprecated since 18)", async () => {
@@ -419,7 +489,7 @@ export class Legacy extends React.Component<{}, {}> {
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("leaves all rules enabled when the React version is unknown (null)", async () => {
+  it("leaves all rules enabled when the React version is unknown (null) — assumes latest", async () => {
     const projectDir = setupReactProject(tempRoot, "gating-null-defaultProps", {
       reactVersion: "*",
       files: {
@@ -430,6 +500,33 @@ Button.defaultProps = { size: "md" };
     });
 
     const hits = await collectRuleHits(projectDir, "no-default-props", null);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // HACK: complement to the deprecation-warning case — `prefer-newer-api`
+  // rules ALSO run when version detection fails, on the assumption that
+  // the user is on the latest React major. Custom resolvers, monorepo
+  // overrides, and `workspace:*` references commonly produce `null`, and
+  // hiding the suggestion silently degrades the scan in those setups.
+  it("DOES flag prefer-use-effect-event when the React version is unknown (null) — assumes latest", async () => {
+    const projectDir = setupReactProject(tempRoot, "gating-null-prefer-use-effect-event", {
+      reactVersion: "*",
+      files: {
+        "src/Search.tsx": `import { useEffect, useState } from "react";
+
+export const Search = ({ onChange }: { onChange: (value: string) => void }) => {
+  const [text, setText] = useState("");
+  useEffect(() => {
+    const id = setTimeout(() => onChange(text), 300);
+    return () => clearTimeout(id);
+  }, [text, onChange]);
+  return <input value={text} onChange={(event) => setText(event.target.value)} />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", null);
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
@@ -3,35 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 
-import { runOxlint } from "../../src/utils/run-oxlint.js";
-import { setupReactProject } from "./_helpers.js";
+import { collectRuleHits, setupReactProject } from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-react19-migration-"));
 
 afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
-
-const collectRuleHits = async (
-  projectDir: string,
-  ruleId: string,
-  reactMajorVersion: number | null = null,
-): Promise<Array<{ filePath: string; message: string }>> => {
-  const diagnostics = await runOxlint({
-    rootDirectory: projectDir,
-    hasTypeScript: true,
-    framework: "unknown",
-    hasReactCompiler: false,
-    hasTanStackQuery: false,
-    reactMajorVersion,
-  });
-  return diagnostics
-    .filter((diagnostic) => diagnostic.rule === ruleId)
-    .map((diagnostic) => ({
-      filePath: diagnostic.filePath,
-      message: diagnostic.message,
-    }));
-};
 
 describe("no-react-dom-deprecated-apis", () => {
   it("flags react-dom legacy root and rendering APIs imported by name", async () => {
@@ -388,7 +366,9 @@ export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", 18);
+    const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", {
+      reactMajorVersion: 18,
+    });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -404,7 +384,9 @@ export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", 19);
+    const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", {
+      reactMajorVersion: 19,
+    });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -423,7 +405,9 @@ export const has = (key: string): boolean => React.hasOwnProperty(key);
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", 19);
+    const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", {
+      reactMajorVersion: 19,
+    });
     expect(hits).toHaveLength(0);
   });
 
@@ -437,7 +421,7 @@ Button.defaultProps = { size: "md" };
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "no-default-props", 18);
+    const hits = await collectRuleHits(projectDir, "no-default-props", { reactMajorVersion: 18 });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -452,7 +436,9 @@ void render;
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "no-react-dom-deprecated-apis", 17);
+    const hits = await collectRuleHits(projectDir, "no-react-dom-deprecated-apis", {
+      reactMajorVersion: 17,
+    });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -467,7 +453,9 @@ void render;
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "no-react-dom-deprecated-apis", 18);
+    const hits = await collectRuleHits(projectDir, "no-react-dom-deprecated-apis", {
+      reactMajorVersion: 18,
+    });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -485,7 +473,9 @@ export class Legacy extends React.Component<{}, {}> {
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "no-legacy-class-lifecycles", 17);
+    const hits = await collectRuleHits(projectDir, "no-legacy-class-lifecycles", {
+      reactMajorVersion: 17,
+    });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -499,7 +489,7 @@ Button.defaultProps = { size: "md" };
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "no-default-props", null);
+    const hits = await collectRuleHits(projectDir, "no-default-props", { reactMajorVersion: null });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -526,7 +516,9 @@ export const Search = ({ onChange }: { onChange: (value: string) => void }) => {
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", null);
+    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", {
+      reactMajorVersion: null,
+    });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/react-doctor/tests/regressions/react-ui-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/react-ui-rules.test.ts
@@ -315,6 +315,29 @@ describe("design-no-default-tailwind-palette", () => {
     const hits = await collectRuleHits(projectDir, "design-no-default-tailwind-palette");
     expect(hits).toHaveLength(0);
   });
+
+  // HACK: regression for the over-broad `\d{2,3}` stop pattern. Radix
+  // Colors (and similar custom themes) re-purpose Tailwind utility
+  // prefixes for a 1..12 step scale (`text-gray-11`, `bg-slate-2`),
+  // which is NOT the Tailwind template default and must not be flagged.
+  it("does not flag custom-scale stops outside the canonical Tailwind palette (Radix Colors style)", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-default-palette-radix", {
+      files: {
+        "src/Card.tsx": `export const Card = () => (
+  <div>
+    <p className="text-gray-11">caption</p>
+    <p className="text-gray-12">heading</p>
+    <div className="bg-slate-2 border border-slate-6" />
+    <span className="text-indigo-1">accent</span>
+  </div>
+);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "design-no-default-tailwind-palette");
+    expect(hits).toHaveLength(0);
+  });
 });
 
 describe("design-no-vague-button-label", () => {

--- a/packages/react-doctor/tests/regressions/react-ui-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/react-ui-rules.test.ts
@@ -3,33 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 
-import { runOxlint } from "../../src/utils/run-oxlint.js";
-import { setupReactProject } from "./_helpers.js";
+import { collectRuleHits, setupReactProject } from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-react-ui-rules-"));
 
 afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
-
-const collectRuleHits = async (
-  projectDir: string,
-  ruleId: string,
-): Promise<Array<{ filePath: string; message: string }>> => {
-  const diagnostics = await runOxlint({
-    rootDirectory: projectDir,
-    hasTypeScript: true,
-    framework: "unknown",
-    hasReactCompiler: false,
-    hasTanStackQuery: false,
-  });
-  return diagnostics
-    .filter((diagnostic) => diagnostic.rule === ruleId)
-    .map((diagnostic) => ({
-      filePath: diagnostic.filePath,
-      message: diagnostic.message,
-    }));
-};
 
 describe("design-no-bold-heading", () => {
   it("flags font-bold on headings and inline fontWeight ≥ 700", async () => {

--- a/packages/react-doctor/tests/regressions/state-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules.test.ts
@@ -1802,6 +1802,115 @@ export const Subscribe = () => {
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
     expect(hits).toHaveLength(0);
   });
+
+  // HACK: regression for the ~36% FP rate measured against
+  // react-grab/excalidraw/etc. The previous detector only inspected the
+  // top-level last statement; cleanup nested inside an `if` block was
+  // invisible. Real-world shape: gated subscription + early-return.
+  it("does NOT flag cleanup nested inside an `if` block (early-return guard pattern)", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-conditional-cleanup", {
+      files: {
+        "src/Popover.tsx": `import { useEffect } from "react";
+
+export const Popover = ({ isOpen }: { isOpen: boolean }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = () => {};
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [isOpen]);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag cleanup that is the last statement *inside* a conditional branch", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-cleanup-in-if-branch", {
+      files: {
+        "src/Watcher.tsx": `import { useEffect } from "react";
+
+declare const enabled: boolean;
+declare const document: { addEventListener: (e: string, h: () => void) => void; removeEventListener: (e: string, h: () => void) => void };
+
+export const Watcher = () => {
+  useEffect(() => {
+    const handler = () => {};
+    if (enabled) {
+      document.addEventListener("scroll", handler);
+      return () => document.removeEventListener("scroll", handler);
+    }
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag cleanup nested inside a try/finally", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-cleanup-in-try", {
+      files: {
+        "src/Subscribe.tsx": `import { useEffect } from "react";
+
+declare const store: { subscribe: (handler: () => void) => () => void };
+declare const handler: () => void;
+
+export const Subscribe = () => {
+  useEffect(() => {
+    try {
+      const unsub = store.subscribe(handler);
+      return () => unsub();
+    } catch {
+      // ignore
+    }
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  // HACK: ensure the broader walk does NOT credit cleanup returns from a
+  // *nested* function expression (e.g. an inner callback) as the effect's
+  // own cleanup. The walker stops at function boundaries; this protects
+  // the bug fix from over-correcting.
+  it("DOES still flag when the only `return cleanup` is inside a nested callback (not the effect's body)", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-nested-fn-return", {
+      files: {
+        "src/Subscribe.tsx": `import { useEffect } from "react";
+
+declare const store: { subscribe: (handler: () => void) => () => void };
+declare const handler: () => void;
+
+export const Subscribe = () => {
+  useEffect(() => {
+    const make = () => {
+      const unsub = store.subscribe(handler);
+      return () => unsub();
+    };
+    make();
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(1);
+  });
 });
 
 describe("no-mirror-prop-effect", () => {
@@ -2667,14 +2776,14 @@ export const SearchInput = ({
     expect(hits[0].message).not.toContain("prefix");
   });
 
-  it("does NOT fire when reactMajorVersion is unknown (null) — `prefer-X` rules need the API to exist", async () => {
-    // Directional gating: `prefer-use-effect-event` recommends a
-    // React-19-only API. Without proof the project HAS the API,
-    // every diagnostic is invalid. See `filterRulesByReactMajor` in
-    // oxlint-config.ts (`VersionGateMode = "prefer-newer-api"`).
-    // `deprecation-warning`-mode rules (`no-react19-deprecated-apis`,
-    // `no-default-props`, `no-react-dom-deprecated-apis`) keep firing
-    // on unknown versions because they're useful during migration.
+  it("DOES fire when reactMajorVersion is unknown (null) — assume latest React, apply every rule", async () => {
+    // When detection fails (custom resolver, monorepo override, mid-clone
+    // state) we optimistically treat the project as if it were on the
+    // latest React major and apply every rule, including
+    // `prefer-newer-api` ones like `prefer-use-effect-event`. Hiding the
+    // suggestion would silently degrade the scan whenever React resolves
+    // through an unusual path. See `filterRulesByReactMajor` in
+    // oxlint-config.ts.
     const projectDir = setupReactProject(tempRoot, "prefer-use-effect-event-unknown-version", {
       files: {
         "src/SearchInput.tsx": `import { useEffect, useState } from "react";
@@ -2692,6 +2801,6 @@ export const SearchInput = ({ onSearch }: { onSearch: (q: string) => void }) => 
     });
 
     const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", null);
-    expect(hits).toHaveLength(0);
+    expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/react-doctor/tests/regressions/state-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules.test.ts
@@ -3,39 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 
-import { runOxlint } from "../../src/utils/run-oxlint.js";
-import { setupReactProject } from "./_helpers.js";
+import { collectRuleHits, setupReactProject } from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-state-rules-"));
 
 afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
-
-// HACK: `setupReactProject` defaults to React ^19.0.0 in the synthetic
-// `package.json`, so the test plumbing must mirror what production
-// detection would yield for that project. Explicit values (17 / 18 /
-// null) still override at the call site.
-const collectRuleHits = async (
-  projectDir: string,
-  ruleId: string,
-  reactMajorVersion: number | null = 19,
-): Promise<Array<{ filePath: string; message: string }>> => {
-  const diagnostics = await runOxlint({
-    rootDirectory: projectDir,
-    hasTypeScript: true,
-    framework: "unknown",
-    hasReactCompiler: false,
-    hasTanStackQuery: false,
-    reactMajorVersion,
-  });
-  return diagnostics
-    .filter((diagnostic) => diagnostic.rule === ruleId)
-    .map((diagnostic) => ({
-      filePath: diagnostic.filePath,
-      message: diagnostic.message,
-    }));
-};
 
 describe("no-direct-state-mutation", () => {
   it("flags push/pop/splice/sort/reverse and member assignment on useState values", async () => {
@@ -2609,7 +2583,9 @@ export const SearchInput = ({ onSearch }: { onSearch: (q: string) => void }) => 
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", 19);
+    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", {
+      reactMajorVersion: 19,
+    });
     expect(hits).toHaveLength(1);
     expect(hits[0].message).toContain("onSearch");
   });
@@ -2634,7 +2610,9 @@ export const SearchInput = ({ onSearch }: { onSearch: (q: string) => void }) => 
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", 18);
+    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", {
+      reactMajorVersion: 18,
+    });
     expect(hits).toHaveLength(0);
   });
 
@@ -2656,7 +2634,9 @@ export const SearchInput = ({ onSearch }: { onSearch: (q: string) => void }) => 
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", 17);
+    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", {
+      reactMajorVersion: 17,
+    });
     expect(hits).toHaveLength(0);
   });
 
@@ -2800,7 +2780,9 @@ export const SearchInput = ({ onSearch }: { onSearch: (q: string) => void }) => 
       },
     });
 
-    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", null);
+    const hits = await collectRuleHits(projectDir, "prefer-use-effect-event", {
+      reactMajorVersion: null,
+    });
     expect(hits.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary

Audited every `OBJECT[someAstName]` lookup in the rule plugin and surrounding utils — converted plain-object indexing to `Map.get` / `Object.hasOwn` so AST-derived names that shadow `Object.prototype` properties (`constructor`, `toString`, `hasOwnProperty`, …) can't fall through to the native value and false-positive. Same audit pass picked up four other shipped regressions: a shallow `effect-needs-cleanup` walker, an over-broad Tailwind palette regex, version-gating that silently dropped rules on R17/18 + unknown React versions, and an `adoptExistingLintConfig` path that emitted misleading stderr warnings on Next.js / CRA scaffolds.

## Fixes

- **Prototype pollution → false positives** (the original `no-legacy-class-lifecycles` constructor bug, reproduced in 5 sibling rules):
  - `no-legacy-class-lifecycles`, `no-react19-deprecated-apis`, `no-react-dom-deprecated-apis`, `rn-no-deprecated-modules`, `no-side-tab-border`, `no-prevent-default` — `Record<string, X>` lookups → `Map.get`
  - `run-oxlint` category/help maps + `run-knip` issue-type map — `Object.hasOwn` guards via new `lookupOwnString` helper / `Map.get`
- **`effect-needs-cleanup` shallow walker** (~36% FP rate measured against react-grab / excalidraw / popover patterns): `effectHasCleanupRelease` now scans every `ReturnStatement` in the effect's own scope via `walkInsideStatementBlocks` (stops at function boundaries so cleanup nested in a callback still fires).
- **`design-no-default-tailwind-palette` over-matching**: regex anchored to canonical Tailwind stops (`50` … `950`) instead of `\d{2,3}`, so Radix Colors utilities (`text-gray-11`, `bg-slate-2`) aren't flagged as the Tailwind template default.
- **`filterRulesByReactMajor` directional gating**: `deprecation-warning` rules now fire on every detected major (R17/18 users planning the R19 upgrade are exactly the audience that benefits). When `reactMajorVersion` is `null` (custom resolver, `workspace:*`, mid-clone state) we optimistically assume the latest React major and apply every rule, including `prefer-newer-api` ones.
- **Adopt-config stderr noise**: new `canOxlintExtendConfig` pre-screens `.eslintrc.json` for bare-package `extends` (`"next"`, `"plugin:foo/bar"`) that oxlint can't resolve, dropping them silently before the parser crashes. Handles JSONC (`//` and `/* */` comments) so real-world configs parse correctly.

## Tests

20 new regression tests:
- `tests/regressions/proto-pollution-defenses.test.ts` — 6 tests (RN, design, prevent-default, with negative + positive each)
- `tests/can-oxlint-extend-config.test.ts` — 9 unit tests (every extends shape + JSONC line/block comments + comments inside string literals)
- `tests/regressions/react-19-migration-rules.test.ts` — +5 (constructor / proto-name member access, R17/18 fail-open, null fallback)
- `tests/regressions/state-rules.test.ts` — +4 (conditional cleanup, try/finally cleanup, nested-fn negative test, null version fires `prefer-use-effect-event`)
- `tests/regressions/react-ui-rules.test.ts` — +1 (Radix Colors stops not flagged)
- `tests/diagnose.test.ts` — flipped null-version assertion to match new policy

Total: 668 tests passing, typecheck/lint/format clean against latest `main` (oxlint 1.63.0).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — 668/668 passing
- [x] `pnpm format` — clean
- [x] Re-bench against `~/Developer/{ami,same,expect,react-grab}` — zero stderr noise, every spot-checked diagnostic is a true positive, no precision regressions

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lint rule gating and several rule detectors, which can materially change diagnostic output (and CI outcomes) across projects. Low runtime/security risk, but moderate risk of behavior regressions in linting heuristics and config adoption paths.
> 
> **Overview**
> **Improves linting correctness and stability** by replacing multiple AST-derived `Record[...]` lookups with `Map.get()`/`Object.hasOwn` guards to prevent `Object.prototype` name collisions (e.g. `constructor`, `toString`) from causing false positives or bad messages across several rules and diagnostic/category/help lookups.
> 
> **Adjusts rule behavior**: React-major version gating now *fails open* when React version is unknown (`null`) and keeps `deprecation-warning` rules enabled across detected majors; `effect-needs-cleanup` now scans all relevant `return` statements within the effect scope to avoid conditional-cleanup false positives; and `design-no-default-tailwind-palette` narrows its regex to canonical Tailwind palette stops to avoid flagging custom scales.
> 
> **Reduces oxlint config-adoption noise** by adding `canOxlintExtendConfig` to pre-screen `.eslintrc.json` (including JSONC comments) and skip extends that oxlint cannot resolve, plus adds/updates regression tests and consolidates repeated test helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1e9005ae34fefdd7d0138ada1f92f0f8a5f2b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->