### PR TITLE
fix(website): keep diagnostic count next to rule name on narrow widths

### DIFF
--- a/packages/website/src/components/terminal.tsx
+++ b/packages/website/src/components/terminal.tsx
@@ -25,7 +25,6 @@ const TOTAL_ISSUE_COUNT = 36;
 const TOTAL_SOURCE_FILE_COUNT = 42;
 const AFFECTED_FILE_COUNT = 18;
 const ELAPSED_TIME = "2.1s";
-const RULE_NAME_COLUMN_WIDTH = 42;
 
 const ANIMATION_COMPLETED_KEY = "react-doctor-animation-completed";
 const COMMAND = "npx react-doctor@latest";
@@ -96,11 +95,6 @@ const FadeIn = ({ children }: { children: React.ReactNode }) => (
   <div className="animate-fade-in">{children}</div>
 );
 
-const padRuleName = (ruleName: string): string => {
-  if (ruleName.length >= RULE_NAME_COLUMN_WIDTH) return ruleName;
-  return ruleName + "\u00A0".repeat(RULE_NAME_COLUMN_WIDTH - ruleName.length);
-};
-
 const ScoreBar = ({ score, barWidth }: { score: number; barWidth: number }) => {
   const filledCount = Math.round((score / PERFECT_SCORE) * barWidth);
   const emptyCount = barWidth - filledCount;
@@ -168,10 +162,8 @@ const DiagnosticItem = ({ diagnostic }: { diagnostic: RuleDiagnostic }) => {
         />
         <span>
           <span className={colorClass}>{icon} </span>
-          <span className={colorClass}>
-            {countBadge ? padRuleName(diagnostic.ruleKey) : diagnostic.ruleKey}
-          </span>
-          {countBadge && <span className="text-neutral-500">{` ${countBadge}`}</span>}
+          <span className={colorClass}>{diagnostic.ruleKey}</span>
+          {countBadge && <span className="text-neutral-500">{`\u00A0${countBadge}`}</span>}
         </span>
       </button>
       <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the website's terminal demo, the per-rule occurrence counts (`×5`, `×12`, etc.) appear to "float" on their own row, far away from the rule name they belong to, on narrow viewports (mobile).

The cause: rule names were padded to a fixed 42-char column with non-breaking spaces so the counts visually right-aligned into a column. When the rule name itself wrapped on a narrow screen, that long run of non-breaking spaces pushed the count to the right edge of a new line, creating the floating effect.

## Fix

- Drop the fixed-width column padding (`padRuleName` / `RULE_NAME_COLUMN_WIDTH`).
- Place the count immediately after the rule name, joined by a single non-breaking space so they always wrap together as one unit.

The desktop terminal aesthetic is preserved (count still flows inline after the rule name), and on mobile the count now stays glued to the rule name instead of being shoved to the right edge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed8a887b-cc01-4889-b38c-38c52828b17e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed8a887b-cc01-4889-b38c-38c52828b17e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

