### PR TITLE
feat(plugin): integrate eslint-plugin-react-you-might-not-need-an-effect

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -78,6 +78,15 @@ React Doctor respects `.gitignore`, `.eslintignore`, `.oxlintignore`, `.prettier
 
 If you have a JSON oxlint or eslint config (`.oxlintrc.json` or `.eslintrc.json`), its rules get merged into the scan automatically and count toward the score. Set `adoptExistingLintConfig: false` to opt out.
 
+#### Optional companion plugins
+
+When the following ESLint plugins are installed in the scanned project (or hoisted in your monorepo), React Doctor folds their rules into the same scan. Both are listed as **optional peer dependencies** — install only what you want.
+
+| Plugin | Adds | Namespace |
+| --- | --- | --- |
+| [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks) (v6 or v7) | The React Compiler frontend's correctness rules — fired when a React Compiler is detected in the project. | `react-hooks-js/*` |
+| [`eslint-plugin-react-you-might-not-need-an-effect`](https://github.com/nickjvandyke/eslint-plugin-react-you-might-not-need-an-effect) (v0.10+) | Complementary effects-as-anti-pattern rules (`no-derived-state`, `no-chain-state-updates`, `no-event-handler`, `no-pass-data-to-parent`, …) that run alongside React Doctor's native State & Effects rules. | `effect/*` |
+
 ### Inline suppressions
 
 ```tsx

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -82,10 +82,10 @@ If you have a JSON oxlint or eslint config (`.oxlintrc.json` or `.eslintrc.json`
 
 When the following ESLint plugins are installed in the scanned project (or hoisted in your monorepo), React Doctor folds their rules into the same scan. Both are listed as **optional peer dependencies** — install only what you want.
 
-| Plugin | Adds | Namespace |
-| --- | --- | --- |
-| [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks) (v6 or v7) | The React Compiler frontend's correctness rules — fired when a React Compiler is detected in the project. | `react-hooks-js/*` |
-| [`eslint-plugin-react-you-might-not-need-an-effect`](https://github.com/nickjvandyke/eslint-plugin-react-you-might-not-need-an-effect) (v0.10+) | Complementary effects-as-anti-pattern rules (`no-derived-state`, `no-chain-state-updates`, `no-event-handler`, `no-pass-data-to-parent`, …) that run alongside React Doctor's native State & Effects rules. | `effect/*` |
+| Plugin                                                                                                                                          | Adds                                                                                                                                                                                                        | Namespace          |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks) (v6 or v7)                                               | The React Compiler frontend's correctness rules — fired when a React Compiler is detected in the project.                                                                                                   | `react-hooks-js/*` |
+| [`eslint-plugin-react-you-might-not-need-an-effect`](https://github.com/nickjvandyke/eslint-plugin-react-you-might-not-need-an-effect) (v0.10+) | Complementary effects-as-anti-pattern rules (`no-derived-state`, `no-chain-state-updates`, `no-event-handler`, `no-pass-data-to-parent`, …) that run alongside React Doctor's native State & Effects rules. | `effect/*`         |
 
 ### Inline suppressions
 

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -75,13 +75,18 @@
   },
   "devDependencies": {
     "@types/prompts": "^2.4.9",
-    "eslint-plugin-react-hooks": "^7.1.1"
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.1"
   },
   "peerDependencies": {
-    "eslint-plugin-react-hooks": "^6 || ^7"
+    "eslint-plugin-react-hooks": "^6 || ^7",
+    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10"
   },
   "peerDependenciesMeta": {
     "eslint-plugin-react-hooks": {
+      "optional": true
+    },
+    "eslint-plugin-react-you-might-not-need-an-effect": {
       "optional": true
     }
   },

--- a/packages/react-doctor/src/oxlint-config.ts
+++ b/packages/react-doctor/src/oxlint-config.ts
@@ -82,6 +82,24 @@ export const TANSTACK_START_RULES: Record<string, RuleSeverity> = {
 // `"warn"` as part of a broader refactor, which made "React Compiler
 // can't optimize this code" diagnostics stop counting toward
 // `errorCount` and stop failing CI; restored here.
+// HACK: complementary rule surface from
+// `eslint-plugin-react-you-might-not-need-an-effect` (#187). These
+// fire alongside react-doctor's native `state-and-effects` rules when
+// the plugin is installed, providing additional anti-pattern
+// detection for effects. Severities are `warn` to match the rest of
+// the effects-rule cohort and avoid changing CI pass/fail behavior
+// for projects that adopt the plugin.
+const YOU_MIGHT_NOT_NEED_EFFECT_RULES: Record<string, RuleSeverity> = {
+  "effect/no-derived-state": "warn",
+  "effect/no-chain-state-updates": "warn",
+  "effect/no-event-handler": "warn",
+  "effect/no-adjust-state-on-prop-change": "warn",
+  "effect/no-reset-all-state-on-prop-change": "warn",
+  "effect/no-pass-live-state-to-parent": "warn",
+  "effect/no-pass-data-to-parent": "warn",
+  "effect/no-initialize-state": "warn",
+};
+
 const REACT_COMPILER_RULES: Record<string, RuleSeverity> = {
   "react-hooks-js/set-state-in-render": "error",
   "react-hooks-js/immutability": "error",
@@ -123,10 +141,12 @@ interface OxlintConfigOptions {
   extendsPaths?: string[];
 }
 
-interface ReactHooksJsPluginEntry {
+interface JsPluginEntry {
   name: string;
   specifier: string;
 }
+
+type ReactHooksJsPluginEntry = JsPluginEntry;
 
 interface ResolvedReactHooksJsPlugin {
   entry: ReactHooksJsPluginEntry;
@@ -171,6 +191,34 @@ const resolveReactHooksJsPlugin = (
   }
   return {
     entry: { name: "react-hooks-js", specifier: pluginSpecifier },
+    availableRuleNames: readPluginRuleNames(pluginSpecifier),
+  };
+};
+
+interface ResolvedYouMightNotNeedEffectPlugin {
+  entry: JsPluginEntry;
+  availableRuleNames: ReadonlySet<string>;
+}
+
+// HACK: oxlint-namespaces this third-party ESLint plugin under
+// `effect` so the long upstream package name doesn't clutter rule
+// keys. Issue #187 — adds the plugin's complementary rule surface
+// alongside react-doctor's native `state-and-effects` rules. The
+// plugin is opt-in: skipped when not installed (peer is optional).
+const YOU_MIGHT_NOT_NEED_EFFECT_NAMESPACE = "effect";
+
+const resolveYouMightNotNeedEffectPlugin = (
+  customRulesOnly: boolean,
+): ResolvedYouMightNotNeedEffectPlugin | null => {
+  if (customRulesOnly) return null;
+  let pluginSpecifier: string;
+  try {
+    pluginSpecifier = esmRequire.resolve("eslint-plugin-react-you-might-not-need-an-effect");
+  } catch {
+    return null;
+  }
+  return {
+    entry: { name: YOU_MIGHT_NOT_NEED_EFFECT_NAMESPACE, specifier: pluginSpecifier },
     availableRuleNames: readPluginRuleNames(pluginSpecifier),
   };
 };
@@ -476,6 +524,19 @@ export const createOxlintConfig = ({
         reactHooksJsPlugin.availableRuleNames,
       )
     : {};
+
+  const youMightNotNeedEffectPlugin = resolveYouMightNotNeedEffectPlugin(customRulesOnly);
+  const youMightNotNeedEffectRules = youMightNotNeedEffectPlugin
+    ? filterRulesToAvailable(
+        YOU_MIGHT_NOT_NEED_EFFECT_RULES,
+        YOU_MIGHT_NOT_NEED_EFFECT_NAMESPACE,
+        youMightNotNeedEffectPlugin.availableRuleNames,
+      )
+    : {};
+
+  const jsPlugins: JsPluginEntry[] = [];
+  if (reactHooksJsPlugin) jsPlugins.push(reactHooksJsPlugin.entry);
+  if (youMightNotNeedEffectPlugin) jsPlugins.push(youMightNotNeedEffectPlugin.entry);
   // HACK: oxlint merges configs from first to last, with later entries
   // overriding earlier ones — and the local config always overrides
   // every entry in `extends`. So adding the user's existing oxlintrc
@@ -497,11 +558,12 @@ export const createOxlintConfig = ({
       nursery: "off",
     },
     plugins: customRulesOnly ? [] : ["react", "jsx-a11y"],
-    jsPlugins: reactHooksJsPlugin ? [reactHooksJsPlugin.entry, pluginPath] : [pluginPath],
+    jsPlugins: [...jsPlugins, pluginPath],
     rules: {
       ...(customRulesOnly ? {} : BUILTIN_REACT_RULES),
       ...(customRulesOnly ? {} : BUILTIN_A11Y_RULES),
       ...reactCompilerRules,
+      ...youMightNotNeedEffectRules,
       ...filterRulesByReactMajor(GLOBAL_REACT_DOCTOR_RULES, reactMajorVersion),
       ...(framework === "nextjs" ? NEXTJS_RULES : {}),
       ...(framework === "expo" || framework === "react-native" ? REACT_NATIVE_RULES : {}),

--- a/packages/react-doctor/src/utils/run-oxlint.ts
+++ b/packages/react-doctor/src/utils/run-oxlint.ts
@@ -26,6 +26,7 @@ const PLUGIN_CATEGORY_MAP: Record<string, string> = {
   "react-doctor": "Other",
   "jsx-a11y": "Accessibility",
   knip: "Dead Code",
+  effect: "State & Effects",
   // Plugins users commonly enable in their own oxlint / eslint config
   // and that react-doctor folds into the scan via `extends`. Sensible
   // defaults so adopted-rule diagnostics don't all collapse into the

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -398,4 +398,64 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
       expect(availableRuleNames.has(ruleName)).toBe(true);
     }
   });
+
+  it("loads eslint-plugin-react-you-might-not-need-an-effect when installed (#187)", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/react-doctor-plugin.js",
+      framework: "unknown",
+      hasReactCompiler: false,
+      hasTanStackQuery: false,
+    });
+
+    const effectRuleKeys = Object.keys(config.rules).filter((ruleKey) =>
+      ruleKey.startsWith("effect/"),
+    );
+    const hasEffectPluginEntry = config.jsPlugins.some(
+      (jsPlugin) => typeof jsPlugin === "object" && jsPlugin.name === "effect",
+    );
+
+    expect(hasEffectPluginEntry).toBe(true);
+    expect(effectRuleKeys.length).toBeGreaterThan(0);
+    expect(effectRuleKeys.every((ruleKey) => config.rules[ruleKey] === "warn")).toBe(true);
+  });
+
+  it("emits no effect/* rules when customRulesOnly skips third-party plugins (#187)", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/react-doctor-plugin.js",
+      framework: "unknown",
+      hasReactCompiler: false,
+      hasTanStackQuery: false,
+      customRulesOnly: true,
+    });
+
+    const effectRuleKeys = Object.keys(config.rules).filter((ruleKey) =>
+      ruleKey.startsWith("effect/"),
+    );
+    const hasEffectPluginEntry = config.jsPlugins.some(
+      (jsPlugin) => typeof jsPlugin === "object" && jsPlugin.name === "effect",
+    );
+
+    expect(effectRuleKeys).toHaveLength(0);
+    expect(hasEffectPluginEntry).toBe(false);
+  });
+
+  it("only enables effect/* rules that the resolved plugin actually exports (#187)", async () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/react-doctor-plugin.js",
+      framework: "unknown",
+      hasReactCompiler: false,
+      hasTanStackQuery: false,
+    });
+    const pluginModule = await import("eslint-plugin-react-you-might-not-need-an-effect");
+    const availableRuleNames = new Set(
+      Object.keys((pluginModule.default ?? pluginModule).rules ?? {}),
+    );
+    const enabledRuleNames = Object.keys(config.rules)
+      .filter((ruleKey) => ruleKey.startsWith("effect/"))
+      .map((ruleKey) => ruleKey.replace(/^effect\//, ""));
+    expect(enabledRuleNames.length).toBeGreaterThan(0);
+    for (const ruleName of enabledRuleNames) {
+      expect(availableRuleNames.has(ruleName)).toBe(true);
+    }
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-you-might-not-need-an-effect:
+        specifier: ^0.10.1
+        version: 0.10.1(eslint@9.39.2(jiti@2.6.1))
 
   packages/website:
     dependencies:
@@ -1909,6 +1912,12 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
+  eslint-plugin-react-you-might-not-need-an-effect@0.10.1:
+    resolution: {integrity: sha512-IK0s/+ShN0bkur5moKCu/lfx2D/9uIeozje8Wv2/XnYdmswa17pDg02aUuytEPb8Gf0eueiQFf/QsvOHHcvujg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2049,6 +2058,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.5.0:
+    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
   globby@11.1.0:
@@ -4174,6 +4187,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-react-you-might-not-need-an-effect@0.10.1(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
+      globals: 16.5.0
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -4333,6 +4351,8 @@ snapshots:
       is-glob: 4.0.3
 
   globals@14.0.0: {}
+
+  globals@16.5.0: {}
 
   globby@11.1.0:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #187.

### What

Adds [`eslint-plugin-react-you-might-not-need-an-effect`](https://github.com/nickjvandyke/eslint-plugin-react-you-might-not-need-an-effect) as an **optional companion plugin** that fires alongside react-doctor's native `state-and-effects` rules. Wiring follows the same pattern as `eslint-plugin-react-hooks`:

- Listed in `peerDependenciesMeta` as optional — projects that don't want the extra surface skip it transparently.
- Resolved at scan-time and filtered against the loaded plugin's `rules` export, so a future plugin upgrade that drops a rule silently skips just that rule instead of crashing the whole scan with `"Rule '<name>' not found in plugin 'effect'"`.
- Namespaced as `effect/` in oxlint's `jsPlugins` array to keep the plugin's long upstream name out of rule keys.
- Categorized under "State & Effects" in `PLUGIN_CATEGORY_MAP` so diagnostics show in the right output bucket.
- Suppressed when `customRulesOnly: true`, identical to the existing `react-hooks-js` gating.

### Rules added

All eight rules from `v0.10`:

```
effect/no-derived-state
effect/no-chain-state-updates
effect/no-event-handler
effect/no-adjust-state-on-prop-change
effect/no-reset-all-state-on-prop-change
effect/no-pass-live-state-to-parent
effect/no-pass-data-to-parent
effect/no-initialize-state
```

All severities are `warn` — matches the rest of the State & Effects cohort and avoids changing CI pass/fail behavior for projects that adopt the plugin.

### Tests

Adds three regressions in `scan-resilience.test.ts`:

1. `effect` plugin entry appears in `jsPlugins`, and its rules are emitted at `warn`.
2. `customRulesOnly: true` strips both the plugin entry and its rules.
3. Every configured `effect/<rule>` exists in the loaded plugin's `rules` map.

### Verification

Run against a sample app with derived state in `useEffect`:

```
⚠ effect/no-derived-state                      ×4
    Avoid storing derived state. Compute "doubled" directly during render…
    src/App.tsx:9
    src/App.tsx:12
    src/App.tsx:15
    src/Bad.tsx:9

⚠ react-doctor/no-derived-state-effect         ×3
    Derived state in useEffect — compute during render instead
    …
```

Both rule cohorts fire side-by-side, matching the issue's "good addition next to `react-doctor/no-derived-state-effect`" suggestion.

### Docs

Adds an **Optional companion plugins** subsection to the README that lists both `eslint-plugin-react-hooks` and the new `eslint-plugin-react-you-might-not-need-an-effect` with their namespaces and what they add.

```
Test Files  51 passed (51)
     Tests  686 passed (686)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18c0d933-79d0-43e8-a79a-c6d8b3bc2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

