### PR TITLE
fix(#206): skip response.headers.set() in nextjs-no-side-effect rule

### DIFF
--- a/packages/react-doctor/src/plugin/utils/find-side-effect.ts
+++ b/packages/react-doctor/src/plugin/utils/find-side-effect.ts
@@ -3,6 +3,7 @@ import { isCookiesOrHeadersCall } from "./is-cookies-or-headers-call.js";
 import { isMutatingDbCall } from "./is-mutating-db-call.js";
 import { isMutatingFetchCall } from "./is-mutating-fetch-call.js";
 import { isMutatingMethodProperty } from "./is-mutating-method-property.js";
+import { isResponseHeadersCall } from "./is-response-headers-call.js";
 import { walkAst } from "./walk-ast.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
@@ -10,6 +11,8 @@ export const findSideEffect = (node: EsTreeNode): string | null => {
   let sideEffectDescription: string | null = null;
   walkAst(node, (child: EsTreeNode) => {
     if (sideEffectDescription) return;
+    // Skip response.headers.set/append/delete - these are response header operations, not server state mutation
+    if (isResponseHeadersCall(child)) return;
     if (isCookiesOrHeadersCall(child, "cookies")) {
       const methodName = child.callee.property.name;
       sideEffectDescription = `cookies().${methodName}()`;

--- a/packages/react-doctor/src/plugin/utils/index.ts
+++ b/packages/react-doctor/src/plugin/utils/index.ts
@@ -43,6 +43,7 @@ export { isMemberProperty } from "./is-member-property.js";
 export { isMutatingDbCall } from "./is-mutating-db-call.js";
 export { isMutatingFetchCall } from "./is-mutating-fetch-call.js";
 export { isMutatingMethodProperty } from "./is-mutating-method-property.js";
+export { isResponseHeadersCall } from "./is-response-headers-call.js";
 export { isNodeOfType } from "./is-node-of-type.js";
 export { isSetterCall } from "./is-setter-call.js";
 export { isSetterIdentifier } from "./is-setter-identifier.js";

--- a/packages/react-doctor/src/plugin/utils/is-response-headers-call.ts
+++ b/packages/react-doctor/src/plugin/utils/is-response-headers-call.ts
@@ -1,0 +1,16 @@
+import { MUTATION_METHOD_NAMES } from "../constants.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+// Check for response.headers.set(), response.headers.append(), response.headers.delete()
+// These are setting response headers, not mutating server state
+export const isResponseHeadersCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression") || !isNodeOfType(node.callee, "MemberExpression"))
+    return false;
+  const { object, property } = node.callee;
+  if (!isNodeOfType(property, "Identifier") || !MUTATION_METHOD_NAMES.has(property.name))
+    return false;
+  if (!isNodeOfType(object, "MemberExpression") || !isNodeOfType(object.object, "Identifier") || !isNodeOfType(object.property, "Identifier"))
+    return false;
+  return object.object.name === "response" && object.property.name === "headers";
+};


### PR DESCRIPTION
## Summary

Issue #206: False positive - nextjs-no-side-effect-in-get-handler flags Response.headers.set()

## Problem

The `nextjs-no-side-effect-in-get-handler` rule was incorrectly flagging `response.headers.set()` calls inside GET route handlers as security-risk side effects. These calls only shape the outbound response (Cache-Control, X-Deprecated, CORS headers) and are idiomatic Next.js — they do not mutate server state.

## Solution

Added `isResponseHeadersCall()` function to detect `response.headers.set()`, `response.headers.append()`, and `response.headers.delete()` calls and skip them during side effect detection.

## Changes

- `packages/react-doctor/src/plugin/utils/is-response-headers-call.ts` (new)
- `packages/react-doctor/src/plugin/utils/find-side-effect.ts` - skip response.headers calls
- `packages/react-doctor/src/plugin/utils/index.ts` - export new function

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk predicate change to a lint rule to reduce false positives; main risk is potentially missing a real side effect if code matches the new `response.headers.*` call shape unexpectedly.
> 
> **Overview**
> Updates side-effect detection used by `nextjs-no-side-effect-in-get-handler` to *ignore* `response.headers.set()`, `.append()`, and `.delete()` calls so response header shaping is no longer reported as a server-state mutation.
> 
> Adds a new `isResponseHeadersCall` AST predicate and exports it via the utils index, then short-circuits `findSideEffect` when this call pattern is encountered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5bacbb1b44f2cb26e96b3e29ecb135d1ccbf0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->