### PR TITLE
Fix no-barrel-import index false positives

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
@@ -1,10 +1,3 @@
-export const BARREL_INDEX_SUFFIXES = [
-  "/index",
-  "/index.js",
-  "/index.ts",
-  "/index.tsx",
-  "/index.mjs",
-];
 export const PASSIVE_EVENT_NAMES = new Set([
   "scroll",
   "wheel",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
@@ -1,97 +1,9 @@
-import fs from "node:fs";
-import path from "node:path";
 import { defineRule } from "../../utils/define-rule.js";
+import { isBarrelIndexModule } from "../../utils/is-barrel-index-module.js";
+import { resolveRelativeImportPath } from "../../utils/resolve-relative-import-path.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-
-const MODULE_FILE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
-const INDEX_MODULE_FILE_PATTERN = /^index\.(?:[cm]?[jt]sx?|mjs)$/;
-const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
-const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
-const BARREL_REEXPORT_DECLARATION_PATTERN =
-  /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+[\w$]+)?|\{[\s\S]*?\})\s+from\s+["'][^"']+["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
-
-const barrelIndexModuleCache = new Map<string, boolean>();
-
-const getExistingFilePath = (filePath: string): string | null => {
-  try {
-    return fs.statSync(filePath).isFile() ? filePath : null;
-  } catch {
-    return null;
-  }
-};
-
-const getModuleFilePathCandidates = (modulePath: string): string[] => {
-  const extension = path.extname(modulePath);
-  if (!extension) {
-    return MODULE_FILE_EXTENSIONS.map((moduleExtension) => `${modulePath}${moduleExtension}`);
-  }
-
-  const modulePathWithoutExtension = modulePath.slice(0, -extension.length);
-  if (extension === ".js") {
-    return [
-      modulePath,
-      `${modulePathWithoutExtension}.ts`,
-      `${modulePathWithoutExtension}.tsx`,
-      `${modulePathWithoutExtension}.jsx`,
-    ];
-  }
-  if (extension === ".jsx") return [modulePath, `${modulePathWithoutExtension}.tsx`];
-  if (extension === ".mjs") return [modulePath, `${modulePathWithoutExtension}.mts`];
-  if (extension === ".cjs") return [modulePath, `${modulePathWithoutExtension}.cts`];
-
-  return [modulePath];
-};
-
-const resolveModuleFilePath = (modulePath: string): string | null => {
-  const exactFilePath = getExistingFilePath(modulePath);
-  if (exactFilePath) return exactFilePath;
-
-  for (const candidateFilePath of getModuleFilePathCandidates(modulePath)) {
-    const filePath = getExistingFilePath(candidateFilePath);
-    if (filePath) return filePath;
-  }
-
-  return null;
-};
-
-const resolveRelativeImportPath = (filename: string, source: string): string | null => {
-  const importPath = path.resolve(path.dirname(filename), source);
-  const directFilePath = resolveModuleFilePath(importPath);
-  if (directFilePath) return directFilePath;
-
-  return resolveModuleFilePath(path.join(importPath, "index"));
-};
-
-const isIndexModuleFilePath = (filePath: string): boolean =>
-  INDEX_MODULE_FILE_PATTERN.test(path.basename(filePath));
-
-const stripComments = (sourceText: string): string =>
-  sourceText.replace(BLOCK_COMMENT_PATTERN, "").replace(LINE_COMMENT_PATTERN, "");
-
-const isPureReExportBarrel = (sourceText: string): boolean => {
-  const strippedSource = stripComments(sourceText).trim();
-  if (!strippedSource) return false;
-
-  const withoutReExports = strippedSource.replace(BARREL_REEXPORT_DECLARATION_PATTERN, "").trim();
-  return withoutReExports.length === 0;
-};
-
-const isBarrelIndexModule = (filePath: string): boolean => {
-  const cachedResult = barrelIndexModuleCache.get(filePath);
-  if (cachedResult !== undefined) return cachedResult;
-
-  let isBarrel = false;
-  try {
-    isBarrel = isPureReExportBarrel(fs.readFileSync(filePath, "utf8"));
-  } catch {
-    isBarrel = false;
-  }
-
-  barrelIndexModuleCache.set(filePath, isBarrel);
-  return isBarrel;
-};
 
 export const noBarrelImport = defineRule<Rule>({
   id: "no-barrel-import",
@@ -112,11 +24,7 @@ export const noBarrelImport = defineRule<Rule>({
         if (!filename) return;
 
         const resolvedImportPath = resolveRelativeImportPath(filename, source);
-        if (
-          resolvedImportPath &&
-          isIndexModuleFilePath(resolvedImportPath) &&
-          isBarrelIndexModule(resolvedImportPath)
-        ) {
+        if (resolvedImportPath && isBarrelIndexModule(resolvedImportPath)) {
           didReportForFile = true;
           context.report({
             node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
@@ -1,8 +1,97 @@
-import { BARREL_INDEX_SUFFIXES } from "../../constants/dom.js";
+import fs from "node:fs";
+import path from "node:path";
 import { defineRule } from "../../utils/define-rule.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+const MODULE_FILE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
+const INDEX_MODULE_FILE_PATTERN = /^index\.(?:[cm]?[jt]sx?|mjs)$/;
+const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
+const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
+const BARREL_REEXPORT_DECLARATION_PATTERN =
+  /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+[\w$]+)?|\{[\s\S]*?\})\s+from\s+["'][^"']+["']\s*;?\s*/gm;
+
+const barrelIndexModuleCache = new Map<string, boolean>();
+
+const getExistingFilePath = (filePath: string): string | null => {
+  try {
+    return fs.statSync(filePath).isFile() ? filePath : null;
+  } catch {
+    return null;
+  }
+};
+
+const getModuleFilePathCandidates = (modulePath: string): string[] => {
+  const extension = path.extname(modulePath);
+  if (!extension) {
+    return MODULE_FILE_EXTENSIONS.map((moduleExtension) => `${modulePath}${moduleExtension}`);
+  }
+
+  const modulePathWithoutExtension = modulePath.slice(0, -extension.length);
+  if (extension === ".js") {
+    return [
+      modulePath,
+      `${modulePathWithoutExtension}.ts`,
+      `${modulePathWithoutExtension}.tsx`,
+      `${modulePathWithoutExtension}.jsx`,
+    ];
+  }
+  if (extension === ".jsx") return [modulePath, `${modulePathWithoutExtension}.tsx`];
+  if (extension === ".mjs") return [modulePath, `${modulePathWithoutExtension}.mts`];
+  if (extension === ".cjs") return [modulePath, `${modulePathWithoutExtension}.cts`];
+
+  return [modulePath];
+};
+
+const resolveModuleFilePath = (modulePath: string): string | null => {
+  const exactFilePath = getExistingFilePath(modulePath);
+  if (exactFilePath) return exactFilePath;
+
+  for (const candidateFilePath of getModuleFilePathCandidates(modulePath)) {
+    const filePath = getExistingFilePath(candidateFilePath);
+    if (filePath) return filePath;
+  }
+
+  return null;
+};
+
+const resolveRelativeImportPath = (filename: string, source: string): string | null => {
+  const importPath = path.resolve(path.dirname(filename), source);
+  const directFilePath = resolveModuleFilePath(importPath);
+  if (directFilePath) return directFilePath;
+
+  return resolveModuleFilePath(path.join(importPath, "index"));
+};
+
+const isIndexModuleFilePath = (filePath: string): boolean =>
+  INDEX_MODULE_FILE_PATTERN.test(path.basename(filePath));
+
+const stripComments = (sourceText: string): string =>
+  sourceText.replace(BLOCK_COMMENT_PATTERN, "").replace(LINE_COMMENT_PATTERN, "");
+
+const isPureReExportBarrel = (sourceText: string): boolean => {
+  const strippedSource = stripComments(sourceText).trim();
+  if (!strippedSource) return false;
+
+  const withoutReExports = strippedSource.replace(BARREL_REEXPORT_DECLARATION_PATTERN, "").trim();
+  return withoutReExports.length === 0;
+};
+
+const isBarrelIndexModule = (filePath: string): boolean => {
+  const cachedResult = barrelIndexModuleCache.get(filePath);
+  if (cachedResult !== undefined) return cachedResult;
+
+  let isBarrel = false;
+  try {
+    isBarrel = isPureReExportBarrel(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    isBarrel = false;
+  }
+
+  barrelIndexModuleCache.set(filePath, isBarrel);
+  return isBarrel;
+};
 
 export const noBarrelImport = defineRule<Rule>({
   id: "no-barrel-import",
@@ -19,7 +108,15 @@ export const noBarrelImport = defineRule<Rule>({
         const source = node.source?.value;
         if (typeof source !== "string" || !source.startsWith(".")) return;
 
-        if (BARREL_INDEX_SUFFIXES.some((suffix) => source.endsWith(suffix))) {
+        const filename = context.getFilename?.() ?? "";
+        if (!filename) return;
+
+        const resolvedImportPath = resolveRelativeImportPath(filename, source);
+        if (
+          resolvedImportPath &&
+          isIndexModuleFilePath(resolvedImportPath) &&
+          isBarrelIndexModule(resolvedImportPath)
+        ) {
           didReportForFile = true;
           context.report({
             node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
@@ -1,9 +1,62 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { createRelativeImportSource } from "../../utils/create-relative-import-source.js";
 import { isBarrelIndexModule } from "../../utils/is-barrel-index-module.js";
+import { resolveBarrelExportFilePath } from "../../utils/resolve-barrel-export-file-path.js";
 import { resolveRelativeImportPath } from "../../utils/resolve-relative-import-path.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+interface RuntimeImportRequest {
+  importedName: string | null;
+}
+
+const getLiteralName = (node: { type: string; name?: string; value?: unknown }): string | null => {
+  if (node.type === "Identifier" && typeof node.name === "string") return node.name;
+  if (node.type === "Literal" && typeof node.value === "string") return node.value;
+  return null;
+};
+
+const getRuntimeImportRequests = (
+  node: EsTreeNodeOfType<"ImportDeclaration">,
+): RuntimeImportRequest[] => {
+  if (node.importKind === "type") return [];
+
+  return node.specifiers.flatMap((specifier) => {
+    if (specifier.type === "ImportSpecifier") {
+      if (specifier.importKind === "type") return [];
+      return [{ importedName: getLiteralName(specifier.imported) }];
+    }
+    if (specifier.type === "ImportDefaultSpecifier") return [{ importedName: "default" }];
+    return [{ importedName: null }];
+  });
+};
+
+const buildReportMessage = (
+  filename: string,
+  barrelFilePath: string,
+  importRequests: RuntimeImportRequest[],
+): string => {
+  const directImportSources = new Set<string>();
+  for (const request of importRequests) {
+    if (!request.importedName) continue;
+
+    const directFilePath = resolveBarrelExportFilePath(barrelFilePath, request.importedName);
+    if (directFilePath)
+      directImportSources.add(createRelativeImportSource(filename, directFilePath));
+  }
+
+  if (directImportSources.size === 1) {
+    const [directImportSource] = directImportSources;
+    return `Import from barrel/index file — import directly from "${directImportSource}" for better tree-shaking`;
+  }
+
+  if (directImportSources.size > 1) {
+    return `Import from barrel/index file — import directly from source modules: ${[...directImportSources].map((source) => `"${source}"`).join(", ")}`;
+  }
+
+  return "Import from barrel/index file — import directly from the source module for better tree-shaking";
+};
 
 export const noBarrelImport = defineRule<Rule>({
   id: "no-barrel-import",
@@ -23,13 +76,15 @@ export const noBarrelImport = defineRule<Rule>({
         const filename = context.getFilename?.() ?? "";
         if (!filename) return;
 
+        const importRequests = getRuntimeImportRequests(node);
+        if (importRequests.length === 0) return;
+
         const resolvedImportPath = resolveRelativeImportPath(filename, source);
         if (resolvedImportPath && isBarrelIndexModule(resolvedImportPath)) {
           didReportForFile = true;
           context.report({
             node,
-            message:
-              "Import from barrel/index file — import directly from the source module for better tree-shaking",
+            message: buildReportMessage(filename, resolvedImportPath, importRequests),
           });
         }
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
@@ -10,7 +10,7 @@ const INDEX_MODULE_FILE_PATTERN = /^index\.(?:[cm]?[jt]sx?|mjs)$/;
 const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
 const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
 const BARREL_REEXPORT_DECLARATION_PATTERN =
-  /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+[\w$]+)?|\{[\s\S]*?\})\s+from\s+["'][^"']+["']\s*;?\s*/gm;
+  /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+[\w$]+)?|\{[\s\S]*?\})\s+from\s+["'][^"']+["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
 
 const barrelIndexModuleCache = new Map<string, boolean>();
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-relative-import-source.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-relative-import-source.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+
+export const createRelativeImportSource = (filename: string, targetFilePath: string): string => {
+  const targetPathWithoutExtension = targetFilePath.slice(
+    0,
+    targetFilePath.length - path.extname(targetFilePath).length,
+  );
+  const targetModulePath =
+    path.basename(targetPathWithoutExtension) === "index"
+      ? path.dirname(targetPathWithoutExtension)
+      : targetPathWithoutExtension;
+  const relativePath = path
+    .relative(path.dirname(filename), targetModulePath)
+    .split(path.sep)
+    .join("/");
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/does-module-export-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/does-module-export-name.ts
@@ -1,25 +1,15 @@
 import fs from "node:fs";
+import { parseExportSpecifiers } from "./parse-export-specifiers.js";
+import { stripJsComments } from "./strip-js-comments.js";
 
-const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
 const DEFAULT_EXPORT_DECLARATION_PATTERN = /^\s*export\s+default\b/m;
-const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
 const NAMED_EXPORT_DECLARATION_PATTERN =
   /^\s*export\s+(?:declare\s+)?(?:(?:async\s+)?function|(?:abstract\s+)?class|const|let|var|enum|interface|type)\s+([\w$]+)/gm;
 const LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN =
   /^\s*export\s+(?:type\s+)?\{([\s\S]*?)\}(?:\s+from\s+["'][^"']+["'])?\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
 
-const stripComments = (sourceText: string): string =>
-  sourceText.replace(BLOCK_COMMENT_PATTERN, "").replace(LINE_COMMENT_PATTERN, "");
-
-const getSpecifierName = (rawName: string): string => rawName.replace(/^type\s+/, "").trim();
-
-const getExportedSpecifierName = (specifierText: string): string => {
-  const [rawLocalName, rawExportedName] = specifierText.trim().split(/\s+as\s+/);
-  return getSpecifierName(rawExportedName ?? rawLocalName ?? "");
-};
-
 const doesSourceTextExportName = (sourceText: string, exportedName: string): boolean => {
-  const strippedSource = stripComments(sourceText);
+  const strippedSource = stripJsComments(sourceText);
   if (exportedName === "default" && DEFAULT_EXPORT_DECLARATION_PATTERN.test(strippedSource)) {
     return true;
   }
@@ -30,7 +20,9 @@ const doesSourceTextExportName = (sourceText: string, exportedName: string): boo
 
   for (const match of strippedSource.matchAll(LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN)) {
     const specifiersText = match[1] ?? "";
-    const exportedNames = specifiersText.split(",").map(getExportedSpecifierName).filter(Boolean);
+    const exportedNames = parseExportSpecifiers(specifiersText, false).map(
+      (specifier) => specifier.exportedName,
+    );
     if (exportedNames.includes(exportedName)) return true;
   }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/does-module-export-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/does-module-export-name.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+
+const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
+const DEFAULT_EXPORT_DECLARATION_PATTERN = /^\s*export\s+default\b/m;
+const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
+const NAMED_EXPORT_DECLARATION_PATTERN =
+  /^\s*export\s+(?:declare\s+)?(?:(?:async\s+)?function|(?:abstract\s+)?class|const|let|var|enum|interface|type)\s+([\w$]+)/gm;
+const LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN =
+  /^\s*export\s+(?:type\s+)?\{([\s\S]*?)\}(?:\s+from\s+["'][^"']+["'])?\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
+
+const stripComments = (sourceText: string): string =>
+  sourceText.replace(BLOCK_COMMENT_PATTERN, "").replace(LINE_COMMENT_PATTERN, "");
+
+const getSpecifierName = (rawName: string): string => rawName.replace(/^type\s+/, "").trim();
+
+const getExportedSpecifierName = (specifierText: string): string => {
+  const [rawLocalName, rawExportedName] = specifierText.trim().split(/\s+as\s+/);
+  return getSpecifierName(rawExportedName ?? rawLocalName ?? "");
+};
+
+const doesSourceTextExportName = (sourceText: string, exportedName: string): boolean => {
+  const strippedSource = stripComments(sourceText);
+  if (exportedName === "default" && DEFAULT_EXPORT_DECLARATION_PATTERN.test(strippedSource)) {
+    return true;
+  }
+
+  for (const match of strippedSource.matchAll(NAMED_EXPORT_DECLARATION_PATTERN)) {
+    if (match[1] === exportedName) return true;
+  }
+
+  for (const match of strippedSource.matchAll(LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN)) {
+    const specifiersText = match[1] ?? "";
+    const exportedNames = specifiersText.split(",").map(getExportedSpecifierName).filter(Boolean);
+    if (exportedNames.includes(exportedName)) return true;
+  }
+
+  return false;
+};
+
+export const doesModuleExportName = (filePath: string, exportedName: string): boolean => {
+  try {
+    return doesSourceTextExportName(fs.readFileSync(filePath, "utf8"), exportedName);
+  } catch {
+    return false;
+  }
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-barrel-index-module.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-barrel-index-module.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const INDEX_MODULE_FILE_PATTERN = /^index\.(?:[cm]?[jt]sx?|mjs)$/;
+const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
+const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
+const BINDING_IMPORT_DECLARATION_PATTERN =
+  /^\s*import\s+(?!["'])(?:type\s+)?[^;]*?\s+from\s+["'][^"']+["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
+const BARREL_REEXPORT_DECLARATION_PATTERN =
+  /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+[\w$]+)?|\{[\s\S]*?\})\s+from\s+["'][^"']+["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
+const LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN =
+  /^\s*export\s+(?:type\s+)?\{[\s\S]*?\}\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
+
+const barrelIndexModuleCache = new Map<string, boolean>();
+
+const stripComments = (sourceText: string): string =>
+  sourceText.replace(BLOCK_COMMENT_PATTERN, "").replace(LINE_COMMENT_PATTERN, "");
+
+const isIndexModuleFilePath = (filePath: string): boolean =>
+  INDEX_MODULE_FILE_PATTERN.test(path.basename(filePath));
+
+const isPureBarrelModule = (sourceText: string): boolean => {
+  const strippedSource = stripComments(sourceText).trim();
+  if (!strippedSource) return false;
+
+  const withoutBarrelDeclarations = strippedSource
+    .replace(BINDING_IMPORT_DECLARATION_PATTERN, "")
+    .replace(BARREL_REEXPORT_DECLARATION_PATTERN, "")
+    .replace(LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN, "")
+    .trim();
+
+  return withoutBarrelDeclarations.length === 0;
+};
+
+export const isBarrelIndexModule = (filePath: string): boolean => {
+  if (!isIndexModuleFilePath(filePath)) return false;
+
+  const cachedResult = barrelIndexModuleCache.get(filePath);
+  if (cachedResult !== undefined) return cachedResult;
+
+  let isBarrel = false;
+  try {
+    isBarrel = isPureBarrelModule(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    isBarrel = false;
+  }
+
+  barrelIndexModuleCache.set(filePath, isBarrel);
+  return isBarrel;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-barrel-index-module.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-barrel-index-module.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
+import { parseExportSpecifiers } from "./parse-export-specifiers.js";
+import { stripJsComments } from "./strip-js-comments.js";
 
 const INDEX_MODULE_FILE_PATTERN = /^index\.(?:[cm]?[jt]sx?|mjs)$/;
-const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
-const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
 const BINDING_IMPORT_DECLARATION_PATTERN =
   /^\s*import\s+(type\s+)?(?!["'])([^;]*?)\s+from\s+["']([^"']+)["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
 const BARREL_REEXPORT_DECLARATION_PATTERN =
@@ -32,16 +32,7 @@ interface ImportedBinding {
   didExport: boolean;
 }
 
-interface ExportSpecifier {
-  localName: string;
-  exportedName: string;
-  isTypeOnly: boolean;
-}
-
 const barrelIndexModuleInfoCache = new Map<string, BarrelIndexModuleInfo>();
-
-const stripComments = (sourceText: string): string =>
-  sourceText.replace(BLOCK_COMMENT_PATTERN, "").replace(LINE_COMMENT_PATTERN, "");
 
 const isIndexModuleFilePath = (filePath: string): boolean =>
   INDEX_MODULE_FILE_PATTERN.test(path.basename(filePath));
@@ -51,27 +42,6 @@ const createNonBarrelInfo = (): BarrelIndexModuleInfo => ({
   exportsByName: new Map<string, BarrelExportTarget>(),
   starExportSources: [],
 });
-
-const getSpecifierName = (rawName: string): string => rawName.replace(/^type\s+/, "").trim();
-
-const parseExportSpecifiers = (
-  specifiersText: string,
-  declarationIsTypeOnly: boolean,
-): ExportSpecifier[] =>
-  specifiersText
-    .split(",")
-    .map((specifierText) => specifierText.trim())
-    .filter(Boolean)
-    .map((specifierText) => {
-      const isTypeOnly = declarationIsTypeOnly || specifierText.startsWith("type ");
-      const [rawLocalName, rawExportedName] = specifierText.split(/\s+as\s+/);
-      const localName = getSpecifierName(rawLocalName ?? "");
-      return {
-        localName,
-        exportedName: getSpecifierName(rawExportedName ?? localName),
-        isTypeOnly,
-      };
-    });
 
 const addImportedBinding = (
   importedBindings: Map<string, ImportedBinding>,
@@ -86,18 +56,12 @@ const collectNamedImportBindings = (
   declarationIsTypeOnly: boolean,
   importedBindings: Map<string, ImportedBinding>,
 ): void => {
-  for (const specifierText of namedSpecifiersText.split(",")) {
-    const trimmedSpecifier = specifierText.trim();
-    if (!trimmedSpecifier) continue;
-
-    const isTypeOnly = declarationIsTypeOnly || trimmedSpecifier.startsWith("type ");
-    const [rawImportedName, rawLocalName] = trimmedSpecifier.split(/\s+as\s+/);
-    const importedName = getSpecifierName(rawImportedName ?? "");
+  for (const specifier of parseExportSpecifiers(namedSpecifiersText, declarationIsTypeOnly)) {
     addImportedBinding(importedBindings, {
-      localName: getSpecifierName(rawLocalName ?? importedName),
-      importedName,
+      localName: specifier.exportedName,
+      importedName: specifier.localName,
       source,
-      isTypeOnly,
+      isTypeOnly: specifier.isTypeOnly,
     });
   }
 };
@@ -225,7 +189,7 @@ const hasUnexportedRuntimeImport = (importedBindings: Map<string, ImportedBindin
 };
 
 const classifyBarrelModule = (sourceText: string): BarrelIndexModuleInfo => {
-  const strippedSource = stripComments(sourceText).trim();
+  const strippedSource = stripJsComments(sourceText).trim();
   if (!strippedSource) return createNonBarrelInfo();
 
   const importedBindings = new Map<string, ImportedBinding>();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-barrel-index-module.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-barrel-index-module.ts
@@ -5,13 +5,40 @@ const INDEX_MODULE_FILE_PATTERN = /^index\.(?:[cm]?[jt]sx?|mjs)$/;
 const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
 const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
 const BINDING_IMPORT_DECLARATION_PATTERN =
-  /^\s*import\s+(?!["'])(?:type\s+)?[^;]*?\s+from\s+["'][^"']+["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
+  /^\s*import\s+(type\s+)?(?!["'])([^;]*?)\s+from\s+["']([^"']+)["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
 const BARREL_REEXPORT_DECLARATION_PATTERN =
-  /^\s*export\s+(?:type\s+)?(?:\*(?:\s+as\s+[\w$]+)?|\{[\s\S]*?\})\s+from\s+["'][^"']+["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
+  /^\s*export\s+(type\s+)?(?:\*(?:\s+as\s+([\w$]+))?|\{([\s\S]*?)\})\s+from\s+["']([^"']+)["']\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
 const LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN =
-  /^\s*export\s+(?:type\s+)?\{[\s\S]*?\}\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
+  /^\s*export\s+(type\s+)?\{([\s\S]*?)\}\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
 
-const barrelIndexModuleCache = new Map<string, boolean>();
+export interface BarrelExportTarget {
+  exportedName: string;
+  importedName: string;
+  source: string;
+  isTypeOnly: boolean;
+}
+
+export interface BarrelIndexModuleInfo {
+  isBarrel: boolean;
+  exportsByName: Map<string, BarrelExportTarget>;
+  starExportSources: string[];
+}
+
+interface ImportedBinding {
+  localName: string;
+  importedName: string;
+  source: string;
+  isTypeOnly: boolean;
+  didExport: boolean;
+}
+
+interface ExportSpecifier {
+  localName: string;
+  exportedName: string;
+  isTypeOnly: boolean;
+}
+
+const barrelIndexModuleInfoCache = new Map<string, BarrelIndexModuleInfo>();
 
 const stripComments = (sourceText: string): string =>
   sourceText.replace(BLOCK_COMMENT_PATTERN, "").replace(LINE_COMMENT_PATTERN, "");
@@ -19,32 +46,226 @@ const stripComments = (sourceText: string): string =>
 const isIndexModuleFilePath = (filePath: string): boolean =>
   INDEX_MODULE_FILE_PATTERN.test(path.basename(filePath));
 
-const isPureBarrelModule = (sourceText: string): boolean => {
-  const strippedSource = stripComments(sourceText).trim();
-  if (!strippedSource) return false;
+const createNonBarrelInfo = (): BarrelIndexModuleInfo => ({
+  isBarrel: false,
+  exportsByName: new Map<string, BarrelExportTarget>(),
+  starExportSources: [],
+});
 
-  const withoutBarrelDeclarations = strippedSource
-    .replace(BINDING_IMPORT_DECLARATION_PATTERN, "")
-    .replace(BARREL_REEXPORT_DECLARATION_PATTERN, "")
-    .replace(LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN, "")
-    .trim();
+const getSpecifierName = (rawName: string): string => rawName.replace(/^type\s+/, "").trim();
 
-  return withoutBarrelDeclarations.length === 0;
+const parseExportSpecifiers = (
+  specifiersText: string,
+  declarationIsTypeOnly: boolean,
+): ExportSpecifier[] =>
+  specifiersText
+    .split(",")
+    .map((specifierText) => specifierText.trim())
+    .filter(Boolean)
+    .map((specifierText) => {
+      const isTypeOnly = declarationIsTypeOnly || specifierText.startsWith("type ");
+      const [rawLocalName, rawExportedName] = specifierText.split(/\s+as\s+/);
+      const localName = getSpecifierName(rawLocalName ?? "");
+      return {
+        localName,
+        exportedName: getSpecifierName(rawExportedName ?? localName),
+        isTypeOnly,
+      };
+    });
+
+const addImportedBinding = (
+  importedBindings: Map<string, ImportedBinding>,
+  binding: Omit<ImportedBinding, "didExport">,
+): void => {
+  importedBindings.set(binding.localName, { ...binding, didExport: false });
 };
 
-export const isBarrelIndexModule = (filePath: string): boolean => {
-  if (!isIndexModuleFilePath(filePath)) return false;
+const collectNamedImportBindings = (
+  namedSpecifiersText: string,
+  source: string,
+  declarationIsTypeOnly: boolean,
+  importedBindings: Map<string, ImportedBinding>,
+): void => {
+  for (const specifierText of namedSpecifiersText.split(",")) {
+    const trimmedSpecifier = specifierText.trim();
+    if (!trimmedSpecifier) continue;
 
-  const cachedResult = barrelIndexModuleCache.get(filePath);
-  if (cachedResult !== undefined) return cachedResult;
+    const isTypeOnly = declarationIsTypeOnly || trimmedSpecifier.startsWith("type ");
+    const [rawImportedName, rawLocalName] = trimmedSpecifier.split(/\s+as\s+/);
+    const importedName = getSpecifierName(rawImportedName ?? "");
+    addImportedBinding(importedBindings, {
+      localName: getSpecifierName(rawLocalName ?? importedName),
+      importedName,
+      source,
+      isTypeOnly,
+    });
+  }
+};
 
-  let isBarrel = false;
-  try {
-    isBarrel = isPureBarrelModule(fs.readFileSync(filePath, "utf8"));
-  } catch {
-    isBarrel = false;
+const collectImportBindings = (
+  importClause: string,
+  source: string,
+  declarationIsTypeOnly: boolean,
+  importedBindings: Map<string, ImportedBinding>,
+): void => {
+  const trimmedImportClause = importClause.trim();
+  const namespaceMatch = trimmedImportClause.match(/(?:^|,\s*)\*\s+as\s+([\w$]+)/);
+  if (namespaceMatch?.[1]) {
+    addImportedBinding(importedBindings, {
+      localName: namespaceMatch[1],
+      importedName: "*",
+      source,
+      isTypeOnly: declarationIsTypeOnly,
+    });
   }
 
-  barrelIndexModuleCache.set(filePath, isBarrel);
-  return isBarrel;
+  const namedImportMatch = trimmedImportClause.match(/\{([\s\S]*?)\}/);
+  if (namedImportMatch?.[1]) {
+    collectNamedImportBindings(
+      namedImportMatch[1],
+      source,
+      declarationIsTypeOnly,
+      importedBindings,
+    );
+  }
+
+  const defaultImportName = trimmedImportClause.split(",")[0]?.trim();
+  if (
+    defaultImportName &&
+    !defaultImportName.startsWith("{") &&
+    !defaultImportName.startsWith("*")
+  ) {
+    addImportedBinding(importedBindings, {
+      localName: defaultImportName,
+      importedName: "default",
+      source,
+      isTypeOnly: declarationIsTypeOnly,
+    });
+  }
 };
+
+const replaceKnownDeclarations = (
+  sourceText: string,
+  importedBindings: Map<string, ImportedBinding>,
+  exportsByName: Map<string, BarrelExportTarget>,
+  starExportSources: string[],
+): string => {
+  let withoutKnownDeclarations = sourceText.replace(
+    BINDING_IMPORT_DECLARATION_PATTERN,
+    (_match, typeKeyword: string | undefined, importClause: string, source: string) => {
+      collectImportBindings(importClause, source, Boolean(typeKeyword), importedBindings);
+      return "";
+    },
+  );
+
+  withoutKnownDeclarations = withoutKnownDeclarations.replace(
+    BARREL_REEXPORT_DECLARATION_PATTERN,
+    (
+      _match,
+      typeKeyword: string | undefined,
+      namespaceExportName: string | undefined,
+      specifiersText: string | undefined,
+      source: string,
+    ) => {
+      const isTypeOnly = Boolean(typeKeyword);
+      if (namespaceExportName) {
+        exportsByName.set(namespaceExportName, {
+          exportedName: namespaceExportName,
+          importedName: "*",
+          source,
+          isTypeOnly,
+        });
+        return "";
+      }
+
+      if (specifiersText) {
+        for (const specifier of parseExportSpecifiers(specifiersText, isTypeOnly)) {
+          exportsByName.set(specifier.exportedName, {
+            exportedName: specifier.exportedName,
+            importedName: specifier.localName,
+            source,
+            isTypeOnly: specifier.isTypeOnly,
+          });
+        }
+        return "";
+      }
+
+      starExportSources.push(source);
+      return "";
+    },
+  );
+
+  withoutKnownDeclarations = withoutKnownDeclarations.replace(
+    LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN,
+    (_match, typeKeyword: string | undefined, specifiersText: string) => {
+      for (const specifier of parseExportSpecifiers(specifiersText, Boolean(typeKeyword))) {
+        const importedBinding = importedBindings.get(specifier.localName);
+        if (!importedBinding) return _match;
+
+        importedBinding.didExport = true;
+        exportsByName.set(specifier.exportedName, {
+          exportedName: specifier.exportedName,
+          importedName: importedBinding.importedName,
+          source: importedBinding.source,
+          isTypeOnly: specifier.isTypeOnly || importedBinding.isTypeOnly,
+        });
+      }
+      return "";
+    },
+  );
+
+  return withoutKnownDeclarations;
+};
+
+const hasUnexportedRuntimeImport = (importedBindings: Map<string, ImportedBinding>): boolean => {
+  for (const binding of importedBindings.values()) {
+    if (!binding.isTypeOnly && !binding.didExport) return true;
+  }
+  return false;
+};
+
+const classifyBarrelModule = (sourceText: string): BarrelIndexModuleInfo => {
+  const strippedSource = stripComments(sourceText).trim();
+  if (!strippedSource) return createNonBarrelInfo();
+
+  const importedBindings = new Map<string, ImportedBinding>();
+  const exportsByName = new Map<string, BarrelExportTarget>();
+  const starExportSources: string[] = [];
+  const remainingSource = replaceKnownDeclarations(
+    strippedSource,
+    importedBindings,
+    exportsByName,
+    starExportSources,
+  ).trim();
+
+  if (remainingSource || hasUnexportedRuntimeImport(importedBindings)) {
+    return createNonBarrelInfo();
+  }
+
+  const hasBarrelExport = exportsByName.size > 0 || starExportSources.length > 0;
+  return {
+    isBarrel: hasBarrelExport,
+    exportsByName,
+    starExportSources,
+  };
+};
+
+export const getBarrelIndexModuleInfo = (filePath: string): BarrelIndexModuleInfo => {
+  if (!isIndexModuleFilePath(filePath)) return createNonBarrelInfo();
+
+  const cachedResult = barrelIndexModuleInfoCache.get(filePath);
+  if (cachedResult !== undefined) return cachedResult;
+
+  let moduleInfo = createNonBarrelInfo();
+  try {
+    moduleInfo = classifyBarrelModule(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    moduleInfo = createNonBarrelInfo();
+  }
+
+  barrelIndexModuleInfoCache.set(filePath, moduleInfo);
+  return moduleInfo;
+};
+
+export const isBarrelIndexModule = (filePath: string): boolean =>
+  getBarrelIndexModuleInfo(filePath).isBarrel;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/parse-export-specifiers.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/parse-export-specifiers.ts
@@ -1,0 +1,26 @@
+export interface ExportSpecifier {
+  localName: string;
+  exportedName: string;
+  isTypeOnly: boolean;
+}
+
+const getSpecifierName = (rawName: string): string => rawName.replace(/^type\s+/, "").trim();
+
+export const parseExportSpecifiers = (
+  specifiersText: string,
+  declarationIsTypeOnly: boolean,
+): ExportSpecifier[] =>
+  specifiersText
+    .split(",")
+    .map((specifierText) => specifierText.trim())
+    .filter(Boolean)
+    .map((specifierText) => {
+      const isTypeOnly = declarationIsTypeOnly || specifierText.startsWith("type ");
+      const [rawLocalName, rawExportedName] = specifierText.split(/\s+as\s+/);
+      const localName = getSpecifierName(rawLocalName ?? "");
+      return {
+        localName,
+        exportedName: getSpecifierName(rawExportedName ?? localName),
+        isTypeOnly,
+      };
+    });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-barrel-export-file-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-barrel-export-file-path.ts
@@ -1,0 +1,44 @@
+import { getBarrelIndexModuleInfo } from "./is-barrel-index-module.js";
+import { resolveRelativeImportPath } from "./resolve-relative-import-path.js";
+
+export const resolveBarrelExportFilePath = (
+  barrelFilePath: string,
+  exportedName: string,
+  visitedFilePaths = new Set<string>(),
+): string | null => {
+  if (visitedFilePaths.has(barrelFilePath)) return null;
+  visitedFilePaths.add(barrelFilePath);
+
+  const moduleInfo = getBarrelIndexModuleInfo(barrelFilePath);
+  if (!moduleInfo.isBarrel) return null;
+
+  const target = moduleInfo.exportsByName.get(exportedName);
+  if (target) {
+    const resolvedTargetPath = resolveRelativeImportPath(barrelFilePath, target.source);
+    if (!resolvedTargetPath) return null;
+
+    const nestedTargetPath = resolveBarrelExportFilePath(
+      resolvedTargetPath,
+      target.importedName,
+      visitedFilePaths,
+    );
+    return nestedTargetPath ?? resolvedTargetPath;
+  }
+
+  if (moduleInfo.starExportSources.length === 1) {
+    const resolvedTargetPath = resolveRelativeImportPath(
+      barrelFilePath,
+      moduleInfo.starExportSources[0] ?? "",
+    );
+    if (!resolvedTargetPath) return null;
+
+    const nestedTargetPath = resolveBarrelExportFilePath(
+      resolvedTargetPath,
+      exportedName,
+      visitedFilePaths,
+    );
+    return nestedTargetPath ?? resolvedTargetPath;
+  }
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-barrel-export-file-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-barrel-export-file-path.ts
@@ -1,5 +1,33 @@
+import { doesModuleExportName } from "./does-module-export-name.js";
 import { getBarrelIndexModuleInfo } from "./is-barrel-index-module.js";
 import { resolveRelativeImportPath } from "./resolve-relative-import-path.js";
+
+const getUniqueFilePath = (filePaths: string[]): string | null => {
+  const uniqueFilePaths = new Set(filePaths);
+  if (uniqueFilePaths.size !== 1) return null;
+
+  const [filePath] = uniqueFilePaths;
+  return filePath ?? null;
+};
+
+const resolveStarExportFilePath = (
+  barrelFilePath: string,
+  exportedName: string,
+  source: string,
+  visitedFilePaths: Set<string>,
+): string | null => {
+  const resolvedTargetPath = resolveRelativeImportPath(barrelFilePath, source);
+  if (!resolvedTargetPath) return null;
+
+  const nestedTargetPath = resolveBarrelExportFilePath(
+    resolvedTargetPath,
+    exportedName,
+    new Set(visitedFilePaths),
+  );
+  if (nestedTargetPath) return nestedTargetPath;
+
+  return doesModuleExportName(resolvedTargetPath, exportedName) ? resolvedTargetPath : null;
+};
 
 export const resolveBarrelExportFilePath = (
   barrelFilePath: string,
@@ -25,20 +53,12 @@ export const resolveBarrelExportFilePath = (
     return nestedTargetPath ?? resolvedTargetPath;
   }
 
-  if (moduleInfo.starExportSources.length === 1) {
-    const resolvedTargetPath = resolveRelativeImportPath(
-      barrelFilePath,
-      moduleInfo.starExportSources[0] ?? "",
-    );
-    if (!resolvedTargetPath) return null;
+  if (exportedName === "default") return null;
 
-    const nestedTargetPath = resolveBarrelExportFilePath(
-      resolvedTargetPath,
-      exportedName,
-      visitedFilePaths,
-    );
-    return nestedTargetPath ?? resolvedTargetPath;
-  }
-
-  return null;
+  const starExportFilePaths = moduleInfo.starExportSources
+    .map((source) =>
+      resolveStarExportFilePath(barrelFilePath, exportedName, source, visitedFilePaths),
+    )
+    .filter((filePath): filePath is string => Boolean(filePath));
+  return getUniqueFilePath(starExportFilePaths);
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const MODULE_FILE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
+
+const getExistingFilePath = (filePath: string): string | null => {
+  try {
+    return fs.statSync(filePath).isFile() ? filePath : null;
+  } catch {
+    return null;
+  }
+};
+
+const getModuleFilePathCandidates = (modulePath: string): string[] => {
+  const extension = path.extname(modulePath);
+  if (!extension) {
+    return MODULE_FILE_EXTENSIONS.map((moduleExtension) => `${modulePath}${moduleExtension}`);
+  }
+
+  const modulePathWithoutExtension = modulePath.slice(0, -extension.length);
+  if (extension === ".js") {
+    return [
+      modulePath,
+      `${modulePathWithoutExtension}.ts`,
+      `${modulePathWithoutExtension}.tsx`,
+      `${modulePathWithoutExtension}.jsx`,
+    ];
+  }
+  if (extension === ".jsx") return [modulePath, `${modulePathWithoutExtension}.tsx`];
+  if (extension === ".mjs") return [modulePath, `${modulePathWithoutExtension}.mts`];
+  if (extension === ".cjs") return [modulePath, `${modulePathWithoutExtension}.cts`];
+
+  return [modulePath];
+};
+
+const resolveModuleFilePath = (modulePath: string): string | null => {
+  const exactFilePath = getExistingFilePath(modulePath);
+  if (exactFilePath) return exactFilePath;
+
+  for (const candidateFilePath of getModuleFilePathCandidates(modulePath)) {
+    const filePath = getExistingFilePath(candidateFilePath);
+    if (filePath) return filePath;
+  }
+
+  return null;
+};
+
+export const resolveRelativeImportPath = (filename: string, source: string): string | null => {
+  const importPath = path.resolve(path.dirname(filename), source);
+  const directFilePath = resolveModuleFilePath(importPath);
+  if (directFilePath) return directFilePath;
+
+  return resolveModuleFilePath(path.join(importPath, "index"));
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
@@ -48,6 +48,13 @@ const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
 
 const getConditionalExportEntry = (exportEntry: unknown): string | null => {
   if (typeof exportEntry === "string") return exportEntry;
+  if (Array.isArray(exportEntry)) {
+    for (const fallbackEntry of exportEntry) {
+      const resolvedFallbackEntry = getConditionalExportEntry(fallbackEntry);
+      if (resolvedFallbackEntry) return resolvedFallbackEntry;
+    }
+    return null;
+  }
   if (!isObjectRecord(exportEntry)) return null;
 
   for (const condition of PACKAGE_EXPORT_CONDITIONS) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
@@ -2,10 +2,19 @@ import fs from "node:fs";
 import path from "node:path";
 
 const MODULE_FILE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
+const PACKAGE_ENTRY_FIELDS = ["module", "main", "browser"];
 
 const getExistingFilePath = (filePath: string): string | null => {
   try {
     return fs.statSync(filePath).isFile() ? filePath : null;
+  } catch {
+    return null;
+  }
+};
+
+const getExistingDirectoryPath = (directoryPath: string): string | null => {
+  try {
+    return fs.statSync(directoryPath).isDirectory() ? directoryPath : null;
   } catch {
     return null;
   }
@@ -33,6 +42,44 @@ const getModuleFilePathCandidates = (modulePath: string): string[] => {
   return [modulePath];
 };
 
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const getPackageExportEntry = (packageJson: Record<string, unknown>): string | null => {
+  const exportsField = packageJson.exports;
+  if (typeof exportsField === "string") return exportsField;
+  if (!isObjectRecord(exportsField)) return null;
+
+  const rootExport = exportsField["."];
+  if (typeof rootExport === "string") return rootExport;
+  if (!isObjectRecord(rootExport)) return null;
+
+  const importEntry = rootExport.import ?? rootExport.default;
+  return typeof importEntry === "string" ? importEntry : null;
+};
+
+const resolvePackageDirectoryEntry = (directoryPath: string): string | null => {
+  const existingDirectoryPath = getExistingDirectoryPath(directoryPath);
+  if (!existingDirectoryPath) return null;
+
+  const packageJsonPath = path.join(existingDirectoryPath, "package.json");
+  try {
+    const packageJson: Record<string, unknown> = JSON.parse(
+      fs.readFileSync(packageJsonPath, "utf8"),
+    );
+    const packageEntry =
+      getPackageExportEntry(packageJson) ??
+      PACKAGE_ENTRY_FIELDS.map((fieldName) => packageJson[fieldName]).find(
+        (value): value is string => typeof value === "string",
+      );
+    if (!packageEntry) return null;
+
+    return resolveModuleFilePath(path.resolve(existingDirectoryPath, packageEntry));
+  } catch {
+    return null;
+  }
+};
+
 const resolveModuleFilePath = (modulePath: string): string | null => {
   const exactFilePath = getExistingFilePath(modulePath);
   if (exactFilePath) return exactFilePath;
@@ -49,6 +96,9 @@ export const resolveRelativeImportPath = (filename: string, source: string): str
   const importPath = path.resolve(path.dirname(filename), source);
   const directFilePath = resolveModuleFilePath(importPath);
   if (directFilePath) return directFilePath;
+
+  const packageEntryFilePath = resolvePackageDirectoryEntry(importPath);
+  if (packageEntryFilePath) return packageEntryFilePath;
 
   return resolveModuleFilePath(path.join(importPath, "index"));
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const MODULE_FILE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
+const PACKAGE_EXPORT_CONDITIONS = ["import", "default", "module", "browser", "require"];
 const PACKAGE_ENTRY_FIELDS = ["module", "main", "browser"];
 
 const getExistingFilePath = (filePath: string): string | null => {
@@ -45,17 +46,34 @@ const getModuleFilePathCandidates = (modulePath: string): string[] => {
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+const getConditionalExportEntry = (exportEntry: unknown): string | null => {
+  if (typeof exportEntry === "string") return exportEntry;
+  if (!isObjectRecord(exportEntry)) return null;
+
+  for (const condition of PACKAGE_EXPORT_CONDITIONS) {
+    const nestedEntry = getConditionalExportEntry(exportEntry[condition]);
+    if (nestedEntry) return nestedEntry;
+  }
+
+  return null;
+};
+
 const getPackageExportEntry = (packageJson: Record<string, unknown>): string | null => {
   const exportsField = packageJson.exports;
-  if (typeof exportsField === "string") return exportsField;
+  if (!exportsField) return null;
+
+  const directExportEntry = getConditionalExportEntry(exportsField);
+  if (directExportEntry) return directExportEntry;
+
   if (!isObjectRecord(exportsField)) return null;
+  return getConditionalExportEntry(exportsField["."]);
+};
 
-  const rootExport = exportsField["."];
-  if (typeof rootExport === "string") return rootExport;
-  if (!isObjectRecord(rootExport)) return null;
+const resolveModulePathWithIndexFallback = (modulePath: string): string | null => {
+  const filePath = resolveModuleFilePath(modulePath);
+  if (filePath) return filePath;
 
-  const importEntry = rootExport.import ?? rootExport.default;
-  return typeof importEntry === "string" ? importEntry : null;
+  return resolveModuleFilePath(path.join(modulePath, "index"));
 };
 
 const resolvePackageDirectoryEntry = (directoryPath: string): string | null => {
@@ -74,7 +92,7 @@ const resolvePackageDirectoryEntry = (directoryPath: string): string | null => {
       );
     if (!packageEntry) return null;
 
-    return resolveModuleFilePath(path.resolve(existingDirectoryPath, packageEntry));
+    return resolveModulePathWithIndexFallback(path.resolve(existingDirectoryPath, packageEntry));
   } catch {
     return null;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/strip-js-comments.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/strip-js-comments.ts
@@ -1,0 +1,5 @@
+const BLOCK_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
+const LINE_COMMENT_PATTERN = /^\s*\/\/.*$/gm;
+
+export const stripJsComments = (sourceText: string): string =>
+  sourceText.replace(BLOCK_COMMENT_PATTERN, "").replace(LINE_COMMENT_PATTERN, "");

--- a/packages/oxlint-plugin-react-doctor/tsconfig.json
+++ b/packages/oxlint-plugin-react-doctor/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
@@ -1,8 +1,13 @@
-import { beforeAll, describe } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeAll, describe, expect, it } from "vite-plus/test";
 import type { Diagnostic } from "@react-doctor/types";
 import { runOxlint } from "@react-doctor/core";
-import { buildTestProject } from "../regressions/_helpers.js";
+import { buildTestProject, collectRuleHits, setupReactProject } from "../regressions/_helpers.js";
 import { BASIC_REACT_DIRECTORY, describeRules } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-no-barrel-import-"));
 
 let basicReactDiagnostics: Diagnostic[];
 
@@ -25,6 +30,10 @@ describe("runOxlint", () => {
         ruleSource: "rules/bundle-size.ts",
         category: "Bundle Size",
       },
+      "no-barrel-import": {
+        fixture: "bundle-issues.tsx",
+        ruleSource: "rules/bundle-size.ts",
+      },
       "no-moment": {
         fixture: "bundle-issues.tsx",
         ruleSource: "rules/bundle-size.ts",
@@ -44,4 +53,47 @@ describe("runOxlint", () => {
     },
     () => basicReactDiagnostics,
   );
+
+  describe("no-barrel-import", () => {
+    it("does not flag a test importing the sibling index module under test", async () => {
+      const projectDir = setupReactProject(tempRoot, "sibling-index-module", {
+        files: {
+          "src/index.ts": "export const Route = '/users';\n",
+          "src/index.e2e.test.ts": "import { Route } from './index';\nvoid Route;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toEqual([]);
+    });
+
+    it("flags explicit index and directory imports when the resolved index is a barrel", async () => {
+      const projectDir = setupReactProject(tempRoot, "barrel-index-module", {
+        files: {
+          "src/components/Button.tsx": "export const Button = () => null;\n",
+          "src/components/index.ts": "export { Button } from './Button';\n",
+          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+          "src/import-explicit-index.tsx":
+            "import { Button } from './components/index';\nvoid Button;\n",
+          "src/import-js-extension.tsx":
+            "import { Button } from './components/index.js';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+      const hitFilePaths = hits.map((hit) => hit.filePath.replaceAll("\\", "/"));
+
+      expect(hits).toHaveLength(3);
+      expect(hitFilePaths.some((filePath) => filePath.endsWith("src/import-directory.tsx"))).toBe(
+        true,
+      );
+      expect(
+        hitFilePaths.some((filePath) => filePath.endsWith("src/import-explicit-index.tsx")),
+      ).toBe(true);
+      expect(
+        hitFilePaths.some((filePath) => filePath.endsWith("src/import-js-extension.tsx")),
+      ).toBe(true);
+    });
+  });
 });

--- a/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
@@ -112,5 +112,22 @@ describe("runOxlint", () => {
         true,
       );
     });
+
+    it("flags import-then-export index barrels", async () => {
+      const projectDir = setupReactProject(tempRoot, "import-export-barrel-index-module", {
+        files: {
+          "src/components/Button.tsx": "export const Button = () => null;\n",
+          "src/components/index.ts": "import { Button } from './Button';\n\nexport { Button };\n",
+          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.filePath.replaceAll("\\", "/").endsWith("src/import-directory.tsx")).toBe(
+        true,
+      );
+    });
   });
 });

--- a/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
@@ -283,5 +283,27 @@ describe("runOxlint", () => {
       expect(hits).toHaveLength(1);
       expect(hits[0]?.message).toContain('"./components/Button"');
     });
+
+    it("resolves package export array fallbacks", async () => {
+      const projectDir = setupReactProject(tempRoot, "package-export-array-barrel", {
+        files: {
+          "src/components/Button.tsx": "export const Button = () => null;\n",
+          "src/components/entry/index.ts": "export { Button } from '../Button';\n",
+          "src/components/package.json": JSON.stringify({
+            exports: [
+              {
+                import: "./entry",
+              },
+            ],
+          }),
+          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.message).toContain('"./components/Button"');
+    });
   });
 });

--- a/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
@@ -72,7 +72,7 @@ describe("runOxlint", () => {
       const projectDir = setupReactProject(tempRoot, "barrel-index-module", {
         files: {
           "src/components/Button.tsx": "export const Button = () => null;\n",
-          "src/components/index.ts": "export { Button } from './Button'; // UI component\n",
+          "src/components/index.ts": "export { Button } from './Button';\n",
           "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
           "src/import-explicit-index.tsx":
             "import { Button } from './components/index';\nvoid Button;\n",
@@ -94,6 +94,23 @@ describe("runOxlint", () => {
       expect(
         hitFilePaths.some((filePath) => filePath.endsWith("src/import-js-extension.tsx")),
       ).toBe(true);
+    });
+
+    it("flags barrel re-exports with trailing inline comments", async () => {
+      const projectDir = setupReactProject(tempRoot, "commented-barrel-index-module", {
+        files: {
+          "src/components/Button.tsx": "export const Button = () => null;\n",
+          "src/components/index.ts": "export { Button } from './Button'; // UI component\n",
+          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.filePath.replaceAll("\\", "/").endsWith("src/import-directory.tsx")).toBe(
+        true,
+      );
     });
   });
 });

--- a/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
@@ -72,7 +72,7 @@ describe("runOxlint", () => {
       const projectDir = setupReactProject(tempRoot, "barrel-index-module", {
         files: {
           "src/components/Button.tsx": "export const Button = () => null;\n",
-          "src/components/index.ts": "export { Button } from './Button';\n",
+          "src/components/index.ts": "export { Button } from './Button'; // UI component\n",
           "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
           "src/import-explicit-index.tsx":
             "import { Button } from './components/index';\nvoid Button;\n",

--- a/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
@@ -134,6 +134,43 @@ describe("runOxlint", () => {
       expect(hits[0]?.message).toContain('"./components/button/Button"');
     });
 
+    it("resolves direct guidance through multi-source star barrels when names are unambiguous", async () => {
+      const projectDir = setupReactProject(tempRoot, "multi-star-barrel-index-module", {
+        files: {
+          "src/components/Button.tsx": "export const Button = () => null;\n",
+          "src/components/Input.tsx": "export const Input = () => null;\n",
+          "src/components/index.ts": "export * from './Button';\nexport * from './Input';\n",
+          "src/import-directory.tsx":
+            "import { Button, Input } from './components';\nvoid Button;\nvoid Input;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.message).toContain('"./components/Button"');
+      expect(hits[0]?.message).toContain('"./components/Input"');
+    });
+
+    it("does not guess direct guidance for ambiguous multi-source star barrels", async () => {
+      const projectDir = setupReactProject(tempRoot, "ambiguous-star-barrel-index-module", {
+        files: {
+          "src/components/PrimaryButton.tsx": "export const Button = () => null;\n",
+          "src/components/SecondaryButton.tsx": "export const Button = () => null;\n",
+          "src/components/index.ts":
+            "export * from './PrimaryButton';\nexport * from './SecondaryButton';\n",
+          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.message).toBe(
+        "Import from barrel/index file — import directly from the source module for better tree-shaking",
+      );
+    });
+
     it("flags barrel re-exports with trailing inline comments", async () => {
       const projectDir = setupReactProject(tempRoot, "commented-barrel-index-module", {
         files: {
@@ -215,6 +252,28 @@ describe("runOxlint", () => {
           "src/components/Button.tsx": "export const Button = () => null;\n",
           "src/components/index.ts": "export { Button } from './Button';\n",
           "src/components/package.json": JSON.stringify({ exports: "./index.ts" }),
+          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.message).toContain('"./components/Button"');
+    });
+
+    it("resolves package export condition objects and directory entries", async () => {
+      const projectDir = setupReactProject(tempRoot, "package-conditional-entry-barrel", {
+        files: {
+          "src/components/Button.tsx": "export const Button = () => null;\n",
+          "src/components/entry/index.ts": "export { Button } from '../Button';\n",
+          "src/components/package.json": JSON.stringify({
+            exports: {
+              import: {
+                default: "./entry",
+              },
+            },
+          }),
           "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
         },
       });

--- a/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/bundle-size.test.ts
@@ -85,6 +85,7 @@ describe("runOxlint", () => {
       const hitFilePaths = hits.map((hit) => hit.filePath.replaceAll("\\", "/"));
 
       expect(hits).toHaveLength(3);
+      expect(hits[0]?.message).toContain('"./components/Button"');
       expect(hitFilePaths.some((filePath) => filePath.endsWith("src/import-directory.tsx"))).toBe(
         true,
       );
@@ -94,6 +95,43 @@ describe("runOxlint", () => {
       expect(
         hitFilePaths.some((filePath) => filePath.endsWith("src/import-js-extension.tsx")),
       ).toBe(true);
+    });
+
+    it("flags aliased default and namespace re-exports with direct source guidance", async () => {
+      const projectDir = setupReactProject(tempRoot, "aliased-barrel-index-module", {
+        files: {
+          "src/components/Button.tsx": "export default function Button() { return null; }\n",
+          "src/components/Input.tsx": "export const Input = () => null;\n",
+          "src/components/parts.ts": "export const Root = () => null;\n",
+          "src/components/index.ts":
+            "export { default as Button } from './Button';\nexport { Input as TextInput } from './Input';\nexport * as ButtonParts from './parts';\n",
+          "src/import-directory.tsx":
+            "import { Button, TextInput, ButtonParts } from './components';\nvoid Button;\nvoid TextInput;\nvoid ButtonParts;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.message).toContain('"./components/Button"');
+      expect(hits[0]?.message).toContain('"./components/Input"');
+      expect(hits[0]?.message).toContain('"./components/parts"');
+    });
+
+    it("flags single-source star barrels and nested barrels", async () => {
+      const projectDir = setupReactProject(tempRoot, "star-and-nested-barrel-index-module", {
+        files: {
+          "src/components/button/Button.tsx": "export const Button = () => null;\n",
+          "src/components/button/index.ts": "export * from './Button';\n",
+          "src/components/index.ts": "export * from './button';\n",
+          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.message).toContain('"./components/button/Button"');
     });
 
     it("flags barrel re-exports with trailing inline comments", async () => {
@@ -117,8 +155,11 @@ describe("runOxlint", () => {
       const projectDir = setupReactProject(tempRoot, "import-export-barrel-index-module", {
         files: {
           "src/components/Button.tsx": "export const Button = () => null;\n",
-          "src/components/index.ts": "import { Button } from './Button';\n\nexport { Button };\n",
-          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+          "src/components/icons.ts": "export const Icon = () => null;\n",
+          "src/components/index.ts":
+            "import { Button } from './Button';\nimport DefaultButton, * as Icons from './icons';\n\nexport { Button, DefaultButton, Icons };\n",
+          "src/import-directory.tsx":
+            "import { Button, DefaultButton, Icons } from './components';\nvoid Button;\nvoid DefaultButton;\nvoid Icons;\n",
         },
       });
 
@@ -128,6 +169,60 @@ describe("runOxlint", () => {
       expect(hits[0]?.filePath.replaceAll("\\", "/").endsWith("src/import-directory.tsx")).toBe(
         true,
       );
+      expect(hits[0]?.message).toContain('"./components/Button"');
+      expect(hits[0]?.message).toContain('"./components/icons"');
+    });
+
+    it("does not flag type-only imports from type-only barrels", async () => {
+      const projectDir = setupReactProject(tempRoot, "type-only-barrel-index-module", {
+        files: {
+          "src/components/Button.tsx": "export interface ButtonProps { label: string }\n",
+          "src/components/index.ts": "export type { ButtonProps } from './Button';\n",
+          "src/import-directory.tsx":
+            "import type { ButtonProps } from './components';\nconst props: ButtonProps = { label: 'Save' };\nvoid props;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toEqual([]);
+    });
+
+    it("does not flag mixed index modules with side effects or runtime work", async () => {
+      const projectDir = setupReactProject(tempRoot, "mixed-barrel-index-module", {
+        files: {
+          "src/components/Button.tsx": "export const Button = () => null;\n",
+          "src/components/styles.css": ".button {}\n",
+          "src/components/with-side-effect/index.ts":
+            "import '../styles.css';\nexport { Button } from '../Button';\n",
+          "src/components/with-runtime-work/index.ts":
+            "console.log('init');\nexport { Button } from '../Button';\n",
+          "src/import-side-effect.tsx":
+            "import { Button } from './components/with-side-effect';\nvoid Button;\n",
+          "src/import-runtime-work.tsx":
+            "import { Button } from './components/with-runtime-work';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toEqual([]);
+    });
+
+    it("resolves package directory entries before index fallback", async () => {
+      const projectDir = setupReactProject(tempRoot, "package-entry-barrel-index-module", {
+        files: {
+          "src/components/Button.tsx": "export const Button = () => null;\n",
+          "src/components/index.ts": "export { Button } from './Button';\n",
+          "src/components/package.json": JSON.stringify({ exports: "./index.ts" }),
+          "src/import-directory.tsx": "import { Button } from './components';\nvoid Button;\n",
+        },
+      });
+
+      const hits = await collectRuleHits(projectDir, "no-barrel-import");
+
+      expect(hits).toHaveLength(1);
+      expect(hits[0]?.message).toContain('"./components/Button"');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Resolve relative imports before applying `no-barrel-import`, so real index modules like `./index` are not treated as barrels.
- Report only index modules that are pure re-export barrels, including directory imports and `.js` specifiers resolving to TS source.
- Add regression coverage for the `index.e2e.test` import shape and real barrel imports.

## Test plan
- `nr format`
- `nr lint`
- `nr typecheck`
- `nr test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `no-barrel-import` to resolve and inspect real filesystem modules (including `package.json` exports) before reporting, which could affect lint results and performance across projects. Logic is covered by expanded regression tests but touches path/FS heuristics that may have edge cases.
> 
> **Overview**
> Fixes `no-barrel-import` to **only report true index-barrel modules** by resolving relative import sources to actual file paths (including directory imports, `.js` specifiers, and `package.json` export/entry resolution) and then verifying the resolved `index.*` is a *pure re-export barrel*.
> 
> Enhances diagnostics to suggest **direct import paths** when the specific re-export target(s) can be determined (including aliased exports, namespace exports, and nested/star re-exports), and adds extensive tests to prevent regressions (e.g., sibling `./index` imports in tests, side-effectful index modules, type-only barrels, and package export conditions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225b37c9cd7077dc4ab72e4c2b16a8eda56c8f23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->