### PR TITLE
fix(react-doctor): detect index-derived key locals

### DIFF
--- a/packages/react-doctor/src/plugin/rules/correctness.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness.ts
@@ -10,22 +10,55 @@ import type { EsTreeNode, Rule, RuleContext } from "../types.js";
 
 const STRING_COERCION_FUNCTIONS = new Set(["String", "Number"]);
 
-const extractIndexName = (node: EsTreeNode): string | null => {
-  if (node.type === "Identifier" && INDEX_PARAMETER_NAMES.has(node.name)) return node.name;
+const isFunctionLikeExpression = (node: EsTreeNode): boolean =>
+  node.type === "ArrowFunctionExpression" || node.type === "FunctionExpression";
+
+const isFunctionBoundary = (node: EsTreeNode): boolean =>
+  isFunctionLikeExpression(node) || node.type === "FunctionDeclaration";
+
+const isMapCallback = (node: EsTreeNode): boolean =>
+  isFunctionLikeExpression(node) &&
+  node.parent?.type === "CallExpression" &&
+  node.parent.callee?.type === "MemberExpression" &&
+  node.parent.callee.property?.type === "Identifier" &&
+  node.parent.callee.property.name === "map" &&
+  node.parent.arguments?.[0] === node;
+
+const findEnclosingMapCallback = (node: EsTreeNode): EsTreeNode | null => {
+  let current = node.parent;
+  while (current) {
+    if (isFunctionBoundary(current)) return isMapCallback(current) ? current : null;
+    current = current.parent;
+  }
+  return null;
+};
+
+const buildIndexParameterNames = (mapCallback: EsTreeNode | null): Set<string> => {
+  const indexNames = new Set(INDEX_PARAMETER_NAMES);
+  const indexParameter = mapCallback?.params?.[1];
+  if (indexParameter?.type === "Identifier") indexNames.add(indexParameter.name);
+  return indexNames;
+};
+
+const extractIndexName = (
+  node: EsTreeNode | null | undefined,
+  indexNames: Set<string> = INDEX_PARAMETER_NAMES,
+): string | null => {
+  if (!node) return null;
+  if (node.type === "Identifier" && indexNames.has(node.name)) return node.name;
 
   if (node.type === "TemplateLiteral") {
-    const indexExpression = node.expressions?.find(
-      (expression: EsTreeNode) =>
-        expression.type === "Identifier" && INDEX_PARAMETER_NAMES.has(expression.name),
-    );
-    if (indexExpression) return indexExpression.name;
+    for (const expression of node.expressions ?? []) {
+      const indexName = extractIndexName(expression, indexNames);
+      if (indexName) return indexName;
+    }
   }
 
   if (
     node.type === "CallExpression" &&
     node.callee?.type === "MemberExpression" &&
     node.callee.object?.type === "Identifier" &&
-    INDEX_PARAMETER_NAMES.has(node.callee.object.name) &&
+    indexNames.has(node.callee.object.name) &&
     node.callee.property?.type === "Identifier" &&
     node.callee.property.name === "toString"
   )
@@ -36,26 +69,46 @@ const extractIndexName = (node: EsTreeNode): string | null => {
     node.callee?.type === "Identifier" &&
     STRING_COERCION_FUNCTIONS.has(node.callee.name) &&
     node.arguments?.[0]?.type === "Identifier" &&
-    INDEX_PARAMETER_NAMES.has(node.arguments[0].name)
+    indexNames.has(node.arguments[0].name)
   )
     return node.arguments[0].name;
 
-  if (
-    node.type === "BinaryExpression" &&
-    node.operator === "+" &&
-    ((node.left?.type === "Identifier" &&
-      INDEX_PARAMETER_NAMES.has(node.left.name) &&
-      node.right?.type === "Literal" &&
-      node.right.value === "") ||
-      (node.right?.type === "Identifier" &&
-        INDEX_PARAMETER_NAMES.has(node.right.name) &&
-        node.left?.type === "Literal" &&
-        node.left.value === ""))
-  ) {
-    return node.left?.type === "Identifier" ? node.left.name : node.right.name;
+  if (node.type === "BinaryExpression" && node.operator === "+") {
+    return extractIndexName(node.left, indexNames) ?? extractIndexName(node.right, indexNames);
   }
 
   return null;
+};
+
+const findTopLevelVariableInitializer = (
+  mapCallback: EsTreeNode,
+  variableName: string,
+): EsTreeNode | null => {
+  if (mapCallback.body?.type !== "BlockStatement") return null;
+  for (const statement of mapCallback.body.body ?? []) {
+    if (statement.type !== "VariableDeclaration") continue;
+    for (const declaration of statement.declarations ?? []) {
+      if (declaration.id?.type === "Identifier" && declaration.id.name === variableName) {
+        return declaration.init ?? null;
+      }
+    }
+  }
+  return null;
+};
+
+const extractIndexNameFromKeyExpression = (
+  node: EsTreeNode,
+  expression: EsTreeNode,
+): string | null => {
+  const mapCallback = findEnclosingMapCallback(node);
+  const indexNames = buildIndexParameterNames(mapCallback);
+  const directIndexName = extractIndexName(expression, indexNames);
+  if (directIndexName) return directIndexName;
+  if (!mapCallback || expression.type !== "Identifier") return null;
+  return extractIndexName(
+    findTopLevelVariableInitializer(mapCallback, expression.name),
+    indexNames,
+  );
 };
 
 const isInsideStaticPlaceholderMap = (node: EsTreeNode): boolean => {
@@ -95,7 +148,7 @@ export const noArrayIndexAsKey: Rule = {
       if (node.name?.type !== "JSXIdentifier" || node.name.name !== "key") return;
       if (!node.value || node.value.type !== "JSXExpressionContainer") return;
 
-      const indexName = extractIndexName(node.value.expression);
+      const indexName = extractIndexNameFromKeyExpression(node, node.value.expression);
       if (!indexName) return;
       if (isInsideStaticPlaceholderMap(node)) return;
 

--- a/packages/react-doctor/tests/regressions/correctness-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/correctness-rules.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import { collectRuleHits, setupReactProject } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-correctness-rules-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("no-array-index-as-key", () => {
+  it("flags a key local that is derived from the map index parameter", async () => {
+    const projectDir = setupReactProject(tempRoot, "array-index-key-local", {
+      files: {
+        "src/Locations.tsx": `interface Location {
+  nodeId: string;
+  documentModuleId: string;
+}
+
+export const Locations = ({ locations }: { locations: Location[] }) => (
+  <ul>
+    {locations.map((location, index) => {
+      const itemKey = \`\${location.nodeId}-\${location.documentModuleId}-\${index}\`;
+      return <li key={itemKey}>{location.nodeId}</li>;
+    })}
+  </ul>
+);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-array-index-as-key");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain('"index"');
+  });
+
+  it("does not flag a key local derived only from stable item fields", async () => {
+    const projectDir = setupReactProject(tempRoot, "stable-local-key", {
+      files: {
+        "src/Locations.tsx": `interface Location {
+  nodeId: string;
+  documentModuleId: string;
+}
+
+export const Locations = ({ locations }: { locations: Location[] }) => (
+  <ul>
+    {locations.map((location) => {
+      const itemKey = \`\${location.nodeId}-\${location.documentModuleId}\`;
+      return <li key={itemKey}>{location.nodeId}</li>;
+    })}
+  </ul>
+);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-array-index-as-key");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not resolve key locals across nested function boundaries", async () => {
+    const projectDir = setupReactProject(tempRoot, "nested-function-shadow-key", {
+      files: {
+        "src/Locations.tsx": `interface Location {
+  nodeId: string;
+}
+
+export const Locations = ({ locations }: { locations: Location[] }) => (
+  <ul>
+    {locations.map((location, index) => {
+      const itemKey = \`\${location.nodeId}-\${index}\`;
+      void itemKey;
+      const renderLocation = () => {
+        const itemKey = location.nodeId;
+        return <li key={itemKey}>{location.nodeId}</li>;
+      };
+      return renderLocation();
+    })}
+  </ul>
+);
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-array-index-as-key");
+    expect(hits).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Detect `no-array-index-as-key` when a JSX `key` references a local constant whose initializer is derived from the `.map()` index parameter.

## Why

The rule already caught inline template literals such as `key={`${item.id}-${index}`}`, but the same expression could be hoisted into `const itemKey = ...` and then used as `key={itemKey}` without a diagnostic.

## How to test

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the `no-array-index-as-key` rule to follow simple local variable initializers inside `.map()` callbacks, which can introduce new diagnostics (potentially false positives/negatives) in existing codebases.
> 
> **Overview**
> Improves `no-array-index-as-key` to also flag `key={itemKey}` patterns where `itemKey` is a local variable derived from a `.map()` index parameter (including custom index parameter names).
> 
> The rule now locates the enclosing `.map()` callback, tracks its index parameter, and (when the `key` expression is an identifier) inspects top-level variable initializers in that callback while stopping at nested function boundaries to avoid accidental cross-scope resolution.
> 
> Adds regression tests covering index-derived locals, stable-field-only locals, and nested function shadowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5afe5094c3f23f2375303c956348084757b79dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->