### PR TITLE
docs(react-doctor): document stacked disable-next-line

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -88,7 +88,18 @@ useEffect(() => {
 }, [value]);
 ```
 
-When two rules fire on the same line, comma-separate the rule ids on a single comment. Block comments work inside JSX:
+When multiple rules fire on the same line, you can either:
+
+- list them on one comment (comma-separated), or
+- stack multiple `react-doctor-disable-next-line` comments (one per rule) directly above the line.
+
+```tsx
+// react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers
+// react-doctor-disable-next-line react-doctor/no-derived-useState
+const [localSearch, setLocalSearch] = useState(searchQuery);
+```
+
+Block comments work inside JSX:
 
 <!-- prettier-ignore -->
 ```tsx


### PR DESCRIPTION
Fixes #159.

Adds an explicit example showing that stacked `react-doctor-disable-next-line` comments work (one rule per line), alongside the existing comma-separated form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or linting behavior is modified.
> 
> **Overview**
> Clarifies README guidance for inline suppressions by documenting two supported ways to disable multiple rules on one line: **comma-separated IDs in a single comment** or **stacked `react-doctor-disable-next-line` comments**.
> 
> Adds a concrete stacked-comment `tsx` example and keeps the existing note about block comments inside JSX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da5b9ba68f102432b4eaccb3e9e6a0364c6e33d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->