### PR TITLE
test: add fixed issue regression coverage

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -7,6 +7,7 @@
 Status: confirmed current, open.
 
 Links:
+
 - Issue: https://github.com/millionco/react-doctor/issues/206
 - PRs: https://github.com/millionco/react-doctor/pull/209, https://github.com/millionco/react-doctor/pull/211, https://github.com/millionco/react-doctor/pull/233, https://github.com/millionco/react-doctor/pull/238, https://github.com/millionco/react-doctor/pull/251
 
@@ -21,11 +22,13 @@ export async function GET(req: NextRequest, ctx: RouteContext) {
 ```
 
 Why it matters:
+
 - One Next.js 14 codebase got 138 errors.
 - Reporter said 0 were real side effects.
 - Workaround required 138 inline suppressions.
 
 Fix:
+
 - Skip `response.headers.set/append/delete`.
 - Skip local request-scoped `Map` / `Set` created inside the handler.
 - Decide and document `cookies().set()` / `headers().set()` semantics.
@@ -38,6 +41,7 @@ Fix:
 Status: confirmed current, open.
 
 Links:
+
 - Issue: https://github.com/millionco/react-doctor/issues/239
 - PR: https://github.com/millionco/react-doctor/pull/240
 
@@ -48,15 +52,16 @@ await auth0.getSession();
 ```
 
 Why it matters:
+
 - Reporter saw 139 false positives.
 - Current check only accepts bare identifiers:
 
 ```ts
-isNodeOfType(callNode?.callee, "Identifier") &&
-AUTH_FUNCTION_NAMES.has(callNode.callee.name)
+isNodeOfType(callNode?.callee, "Identifier") && AUTH_FUNCTION_NAMES.has(callNode.callee.name);
 ```
 
 Fix:
+
 - Accept member calls whose final property is in `AUTH_FUNCTION_NAMES`.
 - Cover `auth0.getSession()`, `ctx.auth.getUser()`, `clerkClient.getUser()`, `session.auth()`.
 - Add project config allowlist for custom auth guards.
@@ -71,16 +76,13 @@ Link: https://github.com/millionco/react-doctor/issues/241
 Repro:
 
 ```ts
-const [flowRow] = await db
-  .select()
-  .from(flowsTable)
-  .where(eq(flowsTable.seq, flowSeq))
-  .limit(1);
+const [flowRow] = await db.select().from(flowsTable).where(eq(flowsTable.seq, flowSeq)).limit(1);
 
 if (!flowRow) return [];
 ```
 
 Fix:
+
 - Add recursive binding collection for `ArrayPattern`, nested patterns, rest elements, and assignment patterns.
 - Add tests for `[row]`, `[, row]`, `[row = fallback]`, `{ rows: [row] }`.
 
@@ -89,18 +91,21 @@ Fix:
 Status: confirmed current.
 
 Sources:
+
 - Screenshot: `async-parallel` in `SettingsPanels.browser.tsx`.
 - Screenshot: ordered test-like `render -> expect -> click -> expect`.
 - Dogfood issues: https://github.com/millionco/react-doctor/issues/216, https://github.com/millionco/react-doctor/issues/219
 - Related PR: https://github.com/millionco/react-doctor/pull/238
 
 Current problem:
+
 - `async-parallel.ts` uses a narrow local `TEST_FILE_PATTERN`.
 - It misses `tests/`, `test/`, `__tests__/`, `e2e/`, `playwright/`, `cypress/`, fixtures, mocks, and `.browser.tsx`.
 - It is not tagged `test-noise`, so shared test suppression does not apply.
 - Dogfood warnings also include intentional `async-await-in-loop` animation/delay sequences.
 
 Fix:
+
 - Tag `async-parallel` as `test-noise` or use shared `isTestFilePath()`.
 - Suppress in files importing Playwright, Testing Library, Vitest, Jest, or browser test helpers.
 - Do not parallelize `render`, `expect`, `locator.click`, `page.click`, setup/teardown, or ordered UI assertions.
@@ -112,15 +117,18 @@ Fix:
 Status: confirmed current.
 
 Sources:
+
 - Screenshot: `rn-no-raw-text` in `apps/web/src/components/ThreadTerminalDrawer.tsx`.
 - Issues: https://github.com/millionco/react-doctor/issues/93, https://github.com/millionco/react-doctor/issues/100, https://github.com/millionco/react-doctor/issues/180, https://github.com/millionco/react-doctor/issues/183
 
 Current problem:
+
 - `rn-no-raw-text.ts` only skips `.web.[jt]sx?` and `"use dom"`.
 - It does not understand `apps/web/**` or package framework boundaries.
 - `rawTextWrapperComponents` helps RN wrappers, not web-package scoping.
 
 Fix:
+
 - Scope RN rules to packages detected as React Native / Expo.
 - Skip RN rules in web, docs, Storybook, Docusaurus, Next/Vite/React DOM packages.
 - Add mixed-monorepo fixture: `apps/web` plus `apps/native`.
@@ -131,13 +139,16 @@ Fix:
 Status: confirmed current.
 
 Source:
+
 - Screenshot: SPA/client-only app got server-action advice for `<form onSubmit preventDefault()>`.
 
 Current problem:
+
 - `no-prevent-default.ts` always recommends server actions for form submit handlers.
 - It has no framework/server-capability gate.
 
 Fix:
+
 - Split generic form semantics from server-action advice.
 - Only recommend server actions in server-capable frameworks.
 - In SPA/client-only apps, suppress the form variant or use client-appropriate wording.
@@ -149,13 +160,16 @@ Fix:
 Status: confirmed current.
 
 Source:
+
 - Screenshot: `.every()` warning fired even though the same condition already checked length equality.
 
 Current problem:
+
 - Rule checks only nearest logical expression's immediate `left`.
 - It misses length guards inside larger `&&` chains.
 
 Fix:
+
 - Flatten surrounding `&&` chains.
 - Search previous operands for matching length equality.
 - Confirm `.every()` receiver and indexed array match the guard.
@@ -166,16 +180,22 @@ Fix:
 Status: open.
 
 Links:
+
 - Issue: https://github.com/millionco/react-doctor/issues/205
 - PR: https://github.com/millionco/react-doctor/pull/212
 
 Repro:
 
 ```ts
-const oddDoubles = numbers.values().filter((value) => value % 2 === 1).map((value) => 2 * value).toArray();
+const oddDoubles = numbers
+  .values()
+  .filter((value) => value % 2 === 1)
+  .map((value) => 2 * value)
+  .toArray();
 ```
 
 Fix:
+
 - Detect chains rooted in `.values()`, `.entries()`, `.keys()`, generators, and Iterator helpers.
 - Keep flagging eager array chains like `array.filter(...).map(...)`.
 
@@ -184,10 +204,12 @@ Fix:
 Status: confirmed current.
 
 Source:
+
 - Screenshot: `w-5 h-5 -> size-5` from `design-no-redundant-size-axes`.
 - Feedback: weak signal from a "React reviewer."
 
 Fix:
+
 - Make `design` rules opt-in, score-neutral, collapsed, or hidden from PR comments by default.
 - Add category/surface controls for CLI, PR comments, score, and CI failure.
 - Keep Tailwind version gating, but do not let style cleanup dilute React findings.
@@ -197,9 +219,11 @@ Fix:
 Status: hosted/product, confirmed by screenshot.
 
 Source:
+
 - Screenshot: score 70, "Needs Improvement", "Below 90", but "This PR leaves the React health score unchanged."
 
 Fix:
+
 - Track baseline score, PR score, delta, new diagnostics, and fixed diagnostics.
 - Use neutral wording when unchanged:
   - `Repository score remains 70/100. This PR did not introduce React Review regressions.`
@@ -213,6 +237,7 @@ Status: confirmed current, open.
 Link: https://github.com/millionco/react-doctor/pull/243
 
 Fix:
+
 - Add max pattern length and max wildcard count.
 - Reject pathological patterns with clear config errors.
 - Prefer a proven glob matcher if possible.
@@ -227,11 +252,13 @@ Status: confirmed current.
 Link: https://github.com/millionco/react-doctor/issues/89
 
 Current problem:
+
 - `inspect.ts` omits score in offline mode.
 - README says offline skips score API and no score is shown.
 - `action.yml` says offline will "calculate score locally."
 
 Fix:
+
 - Implement local score calculation or update `action.yml` and marketplace docs.
 - Add tests for `--offline`, `--score --offline`, Action offline score output, and CI auto-offline.
 
@@ -242,11 +269,13 @@ Status: confirmed current.
 Link: https://github.com/millionco/react-doctor/pull/246
 
 Current problem:
+
 - PR #246 removed Knip/dead-code analysis.
 - README still says React Doctor reports dead code.
 - `skills/react-doctor/SKILL.md` still advertises dead code coverage.
 
 Fix:
+
 - Remove current dead-code claims from README, marketplace copy, hosted copy, and skill docs.
 - Add migration note: dead-code analysis was removed; use Knip directly.
 
@@ -255,15 +284,18 @@ Fix:
 Status: confirmed current.
 
 Links:
+
 - https://github.com/millionco/react-doctor/issues/75
 - https://github.com/millionco/react-doctor/issues/79
 
 Current problem:
+
 - README still uses `uses: millionco/react-doctor@main`.
 - `@main` was explicitly reported as supply-chain risk.
 - No `.github/workflows/release.yml` was found.
 
 Fix:
+
 - Recommend stable action tags.
 - Ensure release workflow exists.
 - Ensure released action inputs match docs.
@@ -276,6 +308,7 @@ Status: partially addressed.
 Link: https://github.com/millionco/react-doctor/issues/81
 
 Fix:
+
 - Add `annotations` input.
 - Pass `--annotations` when enabled.
 - Document annotations-only, comments-only, or both.
@@ -285,6 +318,7 @@ Fix:
 Status: partially addressed.
 
 Fix:
+
 - Support per-rule/per-tag controls for severity, score contribution, PR comment visibility, CLI visibility, and CI failure.
 - Use this for `design`, `test-noise`, React Native, server-action, and migration-hint rules.
 
@@ -293,6 +327,7 @@ Fix:
 Status: partially addressed.
 
 Fix:
+
 - Audit every rule.
 - Tag noisy test rules:
   - async parallel/defer rules,
@@ -307,10 +342,12 @@ Fix:
 Status: partially addressed.
 
 Sources:
+
 - Issue #206 suppression friction.
 - Historical issues: #144, #158, #159, #161.
 
 Fix:
+
 - Show exact suppression snippet in PR comments.
 - Accept bare rule IDs when unambiguous.
 - Support rationale after `--`.
@@ -322,11 +359,13 @@ Fix:
 Status: open.
 
 Links:
+
 - Issue: https://github.com/millionco/react-doctor/issues/203
 - PR: https://github.com/millionco/react-doctor/pull/213
 - Related: #74, #115, #31
 
 Fix:
+
 - Land or replace #213.
 - Explain `--diff`, `--staged`, `--full`, partially staged files, and index-vs-working-tree behavior.
 - Add recipes for Husky, lint-staged, Lefthook, and pre-commit.
@@ -336,10 +375,12 @@ Fix:
 Status: open duplicate PRs.
 
 Links:
+
 - https://github.com/millionco/react-doctor/pull/214
 - https://github.com/millionco/react-doctor/pull/32
 
 Fix:
+
 - Pick `--package-json <path>` or another stable API.
 - Avoid cache bugs when same source dir is analyzed with different manifests.
 - Close duplicate PR.
@@ -349,11 +390,13 @@ Fix:
 Status: partially addressed.
 
 Sources:
+
 - "No React dependency found" reports in Bun workspaces, catalog setups, and non-standard `package.json` layouts.
 - Related fixed issues: #27, #87, #101, #105, #116, #191.
 - Related open PRs: #192, #214, #32.
 
 Fix:
+
 - Keep regression coverage for pnpm/Bun catalogs, grouped catalogs, peer deps, and dev deps.
 - Improve error text with nearest detected package and suggested `--package-json` / `--project` fix.
 - Do not regress root-project and monorepo package discovery.
@@ -365,6 +408,7 @@ Status: open.
 Link: https://github.com/millionco/react-doctor/pull/252
 
 Fix:
+
 - Ensure server/config/test exclusions do not hide real client leaks.
 - Add fixtures for Vite, Next, CRA, Gatsby, TanStack Start.
 - Keep value-pattern secret detection active where appropriate.
@@ -374,13 +418,16 @@ Fix:
 Status: open PRs, recurring feedback.
 
 Links:
+
 - https://github.com/millionco/react-doctor/pull/254
 - https://github.com/millionco/react-doctor/pull/186
 
 Sources:
+
 - Users reported `forwardRef` and React 18-compatible library patterns being penalized.
 
 Fix:
+
 - Do not apply React 19-only advice to React 18 packages.
 - Respect library peer dependency ranges.
 - Add fixtures for `forwardRef`, library exports, local `use`, and React 18/19 split behavior.
@@ -390,11 +437,13 @@ Fix:
 Status: partially addressed.
 
 Sources:
+
 - High RAM / OOM / SIGABRT reports on large monorepos.
 - Historical dead-code crashes: #77, #132, #135, #149.
 - Historical large command/path issue: #46.
 
 Fix:
+
 - Keep crash regressions even after Knip removal.
 - Add clearer partial-output/error reporting for scan aborts.
 - Document memory expectations and large-repo mitigations.
@@ -405,11 +454,13 @@ Fix:
 Status: hosted/product.
 
 User confusion:
+
 - "Should we use react doctor or react review?"
 - "Is there additional benefit if already using react-doctor?"
 - "So a react-doctor clone?"
 
 Fix:
+
 - React Doctor: local CLI, packages, CI command, offline/local workflows.
 - React Review: hosted dashboard, GitHub App, PR comments, baseline/delta, team workflow.
 - Add "Already using React Doctor?" migration path.
@@ -419,6 +470,7 @@ Fix:
 Status: hosted/product.
 
 Fix:
+
 - Audit private repo auth path.
 - Distinguish not installed, missing permission, private repo, rate limit, unsupported host, and backend failure.
 - Add reconnect/retry path.
@@ -428,9 +480,11 @@ Fix:
 Status: hosted/product.
 
 Source:
+
 - Self-hosted GitLab user said they feel left out.
 
 Fix:
+
 - Decide support level for GitLab SaaS, self-hosted GitLab, generic CI annotations, and webhook-based hosted Review.
 - Publish current workaround using CLI JSON/SARIF or CI output.
 - Add GitLab CI recipe if hosted integration is not immediate.
@@ -440,11 +494,13 @@ Fix:
 Status: hosted/product.
 
 Sources:
+
 - Fintech user cannot install third-party GHAs.
 - User saw scary full-account GitHub access.
 - User installed but could not see lints.
 
 Fix:
+
 - Make GitHub App, OAuth, GHA, CLI, and enterprise/self-hosted paths explicit.
 - Explain selected-repo vs account-wide access before redirect.
 - Add states for waiting, queued, running, no issues, comment failed, repo access failed, unsupported project, backend error.
@@ -455,11 +511,13 @@ Fix:
 Status: partially addressed.
 
 Links:
+
 - https://github.com/millionco/react-doctor/issues/35
 - https://github.com/millionco/react-doctor/issues/89
 - https://github.com/millionco/react-doctor/issues/92
 
 Fix:
+
 - Explain what CLI sends to score/share APIs.
 - Explain what `--offline` disables.
 - Explain hosted Review repo/code access.
@@ -470,11 +528,13 @@ Fix:
 Status: partially addressed.
 
 Sources:
+
 - 89 -> 49.
 - 93 -> 68.
 - 44/100 with hundreds of warnings.
 
 Fix:
+
 - Add release notes for material rule changes.
 - Show why scores changed: new rules, changed severities, formula, unique error/warning rules.
 - Avoid encouraging blind 100/100 chasing.
@@ -484,6 +544,7 @@ Fix:
 Status: partially addressed.
 
 Fix:
+
 - Publish mapping for marketing version, npm version, action tag, and hosted Review version.
 - Include rule diff and expected score impact in releases.
 
@@ -492,11 +553,13 @@ Fix:
 Status: partially addressed.
 
 Links:
+
 - #47
 - #60
 - #88
 
 Fix:
+
 - Confirm current JSON/report/share outputs.
 - Document local-only report workflow.
 - Add SARIF or generic report path if needed for non-GitHub CI.
@@ -506,10 +569,12 @@ Fix:
 Status: partially addressed.
 
 Sources:
+
 - Users asked for simple "block merge if score < X" behavior.
 - Existing scoring/delta feedback shows absolute thresholds can be misleading.
 
 Fix:
+
 - Document `fail-on`, score thresholds, annotations, and PR comments together.
 - Separate "fail on new regressions" from "fail because baseline score is below threshold."
 - Add examples for advisory mode, regression-only mode, and strict threshold mode.
@@ -521,9 +586,11 @@ Fix:
 Status: product.
 
 Source:
+
 - User suggested detecting dangerous configs like `pull_request_target` plus shared caches.
 
 Candidate checks:
+
 - `pull_request_target` on untrusted PRs.
 - Shared caches in publish/release pipelines.
 - Cache poisoning.
@@ -538,9 +605,11 @@ Candidate checks:
 Status: product.
 
 Source:
+
 - User said they did not naturally feel a strong urge to install a "react review bot."
 
 Better wedges:
+
 - Catch bad agent-generated React before merge.
 - Stop hooks/rendering/server-client bugs in PRs.
 - Framework-aware React CI guardrail.
@@ -552,10 +621,12 @@ Better wedges:
 Status: hosted/product.
 
 Sources:
+
 - v1 feedback called out dashboard/error states and PR comment quality.
 - Competitive feedback criticized whimsical, filler, low-value, or over-broad bot comments.
 
 Fix:
+
 - Put new regressions first and baseline findings separately.
 - Collapse low-value warnings by default.
 - Keep comments concise, serious, and actionable.
@@ -566,6 +637,7 @@ Fix:
 Status: platform.
 
 Fix:
+
 - Decide no support, best effort, Preact-specific mode, or rule subset.
 - Detect `preact`, `preact/compat`, and `@preact/signals`.
 - Document unsupported React-specific rules.
@@ -575,10 +647,12 @@ Fix:
 Status: partially addressed.
 
 Links:
+
 - Support: #21, #65, #64
 - False positives: #93, #100, #180, #183
 
 Fix:
+
 - Publish RN support matrix.
 - Document `rawTextWrapperComponents`.
 - Fix web-package and `Platform.OS === "web"` scoping.
@@ -590,6 +664,7 @@ Status: open.
 Link: https://github.com/millionco/react-doctor/pull/164
 
 Decision:
+
 - HIR may reduce AST heuristic false positives.
 - Do not merge until false-positive policy is stable and regressions prove it improves real cases.
 
@@ -600,6 +675,7 @@ Status: open.
 Link: https://github.com/millionco/react-doctor/pull/173
 
 Decision:
+
 - Useful for local exploration.
 - Not a blocker for PR trust, install, or false-positive quality.
 - Keep behind subcommand or beta flag.
@@ -609,9 +685,11 @@ Decision:
 Status: product.
 
 Source:
+
 - Requests mention Vue, Angular, Svelte, TypeScript, Python, Solid, and broader agent-friendly-code checks.
 
 Decision:
+
 - Keep React Doctor React-only, or create separate rule packs/products.
 - If broadening, separate branding and diagnostics so React-specific quality is not diluted.
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
@@ -56,10 +56,6 @@ export const LEGACY_EXPO_PACKAGE_REPLACEMENTS = new Map<string, string>([
     "expo-permissions",
     "the permissions API in each module (e.g. Camera.requestPermissionsAsync())",
   ],
-  [
-    "@expo/vector-icons",
-    "expo-symbols or expo-image (see https://docs.expo.dev/versions/latest/sdk/symbols/)",
-  ],
 ]);
 
 export const REACT_NATIVE_LIST_COMPONENTS = new Set([

--- a/packages/react-doctor/tests/discover-project.test.ts
+++ b/packages/react-doctor/tests/discover-project.test.ts
@@ -33,6 +33,22 @@ describe("discoverProject", () => {
     expect(projectInfo.reactVersion).toBe("^18.0.0 || ^19.0.0");
   });
 
+  it("detects React version from devDependencies only", () => {
+    const projectDirectory = path.join(tempDirectory, "react-in-dev-deps-only");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "react-in-dev-deps-only",
+        devDependencies: { react: "^18.3.1", "react-dom": "^18.3.1" },
+      }),
+    );
+
+    const projectInfo = discoverProject(projectDirectory);
+    expect(projectInfo.reactVersion).toBe("^18.3.1");
+    expect(projectInfo.reactMajorVersion).toBe(18);
+  });
+
   it("detects Tailwind version from devDependencies when present", () => {
     const projectDirectory = path.join(tempDirectory, "tw-from-dev-deps");
     fs.mkdirSync(projectDirectory, { recursive: true });
@@ -127,6 +143,36 @@ describe("discoverProject", () => {
     expect(projectInfo.reactVersion).toBe("19.2.0");
   });
 
+  it("resolves React version from a Bun grouped catalog when the leaf also uses devDependencies", () => {
+    const monorepoRoot = path.join(tempDirectory, "bun-grouped-catalog-dev-deps");
+    fs.mkdirSync(path.join(monorepoRoot, "apps", "web"), { recursive: true });
+    fs.writeFileSync(
+      path.join(monorepoRoot, "package.json"),
+      JSON.stringify({
+        name: "monorepo",
+        private: true,
+        workspaces: ["apps/*"],
+        catalogs: {
+          react19: {
+            react: "19.2.1",
+            "react-dom": "19.2.1",
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(monorepoRoot, "apps", "web", "package.json"),
+      JSON.stringify({
+        name: "web",
+        devDependencies: { react: "catalog:react19", "react-dom": "catalog:react19" },
+      }),
+    );
+
+    const projectInfo = discoverProject(path.join(monorepoRoot, "apps", "web"));
+    expect(projectInfo.reactVersion).toBe("19.2.1");
+    expect(projectInfo.reactMajorVersion).toBe(19);
+  });
+
   it("picks the leaf-referenced group when multiple Bun grouped catalogs define the same package", () => {
     const projectInfo = discoverProject(
       path.join(FIXTURES_DIRECTORY, "bun-multiple-grouped-catalogs", "apps", "web"),
@@ -213,6 +259,30 @@ describe("discoverProject", () => {
     expect(projectInfo.reactVersion).toBe("^19.0.0");
   });
 
+  it("discovers React and framework from workspace packages when scanning a monorepo root", () => {
+    const monorepoRoot = path.join(tempDirectory, "root-project-from-workspace-packages");
+    fs.mkdirSync(path.join(monorepoRoot, "apps", "web"), { recursive: true });
+    fs.writeFileSync(
+      path.join(monorepoRoot, "package.json"),
+      JSON.stringify({
+        name: "monorepo-root",
+        private: true,
+        workspaces: ["apps/*"],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(monorepoRoot, "apps", "web", "package.json"),
+      JSON.stringify({
+        name: "web",
+        dependencies: { next: "^15.0.0", react: "^19.0.0", "react-dom": "^19.0.0" },
+      }),
+    );
+
+    const projectInfo = discoverProject(monorepoRoot);
+    expect(projectInfo.reactVersion).toBe("^19.0.0");
+    expect(projectInfo.framework).toBe("nextjs");
+  });
+
   it("does not detect React Compiler when next.config sets reactCompiler to false", () => {
     const projectDirectory = path.join(tempDirectory, "next-react-compiler-disabled");
     fs.mkdirSync(projectDirectory, { recursive: true });
@@ -271,6 +341,26 @@ describe("listWorkspacePackages", () => {
     expect(packageNames).toContain("monorepo-root");
     expect(packageNames).toContain("ui");
     expect(packages).toHaveLength(2);
+  });
+
+  it("supports package.json workspaces object form", () => {
+    const rootDirectory = path.join(tempDirectory, "workspace-object-form");
+    const appDirectory = path.join(rootDirectory, "apps", "web");
+    fs.mkdirSync(appDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(rootDirectory, "package.json"),
+      JSON.stringify({
+        name: "workspace-object-root",
+        workspaces: { packages: ["apps/*"] },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(appDirectory, "package.json"),
+      JSON.stringify({ name: "web", dependencies: { react: "^19.0.0" } }),
+    );
+
+    const packages = listWorkspacePackages(rootDirectory);
+    expect(packages).toEqual([{ name: "web", directory: appDirectory }]);
   });
 });
 

--- a/packages/react-doctor/tests/evaluate-suppression.test.ts
+++ b/packages/react-doctor/tests/evaluate-suppression.test.ts
@@ -7,6 +7,30 @@ const nearMissHintFor = (lines: string[], diagnosticLineIndex: number, ruleId: s
   evaluateSuppression(lines, diagnosticLineIndex, ruleId).nearMissHint;
 
 describe("evaluateSuppression near-miss hints", () => {
+  it("marks same-line disable-line comments as suppressed", () => {
+    const lines = linesOf(
+      `const x = 1; // react-doctor-disable-line react-doctor/no-derived-state-effect\n`,
+    );
+    const result = evaluateSuppression(lines, 0, "react-doctor/no-derived-state-effect");
+    expect(result).toEqual({ isSuppressed: true, nearMissHint: null });
+  });
+
+  it("marks stacked disable-next-line comments as suppressed when each rule is listed separately", () => {
+    const lines = linesOf(
+      `// react-doctor-disable-next-line react-doctor/no-derived-state-effect\n` +
+        `// react-doctor-disable-next-line react-doctor/no-fetch-in-effect\n` +
+        `const x = 1;\n`,
+    );
+    expect(evaluateSuppression(lines, 2, "react-doctor/no-derived-state-effect")).toEqual({
+      isSuppressed: true,
+      nearMissHint: null,
+    });
+    expect(evaluateSuppression(lines, 2, "react-doctor/no-fetch-in-effect")).toEqual({
+      isSuppressed: true,
+      nearMissHint: null,
+    });
+  });
+
   it("returns null when no nearby disable-next-line comment exists", () => {
     const lines = linesOf(`const x = 1;\nconst y = 2;\n`);
     expect(nearMissHintFor(lines, 1, "react-doctor/no-derived-state-effect")).toBeNull();
@@ -46,5 +70,13 @@ describe("evaluateSuppression near-miss hints", () => {
       `// react-doctor-disable-next-line react-doctor/no-derived-state-effect\nconst x = 1;\n`,
     );
     expect(nearMissHintFor(lines, 1, "react-doctor/no-derived-state-effect")).toBeNull();
+  });
+
+  it("returns null when a description follows the matching rule list", () => {
+    const lines = linesOf(
+      `// react-doctor-disable-next-line react-doctor/no-derived-state-effect -- intentional fixture state mirror\nconst x = 1;\n`,
+    );
+    const result = evaluateSuppression(lines, 1, "react-doctor/no-derived-state-effect");
+    expect(result).toEqual({ isSuppressed: true, nearMissHint: null });
   });
 });

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -6,34 +6,57 @@ const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "..", "..", "..");
 const ACTION_YAML_PATH = path.join(REPOSITORY_ROOT, "action.yml");
 
 const readActionYaml = (): string => fs.readFileSync(ACTION_YAML_PATH, "utf8");
+const normalizeWhitespace = (value: string): string => value.replace(/\s+/g, " ");
+
+const extractBlock = (actionYaml: string, startMarker: string, endMarker: string): string => {
+  const startIndex = actionYaml.indexOf(startMarker);
+  if (startIndex < 0) throw new Error(`Missing action.yml marker: ${startMarker}`);
+  const endIndex = actionYaml.indexOf(endMarker, startIndex + startMarker.length);
+  if (endIndex < 0) throw new Error(`Missing action.yml marker: ${endMarker}`);
+  return actionYaml.slice(startIndex, endIndex);
+};
+
+const extractStep = (actionYaml: string, marker: string): string => {
+  const markerIndex = actionYaml.indexOf(marker);
+  if (markerIndex < 0) throw new Error(`Missing action.yml step marker: ${marker}`);
+  const stepStartIndex = actionYaml.lastIndexOf("\n    - ", markerIndex);
+  const stepEndIndex = actionYaml.indexOf("\n    - ", markerIndex + marker.length);
+  return actionYaml.slice(
+    stepStartIndex < 0 ? 0 : stepStartIndex,
+    stepEndIndex < 0 ? undefined : stepEndIndex,
+  );
+};
 
 describe("GitHub Action contract", () => {
   it("issue #190: score collection cannot fail the job on Needs work scores", () => {
-    const actionYaml = readActionYaml();
+    const scoreStep = normalizeWhitespace(extractStep(readActionYaml(), "- id: score"));
 
-    expect(actionYaml).toContain('SCORE_ARGS=("$INPUT_DIRECTORY" "--score" "--fail-on" "none")');
-    expect(actionYaml).toContain('SCORE=$(npx -y react-doctor@latest "${SCORE_ARGS[@]}"');
-    expect(actionYaml).toContain(") || true");
+    expect(scoreStep).toContain("--score");
+    expect(scoreStep).toContain('"--fail-on" "none"');
+    expect(scoreStep).toContain("SCORE=$(npx -y react-doctor@latest");
+    expect(scoreStep).toContain("|| true");
   });
 
   it("issue #188 + #61: action exposes CI inputs used by the scan step", () => {
     const actionYaml = readActionYaml();
-
-    expect(actionYaml).toContain("github-token:");
-    expect(actionYaml).toContain("fail-on:");
-    expect(actionYaml).toContain("diff:");
-    expect(actionYaml).toContain('FLAGS=("--fail-on" "$INPUT_FAIL_ON")');
-    expect(actionYaml).toContain(
-      'if [ -n "$INPUT_DIFF" ]; then FLAGS+=("--diff" "$INPUT_DIFF"); fi',
+    const inputsBlock = extractBlock(actionYaml, "inputs:", "\noutputs:");
+    const scanStep = normalizeWhitespace(
+      extractStep(actionYaml, "INPUT_FAIL_ON: ${{ inputs.fail-on }}"),
     );
-    expect(actionYaml).toContain('if [ -n "$INPUT_GITHUB_TOKEN" ]; then');
+
+    for (const inputName of ["github-token", "fail-on", "diff"]) {
+      expect(inputsBlock).toContain(`  ${inputName}:`);
+    }
+    expect(scanStep).toContain('"--fail-on" "$INPUT_FAIL_ON"');
+    expect(scanStep).toContain('"--diff" "$INPUT_DIFF"');
+    expect(scanStep).toContain("$INPUT_GITHUB_TOKEN");
   });
 
   it("guards diff fetch refs against shell-option injection", () => {
-    const actionYaml = readActionYaml();
+    const fetchStep = extractStep(readActionYaml(), "DIFF_BASE: ${{ inputs.diff }}");
 
-    expect(actionYaml).toContain('case "$DIFF_BASE" in -* )');
-    expect(actionYaml).toContain('case "$HEAD_REF" in -* )');
-    expect(actionYaml).toContain('git fetch origin "$DIFF_BASE"');
+    expect(fetchStep).toContain('case "$DIFF_BASE" in -* )');
+    expect(fetchStep).toContain('case "$HEAD_REF" in -* )');
+    expect(fetchStep).toContain('git fetch origin "$DIFF_BASE"');
   });
 });

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "..", "..", "..");
+const ACTION_YAML_PATH = path.join(REPOSITORY_ROOT, "action.yml");
+
+const readActionYaml = (): string => fs.readFileSync(ACTION_YAML_PATH, "utf8");
+
+describe("GitHub Action contract", () => {
+  it("issue #190: score collection cannot fail the job on Needs work scores", () => {
+    const actionYaml = readActionYaml();
+
+    expect(actionYaml).toContain('SCORE_ARGS=("$INPUT_DIRECTORY" "--score" "--fail-on" "none")');
+    expect(actionYaml).toContain('SCORE=$(npx -y react-doctor@latest "${SCORE_ARGS[@]}"');
+    expect(actionYaml).toContain(") || true");
+  });
+
+  it("issue #188 + #61: action exposes CI inputs used by the scan step", () => {
+    const actionYaml = readActionYaml();
+
+    expect(actionYaml).toContain("github-token:");
+    expect(actionYaml).toContain("fail-on:");
+    expect(actionYaml).toContain("diff:");
+    expect(actionYaml).toContain('FLAGS=("--fail-on" "$INPUT_FAIL_ON")');
+    expect(actionYaml).toContain(
+      'if [ -n "$INPUT_DIFF" ]; then FLAGS+=("--diff" "$INPUT_DIFF"); fi',
+    );
+    expect(actionYaml).toContain('if [ -n "$INPUT_GITHUB_TOKEN" ]; then');
+  });
+
+  it("guards diff fetch refs against shell-option injection", () => {
+    const actionYaml = readActionYaml();
+
+    expect(actionYaml).toContain('case "$DIFF_BASE" in -* )');
+    expect(actionYaml).toContain('case "$HEAD_REF" in -* )');
+    expect(actionYaml).toContain('git fetch origin "$DIFF_BASE"');
+  });
+});

--- a/packages/react-doctor/tests/parse-react-major.test.ts
+++ b/packages/react-doctor/tests/parse-react-major.test.ts
@@ -15,6 +15,8 @@ describe("parseReactMajor", () => {
     expect(parseReactMajor(">=18 <20")).toBe(18);
     expect(parseReactMajor(">=18.3.1 <19")).toBe(18);
     expect(parseReactMajor("18 || 19")).toBe(18);
+    expect(parseReactMajor("^18.0.0 || ^19.0.0")).toBe(18);
+    expect(parseReactMajor(">=17.0.0 <20.0.0")).toBe(17);
   });
 
   it("returns null for tags, workspace protocols, and missing/empty input", () => {
@@ -31,6 +33,8 @@ describe("parseReactMajor", () => {
   it("ignores leading whitespace and prefixes", () => {
     expect(parseReactMajor("  ^19.0.0  ")).toBe(19);
     expect(parseReactMajor("npm:react@^19")).toBe(19);
+    expect(parseReactMajor("npm:@vendor/react@~18.2.0")).toBe(18);
+    expect(parseReactMajor("  v18.3.1  ")).toBe(18);
   });
 
   it("returns null for React experimental / canary builds (0.0.0-...)", () => {

--- a/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
+++ b/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
@@ -89,6 +89,31 @@ describe("issue #72: inline suppressions — variants", () => {
     expect(filtered).toHaveLength(0);
   });
 
+  it("ignores rationale text after `--` in comma-separated rule lists", () => {
+    const filtered = runFilter(
+      "description-tail-comma-list",
+      `// react-doctor-disable-next-line react-doctor/no-derived-state-effect, react-doctor/no-fetch-in-effect -- generated fixture keeps both patterns\nconst x = 1;\n`,
+      [
+        baseDiagnostic({ rule: "no-derived-state-effect", line: 2 }),
+        baseDiagnostic({ rule: "no-fetch-in-effect", line: 2 }),
+      ],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("does not treat rationale words after `--` as rule ids", () => {
+    const filtered = runFilter(
+      "description-tail-not-rule",
+      `// react-doctor-disable-next-line react-doctor/no-derived-state-effect -- no-fetch-in-effect appears only in prose\nconst x = 1;\n`,
+      [
+        baseDiagnostic({ rule: "no-derived-state-effect", line: 2 }),
+        baseDiagnostic({ rule: "no-fetch-in-effect", line: 2 }),
+      ],
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].rule).toBe("no-fetch-in-effect");
+  });
+
   it("a bare disable comment (no rule id) suppresses EVERY diagnostic on that line", () => {
     const filtered = runFilter("bare-comment", `const x = 1; // react-doctor-disable-line\n`, [
       baseDiagnostic({ rule: "no-derived-state-effect", line: 1 }),
@@ -159,6 +184,15 @@ describe("issue #144: inline suppressions — block comment forms", () => {
     );
     expect(filtered).toHaveLength(1);
     expect(filtered[0].rule).toBe("no-cascading-set-state");
+  });
+
+  it("block comment rule lists also ignore rationale text after `--`", () => {
+    const filtered = runFilter(
+      "jsx-block-description-tail",
+      `{/* react-doctor-disable-next-line react-doctor/no-derived-state-effect -- intentional generated mirror */}\nconst x = 1;\n`,
+      [baseDiagnostic({ rule: "no-derived-state-effect", line: 2 })],
+    );
+    expect(filtered).toHaveLength(0);
   });
 });
 

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -251,6 +251,50 @@ export const App = () => (
     expect(diagnostics).toHaveLength(0);
   });
 
+  it("does not emit require-reduced-motion when useReducedMotion is present in source", () => {
+    const projectDir = path.join(tempRoot, "issue-94-use-reduced-motion");
+    fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
+    writeJson(path.join(projectDir, "package.json"), {
+      name: "issue-94-use-reduced-motion",
+      dependencies: { react: "^19.0.0", "framer-motion": "^11.0.0" },
+    });
+    writeFile(
+      path.join(projectDir, "src", "App.tsx"),
+      `import { useReducedMotion } from "framer-motion";
+export const App = () => {
+  const shouldReduceMotion = useReducedMotion();
+  return <div data-reduce-motion={String(shouldReduceMotion)} />;
+};
+`,
+    );
+    initGitRepo(projectDir, { commit: true });
+
+    const diagnostics = checkReducedMotion(projectDir);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("does not emit require-reduced-motion when prefers-reduced-motion appears in CSS", () => {
+    const projectDir = path.join(tempRoot, "issue-94-css-media-query");
+    fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
+    writeJson(path.join(projectDir, "package.json"), {
+      name: "issue-94-css-media-query",
+      dependencies: { react: "^19.0.0", motion: "^12.0.0" },
+    });
+    writeFile(
+      path.join(projectDir, "src", "styles.css"),
+      `@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms;
+  }
+}
+`,
+    );
+    initGitRepo(projectDir, { commit: true });
+
+    const diagnostics = checkReducedMotion(projectDir);
+    expect(diagnostics).toHaveLength(0);
+  });
+
   it("emits require-reduced-motion when motion library is present without ANY handling", () => {
     const projectDir = path.join(tempRoot, "issue-94-negative");
     fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -9,6 +9,8 @@
  *   #94      — `MotionConfig reducedMotion="user"` must satisfy the
  *              reduced-motion accessibility check (so the rule doesn't
  *              false-positive when handling is delegated to the provider)
+ *   #76      — `@expo/vector-icons` is not deprecated and must not be
+ *              flagged by the legacy Expo package rule.
  */
 
 import fs from "node:fs";
@@ -224,6 +226,51 @@ describe("issue #183: rawTextWrapperComponents suppresses string-only wrapper ch
     );
     expect(filtered).toHaveLength(1);
     expect(filtered[0].line).toBe(3);
+  });
+});
+
+describe("issue #76: @expo/vector-icons is not treated as a legacy Expo package", () => {
+  it("does not flag @expo/vector-icons while still flagging deprecated Expo packages", async () => {
+    const projectDir = setupReactProject(tempRoot, "issue-76-vector-icons", {
+      files: {
+        "src/App.tsx": `import { Ionicons } from "@expo/vector-icons";
+import { Audio } from "expo-av";
+
+export const App = () => (
+  <>
+    <Ionicons name="home" size={24} />
+    <Audio.Sound />
+  </>
+);
+`,
+      },
+      packageJsonExtras: {
+        dependencies: {
+          react: "^19.0.0",
+          "react-native": "^0.79.0",
+          "@expo/vector-icons": "^14.0.0",
+          "expo-av": "^15.0.0",
+        },
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: buildTestProject({
+        rootDirectory: projectDir,
+        framework: "react-native",
+      }),
+    });
+
+    const legacyExpoIssues = diagnostics.filter(
+      (diagnostic) => diagnostic.rule === "rn-no-legacy-expo-packages",
+    );
+    expect(
+      legacyExpoIssues.some((diagnostic) => diagnostic.message.includes("@expo/vector-icons")),
+    ).toBe(false);
+    expect(legacyExpoIssues.some((diagnostic) => diagnostic.message.includes("expo-av"))).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -9,8 +9,6 @@
  *   #94      — `MotionConfig reducedMotion="user"` must satisfy the
  *              reduced-motion accessibility check (so the rule doesn't
  *              false-positive when handling is delegated to the provider)
- *   #76      — `@expo/vector-icons` is not deprecated and must not be
- *              flagged by the legacy Expo package rule.
  */
 
 import fs from "node:fs";

--- a/packages/react-doctor/tests/regressions/rule-messages.test.ts
+++ b/packages/react-doctor/tests/regressions/rule-messages.test.ts
@@ -12,6 +12,8 @@
  *                router type: Pages Router users should NOT be told to
  *                use `next/navigation` (which they don't have access to);
  *                App Router users SHOULD see that suggestion.
+ *   #55       — Next.js JSON-LD scripts are data, not executable native
+ *               scripts that should be replaced with `next/script`.
  */
 
 import fs from "node:fs";
@@ -140,5 +142,43 @@ export const AppGuard = () => {
     expect(appIssue, "expected a diagnostic on app/guard.tsx").toBeDefined();
     expect(appIssue?.message).toContain("next/navigation");
     expect(appIssue?.message).not.toContain("getServerSideProps");
+  });
+});
+
+describe("issue #55: nextjs-no-native-script ignores JSON-LD data scripts", () => {
+  it("does not flag application/ld+json scripts but still flags executable native scripts", async () => {
+    const projectDir = setupReactProject(tempRoot, "issue-55-json-ld", {
+      packageJsonExtras: {
+        dependencies: { next: "^15.0.0", react: "^19.0.0", "react-dom": "^19.0.0" },
+      },
+      files: {
+        "src/app/jsonld/page.tsx": `export default function JsonLdPage() {
+  return <script type="application/ld+json">{JSON.stringify({ "@context": "https://schema.org" })}</script>;
+}
+`,
+        "src/app/analytics/page.tsx": `export default function AnalyticsPage() {
+  return <script src="https://cdn.example.com/analytics.js" />;
+}
+`,
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: buildTestProject({
+        rootDirectory: projectDir,
+        framework: "nextjs",
+      }),
+    });
+
+    const nativeScriptIssues = diagnostics.filter(
+      (diagnostic) => diagnostic.rule === "nextjs-no-native-script",
+    );
+    expect(nativeScriptIssues.some((diagnostic) => diagnostic.filePath.includes("jsonld"))).toBe(
+      false,
+    );
+    expect(nativeScriptIssues.some((diagnostic) => diagnostic.filePath.includes("analytics"))).toBe(
+      true,
+    );
   });
 });

--- a/packages/react-doctor/tests/regressions/rule-messages.test.ts
+++ b/packages/react-doctor/tests/regressions/rule-messages.test.ts
@@ -12,8 +12,6 @@
  *                router type: Pages Router users should NOT be told to
  *                use `next/navigation` (which they don't have access to);
  *                App Router users SHOULD see that suggestion.
- *   #55       — Next.js JSON-LD scripts are data, not executable native
- *               scripts that should be replaced with `next/script`.
  */
 
 import fs from "node:fs";

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -73,6 +73,33 @@ describe("issue #46 + #84: oxlint include-path batching", () => {
     expect(batches.flat()).toEqual(includePaths);
   });
 
+  it("batchIncludePaths keeps an exact OXLINT_MAX_FILES_PER_BATCH boundary in one batch", () => {
+    const baseArgs = ["oxlint", "-c", "/tmp/oxlintrc.json", "--format", "json"];
+    const includePaths = Array.from(
+      { length: OXLINT_MAX_FILES_PER_BATCH },
+      (_, index) => `src/exact-${index}.tsx`,
+    );
+
+    const batches = batchIncludePaths(baseArgs, includePaths);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual(includePaths);
+  });
+
+  it("batchIncludePaths never drops paths when splitting long mixed path sets", () => {
+    const baseArgs = ["oxlint", "-c", "/tmp/oxlintrc.json", "--format", "json"];
+    const longSegment = "nested-directory".repeat(12);
+    const includePaths = Array.from({ length: 350 }, (_, index) =>
+      index % 2 === 0 ? `src/${longSegment}/file-${index}.tsx` : `src/file-${index}.tsx`,
+    );
+
+    const batches = batchIncludePaths(baseArgs, includePaths);
+
+    expect(batches.length).toBeGreaterThan(1);
+    expect(new Set(batches.flat()).size).toBe(includePaths.length);
+    expect(batches.flat()).toEqual(includePaths);
+  });
+
   it("batchIncludePaths splits when paths would exceed SPAWN_ARGS_MAX_LENGTH_CHARS (Windows ENAMETOOLONG)", () => {
     const baseArgs = ["oxlint", "-c", "/tmp/oxlintrc.json", "--format", "json"];
     // Each path is 200 chars; 200 paths = ~40k chars, well past Windows

--- a/packages/react-doctor/tests/run-oxlint/performance.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/performance.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe } from "vite-plus/test";
+import { beforeAll, describe, expect, it } from "vite-plus/test";
 import type { Diagnostic } from "@react-doctor/types";
 import { runOxlint } from "@react-doctor/core";
 import { buildTestProject } from "../regressions/_helpers.js";
@@ -79,4 +79,17 @@ describe("runOxlint", () => {
     },
     () => basicReactDiagnostics,
   );
+
+  it("issue #138: passive event listener warning mentions preventDefault risk", () => {
+    const passiveListenerIssue = basicReactDiagnostics.find(
+      (diagnostic) => diagnostic.rule === "client-passive-event-listeners",
+    );
+
+    expect(
+      passiveListenerIssue,
+      "expected client-passive-event-listeners diagnostic",
+    ).toBeDefined();
+    expect(passiveListenerIssue?.message).toContain("preventDefault");
+    expect(passiveListenerIssue?.message).toContain("passive listeners silently ignore");
+  });
 });


### PR DESCRIPTION
## Summary
- Add regression coverage for fixed project discovery and React version parsing cases.
- Add suppression regressions for stacked comments, inline rationale text, and block comment forms.
- Add resilience and accessibility regressions for oxlint batching and reduced-motion detection.

## Test plan
- `nr format`
- `nr lint`
- `nr typecheck`
- `nr test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds/expands test coverage plus a small constant change in React Native legacy Expo replacements; low chance of runtime impact beyond tightening expected behavior.
> 
> **Overview**
> Adds broad regression coverage across project discovery and version parsing, including React in `devDependencies`, Bun grouped catalogs, monorepo-root scanning, and `workspaces` object-form support.
> 
> Hardens suppression behavior with new tests for `disable-line` on the same line, stacked `disable-next-line` comments, and allowing trailing rationale text after `--` (including JSX block comment forms).
> 
> Introduces additional regression suites for GitHub Action `action.yml` contract expectations, oxlint include-path batching edge cases, and rule-specific behavior (e.g. reduced-motion detection signals, JSON-LD `<script type="application/ld+json">` exemption, passive event listener message content). Also stops treating `@expo/vector-icons` as a legacy Expo package by removing it from `LEGACY_EXPO_PACKAGE_REPLACEMENTS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a0bf8165e1551d99220348c1f54e0df23c6618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->