### PR TITLE
refactor(oxlint): split rule-maps.ts into external-plugin-rules + react-doctor-rules

### DIFF
--- a/packages/react-doctor/src/core/runners/oxlint-config.ts
+++ b/packages/react-doctor/src/core/runners/oxlint-config.ts
@@ -6,6 +6,6 @@ export {
   REACT_NATIVE_RULES,
   TANSTACK_QUERY_RULES,
   TANSTACK_START_RULES,
-} from "./oxlint/rule-maps.js";
+} from "./oxlint/react-doctor-rules.js";
 export { createOxlintConfig } from "./oxlint/config.js";
 export type { RuleSeverity } from "./oxlint/types.js";

--- a/packages/react-doctor/src/core/runners/oxlint/config.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/config.ts
@@ -12,7 +12,7 @@ import {
   BUILTIN_REACT_RULES,
   REACT_COMPILER_RULES,
   YOU_MIGHT_NOT_NEED_EFFECT_RULES,
-} from "./rule-maps.js";
+} from "./external-plugin-rules.js";
 import type { OxlintConfigOptions, RuleSeverity } from "./types.js";
 
 export const createOxlintConfig = ({

--- a/packages/react-doctor/src/core/runners/oxlint/external-plugin-rules.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/external-plugin-rules.ts
@@ -1,26 +1,12 @@
-import reactDoctorPlugin from "../../../plugin/react-doctor-plugin.js";
-import type { RuleFramework } from "../../../plugin/utils/rule.js";
 import type { RuleSeverity } from "./types.js";
 
-// Derives a `{ "react-doctor/<rule-id>": <severity> }` map from the rule
-// registry by filtering on each rule's colocated `framework` field. Every
-// react-doctor rule ships `framework` + `severity` next to its `create`
-// function in `defineRule({...})`; rule-maps.ts no longer owns these.
-const collectRulesByFramework = (frameworkName: RuleFramework): Record<string, RuleSeverity> => {
-  const collected: Record<string, RuleSeverity> = {};
-  for (const [ruleId, rule] of Object.entries(reactDoctorPlugin.rules)) {
-    if (rule.framework === frameworkName && rule.severity) {
-      collected[`react-doctor/${ruleId}`] = rule.severity;
-    }
-  }
-  return collected;
-};
-
-export const GLOBAL_REACT_DOCTOR_RULES = collectRulesByFramework("global");
-export const NEXTJS_RULES = collectRulesByFramework("nextjs");
-export const REACT_NATIVE_RULES = collectRulesByFramework("react-native");
-export const TANSTACK_START_RULES = collectRulesByFramework("tanstack-start");
-export const TANSTACK_QUERY_RULES = collectRulesByFramework("tanstack-query");
+// These four maps enumerate rules from OTHER plugins (not react-doctor's own
+// registry) that the scan opts into via the generated oxlint config. They
+// don't have a colocated `defineRule({...})` source like our rules do — the
+// rule definitions live inside their respective npm packages — so the
+// `<rule-key, severity>` pairs have to be enumerated by hand here. New
+// entries land here when we adopt another rule from an upstream plugin or
+// when we want a non-default severity for one already adopted.
 
 // HACK: every diagnostic from `eslint-plugin-react-hooks` (the React
 // Compiler frontend, oxlint-namespaced as `react-hooks-js`) ships at
@@ -99,23 +85,3 @@ export const BUILTIN_A11Y_RULES: Record<string, RuleSeverity> = {
   "jsx-a11y/no-distracting-elements": "error",
   "jsx-a11y/iframe-has-title": "warn",
 };
-
-// HACK: includes every rule that COULD be enabled by createOxlintConfig
-// regardless of framework / TanStack flags. Used only by
-// validateRuleRegistration to assert RULE_CATEGORY_MAP / RULE_HELP_MAP
-// metadata coverage; we want to catch metadata gaps for all conditional
-// rules, not just the ones active in the current scan's framework.
-export const ALL_REACT_DOCTOR_RULE_KEYS: ReadonlySet<string> = new Set([
-  ...Object.keys(GLOBAL_REACT_DOCTOR_RULES),
-  ...Object.keys(NEXTJS_RULES),
-  ...Object.keys(REACT_NATIVE_RULES),
-  ...Object.keys(TANSTACK_START_RULES),
-  ...Object.keys(TANSTACK_QUERY_RULES),
-]);
-
-export const FRAMEWORK_SPECIFIC_RULE_KEYS: ReadonlySet<string> = new Set([
-  ...Object.keys(NEXTJS_RULES),
-  ...Object.keys(REACT_NATIVE_RULES),
-  ...Object.keys(TANSTACK_START_RULES),
-  ...Object.keys(TANSTACK_QUERY_RULES),
-]);

--- a/packages/react-doctor/src/core/runners/oxlint/react-doctor-rules.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/react-doctor-rules.ts
@@ -1,0 +1,49 @@
+import reactDoctorPlugin from "../../../plugin/react-doctor-plugin.js";
+import type { RuleFramework } from "../../../plugin/utils/rule.js";
+import type { RuleSeverity } from "./types.js";
+
+// All exports here are derived at module load from the colocated
+// `defineRule({...})` metadata on each rule in
+// `plugin/rules/<bucket>/<rule>.ts`. None of these values are written by
+// hand — adding a new rule (with `framework` + `severity` in its
+// definition) automatically extends the appropriate map and set.
+
+const formatFullKey = (ruleId: string): string => `react-doctor/${ruleId}`;
+
+// Derives a `{ "react-doctor/<rule-id>": <severity> }` map by filtering
+// the rule registry on each rule's colocated `framework` field. Used by
+// `createOxlintConfig` (oxlint scan) and `eslint-plugin.ts` (ESLint
+// `recommended` / `next` / `react-native` / `tanstack-start` /
+// `tanstack-query` flat configs).
+const collectRulesByFramework = (frameworkName: RuleFramework): Record<string, RuleSeverity> => {
+  const collected: Record<string, RuleSeverity> = {};
+  for (const [ruleId, rule] of Object.entries(reactDoctorPlugin.rules)) {
+    if (rule.framework === frameworkName && rule.severity) {
+      collected[formatFullKey(ruleId)] = rule.severity;
+    }
+  }
+  return collected;
+};
+
+export const GLOBAL_REACT_DOCTOR_RULES = collectRulesByFramework("global");
+export const NEXTJS_RULES = collectRulesByFramework("nextjs");
+export const REACT_NATIVE_RULES = collectRulesByFramework("react-native");
+export const TANSTACK_START_RULES = collectRulesByFramework("tanstack-start");
+export const TANSTACK_QUERY_RULES = collectRulesByFramework("tanstack-query");
+
+// Every rule that COULD be enabled by createOxlintConfig regardless of
+// framework / TanStack flags. Used by `validateRuleRegistration` to assert
+// per-rule metadata coverage (we want to catch metadata gaps for all
+// conditional rules, not just the ones active in the current scan).
+export const ALL_REACT_DOCTOR_RULE_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(reactDoctorPlugin.rules).map(formatFullKey),
+);
+
+// Just the framework-gated rules (`framework !== "global"`) — these need
+// an explicit `requires: [...]` capability gate or they won't activate on
+// any project. Used by `validateRuleRegistration` to enforce that gate.
+export const FRAMEWORK_SPECIFIC_RULE_KEYS: ReadonlySet<string> = new Set(
+  Object.entries(reactDoctorPlugin.rules)
+    .filter(([, rule]) => rule.framework !== "global")
+    .map(([ruleId]) => formatFullKey(ruleId)),
+);

--- a/packages/react-doctor/src/core/runners/oxlint/react-doctor-rules.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/react-doctor-rules.ts
@@ -42,8 +42,11 @@ export const ALL_REACT_DOCTOR_RULE_KEYS: ReadonlySet<string> = new Set(
 // Just the framework-gated rules (`framework !== "global"`) — these need
 // an explicit `requires: [...]` capability gate or they won't activate on
 // any project. Used by `validateRuleRegistration` to enforce that gate.
-export const FRAMEWORK_SPECIFIC_RULE_KEYS: ReadonlySet<string> = new Set(
-  Object.entries(reactDoctorPlugin.rules)
-    .filter(([, rule]) => rule.framework !== "global")
-    .map(([ruleId]) => formatFullKey(ruleId)),
-);
+const collectFrameworkSpecificRuleKeys = (): ReadonlySet<string> => {
+  const collected = new Set<string>();
+  for (const [ruleId, rule] of Object.entries(reactDoctorPlugin.rules)) {
+    if (rule.framework !== "global") collected.add(formatFullKey(ruleId));
+  }
+  return collected;
+};
+export const FRAMEWORK_SPECIFIC_RULE_KEYS = collectFrameworkSpecificRuleKeys();


### PR DESCRIPTION
## Summary

`oxlint/rule-maps.ts` had been mixing two unrelated concerns:
1. Four **hand-maintained** maps of rules adopted from upstream plugins (`react`, `jsx-a11y`, `react-hooks-js`, `you-might-not-need-effect`)
2. Five **derived** react-doctor constants computed from `plugin.rules` (one per framework, plus two `*_KEYS` sets)

After the colocation arc (#228 / #230 / #231 / #234) the file's name and purpose drifted apart. This PR splits the two concerns and deletes the misnamed `rule-maps.ts`.

## Changes

### `oxlint/external-plugin-rules.ts` (new)

The four upstream-plugin maps. Pure data, no derivation. Loaded by `createOxlintConfig` to merge into the generated config:

```ts
export const REACT_COMPILER_RULES: Record<string, RuleSeverity> = { "react-hooks-js/...": "error", ... };
export const YOU_MIGHT_NOT_NEED_EFFECT_RULES: Record<string, RuleSeverity> = { ... };
export const BUILTIN_REACT_RULES: Record<string, RuleSeverity> = { ... };
export const BUILTIN_A11Y_RULES: Record<string, RuleSeverity> = { ... };
```

### `oxlint/react-doctor-rules.ts` (new)

The 5 per-framework maps PLUS `ALL_REACT_DOCTOR_RULE_KEYS` and `FRAMEWORK_SPECIFIC_RULE_KEYS`. All derived at module load from the colocated `defineRule({...})` metadata on each rule:

```ts
export const GLOBAL_REACT_DOCTOR_RULES = collectRulesByFramework("global");
export const NEXTJS_RULES = collectRulesByFramework("nextjs");
// …

export const ALL_REACT_DOCTOR_RULE_KEYS: ReadonlySet<string> = new Set(
  Object.keys(reactDoctorPlugin.rules).map(formatFullKey),
);

export const FRAMEWORK_SPECIFIC_RULE_KEYS: ReadonlySet<string> = new Set(
  Object.entries(reactDoctorPlugin.rules)
    .filter(([, rule]) => rule.framework !== "global")
    .map(([ruleId]) => formatFullKey(ruleId)),
);
```

The two `*_RULE_KEYS` sets now derive **directly** from `plugin.rules` instead of going through the per-framework maps' keys. Cuts one indirection — the source of truth is now `rule.framework` in the registry, not "presence in one of the framework maps".

### `oxlint/rule-maps.ts` (deleted)

## Public API unchanged

`oxlint-config.ts` re-exports the same names from their new locations, so consumers (`run-oxlint.ts`, `merge-and-filter-diagnostics.ts`, `eslint-plugin.ts`) don't move.

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test` — 734 / 734 pass
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean
- [x] Diagnostic snapshot vs `origin/main` — byte-identical 262 lines

## Stats

- 4 files changed, +58 / -43
- 1 file renamed (rule-maps.ts → external-plugin-rules.ts)
- 1 file added (react-doctor-rules.ts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of oxlint rule constant organization with unchanged public exports; minimal behavioral risk aside from potential mis-wiring of imports or rule key sets.
> 
> **Overview**
> Refactors oxlint rule constants by separating *hand-maintained* upstream plugin rule maps into `oxlint/external-plugin-rules.ts` and moving *derived* react-doctor rule maps/sets into `oxlint/react-doctor-rules.ts` (computed from `reactDoctorPlugin.rules`).
> 
> Updates `createOxlintConfig` and `oxlint-config.ts` to import/re-export from the new modules, keeping the existing exported names stable while making `ALL_REACT_DOCTOR_RULE_KEYS`/`FRAMEWORK_SPECIFIC_RULE_KEYS` derive directly from the plugin registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995b9ea1eaf7b12f6e3c607bc64d089779e1c8b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->