### PR TITLE
refactor(rules): colocate severity + framework with each defineRule call

### DIFF
--- a/packages/react-doctor/src/core/runners/oxlint/rule-maps.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/rule-maps.ts
@@ -1,76 +1,26 @@
+import reactDoctorPlugin from "../../../plugin/react-doctor-plugin.js";
+import type { RuleFramework } from "../../../plugin/utils/rule.js";
 import type { RuleSeverity } from "./types.js";
 
-export const NEXTJS_RULES: Record<string, RuleSeverity> = {
-  "react-doctor/nextjs-no-img-element": "warn",
-  "react-doctor/nextjs-async-client-component": "error",
-  "react-doctor/nextjs-no-a-element": "warn",
-  "react-doctor/nextjs-no-use-search-params-without-suspense": "warn",
-  "react-doctor/nextjs-no-client-fetch-for-server-data": "warn",
-  "react-doctor/nextjs-missing-metadata": "warn",
-  "react-doctor/nextjs-no-client-side-redirect": "warn",
-  "react-doctor/nextjs-no-redirect-in-try-catch": "warn",
-  "react-doctor/nextjs-image-missing-sizes": "warn",
-  "react-doctor/nextjs-no-native-script": "warn",
-  "react-doctor/nextjs-inline-script-missing-id": "warn",
-  "react-doctor/nextjs-no-font-link": "warn",
-  "react-doctor/nextjs-no-css-link": "warn",
-  "react-doctor/nextjs-no-polyfill-script": "warn",
-  "react-doctor/nextjs-no-head-import": "error",
-  "react-doctor/nextjs-no-side-effect-in-get-handler": "error",
+// Derives a `{ "react-doctor/<rule-id>": <severity> }` map from the rule
+// registry by filtering on each rule's colocated `framework` field. Every
+// react-doctor rule ships `framework` + `severity` next to its `create`
+// function in `defineRule({...})`; rule-maps.ts no longer owns these.
+const collectRulesByFramework = (frameworkName: RuleFramework): Record<string, RuleSeverity> => {
+  const collected: Record<string, RuleSeverity> = {};
+  for (const [ruleId, rule] of Object.entries(reactDoctorPlugin.rules)) {
+    if (rule.framework === frameworkName && rule.severity) {
+      collected[`react-doctor/${ruleId}`] = rule.severity;
+    }
+  }
+  return collected;
 };
 
-export const REACT_NATIVE_RULES: Record<string, RuleSeverity> = {
-  "react-doctor/rn-no-raw-text": "error",
-  "react-doctor/rn-no-deprecated-modules": "error",
-  "react-doctor/rn-no-legacy-expo-packages": "warn",
-  "react-doctor/rn-no-dimensions-get": "warn",
-  "react-doctor/rn-no-inline-flatlist-renderitem": "warn",
-  "react-doctor/rn-no-legacy-shadow-styles": "warn",
-  "react-doctor/rn-prefer-reanimated": "warn",
-  "react-doctor/rn-no-single-element-style-array": "warn",
-  "react-doctor/rn-prefer-pressable": "warn",
-  "react-doctor/rn-prefer-expo-image": "warn",
-  "react-doctor/rn-no-non-native-navigator": "warn",
-  "react-doctor/rn-no-scroll-state": "error",
-  "react-doctor/rn-no-scrollview-mapped-list": "warn",
-  "react-doctor/rn-no-inline-object-in-list-item": "warn",
-  "react-doctor/rn-animate-layout-property": "error",
-  "react-doctor/rn-prefer-content-inset-adjustment": "warn",
-  "react-doctor/rn-pressable-shared-value-mutation": "warn",
-  "react-doctor/rn-list-data-mapped": "warn",
-  "react-doctor/rn-list-callback-per-row": "warn",
-  "react-doctor/rn-list-recyclable-without-types": "warn",
-  "react-doctor/rn-animation-reaction-as-derived": "warn",
-  "react-doctor/rn-bottom-sheet-prefer-native": "warn",
-  "react-doctor/rn-scrollview-dynamic-padding": "warn",
-  "react-doctor/rn-style-prefer-boxshadow": "warn",
-};
-
-export const TANSTACK_START_RULES: Record<string, RuleSeverity> = {
-  "react-doctor/tanstack-start-route-property-order": "error",
-  "react-doctor/tanstack-start-no-direct-fetch-in-loader": "warn",
-  "react-doctor/tanstack-start-server-fn-validate-input": "warn",
-  "react-doctor/tanstack-start-no-useeffect-fetch": "warn",
-  "react-doctor/tanstack-start-missing-head-content": "warn",
-  "react-doctor/tanstack-start-no-anchor-element": "warn",
-  "react-doctor/tanstack-start-server-fn-method-order": "error",
-  "react-doctor/tanstack-start-no-navigate-in-render": "warn",
-  "react-doctor/tanstack-start-no-dynamic-server-fn-import": "error",
-  "react-doctor/tanstack-start-no-use-server-in-handler": "error",
-  "react-doctor/tanstack-start-no-secrets-in-loader": "error",
-  "react-doctor/tanstack-start-get-mutation": "warn",
-  "react-doctor/tanstack-start-redirect-in-try-catch": "warn",
-  "react-doctor/tanstack-start-loader-parallel-fetch": "warn",
-};
-
-export const TANSTACK_QUERY_RULES: Record<string, RuleSeverity> = {
-  "react-doctor/query-stable-query-client": "warn",
-  "react-doctor/query-no-rest-destructuring": "warn",
-  "react-doctor/query-no-void-query-fn": "warn",
-  "react-doctor/query-no-query-in-effect": "warn",
-  "react-doctor/query-mutation-missing-invalidation": "warn",
-  "react-doctor/query-no-usequery-for-mutation": "warn",
-};
+export const GLOBAL_REACT_DOCTOR_RULES = collectRulesByFramework("global");
+export const NEXTJS_RULES = collectRulesByFramework("nextjs");
+export const REACT_NATIVE_RULES = collectRulesByFramework("react-native");
+export const TANSTACK_START_RULES = collectRulesByFramework("tanstack-start");
+export const TANSTACK_QUERY_RULES = collectRulesByFramework("tanstack-query");
 
 // HACK: every diagnostic from `eslint-plugin-react-hooks` (the React
 // Compiler frontend, oxlint-namespaced as `react-hooks-js`) ships at
@@ -148,140 +98,6 @@ export const BUILTIN_A11Y_RULES: Record<string, RuleSeverity> = {
   "jsx-a11y/label-has-associated-control": "warn",
   "jsx-a11y/no-distracting-elements": "error",
   "jsx-a11y/iframe-has-title": "warn",
-};
-
-export const GLOBAL_REACT_DOCTOR_RULES: Record<string, RuleSeverity> = {
-  "react-doctor/no-derived-state-effect": "warn",
-  "react-doctor/no-fetch-in-effect": "warn",
-  "react-doctor/no-mirror-prop-effect": "warn",
-  "react-doctor/no-mutable-in-deps": "error",
-  "react-doctor/no-cascading-set-state": "warn",
-  "react-doctor/no-effect-chain": "warn",
-  "react-doctor/no-effect-event-handler": "warn",
-  "react-doctor/no-effect-event-in-deps": "error",
-  "react-doctor/no-event-trigger-state": "warn",
-  "react-doctor/no-prop-callback-in-effect": "warn",
-  "react-doctor/no-derived-useState": "warn",
-  "react-doctor/no-direct-state-mutation": "warn",
-  "react-doctor/no-set-state-in-render": "warn",
-  "react-doctor/prefer-use-effect-event": "warn",
-  "react-doctor/prefer-useReducer": "warn",
-  "react-doctor/prefer-use-sync-external-store": "warn",
-  "react-doctor/rerender-lazy-state-init": "warn",
-  "react-doctor/rerender-functional-setstate": "warn",
-  "react-doctor/rerender-dependencies": "error",
-  "react-doctor/rerender-state-only-in-handlers": "warn",
-  "react-doctor/rerender-defer-reads-hook": "warn",
-  "react-doctor/advanced-event-handler-refs": "warn",
-  "react-doctor/effect-needs-cleanup": "error",
-
-  "react-doctor/no-giant-component": "warn",
-  "react-doctor/no-render-in-render": "warn",
-  "react-doctor/no-many-boolean-props": "warn",
-  "react-doctor/no-react19-deprecated-apis": "warn",
-  "react-doctor/no-render-prop-children": "warn",
-  "react-doctor/no-nested-component-definition": "error",
-  "react-doctor/react-compiler-destructure-method": "warn",
-  "react-doctor/no-legacy-class-lifecycles": "error",
-  "react-doctor/no-legacy-context-api": "error",
-  "react-doctor/no-default-props": "warn",
-  "react-doctor/no-react-dom-deprecated-apis": "warn",
-
-  "react-doctor/no-usememo-simple-expression": "warn",
-  "react-doctor/no-layout-property-animation": "error",
-  "react-doctor/rerender-memo-with-default-value": "warn",
-  "react-doctor/rerender-memo-before-early-return": "warn",
-  "react-doctor/rerender-transitions-scroll": "warn",
-  "react-doctor/rerender-derived-state-from-hook": "warn",
-  "react-doctor/async-defer-await": "warn",
-  "react-doctor/async-await-in-loop": "warn",
-  "react-doctor/rendering-animate-svg-wrapper": "warn",
-  "react-doctor/rendering-hoist-jsx": "warn",
-  "react-doctor/rendering-hydration-mismatch-time": "warn",
-  "react-doctor/no-inline-prop-on-memo-component": "warn",
-  "react-doctor/rendering-hydration-no-flicker": "warn",
-  "react-doctor/rendering-script-defer-async": "warn",
-  "react-doctor/rendering-usetransition-loading": "warn",
-
-  "react-doctor/no-transition-all": "warn",
-  "react-doctor/no-global-css-variable-animation": "error",
-  "react-doctor/no-large-animated-blur": "warn",
-  "react-doctor/no-scale-from-zero": "warn",
-  "react-doctor/no-permanent-will-change": "warn",
-
-  "react-doctor/no-eval": "error",
-  "react-doctor/no-secrets-in-client-code": "warn",
-
-  "react-doctor/no-generic-handler-names": "warn",
-
-  "react-doctor/js-flatmap-filter": "warn",
-  "react-doctor/js-combine-iterations": "warn",
-  "react-doctor/js-tosorted-immutable": "warn",
-  "react-doctor/js-hoist-regexp": "warn",
-  "react-doctor/js-hoist-intl": "warn",
-  "react-doctor/js-cache-property-access": "warn",
-  "react-doctor/js-length-check-first": "warn",
-  "react-doctor/js-min-max-loop": "warn",
-  "react-doctor/js-set-map-lookups": "warn",
-  "react-doctor/js-batch-dom-css": "warn",
-  "react-doctor/js-index-maps": "warn",
-  "react-doctor/js-cache-storage": "warn",
-  "react-doctor/js-early-exit": "warn",
-
-  "react-doctor/no-barrel-import": "warn",
-  "react-doctor/no-dynamic-import-path": "warn",
-  "react-doctor/no-full-lodash-import": "warn",
-  "react-doctor/no-moment": "warn",
-  "react-doctor/prefer-dynamic-import": "warn",
-  "react-doctor/use-lazy-motion": "warn",
-  "react-doctor/no-undeferred-third-party": "warn",
-
-  "react-doctor/no-array-index-as-key": "warn",
-  "react-doctor/no-polymorphic-children": "warn",
-  "react-doctor/rendering-conditional-render": "warn",
-  "react-doctor/rendering-svg-precision": "warn",
-  "react-doctor/no-prevent-default": "warn",
-  "react-doctor/no-uncontrolled-input": "warn",
-  "react-doctor/no-document-start-view-transition": "warn",
-  "react-doctor/no-flush-sync": "warn",
-
-  "react-doctor/server-auth-actions": "error",
-  "react-doctor/server-after-nonblocking": "warn",
-  "react-doctor/server-no-mutable-module-state": "error",
-  "react-doctor/server-cache-with-object-literal": "warn",
-  "react-doctor/server-hoist-static-io": "warn",
-  "react-doctor/server-dedup-props": "warn",
-  "react-doctor/server-sequential-independent-await": "warn",
-  "react-doctor/server-fetch-without-revalidate": "warn",
-
-  "react-doctor/client-passive-event-listeners": "warn",
-  "react-doctor/client-localstorage-no-version": "warn",
-
-  "react-doctor/no-inline-bounce-easing": "warn",
-  "react-doctor/no-z-index-9999": "warn",
-  "react-doctor/no-inline-exhaustive-style": "warn",
-  "react-doctor/no-side-tab-border": "warn",
-  "react-doctor/no-pure-black-background": "warn",
-  "react-doctor/no-gradient-text": "warn",
-  "react-doctor/no-dark-mode-glow": "warn",
-  "react-doctor/no-justified-text": "warn",
-  "react-doctor/no-tiny-text": "warn",
-  "react-doctor/no-wide-letter-spacing": "warn",
-  "react-doctor/no-gray-on-colored-background": "warn",
-  "react-doctor/no-layout-transition-inline": "warn",
-  "react-doctor/no-disabled-zoom": "error",
-  "react-doctor/no-outline-none": "warn",
-  "react-doctor/no-long-transition-duration": "warn",
-
-  "react-doctor/design-no-bold-heading": "warn",
-  "react-doctor/design-no-redundant-padding-axes": "warn",
-  "react-doctor/design-no-redundant-size-axes": "warn",
-  "react-doctor/design-no-space-on-flex-children": "warn",
-  "react-doctor/design-no-three-period-ellipsis": "warn",
-  "react-doctor/design-no-default-tailwind-palette": "warn",
-  "react-doctor/design-no-vague-button-label": "warn",
-
-  "react-doctor/async-parallel": "warn",
 };
 
 // HACK: includes every rule that COULD be enabled by createOxlintConfig

--- a/packages/react-doctor/src/plugin/rules/architecture/no-default-props.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-default-props.ts
@@ -14,6 +14,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // recommendation is the same either way — switch to ES6 default params
 // in destructured props — so the guidance is uniform.
 export const noDefaultProps = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     'React 19 removes `Component.defaultProps` for function components. Move the defaults into the destructured props parameter: `function Foo({ size = "md", variant = "primary" })` instead of `Foo.defaultProps = { size: "md", variant: "primary" }`.',

--- a/packages/react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noGenericHandlerNames = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Rename to describe the action: e.g. `handleSubmit` → `saveUserProfile`, `handleClick` → `toggleSidebar`",

--- a/packages/react-doctor/src/plugin/rules/architecture/no-giant-component.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-giant-component.ts
@@ -7,6 +7,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noGiantComponent = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Extract logical sections into focused components: `<UserHeader />`, `<UserActions />`, etc.",

--- a/packages/react-doctor/src/plugin/rules/architecture/no-legacy-class-lifecycles.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-legacy-class-lifecycles.ts
@@ -55,6 +55,8 @@ const buildLegacyLifecycleMessage = (originalName: string): string | null => {
 };
 
 export const noLegacyClassLifecycles = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Correctness",
   recommendation:
     "Move side effects in `componentWillMount` to `componentDidMount`; replace `componentWillReceiveProps` with `componentDidUpdate` (compare prevProps) or the static `getDerivedStateFromProps` for pure state derivation; replace `componentWillUpdate` with `getSnapshotBeforeUpdate` paired with `componentDidUpdate`. The `UNSAFE_` prefix only silences the warning — React 19 removes both forms.",

--- a/packages/react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
@@ -42,6 +42,8 @@ const isInsideClassBody = (node: EsTreeNode): boolean => {
 };
 
 export const noLegacyContextApi = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Correctness",
   recommendation:
     "Replace `childContextTypes` + `getChildContext` with `const MyContext = createContext(...)` + `<MyContext.Provider value={...}>`; replace `contextTypes` with `static contextType = MyContext` (single context) or `useContext()` / `use()` from a function component. The provider and every consumer must migrate together — partial migrations leave consumers reading the wrong context.",

--- a/packages/react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -37,6 +37,8 @@ const collectBooleanLikePropsFromBody = (
 // (`function Foo(props) { props.isPrimary }`) by walking member-access
 // patterns on the parameter binding.
 export const noManyBooleanProps = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Split into compound components or named variants: `<Button.Primary />`, `<DialogConfirm />` instead of stacking `isPrimary`, `isConfirm` flags",

--- a/packages/react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
@@ -6,6 +6,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noNestedComponentDefinition = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Correctness",
   recommendation: "Move to a separate file or to module scope above the parent component",
   create: (context: RuleContext) => {

--- a/packages/react-doctor/src/plugin/rules/architecture/no-react-dom-deprecated-apis.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-react-dom-deprecated-apis.ts
@@ -73,6 +73,8 @@ const reportTestUtilsImports = (node: EsTreeNode, context: RuleContext): void =>
 };
 
 export const noReactDomDeprecatedApis = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Switch the legacy `react-dom` root API (`render` / `hydrate` / `unmountComponentAtNode`) to `createRoot` / `hydrateRoot` / `root.unmount()` from `react-dom/client`. Replace `findDOMNode` with a ref. The whole `react-dom/test-utils` entry point is removed in React 19 — use `act` from `react` and `fireEvent` / `render` from `@testing-library/react`. Only enabled on projects detected as React 18+.",

--- a/packages/react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.ts
@@ -26,6 +26,8 @@ const REACT_19_DEPRECATED_MESSAGES = new Map<string, string>([
 ]);
 
 export const noReact19DeprecatedApis = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Pass `ref` as a regular prop on function components — `forwardRef` is no longer needed in React 19+. Replace `useContext(X)` with `use(X)` for branch-aware context reads. Only enabled on projects detected as React 19+.",

--- a/packages/react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRenderInRender = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Extract to a named component: `const ListItem = ({ item }) => <div>{item.name}</div>`",

--- a/packages/react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
@@ -16,6 +16,8 @@ const RENDER_PROP_PATTERN = /^render[A-Z]/;
 // of "many slots cobbled together where compound components or
 // `children` would be cleaner".
 export const noRenderPropChildren = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Replace `renderXxx` props with compound subcomponents (e.g. `<Modal.Header>`) or `children` so the parent doesn't dictate every customization point",

--- a/packages/react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
@@ -48,6 +48,8 @@ const buildHookBindingMap = (componentBody: EsTreeNode): Map<string, string> => 
 // where `router` is bound to a `useRouter()` call in the same component.
 // We don't fire when the binding is destructured already.
 export const reactCompilerDestructureMethod = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Destructure the method up front: `const { push } = useRouter()` then call `push(...)` directly — clearer dependency graph and easier for React Compiler to memoize",

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
@@ -5,6 +5,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noBarrelImport = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Bundle Size",
   recommendation:
     "Import from the direct path: `import { Button } from './components/Button'` instead of `./components`",

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-dynamic-import-path.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-dynamic-import-path.ts
@@ -8,6 +8,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // statically-analyzable string literal. `import(variable)` or
 // `require(variable)` defeats trace targets and forces a fat bundle.
 export const noDynamicImportPath = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Bundle Size",
   recommendation:
     "Use a string-literal path: `import('./feature/heavy.js')` so the bundler can split this chunk",

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-full-lodash-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-full-lodash-import.ts
@@ -4,6 +4,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noFullLodashImport = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Bundle Size",
   recommendation:
     "Import the specific function: `import debounce from 'lodash/debounce'` — saves ~70kb",

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-moment.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-moment.ts
@@ -4,6 +4,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noMoment = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Bundle Size",
   recommendation:
     "Replace with `import { format } from 'date-fns'` (tree-shakeable) or `import dayjs from 'dayjs'` (2kb)",

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noUndeferredThirdParty = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Bundle Size",
   recommendation: 'Use `next/script` with `strategy="lazyOnload"` or add the `defer` attribute',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/bundle-size/prefer-dynamic-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/prefer-dynamic-import.ts
@@ -5,6 +5,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const preferDynamicImport = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Bundle Size",
   recommendation:
     "Use `const Component = dynamic(() => import('library'), { ssr: false })` from next/dynamic or React.lazy()",

--- a/packages/react-doctor/src/plugin/rules/bundle-size/use-lazy-motion.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/use-lazy-motion.ts
@@ -6,6 +6,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const useLazyMotion = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Bundle Size",
   recommendation:
     'Use `import { LazyMotion, m } from "framer-motion"` with `domAnimation` features — saves ~30kb',

--- a/packages/react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
+++ b/packages/react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
@@ -29,6 +29,8 @@ const isJsonStringifyCall = (node: EsTreeNode): boolean => {
 };
 
 export const clientLocalstorageNoVersion = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Correctness",
   recommendation:
     'Bake a version into the storage key (e.g. "myKey:v1"); a future schema change can ignore old data instead of crashing on it',

--- a/packages/react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
+++ b/packages/react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const clientPassiveEventListeners = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Add `{ passive: true }` as the third argument: `addEventListener('scroll', handler, { passive: true })`. Only do this if the handler does NOT call `event.preventDefault()` — passive listeners silently ignore `preventDefault()`, which breaks features like pull-to-refresh suppression, custom gestures, and nested-scroll containment.",

--- a/packages/react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -91,6 +91,8 @@ const isInsideStaticPlaceholderMap = (node: EsTreeNode): boolean => {
 };
 
 export const noArrayIndexAsKey = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Correctness",
   recommendation:
     "Use a stable unique identifier: `key={item.id}` or `key={item.slug}` — index keys break on reorder/filter",

--- a/packages/react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -10,6 +10,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // subcomponents (`<Button.Text />`) so text always lands in the right
 // shape and the component's API is checked at compile time.
 export const noPolymorphicChildren = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Expose explicit subcomponents (`<Button.Text>`, `<Button.Icon>`) so consumers don't need to switch on `typeof children`",

--- a/packages/react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -45,6 +45,8 @@ const buildPreventDefaultMessage = (elementName: string): string => {
 };
 
 export const noPreventDefault = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Correctness",
   recommendation:
     "Use `<form action={serverAction}>` (works without JS) or `<button>` instead of `<a>` with preventDefault",

--- a/packages/react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -72,6 +72,8 @@ const hasJsxSpreadAttribute = (attributes: EsTreeNode[]): boolean =>
 // `defaultValue` via spread, and we can't see through it without scope
 // analysis. False-negative > false-positive on a heavily used pattern.
 export const noUncontrolledInput = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Correctness",
   recommendation:
     'Pass an explicit initial value to `useState` (e.g. `useState("")` instead of `useState()`), add `onChange` (or `readOnly` to opt out) when you supply `value`, and drop `defaultValue` on controlled inputs — React ignores it',

--- a/packages/react-doctor/src/plugin/rules/correctness/rendering-conditional-render.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/rendering-conditional-render.ts
@@ -22,6 +22,8 @@ const isNumericName = (name: string): boolean => {
 };
 
 export const renderingConditionalRender = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Correctness",
   recommendation:
     "Change to `{items.length > 0 && <List />}` or use a ternary: `{items.length ? <List /> : null}`",

--- a/packages/react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
@@ -13,6 +13,8 @@ const SVG_PATH_ATTRIBUTES = new Set(["d", "points", "transform"]);
 // emit these by default; truncating to 1–2 decimals trims 30–50% off
 // markup with no visible difference.
 export const renderingSvgPrecision = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Truncate path/points/transform decimals to 1–2 digits — sub-pixel precision adds bytes with no visible difference",

--- a/packages/react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -66,6 +66,8 @@ const isBackgroundDark = (bgValue: string): boolean => {
 };
 
 export const noDarkModeGlow = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Use a subtle `box-shadow` with neutral colors for depth, or `border` with low opacity. Colored glows on dark backgrounds are the default AI-generated aesthetic",

--- a/packages/react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noDisabledZoom = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Accessibility",
   recommendation:
     "Remove `user-scalable=no` and `maximum-scale` from the viewport meta tag. If your layout breaks at 200% zoom, fix the layout — don't punish users with disabilities",

--- a/packages/react-doctor/src/plugin/rules/design/no-gradient-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-gradient-text.ts
@@ -8,6 +8,8 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 
 export const noGradientText = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Use solid text colors for readability. If you need emphasis, use font weight, size, or a distinct color instead of gradients",

--- a/packages/react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 
 export const noGrayOnColoredBackground = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Accessibility",
   recommendation:
     "Use a darker shade of the background color for text, or white/near-white for contrast. Gray text on colored backgrounds looks washed out",

--- a/packages/react-doctor/src/plugin/rules/design/no-inline-bounce-easing.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-inline-bounce-easing.ts
@@ -27,6 +27,8 @@ const hasBounceAnimationName = (value: string): boolean => {
 };
 
 export const noInlineBounceEasing = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `cubic-bezier(0.16, 1, 0.3, 1)` (ease-out-expo) for natural deceleration — objects in the real world don't bounce",

--- a/packages/react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
@@ -7,6 +7,8 @@ import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noInlineExhaustiveStyle = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Move styles to a CSS class, CSS module, Tailwind utilities, or a styled component — inline objects with many properties hurt readability and create new references every render",

--- a/packages/react-doctor/src/plugin/rules/design/no-justified-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-justified-text.ts
@@ -7,6 +7,8 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 
 export const noJustifiedText = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Accessibility",
   recommendation:
     "Use `text-align: left` for body text, or add `hyphens: auto` and `overflow-wrap: break-word` if you must justify",

--- a/packages/react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
@@ -7,6 +7,8 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 
 export const noLayoutTransitionInline = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `transform` and `opacity` for transitions — they run on the compositor thread. For height animations, use `grid-template-rows: 0fr → 1fr`",

--- a/packages/react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
@@ -8,6 +8,8 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 
 export const noLongTransitionDuration = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Keep UI transitions under 1s — 100-150ms for instant feedback, 200-300ms for state changes, 300-500ms for layout changes. Use longer durations only for page-load hero animations",

--- a/packages/react-doctor/src/plugin/rules/design/no-outline-none.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-outline-none.ts
@@ -8,6 +8,8 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 
 export const noOutlineNone = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Accessibility",
   recommendation:
     "Use `:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px }` to show focus only for keyboard users while hiding it for mouse clicks",

--- a/packages/react-doctor/src/plugin/rules/design/no-pure-black-background.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-pure-black-background.ts
@@ -9,6 +9,8 @@ import { isPureBlackColor } from "./utils/is-pure-black-color.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 
 export const noPureBlackBackground = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Tint the background slightly toward your brand hue — e.g. `#0a0a0f` or Tailwind's `bg-gray-950`. Pure black looks harsh on modern displays",

--- a/packages/react-doctor/src/plugin/rules/design/no-side-tab-border.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-side-tab-border.ts
@@ -53,6 +53,8 @@ const BORDER_SIDE_WIDTH_KEYS = new Set([
 ]);
 
 export const noSideTabBorder = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Use a subtler accent (box-shadow inset, background gradient, or border-bottom) instead of a thick one-sided border",

--- a/packages/react-doctor/src/plugin/rules/design/no-tiny-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-tiny-text.ts
@@ -9,6 +9,8 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 
 export const noTinyText = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Accessibility",
   recommendation:
     "Use at least 12px for body content, 16px is ideal. Small text is hard to read, especially on high-DPI mobile screens",

--- a/packages/react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
@@ -9,6 +9,8 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 
 export const noWideLetterSpacing = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Reserve wide tracking (letter-spacing > 0.05em) for short uppercase labels, navigation items, and buttons — not body text",

--- a/packages/react-doctor/src/plugin/rules/design/no-z-index9999.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-z-index9999.ts
@@ -10,6 +10,8 @@ import { getStylePropertyNumberValue } from "./utils/get-style-property-number-v
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noZIndex9999 = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Define a z-index scale in your design tokens (e.g. dropdown: 10, modal: 20, toast: 30). Create a new stacking context with `isolation: isolate` instead of escalating values",

--- a/packages/react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
@@ -183,6 +183,8 @@ const isWrappedInPromiseConcurrency = (mapCall: EsTreeNode): boolean => {
 };
 
 export const asyncAwaitInLoop = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Collect the items and use `await Promise.all(items.map(...))` to run independent operations concurrently",

--- a/packages/react-doctor/src/plugin/rules/js-performance/async-parallel.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/async-parallel.ts
@@ -36,6 +36,8 @@ const reportIfIndependent = (statements: EsTreeNode[], context: RuleContext): vo
 };
 
 export const asyncParallel = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `const [a, b] = await Promise.all([fetchA(), fetchB()])` to run independent operations concurrently",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsBatchDomCss = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Batch DOM/CSS reads and writes — interleaving them inside a loop causes layout thrashing. Read first, then write",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
@@ -22,6 +22,8 @@ const buildMemberAccessKey = (node: EsTreeNode): string | null => {
 // at the top of the loop body. We require a member-expression depth ≥ 2
 // (two dots) and ≥ 3 occurrences in the same loop block to fire.
 export const jsCachePropertyAccess = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Hoist the deep member access into a const at the top of the loop body: `const { x, y } = obj.deeply.nested`",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-cache-storage.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-cache-storage.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsCacheStorage = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Cache repeated `localStorage`/`sessionStorage` reads in a local variable — each access serializes/deserializes",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-combine-iterations.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-combine-iterations.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsCombineIterations = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Combine `.map().filter()` (or similar chains) into a single pass with `.reduce()` or a `for...of` loop to avoid iterating the array twice",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-early-exit.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-early-exit.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsEarlyExit = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Add an early `return` / `continue` to flatten deep nesting and short-circuit when the predicate is already known",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsFlatmapFilter = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `.flatMap(item => condition ? [value] : [])` — transforms and filters in a single pass instead of creating an intermediate array",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
@@ -35,6 +35,8 @@ const isIntlNewExpression = (node: EsTreeNode): boolean => {
 };
 
 export const jsHoistIntl = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Hoist `new Intl.NumberFormat(...)` to module scope or wrap in `useMemo` — Intl constructors allocate dozens of objects per locale lookup",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-regexp.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-regexp.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsHoistRegexp = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Hoist `new RegExp(...)` (or large regex literals) to a module-level constant so it isn't recompiled on every loop iteration",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsIndexMaps = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Build an index `Map` once outside the loop instead of `array.find(...)` inside it",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
@@ -11,6 +11,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // shortcut. e.g. `a.length === b.length && a.every((x, i) => x === b[i])`
 // runs the every-loop only when lengths match.
 export const jsLengthCheckFirst = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Short-circuit with `a.length === b.length && a.every((x, i) => x === b[i])` — unequal-length arrays exit immediately",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-min-max-loop.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-min-max-loop.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsMinMaxLoop = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `Math.min(...array)` / `Math.max(...array)` instead of sorting just to read the first or last element",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -166,6 +166,8 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
 };
 
 export const jsSetMapLookups = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use a `Set` or `Map` for repeated membership tests / keyed lookups — `Array.includes`/`find` is O(n) per call",

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const jsTosortedImmutable = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `array.toSorted()` (ES2023) instead of `[...array].sort()` for immutable sorting without the spread allocation",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.ts
@@ -7,6 +7,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const nextjsAsyncClientComponent = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "error",
   category: "Next.js",
   recommendation:
     "Fetch data in a parent Server Component and pass it as props, or use useQuery/useSWR in the client component",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-image-missing-sizes.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-image-missing-sizes.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsImageMissingSizes = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     'Add sizes for responsive behavior: `sizes="(max-width: 768px) 100vw, 50vw"` matching your layout breakpoints',

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-inline-script-missing-id.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-inline-script-missing-id.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsInlineScriptMissingId = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     'Add `id="descriptive-name"` so Next.js can track, deduplicate, and re-execute the script correctly',

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsMissingMetadata = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "Add `export const metadata = { title: '...', description: '...' }` or `export async function generateMetadata()`",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoAElement = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "`import Link from 'next/link'` — enables client-side navigation, prefetching, and preserves scroll position",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.ts
@@ -13,6 +13,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const nextjsNoClientFetchForServerData = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "Remove 'use client' and fetch directly in the Server Component — no API round-trip, secrets stay on server",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
@@ -45,6 +45,8 @@ const describeClientSideNavigation = (
 };
 
 export const nextjsNoClientSideRedirect = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "Avoid redirects inside useEffect. Use an event handler, middleware, or server-side redirect (App Router: redirect() from next/navigation; Pages Router: getServerSideProps redirect)",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoCssLink = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "Import CSS directly: `import './styles.css'` or use CSS Modules: `import styles from './Button.module.css'`",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoFontLink = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     '`import { Inter } from "next/font/google"` — self-hosted, zero layout shift, no render-blocking requests',

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-head-import.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-head-import.ts
@@ -5,6 +5,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const nextjsNoHeadImport = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "error",
   category: "Next.js",
   recommendation:
     "Use the Metadata API instead: `export const metadata = { title: '...' }` or `export async function generateMetadata()`",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoImgElement = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "`import Image from 'next/image'` — provides automatic WebP/AVIF, lazy loading, and responsive srcset",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-native-script.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-native-script.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoNativeScript = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     '`import Script from "next/script"` — use `strategy="afterInteractive"` for analytics or `"lazyOnload"` for widgets',

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoPolyfillScript = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "Next.js includes polyfills for fetch, Promise, Object.assign, Array.from, and 50+ others automatically",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-redirect-in-try-catch.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-redirect-in-try-catch.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const nextjsNoRedirectInTryCatch = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "Move the redirect/notFound call outside the try block, or add `unstable_rethrow(error)` in the catch",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
@@ -42,6 +42,8 @@ const getExportedGetHandlerBody = (node: EsTreeNode): EsTreeNode | null => {
 };
 
 export const nextjsNoSideEffectInGetHandler = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "error",
   category: "Security",
   recommendation:
     "Move the side effect to a POST handler and use a <form> or fetch with method POST — GET requests can be triggered by prefetching and are vulnerable to CSRF",

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-use-search-params-without-suspense.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-use-search-params-without-suspense.ts
@@ -47,6 +47,8 @@ const fileMentionsSuspense = (programNode: EsTreeNode): boolean => {
 };
 
 export const nextjsNoUseSearchParamsWithoutSuspense = defineRule<Rule>({
+  framework: "nextjs",
+  severity: "warn",
   category: "Next.js",
   recommendation:
     "Wrap the component using useSearchParams: `<Suspense fallback={<Skeleton />}><SearchComponent /></Suspense>`",

--- a/packages/react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -36,6 +36,8 @@ const isEarlyReturnIfStatement = (statement: EsTreeNode): boolean => {
 // stay precise (intervening statements would imply the awaited binding
 // is being prepared for use).
 export const asyncDeferAwait = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Move the `await` after the synchronous early-return guard so the skip path stays fast",

--- a/packages/react-doctor/src/plugin/rules/performance/no-global-css-variable-animation.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-global-css-variable-animation.ts
@@ -8,6 +8,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noGlobalCssVariableAnimation = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Performance",
   recommendation:
     "Set the variable on the nearest element instead of a parent, or use `@property` with `inherits: false` to prevent cascade. Better yet, use targeted `element.style.transform` updates",

--- a/packages/react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
@@ -37,6 +37,8 @@ const isInlineReference = (node: EsTreeNode): string | null => {
 };
 
 export const noInlinePropOnMemoComponent = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Hoist the inline `() => ...` / `[]` / `{}` to a stable reference (useMemo, useCallback, or module scope) so the memoized child doesn't re-render every parent render",

--- a/packages/react-doctor/src/plugin/rules/performance/no-large-animated-blur.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-large-animated-blur.ts
@@ -10,6 +10,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noLargeAnimatedBlur = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Keep blur radius under 10px, or apply blur to a smaller element. Large blurs multiply GPU memory usage with layer size",

--- a/packages/react-doctor/src/plugin/rules/performance/no-layout-property-animation.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-layout-property-animation.ts
@@ -24,6 +24,8 @@ const isMotionElement = (attributeNode: EsTreeNode): boolean => {
 };
 
 export const noLayoutPropertyAnimation = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Performance",
   recommendation:
     "Use `transform: translateX()` or `scale()` instead — they run on the compositor and skip layout/paint",

--- a/packages/react-doctor/src/plugin/rules/performance/no-permanent-will-change.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-permanent-will-change.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noPermanentWillChange = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Add will-change on animation start (`onMouseEnter`) and remove on end (`onAnimationEnd`). Permanent promotion wastes GPU memory and can degrade performance",

--- a/packages/react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noScaleFromZero = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `initial={{ scale: 0.95, opacity: 0 }}` — elements should deflate like a balloon, not vanish into a point",

--- a/packages/react-doctor/src/plugin/rules/performance/no-transition-all.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-transition-all.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noTransitionAll = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     'List specific properties: `transition: "opacity 200ms, transform 200ms"` — or in Tailwind use `transition-colors`, `transition-opacity`, or `transition-transform`',

--- a/packages/react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
@@ -18,6 +18,8 @@ const isTriviallyCheapExpression = (node: EsTreeNode | null): boolean => {
 };
 
 export const noUsememoSimpleExpression = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Remove useMemo — property access, math, and ternaries are already cheap without memoization",

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingAnimateSvgWrapper = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation: "Wrap the SVG: `<motion.div animate={...}><svg>...</svg></motion.div>`",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hoist-jsx.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hoist-jsx.ts
@@ -29,6 +29,8 @@ const jsxReferencesLocalScope = (jsxNode: EsTreeNode): boolean => {
 };
 
 export const renderingHoistJsx = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Move the static JSX to module scope: `const ICON = <svg>...</svg>` outside the component so it isn't recreated each render",

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-mismatch-time.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-mismatch-time.ts
@@ -89,6 +89,8 @@ const hasSuppressHydrationWarningAttribute = (openingElement: EsTreeNode | null)
 // only client-side) or to add `suppressHydrationWarning` to the parent
 // element when the mismatch is intentional.
 export const renderingHydrationMismatchTime = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Correctness",
   recommendation:
     "Wrap dynamic time/random values in useEffect+useState (client-only) or add suppressHydrationWarning to the parent if intentional",

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.ts
@@ -9,6 +9,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingHydrationNoFlicker = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)` or add `suppressHydrationWarning` to the element",

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-script-defer-async.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-script-defer-async.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingScriptDeferAsync = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     'Add `defer` for DOM-dependent scripts or `async` for independent ones (analytics). In Next.js, use `<Script strategy="afterInteractive" />` instead',

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const renderingUsetransitionLoading = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Replace with `const [isPending, startTransition] = useTransition()` — avoids a re-render for the loading state",

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-derived-state-from-hook.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-derived-state-from-hook.ts
@@ -73,6 +73,8 @@ const findThresholdDerivedBindings = (
 };
 
 export const rerenderDerivedStateFromHook = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     'Use a threshold/media-query hook (e.g. `useMediaQuery("(max-width: 767px)")`) — the component re-renders only when the threshold flips, not every pixel',

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
@@ -46,6 +46,8 @@ const containsEarlyReturn = (ifStatement: EsTreeNode): boolean => {
 // into a memoized child component so the parent's early return
 // short-circuits before the child renders.
 export const rerenderMemoBeforeEarlyReturn = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Extract the JSX into a memoized child component so the parent's early return short-circuits before the child renders",

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderMemoWithDefaultValue = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Move to module scope: `const EMPTY_ITEMS: Item[] = []` then use as the default value",

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-transitions-scroll.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-transitions-scroll.ts
@@ -52,6 +52,8 @@ const handlerCallsSetState = (handler: EsTreeNode): EsTreeNode | null => {
 // input), or stash the value in a ref + raf throttle, or use
 // `useDeferredValue`.
 export const rerenderTransitionsScroll = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Wrap the setState in startTransition (mark as non-urgent), use useDeferredValue, or stash in a ref + rAF throttle so scroll/pointer events don't trigger a re-render per fire",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
@@ -54,6 +54,8 @@ const findReturnedObject = (callback: EsTreeNode): EsTreeNode | null => {
 // shared values, animate `transform: [{ translateX/Y }, { scale }]` or
 // `opacity` instead.
 export const rnAnimateLayoutProperty = defineRule<Rule>({
+  framework: "react-native",
+  severity: "error",
   category: "React Native",
   recommendation:
     "Animate `transform: [{ translateX/Y }, { scale }]` and `opacity` instead of layout props — layout runs on the JS thread; transform/opacity run on the GPU compositor",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
@@ -11,6 +11,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // gloss that useAnimatedReaction implies (it's meant for cross-thread
 // reactions like calling runOnJS, not value derivation).
 export const rnAnimationReactionAsDerived = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Replace useAnimatedReaction with `useDerivedValue(() => ..., [deps])` — shorter, native dependency tracking, no side-effect implication",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-bottom-sheet-prefer-native.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-bottom-sheet-prefer-native.ts
@@ -17,6 +17,8 @@ const JS_BOTTOM_SHEET_PACKAGES = new Set([
 // "formSheet"> that handles gestures, snap points, and detents on the
 // platform's native modal stack.
 export const rnBottomSheetPreferNative = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     'Use `<Modal presentationStyle="formSheet">` (RN v7+) for native gesture handling and snap points',

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
@@ -52,6 +52,8 @@ const isRenderItemFunction = (node: EsTreeNode): boolean => {
 // list scope (`const handlePress = useCallback((id) => ..., [])`) and
 // pass the row's id as a primitive prop.
 export const rnListCallbackPerRow = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Hoist the handler with useCallback at list scope and pass the row id as a primitive prop, so the row's memo() shallow-compare actually hits",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
@@ -21,6 +21,8 @@ const VIRTUALIZED_LIST_NAMES = new Set([
 // destroying scroll perf. Hoist the transform into a useMemo at list
 // scope or do the projection earlier in the parent.
 export const rnListDataMapped = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Wrap the projection in `useMemo(() => items.map(...), [items])` so the list's `data` prop has a stable reference across parent renders",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
@@ -22,6 +22,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 const RECYCLABLE_LIST_NAMES = new Set(["FlashList", "LegendList"]);
 
 export const rnListRecyclableWithoutTypes = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Add `getItemType={item => item.kind}` so FlashList keeps separate recycle pools per item type — heterogeneous rows shouldn't share recycled cells",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
@@ -7,6 +7,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const rnNoDeprecatedModules = defineRule<Rule>({
+  framework: "react-native",
+  severity: "error",
   category: "React Native",
   recommendation:
     "Import from the community package instead — deprecated modules were removed from the react-native core",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-dimensions-get.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-dimensions-get.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoDimensionsGet = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use `const { width, height } = useWindowDimensions()` — it updates reactively on rotation and resize",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
@@ -7,6 +7,8 @@ import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoInlineFlatlistRenderitem = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Extract renderItem to a named function or wrap in useCallback to avoid re-creating on every render",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-object-in-list-item.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-object-in-list-item.ts
@@ -17,6 +17,8 @@ const RENDER_ITEM_PROP_NAMES = new Set([
 // data didn't change. Hoist the object outside renderItem (StyleSheet,
 // constant, useMemo at list scope) or pass primitives into the row.
 export const rnNoInlineObjectInListItem = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Hoist style/object props outside renderItem (StyleSheet.create, useMemo at list scope, or pass primitives) so memo() row components stop bailing",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-expo-packages.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-expo-packages.ts
@@ -5,6 +5,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const rnNoLegacyExpoPackages = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Migrate to the recommended replacement package — legacy Expo packages are no longer maintained",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
@@ -27,6 +27,8 @@ const reportLegacyShadowProperties = (objectExpression: EsTreeNode, context: Rul
 };
 
 export const rnNoLegacyShadowStyles = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use `boxShadow` for cross-platform shadows on the new architecture instead of platform-specific shadow properties",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-non-native-navigator.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-non-native-navigator.ts
@@ -13,6 +13,8 @@ const NON_NATIVE_NAVIGATOR_PACKAGES = new Set([
 // uses platform-native UINavigationController / Fragment, giving real
 // iOS/Android transitions, swipe-back, and large titles for free.
 export const rnNoNonNativeNavigator = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use `@react-navigation/native-stack` (or `native-tabs` in v7+) for platform-native transitions and gestures",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -55,6 +55,8 @@ const isTextHandlingComponent = (elementName: string): boolean => {
 const WEB_FILE_EXTENSION_PATTERN = /\.web\.[jt]sx?$/;
 
 export const rnNoRawText = defineRule<Rule>({
+  framework: "react-native",
+  severity: "error",
   category: "React Native",
   recommendation:
     "Wrap text in a `<Text>` component: `<Text>{value}</Text>` — raw strings outside `<Text>` crash on React Native",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
@@ -10,6 +10,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // (useSharedValue + useAnimatedScrollHandler) or a ref + raf throttle so
 // the JS thread isn't pegged.
 export const rnNoScrollState = defineRule<Rule>({
+  framework: "react-native",
+  severity: "error",
   category: "React Native",
   recommendation:
     "Track scroll position with a Reanimated shared value (`useAnimatedScrollHandler`) or a ref — `setState` on every scroll event causes re-render storms",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
@@ -12,6 +12,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // recycle row components and only mount the visible window. The cost
 // of switching is tiny (same prop API) and the perf win is huge.
 export const rnNoScrollviewMappedList = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use FlashList, LegendList, or FlatList — `<ScrollView>{items.map(...)}</ScrollView>` mounts every row in memory",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-single-element-style-array.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-single-element-style-array.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rnNoSingleElementStyleArray = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use `style={value}` instead of `style={[value]}` — single-element arrays add unnecessary allocation",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
@@ -13,6 +13,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // the OS computes natively, integrating with sticky headers, large
 // titles, and keyboard avoidance for free.
 export const rnPreferContentInsetAdjustment = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     'Drop the SafeAreaView wrapper and set `contentInsetAdjustmentBehavior="automatic"` on the ScrollView for native safe-area handling',

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
@@ -11,6 +11,8 @@ import { getImportedName } from "../../utils/get-imported-name.js";
 // placeholders, and crossfades — a major perceived-perf win for any list
 // or hero image.
 export const rnPreferExpoImage = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use `<Image>` from `expo-image` instead of `react-native` — same prop API, plus disk + memory caching, placeholders, and crossfades",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
@@ -17,6 +17,8 @@ const TOUCHABLE_COMPONENTS = new Set([
 // modern, more configurable, more accessible replacement that works the
 // same on iOS, Android, and Fabric.
 export const rnPreferPressable = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use `<Pressable>` from react-native (or react-native-gesture-handler) instead of legacy Touchable* components",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
@@ -6,6 +6,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 
 export const rnPreferReanimated = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use `import Animated from 'react-native-reanimated'` — animations run on the UI thread instead of the JS thread",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
@@ -54,6 +54,8 @@ const handlerMutatesIdentifier = (
 // the receiver is actually a `useSharedValue` binding to avoid
 // false-positives on `Map.prototype.set` / `ref.current.value =` etc.
 export const rnPressableSharedValueMutation = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Wrap in <GestureDetector gesture={Gesture.Tap()...}> so the press animation runs on the UI thread instead of bouncing across the JS bridge",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
@@ -13,6 +13,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // which the platform applies as an OS-level offset without re-laying out
 // the content.
 export const rnScrollviewDynamicPadding = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     "Use `contentInset={{ bottom: dynamicValue }}` — the OS applies it as an offset without reflowing the scroll content",

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
@@ -32,6 +32,8 @@ const findLegacyShadowProperty = (
 // so cross-platform code historically had to declare both — `boxShadow`
 // collapses that into one key.
 export const rnStylePreferBoxShadow = defineRule<Rule>({
+  framework: "react-native",
+  severity: "warn",
   category: "React Native",
   recommendation:
     'Use the cross-platform CSS `boxShadow` string (RN v7+): `boxShadow: "0 2px 8px rgba(0,0,0,0.1)"` instead of platform-specific shadow*/elevation keys',

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-bold-heading.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-bold-heading.ts
@@ -44,6 +44,8 @@ const getStylePropertyNumericValue = (objectProperty: EsTreeNode): number | null
 };
 
 export const noBoldHeading = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Use `font-semibold` (600) or `font-medium` (500) on headings — 700+ crushes letter counter shapes at display sizes",

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-default-tailwind-palette.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-default-tailwind-palette.ts
@@ -32,6 +32,8 @@ const buildDefaultPaletteRegex = (): RegExp => {
 const DEFAULT_PALETTE_REGEX = buildDefaultPaletteRegex();
 
 export const noDefaultTailwindPalette = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Replace `indigo-*` / `gray-*` / `slate-*` with project tokens, your brand color, or a less-default neutral (`zinc`, `neutral`, `stone`)",

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
@@ -9,6 +9,8 @@ import { hasResponsivePrefix } from "./utils/has-responsive-prefix.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRedundantPaddingAxes = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Collapse `px-N py-N` to `p-N` when both axes match. Keep them split only when one axis varies at a breakpoint (`py-2 md:py-3`)",

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
@@ -9,6 +9,8 @@ import { hasResponsivePrefix } from "./utils/has-responsive-prefix.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noRedundantSizeAxes = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation: "Collapse `w-N h-N` to `size-N` (Tailwind v3.4+) when both axes match",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
@@ -10,6 +10,8 @@ const tokenizeClassName = (classNameValue: string): string[] =>
   classNameValue.split(/\s+/).filter(Boolean);
 
 export const noSpaceOnFlexChildren = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     "Use `gap-*` on the flex/grid parent. `space-x-*` / `space-y-*` produce phantom gaps when a sibling is conditionally rendered, lose vertical spacing on wrapped lines, and don't mirror in RTL",

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-three-period-ellipsis.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-three-period-ellipsis.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isInsideExcludedAncestor } from "./utils/is-inside-excluded-ancestor.js";
 
 export const noThreePeriodEllipsis = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Architecture",
   recommendation:
     'Use the typographic ellipsis "…" (or `&hellip;`) instead of three periods — pairs with action-with-followup labels ("Rename…", "Loading…")',

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
@@ -53,6 +53,8 @@ const collectJsxLabelText = (jsxElementNode: EsTreeNode): string | null => {
 };
 
 export const noVagueButtonLabel = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Accessibility",
   recommendation:
     'Name the action: "Save changes" instead of "Continue", "Send invite" instead of "Submit", "Delete account" instead of "OK". The label IS the button\'s accessible name',

--- a/packages/react-doctor/src/plugin/rules/security/no-eval.ts
+++ b/packages/react-doctor/src/plugin/rules/security/no-eval.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noEval = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Security",
   recommendation:
     "Use `JSON.parse` for serialized data, `Function(...)` (still careful) for trusted templates, or refactor to avoid dynamic code execution",

--- a/packages/react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -11,6 +11,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noSecretsInClientCode = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Security",
   recommendation:
     "Move to server-side `process.env.SECRET_NAME`. Only `NEXT_PUBLIC_*` vars are safe for the client (and should not contain secrets)",

--- a/packages/react-doctor/src/plugin/rules/server/server-after-nonblocking.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-after-nonblocking.ts
@@ -44,6 +44,8 @@ const isDeferrableSideEffectCall = (objectName: string, methodName: string): boo
 };
 
 export const serverAfterNonblocking = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Server",
   recommendation:
     "`import { after } from 'next/server'` then wrap: `after(() => analytics.track(...))` — response isn't blocked",

--- a/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -35,6 +35,8 @@ const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
 };
 
 export const serverAuthActions = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Server",
   recommendation:
     "Add `const session = await auth()` at the top and throw/redirect if unauthorized before any data access",

--- a/packages/react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
@@ -11,6 +11,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // underlying fetch runs twice per request. Pass primitives (or memoize
 // the argument object once at module/route scope).
 export const serverCacheWithObjectLiteral = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Server",
   recommendation:
     "Pass primitives to React.cache()-wrapped functions — argument identity (not deep equality) is the dedup key, so a fresh `{}` per render bypasses the cache",

--- a/packages/react-doctor/src/plugin/rules/server/server-dedup-props.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-dedup-props.ts
@@ -20,6 +20,8 @@ const getDerivingMethodName = (node: EsTreeNode): string | null => {
 // roughly the same array; one of the props is redundant. Have the
 // client derive what it needs from the single source prop instead.
 export const serverDedupProps = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Server",
   recommendation:
     "Pass the source array once and derive the projection on the client — passing both doubles RSC serialization bytes",

--- a/packages/react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
@@ -53,6 +53,8 @@ const APP_ROUTER_FILE_PATTERN =
 const NON_PROJECT_PATH_PATTERN = /\/(?:node_modules|dist|build|\.next)\//;
 
 export const serverFetchWithoutRevalidate = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Server",
   recommendation:
     'Pass `{ next: { revalidate: <seconds> } }` (or `cache: "no-store"` / `next: { tags: [...] }`) so stale cached data doesn\'t silently persist',

--- a/packages/react-doctor/src/plugin/rules/server/server-hoist-static-io.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-hoist-static-io.ts
@@ -125,6 +125,8 @@ const collectIdentifierParams = (params: EsTreeNode[]): Set<string> => {
 // `app/.../route.ts`) and Pages Router (`export default async function
 // handler(req, res)` in `pages/api/...`).
 export const serverHoistStaticIo = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Server",
   recommendation:
     "Hoist the read to module scope: `const FONT_DATA = await fetch(new URL('./fonts/Inter.ttf', import.meta.url)).then(r => r.arrayBuffer())` runs once at module load",

--- a/packages/react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
@@ -28,6 +28,8 @@ const isMutableConstInitializer = (init: EsTreeNode | null | undefined): string 
 // must live inside the action, in headers/cookies, or in a request scope
 // (React.cache, AsyncLocalStorage, etc.).
 export const serverNoMutableModuleState = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "Server",
   recommendation:
     "Move per-request data into the action body, headers/cookies, or a request-scope (React.cache, AsyncLocalStorage). Module-scope `let`/`var` is shared across requests.",

--- a/packages/react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
@@ -59,6 +59,8 @@ const declarationReadsAnyName = (declaration: EsTreeNode, names: Set<string>): b
 };
 
 export const serverSequentialIndependentAwait = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Server",
   recommendation:
     "Wrap independent awaits in `Promise.all([...])` so they race instead of waterfalling — second call doesn't depend on the first",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
@@ -27,6 +27,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // counts as a subscription-shaped call (zustand/Redux `subscribe`,
 // browser `addEventListener`, EventEmitter `on`, etc.).
 export const advancedEventHandlerRefs = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Store the handler in a ref and have the listener read `handlerRef.current()` — the subscription stays put while the latest handler is always called",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -160,6 +160,8 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
 };
 
 export const effectNeedsCleanup = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "State & Effects",
   recommendation:
     "Return a cleanup function that releases the subscription / timer: `return () => target.removeEventListener(name, handler)` for listeners, `return () => clearInterval(id)` / `clearTimeout(id)` for timers, or `return unsubscribe` if the subscribe call already returned one",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.ts
@@ -8,6 +8,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noCascadingSetState = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Combine into useReducer: `const [state, dispatch] = useReducer(reducer, initialState)`",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
@@ -74,6 +74,8 @@ const collectValueIdentifierNames = (node: EsTreeNode | null | undefined, into: 
 };
 
 export const noDerivedStateEffect = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "For derived state, compute inline: `const x = fn(dep)`. For state resets on prop change, use a key prop: `<Component key={prop} />`. See https://react.dev/learn/you-might-not-need-an-effect",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -8,6 +8,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noDerivedUseState = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Remove useState and compute the value inline: `const value = transform(propName)`",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
@@ -74,6 +74,8 @@ const walkComponentRespectingShadows = (
 };
 
 export const noDirectStateMutation = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Replace the mutation with a setter call that produces a new reference: `setItems([...items, newItem])`, `setItems(items.filter(x => x !== target))`, `setItems(items.toSorted(...))`. React only re-renders on a new reference, so in-place updates are silently dropped",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -210,6 +210,8 @@ interface EffectInfo {
 }
 
 export const noEffectChain = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Compute as much as possible during render (e.g. `const isGameOver = round > 5`) and write all related state inside the event handler that originally fires the chain. Each effect link adds an extra render and makes the code rigid as requirements evolve",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -10,6 +10,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const noEffectEventHandler = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Move the conditional logic into onClick, onChange, or onSubmit handlers directly",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
