### PR TITLE
feat: add --package-json flag for custom package.json path

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -213,6 +213,7 @@ Options:
   --annotations           output diagnostics as GitHub Actions annotations
   --explain <file:line>   diagnose why a rule fired or why a suppression didn't apply
   --why <file:line>       alias for --explain
+  --package-json <path>   path to a custom package.json (default: <directory>/package.json)
   -h, --help              display help
 ```
 

--- a/packages/react-doctor/src/cli.ts
+++ b/packages/react-doctor/src/cli.ts
@@ -52,6 +52,7 @@ interface CliFlags {
   explain?: string;
   why?: string;
   failOn: string;
+  packageJson?: string;
 }
 
 const VALID_FAIL_ON_LEVELS = new Set<FailOnLevel>(["error", "warning", "none"]);
@@ -179,6 +180,7 @@ const resolveCliScanOptions = (
     respectInlineDisables: isCliOverride("respectInlineDisables")
       ? flags.respectInlineDisables
       : (userConfig?.respectInlineDisables ?? true),
+    packageJsonPath: flags.packageJson,
   };
 };
 
@@ -409,6 +411,10 @@ const program = new Command()
   .option(
     "--no-respect-inline-disables",
     "audit mode: neutralize inline lint suppressions before scanning",
+  )
+  .option(
+    "--package-json <path>",
+    "path to a custom package.json, defaults to <directory>/package.json",
   )
   .action(async (directory: string, flags: CliFlags) => {
     const isScoreOnly = flags.score;

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -139,7 +139,7 @@ export const diagnose = async (
     initialLoadedConfig?.config ?? loadConfigWithSource(resolvedDirectory)?.config ?? null;
   const includePaths = options.includePaths ?? [];
   const isDiffMode = includePaths.length > 0;
-  const projectInfo = discoverProject(resolvedDirectory);
+  const projectInfo = discoverProject(resolvedDirectory, options.packageJsonPath);
 
   if (!projectInfo.reactVersion) {
     throw new NoReactDependencyError(resolvedDirectory);

--- a/packages/react-doctor/src/scan.ts
+++ b/packages/react-doctor/src/scan.ts
@@ -589,6 +589,7 @@ interface ResolvedScanOptions {
   respectInlineDisables: boolean;
   adoptExistingLintConfig: boolean;
   ignoredTags: ReadonlySet<string>;
+  packageJsonPath?: string;
 }
 
 const buildIgnoredTags = (userConfig: ReactDoctorConfig | null): ReadonlySet<string> => {
@@ -616,6 +617,7 @@ const mergeScanOptions = (
     inputOptions.respectInlineDisables ?? userConfig?.respectInlineDisables ?? true,
   adoptExistingLintConfig: userConfig?.adoptExistingLintConfig ?? true,
   ignoredTags: buildIgnoredTags(userConfig),
+  packageJsonPath: inputOptions.packageJsonPath,
 });
 
 const printProjectDetection = (
@@ -712,7 +714,7 @@ const runScan = async (
   userConfig: ReactDoctorConfig | null,
   startTime: number,
 ): Promise<ScanResult> => {
-  const projectInfo = discoverProject(directory);
+  const projectInfo = discoverProject(directory, options.packageJsonPath);
   const { includePaths } = options;
   const isDiffMode = includePaths.length > 0;
 

--- a/packages/react-doctor/src/types.ts
+++ b/packages/react-doctor/src/types.ts
@@ -117,6 +117,7 @@ export interface DiagnoseOptions {
    * See that field's docs for the full contract.
    */
   respectInlineDisables?: boolean;
+  packageJsonPath?: string;
 }
 
 export interface DiagnoseResult {
@@ -144,6 +145,7 @@ export interface ScanOptions {
   includePaths?: string[];
   configOverride?: ReactDoctorConfig | null;
   respectInlineDisables?: boolean;
+  packageJsonPath?: string;
 }
 
 export interface DiffInfo {

--- a/packages/react-doctor/src/utils/discover-project.ts
+++ b/packages/react-doctor/src/utils/discover-project.ts
@@ -715,16 +715,16 @@ export const clearProjectCache = (): void => {
   cachedProjectInfos.clear();
 };
 
-export const discoverProject = (directory: string): ProjectInfo => {
+export const discoverProject = (directory: string, packageJsonPath?: string): ProjectInfo => {
   const cached = cachedProjectInfos.get(directory);
   if (cached !== undefined) return cached;
 
-  const packageJsonPath = path.join(directory, "package.json");
-  if (!isFile(packageJsonPath)) {
+  const resolvedPackageJsonPath = packageJsonPath ?? path.join(directory, "package.json");
+  if (!isFile(resolvedPackageJsonPath)) {
     throw new PackageJsonNotFoundError(directory);
   }
 
-  const packageJson = readPackageJson(packageJsonPath);
+  const packageJson = readPackageJson(resolvedPackageJsonPath);
   let { reactVersion, tailwindVersion, framework } = extractDependencyInfo(packageJson);
 
   // HACK: capture the catalog reference (e.g. `catalog:react19`) from


### PR DESCRIPTION
## Summary

Adds `--package-json <path>` CLI flag to allow scanning a directory with a custom package.json location. This is useful when the project's package.json is at a non-standard path or when you want to point react-doctor at a specific workspace's package.json without changing the scan directory.

## Changes

- **`types.ts`**: Added `packageJsonPath?: string` to `DiagnoseOptions` and `ScanOptions`
- **`cli.ts`**: Added `--package-json <path>` CLI option with `resolveCliScanOptions` mapping
- **`scan.ts`**: Added `packageJsonPath` to `ResolvedScanOptions` and `mergeScanOptions`; passes it to `discoverProject`
- **`discover-project.ts`**: `discoverProject()` now accepts optional `packageJsonPath` — uses `??` fallback to `<directory>/package.json` (fully backward compatible)
- **`index.ts`**: `diagnose()` passes `options.packageJsonPath` to `discoverProject`
- **`README.md`**: Added `--package-json` to CLI reference

## Testing

- `pnpm build` ✓
- `pnpm typecheck` ✓
- `pnpm lint` ✓

Closes #32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional CLI/API parameter that only affects project detection input, with a backward-compatible default to `<directory>/package.json`. Main risk is altered caching/detection behavior if callers pass varying paths for the same directory.
> 
> **Overview**
> Adds support for scanning a directory using a **custom `package.json` location** via new `--package-json <path>` CLI flag and matching `packageJsonPath` option in the programmatic `diagnose()`/`scan()` APIs.
> 
> Project detection (`discoverProject`) now accepts an optional package.json path (defaulting to `<directory>/package.json`) and the CLI wiring passes this through, with README updated to document the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3e2b7ced261b5e9eccc3c7bee7525337492ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->