### PR TITLE
refactor(rules): colocate category with each defineRule call

### DIFF
--- a/packages/react-doctor/src/core/runners/run-oxlint.ts
+++ b/packages/react-doctor/src/core/runners/run-oxlint.ts
@@ -31,6 +31,13 @@ import { neutralizeDisableDirectives } from "../diagnostics/neutralize-disable-d
 const getRuleRecommendation = (ruleName: string): string | undefined =>
   reactDoctorPlugin.rules[ruleName]?.recommendation;
 
+// Same shape as `getRuleRecommendation`, but for the diagnostic category
+// (`State & Effects`, `Performance`, …) the rule rolls up under in the
+// scan summary. Used by `resolveDiagnosticCategory` below and by
+// `validateRuleRegistration` to assert per-rule metadata coverage.
+const getRuleCategory = (ruleName: string): string | undefined =>
+  reactDoctorPlugin.rules[ruleName]?.category;
+
 const esmRequire = createRequire(import.meta.url);
 
 const PLUGIN_CATEGORY_MAP: Record<string, string> = {
@@ -56,203 +63,6 @@ const PLUGIN_CATEGORY_MAP: Record<string, string> = {
   vitest: "Correctness",
   jest: "Correctness",
   nextjs: "Next.js",
-};
-
-const RULE_CATEGORY_MAP: Record<string, string> = {
-  "react-doctor/no-derived-state-effect": "State & Effects",
-  "react-doctor/no-fetch-in-effect": "State & Effects",
-  "react-doctor/no-mirror-prop-effect": "State & Effects",
-  "react-doctor/no-mutable-in-deps": "State & Effects",
-  "react-doctor/no-cascading-set-state": "State & Effects",
-  "react-doctor/no-effect-chain": "State & Effects",
-  "react-doctor/no-effect-event-handler": "State & Effects",
-  "react-doctor/no-effect-event-in-deps": "State & Effects",
-  "react-doctor/no-event-trigger-state": "State & Effects",
-  "react-doctor/no-prop-callback-in-effect": "State & Effects",
-  "react-doctor/no-derived-useState": "State & Effects",
-  "react-doctor/no-direct-state-mutation": "State & Effects",
-  "react-doctor/no-set-state-in-render": "State & Effects",
-  "react-doctor/prefer-use-effect-event": "State & Effects",
-  "react-doctor/prefer-useReducer": "State & Effects",
-  "react-doctor/prefer-use-sync-external-store": "State & Effects",
-  "react-doctor/rerender-lazy-state-init": "Performance",
-  "react-doctor/rerender-functional-setstate": "Performance",
-  "react-doctor/rerender-dependencies": "State & Effects",
-  "react-doctor/rerender-state-only-in-handlers": "Performance",
-  "react-doctor/rerender-defer-reads-hook": "Performance",
-  "react-doctor/advanced-event-handler-refs": "Performance",
-  "react-doctor/effect-needs-cleanup": "State & Effects",
-
-  "react-doctor/no-generic-handler-names": "Architecture",
-  "react-doctor/no-giant-component": "Architecture",
-  "react-doctor/no-many-boolean-props": "Architecture",
-  "react-doctor/no-react19-deprecated-apis": "Architecture",
-  "react-doctor/no-render-prop-children": "Architecture",
-  "react-doctor/no-render-in-render": "Architecture",
-  "react-doctor/no-nested-component-definition": "Correctness",
-  "react-doctor/react-compiler-destructure-method": "Architecture",
-  "react-doctor/no-legacy-class-lifecycles": "Correctness",
-  "react-doctor/no-legacy-context-api": "Correctness",
-  "react-doctor/no-default-props": "Architecture",
-  "react-doctor/no-react-dom-deprecated-apis": "Architecture",
-
-  "react-doctor/no-usememo-simple-expression": "Performance",
-  "react-doctor/no-layout-property-animation": "Performance",
-  "react-doctor/rerender-memo-with-default-value": "Performance",
-  "react-doctor/rerender-memo-before-early-return": "Performance",
-  "react-doctor/rerender-transitions-scroll": "Performance",
-  "react-doctor/rerender-derived-state-from-hook": "Performance",
-  "react-doctor/async-defer-await": "Performance",
-  "react-doctor/async-await-in-loop": "Performance",
-  "react-doctor/rendering-animate-svg-wrapper": "Performance",
-  "react-doctor/rendering-hoist-jsx": "Performance",
-  "react-doctor/rendering-hydration-mismatch-time": "Correctness",
-  "react-doctor/rendering-usetransition-loading": "Performance",
-  "react-doctor/rendering-hydration-no-flicker": "Performance",
-  "react-doctor/rendering-script-defer-async": "Performance",
-  "react-doctor/no-inline-prop-on-memo-component": "Performance",
-
-  "react-doctor/no-transition-all": "Performance",
-  "react-doctor/no-global-css-variable-animation": "Performance",
-  "react-doctor/no-large-animated-blur": "Performance",
-  "react-doctor/no-scale-from-zero": "Performance",
-  "react-doctor/no-permanent-will-change": "Performance",
-
-  "react-doctor/no-secrets-in-client-code": "Security",
-
-  "react-doctor/no-barrel-import": "Bundle Size",
-  "react-doctor/no-dynamic-import-path": "Bundle Size",
-  "react-doctor/no-full-lodash-import": "Bundle Size",
-  "react-doctor/no-moment": "Bundle Size",
-  "react-doctor/prefer-dynamic-import": "Bundle Size",
-  "react-doctor/use-lazy-motion": "Bundle Size",
-  "react-doctor/no-undeferred-third-party": "Bundle Size",
-
-  "react-doctor/no-array-index-as-key": "Correctness",
-  "react-doctor/no-polymorphic-children": "Architecture",
-  "react-doctor/rendering-conditional-render": "Correctness",
-  "react-doctor/rendering-svg-precision": "Performance",
-  "react-doctor/no-prevent-default": "Correctness",
-  "react-doctor/no-uncontrolled-input": "Correctness",
-  "react-doctor/no-document-start-view-transition": "Correctness",
-  "react-doctor/no-flush-sync": "Performance",
-  "react-doctor/nextjs-no-img-element": "Next.js",
-  "react-doctor/nextjs-async-client-component": "Next.js",
-  "react-doctor/nextjs-no-a-element": "Next.js",
-  "react-doctor/nextjs-no-use-search-params-without-suspense": "Next.js",
-  "react-doctor/nextjs-no-client-fetch-for-server-data": "Next.js",
-  "react-doctor/nextjs-missing-metadata": "Next.js",
-  "react-doctor/nextjs-no-client-side-redirect": "Next.js",
-  "react-doctor/nextjs-no-redirect-in-try-catch": "Next.js",
-  "react-doctor/nextjs-image-missing-sizes": "Next.js",
-  "react-doctor/nextjs-no-native-script": "Next.js",
-  "react-doctor/nextjs-inline-script-missing-id": "Next.js",
-  "react-doctor/nextjs-no-font-link": "Next.js",
-  "react-doctor/nextjs-no-css-link": "Next.js",
-  "react-doctor/nextjs-no-polyfill-script": "Next.js",
-  "react-doctor/nextjs-no-head-import": "Next.js",
-  "react-doctor/nextjs-no-side-effect-in-get-handler": "Security",
-
-  "react-doctor/server-auth-actions": "Server",
-  "react-doctor/server-after-nonblocking": "Server",
-  "react-doctor/server-no-mutable-module-state": "Server",
-  "react-doctor/server-cache-with-object-literal": "Server",
-  "react-doctor/server-hoist-static-io": "Server",
-  "react-doctor/server-dedup-props": "Server",
-  "react-doctor/server-sequential-independent-await": "Server",
-  "react-doctor/server-fetch-without-revalidate": "Server",
-
-  "react-doctor/client-passive-event-listeners": "Performance",
-  "react-doctor/client-localstorage-no-version": "Correctness",
-
-  "react-doctor/query-stable-query-client": "TanStack Query",
-  "react-doctor/query-no-rest-destructuring": "TanStack Query",
-  "react-doctor/query-no-void-query-fn": "TanStack Query",
-  "react-doctor/query-no-query-in-effect": "TanStack Query",
-  "react-doctor/query-mutation-missing-invalidation": "TanStack Query",
-  "react-doctor/query-no-usequery-for-mutation": "TanStack Query",
-
-  "react-doctor/no-inline-bounce-easing": "Performance",
-  "react-doctor/no-z-index-9999": "Architecture",
-  "react-doctor/no-inline-exhaustive-style": "Architecture",
-  "react-doctor/no-side-tab-border": "Architecture",
-  "react-doctor/no-pure-black-background": "Architecture",
-  "react-doctor/no-gradient-text": "Architecture",
-  "react-doctor/no-dark-mode-glow": "Architecture",
-  "react-doctor/no-justified-text": "Accessibility",
-  "react-doctor/no-tiny-text": "Accessibility",
-  "react-doctor/no-wide-letter-spacing": "Architecture",
-  "react-doctor/no-gray-on-colored-background": "Accessibility",
-  "react-doctor/no-layout-transition-inline": "Performance",
-  "react-doctor/no-disabled-zoom": "Accessibility",
-  "react-doctor/no-outline-none": "Accessibility",
-  "react-doctor/no-long-transition-duration": "Performance",
-
-  "react-doctor/design-no-bold-heading": "Architecture",
-  "react-doctor/design-no-redundant-padding-axes": "Architecture",
-  "react-doctor/design-no-redundant-size-axes": "Architecture",
-  "react-doctor/design-no-space-on-flex-children": "Architecture",
-  "react-doctor/design-no-three-period-ellipsis": "Architecture",
-  "react-doctor/design-no-default-tailwind-palette": "Architecture",
-  "react-doctor/design-no-vague-button-label": "Accessibility",
-
-  "react-doctor/js-flatmap-filter": "Performance",
-  "react-doctor/js-combine-iterations": "Performance",
-  "react-doctor/js-tosorted-immutable": "Performance",
-  "react-doctor/js-hoist-regexp": "Performance",
-  "react-doctor/js-hoist-intl": "Performance",
-  "react-doctor/js-cache-property-access": "Performance",
-  "react-doctor/js-length-check-first": "Performance",
-  "react-doctor/js-min-max-loop": "Performance",
-  "react-doctor/js-set-map-lookups": "Performance",
-  "react-doctor/js-batch-dom-css": "Performance",
-  "react-doctor/js-index-maps": "Performance",
-  "react-doctor/js-cache-storage": "Performance",
-  "react-doctor/js-early-exit": "Performance",
-
-  "react-doctor/no-eval": "Security",
-
-  "react-doctor/async-parallel": "Performance",
-
-  "react-doctor/rn-no-raw-text": "React Native",
-  "react-doctor/rn-no-deprecated-modules": "React Native",
-  "react-doctor/rn-no-legacy-expo-packages": "React Native",
-  "react-doctor/rn-no-dimensions-get": "React Native",
-  "react-doctor/rn-no-inline-flatlist-renderitem": "React Native",
-  "react-doctor/rn-no-legacy-shadow-styles": "React Native",
-  "react-doctor/rn-prefer-reanimated": "React Native",
-  "react-doctor/rn-no-single-element-style-array": "React Native",
-  "react-doctor/rn-prefer-pressable": "React Native",
-  "react-doctor/rn-prefer-expo-image": "React Native",
-  "react-doctor/rn-no-non-native-navigator": "React Native",
-  "react-doctor/rn-no-scroll-state": "React Native",
-  "react-doctor/rn-no-scrollview-mapped-list": "React Native",
-  "react-doctor/rn-no-inline-object-in-list-item": "React Native",
-  "react-doctor/rn-animate-layout-property": "React Native",
-  "react-doctor/rn-prefer-content-inset-adjustment": "React Native",
-  "react-doctor/rn-pressable-shared-value-mutation": "React Native",
-  "react-doctor/rn-list-data-mapped": "React Native",
-  "react-doctor/rn-list-callback-per-row": "React Native",
-  "react-doctor/rn-list-recyclable-without-types": "React Native",
-  "react-doctor/rn-animation-reaction-as-derived": "React Native",
-  "react-doctor/rn-bottom-sheet-prefer-native": "React Native",
-  "react-doctor/rn-scrollview-dynamic-padding": "React Native",
-  "react-doctor/rn-style-prefer-boxshadow": "React Native",
-
-  "react-doctor/tanstack-start-route-property-order": "TanStack Start",
-  "react-doctor/tanstack-start-no-direct-fetch-in-loader": "TanStack Start",
-  "react-doctor/tanstack-start-server-fn-validate-input": "TanStack Start",
-  "react-doctor/tanstack-start-no-useeffect-fetch": "TanStack Start",
-  "react-doctor/tanstack-start-missing-head-content": "TanStack Start",
-  "react-doctor/tanstack-start-no-anchor-element": "TanStack Start",
-  "react-doctor/tanstack-start-server-fn-method-order": "TanStack Start",
-  "react-doctor/tanstack-start-no-navigate-in-render": "TanStack Start",
-  "react-doctor/tanstack-start-no-dynamic-server-fn-import": "TanStack Start",
-  "react-doctor/tanstack-start-no-use-server-in-handler": "TanStack Start",
-  "react-doctor/tanstack-start-no-secrets-in-loader": "Security",
-  "react-doctor/tanstack-start-get-mutation": "Security",
-  "react-doctor/tanstack-start-redirect-in-try-catch": "TanStack Start",
-  "react-doctor/tanstack-start-loader-parallel-fetch": "Performance",
 };
 
 const FILEPATH_WITH_LOCATION_PATTERN = /\S+\.\w+:\d+:\d+[\s\S]*$/;
@@ -307,14 +117,8 @@ const resolvePluginPath = (): string => {
   return pluginPath;
 };
 
-const resolveDiagnosticCategory = (plugin: string, rule: string): string => {
-  const ruleKey = `${plugin}/${rule}`;
-  return (
-    lookupOwnString(RULE_CATEGORY_MAP, ruleKey) ??
-    lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ??
-    "Other"
-  );
-};
+const resolveDiagnosticCategory = (plugin: string, rule: string): string =>
+  getRuleCategory(rule) ?? lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ?? "Other";
 
 // HACK: Sanitize child env so a developer's NODE_OPTIONS=--inspect (or
 // --max-old-space-size=128, etc.) doesn't leak into oxlint and either spawn a
@@ -514,7 +318,7 @@ const validateRuleRegistration = (): void => {
   const missingMetadata: string[] = [];
   for (const fullKey of ALL_REACT_DOCTOR_RULE_KEYS) {
     const ruleName = fullKey.replace(/^react-doctor\//, "");
-    if (!Object.hasOwn(RULE_CATEGORY_MAP, fullKey)) {
+    if (!getRuleCategory(ruleName)) {
       missingCategory.push(fullKey);
     }
     if (!getRuleRecommendation(ruleName)) {
@@ -527,7 +331,7 @@ const validateRuleRegistration = (): void => {
   if (missingCategory.length > 0 || missingHelp.length > 0 || missingMetadata.length > 0) {
     const detail = [
       missingCategory.length > 0
-        ? `Missing RULE_CATEGORY_MAP entries: ${missingCategory.join(", ")}`
+        ? `Missing rule categories (add to defineRule call): ${missingCategory.join(", ")}`
         : null,
       missingHelp.length > 0
         ? `Missing rule recommendations (add to defineRule call): ${missingHelp.join(", ")}`

--- a/packages/react-doctor/src/plugin/rules/architecture/no-default-props.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-default-props.ts
@@ -14,6 +14,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // recommendation is the same either way — switch to ES6 default params
 // in destructured props — so the guidance is uniform.
 export const noDefaultProps = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     'React 19 removes `Component.defaultProps` for function components. Move the defaults into the destructured props parameter: `function Foo({ size = "md", variant = "primary" })` instead of `Foo.defaultProps = { size: "md", variant: "primary" }`.',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noGenericHandlerNames = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Rename to describe the action: e.g. `handleSubmit` → `saveUserProfile`, `handleClick` → `toggleSidebar`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/architecture/no-giant-component.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-giant-component.ts
@@ -7,6 +7,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noGiantComponent = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Extract logical sections into focused components: `<UserHeader />`, `<UserActions />`, etc.",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/architecture/no-legacy-class-lifecycles.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-legacy-class-lifecycles.ts
@@ -55,6 +55,7 @@ const buildLegacyLifecycleMessage = (originalName: string): string | null => {
 };
 
 export const noLegacyClassLifecycles = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     "Move side effects in `componentWillMount` to `componentDidMount`; replace `componentWillReceiveProps` with `componentDidUpdate` (compare prevProps) or the static `getDerivedStateFromProps` for pure state derivation; replace `componentWillUpdate` with `getSnapshotBeforeUpdate` paired with `componentDidUpdate`. The `UNSAFE_` prefix only silences the warning — React 19 removes both forms.",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
@@ -42,6 +42,7 @@ const isInsideClassBody = (node: EsTreeNode): boolean => {
 };
 
 export const noLegacyContextApi = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     "Replace `childContextTypes` + `getChildContext` with `const MyContext = createContext(...)` + `<MyContext.Provider value={...}>`; replace `contextTypes` with `static contextType = MyContext` (single context) or `useContext()` / `use()` from a function component. The provider and every consumer must migrate together — partial migrations leave consumers reading the wrong context.",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -37,6 +37,7 @@ const collectBooleanLikePropsFromBody = (
 // (`function Foo(props) { props.isPrimary }`) by walking member-access
 // patterns on the parameter binding.
 export const noManyBooleanProps = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Split into compound components or named variants: `<Button.Primary />`, `<DialogConfirm />` instead of stacking `isPrimary`, `isConfirm` flags",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
@@ -6,6 +6,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noNestedComponentDefinition = defineRule<Rule>({
+  category: "Correctness",
   recommendation: "Move to a separate file or to module scope above the parent component",
   create: (context: RuleContext) => {
     const componentStack: string[] = [];

--- a/packages/react-doctor/src/plugin/rules/architecture/no-react-dom-deprecated-apis.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-react-dom-deprecated-apis.ts
@@ -73,6 +73,7 @@ const reportTestUtilsImports = (node: EsTreeNode, context: RuleContext): void =>
 };
 
 export const noReactDomDeprecatedApis = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Switch the legacy `react-dom` root API (`render` / `hydrate` / `unmountComponentAtNode`) to `createRoot` / `hydrateRoot` / `root.unmount()` from `react-dom/client`. Replace `findDOMNode` with a ref. The whole `react-dom/test-utils` entry point is removed in React 19 — use `act` from `react` and `fireEvent` / `render` from `@testing-library/react`. Only enabled on projects detected as React 18+.",
   ...createDeprecatedReactImportRule({

--- a/packages/react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.ts
@@ -26,6 +26,7 @@ const REACT_19_DEPRECATED_MESSAGES = new Map<string, string>([
 ]);
 
 export const noReact19DeprecatedApis = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Pass `ref` as a regular prop on function components — `forwardRef` is no longer needed in React 19+. Replace `useContext(X)` with `use(X)` for branch-aware context reads. Only enabled on projects detected as React 19+.",
   ...createDeprecatedReactImportRule({

--- a/packages/react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRenderInRender = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Extract to a named component: `const ListItem = ({ item }) => <div>{item.name}</div>`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
@@ -16,6 +16,7 @@ const RENDER_PROP_PATTERN = /^render[A-Z]/;
 // of "many slots cobbled together where compound components or
 // `children` would be cleaner".
 export const noRenderPropChildren = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Replace `renderXxx` props with compound subcomponents (e.g. `<Modal.Header>`) or `children` so the parent doesn't dictate every customization point",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
@@ -48,6 +48,7 @@ const buildHookBindingMap = (componentBody: EsTreeNode): Map<string, string> => 
 // where `router` is bound to a `useRouter()` call in the same component.
 // We don't fire when the binding is destructured already.
 export const reactCompilerDestructureMethod = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Destructure the method up front: `const { push } = useRouter()` then call `push(...)` directly — clearer dependency graph and easier for React Compiler to memoize",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noBarrelImport = defineRule<Rule>({
+  category: "Bundle Size",
   recommendation:
     "Import from the direct path: `import { Button } from './components/Button'` instead of `./components`",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-dynamic-import-path.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-dynamic-import-path.ts
@@ -8,6 +8,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // statically-analyzable string literal. `import(variable)` or
 // `require(variable)` defeats trace targets and forces a fat bundle.
 export const noDynamicImportPath = defineRule<Rule>({
+  category: "Bundle Size",
   recommendation:
     "Use a string-literal path: `import('./feature/heavy.js')` so the bundler can split this chunk",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-full-lodash-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-full-lodash-import.ts
@@ -4,6 +4,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noFullLodashImport = defineRule<Rule>({
+  category: "Bundle Size",
   recommendation:
     "Import the specific function: `import debounce from 'lodash/debounce'` — saves ~70kb",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-moment.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-moment.ts
@@ -4,6 +4,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noMoment = defineRule<Rule>({
+  category: "Bundle Size",
   recommendation:
     "Replace with `import { format } from 'date-fns'` (tree-shakeable) or `import dayjs from 'dayjs'` (2kb)",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noUndeferredThirdParty = defineRule<Rule>({
+  category: "Bundle Size",
   recommendation: 'Use `next/script` with `strategy="lazyOnload"` or add the `defer` attribute',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {

--- a/packages/react-doctor/src/plugin/rules/bundle-size/prefer-dynamic-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/prefer-dynamic-import.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const preferDynamicImport = defineRule<Rule>({
+  category: "Bundle Size",
   recommendation:
     "Use `const Component = dynamic(() => import('library'), { ssr: false })` from next/dynamic or React.lazy()",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/bundle-size/use-lazy-motion.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/use-lazy-motion.ts
@@ -6,6 +6,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const useLazyMotion = defineRule<Rule>({
+  category: "Bundle Size",
   recommendation:
     'Use `import { LazyMotion, m } from "framer-motion"` with `domAnimation` features — saves ~30kb',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
+++ b/packages/react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
@@ -29,6 +29,7 @@ const isJsonStringifyCall = (node: EsTreeNode): boolean => {
 };
 
 export const clientLocalstorageNoVersion = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     'Bake a version into the storage key (e.g. "myKey:v1"); a future schema change can ignore old data instead of crashing on it',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
+++ b/packages/react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const clientPassiveEventListeners = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Add `{ passive: true }` as the third argument: `addEventListener('scroll', handler, { passive: true })`. Only do this if the handler does NOT call `event.preventDefault()` — passive listeners silently ignore `preventDefault()`, which breaks features like pull-to-refresh suppression, custom gestures, and nested-scroll containment.",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -91,6 +91,7 @@ const isInsideStaticPlaceholderMap = (node: EsTreeNode): boolean => {
 };
 
 export const noArrayIndexAsKey = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     "Use a stable unique identifier: `key={item.id}` or `key={item.slug}` — index keys break on reorder/filter",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -10,6 +10,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // subcomponents (`<Button.Text />`) so text always lands in the right
 // shape and the component's API is checked at compile time.
 export const noPolymorphicChildren = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Expose explicit subcomponents (`<Button.Text>`, `<Button.Icon>`) so consumers don't need to switch on `typeof children`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -45,6 +45,7 @@ const buildPreventDefaultMessage = (elementName: string): string => {
 };
 
 export const noPreventDefault = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     "Use `<form action={serverAction}>` (works without JS) or `<button>` instead of `<a>` with preventDefault",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -72,6 +72,7 @@ const hasJsxSpreadAttribute = (attributes: EsTreeNode[]): boolean =>
 // `defaultValue` via spread, and we can't see through it without scope
 // analysis. False-negative > false-positive on a heavily used pattern.
 export const noUncontrolledInput = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     'Pass an explicit initial value to `useState` (e.g. `useState("")` instead of `useState()`), add `onChange` (or `readOnly` to opt out) when you supply `value`, and drop `defaultValue` on controlled inputs — React ignores it',
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/correctness/rendering-conditional-render.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/rendering-conditional-render.ts
@@ -22,6 +22,7 @@ const isNumericName = (name: string): boolean => {
 };
 
 export const renderingConditionalRender = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     "Change to `{items.length > 0 && <List />}` or use a ternary: `{items.length ? <List /> : null}`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
@@ -13,6 +13,7 @@ const SVG_PATH_ATTRIBUTES = new Set(["d", "points", "transform"]);
 // emit these by default; truncating to 1–2 decimals trims 30–50% off
 // markup with no visible difference.
 export const renderingSvgPrecision = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Truncate path/points/transform decimals to 1–2 digits — sub-pixel precision adds bytes with no visible difference",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -66,6 +66,7 @@ const isBackgroundDark = (bgValue: string): boolean => {
 };
 
 export const noDarkModeGlow = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Use a subtle `box-shadow` with neutral colors for depth, or `border` with low opacity. Colored glows on dark backgrounds are the default AI-generated aesthetic",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noDisabledZoom = defineRule<Rule>({
+  category: "Accessibility",
   recommendation:
     "Remove `user-scalable=no` and `maximum-scale` from the viewport meta tag. If your layout breaks at 200% zoom, fix the layout — don't punish users with disabilities",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-gradient-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-gradient-text.ts
@@ -8,6 +8,7 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 
 export const noGradientText = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Use solid text colors for readability. If you need emphasis, use font weight, size, or a distinct color instead of gradients",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 
 export const noGrayOnColoredBackground = defineRule<Rule>({
+  category: "Accessibility",
   recommendation:
     "Use a darker shade of the background color for text, or white/near-white for contrast. Gray text on colored backgrounds looks washed out",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-inline-bounce-easing.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-inline-bounce-easing.ts
@@ -27,6 +27,7 @@ const hasBounceAnimationName = (value: string): boolean => {
 };
 
 export const noInlineBounceEasing = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `cubic-bezier(0.16, 1, 0.3, 1)` (ease-out-expo) for natural deceleration — objects in the real world don't bounce",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
@@ -7,6 +7,7 @@ import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noInlineExhaustiveStyle = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Move styles to a CSS class, CSS module, Tailwind utilities, or a styled component — inline objects with many properties hurt readability and create new references every render",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-justified-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-justified-text.ts
@@ -7,6 +7,7 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 
 export const noJustifiedText = defineRule<Rule>({
+  category: "Accessibility",
   recommendation:
     "Use `text-align: left` for body text, or add `hyphens: auto` and `overflow-wrap: break-word` if you must justify",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
@@ -7,6 +7,7 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 
 export const noLayoutTransitionInline = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `transform` and `opacity` for transitions — they run on the compositor thread. For height animations, use `grid-template-rows: 0fr → 1fr`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
@@ -8,6 +8,7 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 
 export const noLongTransitionDuration = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Keep UI transitions under 1s — 100-150ms for instant feedback, 200-300ms for state changes, 300-500ms for layout changes. Use longer durations only for page-load hero animations",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-outline-none.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-outline-none.ts
@@ -8,6 +8,7 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 
 export const noOutlineNone = defineRule<Rule>({
+  category: "Accessibility",
   recommendation:
     "Use `:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px }` to show focus only for keyboard users while hiding it for mouse clicks",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-pure-black-background.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-pure-black-background.ts
@@ -9,6 +9,7 @@ import { isPureBlackColor } from "./utils/is-pure-black-color.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 
 export const noPureBlackBackground = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Tint the background slightly toward your brand hue — e.g. `#0a0a0f` or Tailwind's `bg-gray-950`. Pure black looks harsh on modern displays",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-side-tab-border.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-side-tab-border.ts
@@ -53,6 +53,7 @@ const BORDER_SIDE_WIDTH_KEYS = new Set([
 ]);
 
 export const noSideTabBorder = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Use a subtler accent (box-shadow inset, background gradient, or border-bottom) instead of a thick one-sided border",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-tiny-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-tiny-text.ts
@@ -9,6 +9,7 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 
 export const noTinyText = defineRule<Rule>({
+  category: "Accessibility",
   recommendation:
     "Use at least 12px for body content, 16px is ideal. Small text is hard to read, especially on high-DPI mobile screens",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
@@ -9,6 +9,7 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 
 export const noWideLetterSpacing = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Reserve wide tracking (letter-spacing > 0.05em) for short uppercase labels, navigation items, and buttons — not body text",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/design/no-z-index9999.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-z-index9999.ts
@@ -10,6 +10,7 @@ import { getStylePropertyNumberValue } from "./utils/get-style-property-number-v
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noZIndex9999 = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Define a z-index scale in your design tokens (e.g. dropdown: 10, modal: 20, toast: 30). Create a new stacking context with `isolation: isolate` instead of escalating values",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
@@ -183,6 +183,7 @@ const isWrappedInPromiseConcurrency = (mapCall: EsTreeNode): boolean => {
 };
 
 export const asyncAwaitInLoop = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Collect the items and use `await Promise.all(items.map(...))` to run independent operations concurrently",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/js-performance/async-parallel.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/async-parallel.ts
@@ -36,6 +36,7 @@ const reportIfIndependent = (statements: EsTreeNode[], context: RuleContext): vo
 };
 
 export const asyncParallel = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `const [a, b] = await Promise.all([fetchA(), fetchB()])` to run independent operations concurrently",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsBatchDomCss = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Batch DOM/CSS reads and writes — interleaving them inside a loop causes layout thrashing. Read first, then write",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
@@ -22,6 +22,7 @@ const buildMemberAccessKey = (node: EsTreeNode): string | null => {
 // at the top of the loop body. We require a member-expression depth ≥ 2
 // (two dots) and ≥ 3 occurrences in the same loop block to fire.
 export const jsCachePropertyAccess = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Hoist the deep member access into a const at the top of the loop body: `const { x, y } = obj.deeply.nested`",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-cache-storage.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-cache-storage.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsCacheStorage = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Cache repeated `localStorage`/`sessionStorage` reads in a local variable — each access serializes/deserializes",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-combine-iterations.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-combine-iterations.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsCombineIterations = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Combine `.map().filter()` (or similar chains) into a single pass with `.reduce()` or a `for...of` loop to avoid iterating the array twice",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-early-exit.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-early-exit.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsEarlyExit = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Add an early `return` / `continue` to flatten deep nesting and short-circuit when the predicate is already known",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsFlatmapFilter = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `.flatMap(item => condition ? [value] : [])` — transforms and filters in a single pass instead of creating an intermediate array",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
@@ -35,6 +35,7 @@ const isIntlNewExpression = (node: EsTreeNode): boolean => {
 };
 
 export const jsHoistIntl = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Hoist `new Intl.NumberFormat(...)` to module scope or wrap in `useMemo` — Intl constructors allocate dozens of objects per locale lookup",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-regexp.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-regexp.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsHoistRegexp = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Hoist `new RegExp(...)` (or large regex literals) to a module-level constant so it isn't recompiled on every loop iteration",
   create: (context: RuleContext) =>

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsIndexMaps = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Build an index `Map` once outside the loop instead of `array.find(...)` inside it",
   create: (context: RuleContext) =>

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
@@ -11,6 +11,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // shortcut. e.g. `a.length === b.length && a.every((x, i) => x === b[i])`
 // runs the every-loop only when lengths match.
 export const jsLengthCheckFirst = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Short-circuit with `a.length === b.length && a.every((x, i) => x === b[i])` — unequal-length arrays exit immediately",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-min-max-loop.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-min-max-loop.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsMinMaxLoop = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `Math.min(...array)` / `Math.max(...array)` instead of sorting just to read the first or last element",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -166,6 +166,7 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
 };
 
 export const jsSetMapLookups = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use a `Set` or `Map` for repeated membership tests / keyed lookups — `Array.includes`/`find` is O(n) per call",
   create: (context: RuleContext) =>

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsTosortedImmutable = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `array.toSorted()` (ES2023) instead of `[...array].sort()` for immutable sorting without the spread allocation",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.ts
@@ -7,6 +7,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const nextjsAsyncClientComponent = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Fetch data in a parent Server Component and pass it as props, or use useQuery/useSWR in the client component",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-image-missing-sizes.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-image-missing-sizes.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsImageMissingSizes = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     'Add sizes for responsive behavior: `sizes="(max-width: 768px) 100vw, 50vw"` matching your layout breakpoints',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-inline-script-missing-id.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-inline-script-missing-id.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsInlineScriptMissingId = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     'Add `id="descriptive-name"` so Next.js can track, deduplicate, and re-execute the script correctly',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsMissingMetadata = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Add `export const metadata = { title: '...', description: '...' }` or `export async function generateMetadata()`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoAElement = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "`import Link from 'next/link'` — enables client-side navigation, prefetching, and preserves scroll position",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.ts
@@ -13,6 +13,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const nextjsNoClientFetchForServerData = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Remove 'use client' and fetch directly in the Server Component — no API round-trip, secrets stay on server",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
@@ -45,6 +45,7 @@ const describeClientSideNavigation = (
 };
 
 export const nextjsNoClientSideRedirect = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Avoid redirects inside useEffect. Use an event handler, middleware, or server-side redirect (App Router: redirect() from next/navigation; Pages Router: getServerSideProps redirect)",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoCssLink = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Import CSS directly: `import './styles.css'` or use CSS Modules: `import styles from './Button.module.css'`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoFontLink = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     '`import { Inter } from "next/font/google"` — self-hosted, zero layout shift, no render-blocking requests',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-head-import.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-head-import.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const nextjsNoHeadImport = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Use the Metadata API instead: `export const metadata = { title: '...' }` or `export async function generateMetadata()`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoImgElement = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "`import Image from 'next/image'` — provides automatic WebP/AVIF, lazy loading, and responsive srcset",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-native-script.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-native-script.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoNativeScript = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     '`import Script from "next/script"` — use `strategy="afterInteractive"` for analytics or `"lazyOnload"` for widgets',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoPolyfillScript = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Next.js includes polyfills for fetch, Promise, Object.assign, Array.from, and 50+ others automatically",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-redirect-in-try-catch.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-redirect-in-try-catch.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoRedirectInTryCatch = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Move the redirect/notFound call outside the try block, or add `unstable_rethrow(error)` in the catch",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
@@ -42,6 +42,7 @@ const getExportedGetHandlerBody = (node: EsTreeNode): EsTreeNode | null => {
 };
 
 export const nextjsNoSideEffectInGetHandler = defineRule<Rule>({
+  category: "Security",
   recommendation:
     "Move the side effect to a POST handler and use a <form> or fetch with method POST — GET requests can be triggered by prefetching and are vulnerable to CSRF",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-use-search-params-without-suspense.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-use-search-params-without-suspense.ts
@@ -47,6 +47,7 @@ const fileMentionsSuspense = (programNode: EsTreeNode): boolean => {
 };
 
 export const nextjsNoUseSearchParamsWithoutSuspense = defineRule<Rule>({
+  category: "Next.js",
   recommendation:
     "Wrap the component using useSearchParams: `<Suspense fallback={<Skeleton />}><SearchComponent /></Suspense>`",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -36,6 +36,7 @@ const isEarlyReturnIfStatement = (statement: EsTreeNode): boolean => {
 // stay precise (intervening statements would imply the awaited binding
 // is being prepared for use).
 export const asyncDeferAwait = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Move the `await` after the synchronous early-return guard so the skip path stays fast",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/performance/no-global-css-variable-animation.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-global-css-variable-animation.ts
@@ -8,6 +8,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noGlobalCssVariableAnimation = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Set the variable on the nearest element instead of a parent, or use `@property` with `inherits: false` to prevent cascade. Better yet, use targeted `element.style.transform` updates",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
@@ -37,6 +37,7 @@ const isInlineReference = (node: EsTreeNode): string | null => {
 };
 
 export const noInlinePropOnMemoComponent = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Hoist the inline `() => ...` / `[]` / `{}` to a stable reference (useMemo, useCallback, or module scope) so the memoized child doesn't re-render every parent render",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/performance/no-large-animated-blur.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-large-animated-blur.ts
@@ -10,6 +10,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noLargeAnimatedBlur = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Keep blur radius under 10px, or apply blur to a smaller element. Large blurs multiply GPU memory usage with layer size",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/no-layout-property-animation.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-layout-property-animation.ts
@@ -24,6 +24,7 @@ const isMotionElement = (attributeNode: EsTreeNode): boolean => {
 };
 
 export const noLayoutPropertyAnimation = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `transform: translateX()` or `scale()` instead — they run on the compositor and skip layout/paint",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/no-permanent-will-change.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-permanent-will-change.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noPermanentWillChange = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Add will-change on animation start (`onMouseEnter`) and remove on end (`onAnimationEnd`). Permanent promotion wastes GPU memory and can degrade performance",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noScaleFromZero = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `initial={{ scale: 0.95, opacity: 0 }}` — elements should deflate like a balloon, not vanish into a point",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/no-transition-all.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-transition-all.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noTransitionAll = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     'List specific properties: `transition: "opacity 200ms, transform 200ms"` — or in Tailwind use `transition-colors`, `transition-opacity`, or `transition-transform`',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
@@ -18,6 +18,7 @@ const isTriviallyCheapExpression = (node: EsTreeNode | null): boolean => {
 };
 
 export const noUsememoSimpleExpression = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Remove useMemo — property access, math, and ternaries are already cheap without memoization",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingAnimateSvgWrapper = defineRule<Rule>({
+  category: "Performance",
   recommendation: "Wrap the SVG: `<motion.div animate={...}><svg>...</svg></motion.div>`",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNode) {

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hoist-jsx.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hoist-jsx.ts
@@ -29,6 +29,7 @@ const jsxReferencesLocalScope = (jsxNode: EsTreeNode): boolean => {
 };
 
 export const renderingHoistJsx = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Move the static JSX to module scope: `const ICON = <svg>...</svg>` outside the component so it isn't recreated each render",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-mismatch-time.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-mismatch-time.ts
@@ -89,6 +89,7 @@ const hasSuppressHydrationWarningAttribute = (openingElement: EsTreeNode | null)
 // only client-side) or to add `suppressHydrationWarning` to the parent
 // element when the mismatch is intentional.
 export const renderingHydrationMismatchTime = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     "Wrap dynamic time/random values in useEffect+useState (client-only) or add suppressHydrationWarning to the parent if intentional",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.ts
@@ -9,6 +9,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingHydrationNoFlicker = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)` or add `suppressHydrationWarning` to the element",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-script-defer-async.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-script-defer-async.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingScriptDeferAsync = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     'Add `defer` for DOM-dependent scripts or `async` for independent ones (analytics). In Next.js, use `<Script strategy="afterInteractive" />` instead',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingUsetransitionLoading = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Replace with `const [isPending, startTransition] = useTransition()` — avoids a re-render for the loading state",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-derived-state-from-hook.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-derived-state-from-hook.ts
@@ -73,6 +73,7 @@ const findThresholdDerivedBindings = (
 };
 
 export const rerenderDerivedStateFromHook = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     'Use a threshold/media-query hook (e.g. `useMediaQuery("(max-width: 767px)")`) — the component re-renders only when the threshold flips, not every pixel',
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
@@ -46,6 +46,7 @@ const containsEarlyReturn = (ifStatement: EsTreeNode): boolean => {
 // into a memoized child component so the parent's early return
 // short-circuits before the child renders.
 export const rerenderMemoBeforeEarlyReturn = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Extract the JSX into a memoized child component so the parent's early return short-circuits before the child renders",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderMemoWithDefaultValue = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Move to module scope: `const EMPTY_ITEMS: Item[] = []` then use as the default value",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-transitions-scroll.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-transitions-scroll.ts
@@ -52,6 +52,7 @@ const handlerCallsSetState = (handler: EsTreeNode): EsTreeNode | null => {
 // input), or stash the value in a ref + raf throttle, or use
 // `useDeferredValue`.
 export const rerenderTransitionsScroll = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Wrap the setState in startTransition (mark as non-urgent), use useDeferredValue, or stash in a ref + rAF throttle so scroll/pointer events don't trigger a re-render per fire",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
@@ -54,6 +54,7 @@ const findReturnedObject = (callback: EsTreeNode): EsTreeNode | null => {
 // shared values, animate `transform: [{ translateX/Y }, { scale }]` or
 // `opacity` instead.
 export const rnAnimateLayoutProperty = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Animate `transform: [{ translateX/Y }, { scale }]` and `opacity` instead of layout props — layout runs on the JS thread; transform/opacity run on the GPU compositor",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
@@ -11,6 +11,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // gloss that useAnimatedReaction implies (it's meant for cross-thread
 // reactions like calling runOnJS, not value derivation).
 export const rnAnimationReactionAsDerived = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Replace useAnimatedReaction with `useDerivedValue(() => ..., [deps])` — shorter, native dependency tracking, no side-effect implication",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-bottom-sheet-prefer-native.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-bottom-sheet-prefer-native.ts
@@ -17,6 +17,7 @@ const JS_BOTTOM_SHEET_PACKAGES = new Set([
 // "formSheet"> that handles gestures, snap points, and detents on the
 // platform's native modal stack.
 export const rnBottomSheetPreferNative = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     'Use `<Modal presentationStyle="formSheet">` (RN v7+) for native gesture handling and snap points',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
@@ -52,6 +52,7 @@ const isRenderItemFunction = (node: EsTreeNode): boolean => {
 // list scope (`const handlePress = useCallback((id) => ..., [])`) and
 // pass the row's id as a primitive prop.
 export const rnListCallbackPerRow = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Hoist the handler with useCallback at list scope and pass the row id as a primitive prop, so the row's memo() shallow-compare actually hits",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
@@ -21,6 +21,7 @@ const VIRTUALIZED_LIST_NAMES = new Set([
 // destroying scroll perf. Hoist the transform into a useMemo at list
 // scope or do the projection earlier in the parent.
 export const rnListDataMapped = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Wrap the projection in `useMemo(() => items.map(...), [items])` so the list's `data` prop has a stable reference across parent renders",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
@@ -22,6 +22,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 const RECYCLABLE_LIST_NAMES = new Set(["FlashList", "LegendList"]);
 
 export const rnListRecyclableWithoutTypes = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Add `getItemType={item => item.kind}` so FlashList keeps separate recycle pools per item type — heterogeneous rows shouldn't share recycled cells",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
@@ -7,6 +7,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const rnNoDeprecatedModules = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Import from the community package instead — deprecated modules were removed from the react-native core",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-dimensions-get.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-dimensions-get.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoDimensionsGet = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use `const { width, height } = useWindowDimensions()` — it updates reactively on rotation and resize",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
@@ -7,6 +7,7 @@ import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoInlineFlatlistRenderitem = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Extract renderItem to a named function or wrap in useCallback to avoid re-creating on every render",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-object-in-list-item.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-object-in-list-item.ts
@@ -17,6 +17,7 @@ const RENDER_ITEM_PROP_NAMES = new Set([
 // data didn't change. Hoist the object outside renderItem (StyleSheet,
 // constant, useMemo at list scope) or pass primitives into the row.
 export const rnNoInlineObjectInListItem = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Hoist style/object props outside renderItem (StyleSheet.create, useMemo at list scope, or pass primitives) so memo() row components stop bailing",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-expo-packages.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-expo-packages.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const rnNoLegacyExpoPackages = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Migrate to the recommended replacement package — legacy Expo packages are no longer maintained",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
@@ -27,6 +27,7 @@ const reportLegacyShadowProperties = (objectExpression: EsTreeNode, context: Rul
 };
 
 export const rnNoLegacyShadowStyles = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use `boxShadow` for cross-platform shadows on the new architecture instead of platform-specific shadow properties",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-non-native-navigator.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-non-native-navigator.ts
@@ -13,6 +13,7 @@ const NON_NATIVE_NAVIGATOR_PACKAGES = new Set([
 // uses platform-native UINavigationController / Fragment, giving real
 // iOS/Android transitions, swipe-back, and large titles for free.
 export const rnNoNonNativeNavigator = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use `@react-navigation/native-stack` (or `native-tabs` in v7+) for platform-native transitions and gestures",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -55,6 +55,7 @@ const isTextHandlingComponent = (elementName: string): boolean => {
 const WEB_FILE_EXTENSION_PATTERN = /\.web\.[jt]sx?$/;
 
 export const rnNoRawText = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Wrap text in a `<Text>` component: `<Text>{value}</Text>` — raw strings outside `<Text>` crash on React Native",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
@@ -10,6 +10,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // (useSharedValue + useAnimatedScrollHandler) or a ref + raf throttle so
 // the JS thread isn't pegged.
 export const rnNoScrollState = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Track scroll position with a Reanimated shared value (`useAnimatedScrollHandler`) or a ref — `setState` on every scroll event causes re-render storms",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
@@ -12,6 +12,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // recycle row components and only mount the visible window. The cost
 // of switching is tiny (same prop API) and the perf win is huge.
 export const rnNoScrollviewMappedList = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use FlashList, LegendList, or FlatList — `<ScrollView>{items.map(...)}</ScrollView>` mounts every row in memory",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-single-element-style-array.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-single-element-style-array.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoSingleElementStyleArray = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use `style={value}` instead of `style={[value]}` — single-element arrays add unnecessary allocation",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
@@ -13,6 +13,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // the OS computes natively, integrating with sticky headers, large
 // titles, and keyboard avoidance for free.
 export const rnPreferContentInsetAdjustment = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     'Drop the SafeAreaView wrapper and set `contentInsetAdjustmentBehavior="automatic"` on the ScrollView for native safe-area handling',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
@@ -11,6 +11,7 @@ import { getImportedName } from "../../utils/get-imported-name.js";
 // placeholders, and crossfades — a major perceived-perf win for any list
 // or hero image.
 export const rnPreferExpoImage = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use `<Image>` from `expo-image` instead of `react-native` — same prop API, plus disk + memory caching, placeholders, and crossfades",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
@@ -17,6 +17,7 @@ const TOUCHABLE_COMPONENTS = new Set([
 // modern, more configurable, more accessible replacement that works the
 // same on iOS, Android, and Fabric.
 export const rnPreferPressable = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use `<Pressable>` from react-native (or react-native-gesture-handler) instead of legacy Touchable* components",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
@@ -6,6 +6,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const rnPreferReanimated = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use `import Animated from 'react-native-reanimated'` — animations run on the UI thread instead of the JS thread",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
@@ -54,6 +54,7 @@ const handlerMutatesIdentifier = (
 // the receiver is actually a `useSharedValue` binding to avoid
 // false-positives on `Map.prototype.set` / `ref.current.value =` etc.
 export const rnPressableSharedValueMutation = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Wrap in <GestureDetector gesture={Gesture.Tap()...}> so the press animation runs on the UI thread instead of bouncing across the JS bridge",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
@@ -13,6 +13,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // which the platform applies as an OS-level offset without re-laying out
 // the content.
 export const rnScrollviewDynamicPadding = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     "Use `contentInset={{ bottom: dynamicValue }}` — the OS applies it as an offset without reflowing the scroll content",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
@@ -32,6 +32,7 @@ const findLegacyShadowProperty = (
 // so cross-platform code historically had to declare both — `boxShadow`
 // collapses that into one key.
 export const rnStylePreferBoxShadow = defineRule<Rule>({
+  category: "React Native",
   recommendation:
     'Use the cross-platform CSS `boxShadow` string (RN v7+): `boxShadow: "0 2px 8px rgba(0,0,0,0.1)"` instead of platform-specific shadow*/elevation keys',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-bold-heading.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-bold-heading.ts
@@ -44,6 +44,7 @@ const getStylePropertyNumericValue = (objectProperty: EsTreeNode): number | null
 };
 
 export const noBoldHeading = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Use `font-semibold` (600) or `font-medium` (500) on headings — 700+ crushes letter counter shapes at display sizes",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-default-tailwind-palette.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-default-tailwind-palette.ts
@@ -32,6 +32,7 @@ const buildDefaultPaletteRegex = (): RegExp => {
 const DEFAULT_PALETTE_REGEX = buildDefaultPaletteRegex();
 
 export const noDefaultTailwindPalette = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Replace `indigo-*` / `gray-*` / `slate-*` with project tokens, your brand color, or a less-default neutral (`zinc`, `neutral`, `stone`)",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
@@ -9,6 +9,7 @@ import { hasResponsivePrefix } from "./utils/has-responsive-prefix.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRedundantPaddingAxes = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Collapse `px-N py-N` to `p-N` when both axes match. Keep them split only when one axis varies at a breakpoint (`py-2 md:py-3`)",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
@@ -9,6 +9,7 @@ import { hasResponsivePrefix } from "./utils/has-responsive-prefix.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRedundantSizeAxes = defineRule<Rule>({
+  category: "Architecture",
   recommendation: "Collapse `w-N h-N` to `size-N` (Tailwind v3.4+) when both axes match",
   create: (context: RuleContext) => ({
     JSXAttribute(jsxAttribute: EsTreeNode) {

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
@@ -10,6 +10,7 @@ const tokenizeClassName = (classNameValue: string): string[] =>
   classNameValue.split(/\s+/).filter(Boolean);
 
 export const noSpaceOnFlexChildren = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     "Use `gap-*` on the flex/grid parent. `space-x-*` / `space-y-*` produce phantom gaps when a sibling is conditionally rendered, lose vertical spacing on wrapped lines, and don't mirror in RTL",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-three-period-ellipsis.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-three-period-ellipsis.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isInsideExcludedAncestor } from "./utils/is-inside-excluded-ancestor.js";
 
 export const noThreePeriodEllipsis = defineRule<Rule>({
+  category: "Architecture",
   recommendation:
     'Use the typographic ellipsis "…" (or `&hellip;`) instead of three periods — pairs with action-with-followup labels ("Rename…", "Loading…")',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
@@ -53,6 +53,7 @@ const collectJsxLabelText = (jsxElementNode: EsTreeNode): string | null => {
 };
 
 export const noVagueButtonLabel = defineRule<Rule>({
+  category: "Accessibility",
   recommendation:
     'Name the action: "Save changes" instead of "Continue", "Send invite" instead of "Submit", "Delete account" instead of "OK". The label IS the button\'s accessible name',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/security/no-eval.ts
+++ b/packages/react-doctor/src/plugin/rules/security/no-eval.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noEval = defineRule<Rule>({
+  category: "Security",
   recommendation:
     "Use `JSON.parse` for serialized data, `Function(...)` (still careful) for trusted templates, or refactor to avoid dynamic code execution",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -11,6 +11,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noSecretsInClientCode = defineRule<Rule>({
+  category: "Security",
   recommendation:
     "Move to server-side `process.env.SECRET_NAME`. Only `NEXT_PUBLIC_*` vars are safe for the client (and should not contain secrets)",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/server/server-after-nonblocking.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-after-nonblocking.ts
@@ -44,6 +44,7 @@ const isDeferrableSideEffectCall = (objectName: string, methodName: string): boo
 };
 
 export const serverAfterNonblocking = defineRule<Rule>({
+  category: "Server",
   recommendation:
     "`import { after } from 'next/server'` then wrap: `after(() => analytics.track(...))` — response isn't blocked",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -35,6 +35,7 @@ const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
 };
 
 export const serverAuthActions = defineRule<Rule>({
+  category: "Server",
   recommendation:
     "Add `const session = await auth()` at the top and throw/redirect if unauthorized before any data access",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
@@ -11,6 +11,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // underlying fetch runs twice per request. Pass primitives (or memoize
 // the argument object once at module/route scope).
 export const serverCacheWithObjectLiteral = defineRule<Rule>({
+  category: "Server",
   recommendation:
     "Pass primitives to React.cache()-wrapped functions — argument identity (not deep equality) is the dedup key, so a fresh `{}` per render bypasses the cache",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/server/server-dedup-props.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-dedup-props.ts
@@ -20,6 +20,7 @@ const getDerivingMethodName = (node: EsTreeNode): string | null => {
 // roughly the same array; one of the props is redundant. Have the
 // client derive what it needs from the single source prop instead.
 export const serverDedupProps = defineRule<Rule>({
+  category: "Server",
   recommendation:
     "Pass the source array once and derive the projection on the client — passing both doubles RSC serialization bytes",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
@@ -53,6 +53,7 @@ const APP_ROUTER_FILE_PATTERN =
 const NON_PROJECT_PATH_PATTERN = /\/(?:node_modules|dist|build|\.next)\//;
 
 export const serverFetchWithoutRevalidate = defineRule<Rule>({
+  category: "Server",
   recommendation:
     'Pass `{ next: { revalidate: <seconds> } }` (or `cache: "no-store"` / `next: { tags: [...] }`) so stale cached data doesn\'t silently persist',
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/server/server-hoist-static-io.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-hoist-static-io.ts
@@ -125,6 +125,7 @@ const collectIdentifierParams = (params: EsTreeNode[]): Set<string> => {
 // `app/.../route.ts`) and Pages Router (`export default async function
 // handler(req, res)` in `pages/api/...`).
 export const serverHoistStaticIo = defineRule<Rule>({
+  category: "Server",
   recommendation:
     "Hoist the read to module scope: `const FONT_DATA = await fetch(new URL('./fonts/Inter.ttf', import.meta.url)).then(r => r.arrayBuffer())` runs once at module load",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
@@ -28,6 +28,7 @@ const isMutableConstInitializer = (init: EsTreeNode | null | undefined): string 
 // must live inside the action, in headers/cookies, or in a request scope
 // (React.cache, AsyncLocalStorage, etc.).
 export const serverNoMutableModuleState = defineRule<Rule>({
+  category: "Server",
   recommendation:
     "Move per-request data into the action body, headers/cookies, or a request-scope (React.cache, AsyncLocalStorage). Module-scope `let`/`var` is shared across requests.",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
@@ -59,6 +59,7 @@ const declarationReadsAnyName = (declaration: EsTreeNode, names: Set<string>): b
 };
 
 export const serverSequentialIndependentAwait = defineRule<Rule>({
+  category: "Server",
   recommendation:
     "Wrap independent awaits in `Promise.all([...])` so they race instead of waterfalling — second call doesn't depend on the first",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
@@ -27,6 +27,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // counts as a subscription-shaped call (zustand/Redux `subscribe`,
 // browser `addEventListener`, EventEmitter `on`, etc.).
 export const advancedEventHandlerRefs = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Store the handler in a ref and have the listener read `handlerRef.current()` — the subscription stays put while the latest handler is always called",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -160,6 +160,7 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
 };
 
 export const effectNeedsCleanup = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Return a cleanup function that releases the subscription / timer: `return () => target.removeEventListener(name, handler)` for listeners, `return () => clearInterval(id)` / `clearTimeout(id)` for timers, or `return unsubscribe` if the subscribe call already returned one",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.ts
@@ -8,6 +8,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noCascadingSetState = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Combine into useReducer: `const [state, dispatch] = useReducer(reducer, initialState)`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
@@ -74,6 +74,7 @@ const collectValueIdentifierNames = (node: EsTreeNode | null | undefined, into: 
 };
 
 export const noDerivedStateEffect = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "For derived state, compute inline: `const x = fn(dep)`. For state resets on prop change, use a key prop: `<Component key={prop} />`. See https://react.dev/learn/you-might-not-need-an-effect",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -8,6 +8,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noDerivedUseState = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Remove useState and compute the value inline: `const value = transform(propName)`",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
@@ -74,6 +74,7 @@ const walkComponentRespectingShadows = (
 };
 
 export const noDirectStateMutation = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Replace the mutation with a setter call that produces a new reference: `setItems([...items, newItem])`, `setItems(items.filter(x => x !== target))`, `setItems(items.toSorted(...))`. React only re-renders on a new reference, so in-place updates are silently dropped",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -210,6 +210,7 @@ interface EffectInfo {
 }
 
 export const noEffectChain = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Compute as much as possible during render (e.g. `const isGameOver = round > 5`) and write all related state inside the event handler that originally fires the chain. Each effect link adds an extra render and makes the code rigid as requirements evolve",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -10,6 +10,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noEffectEventHandler = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Move the conditional logic into onClick, onChange, or onSubmit handlers directly",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
@@ -17,6 +17,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // binding named `onChange` in ComponentA doesn't taint a regular variable
 // `onChange` in ComponentB in the same file.
 export const noEffectEventInDeps = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Call the useEffectEvent callback inside the effect body without listing it; its identity is intentionally unstable",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
@@ -148,6 +148,7 @@ const collectHandlerOnlyWriteStateNames = (
 };
 
 export const noEventTriggerState = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Delete the trigger state (`useState(null)` plus the `useEffect` that watches it) and call the side-effect (`post(...)` / `navigate(...)` / `track(...)`) directly inside the event handler that previously called the setter. State should not exist purely to schedule effect runs",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -8,6 +8,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noFetchInEffect = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Use `useQuery()` from @tanstack/react-query, `useSWR()`, or fetch in a Server Component instead",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
@@ -53,6 +53,7 @@ interface MirrorBinding {
 }
 
 export const noMirrorPropEffect = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Delete both the `useState` and the `useEffect` and read the prop directly during render. Mirroring a prop into local state forces a stale first render before the effect re-syncs",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
@@ -67,6 +67,7 @@ const findMutableDepIssue = (
 };
 
 export const noMutableInDeps = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Read mutable values (`location.pathname`, `ref.current`) inside the effect body instead of in the deps array, or subscribe with `useSyncExternalStore`. Mutations to these don't trigger re-renders, so listing them in deps doesn't make the effect react to changes",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
@@ -17,6 +17,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // both child and parent read from; the child then doesn't need an
 // effect-driven sync at all.
 export const noPropCallbackInEffect = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Lift the shared state into a Provider so both sides read the same source — no useEffect-driven sync needed",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
@@ -35,6 +35,7 @@ const isUnconditionalSetterCallStatement = (
 };
 
 export const noSetStateInRender = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Move the setter call into a `useEffect`, an event handler, or replace the state with a value computed during render. Calling a setter at render time triggers another render, which calls the setter again — an infinite loop",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-effect-event.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-effect-event.ts
@@ -227,6 +227,7 @@ const classifyCallableReadsInsideEffect = (
 };
 
 export const preferUseEffectEvent = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Wrap the callback with `useEffectEvent(callback)` (React 19+) and call the resulting binding from inside the sub-handler. The Effect Event captures the latest props/state without being a reactive dep, so the effect doesn't re-subscribe on every parent render. See https://react.dev/reference/react/useEffectEvent",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
@@ -9,6 +9,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const preferUseReducer = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Group related state: `const [state, dispatch] = useReducer(reducer, { field1, field2, ... })`",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
@@ -145,6 +145,7 @@ const cleanupReleasesSubscription = (
 };
 
 export const preferUseSyncExternalStore = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Replace the `useState(getSnapshot())` + `useEffect(() => store.subscribe(() => setSnapshot(getSnapshot())))` pair with `useSyncExternalStore(store.subscribe, getSnapshot)`. The hook handles tearing during concurrent renders and SSR snapshots; the manual subscribe pattern doesn't",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
@@ -49,6 +49,7 @@ const findHookCallBindings = (
 // Heuristic: hook value-name appears only inside arrow / function
 // expressions that are themselves bound to JSX `on*` attributes.
 export const rerenderDeferReadsHook = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Read the URL state inside the handler (e.g. `new URL(window.location.href).searchParams`) so the component doesn't subscribe and re-render on every URL change",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderDependencies = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Extract to a useMemo, useRef, or module-level constant so the reference is stable",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-functional-setstate.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-functional-setstate.ts
@@ -17,6 +17,7 @@ const deriveStateVariableName = (setterName: string): string | null => {
 };
 
 export const rerenderFunctionalSetstate = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use the callback form: `setState(prev => prev + 1)` to always read the latest value",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderLazyStateInit = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Wrap in an arrow function so it only runs once: `useState(() => expensiveComputation())`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -13,6 +13,7 @@ import { expandTransitiveDependencies } from "./utils/expand-transitive-dependen
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderStateOnlyInHandlers = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Replace useState with useRef when the value is only mutated and never read in render — `ref.current = ...` updates without re-rendering the component",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryMutationMissingInvalidation = defineRule<Rule>({
+  category: "TanStack Query",
   recommendation:
     "Add `onSuccess: () => queryClient.invalidateQueries({ queryKey: ['...'] })` so cached data stays in sync after the mutation",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-query-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-query-in-effect.ts
@@ -9,6 +9,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoQueryInEffect = defineRule<Rule>({
+  category: "TanStack Query",
   recommendation:
     "React Query manages refetching automatically via queryKey dependencies and the `enabled` option — manual refetch() in useEffect is usually unnecessary",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoRestDestructuring = defineRule<Rule>({
+  category: "TanStack Query",
   recommendation:
     "Destructure only the fields you need: `const { data, isLoading } = useQuery(...)` — rest destructuring subscribes to all fields and causes extra re-renders",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-use-query-for-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-use-query-for-mutation.ts
@@ -7,6 +7,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoUseQueryForMutation = defineRule<Rule>({
+  category: "TanStack Query",
   recommendation:
     "Use `useMutation()` for POST/PUT/DELETE — it provides onSuccess/onError callbacks, doesn't auto-refetch, and correctly models write operations",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-void-query-fn.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-void-query-fn.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoVoidQueryFn = defineRule<Rule>({
+  category: "TanStack Query",
   recommendation:
     "queryFn must return a value for the cache. Use the `enabled` option to conditionally disable the query instead of returning undefined",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-stable-query-client.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-stable-query-client.ts
@@ -11,6 +11,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryStableQueryClient = defineRule<Rule>({
+  category: "TanStack Query",
   recommendation:
     "Move `new QueryClient()` to module scope or wrap in `useState(() => new QueryClient())` — recreating it on every render resets the entire cache",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-get-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-get-mutation.ts
@@ -8,6 +8,7 @@ import { walkServerFnChain } from "./utils/walk-server-fn-chain.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartGetMutation = defineRule<Rule>({
+  category: "Security",
   recommendation:
     "Use `createServerFn({ method: 'POST' })` for data modifications — GET requests can be triggered by prefetching and are vulnerable to CSRF",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-loader-parallel-fetch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-loader-parallel-fetch.ts
@@ -30,6 +30,7 @@ const hasTopLevelAwait = (statement: EsTreeNode): boolean => {
 };
 
 export const tanstackStartLoaderParallelFetch = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use `const [a, b] = await Promise.all([fetchA(), fetchB()])` to avoid request waterfalls in route loaders",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartMissingHeadContent = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "Add `<HeadContent />` inside `<head>` in your __root route — without it, route `head()` meta tags are silently dropped",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoAnchorElement = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "`import { Link } from '@tanstack/react-router'` — enables type-safe routes, preloading via `preload=\"intent\"`, and client-side navigation",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.ts
@@ -8,6 +8,7 @@ import { getPropertyKeyName } from "./utils/get-property-key-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoDirectFetchInLoader = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "Use `createServerFn()` from @tanstack/react-start — provides type-safe RPC, input validation, and proper server/client code splitting",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoDynamicServerFnImport = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "Use `import { myFn } from '~/utils/my.functions'` — the bundler replaces server code with RPC stubs only for static imports",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
@@ -11,6 +11,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoNavigateInRender = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "Use `throw redirect({ to: '/path' })` in `beforeLoad` or `loader` instead — navigate() during render causes hydration issues",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-secrets-in-loader.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-secrets-in-loader.ts
@@ -21,6 +21,7 @@ const isLikelySecret = (envVarName: string): boolean => {
 };
 
 export const tanstackStartNoSecretsInLoader = defineRule<Rule>({
+  category: "Security",
   recommendation:
     "Loaders are isomorphic (run on both server and client). Wrap secret access in `createServerFn()` so it stays server-only",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
@@ -8,6 +8,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoUseEffectFetch = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "Fetch data in the route `loader` instead — the router coordinates loading before rendering to avoid waterfalls",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-server-in-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-server-in-handler.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoUseServerInHandler = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     'TanStack Start handles server boundaries automatically via the Vite plugin — "use server" inside createServerFn causes compilation errors',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-redirect-in-try-catch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-redirect-in-try-catch.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartRedirectInTryCatch = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "TanStack Router's `redirect()` and `notFound()` throw special errors caught by the router. Move them outside the try block or re-throw in the catch",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-route-property-order.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-route-property-order.ts
@@ -7,6 +7,7 @@ import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
 
 export const tanstackStartRoutePropertyOrder = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "Follow the order: params/validateSearch → loaderDeps → context → beforeLoad → loader → head. See https://tanstack.com/router/latest/docs/eslint/create-route-property-order",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartServerFnMethodOrder = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "Chain methods in order: .middleware() → .inputValidator() → .client() → .server() → .handler() — types depend on this sequence",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-validate-input.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-validate-input.ts
@@ -7,6 +7,7 @@ import { walkServerFnChain } from "./utils/walk-server-fn-chain.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartServerFnValidateInput = defineRule<Rule>({
+  category: "TanStack Start",
   recommendation:
     "Add `.inputValidator(schema)` before `.handler()` — data crosses a network boundary and must be validated at runtime",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/view-transitions/no-document-start-view-transition.ts
+++ b/packages/react-doctor/src/plugin/rules/view-transitions/no-document-start-view-transition.ts
@@ -11,6 +11,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // call startViewTransition for you (around startTransition, useDeferredValue,
 // or Suspense reveals).
 export const noDocumentStartViewTransition = defineRule<Rule>({
+  category: "Correctness",
   recommendation:
     "Render a <ViewTransition> component and update inside startTransition / useDeferredValue — React calls startViewTransition for you",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
+++ b/packages/react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
@@ -11,6 +11,7 @@ import { getImportedName } from "../../utils/get-imported-name.js";
 // (a single actionable diagnostic per file) instead of on every call
 // site, which would clutter output for files with several flushSync()s.
 export const noFlushSync = defineRule<Rule>({
+  category: "Performance",
   recommendation:
     "Use startTransition for non-urgent updates — flushSync forces a sync flush that skips View Transitions and concurrent rendering",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/utils/rule.ts
+++ b/packages/react-doctor/src/plugin/utils/rule.ts
@@ -3,6 +3,7 @@ import type { RuleExample } from "./rule-example.js";
 import type { RuleVisitors } from "./rule-visitors.js";
 
 export interface Rule {
+  category?: string;
   recommendation?: string;
   examples?: RuleExample[];
   create: (context: RuleContext) => RuleVisitors;


### PR DESCRIPTION
## Summary

Parallel to #228 (which colocated `recommendation`). Drops the 196-line `RULE_CATEGORY_MAP` table in `run-oxlint.ts` and moves every entry onto the matching rule's `defineRule({...})` call as a `category: "..."` field. `run-oxlint.ts` now reads the category off the plugin registry at diagnostic-rendering time, so output is unchanged but each rule has a single obvious place for both its recommendation AND its category bucket.

178 rule files updated. `run-oxlint.ts` shrinks by ~196 lines.

## Before / after

```diff
 export const noFetchInEffect = defineRule<Rule>({
+  category: "State & Effects",
   recommendation:
     "Use `useQuery()` from @tanstack/react-query, `useSWR()`, or fetch in a Server Component instead",
   create: (context: RuleContext) => ({ ... }),
 });
```

```diff
-const resolveDiagnosticCategory = (plugin: string, rule: string): string => {
-  const ruleKey = `${plugin}/${rule}`;
-  return (
-    lookupOwnString(RULE_CATEGORY_MAP, ruleKey) ??
-    lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ??
-    "Other"
-  );
-};
+const resolveDiagnosticCategory = (plugin: string, rule: string): string =>
+  getRuleCategory(rule) ?? lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ?? "Other";
```

where `getRuleCategory(ruleName)` reads `reactDoctorPlugin.rules[ruleName]?.category`.

The `PLUGIN_CATEGORY_MAP` fallback (for non-react-doctor plugins like `react-hooks-js`, `jsx-a11y`, etc.) stays — those rules aren't in our registry and need a plugin-wide default. The registration validator (`validateRuleRegistration`) keeps the same coverage check; it now asks "does this rule's defineRule call ship a category?" with the warning message updated.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean
- [x] `pnpm test` — 734/734 pass (`run-oxlint.test.ts` asserts the category of representative diagnostics for every framework — those assertions now exercise the new registry-backed lookup path end-to-end)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide-sweeping refactor across ~all rules; while intended to be behavior-preserving, any missing/typoed `category` metadata would change scan summary grouping and validation warnings.
> 
> **Overview**
> **Rule category metadata is now colocated with each rule.** The large `RULE_CATEGORY_MAP` table is removed from `run-oxlint.ts`, and every `defineRule({...})` call gains a `category: "..."` field.
> 
> `run-oxlint.ts` now resolves diagnostic categories via `reactDoctorPlugin.rules[ruleName]?.category`, falling back to the existing plugin-level defaults for non-react-doctor rules, and `validateRuleRegistration` is updated to assert that each rule provides a category. The `Rule` type is extended with optional `category` to support this metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f01c1143c7f88b04c00a31c4557ffd646c2e1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->