### PR TITLE
fix: skip response.headers.set() in GET handler side-effect check (#206)

### DIFF
--- a/packages/react-doctor/src/plugin/helpers.ts
+++ b/packages/react-doctor/src/plugin/helpers.ts
@@ -361,6 +361,16 @@ const isMutatingFetchCall = (node: EsTreeNode): boolean => {
   return Boolean(optionsArgument.properties?.some(isMutatingMethodProperty));
 };
 
+const isHeadersChainCall = (node: EsTreeNode): boolean => {
+  if (node.type !== "CallExpression" || node.callee?.type !== "MemberExpression") return false;
+  let cursor: EsTreeNode | undefined = node.callee.object;
+  while (cursor?.type === "MemberExpression") {
+    if (cursor.property?.type === "Identifier" && cursor.property.name === "headers") return true;
+    cursor = cursor.object;
+  }
+  return false;
+};
+
 export const findSideEffect = (node: EsTreeNode): string | null => {
   let sideEffectDescription: string | null = null;
   walkAst(node, (child: EsTreeNode) => {
@@ -378,7 +388,7 @@ export const findSideEffect = (node: EsTreeNode): string | null => {
       // would).
       const methodProperty = child.arguments[1].properties.find(isMutatingMethodProperty);
       sideEffectDescription = `fetch() with method ${methodProperty.value.value}`;
-    } else if (isMutatingDbCall(child)) {
+    } else if (isMutatingDbCall(child) && !isHeadersChainCall(child)) {
       const methodName = child.callee.property.name;
       const objectName =
         child.callee.object?.type === "Identifier" ? child.callee.object.name : null;


### PR DESCRIPTION
## Summary

Fixes a false positive in `nextjsNoSideEffectInGetHandler` where `response.headers.set()` was flagged as a side effect in GET route handlers.

Setting response headers is a legitimate and expected operation in Next.js GET route handlers — it does not represent a CSRF-vulnerable write. This PR adds an `isHeadersChainCall` helper that excludes `.headers.set()` (and any `.headers.*()` mutation) from the DB mutation check in `findSideEffect`.

Closes #206

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to AST side-effect detection logic to reduce false positives, with minimal impact outside GET-handler lint diagnostics.
> 
> **Overview**
> Prevents `nextjsNoSideEffectInGetHandler` (and other rules using `findSideEffect`) from flagging `response.headers.*()` calls as “DB mutations” in GET handlers.
> 
> Adds an `isHeadersChainCall` AST helper and uses it to exclude any call whose member chain includes `.headers` from the `isMutatingDbCall` branch in `findSideEffect`, fixing the `response.headers.set()` false positive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc441af1d44e66e404d79496f747219dd08c6da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->