### PR TITLE
refactor(types): EsTreeNode = TSESTree.Node (drop the loose [key: string]: any escape hatch)

### DIFF
--- a/packages/react-doctor/src/plugin/rules/architecture/no-default-props.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-default-props.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: React 19 removes `Component.defaultProps` for FUNCTION components
 // (class components still tolerate it but the team recommends ES6
@@ -29,7 +29,7 @@ export const noDefaultProps = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    AssignmentExpression(node: EsTreeNode) {
+    AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
       if (node.operator !== "=") return;
       const left = node.left;
       if (!isNodeOfType(left, "MemberExpression")) return;

--- a/packages/react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
@@ -1,9 +1,9 @@
 import { GENERIC_EVENT_SUFFIXES } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noGenericHandlerNames = defineRule<Rule>({
   framework: "global",
@@ -20,7 +20,7 @@ export const noGenericHandlerNames = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || !node.name.name.startsWith("on")) return;
       if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
 

--- a/packages/react-doctor/src/plugin/rules/architecture/no-giant-component.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-giant-component.ts
@@ -1,10 +1,12 @@
 import { GIANT_COMPONENT_LINE_THRESHOLD } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noGiantComponent = defineRule<Rule>({
   framework: "global",
@@ -36,12 +38,13 @@ export const noGiantComponent = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         reportOversizedComponent(node.id, node.id.name, node);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
+        if (!isNodeOfType(node.id, "Identifier") || !node.init) return;
         reportOversizedComponent(node.id, node.id.name, node.init);
       },
     };

--- a/packages/react-doctor/src/plugin/rules/architecture/no-legacy-class-lifecycles.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-legacy-class-lifecycles.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: the three legacy class lifecycles `componentWillMount`,
 // `componentWillReceiveProps`, and `componentWillUpdate` are unsafe
@@ -80,7 +81,7 @@ export const noLegacyClassLifecycles = defineRule<Rule>({
     };
 
     return {
-      ClassBody(node: EsTreeNode) {
+      ClassBody(node: EsTreeNodeOfType<"ClassBody">) {
         for (const member of node.body ?? []) {
           checkMember(member);
         }

--- a/packages/react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: legacy context (`childContextTypes` + `getChildContext` on
 // providers, `contextTypes` on consumers) was deprecated in 16.3, warns
@@ -72,12 +73,12 @@ export const noLegacyContextApi = defineRule<Rule>({
     };
 
     return {
-      ClassBody(node: EsTreeNode) {
+      ClassBody(node: EsTreeNodeOfType<"ClassBody">) {
         for (const member of node.body ?? []) {
           checkMember(member);
         }
       },
-      AssignmentExpression(node: EsTreeNode) {
+      AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
         if (node.operator !== "=") return;
         const left = node.left;
         if (!isNodeOfType(left, "MemberExpression")) return;

--- a/packages/react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -7,6 +7,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const BOOLEAN_PROP_PREFIX_PATTERN = /^(?:is|has|should|can|show|hide|enable|disable|with)[A-Z]/;
 
@@ -91,13 +92,19 @@ export const noManyBooleanProps = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
-        if (!isComponentDeclaration(node)) return;
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+        if (!isComponentDeclaration(node) || !node.id) return;
         checkComponent(node.params?.[0], node.body, node.id.name, node.id);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.params?.[0], node.init?.body, node.id.name, node.id);
+        if (!isNodeOfType(node.id, "Identifier")) return;
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.params?.[0], node.init.body, node.id.name, node.id);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
@@ -1,9 +1,11 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noNestedComponentDefinition = defineRule<Rule>({
   framework: "global",
@@ -22,8 +24,8 @@ export const noNestedComponentDefinition = defineRule<Rule>({
     const componentStack: string[] = [];
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
-        if (!isComponentDeclaration(node)) return;
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+        if (!isComponentDeclaration(node) || !node.id) return;
         if (componentStack.length > 0) {
           context.report({
             node: node.id,
@@ -35,8 +37,9 @@ export const noNestedComponentDefinition = defineRule<Rule>({
       "FunctionDeclaration:exit"(node: EsTreeNode) {
         if (isComponentDeclaration(node)) componentStack.pop();
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
+        if (!isNodeOfType(node.id, "Identifier")) return;
         if (componentStack.length > 0) {
           context.report({
             node: node.id,

--- a/packages/react-doctor/src/plugin/rules/architecture/no-react-dom-deprecated-apis.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-react-dom-deprecated-apis.ts
@@ -1,5 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { createDeprecatedReactImportRule } from "./utils/create-deprecated-react-import-rule.js";
@@ -57,7 +57,10 @@ const buildTestUtilsMessage = (importedName: string): string => {
   return `react-dom/test-utils is removed in React 19. ${replacementText}`;
 };
 
-const reportTestUtilsImports = (node: EsTreeNode, context: RuleContext): void => {
+const reportTestUtilsImports = (
+  node: EsTreeNodeOfType<"ImportDeclaration">,
+  context: RuleContext,
+): void => {
   for (const specifier of node.specifiers ?? []) {
     if (isNodeOfType(specifier, "ImportSpecifier")) {
       const importedName = getImportedName(specifier) ?? "default";

--- a/packages/react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -1,9 +1,9 @@
 import { RENDER_FUNCTION_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noRenderInRender = defineRule<Rule>({
   framework: "global",
@@ -19,7 +19,7 @@ export const noRenderInRender = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXExpressionContainer(node: EsTreeNode) {
+    JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
       const expression = node.expression;
       if (!isNodeOfType(expression, "CallExpression")) return;
 

--- a/packages/react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const RENDER_PROP_PATTERN = /^render[A-Z]/;
 
@@ -30,7 +31,7 @@ export const noRenderPropChildren = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const renderPropAttrs: Array<{ name: string; node: EsTreeNode }> = [];
       for (const attr of node.attributes ?? []) {
         if (!isNodeOfType(attr, "JSXAttribute")) continue;

--- a/packages/react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const HOOK_OBJECTS_WITH_METHODS = new Map<string, Set<string>>([
   ["useRouter", new Set(["push", "replace", "back", "forward", "refresh", "prefetch"])],
@@ -19,9 +20,9 @@ const HOOK_OBJECTS_WITH_METHODS = new Map<string, Set<string>>([
 // declarations once per component on enter, so subsequent
 // MemberExpression visitors don't re-walk the whole body for every
 // access.
-const buildHookBindingMap = (componentBody: EsTreeNode): Map<string, string> => {
+const buildHookBindingMap = (componentBody: EsTreeNode | null | undefined): Map<string, string> => {
   const result = new Map<string, string>();
-  if (!isNodeOfType(componentBody, "BlockStatement")) return result;
+  if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return result;
   for (const statement of componentBody.body ?? []) {
     if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
@@ -82,7 +83,17 @@ export const reactCompilerDestructureMethod = defineRule<Rule>({
     // correct semantic for "this component declares zero hook bindings".
     const enter = (node: EsTreeNode): void => {
       if (!isComponent(node)) return;
-      const body = isNodeOfType(node, "FunctionDeclaration") ? node.body : node.init?.body;
+      let body: EsTreeNode | null | undefined;
+      if (isNodeOfType(node, "FunctionDeclaration")) {
+        body = node.body;
+      } else if (isNodeOfType(node, "VariableDeclarator")) {
+        const initializer = node.init;
+        body =
+          isNodeOfType(initializer, "ArrowFunctionExpression") ||
+          isNodeOfType(initializer, "FunctionExpression")
+            ? initializer.body
+            : null;
+      }
       hookBindingMapStack.push(buildHookBindingMap(body));
     };
     const exit = (node: EsTreeNode): void => {
@@ -94,7 +105,7 @@ export const reactCompilerDestructureMethod = defineRule<Rule>({
       "FunctionDeclaration:exit": exit,
       VariableDeclarator: enter,
       "VariableDeclarator:exit": exit,
-      MemberExpression(node: EsTreeNode) {
+      MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
         if (hookBindingMapStack.length === 0) return;
         if (node.computed) return;
         if (!isNodeOfType(node.object, "Identifier")) return;

--- a/packages/react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
@@ -1,9 +1,9 @@
 import { getImportedName } from "../../../utils/get-imported-name.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
-import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import type { RuleContext } from "../../../utils/rule-context.js";
 import type { Rule } from "../../../utils/rule.js";
 import type { DeprecatedReactImportRuleOptions } from "./deprecated-react-import-rule-options.js";
+import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
 
 // Returns only the `create` slot so the per-rule defineRule call owns the
 // framework / severity / category / recommendation metadata — the factory
@@ -18,7 +18,7 @@ export const createDeprecatedReactImportRule = ({
     const namespaceBindings = new Set<string>();
 
     return {
-      ImportDeclaration(node: EsTreeNode) {
+      ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
         const sourceValue = node.source?.value;
         if (typeof sourceValue !== "string") return;
         if (handleExtraSource?.(node, context)) return;
@@ -41,7 +41,7 @@ export const createDeprecatedReactImportRule = ({
           }
         }
       },
-      MemberExpression(node: EsTreeNode) {
+      MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
         if (namespaceBindings.size === 0) return;
         if (node.computed) return;
         if (!isNodeOfType(node.object, "Identifier")) return;

--- a/packages/react-doctor/src/plugin/rules/architecture/utils/deprecated-react-import-rule-options.ts
+++ b/packages/react-doctor/src/plugin/rules/architecture/utils/deprecated-react-import-rule-options.ts
@@ -1,4 +1,4 @@
-import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../../utils/rule-context.js";
 
 export interface DeprecatedReactImportRuleOptions {
@@ -12,5 +12,8 @@ export interface DeprecatedReactImportRuleOptions {
    * `react-dom/test-utils` (whole entry point gone in React 19).
    * Return `true` to mark "handled, skip the standard branch".
    */
-  handleExtraSource?: (node: EsTreeNode, context: RuleContext) => boolean;
+  handleExtraSource?: (
+    node: EsTreeNodeOfType<"ImportDeclaration">,
+    context: RuleContext,
+  ) => boolean;
 }

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
@@ -1,8 +1,8 @@
 import { BARREL_INDEX_SUFFIXES } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noBarrelImport = defineRule<Rule>({
   framework: "global",
@@ -20,7 +20,7 @@ export const noBarrelImport = defineRule<Rule>({
     let didReportForFile = false;
 
     return {
-      ImportDeclaration(node: EsTreeNode) {
+      ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
         if (didReportForFile) return;
 
         const source = node.source?.value;

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-dynamic-import-path.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-dynamic-import-path.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: bundlers can only tree-shake / split when the import target is a
 // statically-analyzable string literal. `import(variable)` or
@@ -20,7 +20,7 @@ export const noDynamicImportPath = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportExpression(node: EsTreeNode) {
+    ImportExpression(node: EsTreeNodeOfType<"ImportExpression">) {
       const source = node.source;
       if (source && !isNodeOfType(source, "Literal") && !isNodeOfType(source, "TemplateLiteral")) {
         context.report({
@@ -38,7 +38,7 @@ export const noDynamicImportPath = defineRule<Rule>({
         });
       }
     },
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "require") return;
       const arg = node.arguments?.[0];
       if (!arg) return;

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-full-lodash-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-full-lodash-import.ts
@@ -1,7 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noFullLodashImport = defineRule<Rule>({
   framework: "global",
@@ -16,7 +16,7 @@ export const noFullLodashImport = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       const source = node.source?.value;
       if (source === "lodash" || source === "lodash-es") {
         context.report({

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-moment.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-moment.ts
@@ -1,7 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noMoment = defineRule<Rule>({
   framework: "global",
@@ -16,7 +16,7 @@ export const noMoment = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       if (node.source?.value === "moment") {
         context.report({
           node,

--- a/packages/react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
@@ -1,10 +1,10 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import { hasJsxAttribute } from "../../utils/has-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noUndeferredThirdParty = defineRule<Rule>({
   framework: "global",
@@ -18,7 +18,7 @@ export const noUndeferredThirdParty = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "script") return;
       const attributes = node.attributes ?? [];
       if (!findJsxAttribute(attributes, "src")) return;

--- a/packages/react-doctor/src/plugin/rules/bundle-size/prefer-dynamic-import.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/prefer-dynamic-import.ts
@@ -1,8 +1,8 @@
 import { HEAVY_LIBRARIES } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const preferDynamicImport = defineRule<Rule>({
   framework: "global",
@@ -18,7 +18,7 @@ export const preferDynamicImport = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       const source = node.source?.value;
       if (typeof source === "string" && HEAVY_LIBRARIES.has(source)) {
         context.report({

--- a/packages/react-doctor/src/plugin/rules/bundle-size/use-lazy-motion.ts
+++ b/packages/react-doctor/src/plugin/rules/bundle-size/use-lazy-motion.ts
@@ -4,6 +4,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const useLazyMotion = defineRule<Rule>({
   framework: "global",
@@ -20,7 +21,7 @@ export const useLazyMotion = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       const source = node.source?.value;
       if (source !== "framer-motion" && source !== "motion/react") return;
 

--- a/packages/react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
+++ b/packages/react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const VERSIONED_KEY_PATTERN = /(?:[._:-]v\d+|@\d+|\bv\d+\b)/i;
 
@@ -41,7 +42,7 @@ export const clientLocalstorageNoVersion = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (!isNodeOfType(node.callee.object, "Identifier")) return;
       if (!STORAGE_OBJECTS.has(node.callee.object.name)) return;

--- a/packages/react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
+++ b/packages/react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const clientPassiveEventListeners = defineRule<Rule>({
   framework: "global",
@@ -19,7 +20,7 @@ export const clientPassiveEventListeners = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isMemberProperty(node.callee, "addEventListener")) return;
       if ((node.arguments?.length ?? 0) < 2) return;
 

--- a/packages/react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const STRING_COERCION_FUNCTIONS = new Set(["String", "Number"]);
 
@@ -103,7 +104,7 @@ export const noArrayIndexAsKey = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "key") return;
       if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
 

--- a/packages/react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: `typeof children === "string"` (or `=== 'object'`) is a
 // polymorphic-children smell — the component switches behavior based on
@@ -24,7 +25,7 @@ export const noPolymorphicChildren = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    BinaryExpression(node: EsTreeNode) {
+    BinaryExpression(node: EsTreeNodeOfType<"BinaryExpression">) {
       if (node.operator !== "===" && node.operator !== "==") return;
 
       const isTypeofChildren = (operand: EsTreeNode | undefined): boolean =>

--- a/packages/react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: <button> is intentionally omitted. <button type="submit"> (the
 // HTML default inside a form) has a real default action, so calling
@@ -57,7 +58,7 @@ export const noPreventDefault = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const elementName = isNodeOfType(node.name, "JSXIdentifier") ? node.name.name : null;
       if (!elementName) return;
 

--- a/packages/react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -8,6 +8,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const UNCONTROLLED_INPUT_TAGS = new Set(["input", "textarea", "select"]);
 
@@ -150,13 +151,18 @@ export const noUncontrolledInput = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/correctness/rendering-conditional-render.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/rendering-conditional-render.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const NUMERIC_NAME_HINTS = ["count", "length", "total", "size", "num"];
 
@@ -34,7 +34,7 @@ export const renderingConditionalRender = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    LogicalExpression(node: EsTreeNode) {
+    LogicalExpression(node: EsTreeNodeOfType<"LogicalExpression">) {
       if (node.operator !== "&&") return;
 
       const isRightJsx =

--- a/packages/react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
+++ b/packages/react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const SVG_PATH_HIGH_PRECISION_PATTERN = /\d+\.\d{4,}/;
 
@@ -25,7 +25,7 @@ export const renderingSvgPrecision = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (!SVG_PATH_ATTRIBUTES.has(node.name.name)) return;
       if (!isNodeOfType(node.value, "Literal")) return;

--- a/packages/react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -10,6 +10,7 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { parseColorToRgb } from "./utils/parse-color-to-rgb.js";
 import { hasColorChroma } from "./utils/has-color-chroma.js";
 import { isPureBlackColor } from "./utils/is-pure-black-color.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const splitShadowLayers = (shadowValue: string): string[] => shadowValue.split(/,(?![^(]*\))/);
 
@@ -81,7 +82,7 @@ export const noDarkModeGlow = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noDisabledZoom = defineRule<Rule>({
   framework: "global",
@@ -19,7 +19,7 @@ export const noDisabledZoom = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "meta") return;
 
       const nameAttr = findJsxAttribute(node.attributes ?? [], "name");

--- a/packages/react-doctor/src/plugin/rules/design/no-gradient-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-gradient-text.ts
@@ -1,11 +1,11 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noGradientText = defineRule<Rule>({
   tags: ["design", "test-noise"],
@@ -22,7 +22,7 @@ export const noGradientText = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 
@@ -50,7 +50,7 @@ export const noGradientText = defineRule<Rule>({
         });
       }
     },
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const classStr = getStringFromClassNameAttr(node);
       if (!classStr) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noGrayOnColoredBackground = defineRule<Rule>({
   framework: "global",
@@ -17,7 +17,7 @@ export const noGrayOnColoredBackground = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const classStr = getStringFromClassNameAttr(node);
       if (!classStr) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-inline-bounce-easing.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-inline-bounce-easing.ts
@@ -1,12 +1,12 @@
 import { BOUNCE_ANIMATION_NAMES } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const isOvershootCubicBezier = (value: string): boolean => {
   const match = value.match(
@@ -39,7 +39,7 @@ export const noInlineBounceEasing = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 
@@ -73,7 +73,7 @@ export const noInlineBounceEasing = defineRule<Rule>({
         }
       }
     },
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const classStr = getStringFromClassNameAttr(node);
       if (!classStr) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noInlineExhaustiveStyle = defineRule<Rule>({
   framework: "global",
@@ -20,7 +21,7 @@ export const noInlineExhaustiveStyle = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-justified-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-justified-text.ts
@@ -1,10 +1,10 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noJustifiedText = defineRule<Rule>({
   framework: "global",
@@ -19,7 +19,7 @@ export const noJustifiedText = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
@@ -1,10 +1,10 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noLayoutTransitionInline = defineRule<Rule>({
   framework: "global",
@@ -19,7 +19,7 @@ export const noLayoutTransitionInline = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
@@ -1,11 +1,11 @@
 import { LONG_TRANSITION_DURATION_THRESHOLD_MS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noLongTransitionDuration = defineRule<Rule>({
   framework: "global",
@@ -20,7 +20,7 @@ export const noLongTransitionDuration = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-outline-none.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-outline-none.ts
@@ -6,6 +6,7 @@ import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noOutlineNone = defineRule<Rule>({
   framework: "global",
@@ -21,7 +22,7 @@ export const noOutlineNone = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-pure-black-background.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-pure-black-background.ts
@@ -1,5 +1,4 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
@@ -7,6 +6,7 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { isPureBlackColor } from "./utils/is-pure-black-color.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noPureBlackBackground = defineRule<Rule>({
   tags: ["design", "test-noise"],
@@ -22,7 +22,7 @@ export const noPureBlackBackground = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 
@@ -40,7 +40,7 @@ export const noPureBlackBackground = defineRule<Rule>({
         }
       }
     },
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const classStr = getStringFromClassNameAttr(node);
       if (!classStr) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-side-tab-border.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-side-tab-border.ts
@@ -14,6 +14,7 @@ import { parseColorToRgb } from "./utils/parse-color-to-rgb.js";
 import { hasColorChroma } from "./utils/has-color-chroma.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const isNeutralBorderColor = (value: string): boolean => {
   const trimmed = value.trim().toLowerCase();
@@ -66,7 +67,7 @@ export const noSideTabBorder = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 
@@ -136,7 +137,7 @@ export const noSideTabBorder = defineRule<Rule>({
         }
       }
     },
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const classStr = getStringFromClassNameAttr(node);
       if (!classStr) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-tiny-text.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-tiny-text.ts
@@ -1,12 +1,12 @@
 import { TINY_TEXT_THRESHOLD_PX } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noTinyText = defineRule<Rule>({
   framework: "global",
@@ -21,7 +21,7 @@ export const noTinyText = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
@@ -7,6 +7,7 @@ import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noWideLetterSpacing = defineRule<Rule>({
   framework: "global",
@@ -21,7 +22,7 @@ export const noWideLetterSpacing = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 

--- a/packages/react-doctor/src/plugin/rules/design/no-z-index9999.ts
+++ b/packages/react-doctor/src/plugin/rules/design/no-z-index9999.ts
@@ -8,6 +8,7 @@ import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noZIndex9999 = defineRule<Rule>({
   framework: "global",
@@ -22,7 +23,7 @@ export const noZIndex9999 = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 
@@ -39,7 +40,7 @@ export const noZIndex9999 = defineRule<Rule>({
         }
       }
     },
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (
         !isNodeOfType(node.callee.property, "Identifier") ||

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-inline-style-expression.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-inline-style-expression.ts
@@ -1,7 +1,9 @@
-import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
-export const getInlineStyleExpression = (node: EsTreeNode): EsTreeNode | null => {
+export const getInlineStyleExpression = (
+  node: EsTreeNodeOfType<"JSXAttribute">,
+): EsTreeNodeOfType<"ObjectExpression"> | null => {
   if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return null;
   if (!isNodeOfType(node.value, "JSXExpressionContainer")) return null;
   const expression = node.value.expression;

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-string-from-class-name-attr.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-string-from-class-name-attr.ts
@@ -3,6 +3,7 @@ import { findJsxAttribute } from "../../../utils/find-jsx-attribute.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getStringFromClassNameAttr = (node: EsTreeNode): string | null => {
+  if (!isNodeOfType(node, "JSXOpeningElement")) return null;
   const classAttr = findJsxAttribute(node.attributes ?? [], "className");
   if (!classAttr?.value) return null;
   if (isNodeOfType(classAttr.value, "Literal") && typeof classAttr.value.value === "string") {

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-number-value.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-number-value.ts
@@ -2,6 +2,7 @@ import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getStylePropertyNumberValue = (property: EsTreeNode): number | null => {
+  if (!isNodeOfType(property, "Property")) return null;
   if (isNodeOfType(property.value, "Literal") && typeof property.value.value === "number") {
     return property.value.value;
   }

--- a/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-string-value.ts
+++ b/packages/react-doctor/src/plugin/rules/design/utils/get-style-property-string-value.ts
@@ -2,6 +2,7 @@ import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getStylePropertyStringValue = (property: EsTreeNode): string | null => {
+  if (!isNodeOfType(property, "Property")) return null;
   if (isNodeOfType(property.value, "Literal") && typeof property.value.value === "string") {
     return property.value.value;
   }

--- a/packages/react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const findFirstAwaitOutsideNestedFunctions = (block: EsTreeNode): EsTreeNode | null => {
   let firstAwait: EsTreeNode | null = null;
@@ -42,6 +43,7 @@ const SLEEP_LIKE_FUNCTION_NAMES = new Set([
 ]);
 
 const isAwaitingSleepLikeCall = (awaitNode: EsTreeNode): boolean => {
+  if (!isNodeOfType(awaitNode, "AwaitExpression")) return false;
   const argument = awaitNode.argument;
   if (!argument) return false;
 
@@ -84,7 +86,9 @@ const collectPatternIdentifiers = (pattern: EsTreeNode, target: Set<string>): vo
   }
 };
 
-const isFunctionishExpression = (node: EsTreeNode): boolean =>
+const isFunctionishExpression = (
+  node: EsTreeNode,
+): node is EsTreeNodeOfType<"ArrowFunctionExpression"> | EsTreeNodeOfType<"FunctionExpression"> =>
   isNodeOfType(node, "ArrowFunctionExpression") || isNodeOfType(node, "FunctionExpression");
 
 const collectAssignedIdentifiers = (block: EsTreeNode): Set<string> => {
@@ -210,25 +214,25 @@ export const asyncAwaitInLoop = defineRule<Rule>({
     };
 
     return {
-      ForStatement(node: EsTreeNode) {
+      ForStatement(node: EsTreeNodeOfType<"ForStatement">) {
         inspectLoopBody(node.body, "for-loop");
       },
-      ForInStatement(node: EsTreeNode) {
+      ForInStatement(node: EsTreeNodeOfType<"ForInStatement">) {
         inspectLoopBody(node.body, "for…in loop");
       },
-      ForOfStatement(node: EsTreeNode) {
+      ForOfStatement(node: EsTreeNodeOfType<"ForOfStatement">) {
         // `for await (const x of …)` is the legitimate async-iterator
         // pattern — skip it.
         if (node.await) return;
         inspectLoopBody(node.body, "for…of loop");
       },
-      WhileStatement(node: EsTreeNode) {
+      WhileStatement(node: EsTreeNodeOfType<"WhileStatement">) {
         inspectLoopBody(node.body, "while-loop");
       },
-      DoWhileStatement(node: EsTreeNode) {
+      DoWhileStatement(node: EsTreeNodeOfType<"DoWhileStatement">) {
         inspectLoopBody(node.body, "do-while loop");
       },
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         // arr.forEach(async item => { await fn(item); }) — sequential
         // because forEach doesn't await; even worse, the awaits are
         // dropped on the floor (forEach ignores return values).

--- a/packages/react-doctor/src/plugin/rules/js-performance/async-parallel.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/async-parallel.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const reportIfIndependent = (statements: EsTreeNode[], context: RuleContext): void => {
   const declaredNames = new Set<string>();
@@ -52,7 +53,7 @@ export const asyncParallel = defineRule<Rule>({
     const isTestFile = TEST_FILE_PATTERN.test(filename);
 
     return {
-      BlockStatement(node: EsTreeNode) {
+      BlockStatement(node: EsTreeNodeOfType<"BlockStatement">) {
         if (isTestFile) return;
         const consecutiveAwaitStatements: EsTreeNode[] = [];
 

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsBatchDomCss = defineRule<Rule>({
   framework: "global",
@@ -26,7 +27,7 @@ export const jsBatchDomCss = defineRule<Rule>({
       node.expression.left.object.property.name === "style";
 
     return {
-      BlockStatement(node: EsTreeNode) {
+      BlockStatement(node: EsTreeNodeOfType<"BlockStatement">) {
         const statements = node.body ?? [];
         for (let statementIndex = 1; statementIndex < statements.length; statementIndex++) {
           if (

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
@@ -66,6 +66,15 @@ export const jsCachePropertyAccess = defineRule<Rule>({
     };
 
     const handleLoop = (node: EsTreeNode): void => {
+      if (
+        !isNodeOfType(node, "ForStatement") &&
+        !isNodeOfType(node, "ForInStatement") &&
+        !isNodeOfType(node, "ForOfStatement") &&
+        !isNodeOfType(node, "WhileStatement") &&
+        !isNodeOfType(node, "DoWhileStatement")
+      ) {
+        return;
+      }
       if (node.body) inspectLoopBody(node.body);
     };
 

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-cache-storage.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-cache-storage.ts
@@ -1,10 +1,10 @@
 import { DUPLICATE_STORAGE_READ_THRESHOLD, STORAGE_OBJECTS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { isMemberProperty } from "../../utils/is-member-property.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsCacheStorage = defineRule<Rule>({
   framework: "global",
@@ -23,7 +23,7 @@ export const jsCacheStorage = defineRule<Rule>({
     const storageReadCounts = new Map<string, number>();
 
     return {
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isMemberProperty(node.callee, "getItem")) return;
         if (
           !isNodeOfType(node.callee.object, "Identifier") ||

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-combine-iterations.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-combine-iterations.ts
@@ -1,9 +1,9 @@
 import { CHAINABLE_ITERATION_METHODS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsCombineIterations = defineRule<Rule>({
   framework: "global",
@@ -19,7 +19,7 @@ export const jsCombineIterations = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (
         !isNodeOfType(node.callee, "MemberExpression") ||
         !isNodeOfType(node.callee.property, "Identifier")

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-early-exit.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-early-exit.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsEarlyExit = defineRule<Rule>({
   framework: "global",
@@ -20,13 +21,13 @@ export const jsEarlyExit = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    IfStatement(node: EsTreeNode) {
+    IfStatement(node: EsTreeNodeOfType<"IfStatement">) {
       if (!isNodeOfType(node.consequent, "BlockStatement") || !node.consequent.body) return;
 
       let nestingDepth = 0;
       let currentBlock: EsTreeNode = node.consequent;
       while (isNodeOfType(currentBlock, "BlockStatement") && currentBlock.body?.length === 1) {
-        const innerStatement = currentBlock.body[0];
+        const innerStatement: EsTreeNode = currentBlock.body[0];
         if (!isNodeOfType(innerStatement, "IfStatement")) break;
         nestingDepth++;
         currentBlock = innerStatement.consequent;

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsFlatmapFilter = defineRule<Rule>({
   framework: "global",
@@ -17,7 +17,7 @@ export const jsFlatmapFilter = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (
         !isNodeOfType(node.callee, "MemberExpression") ||
         !isNodeOfType(node.callee.property, "Identifier")

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: `new Intl.NumberFormat()` / `Intl.DateTimeFormat()` is expensive
 // (dozens of allocations per locale lookup). Allocating it inside a render
@@ -49,7 +50,7 @@ export const jsHoistIntl = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    NewExpression(node: EsTreeNode) {
+    NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
       if (!isIntlNewExpression(node)) return;
       // Walk up: if any enclosing function is a function/arrow, this is in
       // a function body. Module-scope `new Intl.X()` is fine; we only flag
@@ -69,7 +70,11 @@ export const jsHoistIntl = defineRule<Rule>({
       }
       if (!inFunctionBody) return;
 
-      const className = node.callee.property?.name ?? "Intl";
+      const className =
+        isNodeOfType(node.callee, "MemberExpression") &&
+        isNodeOfType(node.callee.property, "Identifier")
+          ? node.callee.property.name
+          : "Intl";
       context.report({
         node,
         message: `new Intl.${className}() inside a function — hoist to module scope or wrap in useMemo so it isn't recreated each call`,

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-regexp.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-hoist-regexp.ts
@@ -1,9 +1,9 @@
 import { createLoopAwareVisitors } from "../../utils/create-loop-aware-visitors.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsHoistRegexp = defineRule<Rule>({
   framework: "global",
@@ -21,7 +21,7 @@ export const jsHoistRegexp = defineRule<Rule>({
   ],
   create: (context: RuleContext) =>
     createLoopAwareVisitors({
-      NewExpression(node: EsTreeNode) {
+      NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
         if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "RegExp") {
           context.report({
             node,

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
@@ -1,9 +1,9 @@
 import { createLoopAwareVisitors } from "../../utils/create-loop-aware-visitors.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsIndexMaps = defineRule<Rule>({
   framework: "global",
@@ -20,7 +20,7 @@ export const jsIndexMaps = defineRule<Rule>({
   ],
   create: (context: RuleContext) =>
     createLoopAwareVisitors({
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (
           !isNodeOfType(node.callee, "MemberExpression") ||
           !isNodeOfType(node.callee.property, "Identifier")

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: when comparing two arrays element-by-element via .every / .some /
 // .reduce against another array, a length mismatch is the cheapest possible
@@ -23,7 +24,7 @@ export const jsLengthCheckFirst = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (!isNodeOfType(node.callee.property, "Identifier")) return;
       if (node.callee.property.name !== "every") return;

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-min-max-loop.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-min-max-loop.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { isMemberProperty } from "../../utils/is-member-property.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsMinMaxLoop = defineRule<Rule>({
   framework: "global",
@@ -18,7 +18,7 @@ export const jsMinMaxLoop = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    MemberExpression(node: EsTreeNode) {
+    MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
       if (!node.computed) return;
 
       const object = node.object;

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: methods that ALWAYS return a string when called on a string
 // receiver. Used to recognize `.toLowerCase().includes(x)` chains as
@@ -180,7 +181,7 @@ export const jsSetMapLookups = defineRule<Rule>({
   ],
   create: (context: RuleContext) =>
     createLoopAwareVisitors({
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (
           !isNodeOfType(node.callee, "MemberExpression") ||
           !isNodeOfType(node.callee.property, "Identifier")

--- a/packages/react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
+++ b/packages/react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { isMemberProperty } from "../../utils/is-member-property.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const jsTosortedImmutable = defineRule<Rule>({
   framework: "global",
@@ -18,7 +18,7 @@ export const jsTosortedImmutable = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isMemberProperty(node.callee, "sort")) return;
 
       const receiver = node.callee.object;

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.ts
@@ -1,10 +1,11 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsAsyncClientComponent = defineRule<Rule>({
   requires: ["nextjs"],
@@ -25,10 +26,10 @@ export const nextjsAsyncClientComponent = defineRule<Rule>({
     let fileHasUseClient = false;
 
     return {
-      Program(programNode: EsTreeNode) {
+      Program(programNode: EsTreeNodeOfType<"Program">) {
         fileHasUseClient = hasDirective(programNode, "use client");
       },
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!fileHasUseClient || !node.async) return;
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         context.report({
@@ -36,9 +37,16 @@ export const nextjsAsyncClientComponent = defineRule<Rule>({
           message: `Async client component "${node.id.name}" — client components cannot be async`,
         });
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!fileHasUseClient) return;
-        if (!isComponentAssignment(node) || !node.init?.async) return;
+        if (!isComponentAssignment(node)) return;
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        if (!node.init.async) return;
+        if (!isNodeOfType(node.id, "Identifier")) return;
         context.report({
           node,
           message: `Async client component "${node.id.name}" — client components cannot be async`,

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-image-missing-sizes.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-image-missing-sizes.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { hasJsxAttribute } from "../../utils/has-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsImageMissingSizes = defineRule<Rule>({
   requires: ["nextjs"],
@@ -19,7 +19,7 @@ export const nextjsImageMissingSizes = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "Image") return;
       const attributes = node.attributes ?? [];
       if (!hasJsxAttribute(attributes, "fill")) return;

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-inline-script-missing-id.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-inline-script-missing-id.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { hasJsxAttribute } from "../../utils/has-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsInlineScriptMissingId = defineRule<Rule>({
   requires: ["nextjs"],
@@ -19,7 +19,7 @@ export const nextjsInlineScriptMissingId = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "Script") return;
       const attributes = node.attributes ?? [];
 

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
@@ -1,9 +1,9 @@
 import { INTERNAL_PAGE_PATH_PATTERN, PAGE_FILE_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsMissingMetadata = defineRule<Rule>({
   requires: ["nextjs"],
@@ -20,17 +20,17 @@ export const nextjsMissingMetadata = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    Program(programNode: EsTreeNode) {
+    Program(programNode: EsTreeNodeOfType<"Program">) {
       const filename = context.getFilename?.() ?? "";
       if (!PAGE_FILE_PATTERN.test(filename)) return;
       if (INTERNAL_PAGE_PATH_PATTERN.test(filename)) return;
 
-      const hasMetadataExport = programNode.body?.some((statement: EsTreeNode) => {
+      const hasMetadataExport = programNode.body?.some((statement) => {
         if (!isNodeOfType(statement, "ExportNamedDeclaration")) return false;
         const declaration = statement.declaration;
         if (isNodeOfType(declaration, "VariableDeclaration")) {
           return declaration.declarations?.some(
-            (declarator: EsTreeNode) =>
+            (declarator) =>
               isNodeOfType(declarator.id, "Identifier") &&
               (declarator.id.name === "metadata" || declarator.id.name === "generateMetadata"),
           );

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoAElement = defineRule<Rule>({
   requires: ["nextjs"],
@@ -19,7 +19,7 @@ export const nextjsNoAElement = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a") return;
 
       const hrefAttribute = findJsxAttribute(node.attributes ?? [], "href");

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.ts
@@ -8,9 +8,9 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoClientFetchForServerData = defineRule<Rule>({
   requires: ["nextjs"],
@@ -31,10 +31,10 @@ export const nextjsNoClientFetchForServerData = defineRule<Rule>({
     let fileHasUseClient = false;
 
     return {
-      Program(programNode: EsTreeNode) {
+      Program(programNode: EsTreeNodeOfType<"Program">) {
         fileHasUseClient = hasDirective(programNode, "use client");
       },
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!fileHasUseClient || !isHookCall(node, EFFECT_HOOK_NAMES)) return;
 
         const callback = getEffectCallback(node);

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
@@ -7,6 +7,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const describeClientSideNavigation = (
   node: EsTreeNode,
@@ -62,7 +63,7 @@ export const nextjsNoClientSideRedirect = defineRule<Rule>({
     const isPagesRouterFile = PAGES_DIRECTORY_PATTERN.test(filename);
 
     return {
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
         const callback = getEffectCallback(node);
         if (!callback) return;

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
@@ -1,10 +1,10 @@
 import { GOOGLE_FONTS_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoCssLink = defineRule<Rule>({
   requires: ["nextjs"],
@@ -20,7 +20,7 @@ export const nextjsNoCssLink = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "link") return;
       const attributes = node.attributes ?? [];
 

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
@@ -1,10 +1,10 @@
 import { GOOGLE_FONTS_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoFontLink = defineRule<Rule>({
   requires: ["nextjs"],
@@ -21,7 +21,7 @@ export const nextjsNoFontLink = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "link") return;
       const attributes = node.attributes ?? [];
 

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-head-import.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-head-import.ts
@@ -1,8 +1,8 @@
 import { APP_DIRECTORY_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoHeadImport = defineRule<Rule>({
   requires: ["nextjs"],
@@ -18,7 +18,7 @@ export const nextjsNoHeadImport = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       if (node.source?.value !== "next/head") return;
 
       const filename = context.getFilename?.() ?? "";

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
@@ -1,9 +1,9 @@
 import { OG_ROUTE_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoImgElement = defineRule<Rule>({
   requires: ["nextjs"],
@@ -24,7 +24,7 @@ export const nextjsNoImgElement = defineRule<Rule>({
     const isOgRoute = OG_ROUTE_PATTERN.test(filename);
 
     return {
-      JSXOpeningElement(node: EsTreeNode) {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (isOgRoute) return;
         if (isNodeOfType(node.name, "JSXIdentifier") && node.name.name === "img") {
           context.report({

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-native-script.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-native-script.ts
@@ -1,10 +1,10 @@
 import { EXECUTABLE_SCRIPT_TYPES } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoNativeScript = defineRule<Rule>({
   requires: ["nextjs"],
@@ -21,7 +21,7 @@ export const nextjsNoNativeScript = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "script") return;
 
       const typeAttribute = findJsxAttribute(node.attributes ?? [], "type");

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
@@ -1,10 +1,10 @@
 import { POLYFILL_SCRIPT_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoPolyfillScript = defineRule<Rule>({
   requires: ["nextjs"],
@@ -20,7 +20,7 @@ export const nextjsNoPolyfillScript = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "script" && node.name.name !== "Script") return;
 

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-redirect-in-try-catch.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-redirect-in-try-catch.ts
@@ -1,9 +1,9 @@
 import { NEXTJS_NAVIGATION_FUNCTIONS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoRedirectInTryCatch = defineRule<Rule>({
   requires: ["nextjs"],
@@ -28,7 +28,7 @@ export const nextjsNoRedirectInTryCatch = defineRule<Rule>({
       "TryStatement:exit"() {
         tryCatchDepth--;
       },
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (tryCatchDepth === 0) return;
         if (!isNodeOfType(node.callee, "Identifier")) return;
         if (!NEXTJS_NAVIGATION_FUNCTIONS.has(node.callee.name)) return;

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const extractMutatingRouteSegment = (filename: string): string | null => {
   const segments = filename.split("/");
@@ -57,7 +58,7 @@ export const nextjsNoSideEffectInGetHandler = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ExportNamedDeclaration(node: EsTreeNode) {
+    ExportNamedDeclaration(node: EsTreeNodeOfType<"ExportNamedDeclaration">) {
       const filename = context.getFilename?.() ?? "";
       if (!ROUTE_HANDLER_FILE_PATTERN.test(filename)) return;
 

--- a/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-use-search-params-without-suspense.ts
+++ b/packages/react-doctor/src/plugin/rules/nextjs/nextjs-no-use-search-params-without-suspense.ts
@@ -6,6 +6,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: file-level proxy for "is the developer aware of the Suspense
 // requirement?". Cross-file ancestor analysis would catch every case
@@ -65,10 +66,10 @@ export const nextjsNoUseSearchParamsWithoutSuspense = defineRule<Rule>({
     let hasSuspenseInFile = false;
 
     return {
-      Program(programNode: EsTreeNode) {
+      Program(programNode: EsTreeNodeOfType<"Program">) {
         hasSuspenseInFile = fileMentionsSuspense(programNode);
       },
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (hasSuspenseInFile) return;
         if (!isHookCall(node, "useSearchParams")) return;
         context.report({

--- a/packages/react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -76,6 +76,7 @@ export const asyncDeferAwait = defineRule<Rule>({
 
         const nextStatement = statements[statementIndex + 1];
         if (!isEarlyReturnIfStatement(nextStatement)) continue;
+        if (!isNodeOfType(nextStatement, "IfStatement")) continue;
 
         const testIdentifiers = new Set<string>();
         collectIdentifierNames(nextStatement.test, testIdentifiers);
@@ -100,6 +101,13 @@ export const asyncDeferAwait = defineRule<Rule>({
     };
 
     const enterFunction = (node: EsTreeNode): void => {
+      if (
+        !isNodeOfType(node, "FunctionDeclaration") &&
+        !isNodeOfType(node, "FunctionExpression") &&
+        !isNodeOfType(node, "ArrowFunctionExpression")
+      ) {
+        return;
+      }
       if (!node.async) return;
       if (!isNodeOfType(node.body, "BlockStatement")) return;
       inspectStatements(node.body.body ?? []);

--- a/packages/react-doctor/src/plugin/rules/performance/no-global-css-variable-animation.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-global-css-variable-animation.ts
@@ -6,6 +6,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noGlobalCssVariableAnimation = defineRule<Rule>({
   framework: "global",
@@ -22,7 +23,7 @@ export const noGlobalCssVariableAnimation = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "Identifier")) return;
       if (!ANIMATION_CALLBACK_NAMES.has(node.callee.name)) return;
 

--- a/packages/react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const isMemoCall = (node: EsTreeNode): boolean => {
   if (!isNodeOfType(node, "CallExpression")) return false;
@@ -53,21 +54,25 @@ export const noInlinePropOnMemoComponent = defineRule<Rule>({
     const memoizedComponentNames = new Set<string>();
 
     return {
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isNodeOfType(node.id, "Identifier") || !node.init) return;
         if (isMemoCall(node.init)) {
           memoizedComponentNames.add(node.id.name);
         }
       },
-      ExportDefaultDeclaration(node: EsTreeNode) {
-        if (node.declaration && isMemoCall(node.declaration)) {
+      ExportDefaultDeclaration(node: EsTreeNodeOfType<"ExportDefaultDeclaration">) {
+        if (
+          node.declaration &&
+          isNodeOfType(node.declaration, "CallExpression") &&
+          isMemoCall(node.declaration)
+        ) {
           const innerArgument = node.declaration.arguments?.[0];
           if (isNodeOfType(innerArgument, "Identifier")) {
             memoizedComponentNames.add(innerArgument.name);
           }
         }
       },
-      JSXAttribute(node: EsTreeNode) {
+      JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
         if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
         const openingElement = node.parent;

--- a/packages/react-doctor/src/plugin/rules/performance/no-large-animated-blur.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-large-animated-blur.ts
@@ -4,10 +4,10 @@ import {
   MOTION_ANIMATE_PROPS,
 } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noLargeAnimatedBlur = defineRule<Rule>({
   framework: "global",
@@ -22,7 +22,7 @@ export const noLargeAnimatedBlur = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "style" && !MOTION_ANIMATE_PROPS.has(node.name.name)) return;
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;

--- a/packages/react-doctor/src/plugin/rules/performance/no-layout-property-animation.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-layout-property-animation.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const isMotionElement = (attributeNode: EsTreeNode): boolean => {
   const openingElement = attributeNode.parent;
@@ -36,7 +37,7 @@ export const noLayoutPropertyAnimation = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || !MOTION_ANIMATE_PROPS.has(node.name.name))
         return;
       if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;

--- a/packages/react-doctor/src/plugin/rules/performance/no-permanent-will-change.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-permanent-will-change.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noPermanentWillChange = defineRule<Rule>({
   framework: "global",
@@ -18,7 +18,7 @@ export const noPermanentWillChange = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return;
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 

--- a/packages/react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noScaleFromZero = defineRule<Rule>({
   framework: "global",
@@ -18,7 +18,7 @@ export const noScaleFromZero = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "initial" && node.name.name !== "exit") return;
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;

--- a/packages/react-doctor/src/plugin/rules/performance/no-transition-all.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-transition-all.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noTransitionAll = defineRule<Rule>({
   framework: "global",
@@ -17,7 +17,7 @@ export const noTransitionAll = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return;
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 

--- a/packages/react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // Identifiers and member-access chains are technically "simple", but memoizing
 // them is sometimes intentional (stable reference passing). Only flag arithmetic
@@ -30,7 +31,7 @@ export const noUsememoSimpleExpression = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, "useMemo")) return;
 
       const callback = node.arguments?.[0];

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const renderingAnimateSvgWrapper = defineRule<Rule>({
   framework: "global",
@@ -17,7 +18,7 @@ export const renderingAnimateSvgWrapper = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "svg") return;
 
       const hasAnimationProp = node.attributes?.some(

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hoist-jsx.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hoist-jsx.ts
@@ -6,6 +6,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: detect static JSX declared inside a component body — anything like
 // `const Header = <h1>Hi</h1>` inside a render function gets recreated on
@@ -71,7 +72,7 @@ export const renderingHoistJsx = defineRule<Rule>({
       "FunctionDeclaration:exit": exit,
       VariableDeclarator: enter,
       "VariableDeclarator:exit": exit,
-      VariableDeclaration(node: EsTreeNode) {
+      VariableDeclaration(node: EsTreeNodeOfType<"VariableDeclaration">) {
         if (componentDepth === 0) return;
         if (node.kind !== "const") return;
         for (const declarator of node.declarations ?? []) {

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-mismatch-time.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-mismatch-time.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const NONDETERMINISTIC_RENDER_PATTERNS: Array<{
   matches: (node: EsTreeNode) => boolean;
@@ -69,7 +70,7 @@ const findOpeningElementOfChild = (jsxNode: EsTreeNode): EsTreeNode | null => {
 };
 
 const hasSuppressHydrationWarningAttribute = (openingElement: EsTreeNode | null): boolean => {
-  if (!openingElement) return false;
+  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
   for (const attr of openingElement.attributes ?? []) {
     if (
       isNodeOfType(attr, "JSXAttribute") &&
@@ -102,7 +103,7 @@ export const renderingHydrationMismatchTime = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXExpressionContainer(node: EsTreeNode) {
+    JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
       if (!node.expression) return;
       const matched = NONDETERMINISTIC_RENDER_PATTERNS.find((pattern) =>
         pattern.matches(node.expression),

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.ts
@@ -3,10 +3,10 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isSetterCall } from "../../utils/is-setter-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const renderingHydrationNoFlicker = defineRule<Rule>({
   framework: "global",
@@ -23,14 +23,19 @@ export const renderingHydrationNoFlicker = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
 
       const depsNode = node.arguments[1];
       if (!isNodeOfType(depsNode, "ArrayExpression") || depsNode.elements?.length !== 0) return;
 
       const callback = getEffectCallback(node);
-      if (!callback) return;
+      if (
+        !callback ||
+        (!isNodeOfType(callback, "ArrowFunctionExpression") &&
+          !isNodeOfType(callback, "FunctionExpression"))
+      )
+        return;
 
       const bodyStatements = isNodeOfType(callback.body, "BlockStatement")
         ? callback.body.body

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-script-defer-async.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-script-defer-async.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const renderingScriptDeferAsync = defineRule<Rule>({
   framework: "global",
@@ -18,7 +19,7 @@ export const renderingScriptDeferAsync = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "script") return;
 
       const attributes = node.attributes ?? [];
@@ -32,13 +33,15 @@ export const renderingScriptDeferAsync = defineRule<Rule>({
       if (!hasSrc) return;
 
       const typeAttribute = attributes.find(
-        (attr: EsTreeNode) =>
+        (attr) =>
           isNodeOfType(attr, "JSXAttribute") &&
           isNodeOfType(attr.name, "JSXIdentifier") &&
           attr.name.name === "type",
       );
-      const typeValue = isNodeOfType(typeAttribute?.value, "Literal")
-        ? typeAttribute.value.value
+      const typeAttributeValue =
+        typeAttribute && isNodeOfType(typeAttribute, "JSXAttribute") ? typeAttribute.value : null;
+      const typeValue = isNodeOfType(typeAttributeValue, "Literal")
+        ? typeAttributeValue.value
         : null;
       if (typeof typeValue === "string" && !EXECUTABLE_SCRIPT_TYPES.has(typeValue)) return;
       if (typeValue === "module") return;

--- a/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
@@ -1,10 +1,10 @@
 import { LOADING_STATE_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const renderingUsetransitionLoading = defineRule<Rule>({
   framework: "global",
@@ -21,9 +21,10 @@ export const renderingUsetransitionLoading = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    VariableDeclarator(node: EsTreeNode) {
+    VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
       if (!isNodeOfType(node.id, "ArrayPattern") || !node.id.elements?.length) return;
       if (!node.init || !isHookCall(node.init, "useState")) return;
+      if (!isNodeOfType(node.init, "CallExpression")) return;
       if (!node.init.arguments?.length) return;
 
       const initializer = node.init.arguments[0];

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-derived-state-from-hook.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-derived-state-from-hook.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const CONTINUOUS_VALUE_HOOK_PATTERN =
   /^use(?:Window(?:Width|Height|Dimensions)|Scroll(?:Position|Y|X)|MousePosition|ResizeObserver|IntersectionObserver)/;
@@ -97,13 +98,18 @@ export const rerenderDerivedStateFromHook = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
@@ -6,6 +6,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const callbackReturnsJsx = (callback: EsTreeNode | undefined): boolean => {
   if (!callback) return false;
@@ -30,6 +31,7 @@ const callbackReturnsJsx = (callback: EsTreeNode | undefined): boolean => {
 };
 
 const containsEarlyReturn = (ifStatement: EsTreeNode): boolean => {
+  if (!isNodeOfType(ifStatement, "IfStatement")) return false;
   const consequent = ifStatement.consequent;
   if (!consequent) return false;
   if (isNodeOfType(consequent, "ReturnStatement")) return true;
@@ -91,14 +93,19 @@ export const rerenderMemoBeforeEarlyReturn = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!isUppercaseName(node.id?.name ?? "")) return;
         if (!isNodeOfType(node.body, "BlockStatement")) return;
         inspectFunctionBody(node.body.body ?? []);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        const body = node.init?.body;
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        const body = node.init.body;
         if (!isNodeOfType(body, "BlockStatement")) return;
         inspectFunctionBody(body.body ?? []);
       },

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rerenderMemoWithDefaultValue = defineRule<Rule>({
   framework: "global",
@@ -55,12 +56,17 @@ export const rerenderMemoWithDefaultValue = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkDefaultProps(node.params ?? []);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
         checkDefaultProps(node.init.params ?? []);
       },
     };

--- a/packages/react-doctor/src/plugin/rules/performance/rerender-transitions-scroll.ts
+++ b/packages/react-doctor/src/plugin/rules/performance/rerender-transitions-scroll.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const HIGH_FREQUENCY_DOM_EVENTS = new Set([
   "scroll",
@@ -65,7 +66,7 @@ export const rerenderTransitionsScroll = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isAddEventListenerCall(node)) return;
       const eventArg = node.arguments?.[0];
       if (!isNodeOfType(eventArg, "Literal")) return;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const REANIMATED_LAYOUT_KEYS = new Set([
   "width",
@@ -29,7 +30,7 @@ const REANIMATED_LAYOUT_KEYS = new Set([
   "flexShrink",
 ]);
 
-const findReturnedObject = (callback: EsTreeNode): EsTreeNode | null => {
+const findReturnedObject = (callback: EsTreeNode): EsTreeNodeOfType<"ObjectExpression"> | null => {
   if (
     !isNodeOfType(callback, "ArrowFunctionExpression") &&
     !isNodeOfType(callback, "FunctionExpression")
@@ -67,7 +68,7 @@ export const rnAnimateLayoutProperty = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "useAnimatedStyle")
         return;
       const callback = node.arguments?.[0];

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: useAnimatedReaction with a body that does nothing but assign to
 // another shared value (`sv2.value = current`) is essentially what
@@ -25,7 +26,7 @@ export const rnAnimationReactionAsDerived = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "useAnimatedReaction")
         return;
       const reactionFn = node.arguments?.[1];

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-bottom-sheet-prefer-native.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-bottom-sheet-prefer-native.ts
@@ -1,7 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const JS_BOTTOM_SHEET_PACKAGES = new Set([
   "@gorhom/bottom-sheet",
@@ -31,7 +31,7 @@ export const rnBottomSheetPreferNative = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       const source = node.source?.value;
       if (typeof source !== "string" || !JS_BOTTOM_SHEET_PACKAGES.has(source)) return;
       context.report({

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
@@ -16,6 +16,12 @@ const LIST_ROW_PRESS_HANDLER_PROPS = new Set([
 
 const detectInlineRowHandlers = (renderItemFn: EsTreeNode): EsTreeNode[] => {
   const inlineHandlers: EsTreeNode[] = [];
+  if (
+    !isNodeOfType(renderItemFn, "ArrowFunctionExpression") &&
+    !isNodeOfType(renderItemFn, "FunctionExpression")
+  ) {
+    return inlineHandlers;
+  }
   walkAst(renderItemFn.body, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "JSXAttribute")) return;
     if (!isNodeOfType(child.name, "JSXIdentifier")) return;
@@ -70,9 +76,10 @@ export const rnListCallbackPerRow = defineRule<Rule>({
       if (!isRenderItemFunction(node)) return;
       const inlineHandlers = detectInlineRowHandlers(node);
       for (const handler of inlineHandlers) {
-        const handlerName = isNodeOfType(handler.name, "JSXIdentifier")
-          ? handler.name.name
-          : "<handler>";
+        const handlerName =
+          isNodeOfType(handler, "JSXAttribute") && isNodeOfType(handler.name, "JSXIdentifier")
+            ? handler.name.name
+            : "<handler>";
         context.report({
           node: handler,
           message: `Inline ${handlerName} arrow inside renderItem creates a fresh closure per row — hoist with useCallback at list scope and pass the row id as a primitive prop`,

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // Short-name form: resolveJsxElementName drops the `Animated.` prefix,
 // so `<Animated.FlatList>` resolves to `"FlatList"` and matches here.
@@ -35,7 +35,7 @@ export const rnListDataMapped = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const elementName = resolveJsxElementName(node);
       if (!elementName || !VIRTUALIZED_LIST_NAMES.has(elementName)) return;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: <FlashList recycleItems> (or LegendList) reuses row component
 // instances across rows. For HETEROGENEOUS lists (rows of different
@@ -35,7 +35,7 @@ export const rnListRecyclableWithoutTypes = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const elementName = resolveJsxElementName(node);
       if (!elementName || !RECYCLABLE_LIST_NAMES.has(elementName)) return;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
@@ -1,10 +1,10 @@
 import { DEPRECATED_RN_MODULE_REPLACEMENTS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rnNoDeprecatedModules = defineRule<Rule>({
   requires: ["react-native"],
@@ -20,7 +20,7 @@ export const rnNoDeprecatedModules = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       if (node.source?.value !== "react-native") return;
 
       for (const specifier of node.specifiers ?? []) {

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-dimensions-get.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-dimensions-get.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { isMemberProperty } from "../../utils/is-member-property.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rnNoDimensionsGet = defineRule<Rule>({
   requires: ["react-native"],
@@ -19,7 +19,7 @@ export const rnNoDimensionsGet = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (
         !isNodeOfType(node.callee.object, "Identifier") ||

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
@@ -1,10 +1,10 @@
 import { REACT_NATIVE_LIST_COMPONENTS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rnNoInlineFlatlistRenderitem = defineRule<Rule>({
   requires: ["react-native"],
@@ -21,7 +21,7 @@ export const rnNoInlineFlatlistRenderitem = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "renderItem") return;
       if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-object-in-list-item.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-inline-object-in-list-item.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const RENDER_ITEM_PROP_NAMES = new Set([
   "renderItem",
@@ -64,7 +65,7 @@ export const rnNoInlineObjectInListItem = defineRule<Rule>({
       "ArrowFunctionExpression:exit": exit,
       FunctionExpression: enter,
       "FunctionExpression:exit": exit,
-      JSXAttribute(node: EsTreeNode) {
+      JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
         if (renderItemDepth === 0) return;
         if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
         if (!isNodeOfType(node.value.expression, "ObjectExpression")) return;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-expo-packages.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-expo-packages.ts
@@ -1,8 +1,8 @@
 import { LEGACY_EXPO_PACKAGE_REPLACEMENTS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rnNoLegacyExpoPackages = defineRule<Rule>({
   requires: ["react-native"],
@@ -18,7 +18,7 @@ export const rnNoLegacyExpoPackages = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       const source = node.source?.value;
       if (typeof source !== "string") return;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
@@ -1,12 +1,15 @@
 import { LEGACY_SHADOW_STYLE_PROPERTIES } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { isMemberProperty } from "../../utils/is-member-property.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const reportLegacyShadowProperties = (objectExpression: EsTreeNode, context: RuleContext): void => {
+const reportLegacyShadowProperties = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+  context: RuleContext,
+): void => {
   const legacyShadowPropertyNames: string[] = [];
 
   for (const property of objectExpression.properties ?? []) {
@@ -41,7 +44,7 @@ export const rnNoLegacyShadowStyles = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return;
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
@@ -57,7 +60,7 @@ export const rnNoLegacyShadowStyles = defineRule<Rule>({
         }
       }
     },
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (
         !isNodeOfType(node.callee.object, "Identifier") ||

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-non-native-navigator.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-non-native-navigator.ts
@@ -1,7 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const NON_NATIVE_NAVIGATOR_PACKAGES = new Set([
   "@react-navigation/stack",
@@ -28,7 +28,7 @@ export const rnNoNonNativeNavigator = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       const source = node.source?.value;
       if (typeof source !== "string" || !NON_NATIVE_NAVIGATOR_PACKAGES.has(source)) return;
       const replacement = source.replace("@react-navigation/", "@react-navigation/native-");

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -10,6 +10,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const truncateText = (text: string): string =>
   text.length > RAW_TEXT_PREVIEW_MAX_CHARS
@@ -72,12 +73,12 @@ export const rnNoRawText = defineRule<Rule>({
     let isDomComponentFile = false;
 
     return {
-      Program(programNode: EsTreeNode) {
+      Program(programNode: EsTreeNodeOfType<"Program">) {
         isDomComponentFile = hasDirective(programNode, "use dom");
         const filename = context.getFilename?.() ?? "";
         isWebOnlyFile = WEB_FILE_EXTENSION_PATTERN.test(filename);
       },
-      JSXElement(node: EsTreeNode) {
+      JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
         if (isDomComponentFile || isWebOnlyFile) return;
 
         const elementName = resolveJsxElementName(node.openingElement);

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: setting React state inside an onScroll handler triggers a re-render
 // at scroll-event frequency (60-120Hz). Use a Reanimated shared value
@@ -24,7 +25,7 @@ export const rnNoScrollState = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "onScroll") return;
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
@@ -1,10 +1,10 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: <ScrollView>{items.map(...)}</ScrollView> renders every row in
 // memory — for any list longer than ~10 items this destroys scroll
@@ -25,7 +25,7 @@ export const rnNoScrollviewMappedList = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXElement(node: EsTreeNode) {
+    JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
       const elementName = resolveJsxElementName(node.openingElement);
       if (!elementName || !SCROLLVIEW_NAMES.has(elementName)) return;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-no-single-element-style-array.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-no-single-element-style-array.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rnNoSingleElementStyleArray = defineRule<Rule>({
   requires: ["react-native"],
@@ -18,7 +18,7 @@ export const rnNoSingleElementStyleArray = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const propName = isNodeOfType(node.name, "JSXIdentifier") ? node.name.name : null;
       if (!propName) return;
       if (propName !== "style" && !propName.endsWith("Style")) return;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
@@ -1,10 +1,10 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: <SafeAreaView> wrapping <ScrollView> (or
 // `useSafeAreaInsets()` + `paddingTop: insets.top` in
@@ -26,7 +26,7 @@ export const rnPreferContentInsetAdjustment = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXElement(node: EsTreeNode) {
+    JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
       const elementName = resolveJsxElementName(node.openingElement);
       if (elementName !== "SafeAreaView") return;
 

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: react-native's built-in <Image> has no caching, no placeholders,
 // no progressive loading, and no priority hints. expo-image is a drop-in
@@ -24,7 +24,7 @@ export const rnPreferExpoImage = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       if (node.source?.value !== "react-native") return;
       for (const specifier of node.specifiers ?? []) {
         if (!isNodeOfType(specifier, "ImportSpecifier")) continue;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const TOUCHABLE_COMPONENTS = new Set([
   "TouchableOpacity",
@@ -30,7 +30,7 @@ export const rnPreferPressable = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       if (node.source?.value !== "react-native") return;
       for (const specifier of node.specifiers ?? []) {
         if (!isNodeOfType(specifier, "ImportSpecifier")) continue;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rnPreferReanimated = defineRule<Rule>({
   requires: ["react-native"],
@@ -20,7 +20,7 @@ export const rnPreferReanimated = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       if (node.source?.value !== "react-native") return;
 
       for (const specifier of node.specifiers ?? []) {

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const PRESS_HANDLER_PROP_NAMES = new Set(["onPressIn", "onPressOut"]);
 
@@ -79,6 +80,7 @@ export const rnPressableSharedValueMutation = defineRule<Rule>({
     };
     const trackSharedValueBinding = (declarator: EsTreeNode): void => {
       if (sharedValueBindingsByComponent.length === 0) return;
+      if (!isNodeOfType(declarator, "VariableDeclarator")) return;
       if (!isNodeOfType(declarator.id, "Identifier")) return;
       if (!isNodeOfType(declarator.init, "CallExpression")) return;
       const callee = declarator.init.callee;
@@ -96,10 +98,10 @@ export const rnPressableSharedValueMutation = defineRule<Rule>({
       "FunctionExpression:exit": exitScope,
       ArrowFunctionExpression: enterScope,
       "ArrowFunctionExpression:exit": exitScope,
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         trackSharedValueBinding(node);
       },
-      JSXOpeningElement(node: EsTreeNode) {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         const name = resolveJsxElementName(node);
         if (name !== "Pressable") return;
         if (sharedValueBindingsByComponent.length === 0) return;

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
@@ -1,10 +1,10 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: dynamic `paddingBottom`/`paddingTop` on `contentContainerStyle`
 // (e.g. `paddingBottom: keyboardHeight`) reflows the entire scroll
@@ -26,7 +26,7 @@ export const rnScrollviewDynamicPadding = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const elementName = resolveJsxElementName(node);
       if (!elementName) return;
       if (

--- a/packages/react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const LEGACY_SHADOW_KEYS = new Set([
   "shadowColor",
@@ -13,7 +14,7 @@ const LEGACY_SHADOW_KEYS = new Set([
 ]);
 
 const findLegacyShadowProperty = (
-  objectExpression: EsTreeNode,
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
 ): { keyName: string; node: EsTreeNode } | null => {
   for (const property of objectExpression.properties ?? []) {
     if (!isNodeOfType(property, "Property")) continue;
@@ -47,7 +48,7 @@ export const rnStylePreferBoxShadow = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNode) {
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       const attrName = node.name.name;
       if (attrName !== "style" && !attrName.endsWith("Style")) return;
@@ -61,7 +62,7 @@ export const rnStylePreferBoxShadow = defineRule<Rule>({
         message: `${match.keyName} is iOS/Android-platform-specific — use the cross-platform CSS \`boxShadow\` string (e.g. \`boxShadow: "0 2px 8px rgba(0,0,0,0.1)"\`) on RN v7+`,
       });
     },
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (!isNodeOfType(node.callee.object, "Identifier")) return;
       if (node.callee.object.name !== "StyleSheet") return;

--- a/packages/react-doctor/src/plugin/rules/react-native/utils/resolve-jsx-element-name.ts
+++ b/packages/react-doctor/src/plugin/rules/react-native/utils/resolve-jsx-element-name.ts
@@ -2,9 +2,12 @@ import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const resolveJsxElementName = (openingElement: EsTreeNode): string | null => {
-  const elementName = openingElement?.name;
+  if (!isNodeOfType(openingElement, "JSXOpeningElement")) return null;
+  const elementName = openingElement.name;
   if (!elementName) return null;
   if (isNodeOfType(elementName, "JSXIdentifier")) return elementName.name;
-  if (isNodeOfType(elementName, "JSXMemberExpression")) return elementName.property?.name ?? null;
+  if (isNodeOfType(elementName, "JSXMemberExpression")) {
+    return isNodeOfType(elementName.property, "JSXIdentifier") ? elementName.property.name : null;
+  }
   return null;
 };

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-bold-heading.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-bold-heading.ts
@@ -11,8 +11,12 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getOpeningElementTagName } from "./utils/get-opening-element-tag-name.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const getInlineStyleObjectExpression = (jsxAttribute: EsTreeNode): EsTreeNode | null => {
+const getInlineStyleObjectExpression = (
+  jsxAttribute: EsTreeNode,
+): EsTreeNodeOfType<"ObjectExpression"> | null => {
+  if (!isNodeOfType(jsxAttribute, "JSXAttribute")) return null;
   if (!isNodeOfType(jsxAttribute.name, "JSXIdentifier") || jsxAttribute.name.name !== "style") {
     return null;
   }
@@ -32,6 +36,7 @@ const getStylePropertyKeyName = (objectProperty: EsTreeNode): string | null => {
 };
 
 const getStylePropertyNumericValue = (objectProperty: EsTreeNode): number | null => {
+  if (!isNodeOfType(objectProperty, "Property")) return null;
   const valueNode = objectProperty.value;
   if (!valueNode) return null;
   if (isNodeOfType(valueNode, "Literal") && typeof valueNode.value === "number")
@@ -57,7 +62,7 @@ export const noBoldHeading = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(openingNode: EsTreeNode) {
+    JSXOpeningElement(openingNode: EsTreeNodeOfType<"JSXOpeningElement">) {
       const tagName = getOpeningElementTagName(openingNode);
       if (!tagName || !HEADING_TAG_NAMES.has(tagName)) return;
 

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-default-tailwind-palette.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-default-tailwind-palette.ts
@@ -4,11 +4,11 @@ import {
   TAILWIND_PALETTE_UTILITY_PREFIXES,
 } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const buildDefaultPaletteRegex = (): RegExp => {
   const utilityPrefixGroup = TAILWIND_PALETTE_UTILITY_PREFIXES.join("|");
@@ -45,7 +45,7 @@ export const noDefaultTailwindPalette = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(jsxAttribute: EsTreeNode) {
+    JSXAttribute(jsxAttribute: EsTreeNodeOfType<"JSXAttribute">) {
       if (
         !isNodeOfType(jsxAttribute.name, "JSXIdentifier") ||
         jsxAttribute.name.name !== "className"

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-em-dash-in-jsx-text.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-em-dash-in-jsx-text.ts
@@ -1,9 +1,9 @@
 import { EM_DASH_CHARACTER } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isInsideExcludedAncestor } from "./utils/is-inside-excluded-ancestor.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noEmDashInJsxText = defineRule<Rule>({
   framework: "global",
@@ -18,7 +18,7 @@ export const noEmDashInJsxText = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXText(jsxTextNode: EsTreeNode) {
+    JSXText(jsxTextNode: EsTreeNodeOfType<"JSXText">) {
       const textValue = typeof jsxTextNode.value === "string" ? jsxTextNode.value : "";
       if (!textValue.includes(EM_DASH_CHARACTER)) return;
       if (isInsideExcludedAncestor(jsxTextNode)) return;

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
@@ -1,12 +1,12 @@
 import { PADDING_HORIZONTAL_AXIS_PATTERN, PADDING_VERTICAL_AXIS_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
 import { collectAxisShorthandPairs } from "./utils/collect-axis-shorthand-pairs.js";
 import { hasResponsivePrefix } from "./utils/has-responsive-prefix.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noRedundantPaddingAxes = defineRule<Rule>({
   tags: ["design", "test-noise"],
@@ -22,7 +22,7 @@ export const noRedundantPaddingAxes = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(jsxAttribute: EsTreeNode) {
+    JSXAttribute(jsxAttribute: EsTreeNodeOfType<"JSXAttribute">) {
       if (
         !isNodeOfType(jsxAttribute.name, "JSXIdentifier") ||
         jsxAttribute.name.name !== "className"

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
@@ -1,12 +1,12 @@
 import { SIZE_HEIGHT_AXIS_PATTERN, SIZE_WIDTH_AXIS_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
 import { collectAxisShorthandPairs } from "./utils/collect-axis-shorthand-pairs.js";
 import { hasResponsivePrefix } from "./utils/has-responsive-prefix.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noRedundantSizeAxes = defineRule<Rule>({
   requires: ["tailwind:3.4"],
@@ -22,7 +22,7 @@ export const noRedundantSizeAxes = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(jsxAttribute: EsTreeNode) {
+    JSXAttribute(jsxAttribute: EsTreeNodeOfType<"JSXAttribute">) {
       if (
         !isNodeOfType(jsxAttribute.name, "JSXIdentifier") ||
         jsxAttribute.name.name !== "className"

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
@@ -1,10 +1,10 @@
 import { FLEX_OR_GRID_DISPLAY_TOKENS, SPACE_AXIS_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getClassNameLiteral } from "./utils/get-class-name-literal.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const tokenizeClassName = (classNameValue: string): string[] =>
   classNameValue.split(/\s+/).filter(Boolean);
@@ -23,7 +23,7 @@ export const noSpaceOnFlexChildren = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXAttribute(jsxAttribute: EsTreeNode) {
+    JSXAttribute(jsxAttribute: EsTreeNodeOfType<"JSXAttribute">) {
       if (
         !isNodeOfType(jsxAttribute.name, "JSXIdentifier") ||
         jsxAttribute.name.name !== "className"

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-three-period-ellipsis.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-three-period-ellipsis.ts
@@ -1,9 +1,9 @@
 import { TRAILING_THREE_PERIOD_ELLIPSIS_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isInsideExcludedAncestor } from "./utils/is-inside-excluded-ancestor.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noThreePeriodEllipsis = defineRule<Rule>({
   tags: ["design", "test-noise"],
@@ -19,7 +19,7 @@ export const noThreePeriodEllipsis = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXText(jsxTextNode: EsTreeNode) {
+    JSXText(jsxTextNode: EsTreeNodeOfType<"JSXText">) {
       const textValue = typeof jsxTextNode.value === "string" ? jsxTextNode.value : "";
       if (!TRAILING_THREE_PERIOD_ELLIPSIS_PATTERN.test(textValue)) return;
       if (isInsideExcludedAncestor(jsxTextNode)) return;

--- a/packages/react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getOpeningElementTagName } from "./utils/get-opening-element-tag-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const isButtonLikeTagName = (tagName: string): boolean => {
   if (tagName === "button") return true;
@@ -13,6 +14,8 @@ const isButtonLikeTagName = (tagName: string): boolean => {
 };
 
 const collectJsxLabelText = (jsxElementNode: EsTreeNode): string | null => {
+  if (!isNodeOfType(jsxElementNode, "JSXElement") && !isNodeOfType(jsxElementNode, "JSXFragment"))
+    return null;
   const childList = jsxElementNode.children ?? [];
   if (childList.length === 0) return null;
   const collectedFragments: string[] = [];
@@ -66,7 +69,7 @@ export const noVagueButtonLabel = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXElement(jsxElementNode: EsTreeNode) {
+    JSXElement(jsxElementNode: EsTreeNodeOfType<"JSXElement">) {
       const tagName = getOpeningElementTagName(jsxElementNode.openingElement);
       if (!tagName || !isButtonLikeTagName(tagName)) return;
       const labelText = collectJsxLabelText(jsxElementNode);

--- a/packages/react-doctor/src/plugin/rules/react-ui/utils/get-class-name-literal.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/utils/get-class-name-literal.ts
@@ -2,6 +2,7 @@ import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const getClassNameLiteral = (classAttribute: EsTreeNode): string | null => {
+  if (!isNodeOfType(classAttribute, "JSXAttribute")) return null;
   if (!classAttribute.value) return null;
   if (
     isNodeOfType(classAttribute.value, "Literal") &&

--- a/packages/react-doctor/src/plugin/rules/react-ui/utils/get-opening-element-tag-name.ts
+++ b/packages/react-doctor/src/plugin/rules/react-ui/utils/get-opening-element-tag-name.ts
@@ -5,6 +5,7 @@ export const getOpeningElementTagName = (
   openingElement: EsTreeNode | null | undefined,
 ): string | null => {
   if (!openingElement) return null;
+  if (!isNodeOfType(openingElement, "JSXOpeningElement")) return null;
   if (isNodeOfType(openingElement.name, "JSXIdentifier")) return openingElement.name.name;
   if (isNodeOfType(openingElement.name, "JSXMemberExpression")) {
     let cursor: EsTreeNode = openingElement.name;

--- a/packages/react-doctor/src/plugin/rules/security/no-eval.ts
+++ b/packages/react-doctor/src/plugin/rules/security/no-eval.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noEval = defineRule<Rule>({
   framework: "global",
@@ -17,7 +17,7 @@ export const noEval = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "eval") {
         context.report({
           node,
@@ -38,7 +38,7 @@ export const noEval = defineRule<Rule>({
         });
       }
     },
-    NewExpression(node: EsTreeNode) {
+    NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
       if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "Function") {
         context.report({
           node,

--- a/packages/react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -5,10 +5,10 @@ import {
   SECRET_VARIABLE_PATTERN,
 } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noSecretsInClientCode = defineRule<Rule>({
   framework: "global",
@@ -24,7 +24,7 @@ export const noSecretsInClientCode = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    VariableDeclarator(node: EsTreeNode) {
+    VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
       if (!isNodeOfType(node.id, "Identifier")) return;
       if (!isNodeOfType(node.init, "Literal") || typeof node.init.value !== "string") return;
 

--- a/packages/react-doctor/src/plugin/rules/server/server-after-nonblocking.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-after-nonblocking.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: a (object, method) pair counts as "deferrable side effect" when
 // it either (a) is a synchronous `console.log/info/warn` (still cheap,
@@ -69,7 +70,7 @@ export const serverAfterNonblocking = defineRule<Rule>({
     };
 
     return {
-      Program(programNode: EsTreeNode) {
+      Program(programNode: EsTreeNodeOfType<"Program">) {
         fileHasUseServerDirective = hasDirective(programNode, "use server");
       },
       FunctionDeclaration: enterIfServerFunction,
@@ -78,7 +79,7 @@ export const serverAfterNonblocking = defineRule<Rule>({
       "FunctionExpression:exit": leaveIfServerFunction,
       ArrowFunctionExpression: enterIfServerFunction,
       "ArrowFunctionExpression:exit": leaveIfServerFunction,
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!fileHasUseServerDirective && serverFunctionDepth === 0) return;
         if (!isNodeOfType(node.callee, "MemberExpression")) return;
         if (!isNodeOfType(node.callee.property, "Identifier")) return;

--- a/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -7,6 +7,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
   let foundAuthCall = false;
@@ -52,10 +53,10 @@ export const serverAuthActions = defineRule<Rule>({
     let fileHasUseServerDirective = false;
 
     return {
-      Program(programNode: EsTreeNode) {
+      Program(programNode: EsTreeNodeOfType<"Program">) {
         fileHasUseServerDirective = hasDirective(programNode, "use server");
       },
-      ExportNamedDeclaration(node: EsTreeNode) {
+      ExportNamedDeclaration(node: EsTreeNodeOfType<"ExportNamedDeclaration">) {
         const declaration = node.declaration;
         if (!isNodeOfType(declaration, "FunctionDeclaration") || !declaration?.async) return;
 

--- a/packages/react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: `cache(fn)` from React keys deduplication on REFERENCE equality
 // of the function arguments. Calling the cached function with object
@@ -28,7 +28,7 @@ export const serverCacheWithObjectLiteral = defineRule<Rule>({
     const cachedFunctionNames = new Set<string>();
 
     return {
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isNodeOfType(node.id, "Identifier")) return;
         const init = node.init;
         if (!isNodeOfType(init, "CallExpression")) return;
@@ -43,7 +43,7 @@ export const serverCacheWithObjectLiteral = defineRule<Rule>({
         if (!isCacheCall) return;
         cachedFunctionNames.add(node.id.name);
       },
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isNodeOfType(node.callee, "Identifier")) return;
         if (!cachedFunctionNames.has(node.callee.name)) return;
         const firstArg = node.arguments?.[0];

--- a/packages/react-doctor/src/plugin/rules/server/server-dedup-props.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-dedup-props.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const DERIVING_ARRAY_METHODS = new Set(["toSorted", "toReversed", "filter", "map", "slice"]);
 
@@ -32,7 +33,7 @@ export const serverDedupProps = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const identifierAttributes: Map<string, string> = new Map();
       const derivedAttributes: Array<{ propName: string; rootName: string; node: EsTreeNode }> = [];
 

--- a/packages/react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const isFetchCall = (node: EsTreeNode): boolean => {
   if (!isNodeOfType(node, "CallExpression")) return false;
@@ -69,7 +70,7 @@ export const serverFetchWithoutRevalidate = defineRule<Rule>({
     let isServerSideFile = false;
 
     return {
-      Program(node: EsTreeNode) {
+      Program(node: EsTreeNodeOfType<"Program">) {
         const filename = context.getFilename?.() ?? "";
         if (!APP_ROUTER_FILE_PATTERN.test(filename)) {
           isServerSideFile = false;
@@ -87,7 +88,7 @@ export const serverFetchWithoutRevalidate = defineRule<Rule>({
         );
         isServerSideFile = !hasUseClient;
       },
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isServerSideFile) return;
         if (!isFetchCall(node)) return;
 

--- a/packages/react-doctor/src/plugin/rules/server/server-hoist-static-io.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-hoist-static-io.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const ROUTE_HANDLER_HTTP_METHODS = new Set([
   "GET",
@@ -91,6 +92,7 @@ const inspectHandlerBody = (
     }
     if (!staticCall) return;
     if (callReadsHandlerArgs(staticCall, handlerParamNames)) return;
+    if (!isNodeOfType(staticCall, "CallExpression")) return;
 
     const calleeText =
       isNodeOfType(staticCall.callee, "MemberExpression") &&
@@ -139,7 +141,7 @@ export const serverHoistStaticIo = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ExportNamedDeclaration(node: EsTreeNode) {
+    ExportNamedDeclaration(node: EsTreeNodeOfType<"ExportNamedDeclaration">) {
       const declaration = node.declaration;
       if (!isNodeOfType(declaration, "FunctionDeclaration")) return;
       const handlerName = declaration.id?.name;
@@ -152,7 +154,7 @@ export const serverHoistStaticIo = defineRule<Rule>({
         collectIdentifierParams(declaration.params ?? []),
       );
     },
-    ExportDefaultDeclaration(node: EsTreeNode) {
+    ExportDefaultDeclaration(node: EsTreeNodeOfType<"ExportDefaultDeclaration">) {
       const filename = context.getFilename?.() ?? "";
       if (!PAGES_ROUTER_API_PATH_PATTERN.test(filename)) return;
       const declaration = node.declaration;

--- a/packages/react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const MUTABLE_CONTAINER_CONSTRUCTORS = new Set(["Map", "Set", "WeakMap", "WeakSet"]);
 
@@ -45,10 +46,10 @@ export const serverNoMutableModuleState = defineRule<Rule>({
     let fileHasUseServerDirective = false;
 
     return {
-      Program(programNode: EsTreeNode) {
+      Program(programNode: EsTreeNodeOfType<"Program">) {
         fileHasUseServerDirective = hasDirective(programNode, "use server");
       },
-      VariableDeclaration(node: EsTreeNode) {
+      VariableDeclaration(node: EsTreeNodeOfType<"VariableDeclaration">) {
         if (!fileHasUseServerDirective) return;
         if (!isNodeOfType(node.parent, "Program")) return;
 

--- a/packages/react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
@@ -18,6 +18,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // level of the same block to keep precision high.
 const collectDeclaredNames = (declaration: EsTreeNode): Set<string> => {
   const names = new Set<string>();
+  if (!isNodeOfType(declaration, "VariableDeclaration")) return names;
   for (const declarator of declaration.declarations ?? []) {
     if (isNodeOfType(declarator.id, "Identifier")) {
       names.add(declarator.id.name);
@@ -42,6 +43,7 @@ const collectDeclaredNames = (declaration: EsTreeNode): Set<string> => {
 };
 
 const declarationStartsWithAwait = (declaration: EsTreeNode): boolean => {
+  if (!isNodeOfType(declaration, "VariableDeclaration")) return false;
   for (const declarator of declaration.declarations ?? []) {
     if (isNodeOfType(declarator.init, "AwaitExpression")) return true;
   }
@@ -97,6 +99,13 @@ export const serverSequentialIndependentAwait = defineRule<Rule>({
     };
 
     const visitFunctionBody = (node: EsTreeNode): void => {
+      if (
+        !isNodeOfType(node, "FunctionDeclaration") &&
+        !isNodeOfType(node, "FunctionExpression") &&
+        !isNodeOfType(node, "ArrowFunctionExpression")
+      ) {
+        return;
+      }
       if (!node.async) return;
       if (!isNodeOfType(node.body, "BlockStatement")) return;
       inspectStatements(node.body.body ?? []);

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
@@ -7,6 +7,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: `useEffect(() => { window.addEventListener(name, handler);
 // return () => window.removeEventListener(name, handler); }, [handler])`
@@ -41,11 +42,16 @@ export const advancedEventHandlerRefs = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
       if ((node.arguments?.length ?? 0) < 2) return;
       const callback = getEffectCallback(node);
-      if (!callback) return;
+      if (
+        !callback ||
+        (!isNodeOfType(callback, "ArrowFunctionExpression") &&
+          !isNodeOfType(callback, "FunctionExpression"))
+      )
+        return;
       const depsNode = node.arguments[1];
       if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -14,6 +14,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isSubscribeLikeCallExpression } from "./utils/is-subscribe-like-call-expression.js";
 import { isCleanupReturn } from "./utils/is-cleanup-return.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: From "Lifecycle of Reactive Effects":
 //
@@ -42,6 +43,12 @@ interface SubscribeLikeUsage {
 
 const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => {
   const usages: SubscribeLikeUsage[] = [];
+  if (
+    !isNodeOfType(callback, "ArrowFunctionExpression") &&
+    !isNodeOfType(callback, "FunctionExpression")
+  ) {
+    return usages;
+  }
   // HACK: timer/subscribe calls inside the EFFECT'S CLEANUP RETURN
   // are not new registrations — they're the disposal step. The old
   // walker traversed the full callback including any returned
@@ -94,6 +101,12 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
 // previous "any Identifier is fine" behavior.
 const collectReleasableBindingNames = (effectCallback: EsTreeNode): Set<string> => {
   const releasableNames = new Set<string>();
+  if (
+    !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
+    !isNodeOfType(effectCallback, "FunctionExpression")
+  ) {
+    return releasableNames;
+  }
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) return releasableNames;
   for (const statement of effectCallback.body.body ?? []) {
     if (!isNodeOfType(statement, "VariableDeclaration")) continue;
@@ -117,6 +130,12 @@ const collectReleasableBindingNames = (effectCallback: EsTreeNode): Set<string> 
 };
 
 const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(callback, "ArrowFunctionExpression") &&
+    !isNodeOfType(callback, "FunctionExpression")
+  ) {
+    return false;
+  }
   // HACK: expression-body arrows are the dominant shape for trivial
   // subscribe-only effects:
   //
@@ -173,7 +192,7 @@ export const effectNeedsCleanup = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
       const callback = getEffectCallback(node);
       if (!callback) return;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.ts
@@ -3,9 +3,9 @@ import { countSetStateCalls } from "../../utils/count-set-state-calls.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noCascadingSetState = defineRule<Rule>({
   framework: "global",
@@ -21,7 +21,7 @@ export const noCascadingSetState = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
       const callback = getEffectCallback(node);
       if (!callback) return;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
@@ -15,6 +15,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: AST-aware walker for "what reactive values does this expression
 // actually READ?". The plain `walkAst` adds every Identifier it sees,
@@ -58,17 +59,18 @@ const collectValueIdentifierNames = (node: EsTreeNode | null | undefined, into: 
     into.push(node.name);
     return;
   }
-  for (const key of Object.keys(node)) {
+  const nodeRecord = node as unknown as Record<string, unknown>;
+  for (const key of Object.keys(nodeRecord)) {
     if (key === "parent" || key === "type") continue;
-    const child = node[key];
+    const child = nodeRecord[key];
     if (Array.isArray(child)) {
       for (const item of child) {
-        if (item && typeof item === "object" && item.type) {
-          collectValueIdentifierNames(item, into);
+        if (item && typeof item === "object" && "type" in item) {
+          collectValueIdentifierNames(item as EsTreeNode, into);
         }
       }
-    } else if (child && typeof child === "object" && child.type) {
-      collectValueIdentifierNames(child, into);
+    } else if (child && typeof child === "object" && "type" in child) {
+      collectValueIdentifierNames(child as EsTreeNode, into);
     }
   }
 };
@@ -87,7 +89,7 @@ export const noDerivedStateEffect = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
 
       const callback = getEffectCallback(node);
@@ -122,6 +124,8 @@ export const noDerivedStateEffect = defineRule<Rule>({
       // during render" message.
       let hasExpensiveDerivation = false;
       for (const statement of statements) {
+        if (!isNodeOfType(statement, "ExpressionStatement")) continue;
+        if (!isNodeOfType(statement.expression, "CallExpression")) continue;
         const setStateArguments = statement.expression.arguments;
         if (!setStateArguments?.length) continue;
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -2,10 +2,10 @@ import { createComponentPropStackTracker } from "../../utils/create-component-pr
 import { defineRule } from "../../utils/define-rule.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noDerivedUseState = defineRule<Rule>({
   framework: "global",
@@ -26,7 +26,7 @@ export const noDerivedUseState = defineRule<Rule>({
 
     return {
       ...propStackTracker.visitors,
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isHookCall(node, "useState") || !node.arguments?.length) return;
         const initializer = node.arguments[0];
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
@@ -9,6 +9,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: walks the component AST while tracking which state names are
 // SHADOWED in the current scope by a nested function's params or
@@ -20,6 +21,13 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // >99% of real-world shadowing cases without false positives.
 const collectFunctionLocalBindings = (functionNode: EsTreeNode): Set<string> => {
   const localBindings = new Set<string>();
+  if (
+    !isNodeOfType(functionNode, "FunctionDeclaration") &&
+    !isNodeOfType(functionNode, "FunctionExpression") &&
+    !isNodeOfType(functionNode, "ArrowFunctionExpression")
+  ) {
+    return localBindings;
+  }
   for (const param of functionNode.params ?? []) {
     collectPatternNames(param, localBindings);
   }
@@ -58,17 +66,18 @@ const walkComponentRespectingShadows = (
 
   visit(node, shadowedStateNames);
 
-  for (const key of Object.keys(node)) {
+  const nodeRecord = node as unknown as Record<string, unknown>;
+  for (const key of Object.keys(nodeRecord)) {
     if (key === "parent") continue;
-    const child = node[key];
+    const child = nodeRecord[key];
     if (Array.isArray(child)) {
       for (const item of child) {
-        if (item && typeof item === "object" && item.type) {
-          walkComponentRespectingShadows(item, nextShadowedStateNames, visit);
+        if (item && typeof item === "object" && "type" in item) {
+          walkComponentRespectingShadows(item as EsTreeNode, nextShadowedStateNames, visit);
         }
       }
-    } else if (child && typeof child === "object" && child.type) {
-      walkComponentRespectingShadows(child, nextShadowedStateNames, visit);
+    } else if (child && typeof child === "object" && "type" in child) {
+      walkComponentRespectingShadows(child as EsTreeNode, nextShadowedStateNames, visit);
     }
   }
 };
@@ -132,13 +141,18 @@ export const noDirectStateMutation = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -19,6 +19,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: §7 of "You Might Not Need an Effect" — chains of computations:
 //
@@ -66,6 +67,7 @@ const findTopLevelEffectCalls = (componentBody: EsTreeNode): EsTreeNode[] => {
 
 const collectDepIdentifierNames = (effectNode: EsTreeNode): Set<string> => {
   const depNames = new Set<string>();
+  if (!isNodeOfType(effectNode, "CallExpression")) return depNames;
   const depsNode = effectNode.arguments?.[1];
   if (!isNodeOfType(depsNode, "ArrayExpression")) return depNames;
   for (const element of depsNode.elements ?? []) {
@@ -86,6 +88,12 @@ const collectWrittenStateNamesInEffect = (
   setterToStateName: Map<string, string>,
 ): Set<string> => {
   const writtenStateNames = new Set<string>();
+  if (
+    !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
+    !isNodeOfType(effectCallback, "FunctionExpression")
+  ) {
+    return writtenStateNames;
+  }
   walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
     if (!isNodeOfType(child.callee, "Identifier")) return;
@@ -122,6 +130,12 @@ const isFunctionShapedReturn = (returnedValue: EsTreeNode): boolean => {
 };
 
 const isExternalSyncEffect = (effectCallback: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
+    !isNodeOfType(effectCallback, "FunctionExpression")
+  ) {
+    return false;
+  }
   // A cleanup return is the strongest signal that the effect owns
   // an external resource — once we see one, we don't need to inspect
   // the body for an external-sync call shape.
@@ -275,13 +289,18 @@ export const noEffectChain = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -4,10 +4,10 @@ import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noEffectEventHandler = defineRule<Rule>({
   framework: "global",
@@ -22,7 +22,7 @@ export const noEffectEventHandler = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
 
       const callback = getEffectCallback(node);

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
@@ -6,6 +6,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: useEffectEvent's identity is intentionally unstable — it captures
 // the latest props/state on each call. Listing it in a useEffect/useMemo/
@@ -33,6 +34,7 @@ export const noEffectEventInDeps = defineRule<Rule>({
   create: (context: RuleContext) => {
     const componentBindings = createComponentBindingStackTracker({
       onVariableDeclarator: (declaratorNode: EsTreeNode) => {
+        if (!isNodeOfType(declaratorNode, "VariableDeclarator")) return;
         if (!isNodeOfType(declaratorNode.id, "Identifier")) return;
         const initializer = declaratorNode.init;
         if (!initializer || !isNodeOfType(initializer, "CallExpression")) return;
@@ -43,7 +45,7 @@ export const noEffectEventInDeps = defineRule<Rule>({
 
     return {
       ...componentBindings.visitors,
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isHookCall(node, HOOKS_WITH_DEPS) || node.arguments.length < 2) return;
         if (!componentBindings.isInsideComponent()) return;
         const depsNode = node.arguments[1];

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
@@ -24,6 +24,7 @@ import { expandTransitiveDependencies } from "./utils/expand-transitive-dependen
 import { collectHandlerBindingNames } from "./utils/collect-handler-binding-names.js";
 import { isInsideEventHandler } from "./utils/is-inside-event-handler.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: §6 of "You Might Not Need an Effect" — sending a POST request:
 //
@@ -225,13 +226,18 @@ export const noEventTriggerState = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -3,9 +3,9 @@ import { containsFetchCall } from "../../utils/contains-fetch-call.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const noFetchInEffect = defineRule<Rule>({
   framework: "global",
@@ -22,7 +22,7 @@ export const noFetchInEffect = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
       const callback = getEffectCallback(node);
       if (!callback) return;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
@@ -9,6 +9,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: "Lifecycle of Reactive Effects" — Can global or mutable
 // values be dependencies? — calls out that `location.pathname`,
@@ -110,13 +111,18 @@ export const noMutableInDeps = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
@@ -8,6 +8,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: `useEffect(() => parentCallback(state.x), [state.x])` is the
 // "lift state up via callback" anti-pattern: the child owns state, then
@@ -34,10 +35,15 @@ export const noPropCallbackInEffect = defineRule<Rule>({
 
     return {
       ...propStackTracker.visitors,
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
         const callback = getEffectCallback(node);
-        if (!callback) return;
+        if (
+          !callback ||
+          (!isNodeOfType(callback, "ArrowFunctionExpression") &&
+            !isNodeOfType(callback, "FunctionExpression"))
+        )
+          return;
         const depsNode = node.arguments[1];
         if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
@@ -6,6 +6,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: an UNCONDITIONAL setter call at a component's render path
 // triggers an infinite re-render loop ("Maximum update depth exceeded").
@@ -59,6 +60,8 @@ export const noSetStateInRender = defineRule<Rule>({
       for (const statement of componentBody.body ?? []) {
         const setterCall = isUnconditionalSetterCallStatement(statement, setterNames);
         if (!setterCall) continue;
+        if (!isNodeOfType(setterCall, "CallExpression")) continue;
+        if (!isNodeOfType(setterCall.callee, "Identifier")) continue;
         const setterIdentifierName = setterCall.callee.name;
         context.report({
           node: setterCall,
@@ -68,13 +71,18 @@ export const noSetStateInRender = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
@@ -7,6 +7,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const preferUseReducer = defineRule<Rule>({
   framework: "global",
@@ -41,12 +42,18 @@ export const preferUseReducer = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         reportExcessiveUseState(node.body, node.id.name);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        if (!isNodeOfType(node.id, "Identifier")) return;
         reportExcessiveUseState(node.init.body, node.id.name);
       },
     };

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
@@ -14,6 +14,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isCleanupReturn } from "./utils/is-cleanup-return.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: §11 of "You Might Not Need an Effect" + the linked
 // `useSyncExternalStore` docs warn that pairing a `useState(getSnapshot())`
@@ -87,6 +88,7 @@ const getSubscriptionHandlerArgument = (
   subscribeCall: EsTreeNode,
   effectBodyStatements: EsTreeNode[],
 ): EsTreeNode | null => {
+  if (!isNodeOfType(subscribeCall, "CallExpression")) return null;
   for (const argument of subscribeCall.arguments ?? []) {
     if (
       isNodeOfType(argument, "ArrowFunctionExpression") ||
@@ -167,7 +169,8 @@ export const preferUseSyncExternalStore = defineRule<Rule>({
       const useStateInitializerByValueName = new Map<string, EsTreeNode>();
       for (const binding of useStateBindings) {
         const useStateCall = binding.declarator.init;
-        const initializerArgument = useStateCall?.arguments?.[0];
+        if (!useStateCall || !isNodeOfType(useStateCall, "CallExpression")) continue;
+        const initializerArgument = useStateCall.arguments?.[0];
         if (!initializerArgument) continue;
         // HACK: useState(() => getSnapshot()) — unwrap the lazy
         // initializer so the structural match against the
@@ -189,13 +192,20 @@ export const preferUseSyncExternalStore = defineRule<Rule>({
       }
 
       for (const effectCall of findUseEffectsInComponent(componentBody)) {
+        if (!isNodeOfType(effectCall, "CallExpression")) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
         const depsNode = effectCall.arguments[1];
         if (!isNodeOfType(depsNode, "ArrayExpression")) continue;
         if ((depsNode.elements?.length ?? 0) !== 0) continue;
 
         const callback = getEffectCallback(effectCall);
-        if (!callback || !isNodeOfType(callback.body, "BlockStatement")) continue;
+        if (
+          !callback ||
+          (!isNodeOfType(callback, "ArrowFunctionExpression") &&
+            !isNodeOfType(callback, "FunctionExpression"))
+        )
+          continue;
+        if (!isNodeOfType(callback.body, "BlockStatement")) continue;
         const effectBodyStatements = callback.body.body ?? [];
         if (effectBodyStatements.length < 2) continue;
 
@@ -231,13 +241,18 @@ export const preferUseSyncExternalStore = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
@@ -8,6 +8,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { collectHandlerBindingNames } from "./utils/collect-handler-binding-names.js";
 import { isInsideEventHandler } from "./utils/is-inside-event-handler.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const DEFERRABLE_HOOK_NAMES = new Set(["useSearchParams", "useParams", "usePathname"]);
 
@@ -72,7 +73,11 @@ export const rerenderDeferReadsHook = defineRule<Rule>({
       for (const binding of bindings) {
         const referenceLocations: EsTreeNode[] = [];
         walkAst(componentBody, (child: EsTreeNode) => {
-          if (child === binding.declarator.id) return;
+          if (
+            isNodeOfType(binding.declarator, "VariableDeclarator") &&
+            child === binding.declarator.id
+          )
+            return;
           if (isNodeOfType(child, "Identifier") && child.name === binding.valueName) {
             referenceLocations.push(child);
           }
@@ -93,13 +98,18 @@ export const rerenderDeferReadsHook = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
@@ -1,10 +1,10 @@
 import { HOOKS_WITH_DEPS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rerenderDependencies = defineRule<Rule>({
   framework: "global",
@@ -20,7 +20,7 @@ export const rerenderDependencies = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, HOOKS_WITH_DEPS) || node.arguments.length < 2) return;
       const depsNode = node.arguments[1];
       if (!isNodeOfType(depsNode, "ArrayExpression")) return;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-functional-setstate.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-functional-setstate.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const STATE_ARITHMETIC_OPERATORS = new Set(["+", "-", "*", "/", "%", "**"]);
 
@@ -29,9 +30,10 @@ export const rerenderFunctionalSetstate = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isSetterCall(node)) return;
       if (!node.arguments?.length) return;
+      if (!isNodeOfType(node.callee, "Identifier")) return;
 
       const calleeName = node.callee.name;
       const argument = node.arguments[0];

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
@@ -1,10 +1,10 @@
 import { TRIVIAL_INITIALIZER_NAMES } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rerenderLazyStateInit = defineRule<Rule>({
   framework: "global",
@@ -19,7 +19,7 @@ export const rerenderLazyStateInit = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, "useState") || !node.arguments?.length) return;
       const initializer = node.arguments[0];
       if (!isNodeOfType(initializer, "CallExpression")) return;

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -11,6 +11,7 @@ import { buildLocalDependencyGraph } from "./utils/build-local-dependency-graph.
 import { collectRenderReachableNames } from "./utils/collect-render-reachable-names.js";
 import { expandTransitiveDependencies } from "./utils/expand-transitive-dependencies.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const rerenderStateOnlyInHandlers = defineRule<Rule>({
   framework: "global",
@@ -62,13 +63,18 @@ export const rerenderStateOnlyInHandlers = defineRule<Rule>({
     };
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
         checkComponent(node.body);
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
-        checkComponent(node.init?.body);
+        if (
+          !isNodeOfType(node.init, "ArrowFunctionExpression") &&
+          !isNodeOfType(node.init, "FunctionExpression")
+        )
+          return;
+        checkComponent(node.init.body);
       },
     };
   },

--- a/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-use-state-bindings.ts
+++ b/packages/react-doctor/src/plugin/rules/state-and-effects/utils/collect-use-state-bindings.ts
@@ -1,12 +1,21 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
 import { isHookCall } from "../../../utils/is-hook-call.js";
 import { isSetterIdentifier } from "../../../utils/is-setter-identifier.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const collectUseStateBindings = (
   componentBody: EsTreeNode,
-): Array<{ valueName: string; setterName: string; declarator: EsTreeNode }> => {
-  const bindings: Array<{ valueName: string; setterName: string; declarator: EsTreeNode }> = [];
+): Array<{
+  valueName: string;
+  setterName: string;
+  declarator: EsTreeNodeOfType<"VariableDeclarator">;
+}> => {
+  const bindings: Array<{
+    valueName: string;
+    setterName: string;
+    declarator: EsTreeNodeOfType<"VariableDeclarator">;
+  }> = [];
   if (!isNodeOfType(componentBody, "BlockStatement")) return bindings;
 
   for (const statement of componentBody.body ?? []) {

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const queryMutationMissingInvalidation = defineRule<Rule>({
   requires: ["tanstack-query"],
@@ -21,7 +22,7 @@ export const queryMutationMissingInvalidation = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const calleeName = isNodeOfType(node.callee, "Identifier") ? node.callee.name : null;
 
       if (!calleeName || !TANSTACK_MUTATION_HOOKS.has(calleeName)) return;

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-query-in-effect.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-query-in-effect.ts
@@ -7,6 +7,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const queryNoQueryInEffect = defineRule<Rule>({
   requires: ["tanstack-query"],
@@ -23,7 +24,7 @@ export const queryNoQueryInEffect = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
 
       const callback = getEffectCallback(node);

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const queryNoRestDestructuring = defineRule<Rule>({
   requires: ["tanstack-query"],
@@ -19,7 +20,7 @@ export const queryNoRestDestructuring = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    VariableDeclarator(node: EsTreeNode) {
+    VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
       if (!isNodeOfType(node.id, "ObjectPattern")) return;
       if (!node.init || !isNodeOfType(node.init, "CallExpression")) return;
 

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-use-query-for-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-use-query-for-mutation.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const queryNoUseQueryForMutation = defineRule<Rule>({
   requires: ["tanstack-query"],
@@ -22,7 +23,7 @@ export const queryNoUseQueryForMutation = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const calleeName = isNodeOfType(node.callee, "Identifier") ? node.callee.name : null;
 
       if (!calleeName || !TANSTACK_QUERY_HOOKS.has(calleeName)) return;

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-void-query-fn.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-no-void-query-fn.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const queryNoVoidQueryFn = defineRule<Rule>({
   requires: ["tanstack-query"],
@@ -21,7 +22,7 @@ export const queryNoVoidQueryFn = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const calleeName = isNodeOfType(node.callee, "Identifier") ? node.callee.name : null;
 
       if (!calleeName || !TANSTACK_QUERY_HOOKS.has(calleeName)) return;

--- a/packages/react-doctor/src/plugin/rules/tanstack-query/query-stable-query-client.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-query/query-stable-query-client.ts
@@ -9,6 +9,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const queryStableQueryClient = defineRule<Rule>({
   requires: ["tanstack-query"],
@@ -30,17 +31,21 @@ export const queryStableQueryClient = defineRule<Rule>({
     let stableHookDepth = 0;
 
     return {
-      FunctionDeclaration(node: EsTreeNode) {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (node.id?.name && UPPERCASE_PATTERN.test(node.id.name)) {
           componentDepth++;
         }
       },
       "FunctionDeclaration:exit"(node: EsTreeNode) {
-        if (node.id?.name && UPPERCASE_PATTERN.test(node.id.name)) {
+        if (
+          isNodeOfType(node, "FunctionDeclaration") &&
+          node.id?.name &&
+          UPPERCASE_PATTERN.test(node.id.name)
+        ) {
           componentDepth--;
         }
       },
-      VariableDeclarator(node: EsTreeNode) {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (
           isNodeOfType(node.id, "Identifier") &&
           UPPERCASE_PATTERN.test(node.id.name) &&
@@ -52,6 +57,7 @@ export const queryStableQueryClient = defineRule<Rule>({
       },
       "VariableDeclarator:exit"(node: EsTreeNode) {
         if (
+          isNodeOfType(node, "VariableDeclarator") &&
           isNodeOfType(node.id, "Identifier") &&
           UPPERCASE_PATTERN.test(node.id.name) &&
           (isNodeOfType(node.init, "ArrowFunctionExpression") ||
@@ -60,7 +66,7 @@ export const queryStableQueryClient = defineRule<Rule>({
           componentDepth--;
         }
       },
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (isHookCall(node, STABLE_HOOK_WRAPPERS)) {
           stableHookDepth++;
         }
@@ -70,7 +76,7 @@ export const queryStableQueryClient = defineRule<Rule>({
           stableHookDepth = Math.max(0, stableHookDepth - 1);
         }
       },
-      NewExpression(node: EsTreeNode) {
+      NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
         if (componentDepth <= 0) return;
         if (stableHookDepth > 0) return;
         if (

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-get-mutation.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-get-mutation.ts
@@ -1,11 +1,11 @@
 import { MUTATING_HTTP_METHODS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findSideEffect } from "../../utils/find-side-effect.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { walkServerFnChain } from "./utils/walk-server-fn-chain.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartGetMutation = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -23,7 +23,7 @@ export const tanstackStartGetMutation = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (
         !isNodeOfType(node.callee.property, "Identifier") ||

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-loader-parallel-fetch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-loader-parallel-fetch.ts
@@ -6,10 +6,11 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const hasTopLevelAwait = (statement: EsTreeNode): boolean => {
   if (isNodeOfType(statement, "VariableDeclaration")) {
-    return statement.declarations?.some((declarator: EsTreeNode) =>
+    return statement.declarations?.some((declarator) =>
       isNodeOfType(declarator.init, "AwaitExpression"),
     );
   }
@@ -45,7 +46,7 @@ export const tanstackStartLoaderParallelFetch = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const optionsObject = getRouteOptionsObject(node);
       if (!optionsObject) return;
 
@@ -53,6 +54,7 @@ export const tanstackStartLoaderParallelFetch = defineRule<Rule>({
       for (const property of properties) {
         const keyName = getPropertyKeyName(property);
         if (keyName !== "loader") continue;
+        if (!isNodeOfType(property, "Property")) continue;
 
         const loaderValue = property.value;
         if (

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartMissingHeadContent = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -22,7 +23,7 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
     let hasHeadContentElement = false;
 
     return {
-      JSXOpeningElement(node: EsTreeNode) {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         const filename = context.getFilename?.() ?? "";
         const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
         if (!isRootRouteFile) return;

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
@@ -1,9 +1,9 @@
 import { TANSTACK_ROUTE_FILE_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartNoAnchorElement = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -20,7 +20,7 @@ export const tanstackStartNoAnchorElement = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNode) {
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const filename = context.getFilename?.() ?? "";
       const isRouteFile = TANSTACK_ROUTE_FILE_PATTERN.test(filename);
       if (!isRouteFile) return;
@@ -29,15 +29,16 @@ export const tanstackStartNoAnchorElement = defineRule<Rule>({
 
       const attributes = node.attributes ?? [];
       const hrefAttribute = attributes.find(
-        (attribute: EsTreeNode) =>
+        (attribute) =>
           isNodeOfType(attribute, "JSXAttribute") &&
           isNodeOfType(attribute.name, "JSXIdentifier") &&
           attribute.name.name === "href",
       );
 
-      if (!hrefAttribute?.value) return;
+      if (!hrefAttribute || !isNodeOfType(hrefAttribute, "JSXAttribute")) return;
+      if (!hrefAttribute.value) return;
 
-      let hrefValue: string | null = null;
+      let hrefValue: string | number | bigint | boolean | RegExp | null = null;
       if (isNodeOfType(hrefAttribute.value, "Literal")) {
         hrefValue = hrefAttribute.value.value;
       } else if (

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartNoDirectFetchInLoader = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -22,7 +23,7 @@ export const tanstackStartNoDirectFetchInLoader = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const optionsObject = getRouteOptionsObject(node);
       if (!optionsObject) return;
 
@@ -31,7 +32,7 @@ export const tanstackStartNoDirectFetchInLoader = defineRule<Rule>({
         const keyName = getPropertyKeyName(property);
         if (keyName !== "loader") continue;
 
-        const loaderValue = property.value ?? property;
+        const loaderValue = isNodeOfType(property, "Property") ? property.value : property;
         walkAst(loaderValue, (child: EsTreeNode) => {
           if (!isNodeOfType(child, "CallExpression")) return;
           if (isNodeOfType(child.callee, "Identifier") && child.callee.name === "fetch") {

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.ts
@@ -1,9 +1,9 @@
 import { TANSTACK_SERVER_FN_FILE_PATTERN } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartNoDynamicServerFnImport = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -19,7 +19,7 @@ export const tanstackStartNoDynamicServerFnImport = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportExpression(node: EsTreeNode) {
+    ImportExpression(node: EsTreeNodeOfType<"ImportExpression">) {
       const source = node.source;
       if (!source) return;
 

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
@@ -9,6 +9,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartNoNavigateInRender = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -43,13 +44,14 @@ export const tanstackStartNoNavigateInRender = defineRule<Rule>({
       isHookCall(node, "useMemo");
 
     const isEventHandlerAttribute = (node: EsTreeNode): boolean =>
+      isNodeOfType(node, "JSXAttribute") &&
       isNodeOfType(node.name, "JSXIdentifier") &&
       typeof node.name.name === "string" &&
       node.name.name.startsWith("on") &&
       UPPERCASE_PATTERN.test(node.name.name.charAt(2));
 
     return {
-      CallExpression(node: EsTreeNode) {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         const filename = context.getFilename?.() ?? "";
         if (!TANSTACK_ROUTE_FILE_PATTERN.test(filename)) return;
 
@@ -76,7 +78,7 @@ export const tanstackStartNoNavigateInRender = defineRule<Rule>({
           deferredCallbackDepth = Math.max(0, deferredCallbackDepth - 1);
         }
       },
-      JSXAttribute(node: EsTreeNode) {
+      JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
         const filename = context.getFilename?.() ?? "";
         if (!TANSTACK_ROUTE_FILE_PATTERN.test(filename)) return;
         if (isEventHandlerAttribute(node)) eventHandlerDepth++;

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-secrets-in-loader.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-secrets-in-loader.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const SAFE_BUILD_ENV_VARS = new Set(["NODE_ENV", "MODE", "DEV", "PROD"]);
 
@@ -36,7 +37,7 @@ export const tanstackStartNoSecretsInLoader = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const optionsObject = getRouteOptionsObject(node);
       if (!optionsObject) return;
 
@@ -45,7 +46,7 @@ export const tanstackStartNoSecretsInLoader = defineRule<Rule>({
         const keyName = getPropertyKeyName(property);
         if (keyName !== "loader" && keyName !== "beforeLoad") continue;
 
-        const loaderValue = property.value ?? property;
+        const loaderValue = isNodeOfType(property, "Property") ? property.value : property;
         walkAst(loaderValue, (child: EsTreeNode) => {
           if (!isNodeOfType(child, "MemberExpression")) return;
           const isProcessEnvAccess =

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
@@ -6,6 +6,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartNoUseEffectFetch = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -23,7 +24,7 @@ export const tanstackStartNoUseEffectFetch = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const filename = context.getFilename?.() ?? "";
       const isRouteFile = TANSTACK_ROUTE_FILE_PATTERN.test(filename);
       if (!isRouteFile) return;

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-server-in-handler.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-server-in-handler.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartNoUseServerInHandler = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -19,7 +20,7 @@ export const tanstackStartNoUseServerInHandler = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (
         !isNodeOfType(node.callee.property, "Identifier") ||

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-redirect-in-try-catch.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-redirect-in-try-catch.ts
@@ -1,9 +1,9 @@
 import { TANSTACK_REDIRECT_FUNCTIONS } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartRedirectInTryCatch = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -37,7 +37,7 @@ export const tanstackStartRedirectInTryCatch = defineRule<Rule>({
       "CatchClause:exit"() {
         catchClauseDepth--;
       },
-      ThrowStatement(node: EsTreeNode) {
+      ThrowStatement(node: EsTreeNodeOfType<"ThrowStatement">) {
         if (tryBlockDepth === 0) return;
         if (catchClauseDepth > 0) return;
 

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-route-property-order.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-route-property-order.ts
@@ -1,10 +1,10 @@
 import { TANSTACK_ROUTE_PROPERTY_ORDER } from "../../constants.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
 import { getPropertyKeyName } from "./utils/get-property-key-name.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartRoutePropertyOrder = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -22,11 +22,11 @@ export const tanstackStartRoutePropertyOrder = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const optionsObject = getRouteOptionsObject(node);
       if (!optionsObject) return;
 
-      const properties: EsTreeNode[] = optionsObject.properties ?? [];
+      const properties = optionsObject.properties ?? [];
       const orderedPropertyNames: string[] = [];
       for (const property of properties) {
         const propertyName = getPropertyKeyName(property);

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartServerFnMethodOrder = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -19,7 +20,7 @@ export const tanstackStartServerFnMethodOrder = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
 
       const methodNames: string[] = [];

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-validate-input.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-validate-input.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { walkServerFnChain } from "./utils/walk-server-fn-chain.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const tanstackStartServerFnValidateInput = defineRule<Rule>({
   requires: ["tanstack-start"],
@@ -22,7 +23,7 @@ export const tanstackStartServerFnValidateInput = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       if (!isNodeOfType(node.callee.property, "Identifier")) return;
       if (node.callee.property.name !== "handler") return;
@@ -45,8 +46,10 @@ export const tanstackStartServerFnValidateInput = defineRule<Rule>({
         if (
           isNodeOfType(child, "ObjectPattern") &&
           child.properties?.some(
-            (property: EsTreeNode) =>
-              isNodeOfType(property.key, "Identifier") && property.key.name === "data",
+            (property) =>
+              isNodeOfType(property, "Property") &&
+              isNodeOfType(property.key, "Identifier") &&
+              property.key.name === "data",
           )
         ) {
           accessesData = true;

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/utils/get-route-options-object.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/utils/get-route-options-object.ts
@@ -1,8 +1,11 @@
 import { TANSTACK_ROUTE_CREATION_FUNCTIONS } from "../../../constants.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
-export const getRouteOptionsObject = (node: EsTreeNode): EsTreeNode | null => {
+export const getRouteOptionsObject = (
+  node: EsTreeNode,
+): EsTreeNodeOfType<"ObjectExpression"> | null => {
   if (!isNodeOfType(node, "CallExpression")) return null;
 
   const callee = node.callee;

--- a/packages/react-doctor/src/plugin/rules/tanstack-start/utils/walk-server-fn-chain.ts
+++ b/packages/react-doctor/src/plugin/rules/tanstack-start/utils/walk-server-fn-chain.ts
@@ -11,7 +11,9 @@ export const walkServerFnChain = (outerNode: EsTreeNode): ServerFnChainInfo => {
     hasInputValidator: false,
   };
 
-  let currentNode: EsTreeNode = outerNode.callee?.object;
+  if (!isNodeOfType(outerNode, "CallExpression")) return result;
+  if (!isNodeOfType(outerNode.callee, "MemberExpression")) return result;
+  let currentNode: EsTreeNode = outerNode.callee.object;
 
   while (isNodeOfType(currentNode, "CallExpression")) {
     const calleeName = getCalleeName(currentNode);

--- a/packages/react-doctor/src/plugin/rules/view-transitions/no-document-start-view-transition.ts
+++ b/packages/react-doctor/src/plugin/rules/view-transitions/no-document-start-view-transition.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: in React's <ViewTransition> world, calling
 // `document.startViewTransition()` directly bypasses React's lifecycle
@@ -24,7 +24,7 @@ export const noDocumentStartViewTransition = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const callee = node.callee;
       if (!isNodeOfType(callee, "MemberExpression")) return;
       if (!isNodeOfType(callee.object, "Identifier") || callee.object.name !== "document") return;

--- a/packages/react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
+++ b/packages/react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // HACK: `flushSync` from react-dom forces a synchronous flush, which
 // skips the View Transition snapshot phase entirely — any animation that
@@ -23,7 +23,7 @@ export const noFlushSync = defineRule<Rule>({
     },
   ],
   create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNode) {
+    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       if (node.source?.value !== "react-dom") return;
       for (const specifier of node.specifiers ?? []) {
         if (!isNodeOfType(specifier, "ImportSpecifier")) continue;

--- a/packages/react-doctor/src/plugin/utils/are-expressions-structurally-equal.ts
+++ b/packages/react-doctor/src/plugin/utils/are-expressions-structurally-equal.ts
@@ -16,21 +16,21 @@ export const areExpressionsStructurallyEqual = (
 ): boolean => {
   if (!a || !b) return a === b;
   if (a.type !== b.type) return false;
-  if (isNodeOfType(a, "Identifier")) return a.name === b.name;
-  if (isNodeOfType(a, "Literal")) return a.value === b.value;
-  if (isNodeOfType(a, "MemberExpression")) {
+  if (isNodeOfType(a, "Identifier") && isNodeOfType(b, "Identifier")) return a.name === b.name;
+  if (isNodeOfType(a, "Literal") && isNodeOfType(b, "Literal")) return a.value === b.value;
+  if (isNodeOfType(a, "MemberExpression") && isNodeOfType(b, "MemberExpression")) {
     if (a.computed !== b.computed) return false;
     return (
       areExpressionsStructurallyEqual(a.object, b.object) &&
       areExpressionsStructurallyEqual(a.property, b.property)
     );
   }
-  if (isNodeOfType(a, "CallExpression")) {
+  if (isNodeOfType(a, "CallExpression") && isNodeOfType(b, "CallExpression")) {
     if (!areExpressionsStructurallyEqual(a.callee, b.callee)) return false;
     const argumentsA = a.arguments ?? [];
     const argumentsB = b.arguments ?? [];
     if (argumentsA.length !== argumentsB.length) return false;
-    return argumentsA.every((argument: EsTreeNode, index: number) =>
+    return argumentsA.every((argument, index: number) =>
       areExpressionsStructurallyEqual(argument, argumentsB[index]),
     );
   }

--- a/packages/react-doctor/src/plugin/utils/create-component-binding-stack-tracker.ts
+++ b/packages/react-doctor/src/plugin/utils/create-component-binding-stack-tracker.ts
@@ -2,6 +2,7 @@ import type { ComponentBindingStackTracker } from "./component-binding-stack-tra
 import type { ComponentBindingStackTrackerCallbacks } from "./component-binding-stack-tracker-callbacks.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isComponentAssignment } from "./is-component-assignment.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 import { isUppercaseName } from "./is-uppercase-name.js";
 import type { RuleVisitors } from "./rule-visitors.js";
 
@@ -43,11 +44,13 @@ export const createComponentBindingStackTracker = (
 
   const visitors: RuleVisitors = {
     FunctionDeclaration(node: EsTreeNode) {
-      if (!node.id?.name || !isUppercaseName(node.id.name)) return;
+      if (!isNodeOfType(node, "FunctionDeclaration")) return;
+      if (!node.id || !isUppercaseName(node.id.name)) return;
       componentBindingStack.push(new Set());
     },
     "FunctionDeclaration:exit"(node: EsTreeNode) {
-      if (!node.id?.name || !isUppercaseName(node.id.name)) return;
+      if (!isNodeOfType(node, "FunctionDeclaration")) return;
+      if (!node.id || !isUppercaseName(node.id.name)) return;
       componentBindingStack.pop();
     },
     VariableDeclarator(node: EsTreeNode) {

--- a/packages/react-doctor/src/plugin/utils/create-component-prop-stack-tracker.ts
+++ b/packages/react-doctor/src/plugin/utils/create-component-prop-stack-tracker.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import { extractDestructuredPropNames } from "./extract-destructured-prop-names.js";
 import { isComponentAssignment } from "./is-component-assignment.js";
 import { isFunctionLikeVariableDeclarator } from "./is-function-like-variable-declarator.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 import { isUppercaseName } from "./is-uppercase-name.js";
 import type { RuleVisitors } from "./rule-visitors.js";
 
@@ -50,7 +51,8 @@ export const createComponentPropStackTracker = (
 
   const visitors: RuleVisitors = {
     FunctionDeclaration(node: EsTreeNode) {
-      if (!node.id?.name || !isUppercaseName(node.id.name)) {
+      if (!isNodeOfType(node, "FunctionDeclaration")) return;
+      if (!node.id || !isUppercaseName(node.id.name)) {
         propParamStack.push(new Set());
         return;
       }
@@ -61,9 +63,18 @@ export const createComponentPropStackTracker = (
       propParamStack.pop();
     },
     VariableDeclarator(node: EsTreeNode) {
+      if (!isNodeOfType(node, "VariableDeclarator")) return;
       if (isComponentAssignment(node)) {
-        propParamStack.push(extractDestructuredPropNames(node.init?.params ?? []));
-        callbacks?.onComponentEnter?.(node.init?.body);
+        const initializer = node.init;
+        if (
+          isNodeOfType(initializer, "ArrowFunctionExpression") ||
+          isNodeOfType(initializer, "FunctionExpression")
+        ) {
+          propParamStack.push(extractDestructuredPropNames(initializer.params ?? []));
+          callbacks?.onComponentEnter?.(initializer.body);
+        } else {
+          propParamStack.push(new Set());
+        }
         return;
       }
       if (isFunctionLikeVariableDeclarator(node)) {
@@ -71,6 +82,7 @@ export const createComponentPropStackTracker = (
       }
     },
     "VariableDeclarator:exit"(node: EsTreeNode) {
+      if (!isNodeOfType(node, "VariableDeclarator")) return;
       if (isComponentAssignment(node) || isFunctionLikeVariableDeclarator(node)) {
         propParamStack.pop();
       }

--- a/packages/react-doctor/src/plugin/utils/create-loop-aware-visitors.ts
+++ b/packages/react-doctor/src/plugin/utils/create-loop-aware-visitors.ts
@@ -2,8 +2,14 @@ import { LOOP_TYPES } from "../constants.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import type { RuleVisitors } from "./rule-visitors.js";
 
+// HACK: handlers accept narrower node types (e.g. `NewExpression`) than
+// `EsTreeNode`. TS function-parameter contravariance rejects the wider
+// signature, so use `never` here to satisfy variance while still letting
+// the visitor type erase at the call site.
+type LoopVisitor = (node: never) => void;
+
 export const createLoopAwareVisitors = (
-  innerVisitors: Record<string, (node: EsTreeNode) => void>,
+  innerVisitors: Record<string, LoopVisitor>,
 ): RuleVisitors => {
   let loopDepth = 0;
   const incrementLoopDepth = (): void => {
@@ -22,7 +28,7 @@ export const createLoopAwareVisitors = (
 
   for (const [nodeType, handler] of Object.entries(innerVisitors)) {
     visitors[nodeType] = (node: EsTreeNode) => {
-      if (loopDepth > 0) handler(node);
+      if (loopDepth > 0) (handler as (input: EsTreeNode) => void)(node);
     };
   }
 

--- a/packages/react-doctor/src/plugin/utils/es-tree-node.ts
+++ b/packages/react-doctor/src/plugin/utils/es-tree-node.ts
@@ -1,11 +1,19 @@
-// Loose base shape used everywhere a rule body walks an arbitrary AST. The
-// `type` field stays a plain `string` so existing rule code that checks
-// `node.type === "Literal"` keeps working without exhaustively narrowing first.
-// Real per-node-type shapes live in `EsTreeNodeOfType<T>` (which derives from
-// TSESTree) and are reached via `isNodeOfType(node, "...")`.
-export interface EsTreeNode {
-  type: string;
-  parent?: EsTreeNode | null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
+import type { TSESTree } from "@typescript-eslint/types";
+
+// Distributes over the TSESTree.Node union so each member gets its `parent`
+// relaxed independently — TSESTree pins each node's parent to a specific
+// kind (e.g. JSXAttribute.parent: JSXOpeningElement) but our walker assigns
+// parent freely as it descends, so we re-broaden to `EsTreeNode | null` here.
+type WithLooseParent<NodeType> = NodeType extends NodeType
+  ? Omit<NodeType, "parent"> & { parent?: EsTreeNode | null }
+  : never;
+
+// THE AST node type used everywhere a rule body walks an arbitrary AST.
+// It's the full TSESTree discriminated union (every concrete node kind),
+// with the `parent` field relaxed. Discriminated-union narrowing on
+// `.type` works natively — `node.type === "CallExpression"` narrows
+// `node.callee` to `Expression` etc. — and there's no `[key: string]: any`
+// escape hatch, so every property access requires the narrowing to have
+// happened first. `isNodeOfType(node, "X")` is the runtime-safe entry
+// point for narrowing through opaque helpers; native `===` works inline.
+export type EsTreeNode = WithLooseParent<TSESTree.Node>;

--- a/packages/react-doctor/src/plugin/utils/find-jsx-attribute.ts
+++ b/packages/react-doctor/src/plugin/utils/find-jsx-attribute.ts
@@ -1,12 +1,13 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 export const findJsxAttribute = (
   attributes: EsTreeNode[],
   attributeName: string,
-): EsTreeNode | undefined =>
+): EsTreeNodeOfType<"JSXAttribute"> | undefined =>
   attributes?.find(
-    (attribute: EsTreeNode) =>
+    (attribute): attribute is EsTreeNodeOfType<"JSXAttribute"> =>
       isNodeOfType(attribute, "JSXAttribute") &&
       isNodeOfType(attribute.name, "JSXIdentifier") &&
       attribute.name.name === attributeName,

--- a/packages/react-doctor/src/plugin/utils/find-side-effect.ts
+++ b/packages/react-doctor/src/plugin/utils/find-side-effect.ts
@@ -6,24 +6,49 @@ import { isMutatingMethodProperty } from "./is-mutating-method-property.js";
 import { walkAst } from "./walk-ast.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
+const getCookiesOrHeadersMethodName = (
+  child: EsTreeNode,
+  apiName: "cookies" | "headers",
+): string | null => {
+  if (!isCookiesOrHeadersCall(child, apiName)) return null;
+  if (!isNodeOfType(child, "CallExpression")) return null;
+  if (!isNodeOfType(child.callee, "MemberExpression")) return null;
+  if (!isNodeOfType(child.callee.property, "Identifier")) return null;
+  return child.callee.property.name;
+};
+
 export const findSideEffect = (node: EsTreeNode): string | null => {
   let sideEffectDescription: string | null = null;
   walkAst(node, (child: EsTreeNode) => {
     if (sideEffectDescription) return;
-    if (isCookiesOrHeadersCall(child, "cookies")) {
-      const methodName = child.callee.property.name;
-      sideEffectDescription = `cookies().${methodName}()`;
-    } else if (isCookiesOrHeadersCall(child, "headers")) {
-      const methodName = child.callee.property.name;
-      sideEffectDescription = `headers().${methodName}()`;
-    } else if (isMutatingFetchCall(child)) {
+    const cookiesMethodName = getCookiesOrHeadersMethodName(child, "cookies");
+    if (cookiesMethodName) {
+      sideEffectDescription = `cookies().${cookiesMethodName}()`;
+      return;
+    }
+    const headersMethodName = getCookiesOrHeadersMethodName(child, "headers");
+    if (headersMethodName) {
+      sideEffectDescription = `headers().${headersMethodName}()`;
+      return;
+    }
+    if (isMutatingFetchCall(child) && isNodeOfType(child, "CallExpression")) {
       // HACK: re-use the EXACT predicate `isMutatingFetchCall` already
       // matched on so we can't pick a non-Literal duplicate `method:`
       // entry by mistake (a looser `key.name === "method"` predicate
       // would).
-      const methodProperty = child.arguments[1].properties.find(isMutatingMethodProperty);
+      const optionsArgument = child.arguments[1];
+      if (!isNodeOfType(optionsArgument, "ObjectExpression")) return;
+      const methodProperty = optionsArgument.properties.find(isMutatingMethodProperty);
+      if (
+        !methodProperty ||
+        !isNodeOfType(methodProperty, "Property") ||
+        !isNodeOfType(methodProperty.value, "Literal")
+      )
+        return;
       sideEffectDescription = `fetch() with method ${methodProperty.value.value}`;
-    } else if (isMutatingDbCall(child)) {
+    } else if (isMutatingDbCall(child) && isNodeOfType(child, "CallExpression")) {
+      if (!isNodeOfType(child.callee, "MemberExpression")) return;
+      if (!isNodeOfType(child.callee.property, "Identifier")) return;
       const methodName = child.callee.property.name;
       const objectName = isNodeOfType(child.callee.object, "Identifier")
         ? child.callee.object.name

--- a/packages/react-doctor/src/plugin/utils/get-callback-statements.ts
+++ b/packages/react-doctor/src/plugin/utils/get-callback-statements.ts
@@ -2,6 +2,13 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 export const getCallbackStatements = (callback: EsTreeNode): EsTreeNode[] => {
+  if (
+    !isNodeOfType(callback, "ArrowFunctionExpression") &&
+    !isNodeOfType(callback, "FunctionExpression") &&
+    !isNodeOfType(callback, "FunctionDeclaration")
+  ) {
+    return [];
+  }
   if (isNodeOfType(callback.body, "BlockStatement")) {
     return callback.body.body ?? [];
   }

--- a/packages/react-doctor/src/plugin/utils/get-callee-name.ts
+++ b/packages/react-doctor/src/plugin/utils/get-callee-name.ts
@@ -2,6 +2,7 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 export const getCalleeName = (node: EsTreeNode): string | null => {
+  if (!isNodeOfType(node, "CallExpression") && !isNodeOfType(node, "NewExpression")) return null;
   if (isNodeOfType(node.callee, "Identifier")) return node.callee.name;
   if (
     isNodeOfType(node.callee, "MemberExpression") &&

--- a/packages/react-doctor/src/plugin/utils/get-effect-callback.ts
+++ b/packages/react-doctor/src/plugin/utils/get-effect-callback.ts
@@ -2,6 +2,7 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 export const getEffectCallback = (node: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(node, "CallExpression") && !isNodeOfType(node, "NewExpression")) return null;
   if (!node.arguments?.length) return null;
   const callback = node.arguments[0];
   if (

--- a/packages/react-doctor/src/plugin/utils/get-imported-name.ts
+++ b/packages/react-doctor/src/plugin/utils/get-imported-name.ts
@@ -7,6 +7,7 @@ import { isNodeOfType } from "./is-node-of-type.js";
 // so callers that want a plain name string need both narrowings. Returns
 // undefined for any other node shape so rules can early-return safely.
 export const getImportedName = (importSpecifier: EsTreeNode): string | undefined => {
+  if (!isNodeOfType(importSpecifier, "ImportSpecifier")) return undefined;
   const imported = importSpecifier.imported;
   if (isNodeOfType(imported, "Identifier")) return imported.name;
   if (isNodeOfType(imported, "Literal") && typeof imported.value === "string") {

--- a/packages/react-doctor/src/plugin/utils/has-directive.ts
+++ b/packages/react-doctor/src/plugin/utils/has-directive.ts
@@ -1,12 +1,14 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
-export const hasDirective = (programNode: EsTreeNode, directive: string): boolean =>
-  Boolean(
+export const hasDirective = (programNode: EsTreeNode, directive: string): boolean => {
+  if (!isNodeOfType(programNode, "Program")) return false;
+  return Boolean(
     programNode.body?.some(
-      (statement: EsTreeNode) =>
+      (statement) =>
         isNodeOfType(statement, "ExpressionStatement") &&
         isNodeOfType(statement.expression, "Literal") &&
         statement.expression.value === directive,
     ),
   );
+};

--- a/packages/react-doctor/src/plugin/utils/has-use-server-directive.ts
+++ b/packages/react-doctor/src/plugin/utils/has-use-server-directive.ts
@@ -2,10 +2,17 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 export const hasUseServerDirective = (node: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(node, "FunctionDeclaration") &&
+    !isNodeOfType(node, "FunctionExpression") &&
+    !isNodeOfType(node, "ArrowFunctionExpression")
+  ) {
+    return false;
+  }
   if (!isNodeOfType(node.body, "BlockStatement")) return false;
   return Boolean(
     node.body.body?.some(
-      (statement: EsTreeNode) =>
+      (statement) =>
         isNodeOfType(statement, "ExpressionStatement") && statement.directive === "use server",
     ),
   );

--- a/packages/react-doctor/src/plugin/utils/is-member-property.ts
+++ b/packages/react-doctor/src/plugin/utils/is-member-property.ts
@@ -1,7 +1,14 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
-export const isMemberProperty = (node: EsTreeNode, propertyName: string): boolean =>
-  isNodeOfType(node, "MemberExpression") &&
-  isNodeOfType(node.property, "Identifier") &&
-  node.property.name === propertyName;
+export const isMemberProperty = (
+  node: EsTreeNode | null | undefined,
+  propertyName: string,
+): node is EsTreeNodeOfType<"MemberExpression"> =>
+  Boolean(
+    node &&
+    isNodeOfType(node, "MemberExpression") &&
+    isNodeOfType(node.property, "Identifier") &&
+    node.property.name === propertyName,
+  );

--- a/packages/react-doctor/src/plugin/utils/rule-visitors.ts
+++ b/packages/react-doctor/src/plugin/utils/rule-visitors.ts
@@ -1,5 +1,11 @@
-import type { EsTreeNode } from "./es-tree-node.js";
-
+// The handler parameter is intentionally `any` so each rule can declare its
+// own narrowed `EsTreeNodeOfType<"<SelectorKey>">` annotation without
+// fighting TypeScript's contravariant variance check (the narrow type
+// isn't assignable to `EsTreeNode` in parameter position). The strict
+// `EsTreeNode` (now an alias for the full `TSESTree.Node` union) stays
+// the source of truth for everything else — `any` here is scoped to the
+// visitor entry-point only.
 export interface RuleVisitors {
-  [selector: string]: ((node: EsTreeNode) => void) | (() => void);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [selector: string]: ((node: any) => void) | (() => void);
 }

--- a/packages/react-doctor/src/plugin/utils/walk-ast.ts
+++ b/packages/react-doctor/src/plugin/utils/walk-ast.ts
@@ -9,9 +9,10 @@ import { isAstNode } from "./is-ast-node.js";
 export const walkAst = (node: EsTreeNode, visitor: (child: EsTreeNode) => boolean | void): void => {
   if (!node || typeof node !== "object") return;
   if (visitor(node) === false) return;
-  for (const key of Object.keys(node)) {
+  const nodeRecord = node as unknown as Record<string, unknown>;
+  for (const key of Object.keys(nodeRecord)) {
     if (key === "parent") continue;
-    const child = node[key];
+    const child = nodeRecord[key];
     if (Array.isArray(child)) {
       for (const item of child) {
         if (isAstNode(item)) walkAst(item, visitor);

--- a/packages/react-doctor/src/plugin/utils/walk-inside-statement-blocks.ts
+++ b/packages/react-doctor/src/plugin/utils/walk-inside-statement-blocks.ts
@@ -24,9 +24,10 @@ export const walkInsideStatementBlocks = (
     return;
   }
   visitor(node);
-  for (const key of Object.keys(node)) {
+  const nodeRecord = node as unknown as Record<string, unknown>;
+  for (const key of Object.keys(nodeRecord)) {
     if (key === "parent") continue;
-    const child = node[key];
+    const child = nodeRecord[key];
     if (Array.isArray(child)) {
       for (const item of child) {
         if (isAstNode(item)) walkInsideStatementBlocks(item, visitor);


### PR DESCRIPTION
## Summary

Replaces the custom loose `EsTreeNode` interface (which exposed `[key: string]: any` so any property access typechecked as `any`) with a direct alias for `@typescript-eslint/types`' `TSESTree.Node` discriminated union, with `parent` relaxed via the same `WithLooseParent` helper that already powers `EsTreeNodeOfType<T>`.

```diff
-export interface EsTreeNode {
-  type: string;
-  parent?: EsTreeNode | null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-}
+import type { TSESTree } from "@typescript-eslint/types";
+
+type WithLooseParent<NodeType> = NodeType extends NodeType
+  ? Omit<NodeType, "parent"> & { parent?: EsTreeNode | null }
+  : never;
+
+export type EsTreeNode = WithLooseParent<TSESTree.Node>;
```

## Effect

- **Native discriminated-union narrowing** — `if (node.type === "CallExpression") { node.callee }` now narrows `node` automatically. No `isNodeOfType` ceremony required for inline checks.
- **Strict by default** — every property access on a non-narrowed `EsTreeNode` is a typecheck error. Catches missing narrowings the same way TS catches missing imports.
- **`isNodeOfType` still works** — it's now just a runtime-safe equivalent of `node?.type === "X"` that narrows through opaque inputs (e.g. `.find` results). Most existing call sites keep it for readability.

## Getting to 0 errors (the path from 747 → 0)

Three classes of fixes landed:

### 1. Visitor-parameter retype (codemod, 222 sites across 172 files)

Each visitor method's `(node: EsTreeNode)` annotation tightened to `(node: EsTreeNodeOfType<"<SelectorKey>">)` — the visitor's selector key IS the node type the handler receives.

```diff
-    CallExpression(node: EsTreeNode) {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const callback = getEffectCallback(node);
       …
     }
```

### 2. `RuleVisitors` parameter loosened to `any`

Function-type parameters are contravariant — `(node: CallExpression) => void` is NOT assignable to `(node: EsTreeNode) => void`. Typing the visitor's `any` parameter sidesteps the variance check while keeping `EsTreeNode` strict everywhere else. Scoped to the visitor entry-point only.

### 3. Per-call-site narrowings (~282 sites)

Where helper functions or nested member accesses needed an `isNodeOfType` guard (or further narrowing of an already-narrowed union like `Expression` → `ArrowFunctionExpression`):

```diff
 const containsFetchCall = (node: EsTreeNode): boolean => {
-  if (node.type !== "CallExpression") return false;
-  return node.callee.name === "fetch";
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  return isNodeOfType(node.callee, "Identifier") && node.callee.name === "fetch";
 };
```

Each fix is a tightening — preserves the original behavior on the cases the code handled, silently no-ops on the cases the loose `any` previously let through (matching the original code's `?.name` semantics).

## Verified runtime equivalence

Byte-identical 262-line diagnostic snapshot from `runOxlint` against the three test fixtures (`basic-react`, `nextjs-app`, `tanstack-start-app`) vs `origin/main`. Every diagnostic field (rule, severity, category, file, line, column, message) matches.

## Test plan

- [x] `pnpm typecheck` — 0 errors (was 747 with the index signature dropped)
- [x] `pnpm test` — 734 / 734 pass
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean
- [x] Diagnostic snapshot vs `origin/main` — byte-identical

## Stats

- 205 files changed, +874 / -431

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a TypeScript type-safety refactor; the only behavior impact is added runtime/type guards that may skip diagnostics for previously-unsafe node shapes, which is unlikely but worth a quick spot-check.
> 
> **Overview**
> Refactors `react-doctor` rule implementations to use a **strict** `EsTreeNode` (backed by `@typescript-eslint/types`’ `TSESTree.Node` union with a relaxed `parent`) instead of a permissive index-signature type.
> 
> Across rules and utilities, visitor parameters are retargeted to `EsTreeNodeOfType<...>` and numerous call sites add explicit `isNodeOfType`/shape checks (e.g., verifying `VariableDeclarator` initializers are function expressions, guarding `Property` access, and tightening helper return types) to satisfy the new discriminated-union constraints while preserving existing diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c16a29f9726f444a7f3137e7296ad374687510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->