### PR TITLE
fix(react-doctor): fall back to nested React subproject in diagnose()

### DIFF
--- a/.changeset/diagnose-fallback-to-nested-project.md
+++ b/.changeset/diagnose-fallback-to-nested-project.md
@@ -1,0 +1,12 @@
+---
+"react-doctor": patch
+---
+
+`diagnose()` now falls back to the first nested React subproject when the
+requested directory has no root `package.json`, instead of crashing with
+`No package.json found in <directory>`. This unblocks external review
+runners (e.g. the Vercel AI Code Review sandbox) that point `diagnose()`
+at the cloned repo root for projects whose `package.json` lives in a
+subfolder like `apps/web`. When neither the root nor any nested
+subdirectory contains a React project, `diagnose()` now throws a clearer
+`No React project found in <directory>` error.

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -27,6 +27,7 @@ import { mergeAndFilterDiagnostics } from "./utils/merge-and-filter-diagnostics.
 import { parseReactMajor } from "./utils/parse-react-major.js";
 import { clearPackageJsonCache } from "./utils/read-package-json.js";
 import { createNodeReadFileLinesSync } from "./utils/read-file-lines-node.js";
+import { resolveDiagnoseTarget } from "./utils/resolve-diagnose-target.js";
 import { resolveLintIncludePaths } from "./utils/resolve-lint-include-paths.js";
 import { runKnip } from "./utils/run-knip.js";
 import { runOxlint } from "./utils/run-oxlint.js";
@@ -105,7 +106,13 @@ export const diagnose = async (
   options: DiagnoseOptions = {},
 ): Promise<DiagnoseResult> => {
   const startTime = globalThis.performance.now();
-  const resolvedDirectory = path.resolve(directory);
+  const requestedDirectory = path.resolve(directory);
+  const resolvedDirectory = resolveDiagnoseTarget(requestedDirectory);
+  if (!resolvedDirectory) {
+    throw new Error(
+      `No React project found in ${requestedDirectory}. Expected a package.json at the directory root or a nested package.json with a React dependency.`,
+    );
+  }
   const userConfig = loadConfig(resolvedDirectory);
   const includePaths = options.includePaths ?? [];
   const isDiffMode = includePaths.length > 0;

--- a/packages/react-doctor/src/utils/resolve-diagnose-target.ts
+++ b/packages/react-doctor/src/utils/resolve-diagnose-target.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+import { discoverReactSubprojects } from "./discover-project.js";
+import { isFile } from "./is-file.js";
+
+export const resolveDiagnoseTarget = (directory: string): string | null => {
+  if (isFile(path.join(directory, "package.json"))) return directory;
+
+  const reactSubprojects = discoverReactSubprojects(directory);
+  if (reactSubprojects.length > 0) return reactSubprojects[0].directory;
+
+  return null;
+};

--- a/packages/react-doctor/tests/diagnose.test.ts
+++ b/packages/react-doctor/tests/diagnose.test.ts
@@ -73,4 +73,29 @@ export const Debounced = ({ onChange }: { onChange: (value: string) => void }) =
     );
     expect(preferUseEffectEventHits.length).toBeGreaterThanOrEqual(1);
   });
+
+  // Regression: external review pipelines (e.g. the Vercel AI Code
+  // Review sandbox) call `diagnose()` on the cloned repo root. Some
+  // repos place their app code under `apps/web` (or similar) with NO
+  // root `package.json`, which previously crashed the runner with
+  // `No package.json found in <repo>`. We now fall back to the first
+  // nested package.json that has a React dependency.
+  it("falls back to a nested React subproject when the requested directory has no root package.json", async () => {
+    const wrapperDir = path.join(tempRoot, "diagnose-no-root-package");
+    fs.mkdirSync(wrapperDir, { recursive: true });
+    setupReactProject(wrapperDir, "web");
+
+    const result = await diagnose(wrapperDir, { lint: false, deadCode: false });
+    expect(result.project.rootDirectory).toBe(path.join(wrapperDir, "web"));
+    expect(result.project.reactVersion).toBe("^19.0.0");
+  });
+
+  it("throws a clear error when the directory has no root package.json and no nested React project", async () => {
+    const emptyDir = path.join(tempRoot, "diagnose-no-react-anywhere");
+    fs.mkdirSync(emptyDir, { recursive: true });
+
+    await expect(diagnose(emptyDir, { lint: false, deadCode: false })).rejects.toThrow(
+      "No React project found in",
+    );
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

External review runners (e.g. the Vercel AI Code Review sandbox) call `diagnose()` from `react-doctor/api` on the cloned repo root. When the root has no `package.json` (common for repos that put their app under `apps/web` or similar), the runner crashes with:

```
Analysis failed: Sandbox command failed: node /vercel/sandbox/review-runtime/review-runner.mjs

Error: No package.json found in /vercel/sandbox/review-workspaces/head/repo
    at discoverProject (file:///vercel/sandbox/review-runtime/node_modules/react-doctor/dist/index.js:945:38)
    at diagnose (file:///vercel/sandbox/review-runtime/node_modules/react-doctor/dist/index.js:3085:22)
    at file:///vercel/sandbox/review-runtime/review-runner.mjs:21:3
```

## Fix

`diagnose()` now resolves the target directory before invoking `discoverProject`:

1. If `directory/package.json` exists, use `directory` (existing behavior).
2. Otherwise, walk one level deep via the existing `discoverReactSubprojects` helper and use the first React-containing subproject.
3. If neither the root nor any nested directory has a React project, throw a clearer `No React project found in <directory>` error instead of the misleading `No package.json found` one.

The CLI flow (`scan.ts` → `selectProjects`) was already resilient via `listWorkspacePackages` / `discoverReactSubprojects`; this change brings the programmatic `diagnose()` API to parity for the no-root-package case that the Vercel runner hits.

## Changes

- `packages/react-doctor/src/utils/resolve-diagnose-target.ts` — new helper that returns the directory to diagnose (root if it has `package.json`, else first nested React subproject, else `null`).
- `packages/react-doctor/src/index.ts` — `diagnose()` calls the helper and throws a clearer error when nothing matches.
- `packages/react-doctor/tests/diagnose.test.ts` — two new regression tests covering the fallback path and the no-react-anywhere error.
- `.changeset/diagnose-fallback-to-nested-project.md` — patch release note.

## Verification

```
pnpm typecheck   # passes
pnpm lint        # 0 warnings, 0 errors
pnpm format:check # all files formatted
pnpm test        # 685 tests passed (51 files), including the 2 new ones
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3f8c2d1-154e-42e5-956d-c7ed82fce4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3f8c2d1-154e-42e5-956d-c7ed82fce4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

