### PR TITLE
fix(action): score step is output-only, never fail the job

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,9 +89,14 @@ runs:
         INPUT_DIRECTORY: ${{ inputs.directory }}
         INPUT_OFFLINE: ${{ inputs.offline }}
       run: |
-        SCORE_ARGS=("$INPUT_DIRECTORY" "--score")
+        # HACK: --score is an output-collection step, not a gate. Force
+        # --fail-on none so older react-doctor releases (which exit
+        # non-zero when the score lands in the "Needs work" band, even
+        # though the value itself is the only meaningful signal here)
+        # don't fail the composite action under `set -e -o pipefail`.
+        SCORE_ARGS=("$INPUT_DIRECTORY" "--score" "--fail-on" "none")
         if [ "$INPUT_OFFLINE" = "true" ]; then SCORE_ARGS+=("--offline"); fi
-        SCORE=$(npx -y react-doctor@latest "${SCORE_ARGS[@]}" 2>/dev/null | tail -1 | tr -d '[:space:]')
+        SCORE=$(npx -y react-doctor@latest "${SCORE_ARGS[@]}" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
         if [[ -n "$SCORE" && "$SCORE" =~ ^[0-9]+$ ]]; then
           echo "score=$SCORE" >> "$GITHUB_OUTPUT"
         fi

--- a/packages/react-doctor/src/cli.ts
+++ b/packages/react-doctor/src/cli.ts
@@ -531,6 +531,7 @@ const program = new Command()
           }
 
           if (
+            !isScoreOnly &&
             shouldFailForDiagnostics(
               remappedDiagnostics,
               resolveFailOnLevel(program, flags, userConfig),
@@ -638,6 +639,7 @@ const program = new Command()
       }
 
       if (
+        !isScoreOnly &&
         shouldFailForDiagnostics(allDiagnostics, resolveFailOnLevel(program, flags, userConfig))
       ) {
         process.exitCode = 1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #190.

### Problem

The composite action's score step ran:

```bash
SCORE_ARGS=("$INPUT_DIRECTORY" "--score")
SCORE=$(npx -y react-doctor@latest "${SCORE_ARGS[@]}" 2>/dev/null | tail -1 | tr -d '[:space:]')
```

The CLI's `--fail-on` default is `error`, so the score step inherited it. When the project's score landed in the "Needs work" band (50–74), the underlying scan still hit `--fail-on error` and the score subprocess exited non-zero. With `set -e -o pipefail`, that killed the workflow even when:

- the user configured `fail-on: error` and the diff scan was clean
- the score itself was the only useful signal — and we already validated it with a regex

Repro from the issue:

```bash
$ npx -y react-doctor@latest <dir> --score
54
$ echo $?
1
```

### Fix

Two complementary changes that reinforce each other:

1. **`action.yml`** — the score step now passes `--fail-on none` and tolerates a non-zero pipe (`|| true`). The score's value is the only signal; its exit code is never a gate.
2. **CLI (`packages/react-doctor/src/cli.ts`)** — `--score` is an output-collection mode (per `--help`: *"output only the score"*). Skip the `shouldFailForDiagnostics` exit-code branch when `--score` is set in both the staged-files path and the regular scan path.

### Verification

```bash
# baseline: warnings + --fail-on warning → exit 1
$ react-doctor . --offline -y --fail-on warning ; echo $?
1

# with --score: still exit 0 (score is the signal)
$ react-doctor . --offline -y --fail-on warning --score ; echo $?
0
```

The action.yml change protects users still pulling older `react-doctor@latest`; the CLI change makes the contract documented behavior going forward.

```
Test Files  51 passed (51)
     Tests  683 passed (683)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

