### PR TITLE
chore(dead-code): fallow sweep — drop 2 dead constants, dedupe RuleSeverity, fix test exports

### DIFF
--- a/packages/react-doctor/.fallowrc.json
+++ b/packages/react-doctor/.fallowrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "entry": [
+    "src/cli/index.ts",
+    "src/index.ts",
+    "src/plugin/react-doctor-plugin.ts",
+    "src/eslint-plugin.ts",
+    "scripts/*.mjs"
+  ],
+  "ignorePatterns": ["dist/**", "tests/fixtures/**"]
+}

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -79,7 +79,8 @@
     "@types/prompts": "^2.4.9",
     "@typescript-eslint/types": "^8.59.3",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.1"
+    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.1",
+    "fallow": "^2.74.0"
   },
   "peerDependencies": {
     "eslint-plugin-react-hooks": "^6 || ^7",

--- a/packages/react-doctor/src/constants.ts
+++ b/packages/react-doctor/src/constants.ts
@@ -96,10 +96,6 @@ export const JSX_OPENER_SCAN_MAX_LINES = 32;
 // Larger gaps stop being intentional suppressions and become noise.
 export const SUPPRESSION_NEAR_MISS_MAX_LINES = 10;
 
-// `useEffectEvent` requires React 19+. Below the threshold, the rule
-// that suggests it (`prefer-use-effect-event`) stays silent.
-export const USE_EFFECT_EVENT_MIN_MAJOR = 19;
-
 // In the default human output, show several category sections like an
 // audit report, but cap each section so one noisy category does not
 // bury the rest of the scan.

--- a/packages/react-doctor/src/core/runners/oxlint/config.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/config.ts
@@ -13,7 +13,7 @@ import {
   REACT_COMPILER_RULES,
   YOU_MIGHT_NOT_NEED_EFFECT_RULES,
 } from "./external-plugin-rules.js";
-import type { OxlintConfigOptions, RuleSeverity } from "./types.js";
+import type { OxlintConfigOptions, OxlintRuleSeverity } from "./types.js";
 
 export const createOxlintConfig = ({
   pluginPath,
@@ -46,7 +46,7 @@ export const createOxlintConfig = ({
 
   const capabilities = buildCapabilities(project);
 
-  const enabledReactDoctorRules: Record<string, RuleSeverity> = {};
+  const enabledReactDoctorRules: Record<string, OxlintRuleSeverity> = {};
   for (const [ruleId, rule] of Object.entries(reactDoctorPlugin.rules)) {
     const fullKey = `react-doctor/${ruleId}`;
     // Framework-specific rules MUST opt in via a `requires` capability

--- a/packages/react-doctor/src/core/runners/oxlint/external-plugin-rules.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/external-plugin-rules.ts
@@ -1,4 +1,4 @@
-import type { RuleSeverity } from "./types.js";
+import type { OxlintRuleSeverity } from "./types.js";
 
 // These four maps enumerate rules from OTHER plugins (not react-doctor's own
 // registry) that the scan opts into via the generated oxlint config. They
@@ -17,7 +17,7 @@ import type { RuleSeverity } from "./types.js";
 // `"warn"` as part of a broader refactor, which made "React Compiler
 // can't optimize this code" diagnostics stop counting toward
 // `errorCount` and stop failing CI; restored here.
-export const REACT_COMPILER_RULES: Record<string, RuleSeverity> = {
+export const REACT_COMPILER_RULES: Record<string, OxlintRuleSeverity> = {
   "react-hooks-js/set-state-in-render": "error",
   "react-hooks-js/immutability": "error",
   "react-hooks-js/refs": "error",
@@ -43,7 +43,7 @@ export const REACT_COMPILER_RULES: Record<string, RuleSeverity> = {
 // detection for effects. Severities are `warn` to match the rest of
 // the effects-rule cohort and avoid changing CI pass/fail behavior
 // for projects that adopt the plugin.
-export const YOU_MIGHT_NOT_NEED_EFFECT_RULES: Record<string, RuleSeverity> = {
+export const YOU_MIGHT_NOT_NEED_EFFECT_RULES: Record<string, OxlintRuleSeverity> = {
   "effect/no-derived-state": "warn",
   "effect/no-chain-state-updates": "warn",
   "effect/no-event-handler": "warn",
@@ -54,7 +54,7 @@ export const YOU_MIGHT_NOT_NEED_EFFECT_RULES: Record<string, RuleSeverity> = {
   "effect/no-initialize-state": "warn",
 };
 
-export const BUILTIN_REACT_RULES: Record<string, RuleSeverity> = {
+export const BUILTIN_REACT_RULES: Record<string, OxlintRuleSeverity> = {
   "react/rules-of-hooks": "error",
   "react/no-direct-mutation-state": "error",
   "react/jsx-no-duplicate-props": "error",
@@ -69,7 +69,7 @@ export const BUILTIN_REACT_RULES: Record<string, RuleSeverity> = {
   "react/no-unknown-property": "warn",
 };
 
-export const BUILTIN_A11Y_RULES: Record<string, RuleSeverity> = {
+export const BUILTIN_A11Y_RULES: Record<string, OxlintRuleSeverity> = {
   "jsx-a11y/alt-text": "error",
   "jsx-a11y/anchor-is-valid": "warn",
   "jsx-a11y/click-events-have-key-events": "warn",

--- a/packages/react-doctor/src/core/runners/oxlint/plugin-resolution.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/plugin-resolution.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import type { RuleSeverity } from "./types.js";
+import type { OxlintRuleSeverity } from "./types.js";
 
 const esmRequire = createRequire(import.meta.url);
 
@@ -86,16 +86,16 @@ export const resolveYouMightNotNeedEffectPlugin = (
 };
 
 export const filterRulesToAvailable = (
-  rules: Record<string, RuleSeverity>,
+  rules: Record<string, OxlintRuleSeverity>,
   pluginNamespace: string,
   availableRuleNames: ReadonlySet<string>,
-): Record<string, RuleSeverity> => {
+): Record<string, OxlintRuleSeverity> => {
   // Empty `availableRuleNames` means we couldn't introspect the plugin
   // (e.g. exotic export shape). Fall back to the unfiltered rule set so
   // we don't silently disable rules in supported configurations.
   if (availableRuleNames.size === 0) return rules;
   const ruleKeyPrefix = `${pluginNamespace}/`;
-  const filtered: Record<string, RuleSeverity> = {};
+  const filtered: Record<string, OxlintRuleSeverity> = {};
   for (const [ruleKey, severity] of Object.entries(rules)) {
     if (!ruleKey.startsWith(ruleKeyPrefix)) {
       filtered[ruleKey] = severity;

--- a/packages/react-doctor/src/core/runners/oxlint/react-doctor-rules.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/react-doctor-rules.ts
@@ -1,6 +1,6 @@
 import reactDoctorPlugin from "../../../plugin/react-doctor-plugin.js";
 import type { RuleFramework } from "../../../plugin/utils/rule.js";
-import type { RuleSeverity } from "./types.js";
+import type { OxlintRuleSeverity } from "./types.js";
 
 // All exports here are derived at module load from the colocated
 // `defineRule({...})` metadata on each rule in
@@ -15,8 +15,10 @@ const formatFullKey = (ruleId: string): string => `react-doctor/${ruleId}`;
 // `createOxlintConfig` (oxlint scan) and `eslint-plugin.ts` (ESLint
 // `recommended` / `next` / `react-native` / `tanstack-start` /
 // `tanstack-query` flat configs).
-const collectRulesByFramework = (frameworkName: RuleFramework): Record<string, RuleSeverity> => {
-  const collected: Record<string, RuleSeverity> = {};
+const collectRulesByFramework = (
+  frameworkName: RuleFramework,
+): Record<string, OxlintRuleSeverity> => {
+  const collected: Record<string, OxlintRuleSeverity> = {};
   for (const [ruleId, rule] of Object.entries(reactDoctorPlugin.rules)) {
     if (rule.framework === frameworkName && rule.severity) {
       collected[formatFullKey(ruleId)] = rule.severity;

--- a/packages/react-doctor/src/core/runners/oxlint/types.ts
+++ b/packages/react-doctor/src/core/runners/oxlint/types.ts
@@ -1,6 +1,11 @@
 import type { ProjectInfo } from "../../../types/project-info.js";
+import type { RuleSeverity } from "../../../plugin/utils/rule.js";
 
-export type RuleSeverity = "error" | "warn" | "off";
+// Oxlint config entries accept the plugin's per-rule severities plus
+// `"off"`, which the plugin type intentionally omits (an "off" rule is
+// just one that's never registered). Re-export under a distinct name so
+// duplicate-export warnings don't fire on `RuleSeverity` across layers.
+export type OxlintRuleSeverity = RuleSeverity | "off";
 
 export interface OxlintConfigOptions {
   pluginPath: string;

--- a/packages/react-doctor/src/eslint-plugin.ts
+++ b/packages/react-doctor/src/eslint-plugin.ts
@@ -8,7 +8,7 @@ import {
 } from "./core/runners/oxlint/react-doctor-rules.js";
 import type { EsTreeNode } from "./plugin/utils/es-tree-node.js";
 import type { Rule as PluginRule } from "./plugin/utils/rule.js";
-import type { RuleSeverity } from "./core/runners/oxlint/types.js";
+import type { OxlintRuleSeverity } from "./core/runners/oxlint/types.js";
 import type { RuleVisitors } from "./plugin/utils/rule-visitors.js";
 
 interface EslintRuleContext {
@@ -34,7 +34,7 @@ interface EslintRule {
 interface EslintFlatConfig {
   name: string;
   plugins: Record<string, EslintPlugin>;
-  rules: Record<string, RuleSeverity>;
+  rules: Record<string, OxlintRuleSeverity>;
 }
 
 interface EslintPlugin {
@@ -80,14 +80,14 @@ const eslintShapedRules: Record<string, EslintRule> = Object.fromEntries(
 
 const buildFlatConfig = (
   configName: string,
-  ruleSet: Record<string, RuleSeverity>,
+  ruleSet: Record<string, OxlintRuleSeverity>,
 ): EslintFlatConfig => ({
   name: `react-doctor/${configName}`,
   plugins: {},
   rules: { ...ruleSet },
 });
 
-const ALL_RULES_AT_RECOMMENDED_SEVERITY: Record<string, RuleSeverity> = {
+const ALL_RULES_AT_RECOMMENDED_SEVERITY: Record<string, OxlintRuleSeverity> = {
   ...GLOBAL_REACT_DOCTOR_RULES,
   ...NEXTJS_RULES,
   ...REACT_NATIVE_RULES,

--- a/packages/react-doctor/src/plugin/constants/design.ts
+++ b/packages/react-doctor/src/plugin/constants/design.ts
@@ -86,8 +86,6 @@ export const VAGUE_BUTTON_LABELS = new Set([
 
 export const ELLIPSIS_EXCLUDED_TAG_NAMES = new Set(["code", "pre", "kbd", "samp", "var", "tt"]);
 
-export const EM_DASH_CHARACTER = "\u2014";
-
 // HACK: trailing boundary uses a LOOKAHEAD `(?=...)` so the whitespace
 // between Tailwind tokens isn't consumed. With a consuming `(?:$|\s|:)`
 // trailing group, `matchAll` over `"px-4 px-6"` would catch `px-4` plus

--- a/packages/react-doctor/tests/run-oxlint/_helpers.ts
+++ b/packages/react-doctor/tests/run-oxlint/_helpers.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import type { Diagnostic } from "../../src/types/diagnostic.js";
 
-export const FIXTURES_DIRECTORY = path.resolve(import.meta.dirname, "..", "fixtures");
+const FIXTURES_DIRECTORY = path.resolve(import.meta.dirname, "..", "fixtures");
 export const BASIC_REACT_DIRECTORY = path.join(FIXTURES_DIRECTORY, "basic-react");
 export const NEXTJS_APP_DIRECTORY = path.join(FIXTURES_DIRECTORY, "nextjs-app");
 export const TANSTACK_START_APP_DIRECTORY = path.join(FIXTURES_DIRECTORY, "tanstack-start-app");
@@ -12,7 +12,7 @@ export const USER_OXLINT_CONFIG_BROKEN_DIRECTORY = path.join(
   "user-oxlint-config-broken",
 );
 
-export const findDiagnosticsByRule = (diagnostics: Diagnostic[], rule: string): Diagnostic[] =>
+const findDiagnosticsByRule = (diagnostics: Diagnostic[], rule: string): Diagnostic[] =>
   diagnostics.filter((diagnostic) => diagnostic.rule === rule);
 
 export interface RuleTestCase {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       eslint-plugin-react-you-might-not-need-an-effect:
         specifier: ^0.10.1
         version: 0.10.1(eslint@9.39.2(jiti@2.6.1))
+      fallow:
+        specifier: ^2.74.0
+        version: 2.74.0
 
   packages/website:
     dependencies:
@@ -460,6 +463,46 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fallow-cli/darwin-arm64@2.74.0':
+    resolution: {integrity: sha512-zpxOjs8YdVgq82JSQbjph2Zzp8dlNBLC3vWcyAsmoUlnQxUTfmQbCM6PMugrs+7iMpp1IgTIjVXfZsnbua+L1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@fallow-cli/darwin-x64@2.74.0':
+    resolution: {integrity: sha512-0QCR3fsnbhmaHLLIMdhEMeoyvNAP6oxNAyVA3Te3eGjVum7yVy9P7FzN44D1pPerb1qriG4MsJOOfT8Hix/9jg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@fallow-cli/linux-arm64-gnu@2.74.0':
+    resolution: {integrity: sha512-iGsRcR9+fd5WpybXFTBjw1mJigePJgdqp8T6NAqwgz0DgBUB1s8PpAnOUQRLtshfNAhsJdxZTakFuNdV8R7VTQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-arm64-musl@2.74.0':
+    resolution: {integrity: sha512-9uqyXjhp5kRwJxucRxChN4/YmuDyuoPx2iKzqW73JgU08BGIJyY5Olq4B594MmqRrjwmsFm7jFKT8x9BbSvWlA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-gnu@2.74.0':
+    resolution: {integrity: sha512-K2ghYaXH8kmeos9bAKG7+HQLU7Y/hbm/+p9ZyTD28U/S/PdHtiny8KmuCCC7uisy9nUmTnyy59YX///3lkIqxA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/linux-x64-musl@2.74.0':
+    resolution: {integrity: sha512-3YSBIZLEXs47HX8HI2wr+C0QAuqF3eeB+3uDIijXgF0guE58iUrzFLOoFAqEv4cuv5WTvD/PtMllWyCPWkiIaQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@fallow-cli/win32-arm64-msvc@2.74.0':
+    resolution: {integrity: sha512-wjCHg6iKjTwRg2AJ2wl2ryil5XAtxNwI1JbxC7I32uD4mZUnBqDNkijecC61ZGg18JpE3vsumwzqcZbQgPtwdw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@fallow-cli/win32-x64-msvc@2.74.0':
+    resolution: {integrity: sha512-y5AsMPWWlI3gTrsFA+7ggeAMUbQjBQE15i+wu9LLlQs43RQdfY9DylYcMVw8gcQmxx0d+PcL/1WyJYdr8CeqSw==}
+    cpu: [x64]
+    os: [win32]
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1991,6 +2034,11 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  fallow@2.74.0:
+    resolution: {integrity: sha512-Ym1hY5E/5hex0THEfjMrJ0tDPRc0Ax4q+rS8EeVprpG/etpkOa6hSeWktyuG+Bhj7E+PotHg8vrATEGQpNo6qw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3291,6 +3339,30 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fallow-cli/darwin-arm64@2.74.0':
+    optional: true
+
+  '@fallow-cli/darwin-x64@2.74.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-gnu@2.74.0':
+    optional: true
+
+  '@fallow-cli/linux-arm64-musl@2.74.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-gnu@2.74.0':
+    optional: true
+
+  '@fallow-cli/linux-x64-musl@2.74.0':
+    optional: true
+
+  '@fallow-cli/win32-arm64-msvc@2.74.0':
+    optional: true
+
+  '@fallow-cli/win32-x64-msvc@2.74.0':
+    optional: true
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -4325,6 +4397,19 @@ snapshots:
   esutils@2.0.3: {}
 
   extendable-error@0.1.7: {}
+
+  fallow@2.74.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@fallow-cli/darwin-arm64': 2.74.0
+      '@fallow-cli/darwin-x64': 2.74.0
+      '@fallow-cli/linux-arm64-gnu': 2.74.0
+      '@fallow-cli/linux-arm64-musl': 2.74.0
+      '@fallow-cli/linux-x64-gnu': 2.74.0
+      '@fallow-cli/linux-x64-musl': 2.74.0
+      '@fallow-cli/win32-arm64-msvc': 2.74.0
+      '@fallow-cli/win32-x64-msvc': 2.74.0
 
   fast-deep-equal@3.1.3: {}
 


### PR DESCRIPTION
## Summary

Ran [fallow](https://github.com/fallow-rs/fallow) against the repo for dead-code analysis. After configuring the entry points correctly (`.fallowrc.json`), it surfaced 12 candidates — acted on the 5 genuine ones, skipped the 7 false positives / out-of-scope.

### Genuine dead code (deleted)

- **`USE_EFFECT_EVENT_MIN_MAJOR`** (`src/constants.ts`) — only referenced in a comment, never in actual code.
- **`EM_DASH_CHARACTER`** (`src/plugin/constants/design.ts`) — was used by the `no-em-dash-in-jsx-text` rule that #242 deleted as an orphan; stale leftover.

### Test helpers (made internal)

`tests/run-oxlint/_helpers.ts` had `FIXTURES_DIRECTORY` and `findDiagnosticsByRule` marked `export const`, but neither is consumed outside the file. Stripped the `export` keyword.

### Duplicate-export `RuleSeverity` (renamed)

Two declarations with semantically-different types:
- `plugin/utils/rule.ts`: `"error" | "warn"` (plugin defineRule — never `"off"` because off rules aren't registered)
- `core/runners/oxlint/types.ts`: `"error" | "warn" | "off"` (oxlint config entries)

Unified by making the oxlint version derive: `OxlintRuleSeverity = RuleSeverity | "off"`. Renamed all oxlint-layer usages to `OxlintRuleSeverity` to make the distinction clear in code; plugin's `RuleSeverity` is now the single source of truth.

### Tool integration

- Added `fallow` as a devDependency
- Added `.fallowrc.json` listing this project's actual entry points (`src/cli/index.ts`, `src/index.ts`, `src/plugin/react-doctor-plugin.ts`, `src/eslint-plugin.ts`, `scripts/*.mjs`) and excluding `tests/fixtures/**` (intentional broken-code fixtures)

Run `pnpm exec fallow --summary` from the package to re-audit going forward.

## Not acted on (with reasoning)

- 5 `name` field warnings on `Error` subclasses in `src/errors.ts` — the `name` property is consumed by the JS runtime when formatting errors. False positive.
- 2 "unlisted dependency" warnings (`undici`, `vite-plus`) — both available transitively. Adding to `dependencies` would change install behavior, outside dead-code scope.
- 4 "unresolved import" warnings in `tests/fixtures/**` — intentional broken-code fixtures. Now in `.fallowrc.json` `ignorePatterns`.

## Verification

- `pnpm typecheck` — 0 errors
- `pnpm test` — **734 / 734 pass**
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm format` — clean
- **Diagnostic-snapshot diff vs `origin/main` — byte-identical 262 lines**
- **Fallow re-run after fixes: 12 → 7 findings** (all 7 are the false positives / out-of-scope items listed above)

## Stats

- 12 files changed, +126 / -28 net

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: removes unused constants, tightens a couple test-helper exports, and refactors type aliases without changing linting behavior.
> 
> **Overview**
> Adds `fallow` dead-code tooling to `react-doctor` (new `.fallowrc.json` entry/ignore config and devDependency) to support ongoing audits.
> 
> Cleans up unused exports by deleting two dead constants and making two oxlint test helpers file-private.
> 
> Deduplicates severity typing by making oxlint’s config severity type derive from the plugin’s `RuleSeverity` (`OxlintRuleSeverity = RuleSeverity | "off"`) and updating oxlint/eslint config code to use the renamed alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e79400afa8af1dc462492f9b6f7e4a58db156b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->