### PR TITLE
docs(config): clarify ignore.overrides covers per-file rule ignore

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -64,15 +64,28 @@ Create a `react-doctor.config.json` in your project root:
     "files": ["src/generated/**"],
     "overrides": [
       {
-        "files": ["components/diff/**"],
-        "rules": ["react-doctor/no-array-index-as-key"]
+        "files": ["components/modules/diff/**"],
+        "rules": [
+          "react-doctor/no-array-index-as-key",
+          "react-doctor/no-render-in-render"
+        ]
+      },
+      {
+        "files": ["components/search/HighlightedSnippet.tsx"],
+        "rules": ["react/no-danger"]
       }
     ]
   }
 }
 ```
 
-`ignore.rules` silences a rule everywhere. `ignore.files` silences every rule on matched files. `ignore.overrides` silences specific rules in specific directories. You can also use the `"reactDoctor"` key in `package.json`. CLI flags always override config values.
+Three nested keys, three layers of granularity — pick the narrowest one that fits:
+
+- **`ignore.rules`** silences a rule across the whole codebase.
+- **`ignore.files`** silences **every** rule on the matched files (use sparingly — it loses coverage for unrelated rules).
+- **`ignore.overrides`** silences only the listed rules on the matched files, leaving every other rule active. This is what you want when a single file (or glob) legitimately needs an exemption from one or two rules but should still be scanned for everything else.
+
+You can also use the `"reactDoctor"` key in `package.json`. CLI flags always override config values.
 
 React Doctor respects `.gitignore`, `.eslintignore`, `.oxlintignore`, `.prettierignore`, and `linguist-vendored` / `linguist-generated` annotations in `.gitattributes`. Inline `// eslint-disable*` and `// oxlint-disable*` comments are honored too.
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -65,10 +65,7 @@ Create a `react-doctor.config.json` in your project root:
     "overrides": [
       {
         "files": ["components/modules/diff/**"],
-        "rules": [
-          "react-doctor/no-array-index-as-key",
-          "react-doctor/no-render-in-render"
-        ]
+        "rules": ["react-doctor/no-array-index-as-key", "react-doctor/no-render-in-render"]
       },
       {
         "files": ["components/search/HighlightedSnippet.tsx"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #160.

### Status

The feature requested by #160 already shipped as `ignore.overrides` in #165, with the same shape the issue proposed (`{ files, rules }[]`). The reporter filed at v0.0.47, which predates that feature, so they never saw it. The README's one-line table entry was easy to miss.

### Change

Reworks the **Configuration** section to make the three layers' scopes unambiguous:

- `ignore.rules` — silences a rule **across the whole codebase**
- `ignore.files` — silences **every** rule on the matched files (use sparingly — loses coverage of unrelated rules)
- `ignore.overrides` — silences only the listed rules on the matched files, leaving every other rule active. **This is the per-file rule ignore from #160.**

The example now covers two scenarios from the issue's table verbatim:

```json
{
  "ignore": {
    "overrides": [
      { "files": ["components/modules/diff/**"], "rules": ["react-doctor/no-array-index-as-key", "react-doctor/no-render-in-render"] },
      { "files": ["components/search/HighlightedSnippet.tsx"], "rules": ["react/no-danger"] }
    ]
  }
}
```

No code change needed — the feature is implemented in `apply-ignore-overrides.ts` and already covered by `filter-diagnostics.test.ts` (including a multi-entry case with the issue's exact globs).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

