### PR TITLE
fix(nextjs): ignore response header mutations in GET handlers

### DIFF
--- a/.changeset/quiet-headers-scope.md
+++ b/.changeset/quiet-headers-scope.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Avoid reporting response header mutations and request-scoped collections as GET handler side effects.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/library.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/library.ts
@@ -28,4 +28,8 @@ export const MUTATION_METHOD_NAMES = new Set([
   "append",
 ]);
 
+export const HEADERS_API_MUTATION_METHOD_NAMES = new Set(["append", "delete", "set"]);
+
+export const REQUEST_SCOPED_MUTATION_CONSTRUCTOR_NAMES = new Set(["Headers", "Map", "Set"]);
+
 export const MUTATING_HTTP_METHODS = new Set(["POST", "PUT", "DELETE", "PATCH"]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-side-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-side-effect.ts
@@ -1,4 +1,9 @@
-import { MUTATING_HTTP_METHODS, MUTATION_METHOD_NAMES } from "../constants/library.js";
+import {
+  HEADERS_API_MUTATION_METHOD_NAMES,
+  MUTATING_HTTP_METHODS,
+  MUTATION_METHOD_NAMES,
+  REQUEST_SCOPED_MUTATION_CONSTRUCTOR_NAMES,
+} from "../constants/library.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { walkAst } from "./walk-ast.js";
 import { isNodeOfType } from "./is-node-of-type.js";
@@ -26,6 +31,60 @@ const isCookiesOrHeadersCall = (node: EsTreeNode, methodName: string): boolean =
   if (!isNodeOfType(object, "CallExpression") || !isNodeOfType(object.callee, "Identifier"))
     return false;
   return object.callee.name === methodName;
+};
+
+const isRequestScopedMutationInitializer = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "NewExpression") &&
+  isNodeOfType(node.callee, "Identifier") &&
+  REQUEST_SCOPED_MUTATION_CONSTRUCTOR_NAMES.has(node.callee.name);
+
+const collectRequestScopedMutationBindings = (node: EsTreeNode): Set<string> => {
+  const bindings = new Set<string>();
+  walkAst(node, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "VariableDeclarator")) return;
+    if (!isNodeOfType(child.id, "Identifier")) return;
+    if (!child.init || !isRequestScopedMutationInitializer(child.init)) return;
+    bindings.add(child.id.name);
+  });
+  return bindings;
+};
+
+const isRequestScopedMutationCall = (
+  node: EsTreeNode,
+  requestScopedMutationBindings: Set<string>,
+): boolean => {
+  if (!isNodeOfType(node, "CallExpression") || !isNodeOfType(node.callee, "MemberExpression"))
+    return false;
+  const { object, property } = node.callee;
+  if (!isNodeOfType(object, "Identifier")) return false;
+  if (!isNodeOfType(property, "Identifier")) return false;
+  return requestScopedMutationBindings.has(object.name) && MUTATION_METHOD_NAMES.has(property.name);
+};
+
+const isHeadersApiMutationCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression") || !isNodeOfType(node.callee, "MemberExpression"))
+    return false;
+  const { object, property } = node.callee;
+  if (
+    !isNodeOfType(property, "Identifier") ||
+    !HEADERS_API_MUTATION_METHOD_NAMES.has(property.name)
+  )
+    return false;
+  if (!isNodeOfType(object, "MemberExpression")) return false;
+  return isNodeOfType(object.property, "Identifier") && object.property.name === "headers";
+};
+
+const isHeadersFunctionMutationCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression") || !isNodeOfType(node.callee, "MemberExpression"))
+    return false;
+  const { object, property } = node.callee;
+  if (
+    !isNodeOfType(property, "Identifier") ||
+    !HEADERS_API_MUTATION_METHOD_NAMES.has(property.name)
+  )
+    return false;
+  if (!isNodeOfType(object, "CallExpression")) return false;
+  return isNodeOfType(object.callee, "Identifier") && object.callee.name === "headers";
 };
 
 const isMutatingDbCall = (node: EsTreeNode): boolean => {
@@ -56,8 +115,11 @@ const getCookiesOrHeadersMethodName = (
 
 export const findSideEffect = (node: EsTreeNode): string | null => {
   let sideEffectDescription: string | null = null;
+  const requestScopedMutationBindings = collectRequestScopedMutationBindings(node);
   walkAst(node, (child: EsTreeNode) => {
     if (sideEffectDescription) return;
+    if (isHeadersApiMutationCall(child) || isHeadersFunctionMutationCall(child)) return;
+    if (isRequestScopedMutationCall(child, requestScopedMutationBindings)) return;
     const cookiesMethodName = getCookiesOrHeadersMethodName(child, "cookies");
     if (cookiesMethodName) {
       sideEffectDescription = `cookies().${cookiesMethodName}()`;

--- a/packages/react-doctor/tests/fixtures/nextjs-app/src/app/headers/route.tsx
+++ b/packages/react-doctor/tests/fixtures/nextjs-app/src/app/headers/route.tsx
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const response = NextResponse.json({ ok: true });
+  response.headers.set("Cache-Control", "no-store");
+  response.headers.append("Vary", "Accept");
+  response.headers.delete("X-Deprecated");
+
+  const headers = new Headers();
+  headers.set("X-Route", "headers");
+
+  const requestScope = new Map<string, string>();
+  requestScope.set("seen", "true");
+
+  return response;
+}

--- a/packages/react-doctor/tests/run-oxlint/nextjs.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/nextjs.test.ts
@@ -48,6 +48,15 @@ describe("runOxlint", () => {
       );
       expect(wrappedPageIssues).toHaveLength(0);
     });
+
+    it("does not flag response header shaping in GET route handlers", () => {
+      const headerRouteIssues = nextjsDiagnostics.filter(
+        (diagnostic) =>
+          diagnostic.rule === "nextjs-no-side-effect-in-get-handler" &&
+          diagnostic.filePath.includes("app/headers/route"),
+      );
+      expect(headerRouteIssues).toHaveLength(0);
+    });
   });
 
   describe("server rule scope", () => {


### PR DESCRIPTION
﻿## Summary
- ignore outbound response header mutations like `response.headers.set()` in GET route side-effect detection
- ignore request-scoped `Headers`/`Map` mutations created inside the handler
- add regression coverage for issue #206 using a temporary Next.js route fixture

Fixes #206.

## Testing
- `pnpm exec vp test run tests/regressions/nextjs-side-effects.test.ts`
- `pnpm exec tsc --noEmit` from `packages/react-doctor`
- `pnpm exec vp lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to lint-side-effect heuristics and test fixtures, primarily reducing false positives without affecting runtime behavior.
> 
> **Overview**
> Refines `nextjs-no-side-effect-in-get-handler` detection by teaching `findSideEffect` to **ignore outbound response header shaping** (e.g. `response.headers.set/append/delete` and `headers().*` mutations) and **ignore mutations on request-scoped collections** (`new Headers/Map/Set` created within the handler).
> 
> Adds a Next.js route fixture and a regression test ensuring these patterns no longer produce diagnostics, and includes a patch changeset for `react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcde71350a56c8f3f0f6b23d6e287fd74eaeeaa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->