### PR TITLE
refactor(diagnose): use combineDiagnostics helper instead of inlining its body

### DIFF
--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -18,13 +18,12 @@ import type {
 import { buildJsonReport } from "./core/build-json-report.js";
 import { buildJsonReportError } from "./core/build-json-report-error.js";
 import { calculateScore } from "./core/scoring/calculate-score.js";
-import { checkReducedMotion } from "./core/scoring/check-reduced-motion.js";
 import { clearIgnorePatternsCache } from "./core/config/collect-ignore-patterns.js";
+import { combineDiagnostics } from "./core/diagnostics/combine-diagnostics.js";
 import { clearAutoSuppressionCaches } from "./core/diagnostics/merge-and-filter-diagnostics.js";
 import { clearProjectCache, discoverProject } from "./core/detection/discover-project.js";
 import { computeJsxIncludePaths } from "./core/runners/jsx-include-paths.js";
 import { clearConfigCache, loadConfigWithSource } from "./core/config/load-config.js";
-import { mergeAndFilterDiagnostics } from "./core/diagnostics/merge-and-filter-diagnostics.js";
 import { clearPackageJsonCache } from "./core/detection/read-package-json.js";
 import { createNodeReadFileLinesSync } from "./core/read-file-lines-node.js";
 import { resolveConfigRootDir } from "./core/config/resolve-config-root-dir.js";
@@ -187,15 +186,16 @@ export const diagnose = async (
   const [lintSettled, deadCodeSettled] = await Promise.allSettled([lintPromise, deadCodePromise]);
   const lintDiagnostics = settledOrEmpty(lintSettled, "Lint");
   const deadCodeDiagnostics = settledOrEmpty(deadCodeSettled, "Dead code");
-  const environmentDiagnostics = isDiffMode ? [] : checkReducedMotion(resolvedDirectory);
 
-  const diagnostics = mergeAndFilterDiagnostics(
-    [...lintDiagnostics, ...deadCodeDiagnostics, ...environmentDiagnostics],
-    resolvedDirectory,
+  const diagnostics = combineDiagnostics({
+    lintDiagnostics,
+    deadCodeDiagnostics,
+    directory: resolvedDirectory,
+    isDiffMode,
     userConfig,
     readFileLinesSync,
-    { respectInlineDisables: effectiveRespectInlineDisables },
-  );
+    respectInlineDisables: effectiveRespectInlineDisables,
+  });
   const elapsedMilliseconds = globalThis.performance.now() - startTime;
   const score = await calculateScore(diagnostics);
 


### PR DESCRIPTION
Small, low-risk DRY win surfaced by an audit of the \`inspect()\` / \`diagnose()\` duplication question.

## Finding

\`combineDiagnostics\` is a 3-line helper that wraps \`mergeAndFilterDiagnostics\` + \`checkReducedMotion\`. \`inspect()\` already uses it. \`diagnose()\` doesn't -- it manually inlines the **exact same** logic.

| Concern | Inside \`combineDiagnostics\` | Inlined in \`diagnose()\` (before this PR) |
|---|---|---|
| Add env diagnostics | \`isDiffMode ? [] : checkReducedMotion(directory)\` | \`isDiffMode ? [] : checkReducedMotion(resolvedDirectory)\` |
| Merge arrays | \`[...lintDiagnostics, ...deadCodeDiagnostics, ...extraDiagnostics]\` | \`[...lintDiagnostics, ...deadCodeDiagnostics, ...environmentDiagnostics]\` |
| Filter/suppress | \`mergeAndFilterDiagnostics(merged, dir, cfg, readFileLines, { respectInlineDisables })\` | Same call |

Functionally identical -- the two paths produce the same diagnostics array byte-for-byte.

## Change

\`diagnose()\` now calls \`combineDiagnostics(...)\` like \`inspect()\` does. Both orchestrators now go through one merge helper.

- 1 file changed, +8 / -8 (drop 2 imports, add 1; replace 8-line inline with 8-line helper call)
- No behavior change
- Future bug fixes / behavior tweaks only have to happen in one place

## What's NOT in this PR

The other \`inspect()\` vs \`diagnose()\` differences are intentional behavioral choices (subproject discovery, nvm-Node detection for oxlint compat, offline scoring, skipped-checks tracking, quiet-vs-loud output, error-handling style). Those are product decisions for separate work, not refactoring.

## Verification

- 1 file changed, +8 / -8
- \`pnpm typecheck\` clean
- \`pnpm test\` -- 734/734 pass (including all diagnose() tests in \`tests/diagnose.test.ts\`)
- \`pnpm lint\` -- 0 warnings, 0 errors
- \`pnpm format:check\` clean
- No public API change (\`diagnose\`'s signature and return shape unchanged)

## Test plan

- [x] typecheck / test / lint / format all clean
- [x] All existing \`diagnose()\` tests still pass (they exercise the same merge + filter + score path)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes diagnostic combination logic without changing runner execution or scoring behavior.
> 
> **Overview**
> `diagnose()` now delegates diagnostic aggregation to `combineDiagnostics()` instead of inlining the `checkReducedMotion` + `mergeAndFilterDiagnostics` flow.
> 
> This removes duplicate logic and imports while keeping the same inputs (lint/dead-code results, diff-mode behavior, config-based filtering, and `respectInlineDisables`) and leaving the rest of the diagnose pipeline unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d8041b83963b4a82c0f66914938c9a99edb1eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->