### PR TITLE
refactor(plugin): port inline `node.type === "X"` checks to `isNodeOfType(node, "X")`

### DIFF
--- a/packages/react-doctor/src/plugin/rules/architecture/no-default-props.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-default-props.ts
@@ -3,6 +3,7 @@ import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: React 19 removes `Component.defaultProps` for FUNCTION components
 // (class components still tolerate it but the team recommends ES6
@@ -19,10 +20,11 @@ export const noDefaultProps = defineRule<Rule>({
     AssignmentExpression(node: EsTreeNode) {
       if (node.operator !== "=") return;
       const left = node.left;
-      if (left?.type !== "MemberExpression") return;
+      if (!isNodeOfType(left, "MemberExpression")) return;
       if (left.computed) return;
-      if (left.property?.type !== "Identifier" || left.property.name !== "defaultProps") return;
-      if (left.object?.type !== "Identifier") return;
+      if (!isNodeOfType(left.property, "Identifier") || left.property.name !== "defaultProps")
+        return;
+      if (!isNodeOfType(left.object, "Identifier")) return;
       if (!isUppercaseName(left.object.name)) return;
       context.report({
         node: left,

--- a/packages/react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
@@ -3,21 +3,22 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noGenericHandlerNames = defineRule<Rule>({
   recommendation:
     "Rename to describe the action: e.g. `handleSubmit` → `saveUserProfile`, `handleClick` → `toggleSidebar`",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || !node.name.name.startsWith("on")) return;
-      if (!node.value || node.value.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || !node.name.name.startsWith("on")) return;
+      if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const eventSuffix = node.name.name.slice(2);
       if (!GENERIC_EVENT_SUFFIXES.has(eventSuffix)) return;
 
       const mirroredHandlerName = `handle${eventSuffix}`;
       const expression = node.value.expression;
-      if (expression?.type === "Identifier" && expression.name === mirroredHandlerName) {
+      if (isNodeOfType(expression, "Identifier") && expression.name === mirroredHandlerName) {
         context.report({
           node,
           message: `Non-descriptive handler name "${expression.name}" — name should describe what it does, not when it runs`,

--- a/packages/react-doctor/src/plugin/rules/architecture/no-legacy-class-lifecycles.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-legacy-class-lifecycles.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: the three legacy class lifecycles `componentWillMount`,
 // `componentWillReceiveProps`, and `componentWillUpdate` are unsafe
@@ -59,9 +60,12 @@ export const noLegacyClassLifecycles = defineRule<Rule>({
   create: (context: RuleContext) => {
     const checkMember = (memberNode: EsTreeNode | undefined): void => {
       if (!memberNode) return;
-      if (memberNode.type !== "MethodDefinition" && memberNode.type !== "PropertyDefinition")
+      if (
+        !isNodeOfType(memberNode, "MethodDefinition") &&
+        !isNodeOfType(memberNode, "PropertyDefinition")
+      )
         return;
-      if (memberNode.key?.type !== "Identifier") return;
+      if (!isNodeOfType(memberNode.key, "Identifier")) return;
       const message = buildLegacyLifecycleMessage(memberNode.key.name);
       if (message) context.report({ node: memberNode.key, message });
     };

--- a/packages/react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
@@ -3,6 +3,7 @@ import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: legacy context (`childContextTypes` + `getChildContext` on
 // providers, `contextTypes` on consumers) was deprecated in 16.3, warns
@@ -27,11 +28,11 @@ const buildLegacyContextMessage = (memberName: string): string => {
 const isInsideClassBody = (node: EsTreeNode): boolean => {
   let current = node.parent;
   while (current) {
-    if (current.type === "ClassBody") return true;
+    if (isNodeOfType(current, "ClassBody")) return true;
     if (
-      current.type === "FunctionDeclaration" ||
-      current.type === "FunctionExpression" ||
-      current.type === "ArrowFunctionExpression"
+      isNodeOfType(current, "FunctionDeclaration") ||
+      isNodeOfType(current, "FunctionExpression") ||
+      isNodeOfType(current, "ArrowFunctionExpression")
     ) {
       return false;
     }
@@ -46,9 +47,12 @@ export const noLegacyContextApi = defineRule<Rule>({
   create: (context: RuleContext) => {
     const checkMember = (memberNode: EsTreeNode | undefined): void => {
       if (!memberNode) return;
-      if (memberNode.type !== "MethodDefinition" && memberNode.type !== "PropertyDefinition")
+      if (
+        !isNodeOfType(memberNode, "MethodDefinition") &&
+        !isNodeOfType(memberNode, "PropertyDefinition")
+      )
         return;
-      if (memberNode.key?.type !== "Identifier") return;
+      if (!isNodeOfType(memberNode.key, "Identifier")) return;
       if (!LEGACY_CONTEXT_NAMES.has(memberNode.key.name)) return;
       context.report({
         node: memberNode.key,
@@ -65,11 +69,11 @@ export const noLegacyContextApi = defineRule<Rule>({
       AssignmentExpression(node: EsTreeNode) {
         if (node.operator !== "=") return;
         const left = node.left;
-        if (left?.type !== "MemberExpression") return;
+        if (!isNodeOfType(left, "MemberExpression")) return;
         if (left.computed) return;
-        if (left.property?.type !== "Identifier") return;
+        if (!isNodeOfType(left.property, "Identifier")) return;
         if (!LEGACY_CONTEXT_NAMES.has(left.property.name)) return;
-        if (left.object?.type !== "Identifier") return;
+        if (!isNodeOfType(left.object, "Identifier")) return;
         if (!isUppercaseName(left.object.name)) return;
         if (isInsideClassBody(node)) return;
         context.report({

--- a/packages/react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -6,6 +6,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const BOOLEAN_PROP_PREFIX_PATTERN = /^(?:is|has|should|can|show|hide|enable|disable|with)[A-Z]/;
 
@@ -16,11 +17,11 @@ const collectBooleanLikePropsFromBody = (
   const found = new Set<string>();
   if (!componentBody) return found;
   walkAst(componentBody, (child: EsTreeNode) => {
-    if (child.type !== "MemberExpression") return;
+    if (!isNodeOfType(child, "MemberExpression")) return;
     if (child.computed) return;
-    if (child.object?.type !== "Identifier") return;
+    if (!isNodeOfType(child.object, "Identifier")) return;
     if (child.object.name !== propsParamName) return;
-    if (child.property?.type !== "Identifier") return;
+    if (!isNodeOfType(child.property, "Identifier")) return;
     if (!BOOLEAN_PROP_PREFIX_PATTERN.test(child.property.name)) return;
     found.add(child.property.name);
   });
@@ -59,11 +60,11 @@ export const noManyBooleanProps = defineRule<Rule>({
       reportNode: EsTreeNode,
     ): void => {
       if (!param) return;
-      if (param.type === "ObjectPattern") {
+      if (isNodeOfType(param, "ObjectPattern")) {
         const booleanLikePropNames: string[] = [];
         for (const property of param.properties ?? []) {
-          if (property.type !== "Property") continue;
-          const keyName = property.key?.type === "Identifier" ? property.key.name : null;
+          if (!isNodeOfType(property, "Property")) continue;
+          const keyName = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
           if (!keyName) continue;
           if (BOOLEAN_PROP_PREFIX_PATTERN.test(keyName)) {
             booleanLikePropNames.push(keyName);
@@ -72,7 +73,7 @@ export const noManyBooleanProps = defineRule<Rule>({
         reportIfMany(booleanLikePropNames, componentName, reportNode);
         return;
       }
-      if (param.type === "Identifier") {
+      if (isNodeOfType(param, "Identifier")) {
         const accessed = collectBooleanLikePropsFromBody(body, param.name);
         reportIfMany([...accessed], componentName, reportNode);
       }

--- a/packages/react-doctor/src/plugin/rules/architecture/no-react-dom-deprecated-apis.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-react-dom-deprecated-apis.ts
@@ -3,6 +3,8 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { createDeprecatedReactImportRule } from "./utils/create-deprecated-react-import-rule.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 
 // HACK: companion to `noReact19DeprecatedApis` for the react-dom side
 // of the React 19 migration. Catches the legacy root API (render /
@@ -57,8 +59,8 @@ const buildTestUtilsMessage = (importedName: string): string => {
 
 const reportTestUtilsImports = (node: EsTreeNode, context: RuleContext): void => {
   for (const specifier of node.specifiers ?? []) {
-    if (specifier.type === "ImportSpecifier") {
-      const importedName = specifier.imported?.name ?? "default";
+    if (isNodeOfType(specifier, "ImportSpecifier")) {
+      const importedName = getImportedName(specifier) ?? "default";
       context.report({ node: specifier, message: buildTestUtilsMessage(importedName) });
       continue;
     }

--- a/packages/react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRenderInRender = defineRule<Rule>({
   recommendation:
@@ -10,14 +11,14 @@ export const noRenderInRender = defineRule<Rule>({
   create: (context: RuleContext) => ({
     JSXExpressionContainer(node: EsTreeNode) {
       const expression = node.expression;
-      if (expression?.type !== "CallExpression") return;
+      if (!isNodeOfType(expression, "CallExpression")) return;
 
       let calleeName: string | null = null;
-      if (expression.callee?.type === "Identifier") {
+      if (isNodeOfType(expression.callee, "Identifier")) {
         calleeName = expression.callee.name;
       } else if (
-        expression.callee?.type === "MemberExpression" &&
-        expression.callee.property?.type === "Identifier"
+        isNodeOfType(expression.callee, "MemberExpression") &&
+        isNodeOfType(expression.callee.property, "Identifier")
       ) {
         calleeName = expression.callee.property.name;
       }

--- a/packages/react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const RENDER_PROP_PATTERN = /^render[A-Z]/;
 
@@ -21,8 +22,8 @@ export const noRenderPropChildren = defineRule<Rule>({
     JSXOpeningElement(node: EsTreeNode) {
       const renderPropAttrs: Array<{ name: string; node: EsTreeNode }> = [];
       for (const attr of node.attributes ?? []) {
-        if (attr.type !== "JSXAttribute") continue;
-        if (attr.name?.type !== "JSXIdentifier") continue;
+        if (!isNodeOfType(attr, "JSXAttribute")) continue;
+        if (!isNodeOfType(attr.name, "JSXIdentifier")) continue;
         const name = attr.name.name;
         if (!RENDER_PROP_PATTERN.test(name)) continue;
         renderPropAttrs.push({ name, node: attr });

--- a/packages/react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
@@ -4,6 +4,7 @@ import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const HOOK_OBJECTS_WITH_METHODS = new Map<string, Set<string>>([
   ["useRouter", new Set(["push", "replace", "back", "forward", "refresh", "prefetch"])],
@@ -20,14 +21,14 @@ const HOOK_OBJECTS_WITH_METHODS = new Map<string, Set<string>>([
 // access.
 const buildHookBindingMap = (componentBody: EsTreeNode): Map<string, string> => {
   const result = new Map<string, string>();
-  if (componentBody?.type !== "BlockStatement") return result;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return result;
   for (const statement of componentBody.body ?? []) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
-      if (declarator.id?.type !== "Identifier") continue;
-      if (declarator.init?.type !== "CallExpression") continue;
+      if (!isNodeOfType(declarator.id, "Identifier")) continue;
+      if (!isNodeOfType(declarator.init, "CallExpression")) continue;
       const callee = declarator.init.callee;
-      if (callee?.type !== "Identifier") continue;
+      if (!isNodeOfType(callee, "Identifier")) continue;
       result.set(declarator.id.name, callee.name);
     }
   }
@@ -53,10 +54,10 @@ export const reactCompilerDestructureMethod = defineRule<Rule>({
     const hookBindingMapStack: Array<Map<string, string>> = [];
 
     const isComponent = (node: EsTreeNode): boolean => {
-      if (node.type === "FunctionDeclaration") {
+      if (isNodeOfType(node, "FunctionDeclaration")) {
         return Boolean(node.id?.name && isUppercaseName(node.id.name));
       }
-      if (node.type === "VariableDeclarator") {
+      if (isNodeOfType(node, "VariableDeclarator")) {
         return isComponentAssignment(node);
       }
       return false;
@@ -72,7 +73,7 @@ export const reactCompilerDestructureMethod = defineRule<Rule>({
     // correct semantic for "this component declares zero hook bindings".
     const enter = (node: EsTreeNode): void => {
       if (!isComponent(node)) return;
-      const body = node.type === "FunctionDeclaration" ? node.body : node.init?.body;
+      const body = isNodeOfType(node, "FunctionDeclaration") ? node.body : node.init?.body;
       hookBindingMapStack.push(buildHookBindingMap(body));
     };
     const exit = (node: EsTreeNode): void => {
@@ -87,8 +88,8 @@ export const reactCompilerDestructureMethod = defineRule<Rule>({
       MemberExpression(node: EsTreeNode) {
         if (hookBindingMapStack.length === 0) return;
         if (node.computed) return;
-        if (node.object?.type !== "Identifier") return;
-        if (node.property?.type !== "Identifier") return;
+        if (!isNodeOfType(node.object, "Identifier")) return;
+        if (!isNodeOfType(node.property, "Identifier")) return;
 
         const bindingName = node.object.name;
         const methodName = node.property.name;
@@ -99,7 +100,7 @@ export const reactCompilerDestructureMethod = defineRule<Rule>({
         const allowedMethods = HOOK_OBJECTS_WITH_METHODS.get(hookSource);
         if (!allowedMethods || !allowedMethods.has(methodName)) return;
 
-        if (node.parent?.type !== "CallExpression" || node.parent.callee !== node) return;
+        if (!isNodeOfType(node.parent, "CallExpression") || node.parent.callee !== node) return;
 
         context.report({
           node,

--- a/packages/react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
@@ -1,3 +1,5 @@
+import { getImportedName } from "../../../utils/get-imported-name.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import type { RuleContext } from "../../../utils/rule-context.js";
 import type { Rule } from "../../../utils/rule.js";
@@ -19,16 +21,16 @@ export const createDeprecatedReactImportRule = ({
         if (sourceValue !== source) return;
 
         for (const specifier of node.specifiers ?? []) {
-          if (specifier.type === "ImportSpecifier") {
-            const importedName = specifier.imported?.name;
+          if (isNodeOfType(specifier, "ImportSpecifier")) {
+            const importedName = getImportedName(specifier);
             if (!importedName) continue;
             const message = messages.get(importedName);
             if (message) context.report({ node: specifier, message });
             continue;
           }
           if (
-            specifier.type === "ImportDefaultSpecifier" ||
-            specifier.type === "ImportNamespaceSpecifier"
+            isNodeOfType(specifier, "ImportDefaultSpecifier") ||
+            isNodeOfType(specifier, "ImportNamespaceSpecifier")
           ) {
             const localName = specifier.local?.name;
             if (localName) namespaceBindings.add(localName);
@@ -38,9 +40,9 @@ export const createDeprecatedReactImportRule = ({
       MemberExpression(node: EsTreeNode) {
         if (namespaceBindings.size === 0) return;
         if (node.computed) return;
-        if (node.object?.type !== "Identifier") return;
+        if (!isNodeOfType(node.object, "Identifier")) return;
         if (!namespaceBindings.has(node.object.name)) return;
-        if (node.property?.type !== "Identifier") return;
+        if (!isNodeOfType(node.property, "Identifier")) return;
         const message = messages.get(node.property.name);
         if (message) context.report({ node, message });
       },

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-dynamic-import-path.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-dynamic-import-path.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: bundlers can only tree-shake / split when the import target is a
 // statically-analyzable string literal. `import(variable)` or
@@ -12,7 +13,7 @@ export const noDynamicImportPath = defineRule<Rule>({
   create: (context: RuleContext) => ({
     ImportExpression(node: EsTreeNode) {
       const source = node.source;
-      if (source && source.type !== "Literal" && source.type !== "TemplateLiteral") {
+      if (source && !isNodeOfType(source, "Literal") && !isNodeOfType(source, "TemplateLiteral")) {
         context.report({
           node,
           message:
@@ -20,7 +21,7 @@ export const noDynamicImportPath = defineRule<Rule>({
         });
         return;
       }
-      if (source?.type === "TemplateLiteral" && (source.expressions?.length ?? 0) > 0) {
+      if (isNodeOfType(source, "TemplateLiteral") && (source.expressions?.length ?? 0) > 0) {
         context.report({
           node,
           message:
@@ -29,10 +30,10 @@ export const noDynamicImportPath = defineRule<Rule>({
       }
     },
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "Identifier" || node.callee.name !== "require") return;
+      if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "require") return;
       const arg = node.arguments?.[0];
       if (!arg) return;
-      if (arg.type !== "Literal" && arg.type !== "TemplateLiteral") {
+      if (!isNodeOfType(arg, "Literal") && !isNodeOfType(arg, "TemplateLiteral")) {
         context.report({
           node,
           message:
@@ -40,7 +41,7 @@ export const noDynamicImportPath = defineRule<Rule>({
         });
         return;
       }
-      if (arg.type === "TemplateLiteral" && (arg.expressions?.length ?? 0) > 0) {
+      if (isNodeOfType(arg, "TemplateLiteral") && (arg.expressions?.length ?? 0) > 0) {
         context.report({
           node,
           message:

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
@@ -4,12 +4,13 @@ import { hasJsxAttribute } from "../../utils/has-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noUndeferredThirdParty = defineRule<Rule>({
   recommendation: 'Use `next/script` with `strategy="lazyOnload"` or add the `defer` attribute',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "script") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "script") return;
       const attributes = node.attributes ?? [];
       if (!findJsxAttribute(attributes, "src")) return;
 

--- a/packages/react-doctor/src/plugin/rules/bundle-size/use-lazy-motion.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/use-lazy-motion.ts
@@ -2,6 +2,8 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const useLazyMotion = defineRule<Rule>({
   recommendation:
@@ -13,7 +15,7 @@ export const useLazyMotion = defineRule<Rule>({
 
       const hasFullMotionImport = node.specifiers?.some(
         (specifier: EsTreeNode) =>
-          specifier.type === "ImportSpecifier" && specifier.imported?.name === "motion",
+          isNodeOfType(specifier, "ImportSpecifier") && getImportedName(specifier) === "motion",
       );
 
       if (hasFullMotionImport) {

--- a/packages/react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
+++ b/packages/react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const VERSIONED_KEY_PATTERN = /(?:[._:-]v\d+|@\d+|\bv\d+\b)/i;
 
@@ -19,11 +20,11 @@ const STORAGE_OBJECTS = new Set(["localStorage", "sessionStorage"]);
 // — those are the cases where schema versioning matters. Simple flags
 // like `setItem("count", "5")` don't need versioning and would be noise.
 const isJsonStringifyCall = (node: EsTreeNode): boolean => {
-  if (node.type !== "CallExpression") return false;
-  if (node.callee?.type !== "MemberExpression") return false;
-  if (node.callee.object?.type !== "Identifier") return false;
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (!isNodeOfType(node.callee, "MemberExpression")) return false;
+  if (!isNodeOfType(node.callee.object, "Identifier")) return false;
   if (node.callee.object.name !== "JSON") return false;
-  if (node.callee.property?.type !== "Identifier") return false;
+  if (!isNodeOfType(node.callee.property, "Identifier")) return false;
   return node.callee.property.name === "stringify";
 };
 
@@ -32,15 +33,15 @@ export const clientLocalstorageNoVersion = defineRule<Rule>({
     'Bake a version into the storage key (e.g. "myKey:v1"); a future schema change can ignore old data instead of crashing on it',
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.object?.type !== "Identifier") return;
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (!isNodeOfType(node.callee.object, "Identifier")) return;
       if (!STORAGE_OBJECTS.has(node.callee.object.name)) return;
-      if (node.callee.property?.type !== "Identifier") return;
+      if (!isNodeOfType(node.callee.property, "Identifier")) return;
       if (node.callee.property.name !== "setItem") return;
 
       const keyArg = node.arguments?.[0];
       if (!keyArg) return;
-      if (keyArg.type !== "Literal") return;
+      if (!isNodeOfType(keyArg, "Literal")) return;
       if (typeof keyArg.value !== "string") return;
       if (VERSIONED_KEY_PATTERN.test(keyArg.value)) return;
 

--- a/packages/react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
+++ b/packages/react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
@@ -4,6 +4,7 @@ import { isMemberProperty } from "../../utils/is-member-property.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const clientPassiveEventListeners = defineRule<Rule>({
   recommendation:
@@ -14,7 +15,12 @@ export const clientPassiveEventListeners = defineRule<Rule>({
       if ((node.arguments?.length ?? 0) < 2) return;
 
       const eventNameNode = node.arguments[0];
-      if (eventNameNode.type !== "Literal" || !PASSIVE_EVENT_NAMES.has(eventNameNode.value)) return;
+      if (
+        !isNodeOfType(eventNameNode, "Literal") ||
+        typeof eventNameNode.value !== "string" ||
+        !PASSIVE_EVENT_NAMES.has(eventNameNode.value)
+      )
+        return;
 
       const eventName = eventNameNode.value;
       const optionsArgument = node.arguments[2];
@@ -27,14 +33,14 @@ export const clientPassiveEventListeners = defineRule<Rule>({
         return;
       }
 
-      if (optionsArgument.type !== "ObjectExpression") return;
+      if (!isNodeOfType(optionsArgument, "ObjectExpression")) return;
 
       const hasPassiveTrue = optionsArgument.properties?.some(
         (property: EsTreeNode) =>
-          property.type === "Property" &&
-          property.key?.type === "Identifier" &&
+          isNodeOfType(property, "Property") &&
+          isNodeOfType(property.key, "Identifier") &&
           property.key.name === "passive" &&
-          property.value?.type === "Literal" &&
+          isNodeOfType(property.value, "Literal") &&
           property.value.value === true,
       );
 

--- a/packages/react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -3,52 +3,55 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const STRING_COERCION_FUNCTIONS = new Set(["String", "Number"]);
 
 const extractIndexName = (node: EsTreeNode): string | null => {
-  if (node.type === "Identifier" && INDEX_PARAMETER_NAMES.has(node.name)) return node.name;
+  if (isNodeOfType(node, "Identifier") && INDEX_PARAMETER_NAMES.has(node.name)) return node.name;
 
-  if (node.type === "TemplateLiteral") {
-    const indexExpression = node.expressions?.find(
-      (expression: EsTreeNode) =>
-        expression.type === "Identifier" && INDEX_PARAMETER_NAMES.has(expression.name),
-    );
-    if (indexExpression) return indexExpression.name;
+  if (isNodeOfType(node, "TemplateLiteral")) {
+    for (const expression of node.expressions ?? []) {
+      if (isNodeOfType(expression, "Identifier") && INDEX_PARAMETER_NAMES.has(expression.name)) {
+        return expression.name;
+      }
+    }
   }
 
   if (
-    node.type === "CallExpression" &&
-    node.callee?.type === "MemberExpression" &&
-    node.callee.object?.type === "Identifier" &&
+    isNodeOfType(node, "CallExpression") &&
+    isNodeOfType(node.callee, "MemberExpression") &&
+    isNodeOfType(node.callee.object, "Identifier") &&
     INDEX_PARAMETER_NAMES.has(node.callee.object.name) &&
-    node.callee.property?.type === "Identifier" &&
+    isNodeOfType(node.callee.property, "Identifier") &&
     node.callee.property.name === "toString"
   )
     return node.callee.object.name;
 
   if (
-    node.type === "CallExpression" &&
-    node.callee?.type === "Identifier" &&
+    isNodeOfType(node, "CallExpression") &&
+    isNodeOfType(node.callee, "Identifier") &&
     STRING_COERCION_FUNCTIONS.has(node.callee.name) &&
-    node.arguments?.[0]?.type === "Identifier" &&
+    isNodeOfType(node.arguments?.[0], "Identifier") &&
     INDEX_PARAMETER_NAMES.has(node.arguments[0].name)
   )
     return node.arguments[0].name;
 
   if (
-    node.type === "BinaryExpression" &&
+    isNodeOfType(node, "BinaryExpression") &&
     node.operator === "+" &&
-    ((node.left?.type === "Identifier" &&
+    ((isNodeOfType(node.left, "Identifier") &&
       INDEX_PARAMETER_NAMES.has(node.left.name) &&
-      node.right?.type === "Literal" &&
+      isNodeOfType(node.right, "Literal") &&
       node.right.value === "") ||
-      (node.right?.type === "Identifier" &&
+      (isNodeOfType(node.right, "Identifier") &&
         INDEX_PARAMETER_NAMES.has(node.right.name) &&
-        node.left?.type === "Literal" &&
+        isNodeOfType(node.left, "Literal") &&
         node.left.value === ""))
   ) {
-    return node.left?.type === "Identifier" ? node.left.name : node.right.name;
+    if (isNodeOfType(node.left, "Identifier")) return node.left.name;
+    if (isNodeOfType(node.right, "Identifier")) return node.right.name;
+    return null;
   }
 
   return null;
@@ -59,24 +62,26 @@ const isInsideStaticPlaceholderMap = (node: EsTreeNode): boolean => {
   while (current.parent) {
     current = current.parent;
     if (
-      current.type === "CallExpression" &&
-      current.callee?.type === "MemberExpression" &&
-      current.callee.property?.name === "map"
+      isNodeOfType(current, "CallExpression") &&
+      isNodeOfType(current.callee, "MemberExpression") &&
+      isNodeOfType(current.callee.property, "Identifier") &&
+      current.callee.property.name === "map"
     ) {
       const receiver = current.callee.object;
-      if (receiver?.type === "CallExpression") {
+      if (isNodeOfType(receiver, "CallExpression")) {
         const callee = receiver.callee;
         if (
-          callee?.type === "MemberExpression" &&
-          callee.object?.type === "Identifier" &&
+          isNodeOfType(callee, "MemberExpression") &&
+          isNodeOfType(callee.object, "Identifier") &&
           callee.object.name === "Array" &&
-          callee.property?.name === "from"
+          isNodeOfType(callee.property, "Identifier") &&
+          callee.property.name === "from"
         )
           return true;
       }
       if (
-        receiver?.type === "NewExpression" &&
-        receiver.callee?.type === "Identifier" &&
+        isNodeOfType(receiver, "NewExpression") &&
+        isNodeOfType(receiver.callee, "Identifier") &&
         receiver.callee.name === "Array"
       )
         return true;
@@ -90,8 +95,8 @@ export const noArrayIndexAsKey = defineRule<Rule>({
     "Use a stable unique identifier: `key={item.id}` or `key={item.slug}` — index keys break on reorder/filter",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "key") return;
-      if (!node.value || node.value.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "key") return;
+      if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const indexName = extractIndexName(node.value.expression);
       if (!indexName) return;

--- a/packages/react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: `typeof children === "string"` (or `=== 'object'`) is a
 // polymorphic-children smell — the component switches behavior based on
@@ -16,15 +17,15 @@ export const noPolymorphicChildren = defineRule<Rule>({
       if (node.operator !== "===" && node.operator !== "==") return;
 
       const isTypeofChildren = (operand: EsTreeNode | undefined): boolean =>
-        operand?.type === "UnaryExpression" &&
+        isNodeOfType(operand, "UnaryExpression") &&
         operand.operator === "typeof" &&
-        operand.argument?.type === "Identifier" &&
+        isNodeOfType(operand.argument, "Identifier") &&
         operand.argument.name === "children";
 
       if (!isTypeofChildren(node.left) && !isTypeofChildren(node.right)) return;
 
       const isStringLiteral = (operand: EsTreeNode | undefined): boolean =>
-        operand?.type === "Literal" && operand.value === "string";
+        isNodeOfType(operand, "Literal") && operand.value === "string";
 
       if (!isStringLiteral(node.left) && !isStringLiteral(node.right)) return;
 

--- a/packages/react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -4,6 +4,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: <button> is intentionally omitted. <button type="submit"> (the
 // HTML default inside a form) has a real default action, so calling
@@ -25,9 +26,9 @@ const containsPreventDefaultCall = (node: EsTreeNode): boolean => {
   walkAst(node, (child) => {
     if (didFindPreventDefault) return;
     if (
-      child.type === "CallExpression" &&
-      child.callee?.type === "MemberExpression" &&
-      child.callee.property?.type === "Identifier" &&
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "MemberExpression") &&
+      isNodeOfType(child.callee.property, "Identifier") &&
       child.callee.property.name === "preventDefault"
     ) {
       didFindPreventDefault = true;
@@ -48,7 +49,7 @@ export const noPreventDefault = defineRule<Rule>({
     "Use `<form action={serverAction}>` (works without JS) or `<button>` instead of `<a>` with preventDefault",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      const elementName = node.name?.type === "JSXIdentifier" ? node.name.name : null;
+      const elementName = isNodeOfType(node.name, "JSXIdentifier") ? node.name.name : null;
       if (!elementName) return;
 
       const targetEventProps = PREVENT_DEFAULT_ELEMENTS.get(elementName);
@@ -56,13 +57,13 @@ export const noPreventDefault = defineRule<Rule>({
 
       for (const targetEventProp of targetEventProps) {
         const eventAttribute = findJsxAttribute(node.attributes ?? [], targetEventProp);
-        if (!eventAttribute?.value || eventAttribute.value.type !== "JSXExpressionContainer")
+        if (!eventAttribute?.value || !isNodeOfType(eventAttribute.value, "JSXExpressionContainer"))
           continue;
 
         const expression = eventAttribute.value.expression;
         if (
-          expression?.type !== "ArrowFunctionExpression" &&
-          expression?.type !== "FunctionExpression"
+          !isNodeOfType(expression, "ArrowFunctionExpression") &&
+          !isNodeOfType(expression, "FunctionExpression")
         )
           continue;
 

--- a/packages/react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -7,6 +7,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const UNCONTROLLED_INPUT_TAGS = new Set(["input", "textarea", "select"]);
 
@@ -22,29 +23,29 @@ const VALUE_PARTNER_ATTRIBUTES = ["onChange", "readOnly"];
 
 const getInputTypeLiteral = (attributes: EsTreeNode[]): string | null => {
   const typeAttribute = findJsxAttribute(attributes, "type");
-  if (!typeAttribute || typeAttribute.value?.type !== "Literal") return null;
+  if (!typeAttribute || !isNodeOfType(typeAttribute.value, "Literal")) return null;
   const value = typeAttribute.value.value;
   return typeof value === "string" ? value : null;
 };
 
 const isUseStateUndefinedInitializer = (init: EsTreeNode | null | undefined): boolean => {
-  if (!init || init.type !== "CallExpression") return false;
+  if (!init || !isNodeOfType(init, "CallExpression")) return false;
   if (!isHookCall(init, "useState")) return false;
   const args = init.arguments ?? [];
   if (args.length === 0) return true;
   const firstArgument = args[0];
-  return firstArgument?.type === "Identifier" && firstArgument.name === "undefined";
+  return isNodeOfType(firstArgument, "Identifier") && firstArgument.name === "undefined";
 };
 
 const collectUndefinedInitialStateNames = (componentBody: EsTreeNode): Set<string> => {
   const stateNames = new Set<string>();
-  if (componentBody?.type !== "BlockStatement") return stateNames;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return stateNames;
   for (const statement of componentBody.body ?? []) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
-      if (declarator.id?.type !== "ArrayPattern") continue;
+      if (!isNodeOfType(declarator.id, "ArrayPattern")) continue;
       const valueElement = declarator.id.elements?.[0];
-      if (valueElement?.type !== "Identifier") continue;
+      if (!isNodeOfType(valueElement, "Identifier")) continue;
       if (!isUseStateUndefinedInitializer(declarator.init)) continue;
       stateNames.add(valueElement.name);
     }
@@ -53,7 +54,7 @@ const collectUndefinedInitialStateNames = (componentBody: EsTreeNode): Set<strin
 };
 
 const hasJsxSpreadAttribute = (attributes: EsTreeNode[]): boolean =>
-  attributes.some((attribute) => attribute.type === "JSXSpreadAttribute");
+  attributes.some((attribute) => isNodeOfType(attribute, "JSXSpreadAttribute"));
 
 // HACK: catches three uncontrolled-input mistakes that React's static
 // rule set misses:
@@ -80,14 +81,13 @@ export const noUncontrolledInput = defineRule<Rule>({
       // wrapper; walk the JSX expression directly. There are no useState
       // declarations to collect for the undefined-initializer check, so an
       // empty set is correct.
-      const undefinedInitialStateNames =
-        componentBody.type === "BlockStatement"
-          ? collectUndefinedInitialStateNames(componentBody)
-          : new Set<string>();
+      const undefinedInitialStateNames = isNodeOfType(componentBody, "BlockStatement")
+        ? collectUndefinedInitialStateNames(componentBody)
+        : new Set<string>();
 
       walkAst(componentBody, (child: EsTreeNode) => {
-        if (child.type !== "JSXOpeningElement") return;
-        if (child.name?.type !== "JSXIdentifier") return;
+        if (!isNodeOfType(child, "JSXOpeningElement")) return;
+        if (!isNodeOfType(child.name, "JSXIdentifier")) return;
         const tagName = child.name.name;
         if (!UNCONTROLLED_INPUT_TAGS.has(tagName)) return;
 
@@ -107,8 +107,8 @@ export const noUncontrolledInput = defineRule<Rule>({
         );
 
         if (
-          valueAttribute.value?.type === "JSXExpressionContainer" &&
-          valueAttribute.value.expression?.type === "Identifier" &&
+          isNodeOfType(valueAttribute.value, "JSXExpressionContainer") &&
+          isNodeOfType(valueAttribute.value.expression, "Identifier") &&
           undefinedInitialStateNames.has(valueAttribute.value.expression.name)
         ) {
           const stateName = valueAttribute.value.expression.name;

--- a/packages/react-doctor/src/plugin/rules/correctness/rendering-conditional-render.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/rendering-conditional-render.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const NUMERIC_NAME_HINTS = ["count", "length", "total", "size", "num"];
 
@@ -27,18 +28,19 @@ export const renderingConditionalRender = defineRule<Rule>({
     LogicalExpression(node: EsTreeNode) {
       if (node.operator !== "&&") return;
 
-      const isRightJsx = node.right?.type === "JSXElement" || node.right?.type === "JSXFragment";
+      const isRightJsx =
+        isNodeOfType(node.right, "JSXElement") || isNodeOfType(node.right, "JSXFragment");
       if (!isRightJsx) return;
 
       const left = node.left;
       if (!left) return;
 
       const isLengthMemberAccess =
-        left.type === "MemberExpression" &&
-        left.property?.type === "Identifier" &&
+        isNodeOfType(left, "MemberExpression") &&
+        isNodeOfType(left.property, "Identifier") &&
         left.property.name === "length";
 
-      const isNumericIdentifier = left.type === "Identifier" && isNumericName(left.name);
+      const isNumericIdentifier = isNodeOfType(left, "Identifier") && isNumericName(left.name);
 
       if (isLengthMemberAccess || isNumericIdentifier) {
         context.report({

--- a/packages/react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const SVG_PATH_HIGH_PRECISION_PATTERN = /\d+\.\d{4,}/;
 
@@ -16,9 +17,9 @@ export const renderingSvgPrecision = defineRule<Rule>({
     "Truncate path/points/transform decimals to 1–2 digits — sub-pixel precision adds bytes with no visible difference",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (!SVG_PATH_ATTRIBUTES.has(node.name.name)) return;
-      if (node.value?.type !== "Literal") return;
+      if (!isNodeOfType(node.value, "Literal")) return;
       const value = node.value.value;
       if (typeof value !== "string") return;
       if (!SVG_PATH_HIGH_PRECISION_PATTERN.test(value)) return;

--- a/packages/react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
@@ -3,23 +3,24 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noDisabledZoom = defineRule<Rule>({
   recommendation:
     "Remove `user-scalable=no` and `maximum-scale` from the viewport meta tag. If your layout breaks at 200% zoom, fix the layout — don't punish users with disabilities",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "meta") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "meta") return;
 
       const nameAttr = findJsxAttribute(node.attributes ?? [], "name");
       if (!nameAttr?.value) return;
-      const nameValue = nameAttr.value.type === "Literal" ? nameAttr.value.value : null;
+      const nameValue = isNodeOfType(nameAttr.value, "Literal") ? nameAttr.value.value : null;
       if (nameValue !== "viewport") return;
 
       const contentAttr = findJsxAttribute(node.attributes ?? [], "content");
       if (!contentAttr?.value) return;
       const contentValue =
-        contentAttr.value.type === "Literal" && typeof contentAttr.value.value === "string"
+        isNodeOfType(contentAttr.value, "Literal") && typeof contentAttr.value.value === "string"
           ? contentAttr.value.value
           : null;
       if (!contentValue) return;

--- a/packages/react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noInlineExhaustiveStyle = defineRule<Rule>({
   recommendation:
@@ -14,7 +15,7 @@ export const noInlineExhaustiveStyle = defineRule<Rule>({
       if (!expression) return;
 
       const propertyCount =
-        expression.properties?.filter((property: EsTreeNode) => property.type === "Property")
+        expression.properties?.filter((property: EsTreeNode) => isNodeOfType(property, "Property"))
           .length ?? 0;
 
       if (propertyCount >= INLINE_STYLE_PROPERTY_THRESHOLD) {

--- a/packages/react-doctor/src/plugin/rules/design/no-z-index9999.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-z-index9999.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noZIndex9999 = defineRule<Rule>({
   recommendation:
@@ -30,21 +31,27 @@ export const noZIndex9999 = defineRule<Rule>({
       }
     },
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.property?.type !== "Identifier" || node.callee.property.name !== "create")
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (
+        !isNodeOfType(node.callee.property, "Identifier") ||
+        node.callee.property.name !== "create"
+      )
         return;
-      if (node.callee.object?.type !== "Identifier" || node.callee.object.name !== "StyleSheet")
+      if (
+        !isNodeOfType(node.callee.object, "Identifier") ||
+        node.callee.object.name !== "StyleSheet"
+      )
         return;
 
       const argument = node.arguments?.[0];
-      if (!argument || argument.type !== "ObjectExpression") return;
+      if (!argument || !isNodeOfType(argument, "ObjectExpression")) return;
 
       walkAst(argument, (child: EsTreeNode) => {
-        if (child.type !== "Property") return;
+        if (!isNodeOfType(child, "Property")) return;
         const key = getStylePropertyKey(child);
         if (key !== "zIndex") return;
 
-        if (child.value?.type === "Literal" && typeof child.value.value === "number") {
+        if (isNodeOfType(child.value, "Literal") && typeof child.value.value === "number") {
           const zValue = child.value.value;
           if (Math.abs(zValue) >= Z_INDEX_ABSURD_THRESHOLD) {
             context.report({

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-inline-style-expression.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-inline-style-expression.ts
@@ -1,9 +1,10 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getInlineStyleExpression = (node: EsTreeNode): EsTreeNode | null => {
-  if (node.name?.type !== "JSXIdentifier" || node.name.name !== "style") return null;
-  if (node.value?.type !== "JSXExpressionContainer") return null;
+  if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return null;
+  if (!isNodeOfType(node.value, "JSXExpressionContainer")) return null;
   const expression = node.value.expression;
-  if (expression?.type !== "ObjectExpression") return null;
+  if (!isNodeOfType(expression, "ObjectExpression")) return null;
   return expression;
 };

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-string-from-class-name-attr.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-string-from-class-name-attr.ts
@@ -1,22 +1,23 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { findJsxAttribute } from "../../../utils/find-jsx-attribute.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getStringFromClassNameAttr = (node: EsTreeNode): string | null => {
   const classAttr = findJsxAttribute(node.attributes ?? [], "className");
   if (!classAttr?.value) return null;
-  if (classAttr.value.type === "Literal" && typeof classAttr.value.value === "string") {
+  if (isNodeOfType(classAttr.value, "Literal") && typeof classAttr.value.value === "string") {
     return classAttr.value.value;
   }
   if (
-    classAttr.value.type === "JSXExpressionContainer" &&
-    classAttr.value.expression?.type === "Literal" &&
+    isNodeOfType(classAttr.value, "JSXExpressionContainer") &&
+    isNodeOfType(classAttr.value.expression, "Literal") &&
     typeof classAttr.value.expression.value === "string"
   ) {
     return classAttr.value.expression.value;
   }
   if (
-    classAttr.value.type === "JSXExpressionContainer" &&
-    classAttr.value.expression?.type === "TemplateLiteral" &&
+    isNodeOfType(classAttr.value, "JSXExpressionContainer") &&
+    isNodeOfType(classAttr.value.expression, "TemplateLiteral") &&
     classAttr.value.expression.quasis?.length === 1
   ) {
     return classAttr.value.expression.quasis[0].value?.raw ?? null;

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-key.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-key.ts
@@ -1,9 +1,10 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getStylePropertyKey = (property: EsTreeNode): string | null => {
-  if (property.type !== "Property") return null;
-  if (property.key?.type === "Identifier") return property.key.name;
-  if (property.key?.type === "Literal" && typeof property.key.value === "string")
+  if (!isNodeOfType(property, "Property")) return null;
+  if (isNodeOfType(property.key, "Identifier")) return property.key.name;
+  if (isNodeOfType(property.key, "Literal") && typeof property.key.value === "string")
     return property.key.value;
   return null;
 };

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-number-value.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-number-value.ts
@@ -1,13 +1,14 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getStylePropertyNumberValue = (property: EsTreeNode): number | null => {
-  if (property.value?.type === "Literal" && typeof property.value.value === "number") {
+  if (isNodeOfType(property.value, "Literal") && typeof property.value.value === "number") {
     return property.value.value;
   }
   if (
-    property.value?.type === "UnaryExpression" &&
+    isNodeOfType(property.value, "UnaryExpression") &&
     property.value.operator === "-" &&
-    property.value.argument?.type === "Literal" &&
+    isNodeOfType(property.value.argument, "Literal") &&
     typeof property.value.argument.value === "number"
   ) {
     return -property.value.argument.value;

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-string-value.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-string-value.ts
@@ -1,7 +1,8 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getStylePropertyStringValue = (property: EsTreeNode): string | null => {
-  if (property.value?.type === "Literal" && typeof property.value.value === "string") {
+  if (isNodeOfType(property.value, "Literal") && typeof property.value.value === "string") {
     return property.value.value;
   }
   return null;

--- a/packages/react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
@@ -3,6 +3,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const findFirstAwaitOutsideNestedFunctions = (block: EsTreeNode): EsTreeNode | null => {
   let firstAwait: EsTreeNode | null = null;
@@ -10,9 +11,9 @@ const findFirstAwaitOutsideNestedFunctions = (block: EsTreeNode): EsTreeNode | n
     if (firstAwait) return false;
     if (
       child !== block &&
-      (child.type === "FunctionDeclaration" ||
-        child.type === "FunctionExpression" ||
-        child.type === "ArrowFunctionExpression")
+      (isNodeOfType(child, "FunctionDeclaration") ||
+        isNodeOfType(child, "FunctionExpression") ||
+        isNodeOfType(child, "ArrowFunctionExpression"))
     ) {
       // Don't descend into nested functions — their `await`s belong to
       // their own async parent, not this loop. (`child !== block` so we
@@ -20,7 +21,7 @@ const findFirstAwaitOutsideNestedFunctions = (block: EsTreeNode): EsTreeNode | n
       // the callback's body.)
       return false;
     }
-    if (child.type === "AwaitExpression") {
+    if (isNodeOfType(child, "AwaitExpression")) {
       firstAwait = child;
     }
   });
@@ -44,16 +45,16 @@ const isAwaitingSleepLikeCall = (awaitNode: EsTreeNode): boolean => {
   const argument = awaitNode.argument;
   if (!argument) return false;
 
-  if (argument.type === "CallExpression") {
+  if (isNodeOfType(argument, "CallExpression")) {
     if (
-      argument.callee?.type === "Identifier" &&
+      isNodeOfType(argument.callee, "Identifier") &&
       SLEEP_LIKE_FUNCTION_NAMES.has(argument.callee.name)
     ) {
       return true;
     }
     if (
-      argument.callee?.type === "MemberExpression" &&
-      argument.callee.property?.type === "Identifier" &&
+      isNodeOfType(argument.callee, "MemberExpression") &&
+      isNodeOfType(argument.callee.property, "Identifier") &&
       SLEEP_LIKE_FUNCTION_NAMES.has(argument.callee.property.name)
     ) {
       return true;
@@ -64,36 +65,40 @@ const isAwaitingSleepLikeCall = (awaitNode: EsTreeNode): boolean => {
 };
 
 const collectPatternIdentifiers = (pattern: EsTreeNode, target: Set<string>): void => {
-  if (pattern.type === "Identifier") {
+  if (isNodeOfType(pattern, "Identifier")) {
     target.add(pattern.name);
-  } else if (pattern.type === "ObjectPattern") {
+  } else if (isNodeOfType(pattern, "ObjectPattern")) {
     for (const property of pattern.properties ?? []) {
-      if (property.type === "Property" && property.value) {
+      if (isNodeOfType(property, "Property") && property.value) {
         collectPatternIdentifiers(property.value, target);
-      } else if (property.type === "RestElement" && property.argument) {
+      } else if (isNodeOfType(property, "RestElement") && property.argument) {
         collectPatternIdentifiers(property.argument, target);
       }
     }
-  } else if (pattern.type === "ArrayPattern") {
+  } else if (isNodeOfType(pattern, "ArrayPattern")) {
     for (const element of pattern.elements ?? []) {
       if (element) collectPatternIdentifiers(element, target);
     }
-  } else if (pattern.type === "AssignmentPattern" && pattern.left) {
+  } else if (isNodeOfType(pattern, "AssignmentPattern") && pattern.left) {
     collectPatternIdentifiers(pattern.left, target);
   }
 };
 
 const isFunctionishExpression = (node: EsTreeNode): boolean =>
-  node.type === "ArrowFunctionExpression" || node.type === "FunctionExpression";
+  isNodeOfType(node, "ArrowFunctionExpression") || isNodeOfType(node, "FunctionExpression");
 
 const collectAssignedIdentifiers = (block: EsTreeNode): Set<string> => {
   const assigned = new Set<string>();
   walkAst(block, (child: EsTreeNode): boolean | void => {
-    if (isFunctionishExpression(child) || child.type === "FunctionDeclaration") return false;
-    if (child.type === "AssignmentExpression" && child.left) {
+    if (isFunctionishExpression(child) || isNodeOfType(child, "FunctionDeclaration")) return false;
+    if (isNodeOfType(child, "AssignmentExpression") && child.left) {
       collectPatternIdentifiers(child.left, assigned);
     }
-    if (child.type === "VariableDeclarator" && child.id && child.init?.type === "AwaitExpression") {
+    if (
+      isNodeOfType(child, "VariableDeclarator") &&
+      child.id &&
+      isNodeOfType(child.init, "AwaitExpression")
+    ) {
       collectPatternIdentifiers(child.id, assigned);
     }
   });
@@ -103,11 +108,14 @@ const collectAssignedIdentifiers = (block: EsTreeNode): Set<string> => {
 const collectAwaitedArgIdentifiers = (block: EsTreeNode): Set<string> => {
   const referenced = new Set<string>();
   walkAst(block, (child: EsTreeNode): boolean | void => {
-    if (isFunctionishExpression(child) || child.type === "FunctionDeclaration") return false;
-    if (child.type !== "AwaitExpression" || !child.argument) return;
+    if (isFunctionishExpression(child) || isNodeOfType(child, "FunctionDeclaration")) return false;
+    if (!isNodeOfType(child, "AwaitExpression") || !child.argument) return;
     walkAst(child.argument, (innerChild: EsTreeNode) => {
-      if (innerChild.type === "Identifier") referenced.add(innerChild.name);
-      if (innerChild.type === "MemberExpression" && innerChild.object?.type === "Identifier") {
+      if (isNodeOfType(innerChild, "Identifier")) referenced.add(innerChild.name);
+      if (
+        isNodeOfType(innerChild, "MemberExpression") &&
+        isNodeOfType(innerChild.object, "Identifier")
+      ) {
         referenced.add(innerChild.object.name);
       }
     });
@@ -132,8 +140,8 @@ const loopBodyHasOnlySleepLikeAwaits = (block: EsTreeNode): boolean => {
   let allAreSleepLike = true;
   let foundAny = false;
   walkAst(block, (child: EsTreeNode): boolean | void => {
-    if (isFunctionishExpression(child) || child.type === "FunctionDeclaration") return false;
-    if (child.type === "AwaitExpression") {
+    if (isFunctionishExpression(child) || isNodeOfType(child, "FunctionDeclaration")) return false;
+    if (isNodeOfType(child, "AwaitExpression")) {
       foundAny = true;
       if (!isAwaitingSleepLikeCall(child)) allAreSleepLike = false;
     }
@@ -165,12 +173,12 @@ const PROMISE_CONCURRENCY_METHODS = new Set(["all", "allSettled", "race", "any"]
 
 const isWrappedInPromiseConcurrency = (mapCall: EsTreeNode): boolean => {
   const parent = mapCall.parent;
-  if (parent?.type !== "CallExpression") return false;
+  if (!isNodeOfType(parent, "CallExpression")) return false;
   if (parent.arguments?.[0] !== mapCall) return false;
   const callee = parent.callee;
-  if (callee?.type !== "MemberExpression" || callee.computed) return false;
-  if (callee.object?.type !== "Identifier" || callee.object.name !== "Promise") return false;
-  if (callee.property?.type !== "Identifier") return false;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.object, "Identifier") || callee.object.name !== "Promise") return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
   return PROMISE_CONCURRENCY_METHODS.has(callee.property.name);
 };
 
@@ -214,8 +222,8 @@ export const asyncAwaitInLoop = defineRule<Rule>({
         // arr.forEach(async item => { await fn(item); }) — sequential
         // because forEach doesn't await; even worse, the awaits are
         // dropped on the floor (forEach ignores return values).
-        if (node.callee?.type !== "MemberExpression") return;
-        if (node.callee.property?.type !== "Identifier") return;
+        if (!isNodeOfType(node.callee, "MemberExpression")) return;
+        if (!isNodeOfType(node.callee.property, "Identifier")) return;
         const methodName = node.callee.property.name;
         if (!ITERATION_METHOD_NAMES_WITH_CALLBACK.has(methodName)) return;
 

--- a/packages/react-doctor/src/plugin/rules/js-performance/async-parallel.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/async-parallel.ts
@@ -4,25 +4,27 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const reportIfIndependent = (statements: EsTreeNode[], context: RuleContext): void => {
   const declaredNames = new Set<string>();
 
   for (const statement of statements) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     const declarator = statement.declarations[0];
-    const awaitArgument = declarator.init?.argument;
+    if (!isNodeOfType(declarator.init, "AwaitExpression")) continue;
+    const awaitArgument = declarator.init.argument;
 
     let referencesEarlierResult = false;
     walkAst(awaitArgument, (child: EsTreeNode) => {
-      if (child.type === "Identifier" && declaredNames.has(child.name)) {
+      if (isNodeOfType(child, "Identifier") && declaredNames.has(child.name)) {
         referencesEarlierResult = true;
       }
     });
 
     if (referencesEarlierResult) return;
 
-    if (declarator.id?.type === "Identifier") {
+    if (isNodeOfType(declarator.id, "Identifier")) {
       declaredNames.add(declarator.id.name);
     }
   }
@@ -54,11 +56,11 @@ export const asyncParallel = defineRule<Rule>({
 
         for (const statement of node.body ?? []) {
           const isAwaitStatement =
-            (statement.type === "VariableDeclaration" &&
+            (isNodeOfType(statement, "VariableDeclaration") &&
               statement.declarations?.length === 1 &&
-              statement.declarations[0].init?.type === "AwaitExpression") ||
-            (statement.type === "ExpressionStatement" &&
-              statement.expression?.type === "AwaitExpression");
+              isNodeOfType(statement.declarations[0].init, "AwaitExpression")) ||
+            (isNodeOfType(statement, "ExpressionStatement") &&
+              isNodeOfType(statement.expression, "AwaitExpression"));
 
           if (isAwaitStatement) {
             consecutiveAwaitStatements.push(statement);

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
@@ -2,17 +2,18 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsBatchDomCss = defineRule<Rule>({
   recommendation:
     "Batch DOM/CSS reads and writes — interleaving them inside a loop causes layout thrashing. Read first, then write",
   create: (context: RuleContext) => {
     const isStyleAssignment = (node: EsTreeNode): boolean =>
-      node.type === "ExpressionStatement" &&
-      node.expression?.type === "AssignmentExpression" &&
-      node.expression.left?.type === "MemberExpression" &&
-      node.expression.left.object?.type === "MemberExpression" &&
-      node.expression.left.object.property?.type === "Identifier" &&
+      isNodeOfType(node, "ExpressionStatement") &&
+      isNodeOfType(node.expression, "AssignmentExpression") &&
+      isNodeOfType(node.expression.left, "MemberExpression") &&
+      isNodeOfType(node.expression.left.object, "MemberExpression") &&
+      isNodeOfType(node.expression.left.object.property, "Identifier") &&
       node.expression.left.object.property.name === "style";
 
     return {

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
@@ -4,14 +4,15 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const buildMemberAccessKey = (node: EsTreeNode): string | null => {
-  if (node.type === "Identifier") return node.name;
-  if (node.type === "ThisExpression") return "this";
-  if (node.type !== "MemberExpression" || node.computed) return null;
+  if (isNodeOfType(node, "Identifier")) return node.name;
+  if (isNodeOfType(node, "ThisExpression")) return "this";
+  if (!isNodeOfType(node, "MemberExpression") || node.computed) return null;
   const objectKey = buildMemberAccessKey(node.object);
   if (!objectKey) return null;
-  if (node.property?.type !== "Identifier") return null;
+  if (!isNodeOfType(node.property, "Identifier")) return null;
   return `${objectKey}.${node.property.name}`;
 };
 
@@ -27,11 +28,11 @@ export const jsCachePropertyAccess = defineRule<Rule>({
     const inspectLoopBody = (loopBody: EsTreeNode): void => {
       const counts = new Map<string, { count: number; firstNode: EsTreeNode }>();
       walkAst(loopBody, (child: EsTreeNode) => {
-        if (child.type !== "MemberExpression") return;
+        if (!isNodeOfType(child, "MemberExpression")) return;
         if (child.computed) return;
         // Skip if this MemberExpression is itself nested inside another (only
         // count the deepest reference per chain).
-        if (child.parent?.type === "MemberExpression" && child.parent.object === child) return;
+        if (isNodeOfType(child.parent, "MemberExpression") && child.parent.object === child) return;
         const key = buildMemberAccessKey(child);
         if (!key) return;
         if (key.split(".").length < 3) return;

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-cache-storage.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-cache-storage.ts
@@ -4,6 +4,7 @@ import { isMemberProperty } from "../../utils/is-member-property.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsCacheStorage = defineRule<Rule>({
   recommendation:
@@ -15,11 +16,11 @@ export const jsCacheStorage = defineRule<Rule>({
       CallExpression(node: EsTreeNode) {
         if (!isMemberProperty(node.callee, "getItem")) return;
         if (
-          node.callee.object?.type !== "Identifier" ||
+          !isNodeOfType(node.callee.object, "Identifier") ||
           !STORAGE_OBJECTS.has(node.callee.object.name)
         )
           return;
-        if (node.arguments?.[0]?.type !== "Literal") return;
+        if (!isNodeOfType(node.arguments?.[0], "Literal")) return;
 
         const storageKey = String(node.arguments[0].value);
         const readCount = (storageReadCounts.get(storageKey) ?? 0) + 1;

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-combine-iterations.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-combine-iterations.ts
@@ -3,13 +3,17 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsCombineIterations = defineRule<Rule>({
   recommendation:
     "Combine `.map().filter()` (or similar chains) into a single pass with `.reduce()` or a `for...of` loop to avoid iterating the array twice",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression" || node.callee.property?.type !== "Identifier")
+      if (
+        !isNodeOfType(node.callee, "MemberExpression") ||
+        !isNodeOfType(node.callee.property, "Identifier")
+      )
         return;
 
       const outerMethod = node.callee.property.name;
@@ -17,9 +21,9 @@ export const jsCombineIterations = defineRule<Rule>({
 
       const innerCall = node.callee.object;
       if (
-        innerCall?.type !== "CallExpression" ||
-        innerCall.callee?.type !== "MemberExpression" ||
-        innerCall.callee.property?.type !== "Identifier"
+        !isNodeOfType(innerCall, "CallExpression") ||
+        !isNodeOfType(innerCall.callee, "MemberExpression") ||
+        !isNodeOfType(innerCall.callee.property, "Identifier")
       )
         return;
 
@@ -29,11 +33,11 @@ export const jsCombineIterations = defineRule<Rule>({
       if (innerMethod === "map" && outerMethod === "filter") {
         const filterArgument = node.arguments?.[0];
         const isBooleanOrIdentityFilter =
-          (filterArgument?.type === "Identifier" && filterArgument.name === "Boolean") ||
-          (filterArgument?.type === "ArrowFunctionExpression" &&
+          (isNodeOfType(filterArgument, "Identifier") && filterArgument.name === "Boolean") ||
+          (isNodeOfType(filterArgument, "ArrowFunctionExpression") &&
             filterArgument.params?.length === 1 &&
-            filterArgument.body?.type === "Identifier" &&
-            filterArgument.params[0]?.type === "Identifier" &&
+            isNodeOfType(filterArgument.body, "Identifier") &&
+            isNodeOfType(filterArgument.params[0], "Identifier") &&
             filterArgument.body.name === filterArgument.params[0].name);
         if (isBooleanOrIdentityFilter) return;
       }

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-early-exit.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-early-exit.ts
@@ -3,19 +3,20 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsEarlyExit = defineRule<Rule>({
   recommendation:
     "Add an early `return` / `continue` to flatten deep nesting and short-circuit when the predicate is already known",
   create: (context: RuleContext) => ({
     IfStatement(node: EsTreeNode) {
-      if (node.consequent?.type !== "BlockStatement" || !node.consequent.body) return;
+      if (!isNodeOfType(node.consequent, "BlockStatement") || !node.consequent.body) return;
 
       let nestingDepth = 0;
-      let currentBlock = node.consequent;
-      while (currentBlock?.type === "BlockStatement" && currentBlock.body?.length === 1) {
+      let currentBlock: EsTreeNode = node.consequent;
+      while (isNodeOfType(currentBlock, "BlockStatement") && currentBlock.body?.length === 1) {
         const innerStatement = currentBlock.body[0];
-        if (innerStatement.type !== "IfStatement") break;
+        if (!isNodeOfType(innerStatement, "IfStatement")) break;
         nestingDepth++;
         currentBlock = innerStatement.consequent;
       }

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
@@ -2,13 +2,17 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsFlatmapFilter = defineRule<Rule>({
   recommendation:
     "Use `.flatMap(item => condition ? [value] : [])` — transforms and filters in a single pass instead of creating an intermediate array",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression" || node.callee.property?.type !== "Identifier")
+      if (
+        !isNodeOfType(node.callee, "MemberExpression") ||
+        !isNodeOfType(node.callee.property, "Identifier")
+      )
         return;
 
       const outerMethod = node.callee.property.name;
@@ -18,23 +22,23 @@ export const jsFlatmapFilter = defineRule<Rule>({
       if (!filterArgument) return;
 
       const isIdentityArrow =
-        filterArgument.type === "ArrowFunctionExpression" &&
+        isNodeOfType(filterArgument, "ArrowFunctionExpression") &&
         filterArgument.params?.length === 1 &&
-        filterArgument.body?.type === "Identifier" &&
-        filterArgument.params[0]?.type === "Identifier" &&
+        isNodeOfType(filterArgument.body, "Identifier") &&
+        isNodeOfType(filterArgument.params[0], "Identifier") &&
         filterArgument.body.name === filterArgument.params[0].name;
 
       const isFilterBoolean =
-        (filterArgument.type === "Identifier" && filterArgument.name === "Boolean") ||
+        (isNodeOfType(filterArgument, "Identifier") && filterArgument.name === "Boolean") ||
         isIdentityArrow;
 
       if (!isFilterBoolean) return;
 
       const innerCall = node.callee.object;
       if (
-        innerCall?.type !== "CallExpression" ||
-        innerCall.callee?.type !== "MemberExpression" ||
-        innerCall.callee.property?.type !== "Identifier"
+        !isNodeOfType(innerCall, "CallExpression") ||
+        !isNodeOfType(innerCall.callee, "MemberExpression") ||
+        !isNodeOfType(innerCall.callee.property, "Identifier")
       )
         return;
 

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: `new Intl.NumberFormat()` / `Intl.DateTimeFormat()` is expensive
 // (dozens of allocations per locale lookup). Allocating it inside a render
@@ -19,13 +20,13 @@ const INTL_CLASSES = new Set([
 ]);
 
 const isIntlNewExpression = (node: EsTreeNode): boolean => {
-  if (node.type !== "NewExpression") return false;
+  if (!isNodeOfType(node, "NewExpression")) return false;
   const callee = node.callee;
   if (
-    callee?.type === "MemberExpression" &&
-    callee.object?.type === "Identifier" &&
+    isNodeOfType(callee, "MemberExpression") &&
+    isNodeOfType(callee.object, "Identifier") &&
     callee.object.name === "Intl" &&
-    callee.property?.type === "Identifier" &&
+    isNodeOfType(callee.property, "Identifier") &&
     INTL_CLASSES.has(callee.property.name)
   ) {
     return true;
@@ -46,9 +47,9 @@ export const jsHoistIntl = defineRule<Rule>({
       let inFunctionBody = false;
       while (cursor) {
         if (
-          cursor.type === "FunctionDeclaration" ||
-          cursor.type === "FunctionExpression" ||
-          cursor.type === "ArrowFunctionExpression"
+          isNodeOfType(cursor, "FunctionDeclaration") ||
+          isNodeOfType(cursor, "FunctionExpression") ||
+          isNodeOfType(cursor, "ArrowFunctionExpression")
         ) {
           inFunctionBody = true;
           break;

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-regexp.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-regexp.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsHoistRegexp = defineRule<Rule>({
   recommendation:
@@ -10,7 +11,7 @@ export const jsHoistRegexp = defineRule<Rule>({
   create: (context: RuleContext) =>
     createLoopAwareVisitors({
       NewExpression(node: EsTreeNode) {
-        if (node.callee?.type === "Identifier" && node.callee.name === "RegExp") {
+        if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "RegExp") {
           context.report({
             node,
             message: "new RegExp() inside a loop — hoist to a module-level constant",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsIndexMaps = defineRule<Rule>({
   recommendation:
@@ -10,7 +11,10 @@ export const jsIndexMaps = defineRule<Rule>({
   create: (context: RuleContext) =>
     createLoopAwareVisitors({
       CallExpression(node: EsTreeNode) {
-        if (node.callee?.type !== "MemberExpression" || node.callee.property?.type !== "Identifier")
+        if (
+          !isNodeOfType(node.callee, "MemberExpression") ||
+          !isNodeOfType(node.callee.property, "Identifier")
+        )
           return;
         const methodName = node.callee.property.name;
         if (methodName === "find" || methodName === "findIndex") {

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
@@ -4,6 +4,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: when comparing two arrays element-by-element via .every / .some /
 // .reduce against another array, a length mismatch is the cheapest possible
@@ -14,12 +15,15 @@ export const jsLengthCheckFirst = defineRule<Rule>({
     "Short-circuit with `a.length === b.length && a.every((x, i) => x === b[i])` — unequal-length arrays exit immediately",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.property?.type !== "Identifier") return;
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (!isNodeOfType(node.callee.property, "Identifier")) return;
       if (node.callee.property.name !== "every") return;
 
       const callback = node.arguments?.[0];
-      if (callback?.type !== "ArrowFunctionExpression" && callback?.type !== "FunctionExpression") {
+      if (
+        !isNodeOfType(callback, "ArrowFunctionExpression") &&
+        !isNodeOfType(callback, "FunctionExpression")
+      ) {
         return;
       }
       const params = callback.params ?? [];
@@ -30,10 +34,10 @@ export const jsLengthCheckFirst = defineRule<Rule>({
       walkAst(callback.body, (child: EsTreeNode) => {
         if (referencesOtherArrayByIndex) return;
         if (
-          child.type === "MemberExpression" &&
+          isNodeOfType(child, "MemberExpression") &&
           child.computed &&
-          child.property?.type === "Identifier" &&
-          params[1]?.type === "Identifier" &&
+          isNodeOfType(child.property, "Identifier") &&
+          isNodeOfType(params[1], "Identifier") &&
           child.property.name === params[1].name
         ) {
           referencesOtherArrayByIndex = true;
@@ -44,13 +48,17 @@ export const jsLengthCheckFirst = defineRule<Rule>({
 
       // Walk up to ensure we're not already inside a length-check guard.
       let guard: EsTreeNode | null = node.parent ?? null;
-      while (guard && guard.type !== "LogicalExpression" && guard.type !== "IfStatement") {
+      while (
+        guard &&
+        !isNodeOfType(guard, "LogicalExpression") &&
+        !isNodeOfType(guard, "IfStatement")
+      ) {
         guard = guard.parent ?? null;
       }
-      if (guard?.type === "LogicalExpression" && guard.operator === "&&") {
+      if (isNodeOfType(guard, "LogicalExpression") && guard.operator === "&&") {
         const left = guard.left;
         if (
-          left?.type === "BinaryExpression" &&
+          isNodeOfType(left, "BinaryExpression") &&
           left.operator === "===" &&
           (isMemberProperty(left.left, "length") || isMemberProperty(left.right, "length"))
         ) {

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-min-max-loop.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-min-max-loop.ts
@@ -3,6 +3,7 @@ import { isMemberProperty } from "../../utils/is-member-property.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsMinMaxLoop = defineRule<Rule>({
   recommendation:
@@ -12,13 +13,14 @@ export const jsMinMaxLoop = defineRule<Rule>({
       if (!node.computed) return;
 
       const object = node.object;
-      if (object?.type !== "CallExpression" || !isMemberProperty(object.callee, "sort")) return;
+      if (!isNodeOfType(object, "CallExpression") || !isMemberProperty(object.callee, "sort"))
+        return;
 
-      const isFirstElement = node.property?.type === "Literal" && node.property.value === 0;
+      const isFirstElement = isNodeOfType(node.property, "Literal") && node.property.value === 0;
       const isLastElement =
-        node.property?.type === "BinaryExpression" &&
+        isNodeOfType(node.property, "BinaryExpression") &&
         node.property.operator === "-" &&
-        node.property.right?.type === "Literal" &&
+        isNodeOfType(node.property.right, "Literal") &&
         node.property.right.value === 1;
 
       if (isFirstElement || isLastElement) {

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: methods that ALWAYS return a string when called on a string
 // receiver. Used to recognize `.toLowerCase().includes(x)` chains as
@@ -131,34 +132,34 @@ const STRING_TYPED_IDENTIFIER_NAMES: ReadonlySet<string> = new Set([
 // is obviously a string, so the Set rewrite suggestion doesn't apply.
 const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolean => {
   if (!receiver) return false;
-  if (receiver.type === "Literal" && typeof receiver.value === "string") return true;
-  if (receiver.type === "TemplateLiteral") return true;
+  if (isNodeOfType(receiver, "Literal") && typeof receiver.value === "string") return true;
+  if (isNodeOfType(receiver, "TemplateLiteral")) return true;
   if (
-    receiver.type === "CallExpression" &&
-    receiver.callee?.type === "Identifier" &&
+    isNodeOfType(receiver, "CallExpression") &&
+    isNodeOfType(receiver.callee, "Identifier") &&
     receiver.callee.name === "String"
   ) {
     return true;
   }
   if (
-    receiver.type === "CallExpression" &&
-    receiver.callee?.type === "MemberExpression" &&
-    receiver.callee.property?.type === "Identifier" &&
+    isNodeOfType(receiver, "CallExpression") &&
+    isNodeOfType(receiver.callee, "MemberExpression") &&
+    isNodeOfType(receiver.callee.property, "Identifier") &&
     STRING_RETURNING_METHODS.has(receiver.callee.property.name)
   ) {
     return true;
   }
-  if (receiver.type === "MemberExpression" && receiver.property?.type === "Identifier") {
+  if (isNodeOfType(receiver, "MemberExpression") && isNodeOfType(receiver.property, "Identifier")) {
     if (STRING_TYPED_PROPERTY_NAMES.has(receiver.property.name)) return true;
   }
   if (
-    receiver.type === "ChainExpression" &&
+    isNodeOfType(receiver, "ChainExpression") &&
     receiver.expression &&
     isLikelyStringReceiver(receiver.expression)
   ) {
     return true;
   }
-  if (receiver.type === "Identifier" && STRING_TYPED_IDENTIFIER_NAMES.has(receiver.name)) {
+  if (isNodeOfType(receiver, "Identifier") && STRING_TYPED_IDENTIFIER_NAMES.has(receiver.name)) {
     return true;
   }
   return false;
@@ -170,7 +171,10 @@ export const jsSetMapLookups = defineRule<Rule>({
   create: (context: RuleContext) =>
     createLoopAwareVisitors({
       CallExpression(node: EsTreeNode) {
-        if (node.callee?.type !== "MemberExpression" || node.callee.property?.type !== "Identifier")
+        if (
+          !isNodeOfType(node.callee, "MemberExpression") ||
+          !isNodeOfType(node.callee.property, "Identifier")
+        )
           return;
         const methodName = node.callee.property.name;
         if (methodName !== "includes" && methodName !== "indexOf") return;

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
@@ -3,6 +3,7 @@ import { isMemberProperty } from "../../utils/is-member-property.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsTosortedImmutable = defineRule<Rule>({
   recommendation:
@@ -13,9 +14,9 @@ export const jsTosortedImmutable = defineRule<Rule>({
 
       const receiver = node.callee.object;
       if (
-        receiver?.type === "ArrayExpression" &&
+        isNodeOfType(receiver, "ArrayExpression") &&
         receiver.elements?.length === 1 &&
-        receiver.elements[0]?.type === "SpreadElement"
+        isNodeOfType(receiver.elements[0], "SpreadElement")
       ) {
         context.report({
           node,

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-image-missing-sizes.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-image-missing-sizes.ts
@@ -3,13 +3,14 @@ import { hasJsxAttribute } from "../../utils/has-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsImageMissingSizes = defineRule<Rule>({
   recommendation:
     'Add sizes for responsive behavior: `sizes="(max-width: 768px) 100vw, 50vw"` matching your layout breakpoints',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "Image") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "Image") return;
       const attributes = node.attributes ?? [];
       if (!hasJsxAttribute(attributes, "fill")) return;
       if (hasJsxAttribute(attributes, "sizes")) return;

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-inline-script-missing-id.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-inline-script-missing-id.ts
@@ -3,13 +3,14 @@ import { hasJsxAttribute } from "../../utils/has-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsInlineScriptMissingId = defineRule<Rule>({
   recommendation:
     'Add `id="descriptive-name"` so Next.js can track, deduplicate, and re-execute the script correctly',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "Script") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "Script") return;
       const attributes = node.attributes ?? [];
 
       if (hasJsxAttribute(attributes, "src")) return;

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsMissingMetadata = defineRule<Rule>({
   recommendation:
@@ -14,16 +15,16 @@ export const nextjsMissingMetadata = defineRule<Rule>({
       if (INTERNAL_PAGE_PATH_PATTERN.test(filename)) return;
 
       const hasMetadataExport = programNode.body?.some((statement: EsTreeNode) => {
-        if (statement.type !== "ExportNamedDeclaration") return false;
+        if (!isNodeOfType(statement, "ExportNamedDeclaration")) return false;
         const declaration = statement.declaration;
-        if (declaration?.type === "VariableDeclaration") {
+        if (isNodeOfType(declaration, "VariableDeclaration")) {
           return declaration.declarations?.some(
             (declarator: EsTreeNode) =>
-              declarator.id?.type === "Identifier" &&
+              isNodeOfType(declarator.id, "Identifier") &&
               (declarator.id.name === "metadata" || declarator.id.name === "generateMetadata"),
           );
         }
-        if (declaration?.type === "FunctionDeclaration") {
+        if (isNodeOfType(declaration, "FunctionDeclaration")) {
           return declaration.id?.name === "generateMetadata";
         }
         return false;

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
@@ -3,23 +3,24 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoAElement = defineRule<Rule>({
   recommendation:
     "`import Link from 'next/link'` — enables client-side navigation, prefetching, and preserves scroll position",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "a") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a") return;
 
       const hrefAttribute = findJsxAttribute(node.attributes ?? [], "href");
       if (!hrefAttribute?.value) return;
 
       let hrefValue = null;
-      if (hrefAttribute.value.type === "Literal") {
+      if (isNodeOfType(hrefAttribute.value, "Literal")) {
         hrefValue = hrefAttribute.value.value;
       } else if (
-        hrefAttribute.value.type === "JSXExpressionContainer" &&
-        hrefAttribute.value.expression?.type === "Literal"
+        isNodeOfType(hrefAttribute.value, "JSXExpressionContainer") &&
+        isNodeOfType(hrefAttribute.value.expression, "Literal")
       ) {
         hrefValue = hrefAttribute.value.expression.value;
       }

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
@@ -6,6 +6,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const describeClientSideNavigation = (
   node: EsTreeNode,
@@ -15,18 +16,23 @@ const describeClientSideNavigation = (
     ? "handle navigation in an event handler, getServerSideProps redirect, or middleware"
     : "use redirect() from next/navigation or handle navigation in an event handler";
 
-  if (node.type === "CallExpression" && node.callee?.type === "MemberExpression") {
-    const objectName = node.callee.object?.type === "Identifier" ? node.callee.object.name : null;
-    const methodName =
-      node.callee.property?.type === "Identifier" ? node.callee.property.name : null;
+  if (isNodeOfType(node, "CallExpression") && isNodeOfType(node.callee, "MemberExpression")) {
+    const objectName = isNodeOfType(node.callee.object, "Identifier")
+      ? node.callee.object.name
+      : null;
+    const methodName = isNodeOfType(node.callee.property, "Identifier")
+      ? node.callee.property.name
+      : null;
     if (objectName === "router" && (methodName === "push" || methodName === "replace")) {
       return `router.${methodName}() in useEffect — ${redirectGuidance}`;
     }
   }
 
-  if (node.type === "AssignmentExpression" && node.left?.type === "MemberExpression") {
-    const objectName = node.left.object?.type === "Identifier" ? node.left.object.name : null;
-    const propertyName = node.left.property?.type === "Identifier" ? node.left.property.name : null;
+  if (isNodeOfType(node, "AssignmentExpression") && isNodeOfType(node.left, "MemberExpression")) {
+    const objectName = isNodeOfType(node.left.object, "Identifier") ? node.left.object.name : null;
+    const propertyName = isNodeOfType(node.left.property, "Identifier")
+      ? node.left.property.name
+      : null;
     if (objectName === "window" && propertyName === "location") {
       return `window.location assignment in useEffect — ${redirectGuidance}`;
     }

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
@@ -4,23 +4,28 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoCssLink = defineRule<Rule>({
   recommendation:
     "Import CSS directly: `import './styles.css'` or use CSS Modules: `import styles from './Button.module.css'`",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "link") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "link") return;
       const attributes = node.attributes ?? [];
 
       const relAttribute = findJsxAttribute(attributes, "rel");
       if (!relAttribute?.value) return;
-      const relValue = relAttribute.value.type === "Literal" ? relAttribute.value.value : null;
+      const relValue = isNodeOfType(relAttribute.value, "Literal")
+        ? relAttribute.value.value
+        : null;
       if (relValue !== "stylesheet") return;
 
       const hrefAttribute = findJsxAttribute(attributes, "href");
       if (!hrefAttribute?.value) return;
-      const hrefValue = hrefAttribute.value.type === "Literal" ? hrefAttribute.value.value : null;
+      const hrefValue = isNodeOfType(hrefAttribute.value, "Literal")
+        ? hrefAttribute.value.value
+        : null;
       if (typeof hrefValue === "string" && GOOGLE_FONTS_PATTERN.test(hrefValue)) return;
 
       context.report({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
@@ -4,19 +4,22 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoFontLink = defineRule<Rule>({
   recommendation:
     '`import { Inter } from "next/font/google"` — self-hosted, zero layout shift, no render-blocking requests',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "link") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "link") return;
       const attributes = node.attributes ?? [];
 
       const hrefAttribute = findJsxAttribute(attributes, "href");
       if (!hrefAttribute?.value) return;
 
-      const hrefValue = hrefAttribute.value.type === "Literal" ? hrefAttribute.value.value : null;
+      const hrefValue = isNodeOfType(hrefAttribute.value, "Literal")
+        ? hrefAttribute.value.value
+        : null;
 
       if (typeof hrefValue === "string" && GOOGLE_FONTS_PATTERN.test(hrefValue)) {
         context.report({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoImgElement = defineRule<Rule>({
   recommendation:
@@ -14,7 +15,7 @@ export const nextjsNoImgElement = defineRule<Rule>({
     return {
       JSXOpeningElement(node: EsTreeNode) {
         if (isOgRoute) return;
-        if (node.name?.type === "JSXIdentifier" && node.name.name === "img") {
+        if (isNodeOfType(node.name, "JSXIdentifier") && node.name.name === "img") {
           context.report({
             node,
             message:

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-native-script.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-native-script.ts
@@ -4,16 +4,19 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoNativeScript = defineRule<Rule>({
   recommendation:
     '`import Script from "next/script"` — use `strategy="afterInteractive"` for analytics or `"lazyOnload"` for widgets',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "script") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "script") return;
 
       const typeAttribute = findJsxAttribute(node.attributes ?? [], "type");
-      const typeValue = typeAttribute?.value?.type === "Literal" ? typeAttribute.value.value : null;
+      const typeValue = isNodeOfType(typeAttribute?.value, "Literal")
+        ? typeAttribute.value.value
+        : null;
       if (typeof typeValue === "string" && !EXECUTABLE_SCRIPT_TYPES.has(typeValue)) return;
 
       context.report({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
@@ -4,19 +4,22 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoPolyfillScript = defineRule<Rule>({
   recommendation:
     "Next.js includes polyfills for fetch, Promise, Object.assign, Array.from, and 50+ others automatically",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "script" && node.name.name !== "Script") return;
 
       const srcAttribute = findJsxAttribute(node.attributes ?? [], "src");
       if (!srcAttribute?.value) return;
 
-      const srcValue = srcAttribute.value.type === "Literal" ? srcAttribute.value.value : null;
+      const srcValue = isNodeOfType(srcAttribute.value, "Literal")
+        ? srcAttribute.value.value
+        : null;
 
       if (typeof srcValue === "string" && POLYFILL_SCRIPT_PATTERN.test(srcValue)) {
         context.report({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-redirect-in-try-catch.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-redirect-in-try-catch.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoRedirectInTryCatch = defineRule<Rule>({
   recommendation:
@@ -19,7 +20,7 @@ export const nextjsNoRedirectInTryCatch = defineRule<Rule>({
       },
       CallExpression(node: EsTreeNode) {
         if (tryCatchDepth === 0) return;
-        if (node.callee?.type !== "Identifier") return;
+        if (!isNodeOfType(node.callee, "Identifier")) return;
         if (!NEXTJS_NAVIGATION_FUNCTIONS.has(node.callee.name)) return;
 
         context.report({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
@@ -4,6 +4,7 @@ import { findSideEffect } from "../../utils/find-side-effect.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const extractMutatingRouteSegment = (filename: string): string | null => {
   const segments = filename.split("/");
@@ -15,22 +16,22 @@ const extractMutatingRouteSegment = (filename: string): string | null => {
 };
 
 const getExportedGetHandlerBody = (node: EsTreeNode): EsTreeNode | null => {
-  if (node.type !== "ExportNamedDeclaration") return null;
+  if (!isNodeOfType(node, "ExportNamedDeclaration")) return null;
   const declaration = node.declaration;
   if (!declaration) return null;
 
-  if (declaration.type === "FunctionDeclaration" && declaration.id?.name === "GET") {
+  if (isNodeOfType(declaration, "FunctionDeclaration") && declaration.id?.name === "GET") {
     return declaration.body;
   }
 
-  if (declaration.type === "VariableDeclaration") {
+  if (isNodeOfType(declaration, "VariableDeclaration")) {
     for (const declarator of declaration.declarations ?? []) {
       if (
-        declarator?.id?.type === "Identifier" &&
+        isNodeOfType(declarator?.id, "Identifier") &&
         declarator.id.name === "GET" &&
         declarator.init &&
-        (declarator.init.type === "ArrowFunctionExpression" ||
-          declarator.init.type === "FunctionExpression")
+        (isNodeOfType(declarator.init, "ArrowFunctionExpression") ||
+          isNodeOfType(declarator.init, "FunctionExpression"))
       ) {
         return declarator.init.body;
       }

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-use-search-params-without-suspense.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-use-search-params-without-suspense.ts
@@ -4,6 +4,8 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 
 // HACK: file-level proxy for "is the developer aware of the Suspense
 // requirement?". Cross-file ancestor analysis would catch every case
@@ -23,17 +25,17 @@ const fileMentionsSuspense = (programNode: EsTreeNode): boolean => {
   walkAst(programNode, (child: EsTreeNode) => {
     if (didSee) return false;
     if (
-      child.type === "JSXOpeningElement" &&
-      child.name?.type === "JSXIdentifier" &&
+      isNodeOfType(child, "JSXOpeningElement") &&
+      isNodeOfType(child.name, "JSXIdentifier") &&
       child.name.name === "Suspense"
     ) {
       didSee = true;
       return false;
     }
-    if (child.type === "ImportDeclaration" && child.source?.value === "react") {
+    if (isNodeOfType(child, "ImportDeclaration") && child.source?.value === "react") {
       const importsSuspense = (child.specifiers ?? []).some(
         (specifier: EsTreeNode) =>
-          specifier.type === "ImportSpecifier" && specifier.imported?.name === "Suspense",
+          isNodeOfType(specifier, "ImportSpecifier") && getImportedName(specifier) === "Suspense",
       );
       if (importsSuspense) {
         didSee = true;

--- a/packages/react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -3,22 +3,23 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const collectIdentifierNames = (node: EsTreeNode | null | undefined, into: Set<string>): void => {
   if (!node) return;
   walkAst(node, (child: EsTreeNode) => {
-    if (child.type === "Identifier") into.add(child.name);
+    if (isNodeOfType(child, "Identifier")) into.add(child.name);
   });
 };
 
 const isEarlyReturnIfStatement = (statement: EsTreeNode): boolean => {
-  if (statement.type !== "IfStatement") return false;
+  if (!isNodeOfType(statement, "IfStatement")) return false;
   const consequent = statement.consequent;
   if (!consequent) return false;
-  if (consequent.type === "ReturnStatement") return true;
-  if (consequent.type !== "BlockStatement") return false;
+  if (isNodeOfType(consequent, "ReturnStatement")) return true;
+  if (!isNodeOfType(consequent, "BlockStatement")) return false;
   for (const inner of consequent.body ?? []) {
-    if (inner.type === "ReturnStatement") return true;
+    if (isNodeOfType(inner, "ReturnStatement")) return true;
   }
   return false;
 };
@@ -41,18 +42,21 @@ export const asyncDeferAwait = defineRule<Rule>({
     const inspectStatements = (statements: EsTreeNode[]): void => {
       for (let statementIndex = 0; statementIndex < statements.length - 1; statementIndex++) {
         const currentStatement = statements[statementIndex];
-        if (currentStatement.type !== "VariableDeclaration") continue;
+        if (!isNodeOfType(currentStatement, "VariableDeclaration")) continue;
 
         const awaitedBindingNames = new Set<string>();
         let didAwait = false;
         for (const declarator of currentStatement.declarations ?? []) {
-          if (declarator.init?.type === "AwaitExpression") {
+          if (isNodeOfType(declarator.init, "AwaitExpression")) {
             didAwait = true;
-            if (declarator.id?.type === "Identifier") {
+            if (isNodeOfType(declarator.id, "Identifier")) {
               awaitedBindingNames.add(declarator.id.name);
-            } else if (declarator.id?.type === "ObjectPattern") {
+            } else if (isNodeOfType(declarator.id, "ObjectPattern")) {
               for (const property of declarator.id.properties ?? []) {
-                if (property.type === "Property" && property.value?.type === "Identifier") {
+                if (
+                  isNodeOfType(property, "Property") &&
+                  isNodeOfType(property.value, "Identifier")
+                ) {
                   awaitedBindingNames.add(property.value.name);
                 }
               }
@@ -88,7 +92,7 @@ export const asyncDeferAwait = defineRule<Rule>({
 
     const enterFunction = (node: EsTreeNode): void => {
       if (!node.async) return;
-      if (node.body?.type !== "BlockStatement") return;
+      if (!isNodeOfType(node.body, "BlockStatement")) return;
       inspectStatements(node.body.body ?? []);
     };
 

--- a/packages/react-doctor/src/plugin/rules/performance/no-global-css-variable-animation.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-global-css-variable-animation.ts
@@ -5,13 +5,14 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noGlobalCssVariableAnimation = defineRule<Rule>({
   recommendation:
     "Set the variable on the nearest element instead of a parent, or use `@property` with `inherits: false` to prevent cascade. Better yet, use targeted `element.style.transform` updates",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "Identifier") return;
+      if (!isNodeOfType(node.callee, "Identifier")) return;
       if (!ANIMATION_CALLBACK_NAMES.has(node.callee.name)) return;
 
       const callback = node.arguments?.[0];
@@ -19,9 +20,9 @@ export const noGlobalCssVariableAnimation = defineRule<Rule>({
 
       const calleeName = node.callee.name;
       walkAst(callback, (child: EsTreeNode) => {
-        if (child.type !== "CallExpression") return;
+        if (!isNodeOfType(child, "CallExpression")) return;
         if (!isMemberProperty(child.callee, "setProperty")) return;
-        if (child.arguments?.[0]?.type !== "Literal") return;
+        if (!isNodeOfType(child.arguments?.[0], "Literal")) return;
 
         const variableName = child.arguments[0].value;
         if (typeof variableName !== "string" || !variableName.startsWith("--")) return;

--- a/packages/react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
@@ -2,15 +2,16 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const isMemoCall = (node: EsTreeNode): boolean => {
-  if (node.type !== "CallExpression") return false;
-  if (node.callee?.type === "Identifier" && node.callee.name === "memo") return true;
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "memo") return true;
   if (
-    node.callee?.type === "MemberExpression" &&
-    node.callee.object?.type === "Identifier" &&
+    isNodeOfType(node.callee, "MemberExpression") &&
+    isNodeOfType(node.callee.object, "Identifier") &&
     node.callee.object.name === "React" &&
-    node.callee.property?.type === "Identifier" &&
+    isNodeOfType(node.callee.property, "Identifier") &&
     node.callee.property.name === "memo"
   )
     return true;
@@ -19,17 +20,18 @@ const isMemoCall = (node: EsTreeNode): boolean => {
 
 const isInlineReference = (node: EsTreeNode): string | null => {
   if (
-    node.type === "ArrowFunctionExpression" ||
-    node.type === "FunctionExpression" ||
-    (node.type === "CallExpression" &&
-      node.callee?.type === "MemberExpression" &&
-      node.callee.property?.name === "bind")
+    isNodeOfType(node, "ArrowFunctionExpression") ||
+    isNodeOfType(node, "FunctionExpression") ||
+    (isNodeOfType(node, "CallExpression") &&
+      isNodeOfType(node.callee, "MemberExpression") &&
+      isNodeOfType(node.callee.property, "Identifier") &&
+      node.callee.property.name === "bind")
   )
     return "functions";
 
-  if (node.type === "ObjectExpression") return "objects";
-  if (node.type === "ArrayExpression") return "Arrays";
-  if (node.type === "JSXElement" || node.type === "JSXFragment") return "JSX";
+  if (isNodeOfType(node, "ObjectExpression")) return "objects";
+  if (isNodeOfType(node, "ArrayExpression")) return "Arrays";
+  if (isNodeOfType(node, "JSXElement") || isNodeOfType(node, "JSXFragment")) return "JSX";
 
   return null;
 };
@@ -42,7 +44,7 @@ export const noInlinePropOnMemoComponent = defineRule<Rule>({
 
     return {
       VariableDeclarator(node: EsTreeNode) {
-        if (node.id?.type !== "Identifier" || !node.init) return;
+        if (!isNodeOfType(node.id, "Identifier") || !node.init) return;
         if (isMemoCall(node.init)) {
           memoizedComponentNames.add(node.id.name);
         }
@@ -50,19 +52,19 @@ export const noInlinePropOnMemoComponent = defineRule<Rule>({
       ExportDefaultDeclaration(node: EsTreeNode) {
         if (node.declaration && isMemoCall(node.declaration)) {
           const innerArgument = node.declaration.arguments?.[0];
-          if (innerArgument?.type === "Identifier") {
+          if (isNodeOfType(innerArgument, "Identifier")) {
             memoizedComponentNames.add(innerArgument.name);
           }
         }
       },
       JSXAttribute(node: EsTreeNode) {
-        if (!node.value || node.value.type !== "JSXExpressionContainer") return;
+        if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
         const openingElement = node.parent;
-        if (!openingElement || openingElement.type !== "JSXOpeningElement") return;
+        if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return;
 
         let elementName: string | null = null;
-        if (openingElement.name?.type === "JSXIdentifier") {
+        if (isNodeOfType(openingElement.name, "JSXIdentifier")) {
           elementName = openingElement.name.name;
         }
         if (!elementName || !memoizedComponentNames.has(elementName)) return;

--- a/packages/react-doctor/src/plugin/rules/performance/no-large-animated-blur.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-large-animated-blur.ts
@@ -7,25 +7,26 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noLargeAnimatedBlur = defineRule<Rule>({
   recommendation:
     "Keep blur radius under 10px, or apply blur to a smaller element. Large blurs multiply GPU memory usage with layer size",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "style" && !MOTION_ANIMATE_PROPS.has(node.name.name)) return;
-      if (node.value?.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const expression = node.value.expression;
-      if (expression?.type !== "ObjectExpression") return;
+      if (!isNodeOfType(expression, "ObjectExpression")) return;
 
       for (const property of expression.properties ?? []) {
-        if (property.type !== "Property") continue;
-        const key = property.key?.type === "Identifier" ? property.key.name : null;
+        if (!isNodeOfType(property, "Property")) continue;
+        const key = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
         if (key !== "filter" && key !== "backdropFilter" && key !== "WebkitBackdropFilter")
           continue;
-        if (property.value?.type !== "Literal" || typeof property.value.value !== "string")
+        if (!isNodeOfType(property.value, "Literal") || typeof property.value.value !== "string")
           continue;
 
         const match = BLUR_VALUE_PATTERN.exec(property.value.value);

--- a/packages/react-doctor/src/plugin/rules/performance/no-layout-property-animation.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-layout-property-animation.ts
@@ -3,20 +3,22 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const isMotionElement = (attributeNode: EsTreeNode): boolean => {
   const openingElement = attributeNode.parent;
-  if (!openingElement || openingElement.type !== "JSXOpeningElement") return false;
+  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
 
   const elementName = openingElement.name;
   if (
-    elementName?.type === "JSXMemberExpression" &&
-    elementName.object?.type === "JSXIdentifier" &&
+    isNodeOfType(elementName, "JSXMemberExpression") &&
+    isNodeOfType(elementName.object, "JSXIdentifier") &&
     (elementName.object.name === "motion" || elementName.object.name === "m")
   )
     return true;
 
-  if (elementName?.type === "JSXIdentifier" && elementName.name.startsWith("Motion")) return true;
+  if (isNodeOfType(elementName, "JSXIdentifier") && elementName.name.startsWith("Motion"))
+    return true;
 
   return false;
 };
@@ -26,19 +28,23 @@ export const noLayoutPropertyAnimation = defineRule<Rule>({
     "Use `transform: translateX()` or `scale()` instead — they run on the compositor and skip layout/paint",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || !MOTION_ANIMATE_PROPS.has(node.name.name)) return;
-      if (!node.value || node.value.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || !MOTION_ANIMATE_PROPS.has(node.name.name))
+        return;
+      if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
       if (isMotionElement(node)) return;
 
       const expression = node.value.expression;
-      if (expression?.type !== "ObjectExpression") return;
+      if (!isNodeOfType(expression, "ObjectExpression")) return;
 
       for (const property of expression.properties ?? []) {
-        if (property.type !== "Property") continue;
+        if (!isNodeOfType(property, "Property")) continue;
         let propertyName = null;
-        if (property.key?.type === "Identifier") {
+        if (isNodeOfType(property.key, "Identifier")) {
           propertyName = property.key.name;
-        } else if (property.key?.type === "Literal") {
+        } else if (
+          isNodeOfType(property.key, "Literal") &&
+          typeof property.key.value === "string"
+        ) {
           propertyName = property.key.value;
         }
 

--- a/packages/react-doctor/src/plugin/rules/performance/no-permanent-will-change.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-permanent-will-change.ts
@@ -2,21 +2,22 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noPermanentWillChange = defineRule<Rule>({
   recommendation:
     "Add will-change on animation start (`onMouseEnter`) and remove on end (`onAnimationEnd`). Permanent promotion wastes GPU memory and can degrade performance",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "style") return;
-      if (node.value?.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const expression = node.value.expression;
-      if (expression?.type !== "ObjectExpression") return;
+      if (!isNodeOfType(expression, "ObjectExpression")) return;
 
       for (const property of expression.properties ?? []) {
-        if (property.type !== "Property") continue;
-        const key = property.key?.type === "Identifier" ? property.key.name : null;
+        if (!isNodeOfType(property, "Property")) continue;
+        const key = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
         if (key !== "willChange") continue;
 
         context.report({

--- a/packages/react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
@@ -2,25 +2,26 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noScaleFromZero = defineRule<Rule>({
   recommendation:
     "Use `initial={{ scale: 0.95, opacity: 0 }}` — elements should deflate like a balloon, not vanish into a point",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "initial" && node.name.name !== "exit") return;
-      if (node.value?.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const expression = node.value.expression;
-      if (expression?.type !== "ObjectExpression") return;
+      if (!isNodeOfType(expression, "ObjectExpression")) return;
 
       for (const property of expression.properties ?? []) {
-        if (property.type !== "Property") continue;
-        const key = property.key?.type === "Identifier" ? property.key.name : null;
+        if (!isNodeOfType(property, "Property")) continue;
+        const key = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
         if (key !== "scale") continue;
 
-        if (property.value?.type === "Literal" && property.value.value === 0) {
+        if (isNodeOfType(property.value, "Literal") && property.value.value === 0) {
           context.report({
             node: property,
             message:

--- a/packages/react-doctor/src/plugin/rules/performance/no-transition-all.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-transition-all.ts
@@ -2,25 +2,26 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noTransitionAll = defineRule<Rule>({
   recommendation:
     'List specific properties: `transition: "opacity 200ms, transform 200ms"` — or in Tailwind use `transition-colors`, `transition-opacity`, or `transition-transform`',
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "style") return;
-      if (node.value?.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const expression = node.value.expression;
-      if (expression?.type !== "ObjectExpression") return;
+      if (!isNodeOfType(expression, "ObjectExpression")) return;
 
       for (const property of expression.properties ?? []) {
-        if (property.type !== "Property") continue;
-        const key = property.key?.type === "Identifier" ? property.key.name : null;
+        if (!isNodeOfType(property, "Property")) continue;
+        const key = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
         if (key !== "transition") continue;
 
         if (
-          property.value?.type === "Literal" &&
+          isNodeOfType(property.value, "Literal") &&
           typeof property.value.value === "string" &&
           property.value.value.startsWith("all")
         ) {

--- a/packages/react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
@@ -4,6 +4,7 @@ import { isSimpleExpression } from "../../utils/is-simple-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // Identifiers and member-access chains are technically "simple", but memoizing
 // them is sometimes intentional (stable reference passing). Only flag arithmetic
@@ -11,8 +12,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 const isTriviallyCheapExpression = (node: EsTreeNode | null): boolean => {
   if (!node) return false;
   if (!isSimpleExpression(node)) return false;
-  if (node.type === "Identifier") return false;
-  if (node.type === "MemberExpression") return false;
+  if (isNodeOfType(node, "Identifier")) return false;
+  if (isNodeOfType(node, "MemberExpression")) return false;
   return true;
 };
 
@@ -25,15 +26,18 @@ export const noUsememoSimpleExpression = defineRule<Rule>({
 
       const callback = node.arguments?.[0];
       if (!callback) return;
-      if (callback.type !== "ArrowFunctionExpression" && callback.type !== "FunctionExpression")
+      if (
+        !isNodeOfType(callback, "ArrowFunctionExpression") &&
+        !isNodeOfType(callback, "FunctionExpression")
+      )
         return;
 
       let returnExpression = null;
-      if (callback.body?.type !== "BlockStatement") {
+      if (!isNodeOfType(callback.body, "BlockStatement")) {
         returnExpression = callback.body;
       } else if (
         callback.body.body?.length === 1 &&
-        callback.body.body[0].type === "ReturnStatement"
+        isNodeOfType(callback.body.body[0], "ReturnStatement")
       ) {
         returnExpression = callback.body.body[0].argument;
       }

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
@@ -3,17 +3,18 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingAnimateSvgWrapper = defineRule<Rule>({
   recommendation: "Wrap the SVG: `<motion.div animate={...}><svg>...</svg></motion.div>`",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "svg") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "svg") return;
 
       const hasAnimationProp = node.attributes?.some(
         (attribute: EsTreeNode) =>
-          attribute.type === "JSXAttribute" &&
-          attribute.name?.type === "JSXIdentifier" &&
+          isNodeOfType(attribute, "JSXAttribute") &&
+          isNodeOfType(attribute.name, "JSXIdentifier") &&
           MOTION_ANIMATE_PROPS.has(attribute.name.name),
       );
 

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hoist-jsx.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hoist-jsx.ts
@@ -5,6 +5,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: detect static JSX declared inside a component body — anything like
 // `const Header = <h1>Hi</h1>` inside a render function gets recreated on
@@ -15,12 +16,12 @@ const jsxReferencesLocalScope = (jsxNode: EsTreeNode): boolean => {
   walkAst(jsxNode, (child: EsTreeNode) => {
     if (referencesScope) return;
     if (
-      child.type === "JSXExpressionContainer" &&
-      child.expression?.type !== "JSXEmptyExpression"
+      isNodeOfType(child, "JSXExpressionContainer") &&
+      !isNodeOfType(child.expression, "JSXEmptyExpression")
     ) {
       referencesScope = true;
     }
-    if (child.type === "JSXSpreadAttribute") {
+    if (isNodeOfType(child, "JSXSpreadAttribute")) {
       referencesScope = true;
     }
   });
@@ -34,10 +35,14 @@ export const renderingHoistJsx = defineRule<Rule>({
     let componentDepth = 0;
 
     const isComponentLike = (node: EsTreeNode): boolean => {
-      if (node.type === "FunctionDeclaration" && node.id?.name && isUppercaseName(node.id.name)) {
+      if (
+        isNodeOfType(node, "FunctionDeclaration") &&
+        node.id?.name &&
+        isUppercaseName(node.id.name)
+      ) {
         return true;
       }
-      if (node.type === "VariableDeclarator" && isComponentAssignment(node)) {
+      if (isNodeOfType(node, "VariableDeclarator") && isComponentAssignment(node)) {
         return true;
       }
       return false;
@@ -61,9 +66,9 @@ export const renderingHoistJsx = defineRule<Rule>({
         for (const declarator of node.declarations ?? []) {
           const init = declarator.init;
           if (!init) continue;
-          if (init.type !== "JSXElement" && init.type !== "JSXFragment") continue;
+          if (!isNodeOfType(init, "JSXElement") && !isNodeOfType(init, "JSXFragment")) continue;
           if (jsxReferencesLocalScope(init)) continue;
-          const name = declarator.id?.type === "Identifier" ? declarator.id.name : "<unnamed>";
+          const name = isNodeOfType(declarator.id, "Identifier") ? declarator.id.name : "<unnamed>";
           context.report({
             node: declarator,
             message: `Static JSX "${name}" inside a component — hoist to module scope so it isn't recreated each render`,

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-mismatch-time.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-mismatch-time.ts
@@ -3,6 +3,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const NONDETERMINISTIC_RENDER_PATTERNS: Array<{
   matches: (node: EsTreeNode) => boolean;
@@ -11,48 +12,48 @@ const NONDETERMINISTIC_RENDER_PATTERNS: Array<{
   {
     display: "new Date()",
     matches: (node) =>
-      node.type === "NewExpression" &&
-      node.callee?.type === "Identifier" &&
+      isNodeOfType(node, "NewExpression") &&
+      isNodeOfType(node.callee, "Identifier") &&
       node.callee.name === "Date",
   },
   {
     display: "Date.now()",
     matches: (node) =>
-      node.type === "CallExpression" &&
-      node.callee?.type === "MemberExpression" &&
-      node.callee.object?.type === "Identifier" &&
+      isNodeOfType(node, "CallExpression") &&
+      isNodeOfType(node.callee, "MemberExpression") &&
+      isNodeOfType(node.callee.object, "Identifier") &&
       node.callee.object.name === "Date" &&
-      node.callee.property?.type === "Identifier" &&
+      isNodeOfType(node.callee.property, "Identifier") &&
       node.callee.property.name === "now",
   },
   {
     display: "Math.random()",
     matches: (node) =>
-      node.type === "CallExpression" &&
-      node.callee?.type === "MemberExpression" &&
-      node.callee.object?.type === "Identifier" &&
+      isNodeOfType(node, "CallExpression") &&
+      isNodeOfType(node.callee, "MemberExpression") &&
+      isNodeOfType(node.callee.object, "Identifier") &&
       node.callee.object.name === "Math" &&
-      node.callee.property?.type === "Identifier" &&
+      isNodeOfType(node.callee.property, "Identifier") &&
       node.callee.property.name === "random",
   },
   {
     display: "performance.now()",
     matches: (node) =>
-      node.type === "CallExpression" &&
-      node.callee?.type === "MemberExpression" &&
-      node.callee.object?.type === "Identifier" &&
+      isNodeOfType(node, "CallExpression") &&
+      isNodeOfType(node.callee, "MemberExpression") &&
+      isNodeOfType(node.callee.object, "Identifier") &&
       node.callee.object.name === "performance" &&
-      node.callee.property?.type === "Identifier" &&
+      isNodeOfType(node.callee.property, "Identifier") &&
       node.callee.property.name === "now",
   },
   {
     display: "crypto.randomUUID()",
     matches: (node) =>
-      node.type === "CallExpression" &&
-      node.callee?.type === "MemberExpression" &&
-      node.callee.object?.type === "Identifier" &&
+      isNodeOfType(node, "CallExpression") &&
+      isNodeOfType(node.callee, "MemberExpression") &&
+      isNodeOfType(node.callee.object, "Identifier") &&
       node.callee.object.name === "crypto" &&
-      node.callee.property?.type === "Identifier" &&
+      isNodeOfType(node.callee.property, "Identifier") &&
       node.callee.property.name === "randomUUID",
   },
 ];
@@ -60,8 +61,8 @@ const NONDETERMINISTIC_RENDER_PATTERNS: Array<{
 const findOpeningElementOfChild = (jsxNode: EsTreeNode): EsTreeNode | null => {
   let cursor: EsTreeNode | null = jsxNode.parent ?? null;
   while (cursor) {
-    if (cursor.type === "JSXElement") return cursor.openingElement;
-    if (cursor.type === "JSXFragment") return null;
+    if (isNodeOfType(cursor, "JSXElement")) return cursor.openingElement;
+    if (isNodeOfType(cursor, "JSXFragment")) return null;
     cursor = cursor.parent ?? null;
   }
   return null;
@@ -71,8 +72,8 @@ const hasSuppressHydrationWarningAttribute = (openingElement: EsTreeNode | null)
   if (!openingElement) return false;
   for (const attr of openingElement.attributes ?? []) {
     if (
-      attr.type === "JSXAttribute" &&
-      attr.name?.type === "JSXIdentifier" &&
+      isNodeOfType(attr, "JSXAttribute") &&
+      isNodeOfType(attr.name, "JSXIdentifier") &&
       attr.name.name === "suppressHydrationWarning"
     ) {
       return true;

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.ts
@@ -6,6 +6,7 @@ import { isSetterCall } from "../../utils/is-setter-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingHydrationNoFlicker = defineRule<Rule>({
   recommendation:
@@ -15,17 +16,21 @@ export const renderingHydrationNoFlicker = defineRule<Rule>({
       if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
 
       const depsNode = node.arguments[1];
-      if (depsNode.type !== "ArrayExpression" || depsNode.elements?.length !== 0) return;
+      if (!isNodeOfType(depsNode, "ArrayExpression") || depsNode.elements?.length !== 0) return;
 
       const callback = getEffectCallback(node);
       if (!callback) return;
 
-      const bodyStatements =
-        callback.body?.type === "BlockStatement" ? callback.body.body : [callback.body];
+      const bodyStatements = isNodeOfType(callback.body, "BlockStatement")
+        ? callback.body.body
+        : [callback.body];
       if (!bodyStatements || bodyStatements.length !== 1) return;
 
       const soleStatement = bodyStatements[0];
-      if (soleStatement?.type === "ExpressionStatement" && isSetterCall(soleStatement.expression)) {
+      if (
+        isNodeOfType(soleStatement, "ExpressionStatement") &&
+        isSetterCall(soleStatement.expression)
+      ) {
         context.report({
           node,
           message:

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-script-defer-async.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-script-defer-async.ts
@@ -3,19 +3,20 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingScriptDeferAsync = defineRule<Rule>({
   recommendation:
     'Add `defer` for DOM-dependent scripts or `async` for independent ones (analytics). In Next.js, use `<Script strategy="afterInteractive" />` instead',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "script") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "script") return;
 
       const attributes = node.attributes ?? [];
       const hasSrc = attributes.some(
         (attr: EsTreeNode) =>
-          attr.type === "JSXAttribute" &&
-          attr.name?.type === "JSXIdentifier" &&
+          isNodeOfType(attr, "JSXAttribute") &&
+          isNodeOfType(attr.name, "JSXIdentifier") &&
           attr.name.name === "src",
       );
 
@@ -23,18 +24,20 @@ export const renderingScriptDeferAsync = defineRule<Rule>({
 
       const typeAttribute = attributes.find(
         (attr: EsTreeNode) =>
-          attr.type === "JSXAttribute" &&
-          attr.name?.type === "JSXIdentifier" &&
+          isNodeOfType(attr, "JSXAttribute") &&
+          isNodeOfType(attr.name, "JSXIdentifier") &&
           attr.name.name === "type",
       );
-      const typeValue = typeAttribute?.value?.type === "Literal" ? typeAttribute.value.value : null;
+      const typeValue = isNodeOfType(typeAttribute?.value, "Literal")
+        ? typeAttribute.value.value
+        : null;
       if (typeof typeValue === "string" && !EXECUTABLE_SCRIPT_TYPES.has(typeValue)) return;
       if (typeValue === "module") return;
 
       const hasLoadingStrategy = attributes.some(
         (attr: EsTreeNode) =>
-          attr.type === "JSXAttribute" &&
-          attr.name?.type === "JSXIdentifier" &&
+          isNodeOfType(attr, "JSXAttribute") &&
+          isNodeOfType(attr.name, "JSXIdentifier") &&
           SCRIPT_LOADING_ATTRIBUTES.has(attr.name.name),
       );
 

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
@@ -4,20 +4,23 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingUsetransitionLoading = defineRule<Rule>({
   recommendation:
     "Replace with `const [isPending, startTransition] = useTransition()` — avoids a re-render for the loading state",
   create: (context: RuleContext) => ({
     VariableDeclarator(node: EsTreeNode) {
-      if (node.id?.type !== "ArrayPattern" || !node.id.elements?.length) return;
+      if (!isNodeOfType(node.id, "ArrayPattern") || !node.id.elements?.length) return;
       if (!node.init || !isHookCall(node.init, "useState")) return;
       if (!node.init.arguments?.length) return;
 
       const initializer = node.init.arguments[0];
-      if (initializer.type !== "Literal" || initializer.value !== false) return;
+      if (!isNodeOfType(initializer, "Literal") || initializer.value !== false) return;
 
-      const stateVariableName = node.id.elements[0]?.name;
+      if (!isNodeOfType(node.id, "ArrayPattern")) return;
+      const firstBinding = node.id.elements[0];
+      const stateVariableName = isNodeOfType(firstBinding, "Identifier") ? firstBinding.name : null;
       if (!stateVariableName || !LOADING_STATE_PATTERN.test(stateVariableName)) return;
 
       context.report({

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
@@ -18,7 +18,6 @@ export const renderingUsetransitionLoading = defineRule<Rule>({
       const initializer = node.init.arguments[0];
       if (!isNodeOfType(initializer, "Literal") || initializer.value !== false) return;
 
-      if (!isNodeOfType(node.id, "ArrayPattern")) return;
       const firstBinding = node.id.elements[0];
       const stateVariableName = isNodeOfType(firstBinding, "Identifier") ? firstBinding.name : null;
       if (!stateVariableName || !LOADING_STATE_PATTERN.test(stateVariableName)) return;

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-derived-state-from-hook.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-derived-state-from-hook.ts
@@ -4,6 +4,7 @@ import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const CONTINUOUS_VALUE_HOOK_PATTERN =
   /^use(?:Window(?:Width|Height|Dimensions)|Scroll(?:Position|Y|X)|MousePosition|ResizeObserver|IntersectionObserver)/;
@@ -20,31 +21,31 @@ const CONTINUOUS_VALUE_HOOK_PATTERN =
 // `const y = x [<>=] literal` (or boolean expression on x), where y is
 // the only value referenced in the JSX.
 const isThresholdComparison = (node: EsTreeNode, valueName: string): boolean => {
-  if (node.type !== "BinaryExpression") return false;
+  if (!isNodeOfType(node, "BinaryExpression")) return false;
   if (!["<", "<=", ">", ">=", "===", "!==", "==", "!="].includes(node.operator)) return false;
   const referencesContinuous =
-    (node.left?.type === "Identifier" && node.left.name === valueName) ||
-    (node.right?.type === "Identifier" && node.right.name === valueName);
+    (isNodeOfType(node.left, "Identifier") && node.left.name === valueName) ||
+    (isNodeOfType(node.right, "Identifier") && node.right.name === valueName);
   if (!referencesContinuous) return false;
-  return node.left?.type === "Literal" || node.right?.type === "Literal";
+  return isNodeOfType(node.left, "Literal") || isNodeOfType(node.right, "Literal");
 };
 
 const findThresholdDerivedBindings = (
   componentBody: EsTreeNode,
 ): Array<{ continuousName: string; hookName: string; declarator: EsTreeNode }> => {
   const out: Array<{ continuousName: string; hookName: string; declarator: EsTreeNode }> = [];
-  if (componentBody?.type !== "BlockStatement") return out;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return out;
   const statements = componentBody.body ?? [];
 
   for (let outerIndex = 0; outerIndex < statements.length; outerIndex++) {
     const outerStatement = statements[outerIndex];
-    if (outerStatement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(outerStatement, "VariableDeclaration")) continue;
 
     for (const declarator of outerStatement.declarations ?? []) {
-      if (declarator.id?.type !== "Identifier") continue;
+      if (!isNodeOfType(declarator.id, "Identifier")) continue;
       const init = declarator.init;
-      if (init?.type !== "CallExpression") continue;
-      if (init.callee?.type !== "Identifier") continue;
+      if (!isNodeOfType(init, "CallExpression")) continue;
+      if (!isNodeOfType(init.callee, "Identifier")) continue;
       if (!CONTINUOUS_VALUE_HOOK_PATTERN.test(init.callee.name)) continue;
 
       const continuousName = declarator.id.name;
@@ -53,7 +54,7 @@ const findThresholdDerivedBindings = (
       // Look at the next statement(s) for a derived threshold binding.
       for (let innerIndex = outerIndex + 1; innerIndex < statements.length; innerIndex++) {
         const innerStatement = statements[innerIndex];
-        if (innerStatement.type !== "VariableDeclaration") break;
+        if (!isNodeOfType(innerStatement, "VariableDeclaration")) break;
         let foundThreshold = false;
         for (const innerDecl of innerStatement.declarations ?? []) {
           if (innerDecl.init && isThresholdComparison(innerDecl.init, continuousName)) {
@@ -76,7 +77,7 @@ export const rerenderDerivedStateFromHook = defineRule<Rule>({
     'Use a threshold/media-query hook (e.g. `useMediaQuery("(max-width: 767px)")`) — the component re-renders only when the threshold flips, not every pixel',
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const bindings = findThresholdDerivedBindings(componentBody);
       for (const binding of bindings) {
         context.report({

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
@@ -5,19 +5,23 @@ import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const callbackReturnsJsx = (callback: EsTreeNode | undefined): boolean => {
   if (!callback) return false;
-  if (callback.type !== "ArrowFunctionExpression" && callback.type !== "FunctionExpression") {
+  if (
+    !isNodeOfType(callback, "ArrowFunctionExpression") &&
+    !isNodeOfType(callback, "FunctionExpression")
+  ) {
     return false;
   }
   const body = callback.body;
-  if (body?.type === "JSXElement" || body?.type === "JSXFragment") return true;
-  if (body?.type !== "BlockStatement") return false;
+  if (isNodeOfType(body, "JSXElement") || isNodeOfType(body, "JSXFragment")) return true;
+  if (!isNodeOfType(body, "BlockStatement")) return false;
   for (const stmt of body.body ?? []) {
     if (
-      stmt.type === "ReturnStatement" &&
-      (stmt.argument?.type === "JSXElement" || stmt.argument?.type === "JSXFragment")
+      isNodeOfType(stmt, "ReturnStatement") &&
+      (isNodeOfType(stmt.argument, "JSXElement") || isNodeOfType(stmt.argument, "JSXFragment"))
     ) {
       return true;
     }
@@ -28,10 +32,10 @@ const callbackReturnsJsx = (callback: EsTreeNode | undefined): boolean => {
 const containsEarlyReturn = (ifStatement: EsTreeNode): boolean => {
   const consequent = ifStatement.consequent;
   if (!consequent) return false;
-  if (consequent.type === "ReturnStatement") return true;
-  if (consequent.type !== "BlockStatement") return false;
+  if (isNodeOfType(consequent, "ReturnStatement")) return true;
+  if (!isNodeOfType(consequent, "BlockStatement")) return false;
   for (const stmt of consequent.body ?? []) {
-    if (stmt.type === "ReturnStatement") return true;
+    if (isNodeOfType(stmt, "ReturnStatement")) return true;
   }
   return false;
 };
@@ -50,11 +54,11 @@ export const rerenderMemoBeforeEarlyReturn = defineRule<Rule>({
 
       for (const stmt of statements) {
         if (!memoNode) {
-          if (stmt.type !== "VariableDeclaration") continue;
+          if (!isNodeOfType(stmt, "VariableDeclaration")) continue;
           for (const declarator of stmt.declarations ?? []) {
             const init = declarator.init;
             if (
-              init?.type === "CallExpression" &&
+              isNodeOfType(init, "CallExpression") &&
               isHookCall(init, "useMemo") &&
               callbackReturnsJsx(init.arguments?.[0])
             ) {
@@ -64,7 +68,7 @@ export const rerenderMemoBeforeEarlyReturn = defineRule<Rule>({
           }
           continue;
         }
-        if (stmt.type === "IfStatement" && containsEarlyReturn(stmt)) {
+        if (isNodeOfType(stmt, "IfStatement") && containsEarlyReturn(stmt)) {
           context.report({
             node: memoNode,
             message:
@@ -78,13 +82,13 @@ export const rerenderMemoBeforeEarlyReturn = defineRule<Rule>({
     return {
       FunctionDeclaration(node: EsTreeNode) {
         if (!isUppercaseName(node.id?.name ?? "")) return;
-        if (node.body?.type !== "BlockStatement") return;
+        if (!isNodeOfType(node.body, "BlockStatement")) return;
         inspectFunctionBody(node.body.body ?? []);
       },
       VariableDeclarator(node: EsTreeNode) {
         if (!isComponentAssignment(node)) return;
         const body = node.init?.body;
-        if (body?.type !== "BlockStatement") return;
+        if (!isNodeOfType(body, "BlockStatement")) return;
         inspectFunctionBody(body.body ?? []);
       },
     };

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
@@ -4,6 +4,7 @@ import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderMemoWithDefaultValue = defineRule<Rule>({
   recommendation:
@@ -11,19 +12,28 @@ export const rerenderMemoWithDefaultValue = defineRule<Rule>({
   create: (context: RuleContext) => {
     const checkDefaultProps = (params: EsTreeNode[]): void => {
       for (const param of params) {
-        if (param.type !== "ObjectPattern") continue;
+        if (!isNodeOfType(param, "ObjectPattern")) continue;
         for (const property of param.properties ?? []) {
-          if (property.type !== "Property" || property.value?.type !== "AssignmentPattern")
+          if (
+            !isNodeOfType(property, "Property") ||
+            !isNodeOfType(property.value, "AssignmentPattern")
+          )
             continue;
           const defaultValue = property.value.right;
-          if (defaultValue?.type === "ObjectExpression" && defaultValue.properties?.length === 0) {
+          if (
+            isNodeOfType(defaultValue, "ObjectExpression") &&
+            defaultValue.properties?.length === 0
+          ) {
             context.report({
               node: defaultValue,
               message:
                 "Default prop value {} creates a new object reference every render — extract to a module-level constant",
             });
           }
-          if (defaultValue?.type === "ArrayExpression" && defaultValue.elements?.length === 0) {
+          if (
+            isNodeOfType(defaultValue, "ArrayExpression") &&
+            defaultValue.elements?.length === 0
+          ) {
             context.report({
               node: defaultValue,
               message:

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-transitions-scroll.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-transitions-scroll.ts
@@ -3,6 +3,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const HIGH_FREQUENCY_DOM_EVENTS = new Set([
   "scroll",
@@ -14,23 +15,26 @@ const HIGH_FREQUENCY_DOM_EVENTS = new Set([
 ]);
 
 const isAddEventListenerCall = (node: EsTreeNode): boolean => {
-  if (node.type !== "CallExpression") return false;
-  if (node.callee?.type !== "MemberExpression") return false;
-  if (node.callee.property?.type !== "Identifier") return false;
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (!isNodeOfType(node.callee, "MemberExpression")) return false;
+  if (!isNodeOfType(node.callee.property, "Identifier")) return false;
   if (node.callee.property.name !== "addEventListener") return false;
   return true;
 };
 
 const handlerCallsSetState = (handler: EsTreeNode): EsTreeNode | null => {
-  if (handler.type !== "ArrowFunctionExpression" && handler.type !== "FunctionExpression") {
+  if (
+    !isNodeOfType(handler, "ArrowFunctionExpression") &&
+    !isNodeOfType(handler, "FunctionExpression")
+  ) {
     return null;
   }
   let setStateCall: EsTreeNode | null = null;
   walkAst(handler.body, (child: EsTreeNode) => {
     if (setStateCall) return;
     if (
-      child.type === "CallExpression" &&
-      child.callee?.type === "Identifier" &&
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "Identifier") &&
       /^set[A-Z]/.test(child.callee.name)
     ) {
       setStateCall = child;
@@ -54,7 +58,7 @@ export const rerenderTransitionsScroll = defineRule<Rule>({
     CallExpression(node: EsTreeNode) {
       if (!isAddEventListenerCall(node)) return;
       const eventArg = node.arguments?.[0];
-      if (eventArg?.type !== "Literal") return;
+      if (!isNodeOfType(eventArg, "Literal")) return;
       const eventName = eventArg.value;
       if (typeof eventName !== "string" || !HIGH_FREQUENCY_DOM_EVENTS.has(eventName)) return;
 
@@ -67,8 +71,8 @@ export const rerenderTransitionsScroll = defineRule<Rule>({
       let cursor: EsTreeNode | null = setStateCall.parent ?? null;
       while (cursor && cursor !== handler) {
         if (
-          cursor.type === "CallExpression" &&
-          cursor.callee?.type === "Identifier" &&
+          isNodeOfType(cursor, "CallExpression") &&
+          isNodeOfType(cursor.callee, "Identifier") &&
           (cursor.callee.name === "startTransition" ||
             cursor.callee.name === "requestAnimationFrame" ||
             cursor.callee.name === "requestIdleCallback")

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const REANIMATED_LAYOUT_KEYS = new Set([
   "width",
@@ -29,14 +30,17 @@ const REANIMATED_LAYOUT_KEYS = new Set([
 ]);
 
 const findReturnedObject = (callback: EsTreeNode): EsTreeNode | null => {
-  if (callback.type !== "ArrowFunctionExpression" && callback.type !== "FunctionExpression") {
+  if (
+    !isNodeOfType(callback, "ArrowFunctionExpression") &&
+    !isNodeOfType(callback, "FunctionExpression")
+  ) {
     return null;
   }
   const body = callback.body;
-  if (body?.type === "ObjectExpression") return body;
-  if (body?.type !== "BlockStatement") return null;
+  if (isNodeOfType(body, "ObjectExpression")) return body;
+  if (!isNodeOfType(body, "BlockStatement")) return null;
   for (const stmt of body.body ?? []) {
-    if (stmt.type === "ReturnStatement" && stmt.argument?.type === "ObjectExpression") {
+    if (isNodeOfType(stmt, "ReturnStatement") && isNodeOfType(stmt.argument, "ObjectExpression")) {
       return stmt.argument;
     }
   }
@@ -54,15 +58,16 @@ export const rnAnimateLayoutProperty = defineRule<Rule>({
     "Animate `transform: [{ translateX/Y }, { scale }]` and `opacity` instead of layout props — layout runs on the JS thread; transform/opacity run on the GPU compositor",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "Identifier" || node.callee.name !== "useAnimatedStyle") return;
+      if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "useAnimatedStyle")
+        return;
       const callback = node.arguments?.[0];
       if (!callback) return;
       const returnedObject = findReturnedObject(callback);
       if (!returnedObject) return;
 
       for (const property of returnedObject.properties ?? []) {
-        if (property.type !== "Property") continue;
-        if (property.key?.type !== "Identifier") continue;
+        if (!isNodeOfType(property, "Property")) continue;
+        if (!isNodeOfType(property.key, "Identifier")) continue;
         if (!REANIMATED_LAYOUT_KEYS.has(property.key.name)) continue;
 
         context.report({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: useAnimatedReaction with a body that does nothing but assign to
 // another shared value (`sv2.value = current`) is essentially what
@@ -14,12 +15,13 @@ export const rnAnimationReactionAsDerived = defineRule<Rule>({
     "Replace useAnimatedReaction with `useDerivedValue(() => ..., [deps])` — shorter, native dependency tracking, no side-effect implication",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "Identifier" || node.callee.name !== "useAnimatedReaction") return;
+      if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "useAnimatedReaction")
+        return;
       const reactionFn = node.arguments?.[1];
       if (!reactionFn) return;
       if (
-        reactionFn.type !== "ArrowFunctionExpression" &&
-        reactionFn.type !== "FunctionExpression"
+        !isNodeOfType(reactionFn, "ArrowFunctionExpression") &&
+        !isNodeOfType(reactionFn, "FunctionExpression")
       ) {
         return;
       }
@@ -33,20 +35,20 @@ export const rnAnimationReactionAsDerived = defineRule<Rule>({
       // side-effect semantics are wanted; useDerivedValue would change
       // behavior.
       let singleAssignment: EsTreeNode | null = null;
-      if (body?.type === "BlockStatement") {
+      if (isNodeOfType(body, "BlockStatement")) {
         const statements = body.body ?? [];
         if (statements.length !== 1) return;
         const onlyStatement = statements[0];
-        if (onlyStatement.type !== "ExpressionStatement") return;
+        if (!isNodeOfType(onlyStatement, "ExpressionStatement")) return;
         singleAssignment = onlyStatement.expression;
       } else if (body) {
         // Concise arrow body like `(cur) => sv.value = cur`.
         singleAssignment = body;
       }
       if (!singleAssignment) return;
-      if (singleAssignment.type !== "AssignmentExpression") return;
-      if (singleAssignment.left?.type !== "MemberExpression") return;
-      if (singleAssignment.left.property?.type !== "Identifier") return;
+      if (!isNodeOfType(singleAssignment, "AssignmentExpression")) return;
+      if (!isNodeOfType(singleAssignment.left, "MemberExpression")) return;
+      if (!isNodeOfType(singleAssignment.left.property, "Identifier")) return;
       if (singleAssignment.left.property.name !== "value") return;
 
       context.report({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
@@ -3,6 +3,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const LIST_ROW_PRESS_HANDLER_PROPS = new Set([
   "onPress",
@@ -16,14 +17,14 @@ const LIST_ROW_PRESS_HANDLER_PROPS = new Set([
 const detectInlineRowHandlers = (renderItemFn: EsTreeNode): EsTreeNode[] => {
   const inlineHandlers: EsTreeNode[] = [];
   walkAst(renderItemFn.body, (child: EsTreeNode) => {
-    if (child.type !== "JSXAttribute") return;
-    if (child.name?.type !== "JSXIdentifier") return;
+    if (!isNodeOfType(child, "JSXAttribute")) return;
+    if (!isNodeOfType(child.name, "JSXIdentifier")) return;
     if (!LIST_ROW_PRESS_HANDLER_PROPS.has(child.name.name)) return;
-    if (child.value?.type !== "JSXExpressionContainer") return;
+    if (!isNodeOfType(child.value, "JSXExpressionContainer")) return;
     const expression = child.value.expression;
     if (
-      expression?.type === "ArrowFunctionExpression" ||
-      expression?.type === "FunctionExpression"
+      isNodeOfType(expression, "ArrowFunctionExpression") ||
+      isNodeOfType(expression, "FunctionExpression")
     ) {
       inlineHandlers.push(child);
     }
@@ -32,14 +33,14 @@ const detectInlineRowHandlers = (renderItemFn: EsTreeNode): EsTreeNode[] => {
 };
 
 const isRenderItemJsxAttribute = (parent: EsTreeNode | null | undefined): boolean => {
-  if (parent?.type !== "JSXAttribute") return false;
-  const attrName = parent.name?.type === "JSXIdentifier" ? parent.name.name : null;
+  if (!isNodeOfType(parent, "JSXAttribute")) return false;
+  const attrName = isNodeOfType(parent.name, "JSXIdentifier") ? parent.name.name : null;
   return attrName === "renderItem";
 };
 
 const isRenderItemFunction = (node: EsTreeNode): boolean => {
   const parent = node.parent;
-  if (parent?.type !== "JSXExpressionContainer") return false;
+  if (!isNodeOfType(parent, "JSXExpressionContainer")) return false;
   return isRenderItemJsxAttribute(parent.parent);
 };
 
@@ -58,8 +59,9 @@ export const rnListCallbackPerRow = defineRule<Rule>({
       if (!isRenderItemFunction(node)) return;
       const inlineHandlers = detectInlineRowHandlers(node);
       for (const handler of inlineHandlers) {
-        const handlerName =
-          handler.name?.type === "JSXIdentifier" ? handler.name.name : "<handler>";
+        const handlerName = isNodeOfType(handler.name, "JSXIdentifier")
+          ? handler.name.name
+          : "<handler>";
         context.report({
           node: handler,
           message: `Inline ${handlerName} arrow inside renderItem creates a fresh closure per row — hoist with useCallback at list scope and pass the row id as a primitive prop`,

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // Short-name form: resolveJsxElementName drops the `Animated.` prefix,
 // so `<Animated.FlatList>` resolves to `"FlatList"` and matches here.
@@ -28,13 +29,13 @@ export const rnListDataMapped = defineRule<Rule>({
       if (!elementName || !VIRTUALIZED_LIST_NAMES.has(elementName)) return;
 
       for (const attr of node.attributes ?? []) {
-        if (attr.type !== "JSXAttribute") continue;
-        if (attr.name?.type !== "JSXIdentifier" || attr.name.name !== "data") continue;
-        if (attr.value?.type !== "JSXExpressionContainer") continue;
+        if (!isNodeOfType(attr, "JSXAttribute")) continue;
+        if (!isNodeOfType(attr.name, "JSXIdentifier") || attr.name.name !== "data") continue;
+        if (!isNodeOfType(attr.value, "JSXExpressionContainer")) continue;
         const expression = attr.value.expression;
-        if (expression?.type !== "CallExpression") continue;
-        if (expression.callee?.type !== "MemberExpression") continue;
-        if (expression.callee.property?.type !== "Identifier") continue;
+        if (!isNodeOfType(expression, "CallExpression")) continue;
+        if (!isNodeOfType(expression.callee, "MemberExpression")) continue;
+        if (!isNodeOfType(expression.callee.property, "Identifier")) continue;
         const methodName = expression.callee.property.name;
         if (methodName !== "map" && methodName !== "filter") continue;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: <FlashList recycleItems> (or LegendList) reuses row component
 // instances across rows. For HETEROGENEOUS lists (rows of different
@@ -32,8 +33,8 @@ export const rnListRecyclableWithoutTypes = defineRule<Rule>({
       let hasGetItemType = false;
 
       for (const attr of node.attributes ?? []) {
-        if (attr.type !== "JSXAttribute") continue;
-        if (attr.name?.type !== "JSXIdentifier") continue;
+        if (!isNodeOfType(attr, "JSXAttribute")) continue;
+        if (!isNodeOfType(attr.name, "JSXIdentifier")) continue;
         if (attr.name.name === "recycleItems") {
           // Bare `recycleItems` (no `={...}`) → true. `recycleItems={true}`
           // → true. `recycleItems={false}` → DISABLES recycling, so the
@@ -41,8 +42,8 @@ export const rnListRecyclableWithoutTypes = defineRule<Rule>({
           if (!attr.value) {
             hasRecycleItemsEnabled = true;
           } else if (
-            attr.value.type === "JSXExpressionContainer" &&
-            attr.value.expression?.type === "Literal"
+            isNodeOfType(attr.value, "JSXExpressionContainer") &&
+            isNodeOfType(attr.value.expression, "Literal")
           ) {
             hasRecycleItemsEnabled = attr.value.expression.value === true;
           } else {

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
@@ -3,6 +3,8 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const rnNoDeprecatedModules = defineRule<Rule>({
   recommendation:
@@ -12,8 +14,8 @@ export const rnNoDeprecatedModules = defineRule<Rule>({
       if (node.source?.value !== "react-native") return;
 
       for (const specifier of node.specifiers ?? []) {
-        if (specifier.type !== "ImportSpecifier") continue;
-        const importedName = specifier.imported?.name;
+        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+        const importedName = getImportedName(specifier);
         if (!importedName) continue;
 
         const replacement = DEPRECATED_RN_MODULE_REPLACEMENTS.get(importedName);

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-dimensions-get.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-dimensions-get.ts
@@ -3,14 +3,18 @@ import { isMemberProperty } from "../../utils/is-member-property.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoDimensionsGet = defineRule<Rule>({
   recommendation:
     "Use `const { width, height } = useWindowDimensions()` — it updates reactively on rotation and resize",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.object?.type !== "Identifier" || node.callee.object.name !== "Dimensions")
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (
+        !isNodeOfType(node.callee.object, "Identifier") ||
+        node.callee.object.name !== "Dimensions"
+      )
         return;
 
       if (isMemberProperty(node.callee, "get")) {

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
@@ -4,25 +4,26 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoInlineFlatlistRenderitem = defineRule<Rule>({
   recommendation:
     "Extract renderItem to a named function or wrap in useCallback to avoid re-creating on every render",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "renderItem") return;
-      if (!node.value || node.value.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "renderItem") return;
+      if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const openingElement = node.parent;
-      if (!openingElement || openingElement.type !== "JSXOpeningElement") return;
+      if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return;
 
       const listComponentName = resolveJsxElementName(openingElement);
       if (!listComponentName || !REACT_NATIVE_LIST_COMPONENTS.has(listComponentName)) return;
 
       const expression = node.value.expression;
       if (
-        expression?.type !== "ArrowFunctionExpression" &&
-        expression?.type !== "FunctionExpression"
+        !isNodeOfType(expression, "ArrowFunctionExpression") &&
+        !isNodeOfType(expression, "FunctionExpression")
       )
         return;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-object-in-list-item.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-object-in-list-item.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const RENDER_ITEM_PROP_NAMES = new Set([
   "renderItem",
@@ -22,18 +23,21 @@ export const rnNoInlineObjectInListItem = defineRule<Rule>({
     let renderItemDepth = 0;
 
     const isRenderItemAttribute = (parent: EsTreeNode | null | undefined): boolean => {
-      if (parent?.type !== "JSXAttribute") return false;
-      const attrName = parent.name?.type === "JSXIdentifier" ? parent.name.name : null;
+      if (!isNodeOfType(parent, "JSXAttribute")) return false;
+      const attrName = isNodeOfType(parent.name, "JSXIdentifier") ? parent.name.name : null;
       return attrName ? RENDER_ITEM_PROP_NAMES.has(attrName) : false;
     };
 
     const isRenderItemFunction = (node: EsTreeNode): boolean => {
-      if (node.type !== "ArrowFunctionExpression" && node.type !== "FunctionExpression") {
+      if (
+        !isNodeOfType(node, "ArrowFunctionExpression") &&
+        !isNodeOfType(node, "FunctionExpression")
+      ) {
         return false;
       }
       // Walk up: parent should be JSXExpressionContainer whose parent is JSXAttribute renderItem.
       const expressionContainer = node.parent;
-      if (expressionContainer?.type !== "JSXExpressionContainer") return false;
+      if (!isNodeOfType(expressionContainer, "JSXExpressionContainer")) return false;
       return isRenderItemAttribute(expressionContainer.parent);
     };
 
@@ -51,9 +55,9 @@ export const rnNoInlineObjectInListItem = defineRule<Rule>({
       "FunctionExpression:exit": exit,
       JSXAttribute(node: EsTreeNode) {
         if (renderItemDepth === 0) return;
-        if (node.value?.type !== "JSXExpressionContainer") return;
-        if (node.value.expression?.type !== "ObjectExpression") return;
-        const propName = node.name?.type === "JSXIdentifier" ? node.name.name : "<unknown>";
+        if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
+        if (!isNodeOfType(node.value.expression, "ObjectExpression")) return;
+        const propName = isNodeOfType(node.name, "JSXIdentifier") ? node.name.name : "<unknown>";
         context.report({
           node,
           message: `Inline object literal on "${propName}" inside renderItem — allocates a fresh reference per row and breaks memo() on the row component. Hoist outside renderItem or pass primitives`,

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
@@ -4,13 +4,14 @@ import { isMemberProperty } from "../../utils/is-member-property.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const reportLegacyShadowProperties = (objectExpression: EsTreeNode, context: RuleContext): void => {
   const legacyShadowPropertyNames: string[] = [];
 
   for (const property of objectExpression.properties ?? []) {
-    if (property.type !== "Property") continue;
-    const propertyName = property.key?.type === "Identifier" ? property.key.name : null;
+    if (!isNodeOfType(property, "Property")) continue;
+    const propertyName = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
     if (propertyName && LEGACY_SHADOW_STYLE_PROPERTIES.has(propertyName)) {
       legacyShadowPropertyNames.push(propertyName);
     }
@@ -30,33 +31,36 @@ export const rnNoLegacyShadowStyles = defineRule<Rule>({
     "Use `boxShadow` for cross-platform shadows on the new architecture instead of platform-specific shadow properties",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "style") return;
-      if (node.value?.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const expression = node.value.expression;
 
-      if (expression?.type === "ObjectExpression") {
+      if (isNodeOfType(expression, "ObjectExpression")) {
         reportLegacyShadowProperties(expression, context);
-      } else if (expression?.type === "ArrayExpression") {
+      } else if (isNodeOfType(expression, "ArrayExpression")) {
         for (const element of expression.elements ?? []) {
-          if (element?.type === "ObjectExpression") {
+          if (isNodeOfType(element, "ObjectExpression")) {
             reportLegacyShadowProperties(element, context);
           }
         }
       }
     },
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.object?.type !== "Identifier" || node.callee.object.name !== "StyleSheet")
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (
+        !isNodeOfType(node.callee.object, "Identifier") ||
+        node.callee.object.name !== "StyleSheet"
+      )
         return;
       if (!isMemberProperty(node.callee, "create")) return;
 
       const stylesArgument = node.arguments?.[0];
-      if (stylesArgument?.type !== "ObjectExpression") return;
+      if (!isNodeOfType(stylesArgument, "ObjectExpression")) return;
 
       for (const styleDefinition of stylesArgument.properties ?? []) {
-        if (styleDefinition.type !== "Property") continue;
-        if (styleDefinition.value?.type !== "ObjectExpression") continue;
+        if (!isNodeOfType(styleDefinition, "Property")) continue;
+        if (!isNodeOfType(styleDefinition.value, "ObjectExpression")) continue;
         reportLegacyShadowProperties(styleDefinition.value, context);
       }
     },

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -9,6 +9,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const truncateText = (text: string): string =>
   text.length > RAW_TEXT_PREVIEW_MAX_CHARS
@@ -16,31 +17,31 @@ const truncateText = (text: string): string =>
     : text;
 
 const isRawTextContent = (child: EsTreeNode): boolean => {
-  if (child.type === "JSXText") return Boolean(child.value?.trim());
-  if (child.type !== "JSXExpressionContainer" || !child.expression) return false;
+  if (isNodeOfType(child, "JSXText")) return Boolean(child.value?.trim());
+  if (!isNodeOfType(child, "JSXExpressionContainer") || !child.expression) return false;
 
   const expression = child.expression;
   return (
-    (expression.type === "Literal" &&
+    (isNodeOfType(expression, "Literal") &&
       (typeof expression.value === "string" || typeof expression.value === "number")) ||
-    expression.type === "TemplateLiteral"
+    isNodeOfType(expression, "TemplateLiteral")
   );
 };
 
 const getRawTextDescription = (child: EsTreeNode): string => {
-  if (child.type === "JSXText") {
+  if (isNodeOfType(child, "JSXText")) {
     return `"${truncateText(child.value.trim())}"`;
   }
 
-  if (child.type === "JSXExpressionContainer" && child.expression) {
+  if (isNodeOfType(child, "JSXExpressionContainer") && child.expression) {
     const expression = child.expression;
-    if (expression.type === "Literal" && typeof expression.value === "string") {
+    if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
       return `"${truncateText(expression.value)}"`;
     }
-    if (expression.type === "Literal" && typeof expression.value === "number") {
+    if (isNodeOfType(expression, "Literal") && typeof expression.value === "number") {
       return `{${expression.value}}`;
     }
-    if (expression.type === "TemplateLiteral") return "template literal";
+    if (isNodeOfType(expression, "TemplateLiteral")) return "template literal";
   }
 
   return "text content";

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
@@ -3,6 +3,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: setting React state inside an onScroll handler triggers a re-render
 // at scroll-event frequency (60-120Hz). Use a Reanimated shared value
@@ -13,13 +14,13 @@ export const rnNoScrollState = defineRule<Rule>({
     "Track scroll position with a Reanimated shared value (`useAnimatedScrollHandler`) or a ref — `setState` on every scroll event causes re-render storms",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "onScroll") return;
-      if (node.value?.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
       const expression = node.value.expression;
       if (
-        expression?.type !== "ArrowFunctionExpression" &&
-        expression?.type !== "FunctionExpression"
+        !isNodeOfType(expression, "ArrowFunctionExpression") &&
+        !isNodeOfType(expression, "FunctionExpression")
       ) {
         return;
       }
@@ -28,8 +29,8 @@ export const rnNoScrollState = defineRule<Rule>({
       walkAst(expression.body, (child: EsTreeNode) => {
         if (setStateCallNode) return;
         if (
-          child.type === "CallExpression" &&
-          child.callee?.type === "Identifier" &&
+          isNodeOfType(child, "CallExpression") &&
+          isNodeOfType(child.callee, "Identifier") &&
           /^set[A-Z]/.test(child.callee.name)
         ) {
           setStateCallNode = child;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
@@ -4,6 +4,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: <ScrollView>{items.map(...)}</ScrollView> renders every row in
 // memory — for any list longer than ~10 items this destroys scroll
@@ -19,12 +20,12 @@ export const rnNoScrollviewMappedList = defineRule<Rule>({
       if (!elementName || !SCROLLVIEW_NAMES.has(elementName)) return;
 
       for (const child of node.children ?? []) {
-        if (child.type !== "JSXExpressionContainer") continue;
+        if (!isNodeOfType(child, "JSXExpressionContainer")) continue;
         const expression = child.expression;
         if (
-          expression?.type === "CallExpression" &&
-          expression.callee?.type === "MemberExpression" &&
-          expression.callee.property?.type === "Identifier" &&
+          isNodeOfType(expression, "CallExpression") &&
+          isNodeOfType(expression.callee, "MemberExpression") &&
+          isNodeOfType(expression.callee.property, "Identifier") &&
           expression.callee.property.name === "map"
         ) {
           context.report({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-single-element-style-array.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-single-element-style-array.ts
@@ -2,19 +2,20 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoSingleElementStyleArray = defineRule<Rule>({
   recommendation:
     "Use `style={value}` instead of `style={[value]}` — single-element arrays add unnecessary allocation",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      const propName = node.name?.type === "JSXIdentifier" ? node.name.name : null;
+      const propName = isNodeOfType(node.name, "JSXIdentifier") ? node.name.name : null;
       if (!propName) return;
       if (propName !== "style" && !propName.endsWith("Style")) return;
-      if (node.value?.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const expression = node.value.expression;
-      if (expression?.type !== "ArrayExpression") return;
+      if (!isNodeOfType(expression, "ArrayExpression")) return;
       if (expression.elements?.length !== 1) return;
 
       context.report({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
@@ -4,6 +4,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: <SafeAreaView> wrapping <ScrollView> (or
 // `useSafeAreaInsets()` + `paddingTop: insets.top` in
@@ -20,7 +21,7 @@ export const rnPreferContentInsetAdjustment = defineRule<Rule>({
       if (elementName !== "SafeAreaView") return;
 
       for (const child of node.children ?? []) {
-        if (child.type !== "JSXElement") continue;
+        if (!isNodeOfType(child, "JSXElement")) continue;
         const childName = resolveJsxElementName(child.openingElement);
         if (!childName || !SCROLLVIEW_NAMES.has(childName)) continue;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
@@ -2,6 +2,8 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 
 // HACK: react-native's built-in <Image> has no caching, no placeholders,
 // no progressive loading, and no priority hints. expo-image is a drop-in
@@ -15,8 +17,8 @@ export const rnPreferExpoImage = defineRule<Rule>({
     ImportDeclaration(node: EsTreeNode) {
       if (node.source?.value !== "react-native") return;
       for (const specifier of node.specifiers ?? []) {
-        if (specifier.type !== "ImportSpecifier") continue;
-        if (specifier.imported?.name !== "Image") continue;
+        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+        if (getImportedName(specifier) !== "Image") continue;
         context.report({
           node: specifier,
           message:

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
@@ -2,6 +2,8 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 
 const TOUCHABLE_COMPONENTS = new Set([
   "TouchableOpacity",
@@ -21,8 +23,8 @@ export const rnPreferPressable = defineRule<Rule>({
     ImportDeclaration(node: EsTreeNode) {
       if (node.source?.value !== "react-native") return;
       for (const specifier of node.specifiers ?? []) {
-        if (specifier.type !== "ImportSpecifier") continue;
-        const importedName = specifier.imported?.name;
+        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+        const importedName = getImportedName(specifier);
         if (!importedName || !TOUCHABLE_COMPONENTS.has(importedName)) continue;
         context.report({
           node: specifier,

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
@@ -2,6 +2,8 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const rnPreferReanimated = defineRule<Rule>({
   recommendation:
@@ -11,8 +13,8 @@ export const rnPreferReanimated = defineRule<Rule>({
       if (node.source?.value !== "react-native") return;
 
       for (const specifier of node.specifiers ?? []) {
-        if (specifier.type !== "ImportSpecifier") continue;
-        if (specifier.imported?.name !== "Animated") continue;
+        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+        if (getImportedName(specifier) !== "Animated") continue;
 
         context.report({
           node: specifier,

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const PRESS_HANDLER_PROP_NAMES = new Set(["onPressIn", "onPressOut"]);
 
@@ -11,7 +12,10 @@ const handlerMutatesIdentifier = (
   handler: EsTreeNode,
   sharedValueBindings: Set<string>,
 ): boolean => {
-  if (handler.type !== "ArrowFunctionExpression" && handler.type !== "FunctionExpression") {
+  if (
+    !isNodeOfType(handler, "ArrowFunctionExpression") &&
+    !isNodeOfType(handler, "FunctionExpression")
+  ) {
     return false;
   }
   if (sharedValueBindings.size === 0) return false;
@@ -19,21 +23,21 @@ const handlerMutatesIdentifier = (
   walkAst(handler.body, (child: EsTreeNode) => {
     if (didMutate) return;
     if (
-      child.type === "AssignmentExpression" &&
-      child.left?.type === "MemberExpression" &&
-      child.left.object?.type === "Identifier" &&
+      isNodeOfType(child, "AssignmentExpression") &&
+      isNodeOfType(child.left, "MemberExpression") &&
+      isNodeOfType(child.left.object, "Identifier") &&
       sharedValueBindings.has(child.left.object.name) &&
-      child.left.property?.type === "Identifier" &&
+      isNodeOfType(child.left.property, "Identifier") &&
       child.left.property.name === "value"
     ) {
       didMutate = true;
     }
     if (
-      child.type === "CallExpression" &&
-      child.callee?.type === "MemberExpression" &&
-      child.callee.object?.type === "Identifier" &&
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "MemberExpression") &&
+      isNodeOfType(child.callee.object, "Identifier") &&
       sharedValueBindings.has(child.callee.object.name) &&
-      child.callee.property?.type === "Identifier" &&
+      isNodeOfType(child.callee.property, "Identifier") &&
       (child.callee.property.name === "set" || child.callee.property.name === "value")
     ) {
       didMutate = true;
@@ -63,10 +67,10 @@ export const rnPressableSharedValueMutation = defineRule<Rule>({
     };
     const trackSharedValueBinding = (declarator: EsTreeNode): void => {
       if (sharedValueBindingsByComponent.length === 0) return;
-      if (declarator.id?.type !== "Identifier") return;
-      if (declarator.init?.type !== "CallExpression") return;
+      if (!isNodeOfType(declarator.id, "Identifier")) return;
+      if (!isNodeOfType(declarator.init, "CallExpression")) return;
       const callee = declarator.init.callee;
-      if (callee?.type !== "Identifier") return;
+      if (!isNodeOfType(callee, "Identifier")) return;
       if (callee.name !== "useSharedValue") return;
       sharedValueBindingsByComponent[sharedValueBindingsByComponent.length - 1].add(
         declarator.id.name,
@@ -94,10 +98,10 @@ export const rnPressableSharedValueMutation = defineRule<Rule>({
         if (activeBindings.size === 0) return;
 
         for (const attr of node.attributes ?? []) {
-          if (attr.type !== "JSXAttribute") continue;
-          if (attr.name?.type !== "JSXIdentifier") continue;
+          if (!isNodeOfType(attr, "JSXAttribute")) continue;
+          if (!isNodeOfType(attr.name, "JSXIdentifier")) continue;
           if (!PRESS_HANDLER_PROP_NAMES.has(attr.name.name)) continue;
-          if (attr.value?.type !== "JSXExpressionContainer") continue;
+          if (!isNodeOfType(attr.value, "JSXExpressionContainer")) continue;
           const handler = attr.value.expression;
           if (!handler) continue;
           if (!handlerMutatesIdentifier(handler, activeBindings)) continue;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
@@ -4,6 +4,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: dynamic `paddingBottom`/`paddingTop` on `contentContainerStyle`
 // (e.g. `paddingBottom: keyboardHeight`) reflows the entire scroll
@@ -26,23 +27,23 @@ export const rnScrollviewDynamicPadding = defineRule<Rule>({
         return;
 
       for (const attr of node.attributes ?? []) {
-        if (attr.type !== "JSXAttribute") continue;
-        if (attr.name?.type !== "JSXIdentifier" || attr.name.name !== "contentContainerStyle")
+        if (!isNodeOfType(attr, "JSXAttribute")) continue;
+        if (!isNodeOfType(attr.name, "JSXIdentifier") || attr.name.name !== "contentContainerStyle")
           continue;
-        if (attr.value?.type !== "JSXExpressionContainer") continue;
+        if (!isNodeOfType(attr.value, "JSXExpressionContainer")) continue;
         const expression = attr.value.expression;
-        if (expression?.type !== "ObjectExpression") continue;
+        if (!isNodeOfType(expression, "ObjectExpression")) continue;
 
         for (const property of expression.properties ?? []) {
-          if (property.type !== "Property") continue;
-          if (property.key?.type !== "Identifier") continue;
+          if (!isNodeOfType(property, "Property")) continue;
+          if (!isNodeOfType(property.key, "Identifier")) continue;
           const key = property.key.name;
           if (key !== "paddingBottom" && key !== "paddingTop") continue;
           // Static numeric value is fine — only flag dynamic identifiers /
           // member expressions that change between renders.
           const value = property.value;
           if (!value) continue;
-          if (value.type === "Literal") continue;
+          if (isNodeOfType(value, "Literal")) continue;
 
           context.report({
             node: property,

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const LEGACY_SHADOW_KEYS = new Set([
   "shadowColor",
@@ -15,8 +16,8 @@ const findLegacyShadowProperty = (
   objectExpression: EsTreeNode,
 ): { keyName: string; node: EsTreeNode } | null => {
   for (const property of objectExpression.properties ?? []) {
-    if (property.type !== "Property") continue;
-    if (property.key?.type !== "Identifier") continue;
+    if (!isNodeOfType(property, "Property")) continue;
+    if (!isNodeOfType(property.key, "Identifier")) continue;
     if (LEGACY_SHADOW_KEYS.has(property.key.name)) {
       return { keyName: property.key.name, node: property };
     }
@@ -35,12 +36,12 @@ export const rnStylePreferBoxShadow = defineRule<Rule>({
     'Use the cross-platform CSS `boxShadow` string (RN v7+): `boxShadow: "0 2px 8px rgba(0,0,0,0.1)"` instead of platform-specific shadow*/elevation keys',
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNode) {
-      if (node.name?.type !== "JSXIdentifier") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       const attrName = node.name.name;
       if (attrName !== "style" && !attrName.endsWith("Style")) return;
-      if (node.value?.type !== "JSXExpressionContainer") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
       const expression = node.value.expression;
-      if (expression?.type !== "ObjectExpression") return;
+      if (!isNodeOfType(expression, "ObjectExpression")) return;
       const match = findLegacyShadowProperty(expression);
       if (!match) return;
       context.report({
@@ -49,16 +50,16 @@ export const rnStylePreferBoxShadow = defineRule<Rule>({
       });
     },
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.object?.type !== "Identifier") return;
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (!isNodeOfType(node.callee.object, "Identifier")) return;
       if (node.callee.object.name !== "StyleSheet") return;
-      if (node.callee.property?.type !== "Identifier") return;
+      if (!isNodeOfType(node.callee.property, "Identifier")) return;
       if (node.callee.property.name !== "create") return;
       const arg = node.arguments?.[0];
-      if (arg?.type !== "ObjectExpression") return;
+      if (!isNodeOfType(arg, "ObjectExpression")) return;
       for (const property of arg.properties ?? []) {
-        if (property.type !== "Property") continue;
-        if (property.value?.type !== "ObjectExpression") continue;
+        if (!isNodeOfType(property, "Property")) continue;
+        if (!isNodeOfType(property.value, "ObjectExpression")) continue;
         const match = findLegacyShadowProperty(property.value);
         if (!match) continue;
         context.report({

--- a/packages/react-doctor/src/plugin/rules/react-native/utils/resolve-jsx-element-name.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/utils/resolve-jsx-element-name.ts
@@ -1,9 +1,10 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const resolveJsxElementName = (openingElement: EsTreeNode): string | null => {
   const elementName = openingElement?.name;
   if (!elementName) return null;
-  if (elementName.type === "JSXIdentifier") return elementName.name;
-  if (elementName.type === "JSXMemberExpression") return elementName.property?.name ?? null;
+  if (isNodeOfType(elementName, "JSXIdentifier")) return elementName.name;
+  if (isNodeOfType(elementName, "JSXMemberExpression")) return elementName.property?.name ?? null;
   return null;
 };

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-bold-heading.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-bold-heading.ts
@@ -10,21 +10,22 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getOpeningElementTagName } from "./utils/get-opening-element-tag-name.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const getInlineStyleObjectExpression = (jsxAttribute: EsTreeNode): EsTreeNode | null => {
-  if (jsxAttribute.name?.type !== "JSXIdentifier" || jsxAttribute.name.name !== "style") {
+  if (!isNodeOfType(jsxAttribute.name, "JSXIdentifier") || jsxAttribute.name.name !== "style") {
     return null;
   }
-  if (jsxAttribute.value?.type !== "JSXExpressionContainer") return null;
+  if (!isNodeOfType(jsxAttribute.value, "JSXExpressionContainer")) return null;
   const expression = jsxAttribute.value.expression;
-  if (expression?.type !== "ObjectExpression") return null;
+  if (!isNodeOfType(expression, "ObjectExpression")) return null;
   return expression;
 };
 
 const getStylePropertyKeyName = (objectProperty: EsTreeNode): string | null => {
-  if (objectProperty.type !== "Property") return null;
-  if (objectProperty.key?.type === "Identifier") return objectProperty.key.name;
-  if (objectProperty.key?.type === "Literal" && typeof objectProperty.key.value === "string") {
+  if (!isNodeOfType(objectProperty, "Property")) return null;
+  if (isNodeOfType(objectProperty.key, "Identifier")) return objectProperty.key.name;
+  if (isNodeOfType(objectProperty.key, "Literal") && typeof objectProperty.key.value === "string") {
     return objectProperty.key.value;
   }
   return null;
@@ -33,8 +34,9 @@ const getStylePropertyKeyName = (objectProperty: EsTreeNode): string | null => {
 const getStylePropertyNumericValue = (objectProperty: EsTreeNode): number | null => {
   const valueNode = objectProperty.value;
   if (!valueNode) return null;
-  if (valueNode.type === "Literal" && typeof valueNode.value === "number") return valueNode.value;
-  if (valueNode.type === "Literal" && typeof valueNode.value === "string") {
+  if (isNodeOfType(valueNode, "Literal") && typeof valueNode.value === "number")
+    return valueNode.value;
+  if (isNodeOfType(valueNode, "Literal") && typeof valueNode.value === "string") {
     const parsed = parseFloat(valueNode.value);
     return Number.isFinite(parsed) ? parsed : null;
   }

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-default-tailwind-palette.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-default-tailwind-palette.ts
@@ -8,6 +8,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const buildDefaultPaletteRegex = (): RegExp => {
   const utilityPrefixGroup = TAILWIND_PALETTE_UTILITY_PREFIXES.join("|");
@@ -35,7 +36,10 @@ export const noDefaultTailwindPalette = defineRule<Rule>({
     "Replace `indigo-*` / `gray-*` / `slate-*` with project tokens, your brand color, or a less-default neutral (`zinc`, `neutral`, `stone`)",
   create: (context: RuleContext) => ({
     JSXAttribute(jsxAttribute: EsTreeNode) {
-      if (jsxAttribute.name?.type !== "JSXIdentifier" || jsxAttribute.name.name !== "className") {
+      if (
+        !isNodeOfType(jsxAttribute.name, "JSXIdentifier") ||
+        jsxAttribute.name.name !== "className"
+      ) {
         return;
       }
       const classNameLiteral = getClassNameLiteral(jsxAttribute);

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
@@ -6,13 +6,17 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
 import { collectAxisShorthandPairs } from "./utils/collect-axis-shorthand-pairs.js";
 import { hasResponsivePrefix } from "./utils/has-responsive-prefix.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRedundantPaddingAxes = defineRule<Rule>({
   recommendation:
     "Collapse `px-N py-N` to `p-N` when both axes match. Keep them split only when one axis varies at a breakpoint (`py-2 md:py-3`)",
   create: (context: RuleContext) => ({
     JSXAttribute(jsxAttribute: EsTreeNode) {
-      if (jsxAttribute.name?.type !== "JSXIdentifier" || jsxAttribute.name.name !== "className") {
+      if (
+        !isNodeOfType(jsxAttribute.name, "JSXIdentifier") ||
+        jsxAttribute.name.name !== "className"
+      ) {
         return;
       }
       const classNameLiteral = getClassNameLiteral(jsxAttribute);

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
@@ -6,12 +6,16 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
 import { collectAxisShorthandPairs } from "./utils/collect-axis-shorthand-pairs.js";
 import { hasResponsivePrefix } from "./utils/has-responsive-prefix.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRedundantSizeAxes = defineRule<Rule>({
   recommendation: "Collapse `w-N h-N` to `size-N` (Tailwind v3.4+) when both axes match",
   create: (context: RuleContext) => ({
     JSXAttribute(jsxAttribute: EsTreeNode) {
-      if (jsxAttribute.name?.type !== "JSXIdentifier" || jsxAttribute.name.name !== "className") {
+      if (
+        !isNodeOfType(jsxAttribute.name, "JSXIdentifier") ||
+        jsxAttribute.name.name !== "className"
+      ) {
         return;
       }
       const classNameLiteral = getClassNameLiteral(jsxAttribute);

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const tokenizeClassName = (classNameValue: string): string[] =>
   classNameValue.split(/\s+/).filter(Boolean);
@@ -13,7 +14,10 @@ export const noSpaceOnFlexChildren = defineRule<Rule>({
     "Use `gap-*` on the flex/grid parent. `space-x-*` / `space-y-*` produce phantom gaps when a sibling is conditionally rendered, lose vertical spacing on wrapped lines, and don't mirror in RTL",
   create: (context: RuleContext) => ({
     JSXAttribute(jsxAttribute: EsTreeNode) {
-      if (jsxAttribute.name?.type !== "JSXIdentifier" || jsxAttribute.name.name !== "className") {
+      if (
+        !isNodeOfType(jsxAttribute.name, "JSXIdentifier") ||
+        jsxAttribute.name.name !== "className"
+      ) {
         return;
       }
       const classNameLiteral = getClassNameLiteral(jsxAttribute);

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getOpeningElementTagName } from "./utils/get-opening-element-tag-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const isButtonLikeTagName = (tagName: string): boolean => {
   if (tagName === "button") return true;
@@ -16,17 +17,17 @@ const collectJsxLabelText = (jsxElementNode: EsTreeNode): string | null => {
   if (childList.length === 0) return null;
   const collectedFragments: string[] = [];
   for (const childNode of childList) {
-    if (childNode.type === "JSXText") {
+    if (isNodeOfType(childNode, "JSXText")) {
       collectedFragments.push(typeof childNode.value === "string" ? childNode.value : "");
       continue;
     }
-    if (childNode.type === "JSXExpressionContainer") {
+    if (isNodeOfType(childNode, "JSXExpressionContainer")) {
       const expression = childNode.expression;
-      if (expression?.type === "Literal" && typeof expression.value === "string") {
+      if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
         collectedFragments.push(expression.value);
         continue;
       }
-      if (expression?.type === "TemplateLiteral" && expression.quasis?.length === 1) {
+      if (isNodeOfType(expression, "TemplateLiteral") && expression.quasis?.length === 1) {
         const rawTemplate = expression.quasis[0].value?.raw;
         if (typeof rawTemplate === "string" && expression.expressions.length === 0) {
           collectedFragments.push(rawTemplate);
@@ -36,14 +37,14 @@ const collectJsxLabelText = (jsxElementNode: EsTreeNode): string | null => {
       // Bail on dynamic content (interpolation, identifiers).
       return null;
     }
-    if (childNode.type === "JSXFragment") {
+    if (isNodeOfType(childNode, "JSXFragment")) {
       // Recurse into <>…</> fragments — they're transparent for label purposes.
       const fragmentLabel = collectJsxLabelText(childNode);
       if (fragmentLabel === null) return null;
       collectedFragments.push(fragmentLabel);
       continue;
     }
-    if (childNode.type === "JSXElement") {
+    if (isNodeOfType(childNode, "JSXElement")) {
       // Bail on nested elements (icons, spans) — the leading/trailing text alone isn't the full label.
       return null;
     }

--- a/packages/react-doctor/src/plugin/rules/react-ui/utils/get-class-name-literal.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/utils/get-class-name-literal.ts
@@ -1,16 +1,20 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getClassNameLiteral = (classAttribute: EsTreeNode): string | null => {
   if (!classAttribute.value) return null;
-  if (classAttribute.value.type === "Literal" && typeof classAttribute.value.value === "string") {
+  if (
+    isNodeOfType(classAttribute.value, "Literal") &&
+    typeof classAttribute.value.value === "string"
+  ) {
     return classAttribute.value.value;
   }
-  if (classAttribute.value.type === "JSXExpressionContainer") {
+  if (isNodeOfType(classAttribute.value, "JSXExpressionContainer")) {
     const expression = classAttribute.value.expression;
-    if (expression?.type === "Literal" && typeof expression.value === "string") {
+    if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
       return expression.value;
     }
-    if (expression?.type === "TemplateLiteral" && expression.quasis?.length === 1) {
+    if (isNodeOfType(expression, "TemplateLiteral") && expression.quasis?.length === 1) {
       return expression.quasis[0].value?.raw ?? null;
     }
   }

--- a/packages/react-doctor/src/plugin/rules/react-ui/utils/get-opening-element-tag-name.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/utils/get-opening-element-tag-name.ts
@@ -1,16 +1,17 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getOpeningElementTagName = (
   openingElement: EsTreeNode | null | undefined,
 ): string | null => {
   if (!openingElement) return null;
-  if (openingElement.name?.type === "JSXIdentifier") return openingElement.name.name;
-  if (openingElement.name?.type === "JSXMemberExpression") {
-    let cursor = openingElement.name;
-    while (cursor.type === "JSXMemberExpression") {
+  if (isNodeOfType(openingElement.name, "JSXIdentifier")) return openingElement.name.name;
+  if (isNodeOfType(openingElement.name, "JSXMemberExpression")) {
+    let cursor: EsTreeNode = openingElement.name;
+    while (isNodeOfType(cursor, "JSXMemberExpression")) {
       cursor = cursor.property;
     }
-    if (cursor?.type === "JSXIdentifier") return cursor.name;
+    if (isNodeOfType(cursor, "JSXIdentifier")) return cursor.name;
   }
   return null;
 };

--- a/packages/react-doctor/src/plugin/rules/react-ui/utils/is-inside-excluded-ancestor.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/utils/is-inside-excluded-ancestor.ts
@@ -2,11 +2,12 @@ import { ELLIPSIS_EXCLUDED_TAG_NAMES } from "../../../constants.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { findJsxAttribute } from "../../../utils/find-jsx-attribute.js";
 import { getOpeningElementTagName } from "./get-opening-element-tag-name.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const isInsideExcludedAncestor = (jsxTextNode: EsTreeNode): boolean => {
   let cursor = jsxTextNode.parent;
   while (cursor) {
-    if (cursor.type === "JSXElement") {
+    if (isNodeOfType(cursor, "JSXElement")) {
       const tagName = getOpeningElementTagName(cursor.openingElement);
       if (tagName && ELLIPSIS_EXCLUDED_TAG_NAMES.has(tagName.toLowerCase())) return true;
       const translateAttribute = findJsxAttribute(
@@ -14,7 +15,7 @@ export const isInsideExcludedAncestor = (jsxTextNode: EsTreeNode): boolean => {
         "translate",
       );
       if (
-        translateAttribute?.value?.type === "Literal" &&
+        isNodeOfType(translateAttribute?.value, "Literal") &&
         translateAttribute.value.value === "no"
       ) {
         return true;

--- a/packages/react-doctor/src/plugin/rules/security/no-eval.ts
+++ b/packages/react-doctor/src/plugin/rules/security/no-eval.ts
@@ -2,13 +2,14 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noEval = defineRule<Rule>({
   recommendation:
     "Use `JSON.parse` for serialized data, `Function(...)` (still careful) for trusted templates, or refactor to avoid dynamic code execution",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type === "Identifier" && node.callee.name === "eval") {
+      if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "eval") {
         context.report({
           node,
           message: "eval() is a code injection risk — avoid dynamic code execution",
@@ -17,9 +18,9 @@ export const noEval = defineRule<Rule>({
       }
 
       if (
-        node.callee?.type === "Identifier" &&
+        isNodeOfType(node.callee, "Identifier") &&
         (node.callee.name === "setTimeout" || node.callee.name === "setInterval") &&
-        node.arguments?.[0]?.type === "Literal" &&
+        isNodeOfType(node.arguments?.[0], "Literal") &&
         typeof node.arguments[0].value === "string"
       ) {
         context.report({
@@ -29,7 +30,7 @@ export const noEval = defineRule<Rule>({
       }
     },
     NewExpression(node: EsTreeNode) {
-      if (node.callee?.type === "Identifier" && node.callee.name === "Function") {
+      if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "Function") {
         context.report({
           node,
           message: "new Function() is a code injection risk — avoid dynamic code execution",

--- a/packages/react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -8,14 +8,15 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noSecretsInClientCode = defineRule<Rule>({
   recommendation:
     "Move to server-side `process.env.SECRET_NAME`. Only `NEXT_PUBLIC_*` vars are safe for the client (and should not contain secrets)",
   create: (context: RuleContext) => ({
     VariableDeclarator(node: EsTreeNode) {
-      if (node.id?.type !== "Identifier") return;
-      if (node.init?.type !== "Literal" || typeof node.init.value !== "string") return;
+      if (!isNodeOfType(node.id, "Identifier")) return;
+      if (!isNodeOfType(node.init, "Literal") || typeof node.init.value !== "string") return;
 
       const variableName = node.id.name;
       const literalValue = node.init.value;

--- a/packages/react-doctor/src/plugin/rules/server/server-after-nonblocking.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-after-nonblocking.ts
@@ -4,6 +4,7 @@ import { hasUseServerDirective } from "../../utils/has-use-server-directive.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: a (object, method) pair counts as "deferrable side effect" when
 // it either (a) is a synchronous `console.log/info/warn` (still cheap,
@@ -68,11 +69,12 @@ export const serverAfterNonblocking = defineRule<Rule>({
       "ArrowFunctionExpression:exit": leaveIfServerFunction,
       CallExpression(node: EsTreeNode) {
         if (!fileHasUseServerDirective && serverFunctionDepth === 0) return;
-        if (node.callee?.type !== "MemberExpression") return;
-        if (node.callee.property?.type !== "Identifier") return;
+        if (!isNodeOfType(node.callee, "MemberExpression")) return;
+        if (!isNodeOfType(node.callee.property, "Identifier")) return;
 
-        const objectName =
-          node.callee.object?.type === "Identifier" ? node.callee.object.name : null;
+        const objectName = isNodeOfType(node.callee.object, "Identifier")
+          ? node.callee.object.name
+          : null;
         if (!objectName) return;
 
         const methodName = node.callee.property.name;

--- a/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -6,6 +6,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
   let foundAuthCall = false;
@@ -13,14 +14,17 @@ const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
     walkAst(statement, (child: EsTreeNode) => {
       if (foundAuthCall) return;
       let callNode: EsTreeNode | null = null;
-      if (child.type === "CallExpression") {
+      if (isNodeOfType(child, "CallExpression")) {
         callNode = child;
-      } else if (child.type === "AwaitExpression" && child.argument?.type === "CallExpression") {
+      } else if (
+        isNodeOfType(child, "AwaitExpression") &&
+        isNodeOfType(child.argument, "CallExpression")
+      ) {
         callNode = child.argument;
       }
 
       if (
-        callNode?.callee?.type === "Identifier" &&
+        isNodeOfType(callNode?.callee, "Identifier") &&
         AUTH_FUNCTION_NAMES.has(callNode.callee.name)
       ) {
         foundAuthCall = true;
@@ -42,7 +46,7 @@ export const serverAuthActions = defineRule<Rule>({
       },
       ExportNamedDeclaration(node: EsTreeNode) {
         const declaration = node.declaration;
-        if (declaration?.type !== "FunctionDeclaration" || !declaration?.async) return;
+        if (!isNodeOfType(declaration, "FunctionDeclaration") || !declaration?.async) return;
 
         const isServerAction = fileHasUseServerDirective || hasUseServerDirective(declaration);
         if (!isServerAction) return;

--- a/packages/react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: `cache(fn)` from React keys deduplication on REFERENCE equality
 // of the function arguments. Calling the cached function with object
@@ -17,25 +18,25 @@ export const serverCacheWithObjectLiteral = defineRule<Rule>({
 
     return {
       VariableDeclarator(node: EsTreeNode) {
-        if (node.id?.type !== "Identifier") return;
+        if (!isNodeOfType(node.id, "Identifier")) return;
         const init = node.init;
-        if (init?.type !== "CallExpression") return;
+        if (!isNodeOfType(init, "CallExpression")) return;
         const callee = init.callee;
         const isCacheCall =
-          (callee?.type === "Identifier" && callee.name === "cache") ||
-          (callee?.type === "MemberExpression" &&
-            callee.object?.type === "Identifier" &&
+          (isNodeOfType(callee, "Identifier") && callee.name === "cache") ||
+          (isNodeOfType(callee, "MemberExpression") &&
+            isNodeOfType(callee.object, "Identifier") &&
             callee.object.name === "React" &&
-            callee.property?.type === "Identifier" &&
+            isNodeOfType(callee.property, "Identifier") &&
             callee.property.name === "cache");
         if (!isCacheCall) return;
         cachedFunctionNames.add(node.id.name);
       },
       CallExpression(node: EsTreeNode) {
-        if (node.callee?.type !== "Identifier") return;
+        if (!isNodeOfType(node.callee, "Identifier")) return;
         if (!cachedFunctionNames.has(node.callee.name)) return;
         const firstArg = node.arguments?.[0];
-        if (firstArg?.type !== "ObjectExpression") return;
+        if (!isNodeOfType(firstArg, "ObjectExpression")) return;
 
         context.report({
           node,

--- a/packages/react-doctor/src/plugin/rules/server/server-dedup-props.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-dedup-props.ts
@@ -3,13 +3,14 @@ import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const DERIVING_ARRAY_METHODS = new Set(["toSorted", "toReversed", "filter", "map", "slice"]);
 
 const getDerivingMethodName = (node: EsTreeNode): string | null => {
-  if (node.type !== "CallExpression") return null;
-  if (node.callee?.type !== "MemberExpression") return null;
-  if (node.callee.property?.type !== "Identifier") return null;
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  if (!isNodeOfType(node.callee, "MemberExpression")) return null;
+  if (!isNodeOfType(node.callee.property, "Identifier")) return null;
   return node.callee.property.name;
 };
 
@@ -27,15 +28,15 @@ export const serverDedupProps = defineRule<Rule>({
       const derivedAttributes: Array<{ propName: string; rootName: string; node: EsTreeNode }> = [];
 
       for (const attr of node.attributes ?? []) {
-        if (attr.type !== "JSXAttribute") continue;
-        if (attr.name?.type !== "JSXIdentifier") continue;
-        if (attr.value?.type !== "JSXExpressionContainer") continue;
+        if (!isNodeOfType(attr, "JSXAttribute")) continue;
+        if (!isNodeOfType(attr.name, "JSXIdentifier")) continue;
+        if (!isNodeOfType(attr.value, "JSXExpressionContainer")) continue;
         const expression = attr.value.expression;
         if (!expression) continue;
 
-        if (expression.type === "Identifier") {
+        if (isNodeOfType(expression, "Identifier")) {
           identifierAttributes.set(expression.name, attr.name.name);
-        } else if (expression.type === "CallExpression") {
+        } else if (isNodeOfType(expression, "CallExpression")) {
           const derivingMethod = getDerivingMethodName(expression);
           if (!derivingMethod || !DERIVING_ARRAY_METHODS.has(derivingMethod)) continue;
           const root = getRootIdentifierName(expression, { followCallChains: true });

--- a/packages/react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
@@ -2,23 +2,24 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const isFetchCall = (node: EsTreeNode): boolean => {
-  if (node.type !== "CallExpression") return false;
-  return node.callee?.type === "Identifier" && node.callee.name === "fetch";
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  return isNodeOfType(node.callee, "Identifier") && node.callee.name === "fetch";
 };
 
 const objectExpressionHasNextRevalidate = (objectExpression: EsTreeNode): boolean => {
-  if (objectExpression.type !== "ObjectExpression") return false;
+  if (!isNodeOfType(objectExpression, "ObjectExpression")) return false;
   for (const property of objectExpression.properties ?? []) {
-    if (property.type !== "Property") continue;
-    if (property.key?.type !== "Identifier") continue;
+    if (!isNodeOfType(property, "Property")) continue;
+    if (!isNodeOfType(property.key, "Identifier")) continue;
     if (property.key.name === "cache") return true;
     if (property.key.name !== "next") continue;
-    if (property.value?.type !== "ObjectExpression") return true;
+    if (!isNodeOfType(property.value, "ObjectExpression")) return true;
     for (const innerProperty of property.value.properties ?? []) {
-      if (innerProperty.type !== "Property") continue;
-      if (innerProperty.key?.type !== "Identifier") continue;
+      if (!isNodeOfType(innerProperty, "Property")) continue;
+      if (!isNodeOfType(innerProperty.key, "Identifier")) continue;
       if (innerProperty.key.name === "revalidate" || innerProperty.key.name === "tags") {
         return true;
       }
@@ -70,8 +71,8 @@ export const serverFetchWithoutRevalidate = defineRule<Rule>({
         }
         const hasUseClient = (node.body ?? []).some(
           (statement: EsTreeNode) =>
-            statement.type === "ExpressionStatement" &&
-            statement.expression?.type === "Literal" &&
+            isNodeOfType(statement, "ExpressionStatement") &&
+            isNodeOfType(statement.expression, "Literal") &&
             statement.expression.value === "use client",
         );
         isServerSideFile = !hasUseClient;
@@ -85,7 +86,7 @@ export const serverFetchWithoutRevalidate = defineRule<Rule>({
 
         const urlArg = node.arguments?.[0];
         const urlText =
-          urlArg?.type === "Literal" && typeof urlArg.value === "string"
+          isNodeOfType(urlArg, "Literal") && typeof urlArg.value === "string"
             ? `"${urlArg.value}"`
             : "url";
         context.report({

--- a/packages/react-doctor/src/plugin/rules/server/server-hoist-static-io.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-hoist-static-io.ts
@@ -3,6 +3,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const ROUTE_HANDLER_HTTP_METHODS = new Set([
   "GET",
@@ -27,32 +28,32 @@ const STATIC_IO_FUNCTIONS = new Set([
 
 const isStaticIoCall = (call: EsTreeNode): boolean => {
   // fs.readFileSync(...) / fsPromises.readFile(...) / fs.promises.readFile(...).
-  if (call.type !== "CallExpression") return false;
+  if (!isNodeOfType(call, "CallExpression")) return false;
   const callee = call.callee;
-  if (callee?.type === "Identifier" && STATIC_IO_FUNCTIONS.has(callee.name)) {
+  if (isNodeOfType(callee, "Identifier") && STATIC_IO_FUNCTIONS.has(callee.name)) {
     return true;
   }
-  if (callee?.type !== "MemberExpression") return false;
-  const propertyName = callee.property?.type === "Identifier" ? callee.property.name : null;
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const propertyName = isNodeOfType(callee.property, "Identifier") ? callee.property.name : null;
   if (!propertyName || !STATIC_IO_FUNCTIONS.has(propertyName)) return false;
   return true;
 };
 
 const isFetchOfImportMetaUrl = (call: EsTreeNode): boolean => {
   // fetch(new URL("./fonts/Inter.ttf", import.meta.url))
-  if (call.type !== "CallExpression") return false;
-  if (call.callee?.type !== "Identifier" || call.callee.name !== "fetch") return false;
+  if (!isNodeOfType(call, "CallExpression")) return false;
+  if (!isNodeOfType(call.callee, "Identifier") || call.callee.name !== "fetch") return false;
   const arg = call.arguments?.[0];
   if (!arg) return false;
-  if (arg.type !== "NewExpression") return false;
-  if (arg.callee?.type !== "Identifier" || arg.callee.name !== "URL") return false;
+  if (!isNodeOfType(arg, "NewExpression")) return false;
+  if (!isNodeOfType(arg.callee, "Identifier") || arg.callee.name !== "URL") return false;
   const secondArg = arg.arguments?.[1];
   if (!secondArg) return false;
   // Match `import.meta.url` — MemberExpression on MetaProperty.
   return (
-    secondArg.type === "MemberExpression" &&
-    secondArg.object?.type === "MetaProperty" &&
-    secondArg.property?.type === "Identifier" &&
+    isNodeOfType(secondArg, "MemberExpression") &&
+    isNodeOfType(secondArg.object, "MetaProperty") &&
+    isNodeOfType(secondArg.property, "Identifier") &&
     secondArg.property.name === "url"
   );
 };
@@ -62,7 +63,7 @@ const callReadsHandlerArgs = (call: EsTreeNode, handlerParamNames: Set<string>):
   let referencesArg = false;
   walkAst(call, (child: EsTreeNode) => {
     if (referencesArg) return;
-    if (child.type === "Identifier" && handlerParamNames.has(child.name)) {
+    if (isNodeOfType(child, "Identifier") && handlerParamNames.has(child.name)) {
       referencesArg = true;
     }
   });
@@ -82,7 +83,7 @@ const inspectHandlerBody = (
     if (isStaticIoCall(child)) staticCall = child;
     else if (isFetchOfImportMetaUrl(child)) staticCall = child;
     else if (
-      child.type === "AwaitExpression" &&
+      isNodeOfType(child, "AwaitExpression") &&
       child.argument &&
       (isStaticIoCall(child.argument) || isFetchOfImportMetaUrl(child.argument))
     ) {
@@ -92,12 +93,14 @@ const inspectHandlerBody = (
     if (callReadsHandlerArgs(staticCall, handlerParamNames)) return;
 
     const calleeText =
-      staticCall.callee?.type === "MemberExpression" &&
-      staticCall.callee.property?.type === "Identifier"
+      isNodeOfType(staticCall.callee, "MemberExpression") &&
+      isNodeOfType(staticCall.callee.property, "Identifier")
         ? `${
-            staticCall.callee.object?.type === "Identifier" ? staticCall.callee.object.name : "?"
+            isNodeOfType(staticCall.callee.object, "Identifier")
+              ? staticCall.callee.object.name
+              : "?"
           }.${staticCall.callee.property.name}`
-        : staticCall.callee?.type === "Identifier"
+        : isNodeOfType(staticCall.callee, "Identifier")
           ? staticCall.callee.name
           : "io";
     context.report({
@@ -110,7 +113,7 @@ const inspectHandlerBody = (
 const collectIdentifierParams = (params: EsTreeNode[]): Set<string> => {
   const names = new Set<string>();
   for (const param of params) {
-    if (param.type === "Identifier") names.add(param.name);
+    if (isNodeOfType(param, "Identifier")) names.add(param.name);
   }
   return names;
 };
@@ -127,10 +130,10 @@ export const serverHoistStaticIo = defineRule<Rule>({
   create: (context: RuleContext) => ({
     ExportNamedDeclaration(node: EsTreeNode) {
       const declaration = node.declaration;
-      if (declaration?.type !== "FunctionDeclaration") return;
+      if (!isNodeOfType(declaration, "FunctionDeclaration")) return;
       const handlerName = declaration.id?.name;
       if (!handlerName || !ROUTE_HANDLER_HTTP_METHODS.has(handlerName)) return;
-      if (declaration.body?.type !== "BlockStatement") return;
+      if (!isNodeOfType(declaration.body, "BlockStatement")) return;
       inspectHandlerBody(
         context,
         declaration.body,
@@ -144,15 +147,15 @@ export const serverHoistStaticIo = defineRule<Rule>({
       const declaration = node.declaration;
       if (
         !declaration ||
-        (declaration.type !== "FunctionDeclaration" &&
-          declaration.type !== "FunctionExpression" &&
-          declaration.type !== "ArrowFunctionExpression")
+        (!isNodeOfType(declaration, "FunctionDeclaration") &&
+          !isNodeOfType(declaration, "FunctionExpression") &&
+          !isNodeOfType(declaration, "ArrowFunctionExpression"))
       ) {
         return;
       }
       if (!declaration.async) return;
       const body = declaration.body;
-      if (body?.type !== "BlockStatement") return;
+      if (!isNodeOfType(body, "BlockStatement")) return;
       inspectHandlerBody(
         context,
         body,

--- a/packages/react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
@@ -3,16 +3,17 @@ import { hasDirective } from "../../utils/has-directive.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const MUTABLE_CONTAINER_CONSTRUCTORS = new Set(["Map", "Set", "WeakMap", "WeakSet"]);
 
 const isMutableConstInitializer = (init: EsTreeNode | null | undefined): string | null => {
   if (!init) return null;
-  if (init.type === "ArrayExpression") return "[]";
-  if (init.type === "ObjectExpression") return "{}";
+  if (isNodeOfType(init, "ArrayExpression")) return "[]";
+  if (isNodeOfType(init, "ObjectExpression")) return "{}";
   if (
-    init.type === "NewExpression" &&
-    init.callee?.type === "Identifier" &&
+    isNodeOfType(init, "NewExpression") &&
+    isNodeOfType(init.callee, "Identifier") &&
     MUTABLE_CONTAINER_CONSTRUCTORS.has(init.callee.name)
   ) {
     return `new ${init.callee.name}()`;
@@ -38,11 +39,12 @@ export const serverNoMutableModuleState = defineRule<Rule>({
       },
       VariableDeclaration(node: EsTreeNode) {
         if (!fileHasUseServerDirective) return;
-        if (node.parent?.type !== "Program") return;
+        if (!isNodeOfType(node.parent, "Program")) return;
 
         for (const declarator of node.declarations ?? []) {
-          const variableName =
-            declarator.id?.type === "Identifier" ? declarator.id.name : "<unnamed>";
+          const variableName = isNodeOfType(declarator.id, "Identifier")
+            ? declarator.id.name
+            : "<unnamed>";
 
           if (node.kind === "let" || node.kind === "var") {
             context.report({

--- a/packages/react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
@@ -3,6 +3,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: in async route handlers and Server Components, two consecutive
 // `await fetch()` (or any awaited calls) where the second one doesn't
@@ -18,19 +19,22 @@ import type { RuleContext } from "../../utils/rule-context.js";
 const collectDeclaredNames = (declaration: EsTreeNode): Set<string> => {
   const names = new Set<string>();
   for (const declarator of declaration.declarations ?? []) {
-    if (declarator.id?.type === "Identifier") {
+    if (isNodeOfType(declarator.id, "Identifier")) {
       names.add(declarator.id.name);
-    } else if (declarator.id?.type === "ObjectPattern") {
+    } else if (isNodeOfType(declarator.id, "ObjectPattern")) {
       for (const property of declarator.id.properties ?? []) {
-        if (property.type === "Property" && property.value?.type === "Identifier") {
+        if (isNodeOfType(property, "Property") && isNodeOfType(property.value, "Identifier")) {
           names.add(property.value.name);
-        } else if (property.type === "RestElement" && property.argument?.type === "Identifier") {
+        } else if (
+          isNodeOfType(property, "RestElement") &&
+          isNodeOfType(property.argument, "Identifier")
+        ) {
           names.add(property.argument.name);
         }
       }
-    } else if (declarator.id?.type === "ArrayPattern") {
+    } else if (isNodeOfType(declarator.id, "ArrayPattern")) {
       for (const element of declarator.id.elements ?? []) {
-        if (element?.type === "Identifier") names.add(element.name);
+        if (isNodeOfType(element, "Identifier")) names.add(element.name);
       }
     }
   }
@@ -39,7 +43,7 @@ const collectDeclaredNames = (declaration: EsTreeNode): Set<string> => {
 
 const declarationStartsWithAwait = (declaration: EsTreeNode): boolean => {
   for (const declarator of declaration.declarations ?? []) {
-    if (declarator.init?.type === "AwaitExpression") return true;
+    if (isNodeOfType(declarator.init, "AwaitExpression")) return true;
   }
   return false;
 };
@@ -49,7 +53,7 @@ const declarationReadsAnyName = (declaration: EsTreeNode, names: Set<string>): b
   let didRead = false;
   walkAst(declaration, (child: EsTreeNode) => {
     if (didRead) return;
-    if (child.type === "Identifier" && names.has(child.name)) didRead = true;
+    if (isNodeOfType(child, "Identifier") && names.has(child.name)) didRead = true;
   });
   return didRead;
 };
@@ -61,12 +65,12 @@ export const serverSequentialIndependentAwait = defineRule<Rule>({
     const inspectStatements = (statements: EsTreeNode[]): void => {
       for (let statementIndex = 0; statementIndex < statements.length - 1; statementIndex++) {
         const currentStatement = statements[statementIndex];
-        if (currentStatement.type !== "VariableDeclaration") continue;
+        if (!isNodeOfType(currentStatement, "VariableDeclaration")) continue;
         if (!declarationStartsWithAwait(currentStatement)) continue;
         const declaredNames = collectDeclaredNames(currentStatement);
 
         const nextStatement = statements[statementIndex + 1];
-        if (nextStatement.type !== "VariableDeclaration") continue;
+        if (!isNodeOfType(nextStatement, "VariableDeclaration")) continue;
         if (!declarationStartsWithAwait(nextStatement)) continue;
 
         if (declarationReadsAnyName(nextStatement, declaredNames)) continue;
@@ -83,7 +87,7 @@ export const serverSequentialIndependentAwait = defineRule<Rule>({
 
     const visitFunctionBody = (node: EsTreeNode): void => {
       if (!node.async) return;
-      if (node.body?.type !== "BlockStatement") return;
+      if (!isNodeOfType(node.body, "BlockStatement")) return;
       inspectStatements(node.body.body ?? []);
     };
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
@@ -6,6 +6,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: `useEffect(() => { window.addEventListener(name, handler);
 // return () => window.removeEventListener(name, handler); }, [handler])`
@@ -35,11 +36,11 @@ export const advancedEventHandlerRefs = defineRule<Rule>({
       const callback = getEffectCallback(node);
       if (!callback) return;
       const depsNode = node.arguments[1];
-      if (depsNode.type !== "ArrayExpression" || !depsNode.elements?.length) return;
+      if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 
       const depIdentifierNames = new Set<string>();
       for (const element of depsNode.elements) {
-        if (element?.type === "Identifier") depIdentifierNames.add(element.name);
+        if (isNodeOfType(element, "Identifier")) depIdentifierNames.add(element.name);
       }
       if (depIdentifierNames.size === 0) return;
 
@@ -48,12 +49,12 @@ export const advancedEventHandlerRefs = defineRule<Rule>({
       let registeredHandlerName: string | null = null;
       walkAst(callback.body, (child: EsTreeNode) => {
         if (registeredHandlerName) return;
-        if (child.type !== "CallExpression") return;
-        if (child.callee?.type !== "MemberExpression") return;
-        if (child.callee.property?.type !== "Identifier") return;
+        if (!isNodeOfType(child, "CallExpression")) return;
+        if (!isNodeOfType(child.callee, "MemberExpression")) return;
+        if (!isNodeOfType(child.callee.property, "Identifier")) return;
         if (!SUBSCRIPTION_METHOD_NAMES.has(child.callee.property.name)) return;
         const handlerArg = child.arguments?.[1];
-        if (handlerArg?.type !== "Identifier") return;
+        if (!isNodeOfType(handlerArg, "Identifier")) return;
         if (depIdentifierNames.has(handlerArg.name)) {
           registeredHandlerName = handlerArg.name;
         }

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -13,6 +13,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isSubscribeLikeCallExpression } from "./utils/is-subscribe-like-call-expression.js";
 import { isCleanupReturn } from "./utils/is-cleanup-return.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: From "Lifecycle of Reactive Effects":
 //
@@ -48,20 +49,20 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
   // got counted as a usage. Detect and skip the cleanup ReturnStatement's
   // argument body during the walk.
   let cleanupArgument: EsTreeNode | null = null;
-  if (callback.body?.type === "BlockStatement") {
+  if (isNodeOfType(callback.body, "BlockStatement")) {
     const callbackStatements = callback.body.body ?? [];
     const lastCallbackStatement = callbackStatements[callbackStatements.length - 1];
-    if (lastCallbackStatement?.type === "ReturnStatement" && lastCallbackStatement.argument) {
+    if (isNodeOfType(lastCallbackStatement, "ReturnStatement") && lastCallbackStatement.argument) {
       cleanupArgument = lastCallbackStatement.argument;
     }
   }
 
   walkAst(callback, (child: EsTreeNode) => {
     if (child === cleanupArgument) return false;
-    if (child.type !== "CallExpression") return;
+    if (!isNodeOfType(child, "CallExpression")) return;
 
     if (
-      child.callee?.type === "Identifier" &&
+      isNodeOfType(child.callee, "Identifier") &&
       TIMER_CALLEE_NAMES_REQUIRING_CLEANUP.has(child.callee.name)
     ) {
       usages.push({
@@ -72,8 +73,8 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
     }
 
     if (
-      child.callee?.type === "MemberExpression" &&
-      child.callee.property?.type === "Identifier" &&
+      isNodeOfType(child.callee, "MemberExpression") &&
+      isNodeOfType(child.callee.property, "Identifier") &&
       SUBSCRIPTION_METHOD_NAMES.has(child.callee.property.name)
     ) {
       usages.push({
@@ -93,19 +94,19 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
 // previous "any Identifier is fine" behavior.
 const collectReleasableBindingNames = (effectCallback: EsTreeNode): Set<string> => {
   const releasableNames = new Set<string>();
-  if (effectCallback.body?.type !== "BlockStatement") return releasableNames;
+  if (!isNodeOfType(effectCallback.body, "BlockStatement")) return releasableNames;
   for (const statement of effectCallback.body.body ?? []) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
-      if (declarator.id?.type !== "Identifier") continue;
+      if (!isNodeOfType(declarator.id, "Identifier")) continue;
       const init = declarator.init;
-      if (!init || init.type !== "CallExpression") continue;
+      if (!init || !isNodeOfType(init, "CallExpression")) continue;
       if (isSubscribeLikeCallExpression(init)) {
         releasableNames.add(declarator.id.name);
         continue;
       }
       if (
-        init.callee?.type === "Identifier" &&
+        isNodeOfType(init.callee, "Identifier") &&
         TIMER_CALLEE_NAMES_REQUIRING_CLEANUP.has(init.callee.name)
       ) {
         releasableNames.add(declarator.id.name);
@@ -126,7 +127,7 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   // For subscribe-shaped calls we know the return value is the
   // unsubscribe — accept this case before the BlockStatement-only
   // checks below.
-  if (callback.body?.type !== "BlockStatement") {
+  if (!isNodeOfType(callback.body, "BlockStatement")) {
     return isSubscribeLikeCallExpression(callback.body);
   }
   const knownBoundReleaseNames = collectReleasableBindingNames(callback);
@@ -150,7 +151,7 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   let didFindCleanupReturn = false;
   walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
     if (didFindCleanupReturn) return;
-    if (child.type !== "ReturnStatement") return;
+    if (!isNodeOfType(child, "ReturnStatement")) return;
     if (isCleanupReturn(child.argument, knownBoundReleaseNames)) {
       didFindCleanupReturn = true;
     }

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
@@ -14,6 +14,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: AST-aware walker for "what reactive values does this expression
 // actually READ?". The plain `walkAst` adds every Identifier it sees,
@@ -29,8 +30,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 // derivation" branch could fire.
 const collectValueIdentifierNames = (node: EsTreeNode | null | undefined, into: string[]): void => {
   if (!node || typeof node !== "object") return;
-  if (node.type === "CallExpression") {
-    if (node.callee?.type === "MemberExpression") {
+  if (isNodeOfType(node, "CallExpression")) {
+    if (isNodeOfType(node.callee, "MemberExpression")) {
       // For `state.method(arg)`, `state` is a reactive read; `method`
       // is not. Skip the callee chain entirely when its root is a
       // built-in global (`Math.floor`, `JSON.parse`, ...) — those
@@ -45,7 +46,7 @@ const collectValueIdentifierNames = (node: EsTreeNode | null | undefined, into: 
     }
     return;
   }
-  if (node.type === "MemberExpression") {
+  if (isNodeOfType(node, "MemberExpression")) {
     const rootName = getRootIdentifierName(node);
     if (!rootName || !BUILTIN_GLOBAL_NAMESPACE_NAMES.has(rootName)) {
       collectValueIdentifierNames(node.object, into);
@@ -53,7 +54,7 @@ const collectValueIdentifierNames = (node: EsTreeNode | null | undefined, into: 
     if (node.computed) collectValueIdentifierNames(node.property, into);
     return;
   }
-  if (node.type === "Identifier") {
+  if (isNodeOfType(node, "Identifier")) {
     into.push(node.name);
     return;
   }
@@ -83,20 +84,19 @@ export const noDerivedStateEffect = defineRule<Rule>({
       if (!callback) return;
 
       const depsNode = node.arguments[1];
-      if (depsNode.type !== "ArrayExpression" || !depsNode.elements?.length) return;
+      if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 
-      const dependencyNames = new Set(
-        depsNode.elements
-          .filter((element: EsTreeNode) => element?.type === "Identifier")
-          .map((element: EsTreeNode) => element.name),
-      );
+      const dependencyNames = new Set<string>();
+      for (const element of depsNode.elements ?? []) {
+        if (isNodeOfType(element, "Identifier")) dependencyNames.add(element.name);
+      }
       if (dependencyNames.size === 0) return;
 
       const statements = getCallbackStatements(callback);
       if (statements.length === 0) return;
 
       const containsOnlySetStateCalls = statements.every((statement: EsTreeNode) => {
-        if (statement.type !== "ExpressionStatement") return false;
+        if (!isNodeOfType(statement, "ExpressionStatement")) return false;
         return isSetterCall(statement.expression);
       });
       if (!containsOnlySetStateCalls) return;
@@ -119,8 +119,8 @@ export const noDerivedStateEffect = defineRule<Rule>({
         collectValueIdentifierNames(setStateArguments[0], valueIdentifierNames);
 
         walkAst(setStateArguments[0], (child: EsTreeNode) => {
-          if (child.type !== "CallExpression") return;
-          if (child.callee?.type === "MemberExpression") {
+          if (!isNodeOfType(child, "CallExpression")) return;
+          if (isNodeOfType(child.callee, "MemberExpression")) {
             // `Math.floor(x)` / `Date.now()` are trivial regardless
             // of the property — gate on the chain root, not the
             // method name (which would never match TRIVIAL_*).
@@ -129,7 +129,7 @@ export const noDerivedStateEffect = defineRule<Rule>({
             hasExpensiveDerivation = true;
             return;
           }
-          if (child.callee?.type === "Identifier") {
+          if (isNodeOfType(child.callee, "Identifier")) {
             const calleeName = child.callee.name;
             if (
               !TRIVIAL_DERIVATION_CALLEE_NAMES.has(calleeName) &&

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -5,6 +5,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noDerivedUseState = defineRule<Rule>({
   recommendation:
@@ -18,7 +19,10 @@ export const noDerivedUseState = defineRule<Rule>({
         if (!isHookCall(node, "useState") || !node.arguments?.length) return;
         const initializer = node.arguments[0];
 
-        if (initializer.type === "Identifier" && propStackTracker.isPropName(initializer.name)) {
+        if (
+          isNodeOfType(initializer, "Identifier") &&
+          propStackTracker.isPropName(initializer.name)
+        ) {
           context.report({
             node,
             message: `useState initialized from prop "${initializer.name}" — if this value should stay in sync with the prop, derive it during render instead`,
@@ -26,7 +30,7 @@ export const noDerivedUseState = defineRule<Rule>({
           return;
         }
 
-        if (initializer.type === "MemberExpression" && !initializer.computed) {
+        if (isNodeOfType(initializer, "MemberExpression") && !initializer.computed) {
           const rootIdentifierName = getRootIdentifierName(initializer);
           if (rootIdentifierName && propStackTracker.isPropName(rootIdentifierName)) {
             context.report({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
@@ -8,6 +8,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: walks the component AST while tracking which state names are
 // SHADOWED in the current scope by a nested function's params or
@@ -22,9 +23,9 @@ const collectFunctionLocalBindings = (functionNode: EsTreeNode): Set<string> => 
   for (const param of functionNode.params ?? []) {
     collectPatternNames(param, localBindings);
   }
-  if (functionNode.body?.type === "BlockStatement") {
+  if (isNodeOfType(functionNode.body, "BlockStatement")) {
     for (const statement of functionNode.body.body ?? []) {
-      if (statement.type !== "VariableDeclaration") continue;
+      if (!isNodeOfType(statement, "VariableDeclaration")) continue;
       for (const declarator of statement.declarations ?? []) {
         collectPatternNames(declarator.id, localBindings);
       }
@@ -34,9 +35,9 @@ const collectFunctionLocalBindings = (functionNode: EsTreeNode): Set<string> => 
 };
 
 const isFunctionLikeNode = (node: EsTreeNode): boolean =>
-  node.type === "FunctionDeclaration" ||
-  node.type === "FunctionExpression" ||
-  node.type === "ArrowFunctionExpression";
+  isNodeOfType(node, "FunctionDeclaration") ||
+  isNodeOfType(node, "FunctionExpression") ||
+  isNodeOfType(node, "ArrowFunctionExpression");
 
 const walkComponentRespectingShadows = (
   node: EsTreeNode,
@@ -77,7 +78,7 @@ export const noDirectStateMutation = defineRule<Rule>({
     "Replace the mutation with a setter call that produces a new reference: `setItems([...items, newItem])`, `setItems(items.filter(x => x !== target))`, `setItems(items.toSorted(...))`. React only re-renders on a new reference, so in-place updates are silently dropped",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const bindings = collectUseStateBindings(componentBody);
       if (bindings.length === 0) return;
 
@@ -89,8 +90,8 @@ export const noDirectStateMutation = defineRule<Rule>({
         componentBody,
         new Set(),
         (child: EsTreeNode, currentlyShadowed: ReadonlySet<string>) => {
-          if (child.type === "AssignmentExpression") {
-            if (child.left?.type !== "MemberExpression") return;
+          if (isNodeOfType(child, "AssignmentExpression")) {
+            if (!isNodeOfType(child.left, "MemberExpression")) return;
             const rootName = getRootIdentifierName(child.left);
             if (!rootName || !stateValueToSetter.has(rootName)) return;
             if (currentlyShadowed.has(rootName)) return;
@@ -102,10 +103,10 @@ export const noDirectStateMutation = defineRule<Rule>({
             return;
           }
 
-          if (child.type === "CallExpression") {
+          if (isNodeOfType(child, "CallExpression")) {
             const callee = child.callee;
-            if (callee?.type !== "MemberExpression") return;
-            if (callee.property?.type !== "Identifier") return;
+            if (!isNodeOfType(callee, "MemberExpression")) return;
+            if (!isNodeOfType(callee.property, "Identifier")) return;
             const methodName = callee.property.name;
             if (!MUTATING_ARRAY_METHODS.has(methodName)) return;
             const rootName = getRootIdentifierName(callee.object);

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -18,6 +18,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: §7 of "You Might Not Need an Effect" — chains of computations:
 //
@@ -52,11 +53,11 @@ import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 // contain `fetch`, so the rule won't fire.
 const findTopLevelEffectCalls = (componentBody: EsTreeNode): EsTreeNode[] => {
   const effectCalls: EsTreeNode[] = [];
-  if (componentBody?.type !== "BlockStatement") return effectCalls;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return effectCalls;
   for (const statement of componentBody.body ?? []) {
-    if (statement.type !== "ExpressionStatement") continue;
+    if (!isNodeOfType(statement, "ExpressionStatement")) continue;
     const expression = statement.expression;
-    if (expression?.type !== "CallExpression") continue;
+    if (!isNodeOfType(expression, "CallExpression")) continue;
     if (!isHookCall(expression, EFFECT_HOOK_NAMES)) continue;
     effectCalls.push(expression);
   }
@@ -66,9 +67,9 @@ const findTopLevelEffectCalls = (componentBody: EsTreeNode): EsTreeNode[] => {
 const collectDepIdentifierNames = (effectNode: EsTreeNode): Set<string> => {
   const depNames = new Set<string>();
   const depsNode = effectNode.arguments?.[1];
-  if (depsNode?.type !== "ArrayExpression") return depNames;
+  if (!isNodeOfType(depsNode, "ArrayExpression")) return depNames;
   for (const element of depsNode.elements ?? []) {
-    if (element?.type === "Identifier") depNames.add(element.name);
+    if (isNodeOfType(element, "Identifier")) depNames.add(element.name);
   }
   return depNames;
 };
@@ -86,8 +87,8 @@ const collectWrittenStateNamesInEffect = (
 ): Set<string> => {
   const writtenStateNames = new Set<string>();
   walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
-    if (child.type !== "CallExpression") return;
-    if (child.callee?.type !== "Identifier") return;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (!isNodeOfType(child.callee, "Identifier")) return;
     const stateName = setterToStateName.get(child.callee.name);
     if (stateName) writtenStateNames.add(stateName);
   });
@@ -103,20 +104,20 @@ const collectWrittenStateNamesInEffect = (
 // disable chain detection.
 const isFunctionShapedReturn = (returnedValue: EsTreeNode): boolean => {
   if (
-    returnedValue.type === "ArrowFunctionExpression" ||
-    returnedValue.type === "FunctionExpression"
+    isNodeOfType(returnedValue, "ArrowFunctionExpression") ||
+    isNodeOfType(returnedValue, "FunctionExpression")
   ) {
     return true;
   }
   // Returning a CallExpression result — most cleanup-returning
   // primitives (subscribe, addEventListener helpers) return a
   // function. Conservatively accept this shape.
-  if (returnedValue.type === "CallExpression") return true;
+  if (isNodeOfType(returnedValue, "CallExpression")) return true;
   // Returning a bare Identifier — could be the unsub binding from a
   // `const unsub = subscribe(...)` line. We can't statically prove
   // it's function-typed without scope analysis, but in idiomatic React
   // this is the dominant cleanup pattern. Accept.
-  if (returnedValue.type === "Identifier") return true;
+  if (isNodeOfType(returnedValue, "Identifier")) return true;
   return false;
 };
 
@@ -124,11 +125,11 @@ const isExternalSyncEffect = (effectCallback: EsTreeNode): boolean => {
   // A cleanup return is the strongest signal that the effect owns
   // an external resource — once we see one, we don't need to inspect
   // the body for an external-sync call shape.
-  if (effectCallback.body?.type === "BlockStatement") {
+  if (isNodeOfType(effectCallback.body, "BlockStatement")) {
     const statements = effectCallback.body.body ?? [];
     for (const statement of statements) {
       if (
-        statement.type === "ReturnStatement" &&
+        isNodeOfType(statement, "ReturnStatement") &&
         statement.argument &&
         isFunctionShapedReturn(statement.argument)
       ) {
@@ -141,10 +142,10 @@ const isExternalSyncEffect = (effectCallback: EsTreeNode): boolean => {
   walkAst(effectCallback, (child: EsTreeNode) => {
     if (didFindExternalCall) return false;
 
-    if (child.type === "NewExpression") {
+    if (isNodeOfType(child, "NewExpression")) {
       const constructor = child.callee;
       if (
-        constructor?.type === "Identifier" &&
+        isNodeOfType(constructor, "Identifier") &&
         EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(constructor.name)
       ) {
         didFindExternalCall = true;
@@ -152,10 +153,10 @@ const isExternalSyncEffect = (effectCallback: EsTreeNode): boolean => {
       return;
     }
 
-    if (child.type === "AssignmentExpression") {
+    if (isNodeOfType(child, "AssignmentExpression")) {
       if (
-        child.left?.type === "MemberExpression" &&
-        child.left.property?.type === "Identifier" &&
+        isNodeOfType(child.left, "MemberExpression") &&
+        isNodeOfType(child.left.property, "Identifier") &&
         child.left.property.name === "current"
       ) {
         didFindExternalCall = true;
@@ -163,17 +164,20 @@ const isExternalSyncEffect = (effectCallback: EsTreeNode): boolean => {
       return;
     }
 
-    if (child.type !== "CallExpression") return;
+    if (!isNodeOfType(child, "CallExpression")) return;
 
     if (
-      child.callee?.type === "Identifier" &&
+      isNodeOfType(child.callee, "Identifier") &&
       EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(child.callee.name)
     ) {
       didFindExternalCall = true;
       return;
     }
 
-    if (child.callee?.type === "MemberExpression" && child.callee.property?.type === "Identifier") {
+    if (
+      isNodeOfType(child.callee, "MemberExpression") &&
+      isNodeOfType(child.callee.property, "Identifier")
+    ) {
       const propertyName = child.callee.property.name;
       if (EXTERNAL_SYNC_MEMBER_METHOD_NAMES.has(propertyName)) {
         didFindExternalCall = true;
@@ -210,7 +214,7 @@ export const noEffectChain = defineRule<Rule>({
     "Compute as much as possible during render (e.g. `const isGameOver = round > 5`) and write all related state inside the event handler that originally fires the chain. Each effect link adds an extra render and makes the code rigid as requirements evolve",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
 
       const useStateBindings = collectUseStateBindings(componentBody);
       if (useStateBindings.length === 0) return;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -7,6 +7,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noEffectEventHandler = defineRule<Rule>({
   recommendation:
@@ -19,19 +20,18 @@ export const noEffectEventHandler = defineRule<Rule>({
       if (!callback) return;
 
       const depsNode = node.arguments[1];
-      if (depsNode.type !== "ArrayExpression" || !depsNode.elements?.length) return;
+      if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 
-      const dependencyNames = new Set(
-        depsNode.elements
-          .filter((element: EsTreeNode) => element?.type === "Identifier")
-          .map((element: EsTreeNode) => element.name),
-      );
+      const dependencyNames = new Set<string>();
+      for (const element of depsNode.elements ?? []) {
+        if (isNodeOfType(element, "Identifier")) dependencyNames.add(element.name);
+      }
 
       const statements = getCallbackStatements(callback);
       if (statements.length !== 1) return;
 
       const soleStatement = statements[0];
-      if (soleStatement.type !== "IfStatement") return;
+      if (!isNodeOfType(soleStatement, "IfStatement")) return;
 
       // HACK: §5 of "You Might Not Need an Effect" uses
       // `if (product.isInCart)` — a MemberExpression, not a bare

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
@@ -5,6 +5,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: useEffectEvent's identity is intentionally unstable — it captures
 // the latest props/state on each call. Listing it in a useEffect/useMemo/
@@ -21,9 +22,9 @@ export const noEffectEventInDeps = defineRule<Rule>({
   create: (context: RuleContext) => {
     const componentBindings = createComponentBindingStackTracker({
       onVariableDeclarator: (declaratorNode: EsTreeNode) => {
-        if (declaratorNode.id?.type !== "Identifier") return;
+        if (!isNodeOfType(declaratorNode.id, "Identifier")) return;
         const initializer = declaratorNode.init;
-        if (!initializer || initializer.type !== "CallExpression") return;
+        if (!initializer || !isNodeOfType(initializer, "CallExpression")) return;
         if (!isHookCall(initializer, "useEffectEvent")) return;
         componentBindings.addBindingToCurrentFrame(declaratorNode.id.name);
       },
@@ -35,10 +36,10 @@ export const noEffectEventInDeps = defineRule<Rule>({
         if (!isHookCall(node, HOOKS_WITH_DEPS) || node.arguments.length < 2) return;
         if (!componentBindings.isInsideComponent()) return;
         const depsNode = node.arguments[1];
-        if (depsNode.type !== "ArrayExpression") return;
+        if (!isNodeOfType(depsNode, "ArrayExpression")) return;
 
         for (const element of depsNode.elements ?? []) {
-          if (element?.type !== "Identifier") continue;
+          if (!isNodeOfType(element, "Identifier")) continue;
           if (componentBindings.isBoundName(element.name)) {
             context.report({
               node: element,

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
@@ -23,6 +23,7 @@ import { collectRenderReachableNames } from "./utils/collect-render-reachable-na
 import { expandTransitiveDependencies } from "./utils/expand-transitive-dependencies.js";
 import { collectHandlerBindingNames } from "./utils/collect-handler-binding-names.js";
 import { isInsideEventHandler } from "./utils/is-inside-event-handler.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: §6 of "You Might Not Need an Effect" — sending a POST request:
 //
@@ -65,28 +66,28 @@ import { isInsideEventHandler } from "./utils/is-inside-event-handler.js";
 const SENTINEL_IDENTIFIER_NAMES = new Set(["undefined", "NaN", "null"]);
 
 const isSentinelIdentifier = (node: EsTreeNode): boolean =>
-  node?.type === "Identifier" && SENTINEL_IDENTIFIER_NAMES.has(node.name);
+  isNodeOfType(node, "Identifier") && SENTINEL_IDENTIFIER_NAMES.has(node.name);
 
 const getTriggerGuardRootName = (testNode: EsTreeNode): string | null => {
   if (!testNode) return null;
-  if (testNode.type === "Identifier") return testNode.name;
-  if (testNode.type === "BinaryExpression") {
+  if (isNodeOfType(testNode, "Identifier")) return testNode.name;
+  if (isNodeOfType(testNode, "BinaryExpression")) {
     if (!["!==", "===", "!=", "=="].includes(testNode.operator)) return null;
     for (const side of [testNode.left, testNode.right]) {
-      if (side?.type === "Identifier" && !isSentinelIdentifier(side)) {
+      if (isNodeOfType(side, "Identifier") && !isSentinelIdentifier(side)) {
         return side.name;
       }
     }
     return null;
   }
   if (
-    testNode.type === "MemberExpression" &&
-    testNode.property?.type === "Identifier" &&
+    isNodeOfType(testNode, "MemberExpression") &&
+    isNodeOfType(testNode.property, "Identifier") &&
     testNode.property.name === "length"
   ) {
-    if (testNode.object?.type === "Identifier") return testNode.object.name;
+    if (isNodeOfType(testNode.object, "Identifier")) return testNode.object.name;
   }
-  if (testNode.type === "UnaryExpression" && testNode.operator === "!") {
+  if (isNodeOfType(testNode, "UnaryExpression") && testNode.operator === "!") {
     return getTriggerGuardRootName(testNode.argument);
   }
   return null;
@@ -96,13 +97,16 @@ const findTriggeredSideEffectCalleeName = (consequentNode: EsTreeNode): string |
   let foundCalleeName: string | null = null;
   walkAst(consequentNode, (child: EsTreeNode) => {
     if (foundCalleeName) return false;
-    if (child.type !== "CallExpression") return;
+    if (!isNodeOfType(child, "CallExpression")) return;
     const callee = child.callee;
-    if (callee?.type === "Identifier" && EVENT_TRIGGERED_SIDE_EFFECT_CALLEES.has(callee.name)) {
+    if (
+      isNodeOfType(callee, "Identifier") &&
+      EVENT_TRIGGERED_SIDE_EFFECT_CALLEES.has(callee.name)
+    ) {
       foundCalleeName = callee.name;
       return;
     }
-    if (callee?.type === "MemberExpression" && callee.property?.type === "Identifier") {
+    if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
       const propertyName = callee.property.name;
       const isUnambiguousMethod = EVENT_TRIGGERED_SIDE_EFFECT_MEMBER_METHODS.has(propertyName);
       const isNavigationMethod = EVENT_TRIGGERED_NAVIGATION_METHOD_NAMES.has(propertyName);
@@ -128,8 +132,8 @@ const collectHandlerOnlyWriteStateNames = (
     let areAllSetterCallsInHandlers = true;
     walkAst(componentBody, (child: EsTreeNode) => {
       if (!areAllSetterCallsInHandlers) return false;
-      if (child.type !== "CallExpression") return;
-      if (child.callee?.type !== "Identifier") return;
+      if (!isNodeOfType(child, "CallExpression")) return;
+      if (!isNodeOfType(child.callee, "Identifier")) return;
       if (child.callee.name !== binding.setterName) return;
       didFindAnySetterCall = true;
       if (!isInsideEventHandler(child, handlerBindingNames)) {
@@ -148,7 +152,7 @@ export const noEventTriggerState = defineRule<Rule>({
     "Delete the trigger state (`useState(null)` plus the `useEffect` that watches it) and call the side-effect (`post(...)` / `navigate(...)` / `track(...)`) directly inside the event handler that previously called the setter. State should not exist purely to schedule effect runs",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
 
       const useStateBindings = collectUseStateBindings(componentBody);
       if (useStateBindings.length === 0) return;
@@ -174,16 +178,16 @@ export const noEventTriggerState = defineRule<Rule>({
       const renderReachableNames = expandTransitiveDependencies(directRenderNames, dependencyGraph);
 
       walkAst(componentBody, (effectCall: EsTreeNode) => {
-        if (effectCall.type !== "CallExpression") return;
+        if (!isNodeOfType(effectCall, "CallExpression")) return;
         if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) return;
         if ((effectCall.arguments?.length ?? 0) < 2) return;
 
         const depsNode = effectCall.arguments[1];
-        if (depsNode.type !== "ArrayExpression") return;
+        if (!isNodeOfType(depsNode, "ArrayExpression")) return;
         if ((depsNode.elements?.length ?? 0) !== 1) return;
 
         const depElement = depsNode.elements[0];
-        if (depElement?.type !== "Identifier") return;
+        if (!isNodeOfType(depElement, "Identifier")) return;
         if (!handlerOnlyWriteStateNames.has(depElement.name)) return;
         // Dual-purpose state — used in render too. Don't claim it
         // "exists only to schedule" the effect.
@@ -195,7 +199,7 @@ export const noEventTriggerState = defineRule<Rule>({
         const bodyStatements = getCallbackStatements(callback);
         if (bodyStatements.length !== 1) return;
         const soleStatement = bodyStatements[0];
-        if (soleStatement.type !== "IfStatement") return;
+        if (!isNodeOfType(soleStatement, "IfStatement")) return;
 
         const guardRootName = getTriggerGuardRootName(soleStatement.test);
         if (guardRootName !== depElement.name) return;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
@@ -10,6 +10,7 @@ import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: §1 of "You Might Not Need an Effect" — mirroring a prop into
 // local state with a useEffect that re-syncs it. The combined shape
@@ -56,28 +57,28 @@ export const noMirrorPropEffect = defineRule<Rule>({
     "Delete both the `useState` and the `useEffect` and read the prop directly during render. Mirroring a prop into local state forces a stale first render before the effect re-syncs",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const propNames = propStackTracker.getCurrentPropNames();
       if (propNames.size === 0) return;
 
       const mirrorBindings: MirrorBinding[] = [];
 
       for (const statement of componentBody.body ?? []) {
-        if (statement.type !== "VariableDeclaration") continue;
+        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
         for (const declarator of statement.declarations ?? []) {
-          if (declarator.id?.type !== "ArrayPattern") continue;
+          if (!isNodeOfType(declarator.id, "ArrayPattern")) continue;
           const elements = declarator.id.elements ?? [];
           if (elements.length < 2) continue;
           const valueElement = elements[0];
           const setterElement = elements[1];
           if (
-            valueElement?.type !== "Identifier" ||
-            setterElement?.type !== "Identifier" ||
+            !isNodeOfType(valueElement, "Identifier") ||
+            !isNodeOfType(setterElement, "Identifier") ||
             !isSetterIdentifier(setterElement.name)
           ) {
             continue;
           }
-          if (declarator.init?.type !== "CallExpression") continue;
+          if (!isNodeOfType(declarator.init, "CallExpression")) continue;
           if (!isHookCall(declarator.init, "useState")) continue;
           const initializer = declarator.init.arguments?.[0];
           if (!initializer) continue;
@@ -100,14 +101,14 @@ export const noMirrorPropEffect = defineRule<Rule>({
       // component's surface — its outer prop set wouldn't apply
       // anyway.
       for (const statement of componentBody.body ?? []) {
-        if (statement.type !== "ExpressionStatement") continue;
+        if (!isNodeOfType(statement, "ExpressionStatement")) continue;
         const effectCall = statement.expression;
-        if (effectCall?.type !== "CallExpression") continue;
+        if (!isNodeOfType(effectCall, "CallExpression")) continue;
         if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
 
         const depsNode = effectCall.arguments[1];
-        if (depsNode.type !== "ArrayExpression") continue;
+        if (!isNodeOfType(depsNode, "ArrayExpression")) continue;
         // HACK: previously required EXACTLY one dep, which silently
         // missed the legitimate `useEffect(() => setX(value), [value, otherDep])`
         // mirror shape. Now we accept any deps array as long as the
@@ -115,7 +116,7 @@ export const noMirrorPropEffect = defineRule<Rule>({
         // unused inside the body is a separate (exhaustive-deps) concern.
         const depIdentifierNames = new Set<string>();
         for (const element of depsNode.elements ?? []) {
-          if (element?.type === "Identifier") depIdentifierNames.add(element.name);
+          if (isNodeOfType(element, "Identifier")) depIdentifierNames.add(element.name);
         }
         if (depIdentifierNames.size === 0) continue;
 
@@ -124,17 +125,19 @@ export const noMirrorPropEffect = defineRule<Rule>({
         const bodyStatements = getCallbackStatements(callback);
         if (bodyStatements.length !== 1) continue;
         const onlyStatement = bodyStatements[0];
-        const expression =
-          onlyStatement.type === "ExpressionStatement" ? onlyStatement.expression : onlyStatement;
-        if (expression?.type !== "CallExpression") continue;
-        if (expression.callee?.type !== "Identifier") continue;
+        const expression = isNodeOfType(onlyStatement, "ExpressionStatement")
+          ? onlyStatement.expression
+          : onlyStatement;
+        if (!isNodeOfType(expression, "CallExpression")) continue;
+        if (!isNodeOfType(expression.callee, "Identifier")) continue;
         if (!isSetterIdentifier(expression.callee.name)) continue;
         if (!expression.arguments?.length) continue;
         const setterArgument = expression.arguments[0];
 
+        const calleeName = expression.callee.name;
         const matchedBinding = mirrorBindings.find(
           (binding) =>
-            binding.setterName === expression.callee.name &&
+            binding.setterName === calleeName &&
             depIdentifierNames.has(binding.propRootName) &&
             areExpressionsStructurallyEqual(binding.initializer, setterArgument),
         );

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
@@ -8,6 +8,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: "Lifecycle of Reactive Effects" — Can global or mutable
 // values be dependencies? — calls out that `location.pathname`,
@@ -29,12 +30,12 @@ import type { RuleContext } from "../../utils/rule-context.js";
 // mutable property reads are the bug.
 const collectUseRefBindingNames = (componentBody: EsTreeNode): Set<string> => {
   const useRefBindings = new Set<string>();
-  if (componentBody?.type !== "BlockStatement") return useRefBindings;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return useRefBindings;
   for (const statement of componentBody.body ?? []) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
-      if (declarator.id?.type !== "Identifier") continue;
-      if (declarator.init?.type !== "CallExpression") continue;
+      if (!isNodeOfType(declarator.id, "Identifier")) continue;
+      if (!isNodeOfType(declarator.init, "CallExpression")) continue;
       if (!isHookCall(declarator.init, "useRef")) continue;
       useRefBindings.add(declarator.id.name);
     }
@@ -46,13 +47,13 @@ const findMutableDepIssue = (
   depElement: EsTreeNode,
   useRefBindingNames: Set<string>,
 ): { kind: "global" | "ref-current"; rootName: string } | null => {
-  if (depElement.type !== "MemberExpression") return null;
+  if (!isNodeOfType(depElement, "MemberExpression")) return null;
 
   if (
-    depElement.property?.type === "Identifier" &&
+    isNodeOfType(depElement.property, "Identifier") &&
     depElement.property.name === "current" &&
     !depElement.computed &&
-    depElement.object?.type === "Identifier" &&
+    isNodeOfType(depElement.object, "Identifier") &&
     useRefBindingNames.has(depElement.object.name)
   ) {
     return { kind: "ref-current", rootName: depElement.object.name };
@@ -70,15 +71,15 @@ export const noMutableInDeps = defineRule<Rule>({
     "Read mutable values (`location.pathname`, `ref.current`) inside the effect body instead of in the deps array, or subscribe with `useSyncExternalStore`. Mutations to these don't trigger re-renders, so listing them in deps doesn't make the effect react to changes",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const useRefBindingNames = collectUseRefBindingNames(componentBody);
 
       walkAst(componentBody, (child: EsTreeNode) => {
-        if (child.type !== "CallExpression") return;
+        if (!isNodeOfType(child, "CallExpression")) return;
         if (!isHookCall(child, HOOKS_WITH_DEPS)) return;
         if ((child.arguments?.length ?? 0) < 2) return;
         const depsNode = child.arguments[1];
-        if (depsNode.type !== "ArrayExpression") return;
+        if (!isNodeOfType(depsNode, "ArrayExpression")) return;
 
         for (const element of depsNode.elements ?? []) {
           if (!element) continue;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
@@ -7,6 +7,7 @@ import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blo
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: `useEffect(() => parentCallback(state.x), [state.x])` is the
 // "lift state up via callback" anti-pattern: the child owns state, then
@@ -28,14 +29,14 @@ export const noPropCallbackInEffect = defineRule<Rule>({
         const callback = getEffectCallback(node);
         if (!callback) return;
         const depsNode = node.arguments[1];
-        if (depsNode.type !== "ArrayExpression" || !depsNode.elements?.length) return;
+        if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 
         // Only flag if at least one dep is a non-prop (state-shape)
         // identifier — otherwise the effect is just adapting to prop
         // changes (legit pattern).
-        const hasStateLikeDep = depsNode.elements.some(
-          (element: EsTreeNode) =>
-            element?.type === "Identifier" && !propStackTracker.isPropName(element.name),
+        const hasStateLikeDep = (depsNode.elements ?? []).some(
+          (element) =>
+            isNodeOfType(element, "Identifier") && !propStackTracker.isPropName(element.name),
         );
         if (!hasStateLikeDep) return;
 
@@ -47,8 +48,8 @@ export const noPropCallbackInEffect = defineRule<Rule>({
         // (lift state via callback).
         const reportedNodes = new Set<EsTreeNode>();
         walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
-          if (child.type !== "CallExpression") return;
-          if (child.callee?.type !== "Identifier") return;
+          if (!isNodeOfType(child, "CallExpression")) return;
+          if (!isNodeOfType(child.callee, "Identifier")) return;
           const calleeName = child.callee.name;
           if (!propStackTracker.isPropName(calleeName)) return;
           if (reportedNodes.has(child)) return;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: an UNCONDITIONAL setter call at a component's render path
 // triggers an infinite re-render loop ("Maximum update depth exceeded").
@@ -24,11 +25,11 @@ const isUnconditionalSetterCallStatement = (
   statement: EsTreeNode,
   setterNames: ReadonlySet<string>,
 ): EsTreeNode | null => {
-  if (statement.type !== "ExpressionStatement") return null;
+  if (!isNodeOfType(statement, "ExpressionStatement")) return null;
   const expression = statement.expression;
-  if (expression?.type !== "CallExpression") return null;
+  if (!isNodeOfType(expression, "CallExpression")) return null;
   const callee = expression.callee;
-  if (callee?.type !== "Identifier") return null;
+  if (!isNodeOfType(callee, "Identifier")) return null;
   if (!setterNames.has(callee.name)) return null;
   return expression;
 };
@@ -38,7 +39,7 @@ export const noSetStateInRender = defineRule<Rule>({
     "Move the setter call into a `useEffect`, an event handler, or replace the state with a value computed during render. Calling a setter at render time triggers another render, which calls the setter again — an infinite loop",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const setterNames = new Set(
         collectUseStateBindings(componentBody).map((binding) => binding.setterName),
       );

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-effect-event.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-effect-event.ts
@@ -12,6 +12,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: From "Separating Events from Effects" — when a function-typed
 // prop (or local callback) is read from an effect ONLY inside a sub-
@@ -43,12 +44,12 @@ import type { RuleContext } from "../../utils/rule-context.js";
 //   (4) `F` is NEVER read at the effect's own top level
 const collectFunctionTypedLocalBindings = (componentBody: EsTreeNode): Set<string> => {
   const functionTypedLocals = new Set<string>();
-  if (componentBody?.type !== "BlockStatement") return functionTypedLocals;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return functionTypedLocals;
   for (const statement of componentBody.body ?? []) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
-      if (declarator.id?.type !== "Identifier") continue;
-      if (declarator.init?.type !== "CallExpression") continue;
+      if (!isNodeOfType(declarator.id, "Identifier")) continue;
+      if (!isNodeOfType(declarator.init, "CallExpression")) continue;
       if (!isHookCall(declarator.init, "useCallback")) continue;
       functionTypedLocals.add(declarator.id.name);
     }
@@ -63,9 +64,9 @@ const findEnclosingFunctionInsideEffect = (
   let cursor: EsTreeNode | null = identifierNode.parent ?? null;
   while (cursor && cursor !== effectCallback) {
     if (
-      cursor.type === "ArrowFunctionExpression" ||
-      cursor.type === "FunctionExpression" ||
-      cursor.type === "FunctionDeclaration"
+      isNodeOfType(cursor, "ArrowFunctionExpression") ||
+      isNodeOfType(cursor, "FunctionExpression") ||
+      isNodeOfType(cursor, "FunctionDeclaration")
     ) {
       return cursor;
     }
@@ -75,14 +76,17 @@ const findEnclosingFunctionInsideEffect = (
 };
 
 const isCallExpressionWithSubHandlerCallee = (callExpression: EsTreeNode): boolean => {
-  if (callExpression?.type !== "CallExpression") return false;
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
   const callee = callExpression.callee;
-  if (callee?.type === "Identifier" && TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(callee.name)) {
+  if (
+    isNodeOfType(callee, "Identifier") &&
+    TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(callee.name)
+  ) {
     return true;
   }
   if (
-    callee?.type === "MemberExpression" &&
-    callee.property?.type === "Identifier" &&
+    isNodeOfType(callee, "MemberExpression") &&
+    isNodeOfType(callee.property, "Identifier") &&
     SUBSCRIPTION_METHOD_NAMES.has(callee.property.name)
   ) {
     return true;
@@ -91,10 +95,10 @@ const isCallExpressionWithSubHandlerCallee = (callExpression: EsTreeNode): boole
 };
 
 const getSubHandlerCalleeName = (callExpression: EsTreeNode): string | null => {
-  if (callExpression?.type !== "CallExpression") return null;
+  if (!isNodeOfType(callExpression, "CallExpression")) return null;
   const callee = callExpression.callee;
-  if (callee?.type === "Identifier") return callee.name;
-  if (callee?.type === "MemberExpression" && callee.property?.type === "Identifier") {
+  if (isNodeOfType(callee, "Identifier")) return callee.name;
+  if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
     return callee.property.name;
   }
   return null;
@@ -118,19 +122,22 @@ const getSubHandlerCalleeName = (callExpression: EsTreeNode): string | null => {
 //   let handler; handler = (e) => ... → AssignmentExpression binding
 const getEnclosingFunctionBindingName = (enclosingFunction: EsTreeNode): string | null => {
   if (
-    enclosingFunction.type === "FunctionDeclaration" &&
-    enclosingFunction.id?.type === "Identifier"
+    isNodeOfType(enclosingFunction, "FunctionDeclaration") &&
+    isNodeOfType(enclosingFunction.id, "Identifier")
   ) {
     return enclosingFunction.id.name;
   }
   const directParent = enclosingFunction.parent;
-  if (directParent?.type === "VariableDeclarator" && directParent.id?.type === "Identifier") {
+  if (
+    isNodeOfType(directParent, "VariableDeclarator") &&
+    isNodeOfType(directParent.id, "Identifier")
+  ) {
     return directParent.id.name;
   }
   if (
-    directParent?.type === "AssignmentExpression" &&
+    isNodeOfType(directParent, "AssignmentExpression") &&
     directParent.right === enclosingFunction &&
-    directParent.left?.type === "Identifier"
+    isNodeOfType(directParent.left, "Identifier")
   ) {
     return directParent.left.name;
   }
@@ -143,8 +150,8 @@ const findSubHandlerForEnclosingFunction = (
 ): EsTreeNode | null => {
   const directParent = enclosingFunction.parent;
   if (
-    directParent?.type === "CallExpression" &&
-    directParent.arguments?.includes(enclosingFunction) &&
+    isNodeOfType(directParent, "CallExpression") &&
+    (directParent.arguments ?? []).some((arg: EsTreeNode | null) => arg === enclosingFunction) &&
     isCallExpressionWithSubHandlerCallee(directParent)
   ) {
     return directParent;
@@ -156,10 +163,10 @@ const findSubHandlerForEnclosingFunction = (
   let matchingSubHandlerCall: EsTreeNode | null = null;
   walkAst(effectCallback, (child: EsTreeNode) => {
     if (matchingSubHandlerCall) return false;
-    if (child.type !== "CallExpression") return;
+    if (!isNodeOfType(child, "CallExpression")) return;
     if (!isCallExpressionWithSubHandlerCallee(child)) return;
     for (const argument of child.arguments ?? []) {
-      if (argument?.type === "Identifier" && argument.name === localName) {
+      if (isNodeOfType(argument, "Identifier") && argument.name === localName) {
         matchingSubHandlerCall = child;
         return false;
       }
@@ -183,15 +190,15 @@ const classifyCallableReadsInsideEffect = (
   let firstSubHandlerName: string | null = null;
 
   walkAst(effectCallback, (child: EsTreeNode) => {
-    if (child.type !== "Identifier") return;
+    if (!isNodeOfType(child, "Identifier")) return;
     if (child.name !== callableName) return;
     const parent = child.parent;
-    if (parent?.type === "ArrayExpression") return;
-    if (parent?.type === "MemberExpression" && !parent.computed && parent.property === child) {
+    if (isNodeOfType(parent, "ArrayExpression")) return;
+    if (isNodeOfType(parent, "MemberExpression") && !parent.computed && parent.property === child) {
       return;
     }
     if (
-      parent?.type === "Property" &&
+      isNodeOfType(parent, "Property") &&
       !parent.computed &&
       !parent.shorthand &&
       parent.key === child
@@ -224,21 +231,23 @@ export const preferUseEffectEvent = defineRule<Rule>({
     "Wrap the callback with `useEffectEvent(callback)` (React 19+) and call the resulting binding from inside the sub-handler. The Effect Event captures the latest props/state without being a reactive dep, so the effect doesn't re-subscribe on every parent render. See https://react.dev/reference/react/useEffectEvent",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const functionTypedLocalBindings = collectFunctionTypedLocalBindings(componentBody);
 
       for (const statement of componentBody.body ?? []) {
-        if (statement.type !== "ExpressionStatement") continue;
+        if (!isNodeOfType(statement, "ExpressionStatement")) continue;
         const effectCall = statement.expression;
-        if (effectCall?.type !== "CallExpression") continue;
+        if (!isNodeOfType(effectCall, "CallExpression")) continue;
         if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
 
         const depsNode = effectCall.arguments[1];
-        if (depsNode.type !== "ArrayExpression") continue;
+        if (!isNodeOfType(depsNode, "ArrayExpression")) continue;
         const depElements = depsNode.elements ?? [];
         if (depElements.length < 2) continue;
-        if (!depElements.every((element: EsTreeNode | null) => element?.type === "Identifier")) {
+        if (
+          !depElements.every((element: EsTreeNode | null) => isNodeOfType(element, "Identifier"))
+        ) {
           continue;
         }
 
@@ -246,7 +255,7 @@ export const preferUseEffectEvent = defineRule<Rule>({
         if (!callback) continue;
 
         for (const depElement of depElements) {
-          if (!depElement) continue;
+          if (!isNodeOfType(depElement, "Identifier")) continue;
           const depName: string = depElement.name;
           // HACK: a destructured prop is treated as function-typed
           // ONLY if its name matches the React `on[A-Z]` callback

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
@@ -6,16 +6,17 @@ import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const preferUseReducer = defineRule<Rule>({
   recommendation:
     "Group related state: `const [state, dispatch] = useReducer(reducer, { field1, field2, ... })`",
   create: (context: RuleContext) => {
     const reportExcessiveUseState = (body: EsTreeNode, componentName: string): void => {
-      if (body.type !== "BlockStatement") return;
+      if (!isNodeOfType(body, "BlockStatement")) return;
       let useStateCount = 0;
       for (const statement of body.body ?? []) {
-        if (statement.type !== "VariableDeclaration") continue;
+        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
         for (const declarator of statement.declarations ?? []) {
           if (declarator.init && isHookCall(declarator.init, "useState")) useStateCount++;
         }

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
@@ -13,6 +13,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isCleanupReturn } from "./utils/is-cleanup-return.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: §11 of "You Might Not Need an Effect" + the linked
 // `useSyncExternalStore` docs warn that pairing a `useState(getSnapshot())`
@@ -36,10 +37,10 @@ import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 // are essentially impossible.
 const findUseEffectsInComponent = (componentBody: EsTreeNode | undefined): EsTreeNode[] => {
   const effectCalls: EsTreeNode[] = [];
-  if (componentBody?.type !== "BlockStatement") return effectCalls;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return effectCalls;
   for (const statement of componentBody.body ?? []) {
     walkAst(statement, (child: EsTreeNode) => {
-      if (child.type === "CallExpression" && isHookCall(child, EFFECT_HOOK_NAMES)) {
+      if (isNodeOfType(child, "CallExpression") && isHookCall(child, EFFECT_HOOK_NAMES)) {
         effectCalls.push(child);
       }
     });
@@ -51,23 +52,24 @@ const findSubscriptionCall = (
   effectBodyStatements: EsTreeNode[],
 ): { call: EsTreeNode; boundUnsubscribeName: string | null } | null => {
   for (const statement of effectBodyStatements) {
-    if (statement.type === "VariableDeclaration") {
+    if (isNodeOfType(statement, "VariableDeclaration")) {
       for (const declarator of statement.declarations ?? []) {
         const init = declarator.init;
-        if (init?.type !== "CallExpression") continue;
-        if (init.callee?.type !== "MemberExpression") continue;
-        if (init.callee.property?.type !== "Identifier") continue;
+        if (!isNodeOfType(init, "CallExpression")) continue;
+        if (!isNodeOfType(init.callee, "MemberExpression")) continue;
+        if (!isNodeOfType(init.callee.property, "Identifier")) continue;
         if (!SUBSCRIPTION_METHOD_NAMES.has(init.callee.property.name)) continue;
-        const boundUnsubscribeName =
-          declarator.id?.type === "Identifier" ? declarator.id.name : null;
+        const boundUnsubscribeName = isNodeOfType(declarator.id, "Identifier")
+          ? declarator.id.name
+          : null;
         return { call: init, boundUnsubscribeName };
       }
     }
-    if (statement.type === "ExpressionStatement") {
+    if (isNodeOfType(statement, "ExpressionStatement")) {
       const expression = statement.expression;
-      if (expression?.type !== "CallExpression") continue;
-      if (expression.callee?.type !== "MemberExpression") continue;
-      if (expression.callee.property?.type !== "Identifier") continue;
+      if (!isNodeOfType(expression, "CallExpression")) continue;
+      if (!isNodeOfType(expression.callee, "MemberExpression")) continue;
+      if (!isNodeOfType(expression.callee.property, "Identifier")) continue;
       if (!SUBSCRIPTION_METHOD_NAMES.has(expression.callee.property.name)) continue;
       return { call: expression, boundUnsubscribeName: null };
     }
@@ -86,17 +88,23 @@ const getSubscriptionHandlerArgument = (
   effectBodyStatements: EsTreeNode[],
 ): EsTreeNode | null => {
   for (const argument of subscribeCall.arguments ?? []) {
-    if (argument.type === "ArrowFunctionExpression" || argument.type === "FunctionExpression") {
+    if (
+      isNodeOfType(argument, "ArrowFunctionExpression") ||
+      isNodeOfType(argument, "FunctionExpression")
+    ) {
       return argument;
     }
-    if (argument.type === "Identifier") {
+    if (isNodeOfType(argument, "Identifier")) {
       for (const statement of effectBodyStatements) {
-        if (statement.type !== "VariableDeclaration") continue;
+        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
         for (const declarator of statement.declarations ?? []) {
-          if (declarator.id?.type !== "Identifier") continue;
+          if (!isNodeOfType(declarator.id, "Identifier")) continue;
           if (declarator.id.name !== argument.name) continue;
           const init = declarator.init;
-          if (init?.type === "ArrowFunctionExpression" || init?.type === "FunctionExpression") {
+          if (
+            isNodeOfType(init, "ArrowFunctionExpression") ||
+            isNodeOfType(init, "FunctionExpression")
+          ) {
             return init;
           }
         }
@@ -112,10 +120,11 @@ const getSingleSetterCallFromHandler = (
   const handlerStatements = getCallbackStatements(handler);
   if (handlerStatements.length !== 1) return null;
   const onlyStatement = handlerStatements[0];
-  const expression =
-    onlyStatement.type === "ExpressionStatement" ? onlyStatement.expression : onlyStatement;
-  if (expression?.type !== "CallExpression") return null;
-  if (expression.callee?.type !== "Identifier") return null;
+  const expression = isNodeOfType(onlyStatement, "ExpressionStatement")
+    ? onlyStatement.expression
+    : onlyStatement;
+  if (!isNodeOfType(expression, "CallExpression")) return null;
+  if (!isNodeOfType(expression.callee, "Identifier")) return null;
   if (!isSetterIdentifier(expression.callee.name)) return null;
   if (!expression.arguments?.length) return null;
   return {
@@ -129,7 +138,7 @@ const cleanupReleasesSubscription = (
   boundUnsubscribeName: string | null,
 ): boolean => {
   const lastStatement = effectBodyStatements[effectBodyStatements.length - 1];
-  if (lastStatement?.type !== "ReturnStatement") return false;
+  if (!isNodeOfType(lastStatement, "ReturnStatement")) return false;
   const knownBoundReleaseNames = new Set<string>();
   if (boundUnsubscribeName) knownBoundReleaseNames.add(boundUnsubscribeName);
   return isCleanupReturn(lastStatement.argument, knownBoundReleaseNames);
@@ -140,7 +149,7 @@ export const preferUseSyncExternalStore = defineRule<Rule>({
     "Replace the `useState(getSnapshot())` + `useEffect(() => store.subscribe(() => setSnapshot(getSnapshot())))` pair with `useSyncExternalStore(store.subscribe, getSnapshot)`. The hook handles tearing during concurrent renders and SSR snapshots; the manual subscribe pattern doesn't",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
 
       const useStateBindings = collectUseStateBindings(componentBody);
       if (useStateBindings.length === 0) return;
@@ -154,9 +163,9 @@ export const preferUseSyncExternalStore = defineRule<Rule>({
         // initializer so the structural match against the
         // subscribe-handler's setter argument still resolves.
         if (
-          (initializerArgument.type === "ArrowFunctionExpression" ||
-            initializerArgument.type === "FunctionExpression") &&
-          initializerArgument.body?.type !== "BlockStatement"
+          (isNodeOfType(initializerArgument, "ArrowFunctionExpression") ||
+            isNodeOfType(initializerArgument, "FunctionExpression")) &&
+          !isNodeOfType(initializerArgument.body, "BlockStatement")
         ) {
           useStateInitializerByValueName.set(binding.valueName, initializerArgument.body);
         } else {
@@ -172,11 +181,11 @@ export const preferUseSyncExternalStore = defineRule<Rule>({
       for (const effectCall of findUseEffectsInComponent(componentBody)) {
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
         const depsNode = effectCall.arguments[1];
-        if (depsNode.type !== "ArrayExpression") continue;
+        if (!isNodeOfType(depsNode, "ArrayExpression")) continue;
         if ((depsNode.elements?.length ?? 0) !== 0) continue;
 
         const callback = getEffectCallback(effectCall);
-        if (!callback || callback.body?.type !== "BlockStatement") continue;
+        if (!callback || !isNodeOfType(callback.body, "BlockStatement")) continue;
         const effectBodyStatements = callback.body.body ?? [];
         if (effectBodyStatements.length < 2) continue;
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
@@ -7,6 +7,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectHandlerBindingNames } from "./utils/collect-handler-binding-names.js";
 import { isInsideEventHandler } from "./utils/is-inside-event-handler.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const DEFERRABLE_HOOK_NAMES = new Set(["useSearchParams", "useParams", "usePathname"]);
 
@@ -14,15 +15,15 @@ const findHookCallBindings = (
   componentBody: EsTreeNode,
 ): Array<{ valueName: string; hookName: string; declarator: EsTreeNode }> => {
   const bindings: Array<{ valueName: string; hookName: string; declarator: EsTreeNode }> = [];
-  if (componentBody?.type !== "BlockStatement") return bindings;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return bindings;
 
   for (const statement of componentBody.body ?? []) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
-      if (declarator.id?.type !== "Identifier") continue;
-      if (declarator.init?.type !== "CallExpression") continue;
+      if (!isNodeOfType(declarator.id, "Identifier")) continue;
+      if (!isNodeOfType(declarator.init, "CallExpression")) continue;
       const callee = declarator.init.callee;
-      if (callee?.type !== "Identifier") continue;
+      if (!isNodeOfType(callee, "Identifier")) continue;
       if (!DEFERRABLE_HOOK_NAMES.has(callee.name)) continue;
       bindings.push({
         valueName: declarator.id.name,
@@ -52,7 +53,7 @@ export const rerenderDeferReadsHook = defineRule<Rule>({
     "Read the URL state inside the handler (e.g. `new URL(window.location.href).searchParams`) so the component doesn't subscribe and re-render on every URL change",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const bindings = findHookCallBindings(componentBody);
       if (bindings.length === 0) return;
       const handlerBindingNames = collectHandlerBindingNames(componentBody);
@@ -61,7 +62,7 @@ export const rerenderDeferReadsHook = defineRule<Rule>({
         const referenceLocations: EsTreeNode[] = [];
         walkAst(componentBody, (child: EsTreeNode) => {
           if (child === binding.declarator.id) return;
-          if (child.type === "Identifier" && child.name === binding.valueName) {
+          if (isNodeOfType(child, "Identifier") && child.name === binding.valueName) {
             referenceLocations.push(child);
           }
         });

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
@@ -4,6 +4,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderDependencies = defineRule<Rule>({
   recommendation:
@@ -12,18 +13,18 @@ export const rerenderDependencies = defineRule<Rule>({
     CallExpression(node: EsTreeNode) {
       if (!isHookCall(node, HOOKS_WITH_DEPS) || node.arguments.length < 2) return;
       const depsNode = node.arguments[1];
-      if (depsNode.type !== "ArrayExpression") return;
+      if (!isNodeOfType(depsNode, "ArrayExpression")) return;
 
       for (const element of depsNode.elements ?? []) {
         if (!element) continue;
-        if (element.type === "ObjectExpression") {
+        if (isNodeOfType(element, "ObjectExpression")) {
           context.report({
             node: element,
             message:
               "Object literal in useEffect deps — creates new reference every render, causing infinite re-runs",
           });
         }
-        if (element.type === "ArrayExpression") {
+        if (isNodeOfType(element, "ArrayExpression")) {
           context.report({
             node: element,
             message:
@@ -36,7 +37,10 @@ export const rerenderDependencies = defineRule<Rule>({
         // (if it doesn't read reactive values) or wrap it in
         // `useCallback`. Covered by `Removing Effect Dependencies` §
         // "Does some reactive value change unintentionally?".
-        if (element.type === "ArrowFunctionExpression" || element.type === "FunctionExpression") {
+        if (
+          isNodeOfType(element, "ArrowFunctionExpression") ||
+          isNodeOfType(element, "FunctionExpression")
+        ) {
           context.report({
             node: element,
             message:

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-functional-setstate.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-functional-setstate.ts
@@ -3,6 +3,7 @@ import { isSetterCall } from "../../utils/is-setter-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const STATE_ARITHMETIC_OPERATORS = new Set(["+", "-", "*", "/", "%", "**"]);
 
@@ -28,12 +29,12 @@ export const rerenderFunctionalSetstate = defineRule<Rule>({
       const expectedStateName = deriveStateVariableName(calleeName);
 
       if (
-        argument.type === "BinaryExpression" &&
+        isNodeOfType(argument, "BinaryExpression") &&
         STATE_ARITHMETIC_OPERATORS.has(argument.operator) &&
         expectedStateName
       ) {
         const matchesExpected = (operand: EsTreeNode | undefined): boolean =>
-          operand?.type === "Identifier" && operand.name === expectedStateName;
+          isNodeOfType(operand, "Identifier") && operand.name === expectedStateName;
 
         const stateIdentifier = matchesExpected(argument.left)
           ? argument.left
@@ -41,7 +42,7 @@ export const rerenderFunctionalSetstate = defineRule<Rule>({
             ? argument.right
             : null;
 
-        if (stateIdentifier) {
+        if (isNodeOfType(stateIdentifier, "Identifier")) {
           context.report({
             node,
             message: `${calleeName}(${stateIdentifier.name} ${argument.operator} ...) — use functional update to avoid stale closures`,
@@ -51,9 +52,9 @@ export const rerenderFunctionalSetstate = defineRule<Rule>({
       }
 
       if (
-        argument.type === "UpdateExpression" &&
+        isNodeOfType(argument, "UpdateExpression") &&
         (argument.operator === "++" || argument.operator === "--") &&
-        argument.argument?.type === "Identifier" &&
+        isNodeOfType(argument.argument, "Identifier") &&
         argument.argument.name === expectedStateName
       ) {
         const display = argument.prefix
@@ -77,11 +78,11 @@ export const rerenderFunctionalSetstate = defineRule<Rule>({
       // Detect when one of the spread sources structurally references
       // the derived state variable: `setX([...x, ...])` or
       // `setX({ ...x, key: value })`.
-      if (expectedStateName && argument.type === "ArrayExpression") {
+      if (expectedStateName && isNodeOfType(argument, "ArrayExpression")) {
         const spreadsState = (argument.elements ?? []).some(
           (element: EsTreeNode | null) =>
-            element?.type === "SpreadElement" &&
-            element.argument?.type === "Identifier" &&
+            isNodeOfType(element, "SpreadElement") &&
+            isNodeOfType(element.argument, "Identifier") &&
             element.argument.name === expectedStateName,
         );
         if (spreadsState) {
@@ -93,11 +94,11 @@ export const rerenderFunctionalSetstate = defineRule<Rule>({
         }
       }
 
-      if (expectedStateName && argument.type === "ObjectExpression") {
+      if (expectedStateName && isNodeOfType(argument, "ObjectExpression")) {
         const spreadsState = (argument.properties ?? []).some(
           (property: EsTreeNode | null) =>
-            property?.type === "SpreadElement" &&
-            property.argument?.type === "Identifier" &&
+            isNodeOfType(property, "SpreadElement") &&
+            isNodeOfType(property.argument, "Identifier") &&
             property.argument.name === expectedStateName,
         );
         if (spreadsState) {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
@@ -16,11 +16,15 @@ export const rerenderLazyStateInit = defineRule<Rule>({
       if (!isNodeOfType(initializer, "CallExpression")) return;
 
       const callee = initializer.callee;
+      const memberPropertyName =
+        isNodeOfType(callee, "MemberExpression") &&
+        (isNodeOfType(callee.property, "Identifier") ||
+          isNodeOfType(callee.property, "PrivateIdentifier"))
+          ? callee.property.name
+          : null;
       const calleeName = isNodeOfType(callee, "Identifier")
         ? callee.name
-        : isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")
-          ? callee.property.name
-          : "fn";
+        : (memberPropertyName ?? "fn");
 
       if (TRIVIAL_INITIALIZER_NAMES.has(calleeName)) return;
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
@@ -4,6 +4,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderLazyStateInit = defineRule<Rule>({
   recommendation:
@@ -12,12 +13,14 @@ export const rerenderLazyStateInit = defineRule<Rule>({
     CallExpression(node: EsTreeNode) {
       if (!isHookCall(node, "useState") || !node.arguments?.length) return;
       const initializer = node.arguments[0];
-      if (initializer.type !== "CallExpression") return;
+      if (!isNodeOfType(initializer, "CallExpression")) return;
 
-      const calleeName =
-        initializer.callee?.type === "Identifier"
-          ? initializer.callee.name
-          : (initializer.callee?.property?.name ?? "fn");
+      const callee = initializer.callee;
+      const calleeName = isNodeOfType(callee, "Identifier")
+        ? callee.name
+        : isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")
+          ? callee.property.name
+          : "fn";
 
       if (TRIVIAL_INITIALIZER_NAMES.has(calleeName)) return;
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -10,13 +10,14 @@ import { collectReturnExpressions } from "./utils/collect-return-expressions.js"
 import { buildLocalDependencyGraph } from "./utils/build-local-dependency-graph.js";
 import { collectRenderReachableNames } from "./utils/collect-render-reachable-names.js";
 import { expandTransitiveDependencies } from "./utils/expand-transitive-dependencies.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderStateOnlyInHandlers = defineRule<Rule>({
   recommendation:
     "Replace useState with useRef when the value is only mutated and never read in render — `ref.current = ...` updates without re-rendering the component",
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
-      if (!componentBody || componentBody.type !== "BlockStatement") return;
+      if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const bindings = collectUseStateBindings(componentBody);
       if (bindings.length === 0) return;
 
@@ -34,8 +35,8 @@ export const rerenderStateOnlyInHandlers = defineRule<Rule>({
         walkAst(componentBody, (child: EsTreeNode) => {
           if (setterCalled) return;
           if (
-            child.type === "CallExpression" &&
-            child.callee?.type === "Identifier" &&
+            isNodeOfType(child, "CallExpression") &&
+            isNodeOfType(child.callee, "Identifier") &&
             child.callee.name === binding.setterName
           ) {
             setterCalled = true;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/build-local-dependency-graph.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/build-local-dependency-graph.ts
@@ -1,13 +1,14 @@
 import { collectPatternNames } from "../../../utils/collect-pattern-names.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { collectIdentifierNames } from "./collect-identifier-names.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const buildLocalDependencyGraph = (componentBody: EsTreeNode): Map<string, Set<string>> => {
   const graph = new Map<string, Set<string>>();
-  if (componentBody?.type !== "BlockStatement") return graph;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return graph;
   const declaredNames = new Set<string>();
   for (const statement of componentBody.body ?? []) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
       if (!declarator.init) continue;
       const dependencyNames = collectIdentifierNames(declarator.init);

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-handler-binding-names.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-handler-binding-names.ts
@@ -1,15 +1,16 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { walkAst } from "../../../utils/walk-ast.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const collectHandlerBindingNames = (componentBody: EsTreeNode): Set<string> => {
   const handlerNames = new Set<string>();
   walkAst(componentBody, (child: EsTreeNode) => {
-    if (child.type !== "JSXAttribute") return;
-    if (child.name?.type !== "JSXIdentifier") return;
+    if (!isNodeOfType(child, "JSXAttribute")) return;
+    if (!isNodeOfType(child.name, "JSXIdentifier")) return;
     if (!/^on[A-Z]/.test(child.name.name)) return;
-    if (child.value?.type !== "JSXExpressionContainer") return;
+    if (!isNodeOfType(child.value, "JSXExpressionContainer")) return;
     const expression = child.value.expression;
-    if (expression?.type === "Identifier") handlerNames.add(expression.name);
+    if (isNodeOfType(expression, "Identifier")) handlerNames.add(expression.name);
   });
   return handlerNames;
 };

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-identifier-names.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-identifier-names.ts
@@ -1,10 +1,11 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { walkAst } from "../../../utils/walk-ast.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const collectIdentifierNames = (expression: EsTreeNode): Set<string> => {
   const names = new Set<string>();
   walkAst(expression, (child: EsTreeNode) => {
-    if (child.type === "Identifier") names.add(child.name);
+    if (isNodeOfType(child, "Identifier")) names.add(child.name);
   });
   return names;
 };

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-render-reachable-names.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-render-reachable-names.ts
@@ -1,11 +1,12 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { walkAst } from "../../../utils/walk-ast.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const collectRenderReachableNames = (returnExpressions: EsTreeNode[]): Set<string> => {
   const names = new Set<string>();
   for (const expression of returnExpressions) {
     walkAst(expression, (child: EsTreeNode) => {
-      if (child.type === "Identifier") names.add(child.name);
+      if (isNodeOfType(child, "Identifier")) names.add(child.name);
     });
   }
   return names;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-return-expressions.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-return-expressions.ts
@@ -1,18 +1,19 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { walkInsideStatementBlocks } from "../../../utils/walk-inside-statement-blocks.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const collectReturnExpressions = (componentBody: EsTreeNode): EsTreeNode[] => {
-  if (componentBody?.type !== "BlockStatement") return [];
+  if (!isNodeOfType(componentBody, "BlockStatement")) return [];
   const returns: EsTreeNode[] = [];
   for (const statement of componentBody.body ?? []) {
-    if (statement.type === "ReturnStatement" && statement.argument) {
+    if (isNodeOfType(statement, "ReturnStatement") && statement.argument) {
       returns.push(statement.argument);
       continue;
     }
     // Walk into IfStatement / TryStatement etc. for early-return JSX,
     // but stop at any nested function.
     walkInsideStatementBlocks(statement, (child) => {
-      if (child.type === "ReturnStatement" && child.argument) {
+      if (isNodeOfType(child, "ReturnStatement") && child.argument) {
         returns.push(child.argument);
       }
     });

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-use-state-bindings.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-use-state-bindings.ts
@@ -1,29 +1,30 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isHookCall } from "../../../utils/is-hook-call.js";
 import { isSetterIdentifier } from "../../../utils/is-setter-identifier.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const collectUseStateBindings = (
   componentBody: EsTreeNode,
 ): Array<{ valueName: string; setterName: string; declarator: EsTreeNode }> => {
   const bindings: Array<{ valueName: string; setterName: string; declarator: EsTreeNode }> = [];
-  if (componentBody?.type !== "BlockStatement") return bindings;
+  if (!isNodeOfType(componentBody, "BlockStatement")) return bindings;
 
   for (const statement of componentBody.body ?? []) {
-    if (statement.type !== "VariableDeclaration") continue;
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
-      if (declarator.id?.type !== "ArrayPattern") continue;
+      if (!isNodeOfType(declarator.id, "ArrayPattern")) continue;
       const elements = declarator.id.elements ?? [];
       if (elements.length < 2) continue;
       const valueElement = elements[0];
       const setterElement = elements[1];
       if (
-        valueElement?.type !== "Identifier" ||
-        setterElement?.type !== "Identifier" ||
+        !isNodeOfType(valueElement, "Identifier") ||
+        !isNodeOfType(setterElement, "Identifier") ||
         !isSetterIdentifier(setterElement.name)
       ) {
         continue;
       }
-      if (declarator.init?.type !== "CallExpression") continue;
+      if (!isNodeOfType(declarator.init, "CallExpression")) continue;
       if (!isHookCall(declarator.init, "useState")) continue;
       bindings.push({
         valueName: valueElement.name,

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -1,19 +1,20 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { containsReleaseLikeCall } from "./contains-release-like-call.js";
 import { isSubscribeLikeCallExpression } from "./is-subscribe-like-call-expression.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const isCleanupReturn = (
   returnedValue: EsTreeNode | null | undefined,
   knownBoundReleaseNames: ReadonlySet<string>,
 ): boolean => {
   if (!returnedValue) return false;
-  if (returnedValue.type === "Identifier") {
+  if (isNodeOfType(returnedValue, "Identifier")) {
     return knownBoundReleaseNames.has(returnedValue.name);
   }
   if (isSubscribeLikeCallExpression(returnedValue)) return true;
   if (
-    returnedValue.type === "ArrowFunctionExpression" ||
-    returnedValue.type === "FunctionExpression"
+    isNodeOfType(returnedValue, "ArrowFunctionExpression") ||
+    isNodeOfType(returnedValue, "FunctionExpression")
   ) {
     return containsReleaseLikeCall(returnedValue, knownBoundReleaseNames);
   }

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/is-inside-event-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/is-inside-event-handler.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const isInsideEventHandler = (
   node: EsTreeNode,
@@ -7,22 +8,22 @@ export const isInsideEventHandler = (
   let cursor: EsTreeNode | null = node.parent ?? null;
   while (cursor) {
     if (
-      cursor.type === "ArrowFunctionExpression" ||
-      cursor.type === "FunctionExpression" ||
-      cursor.type === "FunctionDeclaration"
+      isNodeOfType(cursor, "ArrowFunctionExpression") ||
+      isNodeOfType(cursor, "FunctionExpression") ||
+      isNodeOfType(cursor, "FunctionDeclaration")
     ) {
       let outer: EsTreeNode | null = cursor.parent ?? null;
       while (outer) {
-        if (outer.type === "JSXAttribute") {
-          const attrName = outer.name?.type === "JSXIdentifier" ? outer.name.name : null;
+        if (isNodeOfType(outer, "JSXAttribute")) {
+          const attrName = isNodeOfType(outer.name, "JSXIdentifier") ? outer.name.name : null;
           if (attrName && /^on[A-Z]/.test(attrName)) return true;
           return false;
         }
-        if (outer.type === "VariableDeclarator") {
-          const declaredName = outer.id?.type === "Identifier" ? outer.id.name : null;
+        if (isNodeOfType(outer, "VariableDeclarator")) {
+          const declaredName = isNodeOfType(outer.id, "Identifier") ? outer.id.name : null;
           return Boolean(declaredName && handlerBindingNames.has(declaredName));
         }
-        if (outer.type === "Program") return false;
+        if (isNodeOfType(outer, "Program")) return false;
         outer = outer.parent ?? null;
       }
       return false;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/is-release-like-call.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/is-release-like-call.ts
@@ -4,20 +4,21 @@ import {
   UNSUBSCRIPTION_METHOD_NAMES,
 } from "../../../constants.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const isReleaseLikeCall = (
   callNode: EsTreeNode,
   knownBoundReleaseNames: ReadonlySet<string>,
 ): boolean => {
-  if (callNode?.type !== "CallExpression") return false;
+  if (!isNodeOfType(callNode, "CallExpression")) return false;
   const callee = callNode.callee;
-  if (callee?.type === "Identifier") {
+  if (isNodeOfType(callee, "Identifier")) {
     if (TIMER_CLEANUP_CALLEE_NAMES.has(callee.name)) return true;
     if (CLEANUP_LIKE_RELEASE_CALLEE_NAMES.has(callee.name)) return true;
     if (knownBoundReleaseNames.has(callee.name)) return true;
     return false;
   }
-  if (callee?.type === "MemberExpression" && callee.property?.type === "Identifier") {
+  if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
     return UNSUBSCRIPTION_METHOD_NAMES.has(callee.property.name);
   }
   return false;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/is-subscribe-like-call-expression.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/is-subscribe-like-call-expression.ts
@@ -1,9 +1,10 @@
 import { SUBSCRIPTION_METHOD_NAMES } from "../../../constants.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const isSubscribeLikeCallExpression = (node: EsTreeNode): boolean => {
-  if (node?.type !== "CallExpression") return false;
-  if (node.callee?.type !== "MemberExpression") return false;
-  if (node.callee.property?.type !== "Identifier") return false;
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (!isNodeOfType(node.callee, "MemberExpression")) return false;
+  if (!isNodeOfType(node.callee.property, "Identifier")) return false;
   return SUBSCRIPTION_METHOD_NAMES.has(node.callee.property.name);
 };

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
@@ -4,23 +4,24 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryMutationMissingInvalidation = defineRule<Rule>({
   recommendation:
     "Add `onSuccess: () => queryClient.invalidateQueries({ queryKey: ['...'] })` so cached data stays in sync after the mutation",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      const calleeName = node.callee?.type === "Identifier" ? node.callee.name : null;
+      const calleeName = isNodeOfType(node.callee, "Identifier") ? node.callee.name : null;
 
       if (!calleeName || !TANSTACK_MUTATION_HOOKS.has(calleeName)) return;
 
       const optionsArgument = node.arguments?.[0];
-      if (!optionsArgument || optionsArgument.type !== "ObjectExpression") return;
+      if (!optionsArgument || !isNodeOfType(optionsArgument, "ObjectExpression")) return;
 
       const hasMutationFn = optionsArgument.properties?.some(
         (property: EsTreeNode) =>
-          property.type === "Property" &&
-          property.key?.type === "Identifier" &&
+          isNodeOfType(property, "Property") &&
+          isNodeOfType(property.key, "Identifier") &&
           property.key.name === "mutationFn",
       );
 
@@ -30,9 +31,9 @@ export const queryMutationMissingInvalidation = defineRule<Rule>({
       walkAst(optionsArgument, (child: EsTreeNode) => {
         if (hasCacheUpdate) return false;
         if (
-          child.type === "CallExpression" &&
-          child.callee?.type === "MemberExpression" &&
-          child.callee.property?.type === "Identifier" &&
+          isNodeOfType(child, "CallExpression") &&
+          isNodeOfType(child.callee, "MemberExpression") &&
+          isNodeOfType(child.callee.property, "Identifier") &&
           QUERY_CACHE_UPDATE_METHODS.has(child.callee.property.name)
         ) {
           hasCacheUpdate = true;

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-query-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-query-in-effect.ts
@@ -6,6 +6,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoQueryInEffect = defineRule<Rule>({
   recommendation:
@@ -18,9 +19,9 @@ export const queryNoQueryInEffect = defineRule<Rule>({
       if (!callback) return;
 
       walkAst(callback, (child: EsTreeNode) => {
-        if (child.type !== "CallExpression") return;
+        if (!isNodeOfType(child, "CallExpression")) return;
 
-        const calleeName = child.callee?.type === "Identifier" ? child.callee.name : null;
+        const calleeName = isNodeOfType(child.callee, "Identifier") ? child.callee.name : null;
 
         if (calleeName === "refetch") {
           context.report({

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
@@ -3,21 +3,24 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoRestDestructuring = defineRule<Rule>({
   recommendation:
     "Destructure only the fields you need: `const { data, isLoading } = useQuery(...)` — rest destructuring subscribes to all fields and causes extra re-renders",
   create: (context: RuleContext) => ({
     VariableDeclarator(node: EsTreeNode) {
-      if (node.id?.type !== "ObjectPattern") return;
-      if (!node.init || node.init.type !== "CallExpression") return;
+      if (!isNodeOfType(node.id, "ObjectPattern")) return;
+      if (!node.init || !isNodeOfType(node.init, "CallExpression")) return;
 
-      const calleeName = node.init.callee?.type === "Identifier" ? node.init.callee.name : null;
+      const calleeName = isNodeOfType(node.init.callee, "Identifier")
+        ? node.init.callee.name
+        : null;
 
       if (!calleeName || !TANSTACK_QUERY_HOOKS.has(calleeName)) return;
 
-      const hasRestElement = node.id.properties?.some(
-        (property: EsTreeNode) => property.type === "RestElement",
+      const hasRestElement = node.id.properties?.some((property: EsTreeNode) =>
+        isNodeOfType(property, "RestElement"),
       );
 
       if (hasRestElement) {

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-use-query-for-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-use-query-for-mutation.ts
@@ -4,43 +4,45 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoUseQueryForMutation = defineRule<Rule>({
   recommendation:
     "Use `useMutation()` for POST/PUT/DELETE — it provides onSuccess/onError callbacks, doesn't auto-refetch, and correctly models write operations",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      const calleeName = node.callee?.type === "Identifier" ? node.callee.name : null;
+      const calleeName = isNodeOfType(node.callee, "Identifier") ? node.callee.name : null;
 
       if (!calleeName || !TANSTACK_QUERY_HOOKS.has(calleeName)) return;
 
       const optionsArgument = node.arguments?.[0];
-      if (!optionsArgument || optionsArgument.type !== "ObjectExpression") return;
+      if (!optionsArgument || !isNodeOfType(optionsArgument, "ObjectExpression")) return;
 
       const queryFnProperty = optionsArgument.properties?.find(
         (property: EsTreeNode) =>
-          property.type === "Property" &&
-          property.key?.type === "Identifier" &&
+          isNodeOfType(property, "Property") &&
+          isNodeOfType(property.key, "Identifier") &&
           property.key.name === "queryFn",
       );
 
-      if (!queryFnProperty?.value) return;
+      if (!queryFnProperty || !isNodeOfType(queryFnProperty, "Property") || !queryFnProperty.value)
+        return;
 
       let hasMutatingFetch = false;
       walkAst(queryFnProperty.value, (child: EsTreeNode) => {
         if (hasMutatingFetch) return;
-        if (child.type !== "CallExpression") return;
-        if (child.callee?.type !== "Identifier" || child.callee.name !== "fetch") return;
+        if (!isNodeOfType(child, "CallExpression")) return;
+        if (!isNodeOfType(child.callee, "Identifier") || child.callee.name !== "fetch") return;
 
         const optionsArg = child.arguments?.[1];
-        if (!optionsArg || optionsArg.type !== "ObjectExpression") return;
+        if (!optionsArg || !isNodeOfType(optionsArg, "ObjectExpression")) return;
 
         const methodProperty = optionsArg.properties?.find(
           (property: EsTreeNode) =>
-            property.type === "Property" &&
-            property.key?.type === "Identifier" &&
+            isNodeOfType(property, "Property") &&
+            isNodeOfType(property.key, "Identifier") &&
             property.key.name === "method" &&
-            property.value?.type === "Literal" &&
+            isNodeOfType(property.value, "Literal") &&
             typeof property.value.value === "string" &&
             MUTATING_HTTP_METHODS.has(property.value.value.toUpperCase()),
         );

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-void-query-fn.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-void-query-fn.ts
@@ -3,43 +3,45 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoVoidQueryFn = defineRule<Rule>({
   recommendation:
     "queryFn must return a value for the cache. Use the `enabled` option to conditionally disable the query instead of returning undefined",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      const calleeName = node.callee?.type === "Identifier" ? node.callee.name : null;
+      const calleeName = isNodeOfType(node.callee, "Identifier") ? node.callee.name : null;
 
       if (!calleeName || !TANSTACK_QUERY_HOOKS.has(calleeName)) return;
 
       const optionsArgument = node.arguments?.[0];
-      if (!optionsArgument || optionsArgument.type !== "ObjectExpression") return;
+      if (!optionsArgument || !isNodeOfType(optionsArgument, "ObjectExpression")) return;
 
       const queryFnProperty = optionsArgument.properties?.find(
         (property: EsTreeNode) =>
-          property.type === "Property" &&
-          property.key?.type === "Identifier" &&
+          isNodeOfType(property, "Property") &&
+          isNodeOfType(property.key, "Identifier") &&
           property.key.name === "queryFn",
       );
 
-      if (!queryFnProperty?.value) return;
+      if (!queryFnProperty || !isNodeOfType(queryFnProperty, "Property") || !queryFnProperty.value)
+        return;
 
       const queryFnValue = queryFnProperty.value;
 
       if (
-        queryFnValue.type === "ArrowFunctionExpression" &&
-        queryFnValue.body?.type !== "BlockStatement"
+        isNodeOfType(queryFnValue, "ArrowFunctionExpression") &&
+        !isNodeOfType(queryFnValue.body, "BlockStatement")
       ) {
         return;
       }
 
       if (
-        queryFnValue.type === "ArrowFunctionExpression" ||
-        queryFnValue.type === "FunctionExpression"
+        isNodeOfType(queryFnValue, "ArrowFunctionExpression") ||
+        isNodeOfType(queryFnValue, "FunctionExpression")
       ) {
         const body = queryFnValue.body;
-        if (body?.type !== "BlockStatement") return;
+        if (!isNodeOfType(body, "BlockStatement")) return;
 
         const statements = body.body ?? [];
         if (statements.length === 0) {

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-stable-query-client.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-stable-query-client.ts
@@ -8,6 +8,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryStableQueryClient = defineRule<Rule>({
   recommendation:
@@ -29,20 +30,20 @@ export const queryStableQueryClient = defineRule<Rule>({
       },
       VariableDeclarator(node: EsTreeNode) {
         if (
-          node.id?.type === "Identifier" &&
+          isNodeOfType(node.id, "Identifier") &&
           UPPERCASE_PATTERN.test(node.id.name) &&
-          (node.init?.type === "ArrowFunctionExpression" ||
-            node.init?.type === "FunctionExpression")
+          (isNodeOfType(node.init, "ArrowFunctionExpression") ||
+            isNodeOfType(node.init, "FunctionExpression"))
         ) {
           componentDepth++;
         }
       },
       "VariableDeclarator:exit"(node: EsTreeNode) {
         if (
-          node.id?.type === "Identifier" &&
+          isNodeOfType(node.id, "Identifier") &&
           UPPERCASE_PATTERN.test(node.id.name) &&
-          (node.init?.type === "ArrowFunctionExpression" ||
-            node.init?.type === "FunctionExpression")
+          (isNodeOfType(node.init, "ArrowFunctionExpression") ||
+            isNodeOfType(node.init, "FunctionExpression"))
         ) {
           componentDepth--;
         }
@@ -60,7 +61,10 @@ export const queryStableQueryClient = defineRule<Rule>({
       NewExpression(node: EsTreeNode) {
         if (componentDepth <= 0) return;
         if (stableHookDepth > 0) return;
-        if (node.callee?.type !== "Identifier" || node.callee.name !== TANSTACK_QUERY_CLIENT_CLASS)
+        if (
+          !isNodeOfType(node.callee, "Identifier") ||
+          node.callee.name !== TANSTACK_QUERY_CLIENT_CLASS
+        )
           return;
 
         context.report({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-get-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-get-mutation.ts
@@ -5,14 +5,18 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { walkServerFnChain } from "./utils/walk-server-fn-chain.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartGetMutation = defineRule<Rule>({
   recommendation:
     "Use `createServerFn({ method: 'POST' })` for data modifications — GET requests can be triggered by prefetching and are vulnerable to CSRF",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.property?.type !== "Identifier" || node.callee.property.name !== "handler")
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (
+        !isNodeOfType(node.callee.property, "Identifier") ||
+        node.callee.property.name !== "handler"
+      )
         return;
 
       const chainInfo = walkServerFnChain(node);

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-loader-parallel-fetch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-loader-parallel-fetch.ts
@@ -5,24 +5,25 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const hasTopLevelAwait = (statement: EsTreeNode): boolean => {
-  if (statement.type === "VariableDeclaration") {
-    return statement.declarations?.some(
-      (declarator: EsTreeNode) => declarator.init?.type === "AwaitExpression",
+  if (isNodeOfType(statement, "VariableDeclaration")) {
+    return statement.declarations?.some((declarator: EsTreeNode) =>
+      isNodeOfType(declarator.init, "AwaitExpression"),
     );
   }
-  if (statement.type === "ExpressionStatement") {
+  if (isNodeOfType(statement, "ExpressionStatement")) {
     return (
-      statement.expression?.type === "AwaitExpression" ||
-      (statement.expression?.type === "AssignmentExpression" &&
-        statement.expression.right?.type === "AwaitExpression")
+      isNodeOfType(statement.expression, "AwaitExpression") ||
+      (isNodeOfType(statement.expression, "AssignmentExpression") &&
+        isNodeOfType(statement.expression.right, "AwaitExpression"))
     );
   }
-  if (statement.type === "ReturnStatement") {
-    return statement.argument?.type === "AwaitExpression";
+  if (isNodeOfType(statement, "ReturnStatement")) {
+    return isNodeOfType(statement.argument, "AwaitExpression");
   }
-  if (statement.type === "ForOfStatement" && statement.await) {
+  if (isNodeOfType(statement, "ForOfStatement") && statement.await) {
     return true;
   }
   return false;
@@ -44,13 +45,13 @@ export const tanstackStartLoaderParallelFetch = defineRule<Rule>({
         const loaderValue = property.value;
         if (
           !loaderValue ||
-          (loaderValue.type !== "ArrowFunctionExpression" &&
-            loaderValue.type !== "FunctionExpression")
+          (!isNodeOfType(loaderValue, "ArrowFunctionExpression") &&
+            !isNodeOfType(loaderValue, "FunctionExpression"))
         )
           continue;
 
         const functionBody = loaderValue.body;
-        if (!functionBody || functionBody.type !== "BlockStatement") continue;
+        if (!functionBody || !isNodeOfType(functionBody, "BlockStatement")) continue;
 
         let sequentialAwaitCount = 0;
         for (const statement of functionBody.body ?? []) {

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartMissingHeadContent = defineRule<Rule>({
   recommendation:
@@ -16,7 +17,7 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
         const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
         if (!isRootRouteFile) return;
 
-        if (node.name?.type === "JSXIdentifier" && node.name.name === "HeadContent") {
+        if (isNodeOfType(node.name, "JSXIdentifier") && node.name.name === "HeadContent") {
           hasHeadContentElement = true;
         }
       },

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoAnchorElement = defineRule<Rule>({
   recommendation:
@@ -13,24 +14,24 @@ export const tanstackStartNoAnchorElement = defineRule<Rule>({
       const isRouteFile = TANSTACK_ROUTE_FILE_PATTERN.test(filename);
       if (!isRouteFile) return;
 
-      if (node.name?.type !== "JSXIdentifier" || node.name.name !== "a") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a") return;
 
       const attributes = node.attributes ?? [];
       const hrefAttribute = attributes.find(
         (attribute: EsTreeNode) =>
-          attribute.type === "JSXAttribute" &&
-          attribute.name?.type === "JSXIdentifier" &&
+          isNodeOfType(attribute, "JSXAttribute") &&
+          isNodeOfType(attribute.name, "JSXIdentifier") &&
           attribute.name.name === "href",
       );
 
       if (!hrefAttribute?.value) return;
 
       let hrefValue: string | null = null;
-      if (hrefAttribute.value.type === "Literal") {
+      if (isNodeOfType(hrefAttribute.value, "Literal")) {
         hrefValue = hrefAttribute.value.value;
       } else if (
-        hrefAttribute.value.type === "JSXExpressionContainer" &&
-        hrefAttribute.value.expression?.type === "Literal"
+        isNodeOfType(hrefAttribute.value, "JSXExpressionContainer") &&
+        isNodeOfType(hrefAttribute.value.expression, "Literal")
       ) {
         hrefValue = hrefAttribute.value.expression.value;
       }

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoDirectFetchInLoader = defineRule<Rule>({
   recommendation:
@@ -21,8 +22,8 @@ export const tanstackStartNoDirectFetchInLoader = defineRule<Rule>({
 
         const loaderValue = property.value ?? property;
         walkAst(loaderValue, (child: EsTreeNode) => {
-          if (child.type !== "CallExpression") return;
-          if (child.callee?.type === "Identifier" && child.callee.name === "fetch") {
+          if (!isNodeOfType(child, "CallExpression")) return;
+          if (isNodeOfType(child.callee, "Identifier") && child.callee.name === "fetch") {
             context.report({
               node: child,
               message:

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoDynamicServerFnImport = defineRule<Rule>({
   recommendation:
@@ -13,9 +14,9 @@ export const tanstackStartNoDynamicServerFnImport = defineRule<Rule>({
       if (!source) return;
 
       let importPath: string | null = null;
-      if (source.type === "Literal" && typeof source.value === "string") {
+      if (isNodeOfType(source, "Literal") && typeof source.value === "string") {
         importPath = source.value;
-      } else if (source.type === "TemplateLiteral" && source.quasis?.length === 1) {
+      } else if (isNodeOfType(source, "TemplateLiteral") && source.quasis?.length === 1) {
         importPath = source.quasis[0].value?.raw ?? null;
       }
 

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
@@ -8,6 +8,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoNavigateInRender = defineRule<Rule>({
   recommendation:
@@ -30,7 +31,7 @@ export const tanstackStartNoNavigateInRender = defineRule<Rule>({
       isHookCall(node, "useMemo");
 
     const isEventHandlerAttribute = (node: EsTreeNode): boolean =>
-      node.name?.type === "JSXIdentifier" &&
+      isNodeOfType(node.name, "JSXIdentifier") &&
       typeof node.name.name === "string" &&
       node.name.name.startsWith("on") &&
       UPPERCASE_PATTERN.test(node.name.name.charAt(2));
@@ -45,7 +46,7 @@ export const tanstackStartNoNavigateInRender = defineRule<Rule>({
         if (deferredCallbackDepth > 0 || eventHandlerDepth > 0) return;
 
         if (
-          node.callee?.type === "Identifier" &&
+          isNodeOfType(node.callee, "Identifier") &&
           node.callee.name === "navigate" &&
           (node.arguments?.length ?? 0) > 0
         ) {

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-secrets-in-loader.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-secrets-in-loader.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const SAFE_BUILD_ENV_VARS = new Set(["NODE_ENV", "MODE", "DEV", "PROD"]);
 
@@ -34,22 +35,24 @@ export const tanstackStartNoSecretsInLoader = defineRule<Rule>({
 
         const loaderValue = property.value ?? property;
         walkAst(loaderValue, (child: EsTreeNode) => {
-          if (child.type !== "MemberExpression") return;
+          if (!isNodeOfType(child, "MemberExpression")) return;
           const isProcessEnvAccess =
-            child.object?.type === "MemberExpression" &&
-            child.object.object?.type === "Identifier" &&
+            isNodeOfType(child.object, "MemberExpression") &&
+            isNodeOfType(child.object.object, "Identifier") &&
             child.object.object.name === "process" &&
-            child.object.property?.type === "Identifier" &&
+            isNodeOfType(child.object.property, "Identifier") &&
             child.object.property.name === "env";
           const isImportMetaEnvAccess =
-            child.object?.type === "MemberExpression" &&
-            child.object.object?.type === "MetaProperty" &&
-            child.object.property?.type === "Identifier" &&
+            isNodeOfType(child.object, "MemberExpression") &&
+            isNodeOfType(child.object.object, "MetaProperty") &&
+            isNodeOfType(child.object.property, "Identifier") &&
             child.object.property.name === "env";
 
           if (!isProcessEnvAccess && !isImportMetaEnvAccess) return;
 
-          const envVarName = child.property?.type === "Identifier" ? child.property.name : null;
+          const envVarName = isNodeOfType(child.property, "Identifier")
+            ? child.property.name
+            : null;
           if (envVarName && isLikelySecret(envVarName)) {
             const envSource = isImportMetaEnvAccess ? "import.meta.env" : "process.env";
             context.report({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
@@ -5,6 +5,7 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoUseEffectFetch = defineRule<Rule>({
   recommendation:
@@ -24,8 +25,8 @@ export const tanstackStartNoUseEffectFetch = defineRule<Rule>({
       walkAst(callback, (child: EsTreeNode) => {
         if (hasFetchCall) return;
         if (
-          child.type === "CallExpression" &&
-          child.callee?.type === "Identifier" &&
+          isNodeOfType(child, "CallExpression") &&
+          isNodeOfType(child.callee, "Identifier") &&
           child.callee.name === "fetch"
         ) {
           hasFetchCall = true;

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-server-in-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-server-in-handler.ts
@@ -2,32 +2,36 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoUseServerInHandler = defineRule<Rule>({
   recommendation:
     'TanStack Start handles server boundaries automatically via the Vite plugin — "use server" inside createServerFn causes compilation errors',
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.property?.type !== "Identifier" || node.callee.property.name !== "handler")
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (
+        !isNodeOfType(node.callee.property, "Identifier") ||
+        node.callee.property.name !== "handler"
+      )
         return;
 
       const handlerFunction = node.arguments?.[0];
       if (
         !handlerFunction ||
-        (handlerFunction.type !== "ArrowFunctionExpression" &&
-          handlerFunction.type !== "FunctionExpression")
+        (!isNodeOfType(handlerFunction, "ArrowFunctionExpression") &&
+          !isNodeOfType(handlerFunction, "FunctionExpression"))
       )
         return;
 
       const body = handlerFunction.body;
-      if (body?.type !== "BlockStatement") return;
+      if (!isNodeOfType(body, "BlockStatement")) return;
 
       const hasUseServerDirective = body.body?.some(
         (statement: EsTreeNode) =>
-          statement.type === "ExpressionStatement" &&
+          isNodeOfType(statement, "ExpressionStatement") &&
           (statement.directive === "use server" ||
-            (statement.expression?.type === "Literal" &&
+            (isNodeOfType(statement.expression, "Literal") &&
               statement.expression.value === "use server")),
       );
 

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-redirect-in-try-catch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-redirect-in-try-catch.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartRedirectInTryCatch = defineRule<Rule>({
   recommendation:
@@ -29,8 +30,8 @@ export const tanstackStartRedirectInTryCatch = defineRule<Rule>({
         if (catchClauseDepth > 0) return;
 
         const argument = node.argument;
-        if (argument?.type !== "CallExpression") return;
-        if (argument.callee?.type !== "Identifier") return;
+        if (!isNodeOfType(argument, "CallExpression")) return;
+        if (!isNodeOfType(argument.callee, "Identifier")) return;
         if (!TANSTACK_REDIRECT_FUNCTIONS.has(argument.callee.name)) return;
 
         context.report({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
@@ -3,37 +3,41 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartServerFnMethodOrder = defineRule<Rule>({
   recommendation:
     "Chain methods in order: .middleware() → .inputValidator() → .client() → .server() → .handler() — types depend on this sequence",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
 
       const methodNames: string[] = [];
       let currentNode: EsTreeNode = node;
 
       while (
-        currentNode?.type === "CallExpression" &&
-        currentNode.callee?.type === "MemberExpression"
+        isNodeOfType(currentNode, "CallExpression") &&
+        isNodeOfType(currentNode.callee, "MemberExpression")
       ) {
-        const methodName =
-          currentNode.callee.property?.type === "Identifier"
-            ? currentNode.callee.property.name
-            : null;
+        const methodName = isNodeOfType(currentNode.callee.property, "Identifier")
+          ? currentNode.callee.property.name
+          : null;
         if (methodName) methodNames.unshift(methodName);
         currentNode = currentNode.callee.object;
       }
 
-      if (currentNode?.type === "CallExpression" && currentNode.callee?.type === "Identifier") {
+      if (
+        isNodeOfType(currentNode, "CallExpression") &&
+        isNodeOfType(currentNode.callee, "Identifier")
+      ) {
         if (!TANSTACK_SERVER_FN_NAMES.has(currentNode.callee.name)) return;
       } else {
         return;
       }
 
-      const ownMethodName =
-        node.callee.property?.type === "Identifier" ? node.callee.property.name : null;
+      const ownMethodName = isNodeOfType(node.callee.property, "Identifier")
+        ? node.callee.property.name
+        : null;
       if (methodNames[methodNames.length - 1] !== ownMethodName) return;
 
       const orderSensitiveMethods = methodNames.filter((name) =>

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-validate-input.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-validate-input.ts
@@ -4,14 +4,15 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { walkServerFnChain } from "./utils/walk-server-fn-chain.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartServerFnValidateInput = defineRule<Rule>({
   recommendation:
     "Add `.inputValidator(schema)` before `.handler()` — data crosses a network boundary and must be validated at runtime",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
-      if (node.callee?.type !== "MemberExpression") return;
-      if (node.callee.property?.type !== "Identifier") return;
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (!isNodeOfType(node.callee.property, "Identifier")) return;
       if (node.callee.property.name !== "handler") return;
 
       const chainInfo = walkServerFnChain(node);
@@ -23,17 +24,17 @@ export const tanstackStartServerFnValidateInput = defineRule<Rule>({
       let accessesData = false;
       walkAst(handlerFunction, (child: EsTreeNode) => {
         if (
-          child.type === "MemberExpression" &&
-          child.property?.type === "Identifier" &&
+          isNodeOfType(child, "MemberExpression") &&
+          isNodeOfType(child.property, "Identifier") &&
           child.property.name === "data"
         ) {
           accessesData = true;
         }
         if (
-          child.type === "ObjectPattern" &&
+          isNodeOfType(child, "ObjectPattern") &&
           child.properties?.some(
             (property: EsTreeNode) =>
-              property.key?.type === "Identifier" && property.key.name === "data",
+              isNodeOfType(property.key, "Identifier") && property.key.name === "data",
           )
         ) {
           accessesData = true;

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/utils/get-property-key-name.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/utils/get-property-key-name.ts
@@ -1,8 +1,10 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getPropertyKeyName = (property: EsTreeNode): string | null => {
-  if (property.type !== "Property" && property.type !== "MethodDefinition") return null;
-  if (property.key?.type === "Identifier") return property.key.name;
-  if (property.key?.type === "Literal") return String(property.key.value);
+  if (!isNodeOfType(property, "Property") && !isNodeOfType(property, "MethodDefinition"))
+    return null;
+  if (isNodeOfType(property.key, "Identifier")) return property.key.name;
+  if (isNodeOfType(property.key, "Literal")) return String(property.key.value);
   return null;
 };

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/utils/get-route-options-object.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/utils/get-route-options-object.ts
@@ -1,22 +1,23 @@
 import { TANSTACK_ROUTE_CREATION_FUNCTIONS } from "../../../constants.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getRouteOptionsObject = (node: EsTreeNode): EsTreeNode | null => {
-  if (node.type !== "CallExpression") return null;
+  if (!isNodeOfType(node, "CallExpression")) return null;
 
   const callee = node.callee;
 
-  if (callee?.type === "CallExpression" && callee.callee?.type === "Identifier") {
+  if (isNodeOfType(callee, "CallExpression") && isNodeOfType(callee.callee, "Identifier")) {
     if (!TANSTACK_ROUTE_CREATION_FUNCTIONS.has(callee.callee.name)) return null;
     const optionsArgument = node.arguments?.[0];
-    if (optionsArgument?.type === "ObjectExpression") return optionsArgument;
+    if (isNodeOfType(optionsArgument, "ObjectExpression")) return optionsArgument;
     return null;
   }
 
-  if (callee?.type === "Identifier") {
+  if (isNodeOfType(callee, "Identifier")) {
     if (!TANSTACK_ROUTE_CREATION_FUNCTIONS.has(callee.name)) return null;
     const optionsArgument = node.arguments?.[0];
-    if (optionsArgument?.type === "ObjectExpression") return optionsArgument;
+    if (isNodeOfType(optionsArgument, "ObjectExpression")) return optionsArgument;
     return null;
   }
 

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/utils/walk-server-fn-chain.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/utils/walk-server-fn-chain.ts
@@ -2,6 +2,7 @@ import { TANSTACK_SERVER_FN_NAMES } from "../../../constants.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { getCalleeName } from "../../../utils/get-callee-name.js";
 import type { ServerFnChainInfo } from "./server-fn-chain-info.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const walkServerFnChain = (outerNode: EsTreeNode): ServerFnChainInfo => {
   const result: ServerFnChainInfo = {
@@ -12,19 +13,20 @@ export const walkServerFnChain = (outerNode: EsTreeNode): ServerFnChainInfo => {
 
   let currentNode: EsTreeNode = outerNode.callee?.object;
 
-  while (currentNode?.type === "CallExpression") {
+  while (isNodeOfType(currentNode, "CallExpression")) {
     const calleeName = getCalleeName(currentNode);
 
     if (calleeName && TANSTACK_SERVER_FN_NAMES.has(calleeName)) {
       result.isServerFnChain = true;
 
       const optionsArgument = currentNode.arguments?.[0];
-      if (optionsArgument?.type === "ObjectExpression") {
+      if (isNodeOfType(optionsArgument, "ObjectExpression")) {
         for (const property of optionsArgument.properties ?? []) {
           if (
-            property.key?.type === "Identifier" &&
+            isNodeOfType(property, "Property") &&
+            isNodeOfType(property.key, "Identifier") &&
             property.key.name === "method" &&
-            property.value?.type === "Literal" &&
+            isNodeOfType(property.value, "Literal") &&
             typeof property.value.value === "string"
           ) {
             result.specifiedMethod = property.value.value;
@@ -37,7 +39,7 @@ export const walkServerFnChain = (outerNode: EsTreeNode): ServerFnChainInfo => {
       result.hasInputValidator = true;
     }
 
-    if (currentNode.callee?.type === "MemberExpression") {
+    if (isNodeOfType(currentNode.callee, "MemberExpression")) {
       currentNode = currentNode.callee.object;
     } else {
       break;

--- a/packages/react-doctor/src/plugin/rules/view-transitions/no-document-start-view-transition.ts
+++ b/packages/react-doctor/src/plugin/rules/view-transitions/no-document-start-view-transition.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: in React's <ViewTransition> world, calling
 // `document.startViewTransition()` directly bypasses React's lifecycle
@@ -15,9 +16,12 @@ export const noDocumentStartViewTransition = defineRule<Rule>({
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNode) {
       const callee = node.callee;
-      if (callee?.type !== "MemberExpression") return;
-      if (callee.object?.type !== "Identifier" || callee.object.name !== "document") return;
-      if (callee.property?.type !== "Identifier" || callee.property.name !== "startViewTransition")
+      if (!isNodeOfType(callee, "MemberExpression")) return;
+      if (!isNodeOfType(callee.object, "Identifier") || callee.object.name !== "document") return;
+      if (
+        !isNodeOfType(callee.property, "Identifier") ||
+        callee.property.name !== "startViewTransition"
+      )
         return;
       context.report({
         node,

--- a/packages/react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
+++ b/packages/react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
@@ -2,6 +2,8 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 
 // HACK: `flushSync` from react-dom forces a synchronous flush, which
 // skips the View Transition snapshot phase entirely — any animation that
@@ -15,8 +17,8 @@ export const noFlushSync = defineRule<Rule>({
     ImportDeclaration(node: EsTreeNode) {
       if (node.source?.value !== "react-dom") return;
       for (const specifier of node.specifiers ?? []) {
-        if (specifier.type !== "ImportSpecifier") continue;
-        if (specifier.imported?.name === "flushSync") {
+        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+        if (getImportedName(specifier) === "flushSync") {
           context.report({
             node: specifier,
             message:

--- a/packages/react-doctor/src/plugin/utils/are-expressions-structurally-equal.ts
+++ b/packages/react-doctor/src/plugin/utils/are-expressions-structurally-equal.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 // HACK: structural equality for "value-shaped" expressions used by
 // detectors that need to assert two reads of the same external value
@@ -15,16 +16,16 @@ export const areExpressionsStructurallyEqual = (
 ): boolean => {
   if (!a || !b) return a === b;
   if (a.type !== b.type) return false;
-  if (a.type === "Identifier") return a.name === b.name;
-  if (a.type === "Literal") return a.value === b.value;
-  if (a.type === "MemberExpression") {
+  if (isNodeOfType(a, "Identifier")) return a.name === b.name;
+  if (isNodeOfType(a, "Literal")) return a.value === b.value;
+  if (isNodeOfType(a, "MemberExpression")) {
     if (a.computed !== b.computed) return false;
     return (
       areExpressionsStructurallyEqual(a.object, b.object) &&
       areExpressionsStructurallyEqual(a.property, b.property)
     );
   }
-  if (a.type === "CallExpression") {
+  if (isNodeOfType(a, "CallExpression")) {
     if (!areExpressionsStructurallyEqual(a.callee, b.callee)) return false;
     const argumentsA = a.arguments ?? [];
     const argumentsB = b.arguments ?? [];

--- a/packages/react-doctor/src/plugin/utils/collect-pattern-names.ts
+++ b/packages/react-doctor/src/plugin/utils/collect-pattern-names.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 // HACK: collects every locally-bound name introduced by a parameter list,
 // recursing into nested object/array patterns. We need every binding so
@@ -7,35 +8,35 @@ import type { EsTreeNode } from "./es-tree-node.js";
 export const collectPatternNames = (pattern: EsTreeNode | null, into: Set<string>): void => {
   if (!pattern) return;
 
-  if (pattern.type === "Identifier") {
+  if (isNodeOfType(pattern, "Identifier")) {
     into.add(pattern.name);
     return;
   }
 
-  if (pattern.type === "AssignmentPattern") {
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
     collectPatternNames(pattern.left, into);
     return;
   }
 
-  if (pattern.type === "RestElement") {
+  if (isNodeOfType(pattern, "RestElement")) {
     collectPatternNames(pattern.argument, into);
     return;
   }
 
-  if (pattern.type === "ArrayPattern") {
+  if (isNodeOfType(pattern, "ArrayPattern")) {
     for (const element of pattern.elements ?? []) {
       collectPatternNames(element, into);
     }
     return;
   }
 
-  if (pattern.type === "ObjectPattern") {
+  if (isNodeOfType(pattern, "ObjectPattern")) {
     for (const property of pattern.properties ?? []) {
-      if (property.type === "RestElement") {
+      if (isNodeOfType(property, "RestElement")) {
         collectPatternNames(property.argument, into);
         continue;
       }
-      if (property.type === "Property") {
+      if (isNodeOfType(property, "Property")) {
         // The bound name lives in `property.value` (which may itself be
         // a nested pattern). The `property.key` is the source-side name
         // and only matters when it equals `property.value` (shorthand).

--- a/packages/react-doctor/src/plugin/utils/contains-fetch-call.ts
+++ b/packages/react-doctor/src/plugin/utils/contains-fetch-call.ts
@@ -1,17 +1,18 @@
 import { FETCH_CALLEE_NAMES, FETCH_MEMBER_OBJECTS } from "../constants.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { walkAst } from "./walk-ast.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const containsFetchCall = (node: EsTreeNode): boolean => {
   let didFindFetchCall = false;
   walkAst(node, (child) => {
-    if (didFindFetchCall || child.type !== "CallExpression") return;
-    if (child.callee?.type === "Identifier" && FETCH_CALLEE_NAMES.has(child.callee.name)) {
+    if (didFindFetchCall || !isNodeOfType(child, "CallExpression")) return;
+    if (isNodeOfType(child.callee, "Identifier") && FETCH_CALLEE_NAMES.has(child.callee.name)) {
       didFindFetchCall = true;
     }
     if (
-      child.callee?.type === "MemberExpression" &&
-      child.callee.object?.type === "Identifier" &&
+      isNodeOfType(child.callee, "MemberExpression") &&
+      isNodeOfType(child.callee.object, "Identifier") &&
       FETCH_MEMBER_OBJECTS.has(child.callee.object.name)
     ) {
       didFindFetchCall = true;

--- a/packages/react-doctor/src/plugin/utils/find-jsx-attribute.ts
+++ b/packages/react-doctor/src/plugin/utils/find-jsx-attribute.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const findJsxAttribute = (
   attributes: EsTreeNode[],
@@ -6,7 +7,7 @@ export const findJsxAttribute = (
 ): EsTreeNode | undefined =>
   attributes?.find(
     (attribute: EsTreeNode) =>
-      attribute.type === "JSXAttribute" &&
-      attribute.name?.type === "JSXIdentifier" &&
+      isNodeOfType(attribute, "JSXAttribute") &&
+      isNodeOfType(attribute.name, "JSXIdentifier") &&
       attribute.name.name === attributeName,
   );

--- a/packages/react-doctor/src/plugin/utils/find-side-effect.ts
+++ b/packages/react-doctor/src/plugin/utils/find-side-effect.ts
@@ -4,6 +4,7 @@ import { isMutatingDbCall } from "./is-mutating-db-call.js";
 import { isMutatingFetchCall } from "./is-mutating-fetch-call.js";
 import { isMutatingMethodProperty } from "./is-mutating-method-property.js";
 import { walkAst } from "./walk-ast.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const findSideEffect = (node: EsTreeNode): string | null => {
   let sideEffectDescription: string | null = null;
@@ -24,8 +25,9 @@ export const findSideEffect = (node: EsTreeNode): string | null => {
       sideEffectDescription = `fetch() with method ${methodProperty.value.value}`;
     } else if (isMutatingDbCall(child)) {
       const methodName = child.callee.property.name;
-      const objectName =
-        child.callee.object?.type === "Identifier" ? child.callee.object.name : null;
+      const objectName = isNodeOfType(child.callee.object, "Identifier")
+        ? child.callee.object.name
+        : null;
       sideEffectDescription = objectName ? `${objectName}.${methodName}()` : `.${methodName}()`;
     }
   });

--- a/packages/react-doctor/src/plugin/utils/get-callback-statements.ts
+++ b/packages/react-doctor/src/plugin/utils/get-callback-statements.ts
@@ -1,7 +1,8 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const getCallbackStatements = (callback: EsTreeNode): EsTreeNode[] => {
-  if (callback.body?.type === "BlockStatement") {
+  if (isNodeOfType(callback.body, "BlockStatement")) {
     return callback.body.body ?? [];
   }
   return callback.body ? [callback.body] : [];

--- a/packages/react-doctor/src/plugin/utils/get-callee-name.ts
+++ b/packages/react-doctor/src/plugin/utils/get-callee-name.ts
@@ -1,8 +1,12 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const getCalleeName = (node: EsTreeNode): string | null => {
-  if (node.callee?.type === "Identifier") return node.callee.name;
-  if (node.callee?.type === "MemberExpression" && node.callee.property?.type === "Identifier") {
+  if (isNodeOfType(node.callee, "Identifier")) return node.callee.name;
+  if (
+    isNodeOfType(node.callee, "MemberExpression") &&
+    isNodeOfType(node.callee.property, "Identifier")
+  ) {
     return node.callee.property.name;
   }
   return null;

--- a/packages/react-doctor/src/plugin/utils/get-effect-callback.ts
+++ b/packages/react-doctor/src/plugin/utils/get-effect-callback.ts
@@ -1,9 +1,13 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const getEffectCallback = (node: EsTreeNode): EsTreeNode | null => {
   if (!node.arguments?.length) return null;
   const callback = node.arguments[0];
-  if (callback.type === "ArrowFunctionExpression" || callback.type === "FunctionExpression") {
+  if (
+    isNodeOfType(callback, "ArrowFunctionExpression") ||
+    isNodeOfType(callback, "FunctionExpression")
+  ) {
     return callback;
   }
   return null;

--- a/packages/react-doctor/src/plugin/utils/get-imported-name.ts
+++ b/packages/react-doctor/src/plugin/utils/get-imported-name.ts
@@ -1,0 +1,16 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+// Reads the originally-exported identifier off an `ImportSpecifier`.
+// ES2022's arbitrary-module-namespace-identifier (`import { "string name" as
+// foo } from "mod"`) makes `imported` a union of `Identifier | StringLiteral`,
+// so callers that want a plain name string need both narrowings. Returns
+// undefined for any other node shape so rules can early-return safely.
+export const getImportedName = (importSpecifier: EsTreeNode): string | undefined => {
+  const imported = importSpecifier.imported;
+  if (isNodeOfType(imported, "Identifier")) return imported.name;
+  if (isNodeOfType(imported, "Literal") && typeof imported.value === "string") {
+    return imported.value;
+  }
+  return undefined;
+};

--- a/packages/react-doctor/src/plugin/utils/get-root-identifier-name.ts
+++ b/packages/react-doctor/src/plugin/utils/get-root-identifier-name.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 // HACK: walk a MemberExpression chain (computed or not) down to the
 // underlying root identifier. `state.nested.items` -> "state",
@@ -16,21 +17,21 @@ export const getRootIdentifierName = (
   options?: { followCallChains?: boolean },
 ): string | null => {
   if (!node) return null;
-  if (node.type === "Identifier") return node.name;
+  if (isNodeOfType(node, "Identifier")) return node.name;
   const followCallChains = options?.followCallChains === true;
   let cursor: EsTreeNode | undefined = node;
   while (cursor) {
-    if (cursor.type === "MemberExpression") {
+    if (isNodeOfType(cursor, "MemberExpression")) {
       cursor = cursor.object;
       continue;
     }
-    if (followCallChains && cursor.type === "CallExpression") {
-      const callee = cursor.callee;
-      if (callee?.type !== "MemberExpression") return null;
+    if (followCallChains && isNodeOfType(cursor, "CallExpression")) {
+      const callee: EsTreeNode | null | undefined = cursor.callee;
+      if (!isNodeOfType(callee, "MemberExpression")) return null;
       cursor = callee.object;
       continue;
     }
     break;
   }
-  return cursor?.type === "Identifier" ? cursor.name : null;
+  return isNodeOfType(cursor, "Identifier") ? cursor.name : null;
 };

--- a/packages/react-doctor/src/plugin/utils/has-directive.ts
+++ b/packages/react-doctor/src/plugin/utils/has-directive.ts
@@ -1,11 +1,12 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const hasDirective = (programNode: EsTreeNode, directive: string): boolean =>
   Boolean(
     programNode.body?.some(
       (statement: EsTreeNode) =>
-        statement.type === "ExpressionStatement" &&
-        statement.expression?.type === "Literal" &&
+        isNodeOfType(statement, "ExpressionStatement") &&
+        isNodeOfType(statement.expression, "Literal") &&
         statement.expression.value === directive,
     ),
   );

--- a/packages/react-doctor/src/plugin/utils/has-use-server-directive.ts
+++ b/packages/react-doctor/src/plugin/utils/has-use-server-directive.ts
@@ -1,11 +1,12 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const hasUseServerDirective = (node: EsTreeNode): boolean => {
-  if (node.body?.type !== "BlockStatement") return false;
+  if (!isNodeOfType(node.body, "BlockStatement")) return false;
   return Boolean(
     node.body.body?.some(
       (statement: EsTreeNode) =>
-        statement.type === "ExpressionStatement" && statement.directive === "use server",
+        isNodeOfType(statement, "ExpressionStatement") && statement.directive === "use server",
     ),
   );
 };

--- a/packages/react-doctor/src/plugin/utils/is-component-assignment.ts
+++ b/packages/react-doctor/src/plugin/utils/is-component-assignment.ts
@@ -1,9 +1,11 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isUppercaseName } from "./is-uppercase-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const isComponentAssignment = (node: EsTreeNode): boolean =>
-  node.type === "VariableDeclarator" &&
-  node.id?.type === "Identifier" &&
+  isNodeOfType(node, "VariableDeclarator") &&
+  isNodeOfType(node.id, "Identifier") &&
   isUppercaseName(node.id.name) &&
   Boolean(node.init) &&
-  (node.init.type === "ArrowFunctionExpression" || node.init.type === "FunctionExpression");
+  (isNodeOfType(node.init, "ArrowFunctionExpression") ||
+    isNodeOfType(node.init, "FunctionExpression"));

--- a/packages/react-doctor/src/plugin/utils/is-component-declaration.ts
+++ b/packages/react-doctor/src/plugin/utils/is-component-declaration.ts
@@ -1,5 +1,9 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isUppercaseName } from "./is-uppercase-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const isComponentDeclaration = (node: EsTreeNode): boolean =>
-  node.type === "FunctionDeclaration" && Boolean(node.id?.name) && isUppercaseName(node.id.name);
+  isNodeOfType(node, "FunctionDeclaration") &&
+  node.id !== null &&
+  Boolean(node.id?.name) &&
+  isUppercaseName(node.id.name);

--- a/packages/react-doctor/src/plugin/utils/is-cookies-or-headers-call.ts
+++ b/packages/react-doctor/src/plugin/utils/is-cookies-or-headers-call.ts
@@ -1,10 +1,14 @@
 import { MUTATION_METHOD_NAMES } from "../constants.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const isCookiesOrHeadersCall = (node: EsTreeNode, methodName: string): boolean => {
-  if (node.type !== "CallExpression" || node.callee?.type !== "MemberExpression") return false;
+  if (!isNodeOfType(node, "CallExpression") || !isNodeOfType(node.callee, "MemberExpression"))
+    return false;
   const { object, property } = node.callee;
-  if (property?.type !== "Identifier" || !MUTATION_METHOD_NAMES.has(property.name)) return false;
-  if (object?.type !== "CallExpression" || object.callee?.type !== "Identifier") return false;
+  if (!isNodeOfType(property, "Identifier") || !MUTATION_METHOD_NAMES.has(property.name))
+    return false;
+  if (!isNodeOfType(object, "CallExpression") || !isNodeOfType(object.callee, "Identifier"))
+    return false;
   return object.callee.name === methodName;
 };

--- a/packages/react-doctor/src/plugin/utils/is-function-like-variable-declarator.ts
+++ b/packages/react-doctor/src/plugin/utils/is-function-like-variable-declarator.ts
@@ -1,10 +1,14 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 // HACK: barrier-frame predicate used by `createComponentPropStackTracker`
 // - a non-component arrow / function-expression VariableDeclarator
 // pushes an empty stack frame so closed-over names from an outer
 // component don't leak into the helper's prop check.
 export const isFunctionLikeVariableDeclarator = (node: EsTreeNode): boolean => {
-  if (node.type !== "VariableDeclarator") return false;
-  return node.init?.type === "ArrowFunctionExpression" || node.init?.type === "FunctionExpression";
+  if (!isNodeOfType(node, "VariableDeclarator")) return false;
+  return (
+    isNodeOfType(node.init, "ArrowFunctionExpression") ||
+    isNodeOfType(node.init, "FunctionExpression")
+  );
 };

--- a/packages/react-doctor/src/plugin/utils/is-hook-call.ts
+++ b/packages/react-doctor/src/plugin/utils/is-hook-call.ts
@@ -1,8 +1,9 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { getCalleeName } from "./get-callee-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const isHookCall = (node: EsTreeNode, hookName: string | Set<string>): boolean => {
-  if (node.type !== "CallExpression") return false;
+  if (!isNodeOfType(node, "CallExpression")) return false;
   const calleeName = getCalleeName(node);
   if (!calleeName) return false;
   return typeof hookName === "string" ? calleeName === hookName : hookName.has(calleeName);

--- a/packages/react-doctor/src/plugin/utils/is-member-property.ts
+++ b/packages/react-doctor/src/plugin/utils/is-member-property.ts
@@ -1,6 +1,7 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const isMemberProperty = (node: EsTreeNode, propertyName: string): boolean =>
-  node.type === "MemberExpression" &&
-  node.property?.type === "Identifier" &&
+  isNodeOfType(node, "MemberExpression") &&
+  isNodeOfType(node.property, "Identifier") &&
   node.property.name === propertyName;

--- a/packages/react-doctor/src/plugin/utils/is-mutating-db-call.ts
+++ b/packages/react-doctor/src/plugin/utils/is-mutating-db-call.ts
@@ -1,8 +1,10 @@
 import { MUTATION_METHOD_NAMES } from "../constants.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const isMutatingDbCall = (node: EsTreeNode): boolean => {
-  if (node.type !== "CallExpression" || node.callee?.type !== "MemberExpression") return false;
+  if (!isNodeOfType(node, "CallExpression") || !isNodeOfType(node.callee, "MemberExpression"))
+    return false;
   const { property } = node.callee;
-  return property?.type === "Identifier" && MUTATION_METHOD_NAMES.has(property.name);
+  return isNodeOfType(property, "Identifier") && MUTATION_METHOD_NAMES.has(property.name);
 };

--- a/packages/react-doctor/src/plugin/utils/is-mutating-fetch-call.ts
+++ b/packages/react-doctor/src/plugin/utils/is-mutating-fetch-call.ts
@@ -1,10 +1,11 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isMutatingMethodProperty } from "./is-mutating-method-property.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const isMutatingFetchCall = (node: EsTreeNode): boolean => {
-  if (node.type !== "CallExpression") return false;
-  if (node.callee?.type !== "Identifier" || node.callee.name !== "fetch") return false;
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "fetch") return false;
   const optionsArgument = node.arguments?.[1];
-  if (!optionsArgument || optionsArgument.type !== "ObjectExpression") return false;
+  if (!optionsArgument || !isNodeOfType(optionsArgument, "ObjectExpression")) return false;
   return Boolean(optionsArgument.properties?.some(isMutatingMethodProperty));
 };

--- a/packages/react-doctor/src/plugin/utils/is-mutating-method-property.ts
+++ b/packages/react-doctor/src/plugin/utils/is-mutating-method-property.ts
@@ -1,5 +1,6 @@
 import { MUTATING_HTTP_METHODS } from "../constants.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 // HACK: extracted so `findSideEffect` can re-use the EXACT same shape
 // predicate when it goes hunting for the literal method to render in
@@ -8,9 +9,9 @@ import type { EsTreeNode } from "./es-tree-node.js";
 // (when duplicate keys are present), producing
 // `"fetch() with method undefined"` in the message.
 export const isMutatingMethodProperty = (property: EsTreeNode): boolean =>
-  property.type === "Property" &&
-  property.key?.type === "Identifier" &&
+  isNodeOfType(property, "Property") &&
+  isNodeOfType(property.key, "Identifier") &&
   property.key.name === "method" &&
-  property.value?.type === "Literal" &&
+  isNodeOfType(property.value, "Literal") &&
   typeof property.value.value === "string" &&
   MUTATING_HTTP_METHODS.has(property.value.value.toUpperCase());

--- a/packages/react-doctor/src/plugin/utils/is-setter-call.ts
+++ b/packages/react-doctor/src/plugin/utils/is-setter-call.ts
@@ -1,7 +1,8 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isSetterIdentifier } from "./is-setter-identifier.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const isSetterCall = (node: EsTreeNode): boolean =>
-  node.type === "CallExpression" &&
-  node.callee?.type === "Identifier" &&
+  isNodeOfType(node, "CallExpression") &&
+  isNodeOfType(node.callee, "Identifier") &&
   isSetterIdentifier(node.callee.name);


### PR DESCRIPTION
## Summary

Replaces **1127** inline `<chain>(?.|.)type ===/!== "TypeName"` checks across the rules with calls to the existing `isNodeOfType(<chain>, "TypeName")` type-guard helper. The helper narrows the chain to the real TSESTree node shape so subsequent property access is type-checked; the inline string comparison only checks at runtime (`EsTreeNode.type: string` doesn't form a discriminated union, so `if (node.type === "Identifier")` did NOT narrow `node` for TypeScript).

**193 files touched.** Same runtime behavior — but the new narrowing exposed **~42 latent type errors** that were previously swallowed by the loose `EsTreeNode[key: string]: any` index signature. Each was fixed by adding the narrowing the code had implicitly assumed.

## Why now

`isNodeOfType` already exists in `plugin/utils/`, but only 5 places used it. Every other rule reached for the equivalent-but-untyped `node.type === "X"` pattern, so:
- IDE autocomplete inside the narrowed branch was bare (every property was `any`)
- TypeScript silently accepted typos like `node.callee.property.nme` (now caught)
- Several real bugs were hiding: rules that assumed `MemberExpression.property` was always an `Identifier` would silently miss `PrivateIdentifier` cases, etc.

## Mechanical replacement

```diff
- if (node.callee?.type === "Identifier" && node.callee.name === "fetch") return;
+ if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "fetch") return;
```

```diff
- if (statement.expression?.type !== "Literal") return;
+ if (!isNodeOfType(statement.expression, "Literal")) return;
```

`isNodeOfType` is null-safe (delegates to `hasTypeProperty`), so all optional-chain forms (`x?.type ===` etc.) are preserved in semantics.

## Latent type errors fixed

Grouped by pattern:

- **`ImportSpecifier.imported.name`** (9 rule files) — `imported` is `Identifier | StringLiteral` (ES2022 module-string imports). Adds a `getImportedName(specifier)` helper that reads the name from either shape.
- **`MemberExpression.property.name`** (4 rules) — `property` is `PrivateIdentifier | Expression`. Rules that wanted the property's name now narrow to `Identifier` first (`no-array-index-as-key`, `no-inline-prop-on-memo-component`, `rerender-functional-setstate`).
- **`ObjectExpression.properties[].key/.value`** (9 sites) — `properties` is `(Property | SpreadElement | RestElement)[]`. Rules that read `.key` / `.value` now narrow to `Property` first (`query-no-void-query-fn`, `query-no-use-query-for-mutation`, `walk-server-fn-chain`).
- **`Literal.value`** as `string` (2 rules) — the value union is `string | number | bigint | boolean | RegExp | null`. Callers that fed it to a `string` API now `typeof === "string"` first (`client-passive-event-listeners`, `no-layout-property-animation`).
- **`Array.find/some` predicate** (5 sites) — when narrowed, `<ArrayExpression>.elements` becomes `(SpreadElement | Expression | null)[]`. Predicates with the over-tight `(element: EsTreeNode)` annotation now either drop the annotation or iterate with a `for ... of` loop.
- A handful of other one-off narrowings (recursive `callee`, JSX member chain, destructuring-pattern element, `node.id` null-check).

## Test plan

- [x] `pnpm typecheck` — 0 errors (was 42 mid-refactor)
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean
- [x] `pnpm test` — 734/734 pass

All replacements are runtime-equivalent (`isNodeOfType` performs the same equality check the inline form did, plus a `hasTypeProperty` null-guard that exactly mirrors what `?.type === "X"` did at runtime). The narrowing fixes are tightenings — each one preserves the original code's behavior on the cases it already handled, and turns previously-silent failures (e.g. `MemberExpression.property` being a `PrivateIdentifier`) into explicit no-ops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad mechanical refactor across many lint rules; while intended to be runtime-equivalent, the large surface area could subtly change rule triggering on edge AST shapes (e.g., import specifiers or member properties).
> 
> **Overview**
> Replaces hundreds of inline AST checks (e.g. `node?.type === "Identifier"`) across the `react-doctor` plugin rules with the shared `isNodeOfType(...)` type guard to get consistent null-safety and TypeScript narrowing.
> 
> Updates several rules and shared helpers to handle wider AST unions explicitly (notably import specifiers via `getImportedName`, and safer checks around `Literal` value types and `MemberExpression`/object property shapes) while keeping rule behavior conceptually the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9135d07354eb06ff4405a29fd860a9ae08557c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->