### PR TITLE
fix(react-doctor): restore React Compiler rules to error severity

### DIFF
--- a/packages/react-doctor/src/oxlint-config.ts
+++ b/packages/react-doctor/src/oxlint-config.ts
@@ -73,23 +73,32 @@ export const TANSTACK_START_RULES: Record<string, RuleSeverity> = {
   "react-doctor/tanstack-start-loader-parallel-fetch": "warn",
 };
 
+// HACK: every diagnostic from `eslint-plugin-react-hooks` (the React
+// Compiler frontend, oxlint-namespaced as `react-hooks-js`) ships at
+// `"error"` severity. Each one represents a code shape the compiler
+// cannot optimize — leaving the surrounding component un-memoized at
+// runtime — so we want the GitHub Action's default `--fail-on error`
+// to trip on these. PR #140 silently downgraded the whole map to
+// `"warn"` as part of a broader refactor, which made "React Compiler
+// can't optimize this code" diagnostics stop counting toward
+// `errorCount` and stop failing CI; restored here.
 const REACT_COMPILER_RULES: Record<string, RuleSeverity> = {
-  "react-hooks-js/set-state-in-render": "warn",
-  "react-hooks-js/immutability": "warn",
-  "react-hooks-js/refs": "warn",
-  "react-hooks-js/purity": "warn",
-  "react-hooks-js/hooks": "warn",
-  "react-hooks-js/set-state-in-effect": "warn",
-  "react-hooks-js/globals": "warn",
-  "react-hooks-js/error-boundaries": "warn",
-  "react-hooks-js/preserve-manual-memoization": "warn",
-  "react-hooks-js/unsupported-syntax": "warn",
-  "react-hooks-js/component-hook-factories": "warn",
-  "react-hooks-js/static-components": "warn",
-  "react-hooks-js/use-memo": "warn",
-  "react-hooks-js/void-use-memo": "warn",
-  "react-hooks-js/incompatible-library": "warn",
-  "react-hooks-js/todo": "warn",
+  "react-hooks-js/set-state-in-render": "error",
+  "react-hooks-js/immutability": "error",
+  "react-hooks-js/refs": "error",
+  "react-hooks-js/purity": "error",
+  "react-hooks-js/hooks": "error",
+  "react-hooks-js/set-state-in-effect": "error",
+  "react-hooks-js/globals": "error",
+  "react-hooks-js/error-boundaries": "error",
+  "react-hooks-js/preserve-manual-memoization": "error",
+  "react-hooks-js/unsupported-syntax": "error",
+  "react-hooks-js/component-hook-factories": "error",
+  "react-hooks-js/static-components": "error",
+  "react-hooks-js/use-memo": "error",
+  "react-hooks-js/void-use-memo": "error",
+  "react-hooks-js/incompatible-library": "error",
+  "react-hooks-js/todo": "error",
 };
 
 interface OxlintConfigOptions {

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -350,6 +350,30 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
     expect(hasReactHooksJsPluginEntry).toBe(false);
   });
 
+  it("emits every react-hooks-js rule at error severity (so they fail CI under --fail-on error)", () => {
+    // Regression for the silent severity downgrade introduced in PR
+    // #140: every `react-hooks-js/*` entry got mass-converted from
+    // `"error"` to `"warn"`, which made "React Compiler can't optimize
+    // this code" diagnostics stop counting toward `errorCount` and
+    // stop tripping the GitHub Action's default `--fail-on error`.
+    // Each compiler diagnostic represents an unoptimizable component
+    // shape — surfacing as warnings hid real perf regressions.
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/react-doctor-plugin.js",
+      framework: "unknown",
+      hasReactCompiler: true,
+      hasTanStackQuery: false,
+    });
+
+    const compilerSeverities = Object.entries(config.rules)
+      .filter(([ruleKey]) => ruleKey.startsWith("react-hooks-js/"))
+      .map(([ruleKey, severity]) => ({ ruleKey, severity }));
+
+    expect(compilerSeverities.length).toBeGreaterThan(0);
+    const nonErrorEntries = compilerSeverities.filter((entry) => entry.severity !== "error");
+    expect(nonErrorEntries).toEqual([]);
+  });
+
   it("only enables react-hooks-js rules that the resolved plugin actually exports", async () => {
     // The workspace pins eslint-plugin-react-hooks@7, so every
     // configured react-hooks-js/* rule MUST exist in the loaded


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

"React Compiler can't optimize this code" diagnostics are no longer triggering as **errors** — they were silently downgraded to **warnings** in PR #140 ("Address review-report.md findings + self-review regressions"). Restored to `"error"` so they fail CI again.

### Investigation

`git log -S '"react-hooks-js/set-state-in-render": "warn"'` on `packages/react-doctor/src/oxlint-config.ts` points at exactly one commit:

```
03a9435 Address review-report.md findings + self-review regressions (#140)
```

That commit's diff on `oxlint-config.ts` mass-converted the entire `REACT_COMPILER_RULES` map from `"error"` to `"warn"` (16 entries), as part of a broader 88-file refactor. The PR description doesn't justify the severity change for these specific rules — it only mentions `rule severity types tightened to RuleSeverity` (a TypeScript typing change). Other rule sets that had been `"error"` (e.g. `react/rules-of-hooks`, `react-doctor/no-mutable-in-deps`) were preserved at error in the same commit; only `REACT_COMPILER_RULES` was uniformly downgraded.

### Effects of the regression

Reproduced with a minimal fixture (`useState` + in-place `push` + `setN(n + 1)` at render time, with `babel-plugin-react-compiler` listed as a dep so detection fires):

Before this PR:
```
summary: { errorCount: 0, warningCount: 6, ... }
warning set-state-in-render React Compiler can't optimize this code
warning todo            React Compiler can't optimize this code
```

After this PR:
```
summary: { errorCount: 2, warningCount: 4, ... }
error set-state-in-render React Compiler can't optimize this code
error todo            React Compiler can't optimize this code
```

So the user-visible regression triggered by PR #140 was:

- The CLI rendered React Compiler diagnostics with `⚠` (warning) instead of `✘` (error).
- `errorCount` in the JSON summary stopped counting them.
- The GitHub Action defaults to `fail-on: error` (`action.yml`); compiler-blocked code stopped failing CI.

### Fix

`packages/react-doctor/src/oxlint-config.ts` — every `react-hooks-js/*` entry in `REACT_COMPILER_RULES` set back to `"error"`, with a HACK comment explaining why so a future refactor doesn't accidentally undo it. Each compiler diagnostic represents a code shape that prevents memoization of the surrounding component, so the previous "if the compiler can't handle it, fail CI" contract is correct.

### Regression test

`packages/react-doctor/tests/regressions/scan-resilience.test.ts` — new assertion that every `react-hooks-js/*` rule emitted by `createOxlintConfig` is at `error` severity. A future mass-rewrite that downgrades them again will fail this test.

### Validation

- `pnpm typecheck` — passes
- `pnpm test` — 673/673 pass (added 1 regression)
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm format:check` — clean
- Manual CLI reproduction on a fixture with React Compiler detected confirms `errorCount: 2` (was `0`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81825841-abd2-417a-8385-4e652c537dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81825841-abd2-417a-8385-4e652c537dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

