### PR TITLE
fix(suppressions): match disable comments with descriptive trailing text

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -88,7 +88,24 @@ useEffect(() => {
 }, [value]);
 ```
 
-When two rules fire on the same line, comma-separate the rule ids on a single comment. Block comments work inside JSX:
+When two rules fire on the same line, you have two equivalent options. Comma-separate the rule ids on a single comment:
+
+```tsx
+// react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers, react-doctor/no-derived-useState
+const [localSearch, setLocalSearch] = useState(searchQuery);
+```
+
+Or stack one comment per rule directly above the diagnostic. Stacked comments are honored as long as nothing but other `react-doctor-disable-next-line` comments sits between them and the target line:
+
+```tsx
+// react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers
+// react-doctor-disable-next-line react-doctor/no-derived-useState
+const [localSearch, setLocalSearch] = useState(searchQuery);
+```
+
+A code line between stacked comments breaks the chain: only the comment immediately above the diagnostic (and any contiguous `react-doctor-disable-next-line` comments stacked on top of it) is honored. If a comment looks adjacent but the rule still fires, run `react-doctor --explain <file:line>` — it reports whether a nearby suppression was found, what rules it covers, and why it didn't apply.
+
+Block comments work inside JSX:
 
 <!-- prettier-ignore -->
 ```tsx

--- a/packages/react-doctor/src/utils/evaluate-suppression.ts
+++ b/packages/react-doctor/src/utils/evaluate-suppression.ts
@@ -6,7 +6,7 @@ import {
 import { isRuleListedInComment } from "./is-rule-listed-in-comment.js";
 
 const DISABLE_LINE_PATTERN =
-  /(?:\/\/|\/\*)\s*react-doctor-disable-line\b(?:\s+([\w/\-.,\s]+?))?\s*(?:\*\/)?\s*\}?\s*$/;
+  /(?:\/\/|\/\*)\s*react-doctor-disable-line\b(?:\s+([^\r\n]*?))?\s*(?:\*\/)?\s*\}?\s*$/;
 
 export interface SuppressionEvaluation {
   isSuppressed: boolean;

--- a/packages/react-doctor/src/utils/find-stacked-disable-comments.ts
+++ b/packages/react-doctor/src/utils/find-stacked-disable-comments.ts
@@ -1,7 +1,15 @@
 import { SUPPRESSION_NEAR_MISS_MAX_LINES } from "../constants.js";
 
+// HACK: the rule-list capture is intentionally permissive ([^\r\n]*?) so
+// it matches any content following `disable-next-line`. The narrower
+// `[\w/\-.,\s]` class previously excluded common comment punctuation
+// (`;`, `:`, `(`, `'`, …) which silently prevented the regex from
+// matching at all whenever someone added an explanatory `-- ...` tail
+// (#159). The captured string is later split at ` -- ` and tokenized
+// in isRuleListedInComment, so only the rule-id tokens before the
+// description are tested against the diagnostic's rule.
 const DISABLE_NEXT_LINE_PATTERN =
-  /(?:\/\/|\/\*)\s*react-doctor-disable-next-line\b(?:\s+([\w/\-.,\s]+?))?\s*(?:\*\/)?\s*\}?\s*$/;
+  /(?:\/\/|\/\*)\s*react-doctor-disable-next-line\b(?:\s+([^\r\n]*?))?\s*(?:\*\/)?\s*\}?\s*$/;
 
 export interface StackedDisableComment {
   commentLineIndex: number;

--- a/packages/react-doctor/src/utils/is-rule-listed-in-comment.ts
+++ b/packages/react-doctor/src/utils/is-rule-listed-in-comment.ts
@@ -1,4 +1,18 @@
+// HACK: ESLint convention — text after ` -- ` on a disable comment is a
+// human-readable description, not part of the rule list. Strip it
+// before tokenizing so trailing prose like `-- read in render via
+// useDebounce; user can type before commit` doesn't pollute the
+// rule-equality check or get matched against `ruleId`.
+const stripDescriptionTail = (ruleList: string): string => {
+  const descriptionMatch = ruleList.match(/(?:^|\s)--\s/);
+  if (!descriptionMatch || descriptionMatch.index === undefined) return ruleList;
+  return ruleList.slice(0, descriptionMatch.index);
+};
+
 export const isRuleListedInComment = (ruleList: string | undefined, ruleId: string): boolean => {
-  if (!ruleList?.trim()) return true;
-  return ruleList.split(/[,\s]+/).some((token) => token.trim() === ruleId);
+  const trimmed = ruleList?.trim();
+  if (!trimmed) return true;
+  const ruleSection = stripDescriptionTail(trimmed).trim();
+  if (!ruleSection) return true;
+  return ruleSection.split(/[,\s]+/).some((token) => token.trim() === ruleId);
 };

--- a/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
+++ b/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
@@ -299,6 +299,33 @@ describe("issue #159: stacked disable-next-line comments", () => {
     );
     expect(filtered).toHaveLength(1);
   });