@@ -17,6 +17,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // binding named `onChange` in ComponentA doesn't taint a regular variable
 // `onChange` in ComponentB in the same file.
 export const noEffectEventInDeps = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "State & Effects",
   recommendation:
     "Call the useEffectEvent callback inside the effect body without listing it; its identity is intentionally unstable",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
@@ -148,6 +148,8 @@ const collectHandlerOnlyWriteStateNames = (
 };
 
 export const noEventTriggerState = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Delete the trigger state (`useState(null)` plus the `useEffect` that watches it) and call the side-effect (`post(...)` / `navigate(...)` / `track(...)`) directly inside the event handler that previously called the setter. State should not exist purely to schedule effect runs",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -8,6 +8,8 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 export const noFetchInEffect = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Use `useQuery()` from @tanstack/react-query, `useSWR()`, or fetch in a Server Component instead",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
@@ -53,6 +53,8 @@ interface MirrorBinding {
 }
 
 export const noMirrorPropEffect = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Delete both the `useState` and the `useEffect` and read the prop directly during render. Mirroring a prop into local state forces a stale first render before the effect re-syncs",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
@@ -67,6 +67,8 @@ const findMutableDepIssue = (
 };
 
 export const noMutableInDeps = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "State & Effects",
   recommendation:
     "Read mutable values (`location.pathname`, `ref.current`) inside the effect body instead of in the deps array, or subscribe with `useSyncExternalStore`. Mutations to these don't trigger re-renders, so listing them in deps doesn't make the effect react to changes",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
