### PR TITLE
feat(cli): expose --why as documented public alias for --explain

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -151,10 +151,11 @@ Options:
   --fail-on <level>       exit with error on diagnostics: error, warning, none
   --annotations           output diagnostics as GitHub Actions annotations
   --explain <file:line>   diagnose why a rule fired or why a suppression didn't apply
+  --why <file:line>       alias for --explain
   -h, --help              display help
 ```
 
-When a suppression isn't working, `--explain <file:line>` reports what the scanner sees at that location, including why a nearby `react-doctor-disable-next-line` didn't apply. The same hint surfaces inline with `--verbose` and in `--json` output as `diagnostic.suppressionHint`.
+When a suppression isn't working, `--explain <file:line>` (or its alias `--why <file:line>`) reports what the scanner sees at that location, including why a nearby `react-doctor-disable-next-line` didn't apply. The diagnosis distinguishes the common failure modes — adjacent comment for a different rule (use the comma form), a code line between the comment and the diagnostic (the chain is broken), or no nearby suppression at all. The same hint surfaces inline with `--verbose` for every flagged site, and in `--json` output as `diagnostic.suppressionHint`, so a single scan doubles as a suppression audit without a separate flag.
 
 `--json` produces a parsable object on stdout with all human-readable output suppressed. Errors still produce a JSON object with `ok: false`, so stdout is always a valid document.
 

--- a/packages/react-doctor/src/cli.ts
+++ b/packages/react-doctor/src/cli.ts
@@ -2,7 +2,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { Command, Option } from "commander";
+import { Command } from "commander";
 import { CANONICAL_GITHUB_URL } from "./constants.js";
 import { runInstallSkill } from "./install-skill.js";
 import { scan } from "./scan.js";
@@ -400,7 +400,7 @@ const program = new Command()
     "--explain <file:line>",
     "diagnose why a rule fired or why a suppression didn't apply at a specific location",
   )
-  .addOption(new Option("--why <file:line>", "alias for --explain").hideHelp())
+  .option("--why <file:line>", "alias for --explain")
   .option(
     "--respect-inline-disables",
     "respect inline `// eslint-disable*` / `// oxlint-disable*` comments (default)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #161.

### Status

The MVP requested by #161 — a single-site suppression diagnosis at `react-doctor --why <file:line>` — has been implemented since #165 as a hidden alias for `--explain`. The reporter (writing at v0.0.47) wouldn't have seen it. Promoting it to a documented option closes the discovery gap.

### What's changed

- `--why <file:line>` is now a normal `commander` option instead of `hideHelp()`, so it surfaces in `react-doctor --help`.
- README's CLI reference and **Inline suppressions** section now explain the full audit story:
  - `--explain` / `--why` classify a single site (covers every status in the issue's classifier table — `MISSING`, `WRONG_RULE`, `GAP_CODE`, `ADJACENT_BUT_FAILED`, etc.).
  - `--verbose` already prints the same `suppressionHint` next to every flagged site.
  - `--json` already attaches `suppressionHint` to each diagnostic.
  - Combined, a single scan doubles as a suppression audit without a separate `--audit-suppressions` flag.

### Verification

```bash
$ react-doctor --help | grep -E "explain|why"
  --explain <file:line>         diagnose why a rule fired or why a suppression
  --why <file:line>             alias for --explain

$ react-doctor --why src/Bad.tsx:8
⚠ react-doctor/no-derived-state-effect (warning) — Derived state in useEffect — compute during render instead
  Suppression diagnosis: A react-doctor-disable-next-line for react-doctor/no-derived-state-effect sits at line 5,
  but 2 lines of code separate it from the diagnostic on line 8. Move the comment immediately above line 8, or
  extract the surrounding code into a helper so the suppression is adjacent.
```

Drive-by: removes the now-unused `Option` import that the previous `addOption(...).hideHelp()` wiring left behind.

```
Test Files  51 passed (51)
     Tests  683 passed (683)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

