### PR TITLE
chore: dead-code sweep (16 -> 1 unused exports)

### DIFF
--- a/packages/react-doctor/src/cli/parse-file-line-argument.ts
+++ b/packages/react-doctor/src/cli/parse-file-line-argument.ts
@@ -1,4 +1,4 @@
-export interface ParsedFileLineArgument {
+interface ParsedFileLineArgument {
   filePath: string;
   line: number;
 }

--- a/packages/react-doctor/src/constants.ts
+++ b/packages/react-doctor/src/constants.ts
@@ -88,16 +88,6 @@ export const PROXY_OUTPUT_MAX_BYTES = 50 * 1024 * 1024;
 export const buildNoReactDependencyError = (directory: string): string =>
   `No React dependency found in ${directory}/package.json. Add "react" to dependencies (or peerDependencies) and re-run.`;
 
-// HACK: minimum React major versions for the deprecation rule gates in
-// `oxlint-config.ts`. React-19-deprecated APIs (forwardRef, useContext,
-// Foo.defaultProps) shouldn't fire on 17/18 codebases — those are still
-// the current surface there. The legacy react-dom root API
-// (render/hydrate/unmountComponentAtNode/findDOMNode) was deprecated
-// in 18, so we light those up one major earlier.
-export const REACT_19_DEPRECATION_MIN_MAJOR = 19;
-
-export const REACT_DOM_LEGACY_API_MIN_MAJOR = 18;
-
 // HACK: lookahead cap for JSX opener-span scanning; bounds worst-case
 // work on pathological files. Real openers stay well under this.
 export const JSX_OPENER_SCAN_MAX_LINES = 32;
@@ -109,15 +99,6 @@ export const SUPPRESSION_NEAR_MISS_MAX_LINES = 10;
 // `useEffectEvent` requires React 19+. Below the threshold, the rule
 // that suggests it (`prefer-use-effect-event`) stays silent.
 export const USE_EFFECT_EVENT_MIN_MAJOR = 19;
-
-// HACK: minimum Tailwind major.minor for the `size-N` shorthand. The
-// rule that suggests collapsing `w-N h-N` (`design-no-redundant-size-axes`)
-// requires Tailwind v3.4+ — recommending `size-N` to a v3.0…v3.3
-// project would generate classes that simply don't compile. Below
-// the threshold the rule stays silent. v4 inherits the shorthand,
-// so a single major.minor floor covers every supported Tailwind line.
-export const TAILWIND_SIZE_SHORTHAND_MIN_MAJOR = 3;
-export const TAILWIND_SIZE_SHORTHAND_MIN_MINOR = 4;
 
 // In the default human output, show several category sections like an
 // audit report, but cap each section so one noisy category does not

--- a/packages/react-doctor/src/oxlint-config.ts
+++ b/packages/react-doctor/src/oxlint-config.ts
@@ -424,7 +424,7 @@ export const FRAMEWORK_SPECIFIC_RULE_KEYS: ReadonlySet<string> = new Set([
   ...Object.keys(TANSTACK_QUERY_RULES),
 ]);
 
-export interface RuleMetadataEntry {
+interface RuleMetadataEntry {
   requires?: ReadonlyArray<string>;
   tags: ReadonlySet<string>;
 }
@@ -591,7 +591,7 @@ export const RULE_METADATA: ReadonlyMap<string, RuleMetadataEntry> = new Map([
   ["react-doctor/no-dark-mode-glow", { tags: DESIGN_AND_TEST_NOISE_TAGS }],
 ]);
 
-export const buildCapabilities = (project: ProjectInfo): ReadonlySet<string> => {
+const buildCapabilities = (project: ProjectInfo): ReadonlySet<string> => {
   const capabilities = new Set<string>();
 
   capabilities.add(project.framework);
@@ -625,7 +625,7 @@ export const buildCapabilities = (project: ProjectInfo): ReadonlySet<string> => 
   return capabilities;
 };
 
-export const shouldEnableRule = (
+const shouldEnableRule = (
   requires: ReadonlyArray<string> | undefined,
   tags: ReadonlySet<string>,
   capabilities: ReadonlySet<string>,

--- a/packages/react-doctor/src/utils/apply-ignore-overrides.ts
+++ b/packages/react-doctor/src/utils/apply-ignore-overrides.ts
@@ -3,7 +3,7 @@ import { isPlainObject } from "./is-plain-object.js";
 import { compileGlobPattern } from "./match-glob-pattern.js";
 import { toRelativePath } from "./to-relative-path.js";
 
-export interface CompiledIgnoreOverride {
+interface CompiledIgnoreOverride {
   filePatterns: RegExp[];
   ruleIds: ReadonlySet<string>;
 }

--- a/packages/react-doctor/src/utils/build-category-breakdown.ts
+++ b/packages/react-doctor/src/utils/build-category-breakdown.ts
@@ -1,6 +1,6 @@
 import type { Diagnostic } from "../types.js";
 
-export interface CategoryBreakdownEntry {
+interface CategoryBreakdownEntry {
   category: string;
   totalCount: number;
   errorCount: number;

--- a/packages/react-doctor/src/utils/calculate-score-locally.ts
+++ b/packages/react-doctor/src/utils/calculate-score-locally.ts
@@ -7,7 +7,7 @@ import {
 } from "../constants.js";
 import type { Diagnostic, ScoreResult } from "../types.js";
 
-export interface ScoreBreakdown {
+interface ScoreBreakdown {
   errorRules: string[];
   warningRules: string[];
   errorPenalty: number;

--- a/packages/react-doctor/src/utils/evaluate-suppression.ts
+++ b/packages/react-doctor/src/utils/evaluate-suppression.ts
@@ -8,7 +8,7 @@ import { isRuleListedInComment } from "./is-rule-listed-in-comment.js";
 const DISABLE_LINE_PATTERN =
   /(?:\/\/|\/\*)\s*react-doctor-disable-line\b(?:\s+([^\r\n]*?))?\s*(?:\*\/)?\s*\}?\s*$/;
 
-export interface SuppressionEvaluation {
+interface SuppressionEvaluation {
   isSuppressed: boolean;
   nearMissHint: string | null;
 }

--- a/packages/react-doctor/src/utils/is-rule-suppressed-at.ts
+++ b/packages/react-doctor/src/utils/is-rule-suppressed-at.ts
@@ -1,7 +1,0 @@
-import { evaluateSuppression } from "./evaluate-suppression.js";
-
-export const isRuleSuppressedAt = (
-  lines: string[],
-  diagnosticLineIndex: number,
-  ruleId: string,
-): boolean => evaluateSuppression(lines, diagnosticLineIndex, ruleId).isSuppressed;

--- a/packages/react-doctor/src/utils/load-config.ts
+++ b/packages/react-doctor/src/utils/load-config.ts
@@ -10,7 +10,7 @@ import { validateConfigTypes } from "./validate-config-types.js";
 const CONFIG_FILENAME = "react-doctor.config.json";
 const PACKAGE_JSON_CONFIG_KEY = "reactDoctor";
 
-export interface LoadedReactDoctorConfig {
+interface LoadedReactDoctorConfig {
   config: ReactDoctorConfig;
   /**
    * Absolute path of the directory that contained the resolved config

--- a/packages/react-doctor/src/utils/parse-tailwind-major-minor.ts
+++ b/packages/react-doctor/src/utils/parse-tailwind-major-minor.ts
@@ -5,7 +5,7 @@
 // in addition to the major (e.g. the `size-N` shorthand only landed in
 // Tailwind v3.4 — gating purely on `major >= 3` would mis-fire on
 // v3.0 … v3.3 codebases).
-export interface TailwindMajorMinor {
+interface TailwindMajorMinor {
   major: number;
   minor: number;
 }


### PR DESCRIPTION
Audit pass after the refactor wave (#218 #220 #221 #222) to catch unused exports / dead consts / orphan files.

## Findings

A repo-wide scan for exported symbols with **zero** non-self references found 16 candidates. 15 were genuinely dead; 1 (\`clearCaches\` in \`src/index.ts\`) is intentionally exposed as public API and was kept.

## Removed

| File | What | Why |
|---|---|---|
| \`src/utils/is-rule-suppressed-at.ts\` | Entire file (8 LOC) | Single-function module that wrapped \`evaluateSuppression\`. **Nothing imports it.** |
| \`src/constants.ts\` | \`REACT_19_DEPRECATION_MIN_MAJOR\` | Defined for rule version-gating that ended up inlining the number in \`oxlint-config.ts\` (line 607: \`major = 17; major <= effectiveReactMajor\`) instead of importing the constant. |
| \`src/constants.ts\` | \`REACT_DOM_LEGACY_API_MIN_MAJOR\` | Same — never wired up |
| \`src/constants.ts\` | \`TAILWIND_SIZE_SHORTHAND_MIN_MAJOR\` | Same — \`oxlint-config.ts\` inlines \`{ major: 3, minor: 4 }\` (line 616) |
| \`src/constants.ts\` | \`TAILWIND_SIZE_SHORTHAND_MIN_MINOR\` | Same |
| \`src/constants.ts\` | Orphaned HACK comment block | Described the now-deleted constants |

## Un-exported (interface/helper only used inside its own file)

| File | Symbol |
|---|---|
| \`src/cli/parse-file-line-argument.ts\` | \`ParsedFileLineArgument\` (interface) |
| \`src/oxlint-config.ts\` | \`RuleMetadataEntry\`, \`buildCapabilities\`, \`shouldEnableRule\` |
| \`src/utils/apply-ignore-overrides.ts\` | \`CompiledIgnoreOverride\` |
| \`src/utils/build-category-breakdown.ts\` | \`CategoryBreakdownEntry\` |
| \`src/utils/calculate-score-locally.ts\` | \`ScoreBreakdown\` |
| \`src/utils/evaluate-suppression.ts\` | \`SuppressionEvaluation\` |
| \`src/utils/load-config.ts\` | \`LoadedReactDoctorConfig\` |
| \`src/utils/parse-tailwind-major-minor.ts\` | \`TailwindMajorMinor\` |

## Kept

| Symbol | Reason |
|---|---|
| \`clearCaches\` from \`src/index.ts\` | Public-API entry. Even though no internal caller uses it, library consumers may, so it stays exported. |

## Verification

- 10 files changed, **+10 / −36**
- Re-running the dead-export audit after this PR shows exactly 1 zero-reference export remaining (\`clearCaches\`, intentionally kept)
- \`pnpm typecheck\` — clean
- \`pnpm test\` — 734/734 pass
- \`pnpm lint\` — 0 warnings, 0 errors
- \`pnpm format:check\` — clean

## Test plan

- [x] typecheck / test / lint / format all clean
- [x] Re-audit confirms only \`clearCaches\` (public API) remains
- [x] No public API surface change (only \`clearCaches\` is exported from \`src/index.ts\` and we kept it)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly removes unused exported types/helpers and deletes an unreferenced wrapper module/constants; behavior should be unchanged but any external consumers relying on these non-API exports could break.
> 
> **Overview**
> Removes several unused exported symbols across `react-doctor` by making file-local interfaces/helpers non-exported (e.g. in `oxlint-config.ts`, various `utils/*`, and CLI parsing).
> 
> Deletes dead code: drops unused version-gating constants from `constants.ts` and removes the unreferenced `utils/is-rule-suppressed-at.ts` wrapper around `evaluateSuppression`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ace7339a13499c0d4774999045e4d3220c327d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->