### PR TITLE
docs: add husky and lint-staged pre-commit integration guide (#203)

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -279,6 +279,26 @@ When on a feature branch without explicit flags, you'll be prompted: "Only scan 
 
 `--staged` and `--diff` cannot be combined. Both modes skip dead-code detection (knip needs the full project to detect unused files).
 
+### Pre-commit integration with husky + lint-staged
+
+Wire react-doctor into your pre-commit hook to catch issues before they're committed:
+
+```bash
+npx husky add .husky/pre-commit "npx lint-staged"
+```
+
+Then configure lint-staged in `package.json`:
+
+```json
+{
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": "react-doctor --staged --fail-on error --yes"
+  }
+}
+```
+
+This scans only the staged files using `--staged`, failing the commit if any error-severity diagnostics are found. Use `--fail-on warning` for a stricter gate, or `--json` for machine-parseable output in custom workflows.
+
 ## Agent and CI integration
 
 React Doctor detects 50+ coding agents (Claude Code, Cursor, Codex, OpenCode, Windsurf, and more) and adapts its behavior automatically:


### PR DESCRIPTION
## Summary

Adds documentation for integrating react-doctor with husky and lint-staged as a pre-commit hook. The `--staged` mode is already designed for pre-commit workflows — this just shows users how to wire it up.

Closes #203

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that doesn’t alter runtime behavior or interfaces.
> 
> **Overview**
> Adds a new README section describing how to run `react-doctor` in a pre-commit hook using **Husky + lint-staged**, including example commands and a `lint-staged` config that runs `react-doctor --staged --fail-on error --yes` to block commits on errors (with notes on stricter `warning` gating / `--json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3f3e46b1a73bc41aa42debeeed43412da0ea0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->