@@ -17,6 +17,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // both child and parent read from; the child then doesn't need an
 // effect-driven sync at all.
 export const noPropCallbackInEffect = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Lift the shared state into a Provider so both sides read the same source — no useEffect-driven sync needed",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
@@ -35,6 +35,8 @@ const isUnconditionalSetterCallStatement = (
 };
 
 export const noSetStateInRender = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Move the setter call into a `useEffect`, an event handler, or replace the state with a value computed during render. Calling a setter at render time triggers another render, which calls the setter again — an infinite loop",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-effect-event.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-effect-event.ts
@@ -227,6 +227,8 @@ const classifyCallableReadsInsideEffect = (
 };
 
 export const preferUseEffectEvent = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Wrap the callback with `useEffectEvent(callback)` (React 19+) and call the resulting binding from inside the sub-handler. The Effect Event captures the latest props/state without being a reactive dep, so the effect doesn't re-subscribe on every parent render. See https://react.dev/reference/react/useEffectEvent",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
@@ -9,6 +9,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const preferUseReducer = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Group related state: `const [state, dispatch] = useReducer(reducer, { field1, field2, ... })`",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
@@ -145,6 +145,8 @@ const cleanupReleasesSubscription = (
 };
 
 export const preferUseSyncExternalStore = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "State & Effects",
   recommendation:
     "Replace the `useState(getSnapshot())` + `useEffect(() => store.subscribe(() => setSnapshot(getSnapshot())))` pair with `useSyncExternalStore(store.subscribe, getSnapshot)`. The hook handles tearing during concurrent renders and SSR snapshots; the manual subscribe pattern doesn't",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
