### PR TITLE
fix: narrow effect event handler detection

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -4,8 +4,8 @@ import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import { findDocumentClassListMutationName } from "./utils/find-document-class-list-mutation-name.js";
 import { findTriggeredSideEffectCalleeName } from "./utils/find-triggered-side-effect-callee-name.js";
+import { hasDocumentClassListMutation } from "./utils/has-document-class-list-mutation.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -15,7 +15,7 @@ const hasEventLikeConsequent = (
   consequentNode: EsTreeNodeOfType<"IfStatement">["consequent"],
 ): boolean =>
   findTriggeredSideEffectCalleeName(consequentNode) !== null ||
-  findDocumentClassListMutationName(consequentNode) !== null;
+  hasDocumentClassListMutation(consequentNode);
 
 export const noEffectEventHandler = defineRule<Rule>({
   id: "no-effect-event-handler",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -10,6 +10,7 @@ import { hasDocumentClassListMutation } from "./utils/has-document-class-list-mu
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const hasEventLikeConsequent = (
@@ -17,6 +18,66 @@ const hasEventLikeConsequent = (
 ): boolean =>
   findTriggeredSideEffectCalleeName(consequentNode) !== null ||
   hasDocumentClassListMutation(consequentNode);
+
+const hasEventLikeNode = (node: EsTreeNode): boolean =>
+  findTriggeredSideEffectCalleeName(node) !== null || hasDocumentClassListMutation(node);
+
+const collectConditionalRootNames = (
+  node: EsTreeNode | null | undefined,
+  into: Set<string>,
+): void => {
+  if (!node) return;
+  const rootIdentifierName = getRootIdentifierName(node);
+  if (rootIdentifierName) {
+    into.add(rootIdentifierName);
+    return;
+  }
+
+  if (isNodeOfType(node, "ChainExpression")) {
+    collectConditionalRootNames(node.expression, into);
+    return;
+  }
+
+  if (isNodeOfType(node, "UnaryExpression")) {
+    collectConditionalRootNames(node.argument, into);
+    return;
+  }
+
+  if (isNodeOfType(node, "BinaryExpression") || isNodeOfType(node, "LogicalExpression")) {
+    collectConditionalRootNames(node.left, into);
+    collectConditionalRootNames(node.right, into);
+    return;
+  }
+
+  if (isNodeOfType(node, "ConditionalExpression")) {
+    collectConditionalRootNames(node.test, into);
+    collectConditionalRootNames(node.consequent, into);
+    collectConditionalRootNames(node.alternate, into);
+  }
+};
+
+const collectDependencyRootNames = (depsNode: EsTreeNodeOfType<"ArrayExpression">): Set<string> => {
+  const dependencyNames = new Set<string>();
+  for (const element of depsNode.elements ?? []) {
+    const rootIdentifierName = getRootIdentifierName(element);
+    if (rootIdentifierName) dependencyNames.add(rootIdentifierName);
+  }
+  return dependencyNames;
+};
+
+const isReturnOnlyStatement = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "ReturnStatement")) return true;
+  return (
+    isNodeOfType(node, "BlockStatement") &&
+    (node.body?.length ?? 0) === 1 &&
+    isNodeOfType(node.body?.[0], "ReturnStatement")
+  );
+};
+
+const hasEventLikeRemainingStatements = (statements: EsTreeNode[]): boolean =>
+  statements.some(
+    (statement) => !isNodeOfType(statement, "ReturnStatement") && hasEventLikeNode(statement),
+  );
 
 export const noEffectEventHandler = defineRule<Rule>({
   id: "no-effect-event-handler",
@@ -37,29 +98,31 @@ export const noEffectEventHandler = defineRule<Rule>({
         const depsNode = node.arguments[1];
         if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 
-        const dependencyNames = new Set<string>();
-        for (const element of depsNode.elements ?? []) {
-          if (isNodeOfType(element, "Identifier")) dependencyNames.add(element.name);
-        }
+        const dependencyNames = collectDependencyRootNames(depsNode);
 
         const statements = getCallbackStatements(callback);
-        if (statements.length !== 1) return;
+        if (statements.length === 0) return;
 
         const soleStatement = statements[0];
         if (!isNodeOfType(soleStatement, "IfStatement")) return;
 
-        // HACK: §5 of "You Might Not Need an Effect" uses
-        // `if (product.isInCart)` — a MemberExpression, not a bare
-        // Identifier. The earlier detector hard-required `Identifier`
-        // and missed the article's literal example. Walk the test
-        // down to its root identifier so both shapes match:
-        //   if (isOpen)            → root = "isOpen"
-        //   if (product.isInCart)  → root = "product"
-        const rootIdentifierName = getRootIdentifierName(soleStatement.test);
-        if (!rootIdentifierName || !dependencyNames.has(rootIdentifierName)) return;
-        if (!propStackTracker.isPropName(rootIdentifierName, node)) return;
+        const conditionalRootNames = new Set<string>();
+        collectConditionalRootNames(soleStatement.test, conditionalRootNames);
+        const hasPropDependency = [...conditionalRootNames].some(
+          (rootIdentifierName) =>
+            dependencyNames.has(rootIdentifierName) &&
+            propStackTracker.isPropName(rootIdentifierName, node),
+        );
+        if (!hasPropDependency) return;
 
-        if (!hasEventLikeConsequent(soleStatement.consequent)) return;
+        const isSingleGuardedEventLikeStatement =
+          statements.length === 1 && hasEventLikeConsequent(soleStatement.consequent);
+        const isEarlyReturnGuardedEventLikeBody =
+          statements.length > 1 &&
+          !soleStatement.alternate &&
+          isReturnOnlyStatement(soleStatement.consequent) &&
+          hasEventLikeRemainingStatements(statements.slice(1));
+        if (!isSingleGuardedEventLikeStatement && !isEarlyReturnGuardedEventLikeBody) return;
 
         context.report({
           node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -5,6 +5,8 @@ import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { createComponentPropStackTracker } from "../../utils/create-component-prop-stack-tracker.js";
+import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
+import { walkAst } from "../../utils/walk-ast.js";
 import { findTriggeredSideEffectCalleeName } from "./utils/find-triggered-side-effect-callee-name.js";
 import { hasDocumentClassListMutation } from "./utils/has-document-class-list-mutation.js";
 import type { Rule } from "../../utils/rule.js";
@@ -12,6 +14,11 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+interface GuardExpression {
+  expression: EsTreeNode;
+  rootIdentifierName: string;
+}
 
 const hasEventLikeConsequent = (
   consequentNode: EsTreeNodeOfType<"IfStatement">["consequent"],
@@ -22,47 +29,45 @@ const hasEventLikeConsequent = (
 const hasEventLikeNode = (node: EsTreeNode): boolean =>
   findTriggeredSideEffectCalleeName(node) !== null || hasDocumentClassListMutation(node);
 
-const collectConditionalRootNames = (
-  node: EsTreeNode | null | undefined,
-  into: Set<string>,
-): void => {
-  if (!node) return;
-  const rootIdentifierName = getRootIdentifierName(node);
-  if (rootIdentifierName) {
-    into.add(rootIdentifierName);
-    return;
-  }
-
-  if (isNodeOfType(node, "ChainExpression")) {
-    collectConditionalRootNames(node.expression, into);
-    return;
-  }
-
-  if (isNodeOfType(node, "UnaryExpression")) {
-    collectConditionalRootNames(node.argument, into);
-    return;
-  }
-
-  if (isNodeOfType(node, "BinaryExpression") || isNodeOfType(node, "LogicalExpression")) {
-    collectConditionalRootNames(node.left, into);
-    collectConditionalRootNames(node.right, into);
-    return;
-  }
-
-  if (isNodeOfType(node, "ConditionalExpression")) {
-    collectConditionalRootNames(node.test, into);
-    collectConditionalRootNames(node.consequent, into);
-    collectConditionalRootNames(node.alternate, into);
-  }
+const unwrapChainExpression = (node: EsTreeNode | null | undefined): EsTreeNode | null => {
+  if (!node) return null;
+  if (isNodeOfType(node, "ChainExpression")) return node.expression;
+  return node;
 };
 
-const collectDependencyRootNames = (depsNode: EsTreeNodeOfType<"ArrayExpression">): Set<string> => {
-  const dependencyNames = new Set<string>();
-  for (const element of depsNode.elements ?? []) {
-    const rootIdentifierName = getRootIdentifierName(element);
-    if (rootIdentifierName) dependencyNames.add(rootIdentifierName);
+const collectGuardExpressions = (
+  node: EsTreeNode | null | undefined,
+  into: GuardExpression[],
+): void => {
+  if (!node) return;
+  const unwrappedNode = unwrapChainExpression(node);
+  if (!unwrappedNode) return;
+
+  const rootIdentifierName = getRootIdentifierName(unwrappedNode);
+  if (rootIdentifierName) {
+    into.push({ expression: unwrappedNode, rootIdentifierName });
+    return;
   }
-  return dependencyNames;
+
+  if (isNodeOfType(unwrappedNode, "UnaryExpression")) {
+    collectGuardExpressions(unwrappedNode.argument, into);
+    return;
+  }
+
+  if (
+    isNodeOfType(unwrappedNode, "BinaryExpression") ||
+    isNodeOfType(unwrappedNode, "LogicalExpression")
+  ) {
+    collectGuardExpressions(unwrappedNode.left, into);
+    collectGuardExpressions(unwrappedNode.right, into);
+    return;
+  }
+
+  if (isNodeOfType(unwrappedNode, "ConditionalExpression")) {
+    collectGuardExpressions(unwrappedNode.test, into);
+    collectGuardExpressions(unwrappedNode.consequent, into);
+    collectGuardExpressions(unwrappedNode.alternate, into);
+  }
 };
 
 const isReturnOnlyStatement = (node: EsTreeNode): boolean => {
@@ -78,6 +83,81 @@ const hasEventLikeRemainingStatements = (statements: EsTreeNode[]): boolean =>
   statements.some(
     (statement) => !isNodeOfType(statement, "ReturnStatement") && hasEventLikeNode(statement),
   );
+
+const doesGuardMatchDependency = (
+  guardExpression: GuardExpression,
+  dependencyExpression: EsTreeNode | null | undefined,
+): boolean => {
+  const unwrappedDependencyExpression = unwrapChainExpression(dependencyExpression);
+  if (!unwrappedDependencyExpression) return false;
+  if (areExpressionsStructurallyEqual(guardExpression.expression, unwrappedDependencyExpression)) {
+    return true;
+  }
+  return (
+    isNodeOfType(unwrappedDependencyExpression, "Identifier") &&
+    unwrappedDependencyExpression.name === guardExpression.rootIdentifierName
+  );
+};
+
+const hasDependencyMatch = (
+  guardExpression: GuardExpression,
+  dependencyExpressions: Array<EsTreeNode | null | undefined>,
+): boolean =>
+  dependencyExpressions.some((dependencyExpression) =>
+    doesGuardMatchDependency(guardExpression, dependencyExpression),
+  );
+
+const isStandaloneIdentifier = (node: EsTreeNode): node is EsTreeNodeOfType<"Identifier"> =>
+  isNodeOfType(node, "Identifier") &&
+  !(
+    isNodeOfType(node.parent, "MemberExpression") &&
+    node.parent.property === node &&
+    node.parent.computed !== true
+  );
+
+const doesNodeReferenceAnyRoot = (node: EsTreeNode, rootIdentifierNames: Set<string>): boolean => {
+  let didFindReference = false;
+  const visit = (child: EsTreeNode): boolean | void => {
+    if (didFindReference) return false;
+    if (isNodeOfType(child, "MemberExpression")) {
+      const rootIdentifierName = getRootIdentifierName(child);
+      if (rootIdentifierName && rootIdentifierNames.has(rootIdentifierName)) {
+        didFindReference = true;
+        return false;
+      }
+    }
+    if (isStandaloneIdentifier(child) && rootIdentifierNames.has(child.name)) {
+      didFindReference = true;
+      return false;
+    }
+  };
+  walkAst(node, visit);
+  return didFindReference;
+};
+
+const doesEventLikeCallReferenceAnyRoot = (
+  node: EsTreeNode,
+  rootIdentifierNames: Set<string>,
+): boolean => {
+  let didFindReference = false;
+  walkAst(node, (child: EsTreeNode) => {
+    if (didFindReference) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (findTriggeredSideEffectCalleeName(child) === null && !hasDocumentClassListMutation(child)) {
+      return;
+    }
+    if (doesNodeReferenceAnyRoot(child, rootIdentifierNames)) {
+      didFindReference = true;
+      return false;
+    }
+  });
+  return didFindReference;
+};
+
+const doesAnyEventLikeCallReferenceAnyRoot = (
+  nodes: EsTreeNode[],
+  rootIdentifierNames: Set<string>,
+): boolean => nodes.some((node) => doesEventLikeCallReferenceAnyRoot(node, rootIdentifierNames));
 
 export const noEffectEventHandler = defineRule<Rule>({
   id: "no-effect-event-handler",
@@ -98,7 +178,7 @@ export const noEffectEventHandler = defineRule<Rule>({
         const depsNode = node.arguments[1];
         if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 
-        const dependencyNames = collectDependencyRootNames(depsNode);
+        const dependencyExpressions = depsNode.elements ?? [];
 
         const statements = getCallbackStatements(callback);
         if (statements.length === 0) return;
@@ -106,14 +186,14 @@ export const noEffectEventHandler = defineRule<Rule>({
         const soleStatement = statements[0];
         if (!isNodeOfType(soleStatement, "IfStatement")) return;
 
-        const conditionalRootNames = new Set<string>();
-        collectConditionalRootNames(soleStatement.test, conditionalRootNames);
-        const hasPropDependency = [...conditionalRootNames].some(
-          (rootIdentifierName) =>
-            dependencyNames.has(rootIdentifierName) &&
-            propStackTracker.isPropName(rootIdentifierName, node),
+        const guardExpressions: GuardExpression[] = [];
+        collectGuardExpressions(soleStatement.test, guardExpressions);
+        const matchingPropGuardExpressions = guardExpressions.filter(
+          (guardExpression) =>
+            hasDependencyMatch(guardExpression, dependencyExpressions) &&
+            propStackTracker.isPropName(guardExpression.rootIdentifierName, node),
         );
-        if (!hasPropDependency) return;
+        if (matchingPropGuardExpressions.length === 0) return;
 
         const isSingleGuardedEventLikeStatement =
           statements.length === 1 && hasEventLikeConsequent(soleStatement.consequent);
@@ -123,6 +203,25 @@ export const noEffectEventHandler = defineRule<Rule>({
           isReturnOnlyStatement(soleStatement.consequent) &&
           hasEventLikeRemainingStatements(statements.slice(1));
         if (!isSingleGuardedEventLikeStatement && !isEarlyReturnGuardedEventLikeBody) return;
+
+        const hasUnmatchedGuardExpression = guardExpressions.some(
+          (guardExpression) =>
+            !matchingPropGuardExpressions.some(
+              (matchingGuardExpression) =>
+                matchingGuardExpression.expression === guardExpression.expression,
+            ),
+        );
+        if (hasUnmatchedGuardExpression) {
+          const matchingPropRootNames = new Set(
+            matchingPropGuardExpressions.map(
+              (guardExpression) => guardExpression.rootIdentifierName,
+            ),
+          );
+          const doesEventLikeRegionReferenceMatchedProp = isSingleGuardedEventLikeStatement
+            ? doesEventLikeCallReferenceAnyRoot(soleStatement.consequent, matchingPropRootNames)
+            : doesAnyEventLikeCallReferenceAnyRoot(statements.slice(1), matchingPropRootNames);
+          if (!doesEventLikeRegionReferenceMatchedProp) return;
+        }
 
         context.report({
           node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -20,12 +20,6 @@ interface GuardExpression {
   rootIdentifierName: string;
 }
 
-const hasEventLikeConsequent = (
-  consequentNode: EsTreeNodeOfType<"IfStatement">["consequent"],
-): boolean =>
-  findTriggeredSideEffectCalleeName(consequentNode) !== null ||
-  hasDocumentClassListMutation(consequentNode);
-
 const hasEventLikeNode = (node: EsTreeNode): boolean =>
   findTriggeredSideEffectCalleeName(node) !== null || hasDocumentClassListMutation(node);
 
@@ -196,7 +190,7 @@ export const noEffectEventHandler = defineRule<Rule>({
         if (matchingPropGuardExpressions.length === 0) return;
 
         const isSingleGuardedEventLikeStatement =
-          statements.length === 1 && hasEventLikeConsequent(soleStatement.consequent);
+          statements.length === 1 && hasEventLikeNode(soleStatement.consequent);
         const isEarlyReturnGuardedEventLikeBody =
           statements.length > 1 &&
           !soleStatement.alternate &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -4,51 +4,18 @@ import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
-import { walkAst } from "../../utils/walk-ast.js";
+import { findDocumentClassListMutationName } from "./utils/find-document-class-list-mutation-name.js";
 import { findTriggeredSideEffectCalleeName } from "./utils/find-triggered-side-effect-callee-name.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const DOCUMENT_CLASS_LIST_MUTATION_METHOD_NAMES = new Set(["add", "remove", "toggle"]);
-
-const getDocumentClassListMutationName = (consequentNode: EsTreeNode): string | null => {
-  let mutationName: string | null = null;
-  walkAst(consequentNode, (child: EsTreeNode) => {
-    if (mutationName) return false;
-    if (!isNodeOfType(child, "CallExpression")) return;
-    const callee = child.callee;
-    if (
-      !isNodeOfType(callee, "MemberExpression") ||
-      !isNodeOfType(callee.property, "Identifier") ||
-      !DOCUMENT_CLASS_LIST_MUTATION_METHOD_NAMES.has(callee.property.name)
-    ) {
-      return;
-    }
-    const classListExpression = callee.object;
-    if (
-      !isNodeOfType(classListExpression, "MemberExpression") ||
-      !isNodeOfType(classListExpression.property, "Identifier") ||
-      classListExpression.property.name !== "classList"
-    ) {
-      return;
-    }
-    const elementExpression = classListExpression.object;
-    if (
-      !isNodeOfType(elementExpression, "MemberExpression") ||
-      !isNodeOfType(elementExpression.object, "Identifier") ||
-      elementExpression.object.name !== "document" ||
-      !isNodeOfType(elementExpression.property, "Identifier") ||
-      elementExpression.property.name !== "body"
-    ) {
-      return;
-    }
-    mutationName = `document.body.classList.${callee.property.name}`;
-  });
-  return mutationName;
-};
+const hasEventLikeConsequent = (
+  consequentNode: EsTreeNodeOfType<"IfStatement">["consequent"],
+): boolean =>
+  findTriggeredSideEffectCalleeName(consequentNode) !== null ||
+  findDocumentClassListMutationName(consequentNode) !== null;
 
 export const noEffectEventHandler = defineRule<Rule>({
   id: "no-effect-event-handler",
@@ -86,10 +53,7 @@ export const noEffectEventHandler = defineRule<Rule>({
       const rootIdentifierName = getRootIdentifierName(soleStatement.test);
       if (!rootIdentifierName || !dependencyNames.has(rootIdentifierName)) return;
 
-      const sideEffectCalleeName =
-        findTriggeredSideEffectCalleeName(soleStatement.consequent) ??
-        getDocumentClassListMutationName(soleStatement.consequent);
-      if (!sideEffectCalleeName) return;
+      if (!hasEventLikeConsequent(soleStatement.consequent)) return;
 
       context.report({
         node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -4,6 +4,7 @@ import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { createComponentPropStackTracker } from "../../utils/create-component-prop-stack-tracker.js";
 import { findTriggeredSideEffectCalleeName } from "./utils/find-triggered-side-effect-callee-name.js";
 import { hasDocumentClassListMutation } from "./utils/has-document-class-list-mutation.js";
 import type { Rule } from "../../utils/rule.js";
@@ -22,44 +23,50 @@ export const noEffectEventHandler = defineRule<Rule>({
   severity: "warn",
   recommendation:
     "Move the conditional logic into onClick, onChange, or onSubmit handlers directly",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
+  create: (context: RuleContext) => {
+    const propStackTracker = createComponentPropStackTracker();
 
-      const callback = getEffectCallback(node);
-      if (!callback) return;
+    return {
+      ...propStackTracker.visitors,
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
 
-      const depsNode = node.arguments[1];
-      if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
+        const callback = getEffectCallback(node);
+        if (!callback) return;
 
-      const dependencyNames = new Set<string>();
-      for (const element of depsNode.elements ?? []) {
-        if (isNodeOfType(element, "Identifier")) dependencyNames.add(element.name);
-      }
+        const depsNode = node.arguments[1];
+        if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
 
-      const statements = getCallbackStatements(callback);
-      if (statements.length !== 1) return;
+        const dependencyNames = new Set<string>();
+        for (const element of depsNode.elements ?? []) {
+          if (isNodeOfType(element, "Identifier")) dependencyNames.add(element.name);
+        }
 
-      const soleStatement = statements[0];
-      if (!isNodeOfType(soleStatement, "IfStatement")) return;
+        const statements = getCallbackStatements(callback);
+        if (statements.length !== 1) return;
 
-      // HACK: §5 of "You Might Not Need an Effect" uses
-      // `if (product.isInCart)` — a MemberExpression, not a bare
-      // Identifier. The earlier detector hard-required `Identifier`
-      // and missed the article's literal example. Walk the test
-      // down to its root identifier so both shapes match:
-      //   if (isOpen)            → root = "isOpen"
-      //   if (product.isInCart)  → root = "product"
-      const rootIdentifierName = getRootIdentifierName(soleStatement.test);
-      if (!rootIdentifierName || !dependencyNames.has(rootIdentifierName)) return;
+        const soleStatement = statements[0];
+        if (!isNodeOfType(soleStatement, "IfStatement")) return;
 
-      if (!hasEventLikeConsequent(soleStatement.consequent)) return;
+        // HACK: §5 of "You Might Not Need an Effect" uses
+        // `if (product.isInCart)` — a MemberExpression, not a bare
+        // Identifier. The earlier detector hard-required `Identifier`
+        // and missed the article's literal example. Walk the test
+        // down to its root identifier so both shapes match:
+        //   if (isOpen)            → root = "isOpen"
+        //   if (product.isInCart)  → root = "product"
+        const rootIdentifierName = getRootIdentifierName(soleStatement.test);
+        if (!rootIdentifierName || !dependencyNames.has(rootIdentifierName)) return;
+        if (!propStackTracker.isPropName(rootIdentifierName)) return;
 
-      context.report({
-        node,
-        message:
-          "useEffect simulating an event handler — move logic to an actual event handler instead",
-      });
-    },
-  }),
+        if (!hasEventLikeConsequent(soleStatement.consequent)) return;
+
+        context.report({
+          node,
+          message:
+            "useEffect simulating an event handler — move logic to an actual event handler instead",
+        });
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -4,10 +4,51 @@ import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { findTriggeredSideEffectCalleeName } from "./utils/find-triggered-side-effect-callee-name.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+const DOCUMENT_CLASS_LIST_MUTATION_METHOD_NAMES = new Set(["add", "remove", "toggle"]);
+
+const getDocumentClassListMutationName = (consequentNode: EsTreeNode): string | null => {
+  let mutationName: string | null = null;
+  walkAst(consequentNode, (child: EsTreeNode) => {
+    if (mutationName) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = child.callee;
+    if (
+      !isNodeOfType(callee, "MemberExpression") ||
+      !isNodeOfType(callee.property, "Identifier") ||
+      !DOCUMENT_CLASS_LIST_MUTATION_METHOD_NAMES.has(callee.property.name)
+    ) {
+      return;
+    }
+    const classListExpression = callee.object;
+    if (
+      !isNodeOfType(classListExpression, "MemberExpression") ||
+      !isNodeOfType(classListExpression.property, "Identifier") ||
+      classListExpression.property.name !== "classList"
+    ) {
+      return;
+    }
+    const elementExpression = classListExpression.object;
+    if (
+      !isNodeOfType(elementExpression, "MemberExpression") ||
+      !isNodeOfType(elementExpression.object, "Identifier") ||
+      elementExpression.object.name !== "document" ||
+      !isNodeOfType(elementExpression.property, "Identifier") ||
+      elementExpression.property.name !== "body"
+    ) {
+      return;
+    }
+    mutationName = `document.body.classList.${callee.property.name}`;
+  });
+  return mutationName;
+};
 
 export const noEffectEventHandler = defineRule<Rule>({
   id: "no-effect-event-handler",
@@ -45,19 +86,11 @@ export const noEffectEventHandler = defineRule<Rule>({
       const rootIdentifierName = getRootIdentifierName(soleStatement.test);
       if (!rootIdentifierName || !dependencyNames.has(rootIdentifierName)) return;
 
-      // Don't defer to `noEventTriggerState` here. The previous
-      // implementation tried to ("if the body looks event-shaped,
-      // let the more specific rule report"), but that deference
-      // could silently drop diagnostics: `noEventTriggerState`
-      // requires several preconditions this visitor can't cheaply
-      // verify (single dep, handler-only writes for that state,
-      // and not render-reachable). When any of those failed, the
-      // narrow rule didn't fire AND this rule deferred, so the
-      // user got nothing. Both rules fire independently — the two
-      // messages frame the same code differently ("this useEffect
-      // simulates a handler" vs "this state exists only to schedule
-      // X from an effect") and a duplicate diagnostic is strictly
-      // better than a silent drop.
+      const sideEffectCalleeName =
+        findTriggeredSideEffectCalleeName(soleStatement.consequent) ??
+        getDocumentClassListMutationName(soleStatement.consequent);
+      if (!sideEffectCalleeName) return;
+
       context.report({
         node,
         message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -57,7 +57,7 @@ export const noEffectEventHandler = defineRule<Rule>({
         //   if (product.isInCart)  → root = "product"
         const rootIdentifierName = getRootIdentifierName(soleStatement.test);
         if (!rootIdentifierName || !dependencyNames.has(rootIdentifierName)) return;
-        if (!propStackTracker.isPropName(rootIdentifierName)) return;
+        if (!propStackTracker.isPropName(rootIdentifierName, node)) return;
 
         if (!hasEventLikeConsequent(soleStatement.consequent)) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
@@ -1,14 +1,7 @@
-import {
-  EFFECT_HOOK_NAMES,
-  EVENT_TRIGGERED_NAVIGATION_METHOD_NAMES,
-  EVENT_TRIGGERED_SIDE_EFFECT_CALLEES,
-  EVENT_TRIGGERED_SIDE_EFFECT_MEMBER_METHODS,
-  NAVIGATION_RECEIVER_NAMES,
-} from "../../constants/react.js";
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
-import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
@@ -23,6 +16,7 @@ import { collectRenderReachableNames } from "./utils/collect-render-reachable-na
 import { expandTransitiveDependencies } from "./utils/expand-transitive-dependencies.js";
 import { collectHandlerBindingNames } from "./utils/collect-handler-binding-names.js";
 import { isInsideEventHandler } from "./utils/is-inside-event-handler.js";
+import { findTriggeredSideEffectCalleeName } from "./utils/find-triggered-side-effect-callee-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -92,34 +86,6 @@ const getTriggerGuardRootName = (testNode: EsTreeNode): string | null => {
     return getTriggerGuardRootName(testNode.argument);
   }
   return null;
-};
-
-const findTriggeredSideEffectCalleeName = (consequentNode: EsTreeNode): string | null => {
-  let foundCalleeName: string | null = null;
-  walkAst(consequentNode, (child: EsTreeNode) => {
-    if (foundCalleeName) return false;
-    if (!isNodeOfType(child, "CallExpression")) return;
-    const callee = child.callee;
-    if (
-      isNodeOfType(callee, "Identifier") &&
-      EVENT_TRIGGERED_SIDE_EFFECT_CALLEES.has(callee.name)
-    ) {
-      foundCalleeName = callee.name;
-      return;
-    }
-    if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
-      const propertyName = callee.property.name;
-      const isUnambiguousMethod = EVENT_TRIGGERED_SIDE_EFFECT_MEMBER_METHODS.has(propertyName);
-      const isNavigationMethod = EVENT_TRIGGERED_NAVIGATION_METHOD_NAMES.has(propertyName);
-      if (!isUnambiguousMethod && !isNavigationMethod) return;
-      const rootName = getRootIdentifierName(callee);
-      if (isNavigationMethod && (rootName === null || !NAVIGATION_RECEIVER_NAMES.has(rootName))) {
-        return;
-      }
-      foundCalleeName = rootName ? `${rootName}.${propertyName}` : propertyName;
-    }
-  });
-  return foundCalleeName;
 };
 
 const collectHandlerOnlyWriteStateNames = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/find-document-class-list-mutation-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/find-document-class-list-mutation-name.ts
@@ -3,6 +3,7 @@ import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import { walkAst } from "../../../utils/walk-ast.js";
 
 const DOCUMENT_CLASS_LIST_MUTATION_METHOD_NAMES = new Set(["add", "remove", "toggle"]);
+const DOCUMENT_CLASS_LIST_TARGET_NAMES = new Set(["body", "documentElement"]);
 
 export const findDocumentClassListMutationName = (node: EsTreeNode): string | null => {
   let mutationName: string | null = null;
@@ -31,11 +32,11 @@ export const findDocumentClassListMutationName = (node: EsTreeNode): string | nu
       !isNodeOfType(elementExpression.object, "Identifier") ||
       elementExpression.object.name !== "document" ||
       !isNodeOfType(elementExpression.property, "Identifier") ||
-      elementExpression.property.name !== "body"
+      !DOCUMENT_CLASS_LIST_TARGET_NAMES.has(elementExpression.property.name)
     ) {
       return;
     }
-    mutationName = `document.body.classList.${callee.property.name}`;
+    mutationName = `document.${elementExpression.property.name}.classList.${callee.property.name}`;
   });
   return mutationName;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/find-document-class-list-mutation-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/find-document-class-list-mutation-name.ts
@@ -1,0 +1,41 @@
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { walkAst } from "../../../utils/walk-ast.js";
+
+const DOCUMENT_CLASS_LIST_MUTATION_METHOD_NAMES = new Set(["add", "remove", "toggle"]);
+
+export const findDocumentClassListMutationName = (node: EsTreeNode): string | null => {
+  let mutationName: string | null = null;
+  walkAst(node, (child: EsTreeNode) => {
+    if (mutationName) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = child.callee;
+    if (
+      !isNodeOfType(callee, "MemberExpression") ||
+      !isNodeOfType(callee.property, "Identifier") ||
+      !DOCUMENT_CLASS_LIST_MUTATION_METHOD_NAMES.has(callee.property.name)
+    ) {
+      return;
+    }
+    const classListExpression = callee.object;
+    if (
+      !isNodeOfType(classListExpression, "MemberExpression") ||
+      !isNodeOfType(classListExpression.property, "Identifier") ||
+      classListExpression.property.name !== "classList"
+    ) {
+      return;
+    }
+    const elementExpression = classListExpression.object;
+    if (
+      !isNodeOfType(elementExpression, "MemberExpression") ||
+      !isNodeOfType(elementExpression.object, "Identifier") ||
+      elementExpression.object.name !== "document" ||
+      !isNodeOfType(elementExpression.property, "Identifier") ||
+      elementExpression.property.name !== "body"
+    ) {
+      return;
+    }
+    mutationName = `document.body.classList.${callee.property.name}`;
+  });
+  return mutationName;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/find-triggered-side-effect-callee-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/find-triggered-side-effect-callee-name.ts
@@ -1,0 +1,38 @@
+import {
+  EVENT_TRIGGERED_NAVIGATION_METHOD_NAMES,
+  EVENT_TRIGGERED_SIDE_EFFECT_CALLEES,
+  EVENT_TRIGGERED_SIDE_EFFECT_MEMBER_METHODS,
+  NAVIGATION_RECEIVER_NAMES,
+} from "../../../constants/react.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { getRootIdentifierName } from "../../../utils/get-root-identifier-name.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { walkAst } from "../../../utils/walk-ast.js";
+
+export const findTriggeredSideEffectCalleeName = (consequentNode: EsTreeNode): string | null => {
+  let foundCalleeName: string | null = null;
+  walkAst(consequentNode, (child: EsTreeNode) => {
+    if (foundCalleeName) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = child.callee;
+    if (
+      isNodeOfType(callee, "Identifier") &&
+      EVENT_TRIGGERED_SIDE_EFFECT_CALLEES.has(callee.name)
+    ) {
+      foundCalleeName = callee.name;
+      return;
+    }
+    if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
+      const propertyName = callee.property.name;
+      const isUnambiguousMethod = EVENT_TRIGGERED_SIDE_EFFECT_MEMBER_METHODS.has(propertyName);
+      const isNavigationMethod = EVENT_TRIGGERED_NAVIGATION_METHOD_NAMES.has(propertyName);
+      if (!isUnambiguousMethod && !isNavigationMethod) return;
+      const rootName = getRootIdentifierName(callee);
+      if (isNavigationMethod && (rootName === null || !NAVIGATION_RECEIVER_NAMES.has(rootName))) {
+        return;
+      }
+      foundCalleeName = rootName ? `${rootName}.${propertyName}` : propertyName;
+    }
+  });
+  return foundCalleeName;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-document-class-list-mutation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-document-class-list-mutation.ts
@@ -5,10 +5,10 @@ import { walkAst } from "../../../utils/walk-ast.js";
 const DOCUMENT_CLASS_LIST_MUTATION_METHOD_NAMES = new Set(["add", "remove", "toggle"]);
 const DOCUMENT_CLASS_LIST_TARGET_NAMES = new Set(["body", "documentElement"]);
 
-export const findDocumentClassListMutationName = (node: EsTreeNode): string | null => {
-  let mutationName: string | null = null;
+export const hasDocumentClassListMutation = (node: EsTreeNode): boolean => {
+  let didFindMutation = false;
   walkAst(node, (child: EsTreeNode) => {
-    if (mutationName) return false;
+    if (didFindMutation) return false;
     if (!isNodeOfType(child, "CallExpression")) return;
     const callee = child.callee;
     if (
@@ -26,17 +26,17 @@ export const findDocumentClassListMutationName = (node: EsTreeNode): string | nu
     ) {
       return;
     }
-    const elementExpression = classListExpression.object;
+    const documentElementExpression = classListExpression.object;
     if (
-      !isNodeOfType(elementExpression, "MemberExpression") ||
-      !isNodeOfType(elementExpression.object, "Identifier") ||
-      elementExpression.object.name !== "document" ||
-      !isNodeOfType(elementExpression.property, "Identifier") ||
-      !DOCUMENT_CLASS_LIST_TARGET_NAMES.has(elementExpression.property.name)
+      !isNodeOfType(documentElementExpression, "MemberExpression") ||
+      !isNodeOfType(documentElementExpression.object, "Identifier") ||
+      documentElementExpression.object.name !== "document" ||
+      !isNodeOfType(documentElementExpression.property, "Identifier") ||
+      !DOCUMENT_CLASS_LIST_TARGET_NAMES.has(documentElementExpression.property.name)
     ) {
       return;
     }
-    mutationName = `document.${elementExpression.property.name}.classList.${callee.property.name}`;
+    didFindMutation = true;
   });
-  return mutationName;
+  return didFindMutation;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-component-prop-stack-tracker.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-component-prop-stack-tracker.ts
@@ -1,13 +1,13 @@
 import { collectPatternNames } from "./collect-pattern-names.js";
 import type { ComponentPropStackTrackerCallbacks } from "./component-prop-stack-tracker-callbacks.js";
 import type { EsTreeNode } from "./es-tree-node.js";
-import { isComponentAssignment } from "./is-component-assignment.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isUppercaseName } from "./is-uppercase-name.js";
 import type { RuleVisitors } from "./rule-visitors.js";
 
 export interface ComponentPropStackTracker {
-  isPropName: (name: string) => boolean;
+  isPropName: (name: string, referenceNode?: EsTreeNode) => boolean;
   getCurrentPropNames: () => Set<string>;
   visitors: RuleVisitors;
 }
@@ -18,6 +18,91 @@ const extractDestructuredPropNames = (params: EsTreeNode[]): Set<string> => {
     collectPatternNames(param, propNames);
   }
   return propNames;
+};
+
+const isFunctionNode = (
+  node: EsTreeNode | null | undefined,
+): node is
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | EsTreeNodeOfType<"FunctionExpression"> =>
+  Boolean(node) &&
+  (isNodeOfType(node, "ArrowFunctionExpression") ||
+    isNodeOfType(node, "FunctionDeclaration") ||
+    isNodeOfType(node, "FunctionExpression"));
+
+const getInlineFunctionNode = (
+  node: EsTreeNode | null | undefined,
+):
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | null => {
+  if (!node) return null;
+  if (isFunctionNode(node)) return node;
+  if (!isNodeOfType(node, "CallExpression")) return null;
+
+  for (const argument of node.arguments ?? []) {
+    const inlineFunctionNode = getInlineFunctionNode(argument);
+    if (inlineFunctionNode) return inlineFunctionNode;
+  }
+
+  return null;
+};
+
+const getNearestComponentFunction = (
+  node: EsTreeNode,
+):
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | null => {
+  let cursor: EsTreeNode | null = node.parent ?? null;
+  while (cursor) {
+    if (isFunctionNode(cursor)) return cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+const isFunctionAssignedToComponent = (
+  functionNode:
+    | EsTreeNodeOfType<"ArrowFunctionExpression">
+    | EsTreeNodeOfType<"FunctionDeclaration">
+    | EsTreeNodeOfType<"FunctionExpression">,
+): boolean => {
+  let cursor: EsTreeNode | null = functionNode.parent ?? null;
+  while (isNodeOfType(cursor, "CallExpression")) {
+    cursor = cursor.parent ?? null;
+  }
+
+  if (
+    isNodeOfType(cursor, "VariableDeclarator") &&
+    isNodeOfType(cursor.id, "Identifier") &&
+    isUppercaseName(cursor.id.name)
+  ) {
+    return true;
+  }
+
+  return isNodeOfType(cursor, "ExportDefaultDeclaration");
+};
+
+const isComponentFunction = (
+  functionNode:
+    | EsTreeNodeOfType<"ArrowFunctionExpression">
+    | EsTreeNodeOfType<"FunctionDeclaration">
+    | EsTreeNodeOfType<"FunctionExpression">,
+): boolean => {
+  if (isNodeOfType(functionNode, "FunctionDeclaration")) {
+    return (
+      !functionNode.id ||
+      functionNode.id.name === "default" ||
+      isUppercaseName(functionNode.id.name) ||
+      isNodeOfType(functionNode.parent, "ExportDefaultDeclaration")
+    );
+  }
+
+  return isFunctionAssignedToComponent(functionNode);
 };
 
 // HACK: barrier-frame predicate - a non-component arrow / function-expression
@@ -53,12 +138,20 @@ export const createComponentPropStackTracker = (
   callbacks?: ComponentPropStackTrackerCallbacks,
 ): ComponentPropStackTracker => {
   const propParamStack: Array<Set<string>> = [];
+  const exportDefaultDeclarationsWithFrames = new WeakSet<EsTreeNode>();
+  const functionDeclarationsWithFrames = new WeakSet<EsTreeNode>();
+  const variableDeclaratorsWithFrames = new WeakSet<EsTreeNode>();
 
-  const isPropName = (name: string): boolean => {
+  const isPropName = (name: string, referenceNode?: EsTreeNode): boolean => {
     for (let frameIndex = propParamStack.length - 1; frameIndex >= 0; frameIndex--) {
       const frame = propParamStack[frameIndex];
-      if (frame.size === 0) return false;
+      if (frame.size === 0) break;
       if (frame.has(name)) return true;
+    }
+    if (referenceNode) {
+      const componentFunctionNode = getNearestComponentFunction(referenceNode);
+      if (!componentFunctionNode || !isComponentFunction(componentFunctionNode)) return false;
+      return extractDestructuredPropNames(componentFunctionNode.params ?? []).has(name);
     }
     return false;
   };
@@ -72,43 +165,70 @@ export const createComponentPropStackTracker = (
     return new Set();
   };
 
+  const pushFunctionPropFrame = (
+    functionNode:
+      | EsTreeNodeOfType<"ArrowFunctionExpression">
+      | EsTreeNodeOfType<"FunctionDeclaration">
+      | EsTreeNodeOfType<"FunctionExpression">,
+  ): void => {
+    propParamStack.push(extractDestructuredPropNames(functionNode.params ?? []));
+    callbacks?.onComponentEnter?.(functionNode.body);
+  };
+
   const visitors: RuleVisitors = {
+    ExportDefaultDeclaration(node: EsTreeNode) {
+      if (!isNodeOfType(node, "ExportDefaultDeclaration")) return;
+      const inlineFunctionNode = getInlineFunctionNode(node.declaration);
+      if (!inlineFunctionNode) return;
+      if (isNodeOfType(inlineFunctionNode, "FunctionDeclaration")) return;
+      pushFunctionPropFrame(inlineFunctionNode);
+      exportDefaultDeclarationsWithFrames.add(node);
+    },
+    "ExportDefaultDeclaration:exit"(node: EsTreeNode) {
+      if (!isNodeOfType(node, "ExportDefaultDeclaration")) return;
+      if (!exportDefaultDeclarationsWithFrames.has(node)) return;
+      propParamStack.pop();
+    },
     FunctionDeclaration(node: EsTreeNode) {
       if (!isNodeOfType(node, "FunctionDeclaration")) return;
-      if (!node.id || !isUppercaseName(node.id.name)) {
+      if (!node.id || node.id.name === "default") {
+        propParamStack.push(extractDestructuredPropNames(node.params ?? []));
+        callbacks?.onComponentEnter?.(node.body);
+        functionDeclarationsWithFrames.add(node);
+        return;
+      }
+      if (!isUppercaseName(node.id.name)) {
         propParamStack.push(new Set());
+        functionDeclarationsWithFrames.add(node);
         return;
       }
       propParamStack.push(extractDestructuredPropNames(node.params ?? []));
       callbacks?.onComponentEnter?.(node.body);
+      functionDeclarationsWithFrames.add(node);
     },
-    "FunctionDeclaration:exit"() {
+    "FunctionDeclaration:exit"(node: EsTreeNode) {
+      if (!isNodeOfType(node, "FunctionDeclaration")) return;
+      if (!functionDeclarationsWithFrames.has(node)) return;
       propParamStack.pop();
     },
     VariableDeclarator(node: EsTreeNode) {
       if (!isNodeOfType(node, "VariableDeclarator")) return;
-      if (isComponentAssignment(node)) {
-        const initializer = node.init;
-        if (
-          isNodeOfType(initializer, "ArrowFunctionExpression") ||
-          isNodeOfType(initializer, "FunctionExpression")
-        ) {
-          propParamStack.push(extractDestructuredPropNames(initializer.params ?? []));
-          callbacks?.onComponentEnter?.(initializer.body);
-        } else {
-          propParamStack.push(new Set());
-        }
+      if (isNodeOfType(node.id, "Identifier") && isUppercaseName(node.id.name)) {
+        const inlineFunctionNode = getInlineFunctionNode(node.init);
+        if (!inlineFunctionNode) return;
+        pushFunctionPropFrame(inlineFunctionNode);
+        variableDeclaratorsWithFrames.add(node);
         return;
       }
       if (isFunctionLikeVariableDeclarator(node)) {
         propParamStack.push(new Set());
+        variableDeclaratorsWithFrames.add(node);
       }
     },
     "VariableDeclarator:exit"(node: EsTreeNode) {
       if (!isNodeOfType(node, "VariableDeclarator")) return;
-      if (isComponentAssignment(node) || isFunctionLikeVariableDeclarator(node)) {
-        propParamStack.pop();
-      }
+      if (!variableDeclaratorsWithFrames.has(node)) return;
+      propParamStack.pop();
     },
   };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-root-identifier-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-root-identifier-name.ts
@@ -21,6 +21,10 @@ export const getRootIdentifierName = (
   const followCallChains = options?.followCallChains === true;
   let cursor: EsTreeNode | undefined = node;
   while (cursor) {
+    if (isNodeOfType(cursor, "ChainExpression")) {
+      cursor = cursor.expression;
+      continue;
+    }
     if (isNodeOfType(cursor, "MemberExpression")) {
       cursor = cursor.object;
       continue;

--- a/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
@@ -54,6 +54,31 @@ export const Modal = ({ isOpen }: { isOpen: boolean }) => {
     expect(hits).toHaveLength(1);
   });
 
+  it("flags documentElement classList mutations", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-effect-event-handler-document-element-class-list",
+      {
+        files: {
+          "src/Theme.tsx": `import { useEffect } from "react";
+
+export const Theme = ({ isDark }: { isDark: boolean }) => {
+  useEffect(() => {
+    if (isDark) {
+      document.documentElement.classList.add("dark");
+    }
+  }, [isDark]);
+  return <div />;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
   it("does NOT flag when the test's root identifier is not in the deps", async () => {
     const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-unrelated-test", {
       files: {

--- a/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
@@ -370,6 +370,64 @@ export const Page = ({ unrelated }: { unrelated: boolean }) => {
     expect(hits).toHaveLength(0);
   });
 
+  it("does NOT flag when a member dep is for a different prop field than the guard", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-effect-event-handler-mismatched-member-dep",
+      {
+        files: {
+          "src/ProductPage.tsx": `import { useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export const ProductPage = ({ product }: { product: Product }) => {
+  useEffect(() => {
+    if (product.name) {
+      showNotification(\`Added \${product.name} to the shopping cart!\`);
+    }
+  }, [product.isInCart]);
+
+  return <div>{product.name}</div>;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT claim mixed local-trigger and prop guards belong to the prop rule", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-effect-event-handler-mixed-local-trigger-and-prop-guard",
+      {
+        files: {
+          "src/Wizard.tsx": `import { useEffect, useState } from "react";
+
+declare const navigate: (path: string) => void;
+
+export const Wizard = ({ isEnabled }: { isEnabled: boolean }) => {
+  const [destination, setDestination] = useState<string | null>(null);
+  useEffect(() => {
+    if (destination && isEnabled) {
+      navigate(destination);
+    }
+  }, [destination, isEnabled]);
+  return <button onClick={() => setDestination("/next")}>Next</button>;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(0);
+  });
+
   it("does NOT flag event-shaped effects for custom-hook-derived data", async () => {
     const projectDir = setupReactProject(
       tempRoot,

--- a/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
@@ -79,6 +79,160 @@ export const Theme = ({ isDark }: { isDark: boolean }) => {
     expect(hits).toHaveLength(1);
   });
 
+  it("flags member-expression dependency arrays", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-member-dep", {
+      files: {
+        "src/ProductPage.tsx": `import { useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export const ProductPage = ({ product }: { product: Product }) => {
+  useEffect(() => {
+    if (product.isInCart) {
+      showNotification(\`Added \${product.name} to the shopping cart!\`);
+    }
+  }, [product.isInCart]);
+
+  return <div>{product.name}</div>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags non-destructured prop parameters", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-props-parameter", {
+      files: {
+        "src/ProductPage.tsx": `import { useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export const ProductPage = (props: { product: Product }) => {
+  useEffect(() => {
+    if (props.product.isInCart) {
+      showNotification(\`Added \${props.product.name} to the shopping cart!\`);
+    }
+  }, [props.product.isInCart]);
+
+  return <div>{props.product.name}</div>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags aliased destructured props with binary guards", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-aliased-binary", {
+      files: {
+        "src/ProductPage.tsx": `import { useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export const ProductPage = ({ product: item }: { product: Product }) => {
+  useEffect(() => {
+    if (item.isInCart === true) {
+      showNotification(\`Added \${item.name} to the shopping cart!\`);
+    }
+  }, [item.isInCart]);
+
+  return <div>{item.name}</div>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags optional-chain logical guards", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-optional-logical", {
+      files: {
+        "src/ProductPage.tsx": `import { useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export const ProductPage = ({
+  product,
+  shouldNotify,
+}: {
+  product: Product | null;
+  shouldNotify: boolean;
+}) => {
+  useEffect(() => {
+    if (product?.isInCart && shouldNotify) {
+      showNotification(\`Added \${product.name} to the shopping cart!\`);
+    }
+  }, [product?.isInCart, shouldNotify]);
+
+  return <div>{product?.name}</div>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags early-return guarded event-like effects", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-early-return", {
+      files: {
+        "src/Modal.tsx": `import { useEffect } from "react";
+
+export const Modal = ({ isOpen }: { isOpen: boolean }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+    document.body.classList.add("modal-open");
+  }, [isOpen]);
+  return <div />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("does NOT treat cleanup-only early returns as event-like effects", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-effect-event-handler-early-return-cleanup-only",
+      {
+        files: {
+          "src/Modal.tsx": `import { useEffect } from "react";
+
+export const Modal = ({ isOpen }: { isOpen: boolean }) => {
+  useEffect(() => {
+    if (!isOpen) return;
+    return () => document.body.classList.remove("modal-open");
+  }, [isOpen]);
+  return <div />;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(0);
+  });
+
   it("flags wrapped component assignments", async () => {
     const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-memo-component", {
       files: {
@@ -97,6 +251,34 @@ export const ProductPage = memo(({ product }: { product: Product }) => {
 
   return <div>{product.name}</div>;
 });
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags forwardRef component assignments", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-forward-ref", {
+      files: {
+        "src/ProductPage.tsx": `import { forwardRef, useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export const ProductPage = forwardRef<HTMLDivElement, { product: Product }>(
+  ({ product }, ref) => {
+    useEffect(() => {
+      if (product.isInCart) {
+        showNotification(\`Added \${product.name} to the shopping cart!\`);
+      }
+    }, [product.isInCart]);
+
+    return <div ref={ref}>{product.name}</div>;
+  },
+);
 `,
       },
     });
@@ -207,6 +389,36 @@ export const CartNotification = () => {
       showNotification(\`Added \${product.name} to the shopping cart!\`);
     }
   }, [product]);
+
+  return <div>{product.name}</div>;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag early-return effects for custom-hook-derived data", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-effect-event-handler-hook-derived-early-return",
+      {
+        files: {
+          "src/CartNotification.tsx": `import { useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+declare const useCartProduct: () => { product: { isInCart: boolean; name: string } };
+
+export const CartNotification = () => {
+  const { product } = useCartProduct();
+
+  useEffect(() => {
+    if (!product.isInCart) return;
+    showNotification(\`Added \${product.name} to the shopping cart!\`);
+  }, [product.isInCart]);
 
   return <div>{product.name}</div>;
 };

--- a/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
@@ -102,6 +102,61 @@ export const Page = ({ unrelated }: { unrelated: boolean }) => {
     expect(hits).toHaveLength(0);
   });
 
+  it("does NOT flag event-shaped effects for custom-hook-derived data", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-effect-event-handler-hook-derived-event-shaped",
+      {
+        files: {
+          "src/CartNotification.tsx": `import { useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+declare const useCartProduct: () => { product: { isInCart: boolean; name: string } };
+
+export const CartNotification = () => {
+  const { product } = useCartProduct();
+
+  useEffect(() => {
+    if (product.isInCart) {
+      showNotification(\`Added \${product.name} to the shopping cart!\`);
+    }
+  }, [product]);
+
+  return <div>{product.name}</div>;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag local trigger state handled by no-event-trigger-state", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-local-trigger-state", {
+      files: {
+        "src/Wizard.tsx": `import { useEffect, useState } from "react";
+
+declare const navigate: (path: string) => void;
+
+export const Wizard = () => {
+  const [destination, setDestination] = useState<string | null>(null);
+  useEffect(() => {
+    if (destination) {
+      navigate(destination);
+    }
+  }, [destination]);
+  return <button onClick={() => setDestination("/next")}>Next</button>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(0);
+  });
+
   it("does NOT flag imported setUser external synchronization", async () => {
     const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-imported-set-user", {
       files: {

--- a/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
@@ -76,4 +76,58 @@ export const Page = ({ unrelated }: { unrelated: boolean }) => {
     const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
     expect(hits).toHaveLength(0);
   });
+
+  it("does NOT flag imported setUser external synchronization", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-imported-set-user", {
+      files: {
+        "src/SentryUserScope.tsx": `import { setUser } from "@sentry/react";
+import { useEffect } from "react";
+
+declare const useViewer: () => { viewer: { userId: string; screenName: string } | null };
+
+export const SentryUserScope = () => {
+  const { viewer } = useViewer();
+
+  useEffect(() => {
+    if (viewer) {
+      setUser({ id: viewer.userId, username: viewer.screenName });
+    }
+  }, [viewer]);
+
+  return null;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag namespace setUser external synchronization", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-namespace-set-user", {
+      files: {
+        "src/SentryUserScope.tsx": `import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
+
+declare const useViewer: () => { viewer: { userId: string; screenName: string } | null };
+
+export const SentryUserScope = () => {
+  const { viewer } = useViewer();
+
+  useEffect(() => {
+    if (viewer) {
+      Sentry.setUser({ id: viewer.userId, username: viewer.screenName });
+    }
+  }, [viewer]);
+
+  return null;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(0);
+  });
 });

--- a/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-effect-event-handler.test.ts
@@ -79,6 +79,92 @@ export const Theme = ({ isDark }: { isDark: boolean }) => {
     expect(hits).toHaveLength(1);
   });
 
+  it("flags wrapped component assignments", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-memo-component", {
+      files: {
+        "src/ProductPage.tsx": `import { memo, useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export const ProductPage = memo(({ product }: { product: Product }) => {
+  useEffect(() => {
+    if (product.isInCart) {
+      showNotification(\`Added \${product.name} to the shopping cart!\`);
+    }
+  }, [product]);
+
+  return <div>{product.name}</div>;
+});
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags anonymous default-exported arrow components", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-effect-event-handler-default-export-component",
+      {
+        files: {
+          "src/ProductPage.tsx": `import { useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export default ({ product }: { product: Product }) => {
+  useEffect(() => {
+    if (product.isInCart) {
+      showNotification(\`Added \${product.name} to the shopping cart!\`);
+    }
+  }, [product]);
+
+  return <div>{product.name}</div>;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags wrapped default-exported components", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-effect-event-handler-wrapped-default-export-component",
+      {
+        files: {
+          "src/ProductPage.tsx": `import { memo, useEffect } from "react";
+
+declare const showNotification: (message: string) => void;
+
+interface Product { isInCart: boolean; name: string }
+
+export default memo(({ product }: { product: Product }) => {
+  useEffect(() => {
+    if (product.isInCart) {
+      showNotification(\`Added \${product.name} to the shopping cart!\`);
+    }
+  }, [product]);
+
+  return <div>{product.name}</div>;
+});
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "no-effect-event-handler");
+    expect(hits).toHaveLength(1);
+  });
+
   it("does NOT flag when the test's root identifier is not in the deps", async () => {
     const projectDir = setupReactProject(tempRoot, "no-effect-event-handler-unrelated-test", {
       files: {

--- a/packages/react-doctor/tests/regressions/state-rules/no-event-trigger-state.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-event-trigger-state.test.ts
@@ -334,17 +334,7 @@ export const Custom = () => {
     expect(triggerHits.length).toBe(0);
   });
 
-  it("intentionally double-warns on the bare-truthy state shape (handler + trigger-state both fire)", async () => {
-    // Regression: \`if (destination) navigate(destination)\` triggers
-    // BOTH no-effect-event-handler and no-event-trigger-state. An
-    // earlier implementation tried to defer the former to the latter,
-    // but that deference silently dropped diagnostics whenever the
-    // narrower rule's preconditions (handler-only writes,
-    // not render-reachable, etc.) didn't hold. Both rules now fire
-    // independently — the messages frame the same code differently
-    // ("this useEffect simulates a handler" vs "this state exists
-    // only to schedule navigate from an effect") so a duplicate is
-    // strictly better than a silent drop.
+  it("reports local trigger state without a no-effect-event-handler duplicate", async () => {
     const projectDir = setupReactProject(tempRoot, "no-event-trigger-state-double-warn", {
       files: {
         "src/Wizard.tsx": `import { useEffect, useState } from "react";
@@ -367,7 +357,7 @@ export const Wizard = () => {
     const triggerHits = await collectRuleHits(projectDir, "no-event-trigger-state");
     const handlerHits = await collectRuleHits(projectDir, "no-effect-event-handler");
     expect(triggerHits.length).toBe(1);
-    expect(handlerHits.length).toBe(1);
+    expect(handlerHits.length).toBe(0);
   });
 
   it("does NOT flag dual-purpose state that's also read in render (Bugbot #155)", async () => {

--- a/packages/react-doctor/tests/regressions/state-rules/no-event-trigger-state.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-event-trigger-state.test.ts
@@ -304,14 +304,7 @@ export const Game = () => {
     expect(triggerHits[0].message).toContain("analytics.track");
   });
 
-  it("KEEPS no-effect-event-handler warning when state-typed dep has a non-allowlisted callee (Bugbot #155 round 3)", async () => {
-    // Regression: round-2 deference was too eager — it skipped
-    // no-effect-event-handler whenever the trigger was a useState
-    // value, but no-event-trigger-state has a tighter side-effect-
-    // callee allowlist. \`customAction()\` isn't in the allowlist, so
-    // no-event-trigger-state would NOT fire — and the round-2
-    // version then silently dropped the warning. Now no-effect-
-    // event-handler fires unless BOTH predicates match.
+  it("does NOT report event-only trigger state when the callee is not event-shaped", async () => {
     const projectDir = setupReactProject(
       tempRoot,
       "no-event-trigger-state-no-overshadow-on-custom-callee",
@@ -337,10 +330,7 @@ export const Custom = () => {
 
     const handlerHits = await collectRuleHits(projectDir, "no-effect-event-handler");
     const triggerHits = await collectRuleHits(projectDir, "no-event-trigger-state");
-    // customAction isn't in the side-effect allowlist → no-event-
-    // trigger-state stays silent. no-effect-event-handler MUST still
-    // warn (otherwise we silently dropped the diagnostic).
-    expect(handlerHits.length).toBe(1);
+    expect(handlerHits.length).toBe(0);
     expect(triggerHits.length).toBe(0);
   });
 

--- a/packages/react-doctor/tests/regressions/state-rules/no-event-trigger-state.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/no-event-trigger-state.test.ts
@@ -335,9 +335,12 @@ export const Custom = () => {
   });
 
   it("reports local trigger state without a no-effect-event-handler duplicate", async () => {
-    const projectDir = setupReactProject(tempRoot, "no-event-trigger-state-double-warn", {
-      files: {
-        "src/Wizard.tsx": `import { useEffect, useState } from "react";
+    const projectDir = setupReactProject(
+      tempRoot,
+      "no-event-trigger-state-without-handler-duplicate",
+      {
+        files: {
+          "src/Wizard.tsx": `import { useEffect, useState } from "react";
 
 declare const navigate: (path: string) => void;
 
@@ -351,8 +354,9 @@ export const Wizard = () => {
   return <button onClick={() => setDestination("/next")}>Next</button>;
 };
 `,
+        },
       },
-    });
+    );
 
     const triggerHits = await collectRuleHits(projectDir, "no-event-trigger-state");
     const handlerHits = await collectRuleHits(projectDir, "no-effect-event-handler");


### PR DESCRIPTION
## Summary
- Require `no-effect-event-handler` guarded effects to contain an event-shaped side effect before reporting.
- Share the event-triggered side-effect callee classifier with `no-event-trigger-state`.
- Add regressions for Sentry-style `setUser` synchronization and the narrowed custom-callee behavior.

## Test plan
- `nr build`
- `nr test tests/regressions/state-rules/no-effect-event-handler.test.ts tests/regressions/state-rules/no-event-trigger-state.test.ts`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static-analysis heuristics for two effect/state rules, which may add/remove diagnostics across user code depending on AST shapes and side-effect classification.
> 
> **Overview**
> Tightens `no-effect-event-handler` to require **prop-guarded effects** whose guarded/early-return body contains an *event-like* side effect (shared callee allowlist plus `document.(body|documentElement).classList.*` mutations), reducing false positives on generic synchronization work.
> 
> Extracts the side-effect callee classifier into `find-triggered-side-effect-callee-name.ts` for reuse by `no-event-trigger-state`, and updates component/prop detection (`createComponentPropStackTracker`, `getRootIdentifierName`) to better handle wrapped components, default exports, and optional chaining.
> 
> Expands regression coverage and updates expectations to avoid duplicate warnings between `no-event-trigger-state` and `no-effect-event-handler`, and to suppress cases like Sentry `setUser(...)` sync and non-event-shaped custom callees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d086424750e8884ce758a6efb8a154c7271152f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->