### PR TITLE
fix(catalog): resolve react version from Bun grouped catalogs

### DIFF
--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -71,7 +71,13 @@ export interface PackageJson {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
-  workspaces?: string[] | { packages?: string[]; catalog?: Record<string, string> };
+  workspaces?:
+    | string[]
+    | {
+        packages?: string[];
+        catalog?: Record<string, string>;
+        catalogs?: Record<string, Record<string, string>>;
+      };
   catalog?: unknown;
   catalogs?: unknown;
 }

--- a/packages/react-doctor/src/utils/discover-project.ts
+++ b/packages/react-doctor/src/utils/discover-project.ts
@@ -273,10 +273,27 @@ const resolveCatalogVersion = (
   packageJson: PackageJson,
   packageName: string,
   rootDirectory?: string,
+  // HACK: when this resolver runs against the MONOREPO ROOT
+  // package.json (which typically has no `react` dep of its own),
+  // the catalog reference must come from the LEAF package that
+  // actually wrote `"react": "catalog:react19"`. Without an explicit
+  // reference, the named-catalog lookup below would always fall
+  // through to the `Object.values()` scan and return an arbitrary
+  // group — losing fidelity when multiple grouped catalogs (e.g.
+  // `react18` and `react19`) define the same package at different
+  // versions. Callers that already have the leaf's catalog reference
+  // pass it in; everyone else falls back to the in-this-package
+  // dependency, which still covers the common single-package case.
+  explicitCatalogReference?: string | null,
 ): string | null => {
   const allDependencies = collectAllDependencies(packageJson);
   const rawVersion = allDependencies[packageName];
-  const catalogName = rawVersion ? extractCatalogName(rawVersion) : null;
+  const catalogName =
+    explicitCatalogReference !== undefined
+      ? explicitCatalogReference
+      : rawVersion
+        ? extractCatalogName(rawVersion)
+        : null;
 
   if (isPlainObject(packageJson.catalog)) {
     const version = resolveVersionFromCatalog(packageJson.catalog, packageName);
@@ -442,7 +459,18 @@ const findDependencyInfoFromMonorepoRoot = (directory: string): DependencyInfo =
 
   const rootPackageJson = readPackageJson(monorepoPackageJsonPath);
   const rootInfo = extractDependencyInfo(rootPackageJson);
-  const catalogVersion = resolveCatalogVersion(rootPackageJson, "react", monorepoRoot);
+  const leafPackageJsonPath = path.join(directory, "package.json");
+  const leafCatalogReference = isFile(leafPackageJsonPath)
+    ? (extractCatalogName(
+        collectAllDependencies(readPackageJson(leafPackageJsonPath)).react ?? "",
+      ) ?? null)
+    : null;
+  const catalogVersion = resolveCatalogVersion(
+    rootPackageJson,
+    "react",
+    monorepoRoot,
+    leafCatalogReference,
+  );
   const workspaceInfo = findReactInWorkspaces(monorepoRoot, rootPackageJson);
 
   return {
@@ -621,8 +649,15 @@ export const discoverProject = (directory: string): ProjectInfo => {
   const packageJson = readPackageJson(packageJsonPath);
   let { reactVersion, framework } = extractDependencyInfo(packageJson);
 
+  // HACK: capture the catalog reference (e.g. `catalog:react19`) from
+  // the LEAF package once so every fallback resolver below can route
+  // named-catalog lookups to the right group, even when the root
+  // package.json has no `react` dependency to derive a name from.
+  const leafCatalogReference =
+    extractCatalogName(collectAllDependencies(packageJson).react ?? "") ?? null;
+
   if (!reactVersion) {
-    reactVersion = resolveCatalogVersion(packageJson, "react", directory);
+    reactVersion = resolveCatalogVersion(packageJson, "react", directory, leafCatalogReference);
   }
 
   if (!reactVersion) {
@@ -631,7 +666,12 @@ export const discoverProject = (directory: string): ProjectInfo => {
       const monorepoPackageJsonPath = path.join(monorepoRoot, "package.json");
       if (isFile(monorepoPackageJsonPath)) {
         const rootPackageJson = readPackageJson(monorepoPackageJsonPath);
-        reactVersion = resolveCatalogVersion(rootPackageJson, "react", monorepoRoot);
+        reactVersion = resolveCatalogVersion(
+          rootPackageJson,
+          "react",
+          monorepoRoot,
+          leafCatalogReference,
+        );
       }
     }
   }

--- a/packages/react-doctor/src/utils/discover-project.ts
+++ b/packages/react-doctor/src/utils/discover-project.ts
@@ -298,9 +298,25 @@ const resolveCatalogVersion = (
   }
 
   const workspaces = packageJson.workspaces;
-  if (workspaces && !Array.isArray(workspaces) && isPlainObject(workspaces.catalog)) {
-    const version = resolveVersionFromCatalog(workspaces.catalog, packageName);
-    if (version) return version;
+  if (workspaces && !Array.isArray(workspaces)) {
+    if (isPlainObject(workspaces.catalog)) {
+      const version = resolveVersionFromCatalog(workspaces.catalog, packageName);
+      if (version) return version;
+    }
+
+    if (isPlainObject(workspaces.catalogs)) {
+      const namedCatalog = catalogName ? workspaces.catalogs[catalogName] : undefined;
+      if (namedCatalog && isPlainObject(namedCatalog)) {
+        const version = resolveVersionFromCatalog(namedCatalog, packageName);
+        if (version) return version;
+      }
+      for (const catalogEntries of Object.values(workspaces.catalogs)) {
+        if (isPlainObject(catalogEntries)) {
+          const version = resolveVersionFromCatalog(catalogEntries, packageName);
+          if (version) return version;
+        }
+      }
+    }
   }
 
   if (rootDirectory) {

--- a/packages/react-doctor/src/utils/discover-project.ts
+++ b/packages/react-doctor/src/utils/discover-project.ts
@@ -288,12 +288,14 @@ const resolveCatalogVersion = (
 ): string | null => {
   const allDependencies = collectAllDependencies(packageJson);
   const rawVersion = allDependencies[packageName];
+  // HACK: prefer the caller-provided reference when present, but fall
+  // through (?? rather than !== undefined) when the leaf had no
+  // catalog reference of its own. That way a root package.json that
+  // happens to declare its own `react: "catalog:<group>"` still drives
+  // the named lookup, instead of being silently ignored just because
+  // the leaf passed `null`.
   const catalogName =
-    explicitCatalogReference !== undefined
-      ? explicitCatalogReference
-      : rawVersion
-        ? extractCatalogName(rawVersion)
-        : null;
+    explicitCatalogReference ?? (rawVersion ? extractCatalogName(rawVersion) : null);
 
   if (isPlainObject(packageJson.catalog)) {
     const version = resolveVersionFromCatalog(packageJson.catalog, packageName);

--- a/packages/react-doctor/tests/discover-project.test.ts
+++ b/packages/react-doctor/tests/discover-project.test.ts
@@ -66,6 +66,13 @@ describe("discoverProject", () => {
     expect(projectInfo.reactVersion).toBe("^19.1.4");
   });
 
+  it("resolves React version from Bun grouped workspace catalog", () => {
+    const projectInfo = discoverProject(
+      path.join(FIXTURES_DIRECTORY, "bun-grouped-catalog", "apps", "web"),
+    );
+    expect(projectInfo.reactVersion).toBe("19.2.0");
+  });
+
   it("resolves React version when only in peerDependencies with catalog reference", () => {
     const monorepoRoot = path.join(tempDirectory, "peer-deps-catalog-root");
     fs.mkdirSync(path.join(monorepoRoot, "packages", "ui"), { recursive: true });

--- a/packages/react-doctor/tests/discover-project.test.ts
+++ b/packages/react-doctor/tests/discover-project.test.ts
@@ -73,6 +73,13 @@ describe("discoverProject", () => {
     expect(projectInfo.reactVersion).toBe("19.2.0");
   });
 
+  it("picks the leaf-referenced group when multiple Bun grouped catalogs define the same package", () => {
+    const projectInfo = discoverProject(
+      path.join(FIXTURES_DIRECTORY, "bun-multiple-grouped-catalogs", "apps", "web"),
+    );
+    expect(projectInfo.reactVersion).toBe("19.2.0");
+  });
+
   it("resolves React version when only in peerDependencies with catalog reference", () => {
     const monorepoRoot = path.join(tempDirectory, "peer-deps-catalog-root");
     fs.mkdirSync(path.join(monorepoRoot, "packages", "ui"), { recursive: true });

--- a/packages/react-doctor/tests/fixtures/bun-grouped-catalog/apps/web/package.json
+++ b/packages/react-doctor/tests/fixtures/bun-grouped-catalog/apps/web/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web",
+  "private": true,
+  "dependencies": {
+    "react": "catalog:react19",
+    "react-dom": "catalog:react19"
+  }
+}

--- a/packages/react-doctor/tests/fixtures/bun-grouped-catalog/package.json
+++ b/packages/react-doctor/tests/fixtures/bun-grouped-catalog/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bun-grouped-catalog",
+  "private": true,
+  "workspaces": {
+    "packages": [
+      "apps/*"
+    ],
+    "catalogs": {
+      "react19": {
+        "react": "19.2.0",
+        "react-dom": "19.2.0"
+      }
+    }
+  }
+}

--- a/packages/react-doctor/tests/fixtures/bun-multiple-grouped-catalogs/apps/web/package.json
+++ b/packages/react-doctor/tests/fixtures/bun-multiple-grouped-catalogs/apps/web/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web",
+  "private": true,
+  "dependencies": {
+    "react": "catalog:react19",
+    "react-dom": "catalog:react19"
+  }
+}

--- a/packages/react-doctor/tests/fixtures/bun-multiple-grouped-catalogs/package.json
+++ b/packages/react-doctor/tests/fixtures/bun-multiple-grouped-catalogs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bun-multiple-grouped-catalogs",
+  "private": true,
+  "workspaces": {
+    "packages": [
+      "apps/*"
+    ],
+    "catalogs": {
+      "react18": {
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
+      },
+      "react19": {
+        "react": "19.2.0",
+        "react-dom": "19.2.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #191.

### Summary

`workspaces.catalogs.<group>` (Bun grouped catalogs) were never read in `resolveCatalogVersion`, so any dependency declared as `catalog:<group>` resolved to `null` and surfaced as the misleading "No React dependency found" error.

### Change

In `discover-project.ts`, after the existing `workspaces.catalog` branch, walk `workspaces.catalogs[<group>]` (when present) the same way top-level `packageJson.catalogs` is already walked:

1. Try the named group from the `catalog:<name>` reference, then
2. Fall back to scanning every group in `workspaces.catalogs`.

`PackageJson["workspaces"]` is updated to include `catalogs?: Record<string, Record<string, string>>`.

### Tests

Added `bun-grouped-catalog` fixture and a `discoverProject` test that mirrors the issue's reproduction (`react: "catalog:react19"` → `19.2.0`).

```
Test Files  51 passed (51)
     Tests  684 passed (684)
```

### Reference

[Bun docs — grouped catalogs](https://bun.com/docs/install/catalogs)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