+
+  it("issue repro: stacked single-rule disables both apply on a useState line", () => {
+    const filtered = runFilter(
+      "stacked-issue-repro",
+      `// react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers -- read in render via useDebounce\n` +
+        `// react-doctor-disable-next-line react-doctor/no-derived-useState -- searchQuery is the initial value; user can type before debounce commits\n` +
+        `const [localSearch, setLocalSearch] = useState(searchQuery);\n`,
+      [
+        baseDiagnostic({ rule: "rerender-state-only-in-handlers", line: 3 }),
+        baseDiagnostic({ rule: "no-derived-useState", line: 3 }),
+      ],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("equivalent comma-separated form (referenced in #159) also suppresses both rules", () => {
+    const filtered = runFilter(
+      "stacked-issue-repro-comma",
+      `// react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers, react-doctor/no-derived-useState -- searchQuery initial; read in render via useDebounce\n` +
+        `const [localSearch, setLocalSearch] = useState(searchQuery);\n`,
+      [
+        baseDiagnostic({ rule: "rerender-state-only-in-handlers", line: 2 }),
+        baseDiagnostic({ rule: "no-derived-useState", line: 2 }),
+      ],
+    );
+    expect(filtered).toHaveLength(0);
+  });
 });
 
 describe("issue #72: inline suppressions — boundary safety", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #159.

### Root cause

The reporter wrote that stacked single-rule `// react-doctor-disable-next-line` comments shadowed each other. Stacking itself was fixed when #165 landed, but their reproduction still fails on `main` for a subtler reason: every disable line in the report carries an explanatory `-- ...` tail with prose, and prose contains `;`, `:`, `(`, `'` — punctuation **not** in the rule-list capture's character class. When the regex saw a character outside `[\w/\-.,\s]`, the entire `disable-next-line` line stopped matching, and the suppression was silently dropped.

```
// react-doctor-disable-next-line react-doctor/no-derived-useState -- searchQuery is the initial value; user can type before debounce commits
```

The `;` (and trailing words after it) breaks the regex match entirely.

### Fix

1. Broaden the disable-line / disable-next-line capture to `[^\r\n]*?` so any same-line content is accepted. The rule section is split out in a follow-up step.
2. Teach `isRuleListedInComment` to strip text after ` -- ` before tokenizing — ESLint convention is that a trailing ` -- description` is human prose, not part of the rule list. This keeps comments with descriptive tails working without confusing the equality check.

### Tests

Two new regressions in `inline-suppressions.test.ts`:

- The exact issue repro — two stacked `disable-next-line` comments with descriptive tails over a `useState(searchQuery)` line, both rules expected to be suppressed.
- The equivalent comma-separated form (which the issue notes "works but is undocumented") — also expected to suppress both rules.

Also documents both forms (stacking and comma-syntax) in the README, plus the rule that an intervening code line breaks the chain.

```
Test Files  51 passed (51)
     Tests  685 passed (685)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

