### PR TITLE
fix: skip Iterator helper chains in jsCombineIterations rule (#205)

### DIFF
--- a/packages/react-doctor/src/plugin/rules/js-performance.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance.ts
@@ -42,6 +42,18 @@ export const jsCombineIterations: Rule = {
         if (isBooleanOrIdentityFilter) return;
       }
 
+      const innerReceiver = innerCall.callee.object;
+      if (
+        innerReceiver?.type === "CallExpression" &&
+        innerReceiver.callee?.type === "MemberExpression" &&
+        innerReceiver.callee.property?.type === "Identifier" &&
+        (innerReceiver.callee.property.name === "values" ||
+          innerReceiver.callee.property.name === "entries" ||
+          innerReceiver.callee.property.name === "keys")
+      ) {
+        return;
+      }
+
       context.report({
         node,
         message: `.${innerMethod}().${outerMethod}() iterates the array twice — combine into a single loop with .reduce() or for...of`,


### PR DESCRIPTION
## Summary

Fixes a false positive in `jsCombineIterations` where `.values().filter().map()` and similar Iterator helper chains were flagged as inefficient double iterations.

Iterator helpers (`.values()`, `.entries()`, `.keys()`) produce lazy iterators, not intermediate arrays — chaining `.filter()` and `.map()` on them does NOT create multiple array allocations. This PR adds a check that skips the rule when the inner call's receiver is an iterator-producing method call.

Closes #205

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rule tweak that only narrows when `jsCombineIterations` reports, reducing false positives; primary risk is missing some real double-iteration warnings in edge cases.
> 
> **Overview**
> Updates `jsCombineIterations` to **skip reporting** when the inner chained call’s receiver is an iterator-producing helper (`.values()`, `.entries()`, `.keys()`), preventing false positives for lazy iterator chains like `.values().filter().map()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0f1e6e15b6e0ca0d25fe3f3d7bc5cbe79ff4a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->