### PR TITLE
Security: Regular Expression Denial of Service (ReDoS) in glob pattern compilation

### DIFF
--- a/packages/react-doctor/src/core/config/match-glob-pattern.ts
+++ b/packages/react-doctor/src/core/config/match-glob-pattern.ts
@@ -1,6 +1,17 @@
 const REGEX_SPECIAL_CHARACTERS = /[.+^${}()|[\]\\]/g;
 
+const MAX_PATTERN_LENGTH = 500;
+const MAX_WILDCARDS = 20;
+
 export const compileGlobPattern = (pattern: string): RegExp => {
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    throw new Error(`Glob pattern exceeds maximum length of ${MAX_PATTERN_LENGTH}`);
+  }
+
+  const wildcardCount = (pattern.match(/[*?]/g) || []).length;
+  if (wildcardCount > MAX_WILDCARDS) {
+    throw new Error(`Glob pattern exceeds maximum wildcard count of ${MAX_WILDCARDS}`);
+  }
   const normalizedPattern = pattern.replace(/\\/g, "/").replace(/^\//, "");
 
   let regexSource = "^";


### PR DESCRIPTION
## Problem

The `compileGlobPattern` function in match-glob-pattern.ts compiles user-provided glob patterns into regular expressions without any timeout or complexity limits. Malicious patterns like `**/a*` repeated many times or with nested quantifiers could cause catastrophic backtracking.

**Severity**: `high`
**File**: `packages/react-doctor/src/core/config/match-glob-pattern.ts`

## Solution

Implement a regex complexity check or use a library like `safe-regex` to validate the compiled regex for potential ReDoS. Alternatively, use a glob-to-regex library with built-in protection.

## Changes

- `packages/react-doctor/src/core/config/match-glob-pattern.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds hard limits that now throw errors for overly long or wildcard-heavy ignore patterns, which could break existing configs that relied on very large globs. Change is localized but affects config parsing for ignore rules.
> 
> **Overview**
> Mitigates potential ReDoS in `compileGlobPattern` by enforcing maximum glob *length* and *wildcard count* before compiling to a `RegExp`.
> 
> Invalid/overly complex patterns now throw explicit errors, impacting ignore file/override pattern compilation that calls this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f7bc6619e568f5a948b61bc9eff2d574a95361. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->