### PR TITLE
feat(react-doctor): add `rawTextWrapperComponents` config (#183)

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -160,21 +160,26 @@ When a suppression isn't working, `--explain <file:line>` reports what the scann
 
 ### Config keys
 
-| Key                       | Type                             | Default  |
-| ------------------------- | -------------------------------- | -------- |
-| `ignore.rules`            | `string[]`                       | `[]`     |
-| `ignore.files`            | `string[]`                       | `[]`     |
-| `ignore.overrides`        | `{ files, rules? }[]`            | `[]`     |
-| `lint`                    | `boolean`                        | `true`   |
-| `deadCode`                | `boolean`                        | `true`   |
-| `verbose`                 | `boolean`                        | `false`  |
-| `diff`                    | `boolean \| string`              |          |
-| `failOn`                  | `"error" \| "warning" \| "none"` | `"none"` |
-| `customRulesOnly`         | `boolean`                        | `false`  |
-| `share`                   | `boolean`                        | `true`   |
-| `textComponents`          | `string[]`                       | `[]`     |
-| `respectInlineDisables`   | `boolean`                        | `true`   |
-| `adoptExistingLintConfig` | `boolean`                        | `true`   |
+| Key                        | Type                             | Default  |
+| -------------------------- | -------------------------------- | -------- |
+| `ignore.rules`             | `string[]`                       | `[]`     |
+| `ignore.files`             | `string[]`                       | `[]`     |
+| `ignore.overrides`         | `{ files, rules? }[]`            | `[]`     |
+| `lint`                     | `boolean`                        | `true`   |
+| `deadCode`                 | `boolean`                        | `true`   |
+| `verbose`                  | `boolean`                        | `false`  |
+| `diff`                     | `boolean \| string`              |          |
+| `failOn`                   | `"error" \| "warning" \| "none"` | `"none"` |
+| `customRulesOnly`          | `boolean`                        | `false`  |
+| `share`                    | `boolean`                        | `true`   |
+| `textComponents`           | `string[]`                       | `[]`     |
+| `rawTextWrapperComponents` | `string[]`                       | `[]`     |
+| `respectInlineDisables`    | `boolean`                        | `true`   |
+| `adoptExistingLintConfig`  | `boolean`                        | `true`   |
+
+`textComponents` is the broad escape hatch for `rn-no-raw-text` — list components that themselves behave like React Native's `<Text>` (custom `Typography`, `NativeTabs.Trigger.Label`, etc.) and the rule will treat them as text containers regardless of what their children look like.
+
+`rawTextWrapperComponents` is the narrower option for components that are not text elements but safely route string-only children through an internal `<Text>` (e.g. `heroui-native`'s `Button`, which stringifies its children and renders them through a `ButtonLabel`). Listed wrappers suppress `rn-no-raw-text` only when their children are entirely stringifiable. A wrapper with mixed children — e.g. `<Button>Save<Icon /></Button>` — still reports because the wrapper can't safely route raw text alongside a sibling JSX element.
 
 ## Node.js API
 

--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -205,6 +205,23 @@ export interface ReactDoctorConfig {
   share?: boolean;
   textComponents?: string[];
   /**
+   * Names of components that safely route string-only children through a
+   * React Native `<Text>` internally (e.g. `heroui-native`'s `Button`,
+   * which stringifies its children and renders them through a
+   * `ButtonLabel` → `Text`). For listed components, `rn-no-raw-text`
+   * is suppressed ONLY when the wrapper's children are entirely
+   * stringifiable (no nested JSX elements). A wrapper with mixed
+   * children — e.g. `<Button>Save<Icon /></Button>` — still reports,
+   * because the wrapper can't safely route raw text alongside a
+   * sibling JSX element.
+   *
+   * Use this instead of `textComponents` when the component is not
+   * itself a text element but is known to wrap its string children
+   * in one. `textComponents` is the broader escape hatch and
+   * suppresses regardless of sibling content.
+   */
+  rawTextWrapperComponents?: string[];
+  /**
    * Whether to respect inline `// eslint-disable*`, `// oxlint-disable*`,
    * and `// react-doctor-disable*` comments in source files. Default: `true`.
    *

--- a/packages/react-doctor/src/utils/filter-diagnostics.ts
+++ b/packages/react-doctor/src/utils/filter-diagnostics.ts
@@ -58,17 +58,20 @@ const isInsideTextComponent = (
   return false;
 };
 
-interface EnclosingJsxOpener {
+interface JsxOpener {
   fullName: string;
   leafName: string;
   lineIndex: number;
 }
 
-const findEnclosingJsxOpener = (
-  lines: string[],
-  diagnosticLine: number,
-): EnclosingJsxOpener | null => {
-  for (let lineIndex = diagnosticLine - 1; lineIndex >= 0; lineIndex--) {
+interface ResolvedJsxRange {
+  closerLineIndex: number;
+  closerColumn: number;
+  bodyText: string;
+}
+
+const findOpenerAtOrAbove = (lines: string[], upperBoundLineIndex: number): JsxOpener | null => {
+  for (let lineIndex = upperBoundLineIndex; lineIndex >= 0; lineIndex--) {
     const match = lines[lineIndex].match(OPENING_TAG_PATTERN);
     if (!match) continue;
     const fullName = match[1];
@@ -78,65 +81,99 @@ const findEnclosingJsxOpener = (
   return null;
 };
 
-// Returns the inner-body text of a JSX element starting at `opener`,
-// using a forward scan for the matching `</fullName>` or `</leafName>`
-// closing tag. Heuristic — operates on raw lines without an AST — but
-// good enough to distinguish "wrapper holds only stringifiable
-// children" from "wrapper also holds a JSX child element".
+// Resolves the inner-body text of a JSX element starting at `opener`,
+// plus the position of its matching closing tag. Heuristic — operates
+// on raw lines without an AST — but good enough to (a) distinguish
+// "wrapper holds only stringifiable children" from "wrapper also
+// holds a JSX child element", and (b) verify the opener actually
+// encloses a given diagnostic position (vs. being a closed sibling).
 //
-// Returns `null` when we couldn't confidently locate the enclosing
-// element's body (e.g. no matching closing tag, opening tag's `>`
-// missing on its own line). Callers should treat `null` as "don't
-// suppress" — staying conservative when the heuristic loses
-// confidence.
-const extractWrapperBodyText = (lines: string[], opener: EnclosingJsxOpener): string | null => {
+// Returns `null` when we couldn't confidently locate the element's
+// closing tag or body (no matching `</Tag>`, opening `>` missing on
+// its own line, self-closing tag, etc.). Callers should treat `null`
+// as "this opener can't enclose anything we care about" and walk
+// further up.
+const resolveJsxRange = (lines: string[], opener: JsxOpener): ResolvedJsxRange | null => {
   const closingPattern = new RegExp(
     `</(?:${escapeRegExpSpecials(opener.fullName)}|${escapeRegExpSpecials(opener.leafName)})\\s*>`,
   );
 
-  let closingLineIndex = -1;
-  let closingMatchColumn = -1;
+  let closerLineIndex = -1;
+  let closerColumn = -1;
   for (let lineIndex = opener.lineIndex; lineIndex < lines.length; lineIndex++) {
     const match = closingPattern.exec(lines[lineIndex]);
     if (!match) continue;
-    closingLineIndex = lineIndex;
-    closingMatchColumn = match.index;
+    closerLineIndex = lineIndex;
+    closerColumn = match.index;
     break;
   }
-  if (closingLineIndex < 0) return null;
+  if (closerLineIndex < 0) return null;
 
   const openerLine = lines[opener.lineIndex];
   const tagStartIndex = openerLine.indexOf(`<${opener.fullName}`);
   if (tagStartIndex < 0) return null;
   const openerEndIndex = openerLine.indexOf(">", tagStartIndex);
 
-  if (opener.lineIndex === closingLineIndex) {
-    if (openerEndIndex < 0 || openerEndIndex >= closingMatchColumn) return null;
-    return openerLine.slice(openerEndIndex + 1, closingMatchColumn);
+  let bodyText: string;
+  if (opener.lineIndex === closerLineIndex) {
+    if (openerEndIndex < 0 || openerEndIndex >= closerColumn) return null;
+    bodyText = openerLine.slice(openerEndIndex + 1, closerColumn);
+  } else {
+    const segments: string[] = [];
+    if (openerEndIndex >= 0) segments.push(openerLine.slice(openerEndIndex + 1));
+    for (let lineIndex = opener.lineIndex + 1; lineIndex < closerLineIndex; lineIndex++) {
+      segments.push(lines[lineIndex]);
+    }
+    segments.push(lines[closerLineIndex].slice(0, closerColumn));
+    bodyText = segments.join("\n");
   }
 
-  const segments: string[] = [];
-  if (openerEndIndex >= 0) {
-    segments.push(openerLine.slice(openerEndIndex + 1));
-  }
-  for (let lineIndex = opener.lineIndex + 1; lineIndex < closingLineIndex; lineIndex++) {
-    segments.push(lines[lineIndex]);
-  }
-  segments.push(lines[closingLineIndex].slice(0, closingMatchColumn));
-  return segments.join("\n");
+  return { closerLineIndex, closerColumn, bodyText };
 };
 
+// Iterates openers from nearest-above the diagnostic outward, skipping
+// those whose closing tag falls BEFORE the diagnostic position (those
+// are closed siblings, not enclosing parents). Returns `true` when the
+// nearest actually-enclosing opener is in `wrapperNames` AND its body
+// has no JSX child elements.
+//
+// Diagnostic line and column are 1-indexed; column may be 0 when
+// oxlint omits the span (we treat that as "earliest position on the
+// line", which is conservative for enclosure checks).
 const isInsideStringOnlyWrapper = (
   lines: string[],
   diagnosticLine: number,
+  diagnosticColumn: number,
   wrapperNames: Set<string>,
 ): boolean => {
-  const opener = findEnclosingJsxOpener(lines, diagnosticLine);
-  if (!opener) return false;
-  if (!wrapperNames.has(opener.fullName) && !wrapperNames.has(opener.leafName)) return false;
-  const bodyText = extractWrapperBodyText(lines, opener);
-  if (bodyText === null) return false;
-  return !JSX_CHILD_OPEN_PATTERN.test(bodyText);
+  const diagnosticLineIndex = diagnosticLine - 1;
+  const diagnosticColumnIndex = Math.max(0, diagnosticColumn - 1);
+  let upperBoundLineIndex = diagnosticLineIndex;
+
+  while (upperBoundLineIndex >= 0) {
+    const opener = findOpenerAtOrAbove(lines, upperBoundLineIndex);
+    if (!opener) return false;
+
+    const range = resolveJsxRange(lines, opener);
+    if (range === null) {
+      upperBoundLineIndex = opener.lineIndex - 1;
+      continue;
+    }
+
+    const isClosedBeforeDiagnostic =
+      range.closerLineIndex < diagnosticLineIndex ||
+      (range.closerLineIndex === diagnosticLineIndex &&
+        range.closerColumn <= diagnosticColumnIndex);
+    if (isClosedBeforeDiagnostic) {
+      upperBoundLineIndex = opener.lineIndex - 1;
+      continue;
+    }
+
+    if (!wrapperNames.has(opener.fullName) && !wrapperNames.has(opener.leafName)) return false;
+    return !JSX_CHILD_OPEN_PATTERN.test(range.bodyText);
+  }
+
+  return false;
 };
 
 export const filterIgnoredDiagnostics = (
@@ -189,7 +226,12 @@ export const filterIgnoredDiagnostics = (
         }
         if (
           hasRawTextWrappers &&
-          isInsideStringOnlyWrapper(lines, diagnostic.line, rawTextWrapperComponentNames)
+          isInsideStringOnlyWrapper(
+            lines,
+            diagnostic.line,
+            diagnostic.column,
+            rawTextWrapperComponentNames,
+          )
         ) {
           return false;
         }

--- a/packages/react-doctor/src/utils/filter-diagnostics.ts
+++ b/packages/react-doctor/src/utils/filter-diagnostics.ts
@@ -7,6 +7,10 @@ import { evaluateSuppression } from "./evaluate-suppression.js";
 import { compileIgnoredFilePatterns, isFileIgnoredByPatterns } from "./is-ignored-file.js";
 
 const OPENING_TAG_PATTERN = /<([A-Z][\w.]*)/;
+const JSX_CHILD_OPEN_PATTERN = /<[A-Za-z]/;
+
+const escapeRegExpSpecials = (rawText: string): string =>
+  rawText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const resolveCandidateReadPath = (rootDirectory: string, filePath: string): string => {
   const normalizedFile = filePath.replace(/\\/g, "/");
@@ -54,6 +58,87 @@ const isInsideTextComponent = (
   return false;
 };
 
+interface EnclosingJsxOpener {
+  fullName: string;
+  leafName: string;
+  lineIndex: number;
+}
+
+const findEnclosingJsxOpener = (
+  lines: string[],
+  diagnosticLine: number,
+): EnclosingJsxOpener | null => {
+  for (let lineIndex = diagnosticLine - 1; lineIndex >= 0; lineIndex--) {
+    const match = lines[lineIndex].match(OPENING_TAG_PATTERN);
+    if (!match) continue;
+    const fullName = match[1];
+    const leafName = fullName.includes(".") ? (fullName.split(".").at(-1) ?? fullName) : fullName;
+    return { fullName, leafName, lineIndex };
+  }
+  return null;
+};
+
+// Returns the inner-body text of a JSX element starting at `opener`,
+// using a forward scan for the matching `</fullName>` or `</leafName>`
+// closing tag. Heuristic — operates on raw lines without an AST — but
+// good enough to distinguish "wrapper holds only stringifiable
+// children" from "wrapper also holds a JSX child element".
+//
+// Returns `null` when we couldn't confidently locate the enclosing
+// element's body (e.g. no matching closing tag, opening tag's `>`
+// missing on its own line). Callers should treat `null` as "don't
+// suppress" — staying conservative when the heuristic loses
+// confidence.
+const extractWrapperBodyText = (lines: string[], opener: EnclosingJsxOpener): string | null => {
+  const closingPattern = new RegExp(
+    `</(?:${escapeRegExpSpecials(opener.fullName)}|${escapeRegExpSpecials(opener.leafName)})\\s*>`,
+  );
+
+  let closingLineIndex = -1;
+  let closingMatchColumn = -1;
+  for (let lineIndex = opener.lineIndex; lineIndex < lines.length; lineIndex++) {
+    const match = closingPattern.exec(lines[lineIndex]);
+    if (!match) continue;
+    closingLineIndex = lineIndex;
+    closingMatchColumn = match.index;
+    break;
+  }
+  if (closingLineIndex < 0) return null;
+
+  const openerLine = lines[opener.lineIndex];
+  const tagStartIndex = openerLine.indexOf(`<${opener.fullName}`);
+  if (tagStartIndex < 0) return null;
+  const openerEndIndex = openerLine.indexOf(">", tagStartIndex);
+
+  if (opener.lineIndex === closingLineIndex) {
+    if (openerEndIndex < 0 || openerEndIndex >= closingMatchColumn) return null;
+    return openerLine.slice(openerEndIndex + 1, closingMatchColumn);
+  }
+
+  const segments: string[] = [];
+  if (openerEndIndex >= 0) {
+    segments.push(openerLine.slice(openerEndIndex + 1));
+  }
+  for (let lineIndex = opener.lineIndex + 1; lineIndex < closingLineIndex; lineIndex++) {
+    segments.push(lines[lineIndex]);
+  }
+  segments.push(lines[closingLineIndex].slice(0, closingMatchColumn));
+  return segments.join("\n");
+};
+
+const isInsideStringOnlyWrapper = (
+  lines: string[],
+  diagnosticLine: number,
+  wrapperNames: Set<string>,
+): boolean => {
+  const opener = findEnclosingJsxOpener(lines, diagnosticLine);
+  if (!opener) return false;
+  if (!wrapperNames.has(opener.fullName) && !wrapperNames.has(opener.leafName)) return false;
+  const bodyText = extractWrapperBodyText(lines, opener);
+  if (bodyText === null) return false;
+  return !JSX_CHILD_OPEN_PATTERN.test(bodyText);
+};
+
 export const filterIgnoredDiagnostics = (
   diagnostics: Diagnostic[],
   config: ReactDoctorConfig,
@@ -73,6 +158,12 @@ export const filterIgnoredDiagnostics = (
       : [],
   );
   const hasTextComponents = textComponentNames.size > 0;
+  const rawTextWrapperComponentNames = new Set(
+    Array.isArray(config.rawTextWrapperComponents)
+      ? config.rawTextWrapperComponents.filter((name): name is string => typeof name === "string")
+      : [],
+  );
+  const hasRawTextWrappers = rawTextWrapperComponentNames.size > 0;
   const getFileLines = createFileLinesCache(rootDirectory, readFileLinesSync);
 
   return diagnostics.filter((diagnostic) => {
@@ -83,10 +174,25 @@ export const filterIgnoredDiagnostics = (
     }
     if (isDiagnosticIgnoredByOverrides(diagnostic, rootDirectory, compiledOverrides)) return false;
 
-    if (hasTextComponents && diagnostic.rule === "rn-no-raw-text" && diagnostic.line > 0) {
+    if (
+      (hasTextComponents || hasRawTextWrappers) &&
+      diagnostic.rule === "rn-no-raw-text" &&
+      diagnostic.line > 0
+    ) {
       const lines = getFileLines(diagnostic.filePath);
-      if (lines && isInsideTextComponent(lines, diagnostic.line, textComponentNames)) {
-        return false;
+      if (lines) {
+        if (
+          hasTextComponents &&
+          isInsideTextComponent(lines, diagnostic.line, textComponentNames)
+        ) {
+          return false;
+        }
+        if (
+          hasRawTextWrappers &&
+          isInsideStringOnlyWrapper(lines, diagnostic.line, rawTextWrapperComponentNames)
+        ) {
+          return false;
+        }
       }
     }
 

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -19,7 +19,16 @@ import { afterAll, describe, expect, it } from "vite-plus/test";
 import type { ReactDoctorConfig } from "../../src/types.js";
 import { checkReducedMotion } from "../../src/utils/check-reduced-motion.js";
 import { filterIgnoredDiagnostics } from "../../src/utils/filter-diagnostics.js";
-import { buildDiagnostic, initGitRepo, writeFile, writeJson } from "./_helpers.js";
+import { mergeAndFilterDiagnostics } from "../../src/utils/merge-and-filter-diagnostics.js";
+import { runOxlint } from "../../src/utils/run-oxlint.js";
+import { createNodeReadFileLinesSync } from "../../src/utils/read-file-lines-node.js";
+import {
+  buildDiagnostic,
+  initGitRepo,
+  setupReactProject,
+  writeFile,
+  writeJson,
+} from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-rn-motion-"));
 
@@ -148,6 +157,51 @@ describe("issue #183: rawTextWrapperComponents suppresses string-only wrapper ch
       stubReadFileLines(file),
     );
     expect(filtered).toHaveLength(1);
+  });
+
+  it("does NOT suppress raw text whose enclosing parent is a non-wrapper, even when a SIBLING is a configured wrapper (closed-sibling regression)", () => {
+    const config: ReactDoctorConfig = { rawTextWrapperComponents: ["Button"] };
+    const file = `<View>\n  <Button>Inner</Button>\n  Save\n</View>\n`;
+    const filtered = filterIgnoredDiagnostics(
+      [buildRnTextDiagnostic({ line: 3 })],
+      config,
+      VIRTUAL_ROOT,
+      stubReadFileLines(file),
+    );
+    expect(filtered).toHaveLength(1);
+  });
+
+  it("end-to-end: a real oxlint run on a React Native project gets its rn-no-raw-text diagnostics suppressed when `rawTextWrapperComponents` matches", async () => {
+    const projectDir = setupReactProject(tempRoot, "issue-183-e2e", {
+      packageJsonExtras: { dependencies: { react: "^19.0.0", "react-native": "0.76.0" } },
+      files: {
+        "src/App.tsx": `export const App = () => <Button>Cancel</Button>;\n`,
+      },
+    });
+
+    const rawDiagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      hasTypeScript: true,
+      framework: "react-native",
+      hasReactCompiler: false,
+      hasTanStackQuery: false,
+      reactMajorVersion: 19,
+    });
+    const rnRawTextDiagnostics = rawDiagnostics.filter(
+      (diagnostic) => diagnostic.rule === "rn-no-raw-text",
+    );
+    expect(rnRawTextDiagnostics.length).toBeGreaterThan(0);
+
+    const filtered = mergeAndFilterDiagnostics(
+      rawDiagnostics,
+      projectDir,
+      { rawTextWrapperComponents: ["Button"] },
+      createNodeReadFileLinesSync(projectDir),
+    );
+    const remainingRnRawText = filtered.filter(
+      (diagnostic) => diagnostic.rule === "rn-no-raw-text",
+    );
+    expect(remainingRnRawText).toHaveLength(0);
   });
 
   it("composes with textComponents (each suppresses its own diagnostics)", () => {

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -89,6 +89,88 @@ describe("issue #93 + #100: textComponents allowlists custom RN text wrappers", 
   });
 });
 
+describe("issue #183: rawTextWrapperComponents suppresses string-only wrapper children", () => {
+  it("suppresses raw string children inside configured raw text wrappers", () => {
+    const config: ReactDoctorConfig = { rawTextWrapperComponents: ["Button"] };
+    const file = `<Button>Cancel</Button>\n`;
+    const filtered = filterIgnoredDiagnostics(
+      [buildRnTextDiagnostic({ line: 1 })],
+      config,
+      VIRTUAL_ROOT,
+      stubReadFileLines(file),
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("suppresses raw template-literal children inside configured raw text wrappers", () => {
+    const config: ReactDoctorConfig = { rawTextWrapperComponents: ["Button"] };
+    const file = "<Button>{`Save changes`}</Button>\n";
+    const filtered = filterIgnoredDiagnostics(
+      [buildRnTextDiagnostic({ line: 1 })],
+      config,
+      VIRTUAL_ROOT,
+      stubReadFileLines(file),
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("recognizes wrappers by their LEAF name when the JSX uses a member expression", () => {
+    const config: ReactDoctorConfig = { rawTextWrapperComponents: ["Button"] };
+    const file = `<HeroUi.Button>Cancel</HeroUi.Button>\n`;
+    const filtered = filterIgnoredDiagnostics(
+      [buildRnTextDiagnostic({ line: 1 })],
+      config,
+      VIRTUAL_ROOT,
+      stubReadFileLines(file),
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("still reports raw text inside a wrapper that ALSO contains a JSX child element", () => {
+    const config: ReactDoctorConfig = { rawTextWrapperComponents: ["Button"] };
+    const file = `<Button>\n  Save\n  <Icon />\n</Button>\n`;
+    const filtered = filterIgnoredDiagnostics(
+      [buildRnTextDiagnostic({ line: 2 })],
+      config,
+      VIRTUAL_ROOT,
+      stubReadFileLines(file),
+    );
+    expect(filtered).toHaveLength(1);
+  });
+
+  it("does not affect wrappers that aren't listed", () => {
+    const config: ReactDoctorConfig = { rawTextWrapperComponents: ["Button"] };
+    const file = `<Card>Cancel</Card>\n`;
+    const filtered = filterIgnoredDiagnostics(
+      [buildRnTextDiagnostic({ line: 1 })],
+      config,
+      VIRTUAL_ROOT,
+      stubReadFileLines(file),
+    );
+    expect(filtered).toHaveLength(1);
+  });
+
+  it("composes with textComponents (each suppresses its own diagnostics)", () => {
+    const config: ReactDoctorConfig = {
+      textComponents: ["Typography"],
+      rawTextWrapperComponents: ["Button"],
+    };
+    const file = `<Typography>Hello</Typography>\n<Button>Cancel</Button>\n<View>Bad</View>\n`;
+    const filtered = filterIgnoredDiagnostics(
+      [
+        buildRnTextDiagnostic({ line: 1 }),
+        buildRnTextDiagnostic({ line: 2 }),
+        buildRnTextDiagnostic({ line: 3 }),
+      ],
+      config,
+      VIRTUAL_ROOT,
+      stubReadFileLines(file),
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].line).toBe(3);
+  });
+});
+
 describe("issue #94: MotionConfig satisfies the reduced-motion accessibility check", () => {
   it("does not emit require-reduced-motion when MotionConfig is present in source", () => {
     const projectDir = path.join(tempRoot, "issue-94-positive");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #183.

## Problem

`rn-no-raw-text` reports false positives for React Native components that safely transform string children into a `<Text>` internally — e.g. `heroui-native`'s `Button`, which stringifies its children and renders them through a `ButtonLabel` → `Text` path:

```tsx
import { Button } from "heroui-native";

export function Example() {
  return <Button>Cancel</Button>; // false positive: rn-no-raw-text
}
```

The existing `textComponents` escape hatch suppresses unconditionally, but `Button` is not semantically a text component — listing it there would also hide legitimate diagnostics for mixed children:

```tsx
<Button>
  Save
  <Icon />
</Button>
```

## Fix

Adds a separate, narrower config option: `rawTextWrapperComponents`.

- Listed wrappers suppress `rn-no-raw-text` **only when** the wrapper's children are entirely stringifiable (no nested JSX child element).
- A wrapper with a sibling JSX child (e.g. `<Button>Save<Icon /></Button>`) still reports — the wrapper can't safely route raw text alongside a JSX child it might pass through.

## Changes

- `packages/react-doctor/src/types.ts`: new `ReactDoctorConfig.rawTextWrapperComponents?: string[]` field with documenting JSDoc.
- `packages/react-doctor/src/utils/filter-diagnostics.ts`: line-based heuristic that
  - walks back from the diagnostic to find the nearest JSX opener,
  - **verifies enclosure** by checking the opener's matching closing tag falls *after* the diagnostic position — closed-sibling openers are skipped and the walk continues outward,
  - inspects the wrapper body for `<[A-Za-z]` JSX child opens; any present means we still report.

  Member-expression wrappers are matched on either the full dotted name or the leaf name (mirroring the existing `textComponents` semantics). Falls back to "don't suppress" whenever the heuristic can't confidently locate a wrapper body — unknown matches stay visible.
- `packages/react-doctor/README.md`: documents the new config key alongside `textComponents` and explains when each is appropriate.
- `packages/react-doctor/tests/regressions/rn-and-motion.test.ts`: 8 new regression tests under an `issue #183` describe block:
  - suppresses raw string children inside a configured wrapper
  - suppresses template-literal children
  - matches member-expression wrappers by leaf name (`<HeroUi.Button>...`)
  - **still reports** when the wrapper has a sibling JSX child (negative case from the issue)
  - leaves unrelated wrappers untouched
  - **closed-sibling regression**: a `<Button>` adjacent to a non-wrapper `<View>` does NOT cause `<View>`'s raw text to be suppressed (caught during deep review)
  - composes with `textComponents` (each suppresses its own diagnostics)
  - **end-to-end**: real oxlint run on a synthetic React Native project — verifies that the rule actually fires, then that `rawTextWrapperComponents` filtering removes the diagnostic with the real line/column oxlint emits

## Verification

- `pnpm test` — 50 files / 680 tests passing
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm format:check` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98a518ce-5605-4806-a5f5-3d42995196e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98a518ce-5605-4806-a5f5-3d42995196e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

