### PR TITLE
fix(#206): skip response.headers.set() in nextjs-no-side-effect rule

### DIFF
--- a/packages/react-doctor/src/plugin/helpers.ts
+++ b/packages/react-doctor/src/plugin/helpers.ts
@@ -333,6 +333,16 @@ const isCookiesOrHeadersCall = (node: EsTreeNode, methodName: string): boolean =
   return object.callee.name === methodName;
 };
 
+// Check for response.headers.set(), response.headers.append(), response.headers.delete()
+// These are setting response headers, not mutating server state
+const isResponseHeadersCall = (node: EsTreeNode): boolean => {
+  if (node.type !== "CallExpression" || node.callee?.type !== "MemberExpression") return false;
+  const { object, property } = node.callee;
+  if (property?.type !== "Identifier" || !MUTATION_METHOD_NAMES.has(property.name)) return false;
+  if (object?.type !== "MemberExpression" || object.object?.type !== "Identifier" || object.property?.type !== "Identifier") return false;
+  return object.object.name === "response" && object.property.name === "headers";
+};
+
 const isMutatingDbCall = (node: EsTreeNode): boolean => {
   if (node.type !== "CallExpression" || node.callee?.type !== "MemberExpression") return false;
   const { property } = node.callee;
@@ -365,6 +375,8 @@ export const findSideEffect = (node: EsTreeNode): string | null => {
   let sideEffectDescription: string | null = null;
   walkAst(node, (child: EsTreeNode) => {
     if (sideEffectDescription) return;
+    // Skip response.headers.set/append/delete - these are response header operations, not server state mutation
+    if (isResponseHeadersCall(child)) return;
     if (isCookiesOrHeadersCall(child, "cookies")) {
       const methodName = child.callee.property.name;
       sideEffectDescription = `cookies().${methodName}()`;


### PR DESCRIPTION
## Summary

Issue #206: False positive - nextjs-no-side-effect-in-get-handler flags Response.headers.set()

## Problem

The `nextjs-no-side-effect-in-get-handler` rule was incorrectly flagging `response.headers.set()` calls inside GET route handlers as security-risk side effects.

## Solution

Added `isResponseHeadersCall()` function to detect response.headers calls and skip them during side effect detection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rule tweak: narrows `findSideEffect` detection to avoid false positives, with minimal impact beyond potentially missing misclassified `response.headers.*` calls.
> 
> **Overview**
> Updates side-effect detection used by `nextjs-no-side-effect-in-get-handler` (and other callers of `findSideEffect`) to **ignore** `response.headers.set/append/delete()` calls.
> 
> Adds `isResponseHeadersCall()` and short-circuits `findSideEffect` when encountering these header operations so GET handlers that only set response headers are no longer flagged as mutating server state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9ec02f2555bd6f396f7bf08058ea4926ae16bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->