### PR TITLE
fix(react-doctor): resolve React from Bun grouped catalogs

### DIFF
--- a/.changeset/fix-bun-grouped-catalogs.md
+++ b/.changeset/fix-bun-grouped-catalogs.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Resolve React version from Bun grouped catalogs (`workspaces.catalogs.<group>`). Previously, dependencies declared as `"react": "catalog:<group>"` against a Bun grouped catalog at `workspaces.catalogs` failed with "No React dependency found"; only the default `workspaces.catalog` was supported.

--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -71,7 +71,13 @@ export interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
-  workspaces?: string[] | { packages?: string[]; catalog?: Record<string, string> };
+  workspaces?:
+    | string[]
+    | {
+        packages?: string[];
+        catalog?: Record<string, string>;
+        catalogs?: Record<string, Record<string, string>>;
+      };
   catalog?: unknown;
   catalogs?: unknown;
 }

--- a/packages/react-doctor/src/utils/discover-project.ts
+++ b/packages/react-doctor/src/utils/discover-project.ts
@@ -303,6 +303,20 @@ const resolveCatalogVersion = (
     if (version) return version;
   }
 
+  if (workspaces && !Array.isArray(workspaces) && isPlainObject(workspaces.catalogs)) {
+    const namedCatalog = catalogName ? workspaces.catalogs[catalogName] : undefined;
+    if (namedCatalog && isPlainObject(namedCatalog)) {
+      const version = resolveVersionFromCatalog(namedCatalog, packageName);
+      if (version) return version;
+    }
+    for (const catalogEntries of Object.values(workspaces.catalogs)) {
+      if (isPlainObject(catalogEntries)) {
+        const version = resolveVersionFromCatalog(catalogEntries, packageName);
+        if (version) return version;
+      }
+    }
+  }
+
   if (rootDirectory) {
     const pnpmCatalogs = parsePnpmWorkspaceCatalogs(rootDirectory);
     const pnpmVersion = resolveCatalogVersionFromCollection(pnpmCatalogs, packageName, catalogName);

--- a/packages/react-doctor/tests/discover-project.test.ts
+++ b/packages/react-doctor/tests/discover-project.test.ts
@@ -66,6 +66,13 @@ describe("discoverProject", () => {
     expect(projectInfo.reactVersion).toBe("^19.1.4");
   });
 
+  it("resolves React version from Bun workspace named catalog", () => {
+    const projectInfo = discoverProject(
+      path.join(FIXTURES_DIRECTORY, "bun-named-catalog-workspace", "apps", "web"),
+    );
+    expect(projectInfo.reactVersion).toBe("^19.1.4");
+  });
+
   it("resolves React version when only in peerDependencies with catalog reference", () => {
     const monorepoRoot = path.join(tempDirectory, "peer-deps-catalog-root");
     fs.mkdirSync(path.join(monorepoRoot, "packages", "ui"), { recursive: true });

--- a/packages/react-doctor/tests/fixtures/bun-named-catalog-workspace/apps/web/package.json
+++ b/packages/react-doctor/tests/fixtures/bun-named-catalog-workspace/apps/web/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web",
+  "private": true,
+  "dependencies": {
+    "react": "catalog:react19",
+    "react-dom": "catalog:react19"
+  }
+}

--- a/packages/react-doctor/tests/fixtures/bun-named-catalog-workspace/package.json
+++ b/packages/react-doctor/tests/fixtures/bun-named-catalog-workspace/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bun-named-catalog-workspace",
+  "private": true,
+  "workspaces": {
+    "packages": [
+      "apps/*"
+    ],
+    "catalogs": {
+      "react19": {
+        "react": "^19.1.4",
+        "react-dom": "^19.1.4"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #191.

`resolveCatalogVersion` already supports Bun's general catalog (`workspaces.catalog`) and pnpm catalogs, but ignores Bun's **grouped/named catalogs** at `workspaces.catalogs.<group>`. Any dependency declared as `"react": "catalog:<group>"` therefore resolved to `null` and the user got the misleading `No React dependency found` error.

This PR adds a parallel branch in `resolveCatalogVersion` that walks `workspaces.catalogs`, mirroring the existing handling of the top-level `packageJson.catalogs` key:

- Try the named catalog matching the `catalog:<name>` reference first.
- Fall back to scanning all named catalogs (matching the existing fallback behavior used elsewhere).

Bun's grouped catalogs are documented at https://bun.com/docs/install/catalogs.

### Repro (added as a test)

Root `package.json`:
```json
{
  "workspaces": {
    "packages": ["apps/*"],
    "catalogs": {
      "react19": { "react": "^19.1.4", "react-dom": "^19.1.4" }
    }
  }
}
```

App `package.json`:
```json
{ "dependencies": { "react": "catalog:react19" } }
```

- **Before:** `discoverProject(...).reactVersion === null` → throws `No React dependency found`.
- **After:** `discoverProject(...).reactVersion === "^19.1.4"`.

## Changes

- `src/utils/discover-project.ts` — new branch in `resolveCatalogVersion` for `workspaces.catalogs`.
- `src/types.ts` — extend `PackageJson["workspaces"]` with `catalogs?: Record<string, Record<string, string>>`.
- `tests/discover-project.test.ts` — new test mirroring the existing Bun default-catalog test.
- `tests/fixtures/bun-named-catalog-workspace/` — minimal fixture.
- `.changeset/fix-bun-grouped-catalogs.md` — patch changeset.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm exec vp test run discover-project` — 27 passed (was 26)
- [x] Negative check: stashed only `src/utils/discover-project.ts` + `src/types.ts`, the new test fails (`reactVersion` is `null`); reapplied, passes.
- [x] `pnpm format`
- [x] `pnpm lint` — 0 warnings, 0 errors
- [ ] Full `pnpm test` was not run cleanly; on a fresh checkout the regression suite fails for an unrelated reason (`Cannot find module .../utils/react-doctor-plugin.js` — the oxlint JS plugin appears to need a build step before tests). Happy to chase down the right pre-test command if you can point me at it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive change to dependency version resolution logic with a focused test/fixture; main risk is unintended precedence when multiple catalogs define the same package.
> 
> **Overview**
> Fixes React version detection for Bun workspaces that use **grouped/named catalogs** under `workspaces.catalogs.<name>` when dependencies are declared as `"react": "catalog:<name>"`.
> 
> `resolveCatalogVersion` now checks `workspaces.catalogs` by first trying the referenced named catalog and then falling back to scanning all catalogs, and `PackageJson` typing plus tests/fixtures and a patch changeset are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f36880f3709fd5c1de542358aec25b3a0da73c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->