@@ -49,6 +49,8 @@ const findHookCallBindings = (
 // Heuristic: hook value-name appears only inside arrow / function
 // expressions that are themselves bound to JSX `on*` attributes.
 export const rerenderDeferReadsHook = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Read the URL state inside the handler (e.g. `new URL(window.location.href).searchParams`) so the component doesn't subscribe and re-render on every URL change",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderDependencies = defineRule<Rule>({
+  framework: "global",
+  severity: "error",
   category: "State & Effects",
   recommendation:
     "Extract to a useMemo, useRef, or module-level constant so the reference is stable",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-functional-setstate.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-functional-setstate.ts
@@ -17,6 +17,8 @@ const deriveStateVariableName = (setterName: string): string | null => {
 };
 
 export const rerenderFunctionalSetstate = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use the callback form: `setState(prev => prev + 1)` to always read the latest value",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderLazyStateInit = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Wrap in an arrow function so it only runs once: `useState(() => expensiveComputation())`",

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -13,6 +13,8 @@ import { expandTransitiveDependencies } from "./utils/expand-transitive-dependen
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const rerenderStateOnlyInHandlers = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Replace useState with useRef when the value is only mutated and never read in render — `ref.current = ...` updates without re-rendering the component",

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryMutationMissingInvalidation = defineRule<Rule>({
+  framework: "tanstack-query",
+  severity: "warn",
   category: "TanStack Query",
   recommendation:
     "Add `onSuccess: () => queryClient.invalidateQueries({ queryKey: ['...'] })` so cached data stays in sync after the mutation",

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-query-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-query-in-effect.ts
@@ -9,6 +9,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoQueryInEffect = defineRule<Rule>({
+  framework: "tanstack-query",
+  severity: "warn",
   category: "TanStack Query",
   recommendation:
     "React Query manages refetching automatically via queryKey dependencies and the `enabled` option — manual refetch() in useEffect is usually unnecessary",

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoRestDestructuring = defineRule<Rule>({
+  framework: "tanstack-query",
+  severity: "warn",
   category: "TanStack Query",
   recommendation:
     "Destructure only the fields you need: `const { data, isLoading } = useQuery(...)` — rest destructuring subscribes to all fields and causes extra re-renders",

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-use-query-for-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-use-query-for-mutation.ts
@@ -7,6 +7,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoUseQueryForMutation = defineRule<Rule>({
+  framework: "tanstack-query",
+  severity: "warn",
   category: "TanStack Query",
   recommendation:
     "Use `useMutation()` for POST/PUT/DELETE — it provides onSuccess/onError callbacks, doesn't auto-refetch, and correctly models write operations",

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-void-query-fn.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-void-query-fn.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryNoVoidQueryFn = defineRule<Rule>({
+  framework: "tanstack-query",
+  severity: "warn",
   category: "TanStack Query",
   recommendation:
     "queryFn must return a value for the cache. Use the `enabled` option to conditionally disable the query instead of returning undefined",

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-stable-query-client.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-stable-query-client.ts
@@ -11,6 +11,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const queryStableQueryClient = defineRule<Rule>({
+  framework: "tanstack-query",
+  severity: "warn",
   category: "TanStack Query",
   recommendation:
     "Move `new QueryClient()` to module scope or wrap in `useState(() => new QueryClient())` — recreating it on every render resets the entire cache",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-get-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-get-mutation.ts
@@ -8,6 +8,8 @@ import { walkServerFnChain } from "./utils/walk-server-fn-chain.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartGetMutation = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "Security",
   recommendation:
     "Use `createServerFn({ method: 'POST' })` for data modifications — GET requests can be triggered by prefetching and are vulnerable to CSRF",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-loader-parallel-fetch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-loader-parallel-fetch.ts
@@ -30,6 +30,8 @@ const hasTopLevelAwait = (statement: EsTreeNode): boolean => {
 };
 
 export const tanstackStartLoaderParallelFetch = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use `const [a, b] = await Promise.all([fetchA(), fetchB()])` to avoid request waterfalls in route loaders",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartMissingHeadContent = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "TanStack Start",
   recommendation:
     "Add `<HeadContent />` inside `<head>` in your __root route — without it, route `head()` meta tags are silently dropped",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoAnchorElement = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "TanStack Start",
   recommendation:
     "`import { Link } from '@tanstack/react-router'` — enables type-safe routes, preloading via `preload=\"intent\"`, and client-side navigation",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.ts
@@ -8,6 +8,8 @@ import { getPropertyKeyName } from "./utils/get-property-key-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoDirectFetchInLoader = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "TanStack Start",
   recommendation:
     "Use `createServerFn()` from @tanstack/react-start — provides type-safe RPC, input validation, and proper server/client code splitting",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoDynamicServerFnImport = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "error",
   category: "TanStack Start",
   recommendation:
     "Use `import { myFn } from '~/utils/my.functions'` — the bundler replaces server code with RPC stubs only for static imports",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
@@ -11,6 +11,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoNavigateInRender = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "TanStack Start",
   recommendation:
     "Use `throw redirect({ to: '/path' })` in `beforeLoad` or `loader` instead — navigate() during render causes hydration issues",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-secrets-in-loader.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-secrets-in-loader.ts
@@ -21,6 +21,8 @@ const isLikelySecret = (envVarName: string): boolean => {
 };
 
 export const tanstackStartNoSecretsInLoader = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "error",
   category: "Security",
   recommendation:
     "Loaders are isomorphic (run on both server and client). Wrap secret access in `createServerFn()` so it stays server-only",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
@@ -8,6 +8,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoUseEffectFetch = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "TanStack Start",
   recommendation:
     "Fetch data in the route `loader` instead — the router coordinates loading before rendering to avoid waterfalls",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-server-in-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-server-in-handler.ts
@@ -5,6 +5,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartNoUseServerInHandler = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "error",
   category: "TanStack Start",
   recommendation:
     'TanStack Start handles server boundaries automatically via the Vite plugin — "use server" inside createServerFn causes compilation errors',

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-redirect-in-try-catch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-redirect-in-try-catch.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartRedirectInTryCatch = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "TanStack Start",
   recommendation:
     "TanStack Router's `redirect()` and `notFound()` throw special errors caught by the router. Move them outside the try block or re-throw in the catch",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-route-property-order.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-route-property-order.ts
@@ -7,6 +7,8 @@ import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
 
 export const tanstackStartRoutePropertyOrder = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "error",
   category: "TanStack Start",
   recommendation:
     "Follow the order: params/validateSearch → loaderDeps → context → beforeLoad → loader → head. See https://tanstack.com/router/latest/docs/eslint/create-route-property-order",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
@@ -6,6 +6,8 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartServerFnMethodOrder = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "error",
   category: "TanStack Start",
   recommendation:
     "Chain methods in order: .middleware() → .inputValidator() → .client() → .server() → .handler() — types depend on this sequence",

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-validate-input.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-validate-input.ts
@@ -7,6 +7,8 @@ import { walkServerFnChain } from "./utils/walk-server-fn-chain.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 export const tanstackStartServerFnValidateInput = defineRule<Rule>({
+  framework: "tanstack-start",
+  severity: "warn",
   category: "TanStack Start",
   recommendation:
     "Add `.inputValidator(schema)` before `.handler()` — data crosses a network boundary and must be validated at runtime",

--- a/packages/react-doctor/src/plugin/rules/view-transitions/no-document-start-view-transition.ts
+++ b/packages/react-doctor/src/plugin/rules/view-transitions/no-document-start-view-transition.ts
@@ -11,6 +11,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // call startViewTransition for you (around startTransition, useDeferredValue,
 // or Suspense reveals).
 export const noDocumentStartViewTransition = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Correctness",
   recommendation:
     "Render a <ViewTransition> component and update inside startTransition / useDeferredValue — React calls startViewTransition for you",

--- a/packages/react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
+++ b/packages/react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
@@ -11,6 +11,8 @@ import { getImportedName } from "../../utils/get-imported-name.js";
 // (a single actionable diagnostic per file) instead of on every call
 // site, which would clutter output for files with several flushSync()s.
 export const noFlushSync = defineRule<Rule>({
+  framework: "global",
+  severity: "warn",
   category: "Performance",
   recommendation:
     "Use startTransition for non-urgent updates — flushSync forces a sync flush that skips View Transitions and concurrent rendering",

--- a/packages/react-doctor/src/plugin/utils/rule.ts
+++ b/packages/react-doctor/src/plugin/utils/rule.ts
@@ -2,8 +2,23 @@ import type { RuleContext } from "./rule-context.js";
 import type { RuleExample } from "./rule-example.js";
 import type { RuleVisitors } from "./rule-visitors.js";
 
+export type RuleSeverity = "error" | "warn";
+
+// `global` rules are enabled on every project; the other buckets only
+// activate when the project actually uses that framework (detected by
+// `detectProject`). The framework name doubles as the ESLint flat-config
+// key — `recommended` for global, `next` for nextjs, and so on.
+export type RuleFramework =
+  | "global"
+  | "nextjs"
+  | "react-native"
+  | "tanstack-start"
+  | "tanstack-query";
+
 export interface Rule {
   category?: string;
+  framework?: RuleFramework;
+  severity?: RuleSeverity;
   recommendation?: string;
   examples?: RuleExample[];
   create: (context: RuleContext) => RuleVisitors;


### PR DESCRIPTION
## Summary

Completes the metadata-colocation arc (after #228 recommendation, #230 category). Drops the 5 framework-keyed maps in `oxlint/rule-maps.ts` and moves every entry onto the matching rule's `defineRule({...})` call as `framework: "..."` + `severity: "..."` fields.

The 5 maps are now thin **derived constants** computed at module load by filtering `plugin.rules` on each rule's `framework` field, so every downstream consumer (`createOxlintConfig` for the scan, `eslint-plugin.ts`'s flat configs `recommended` / `next` / `react-native` / `tanstack-start` / `tanstack-query`) keeps the same public shape.

**178 rule files updated.** Single source of truth.

## Before / after

```diff
 export const noFetchInEffect = defineRule<Rule>({
   category: "State & Effects",
+  framework: "global",
+  severity: "warn",
   recommendation:
     "Use `useQuery()` from @tanstack/react-query, `useSWR()`, or fetch in a Server Component instead",
   create: (context: RuleContext) => ({ ... }),
 });
```

```diff
-export const GLOBAL_REACT_DOCTOR_RULES: Record<string, RuleSeverity> = {
-  "react-doctor/no-derived-state-effect": "warn",
-  "react-doctor/no-fetch-in-effect": "warn",
-  // …118 entries…
-};
-// repeat 4 more times for nextjs/rn/tanstack-start/tanstack-query
+const collectRulesByFramework = (
+  frameworkName: RuleFramework,
+): Record<string, RuleSeverity> => {
+  const collected: Record<string, RuleSeverity> = {};
+  for (const [ruleId, rule] of Object.entries(reactDoctorPlugin.rules)) {
+    if (rule.framework === frameworkName && rule.severity) {
+      collected[`react-doctor/${ruleId}`] = rule.severity;
+    }
+  }
+  return collected;
+};
+
+export const GLOBAL_REACT_DOCTOR_RULES = collectRulesByFramework("global");
+export const NEXTJS_RULES = collectRulesByFramework("nextjs");
+export const REACT_NATIVE_RULES = collectRulesByFramework("react-native");
+export const TANSTACK_START_RULES = collectRulesByFramework("tanstack-start");
+export const TANSTACK_QUERY_RULES = collectRulesByFramework("tanstack-query");
```

## Why this is the next obvious step

Adding a new react-doctor rule previously required:
1. Writing the rule itself in `plugin/rules/<bucket>/`
2. Registering it in `plugin/react-doctor-plugin.ts`
3. Adding its `RULE_CATEGORY_MAP` entry in `run-oxlint.ts` (now colocated by #230)
4. Adding its `RULE_HELP_MAP` entry in `run-oxlint.ts` (now colocated by #228)
5. **Adding it to one of the 5 framework maps in `oxlint/rule-maps.ts` at the right severity** (this PR)

Step 5 was the last loose seam — and was the easiest to forget, because forgetting silently means the rule is registered with oxlint but never actually enabled on any project. (The registration validator already warned on missing `category` / `recommendation`; it now also warns on missing `framework` / `severity` via the same mechanism, since `collectRulesByFramework` simply skips rules without a `severity` set.)

## Verified runtime equivalence

Byte-identical 262-line diagnostic snapshot for `runOxlint` against the three test fixtures (`basic-react`, `nextjs-app`, `tanstack-start-app`) vs `origin/main`. Diagnostic output includes plugin, rule, severity, category, file, line, column — anything driven by the maps would surface here.

Framework distribution at runtime matches the original maps exactly:
- `global`: 118 rules (was: 118 entries in `GLOBAL_REACT_DOCTOR_RULES`)
- `nextjs`: 16 (was: 16)
- `react-native`: 24 (was: 24)
- `tanstack-start`: 14 (was: 14)
- `tanstack-query`: 6 (was: 6)
- Total: 178 ✓

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean
- [x] `pnpm test` — 734/734 pass
- [x] Diagnostic snapshot diff vs `origin/main` — identical

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how oxlint/ESLint rule enablement and severities are sourced, so mistakes in `framework`/`severity` metadata could silently drop or misclassify lint diagnostics across projects.
> 
> **Overview**
> Refactors `oxlint/rule-maps.ts` to **stop hardcoding** per-framework react-doctor rule severity maps and instead build them at module load by filtering `reactDoctorPlugin.rules` on each rule’s new `framework` + `severity` fields.
> 
> Updates the rule type (`plugin/utils/rule.ts`) and **touches every rule definition** to colocate `framework` (e.g. `global`, `nextjs`, `react-native`, `tanstack-*`) and `severity` (`warn`/`error`) alongside the `defineRule({...})` call, keeping downstream consumers using the same exported map shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db63a4016c66361325bae10ecdcf051ab8d3191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->