### PR TITLE
fix: support member expressions in containsAuthCheck

### DIFF
--- a/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -38,7 +38,7 @@ const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
       // Indirect call e.g. auth0.getSession()
       else if (
         isNodeOfType(callee, "MemberExpression") &&
-        isNodeOfType(callee.property, "Identified") &&
+        isNodeOfType(callee.property, "Identifier") &&
         AUTH_FUNCTION_NAMES.has(callee.property.name)
        ) {
         foundAuthCall = true;

--- a/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -24,12 +24,25 @@ const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
         callNode = child.argument;
       }
 
+      const callee = callNode?.callee;
+      if(!callee) return;
+
+      // Direct call e.g. getSession()
       if (
-        isNodeOfType(callNode?.callee, "Identifier") &&
-        AUTH_FUNCTION_NAMES.has(callNode.callee.name)
+        isNodeOfType(callee, "Identifier") &&
+        AUTH_FUNCTION_NAMES.has(callee.name)
       ) {
         foundAuthCall = true;
-      }
+      } 
+      
+      // Indirect call e.g. auth0.getSession()
+      else if (
+        isNodeOfType(callee, "MemberExpression") &&
+        isNodeOfType(callee.property, "Identified") &&
+        AUTH_FUNCTION_NAMES.has(callee.property.name)
+       ) {
+        foundAuthCall = true;
+       }
     });
   }
   return foundAuthCall;


### PR DESCRIPTION
# Support member expressions for server auth rule

Fixes this case:
```ts
await auth0.getSession() // Currently undetected

// Current workaround
const getSession = async () => await auth0.getSession()
await getSession() // Gets detected
```

I just added an else if to catch that - small diff.

Closes #239

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to AST pattern matching for auth-check detection; main risk is minor false positives/negatives in linting rather than runtime behavior.
> 
> **Overview**
> Updates `containsAuthCheck` in `server-auth-actions.ts` to treat member-expression calls like `auth0.getSession()` (and awaited variants) as valid auth checks, in addition to direct identifier calls such as `getSession()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48965d85ef20a461a8953184bf96d3ffb471e64a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->