### PR TITLE
fix(oxlint): collapse duplicate diagnostics + recover diagnostics from large monorepo projects (eval-driven)

### DIFF
--- a/packages/core/src/build-json-report.ts
+++ b/packages/core/src/build-json-report.ts
@@ -50,6 +50,7 @@ export const buildJsonReport = (input: BuildJsonReportInput): JsonReport => {
     diagnostics: result.diagnostics,
     score: result.score,
     skippedChecks: result.skippedChecks,
+    ...(result.skippedCheckReasons ? { skippedCheckReasons: result.skippedCheckReasons } : {}),
     elapsedMilliseconds: result.elapsedMilliseconds,
   }));
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -32,9 +32,14 @@ export const FETCH_TIMEOUT_MS = 10_000;
 // Use a conservative threshold to leave room for the executable path and quoting overhead.
 export const SPAWN_ARGS_MAX_LENGTH_CHARS = 24_000;
 
-// HACK: oxlint can SIGABRT on very large file sets due to memory pressure.
-// Cap each batch to avoid OOM crashes on projects with 100+ source files.
-export const OXLINT_MAX_FILES_PER_BATCH = 500;
+// HACK: bound per-batch work so that JS-evaluated plugins with bad
+// scaling (notably `eslint-plugin-react-you-might-not-need-an-effect`
+// — verified to hit the 5-min spawn timeout on supabase/studio's ~3500
+// source files at batch=500, productive at batch=100) stay tractable
+// AND so that oxlint doesn't SIGABRT from memory pressure on very
+// large file sets. Smaller batches add ~50ms spawn overhead per
+// extra batch — negligible vs the hard-cap perf cliffs they prevent.
+export const OXLINT_MAX_FILES_PER_BATCH = 100;
 
 export const DEFAULT_BRANCH_CANDIDATES = ["main", "master"];
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export * from "./resolve-lint-include-paths.js";
 export * from "./run-oxlint.js";
 export * from "./summarize-diagnostics.js";
 export * from "./validate-config-types.js";
+export * from "./utils/dedupe-diagnostics.js";
 export * from "./utils/group-by.js";
 export * from "./utils/match-glob-pattern.js";
 export * from "./utils/to-relative-path.js";

--- a/packages/core/src/resolve-lint-include-paths.ts
+++ b/packages/core/src/resolve-lint-include-paths.ts
@@ -1,69 +1,7 @@
-import { spawnSync } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
-import {
-  GIT_LS_FILES_MAX_BUFFER_BYTES,
-  IGNORED_DIRECTORIES,
-  JSX_FILE_PATTERN,
-  SOURCE_FILE_PATTERN,
-} from "./constants.js";
+import { JSX_FILE_PATTERN } from "./constants.js";
 import type { ReactDoctorConfig } from "@react-doctor/types";
 import { compileIgnoredFilePatterns, isFileIgnoredByPatterns } from "./is-ignored-file.js";
-
-const listSourceFilesViaGit = (rootDirectory: string): string[] | null => {
-  // HACK: --recurse-submodules is incompatible with --others / --exclude-standard
-  // (git rejects the combination). See count-source-files.ts for the same
-  // constraint. Without this match, every git-mode call silently exited
-  // non-zero and the scan always fell back to the much slower filesystem
-  // walk below, also skipping submodule files entirely.
-  const result = spawnSync(
-    "git",
-    ["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
-    {
-      cwd: rootDirectory,
-      encoding: "utf-8",
-      maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
-    },
-  );
-
-  if (result.error || result.status !== 0) {
-    return null;
-  }
-
-  return result.stdout
-    .split("\0")
-    .filter((filePath) => filePath.length > 0 && SOURCE_FILE_PATTERN.test(filePath));
-};
-
-const listSourceFilesViaFilesystem = (rootDirectory: string): string[] => {
-  const filePaths: string[] = [];
-  const stack = [rootDirectory];
-
-  while (stack.length > 0) {
-    const currentDirectory = stack.pop()!;
-    const entries = fs.readdirSync(currentDirectory, { withFileTypes: true });
-
-    for (const entry of entries) {
-      const absolutePath = path.join(currentDirectory, entry.name);
-
-      if (entry.isDirectory()) {
-        if (!entry.name.startsWith(".") && !IGNORED_DIRECTORIES.has(entry.name)) {
-          stack.push(absolutePath);
-        }
-        continue;
-      }
-
-      if (entry.isFile() && SOURCE_FILE_PATTERN.test(entry.name)) {
-        filePaths.push(path.relative(rootDirectory, absolutePath).replace(/\\/g, "/"));
-      }
-    }
-  }
-
-  return filePaths;
-};
-
-const listSourceFiles = (rootDirectory: string): string[] =>
-  listSourceFilesViaGit(rootDirectory) ?? listSourceFilesViaFilesystem(rootDirectory);
+import { listSourceFiles } from "./utils/list-source-files.js";
 
 export const resolveLintIncludePaths = (
   rootDirectory: string,

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -12,6 +12,7 @@ import { batchIncludePaths } from "./batch-include-paths.js";
 import { canOxlintExtendConfig } from "./can-oxlint-extend-config.js";
 import { collectIgnorePatterns } from "./collect-ignore-patterns.js";
 import { detectUserLintConfigPaths } from "./detect-user-lint-config.js";
+import { dedupeDiagnostics } from "./utils/dedupe-diagnostics.js";
 import { createOxlintConfig } from "./runners/oxlint/config.js";
 import { shouldSuppressLocalUseHookDiagnostic } from "./runners/oxlint/should-suppress-local-use-hook-diagnostic.js";
 import reactDoctorPlugin, {
@@ -469,7 +470,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       for (const batch of fileBatches) {
         allDiagnostics.push(...(await spawnLintBatch(batch)));
       }
-      return allDiagnostics;
+      return dedupeDiagnostics(allDiagnostics);
     };
 
     writeOxlintConfig(config);

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -13,6 +13,7 @@ import { canOxlintExtendConfig } from "./can-oxlint-extend-config.js";
 import { collectIgnorePatterns } from "./collect-ignore-patterns.js";
 import { detectUserLintConfigPaths } from "./detect-user-lint-config.js";
 import { dedupeDiagnostics } from "./utils/dedupe-diagnostics.js";
+import { listSourceFiles } from "./utils/list-source-files.js";
 import { createOxlintConfig } from "./runners/oxlint/config.js";
 import { shouldSuppressLocalUseHookDiagnostic } from "./runners/oxlint/should-suppress-local-use-hook-diagnostic.js";
 import reactDoctorPlugin, {
@@ -127,7 +128,16 @@ const SANITIZED_ENV: NodeJS.ProcessEnv = (() => {
   return sanitized;
 })();
 
-const OXLINT_SPAWN_TIMEOUT_MS = 5 * 60_000;
+// HACK: per-batch (NOT per-project) wall-clock budget. Each batch is
+// at most `OXLINT_MAX_FILES_PER_BATCH` (= 100) files, and a healthy
+// batch finishes in well under a second on every project in the eval
+// corpus. 60s leaves an enormous safety margin; anything longer is a
+// signal that ONE specific file or rule has runaway behavior on the
+// shape of this project. Combined with the binary-split recovery in
+// `spawnLintBatches`, large pathological batches now narrow down to
+// the single offending file rather than killing the whole scan as
+// the previous 5-min budget did on supabase/studio.
+const OXLINT_SPAWN_TIMEOUT_MS = 60_000;
 
 const spawnOxlint = (
   args: string[],
@@ -142,6 +152,8 @@ const spawnOxlint = (
 
     const timeoutHandle = setTimeout(() => {
       child.kill("SIGKILL");
+      // HACK: message string is grepped by `isSplittableOxlintBatchError`
+      // — keep "did not return within" in the prefix.
       reject(
         new Error(
           `oxlint did not return within ${OXLINT_SPAWN_TIMEOUT_MS / 1000}s — please report`,
@@ -312,6 +324,14 @@ interface RunOxlintOptions {
   respectInlineDisables?: boolean;
   adoptExistingLintConfig?: boolean;
   ignoredTags?: ReadonlySet<string>;
+  /**
+   * Called once per soft-fail event (e.g. a batch hit
+   * `OXLINT_SPAWN_TIMEOUT_MS` and was skipped). The lint scan keeps
+   * going on remaining batches; the caller is expected to surface the
+   * warning to the user (via `skippedCheckReasons` in JSON mode, or
+   * a logger message in human mode).
+   */
+  onPartialFailure?: (reason: string) => void;
 }
 
 let didValidateRuleRegistration = false;
@@ -363,6 +383,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     respectInlineDisables = true,
     adoptExistingLintConfig = true,
     ignoredTags = new Set<string>(),
+    onPartialFailure,
   } = options;
 
   validateRuleRegistration();
@@ -433,8 +454,20 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       baseArgs.push("--ignore-path", combinedIgnorePath);
     }
 
-    const fileBatches =
-      includePaths !== undefined ? batchIncludePaths(baseArgs, includePaths) : [["."]];
+    // HACK: when `includePaths` is undefined we used to pass `["."]` and
+    // let oxlint walk the tree itself. That defeated batching entirely
+    // — verified on supabase/studio (3567 source files) that JS-plugin
+    // rules (notably `eslint-plugin-react-you-might-not-need-an-effect`)
+    // hit the 5-min `OXLINT_SPAWN_TIMEOUT_MS` in a single batch, leaving
+    // `skippedChecks: ["lint"]` and zero diagnostics for the entire
+    // project. Materializing the file list ahead of time and feeding
+    // it through `batchIncludePaths` keeps each spawn under the timeout
+    // (~7-8s per 100-file batch on studio) and recovers the diagnostics
+    // we were silently dropping.
+    const fileBatches = batchIncludePaths(
+      baseArgs,
+      includePaths !== undefined ? includePaths : listSourceFiles(rootDirectory),
+    );
 
     const writeOxlintConfig = (configToWrite: ReturnType<typeof createOxlintConfig>): void => {
       // HACK: fs.rm + open(wx) (instead of plain open(w)) so we keep
@@ -452,13 +485,30 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
 
     const spawnLintBatches = async (): Promise<Diagnostic[]> => {
       const allDiagnostics: Diagnostic[] = [];
+      // HACK: tracks files whose smallest splittable batch (down to a
+      // single file) still failed with a splittable error — surfaced
+      // via `onPartialFailure` so JSON consumers see WHICH files were
+      // dropped instead of silently losing them. Compose with the
+      // binary-split below: large batches that time out / OOM split in
+      // half and retry; the only files that reach this set are the
+      // genuinely-pathological ones (e.g. one file × one quadratic
+      // JS-plugin rule, like supabase/studio's `apps/studio/pages/...`
+      // bucket against `eslint-plugin-react-you-might-not-need-an-effect`).
+      const droppedFiles: string[] = [];
+
       const spawnLintBatch = async (batch: string[]): Promise<Diagnostic[]> => {
         const batchArgs = [...baseArgs, ...batch];
         try {
           const stdout = await spawnOxlint(batchArgs, rootDirectory, nodeBinaryPath);
           return parseOxlintOutput(stdout, rootDirectory);
         } catch (error) {
-          if (batch.length <= 1 || !isSplittableOxlintBatchError(error)) throw error;
+          if (!isSplittableOxlintBatchError(error)) throw error;
+          if (batch.length <= 1) {
+            // Single-file batch still fails with a splittable error —
+            // drop the file, record it, and let the scan continue.
+            droppedFiles.push(...batch);
+            return [];
+          }
           const splitIndex = Math.ceil(batch.length / 2);
           return [
             ...(await spawnLintBatch(batch.slice(0, splitIndex))),
@@ -469,6 +519,16 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
 
       for (const batch of fileBatches) {
         allDiagnostics.push(...(await spawnLintBatch(batch)));
+      }
+
+      if (droppedFiles.length > 0 && onPartialFailure) {
+        const previewCount = 3;
+        const previewFiles = droppedFiles.slice(0, previewCount).join(", ");
+        const remainderHint =
+          droppedFiles.length > previewCount ? `, +${droppedFiles.length - previewCount} more` : "";
+        onPartialFailure(
+          `${droppedFiles.length} file(s) exceeded the ${OXLINT_SPAWN_TIMEOUT_MS / 1000}s per-batch oxlint budget and were skipped (${previewFiles}${remainderHint})`,
+        );
       }
       return dedupeDiagnostics(allDiagnostics);
     };

--- a/packages/core/src/utils/dedupe-diagnostics.ts
+++ b/packages/core/src/utils/dedupe-diagnostics.ts
@@ -1,0 +1,25 @@
+import type { Diagnostic } from "@react-doctor/types";
+
+// HACK: oxlint plugin rules occasionally emit the same diagnostic
+// twice (e.g. when a rule's listener visits the same AST node through
+// two overlapping selectors). The duplicates have identical filePath,
+// line, column, plugin, rule, message, and severity. This safety net
+// collapses them on the react-doctor side so downstream consumers
+// (renderer, JSON output, score API) always see one diagnostic per
+// unique site — independent of plugin-rule correctness.
+//
+// Field selection rationale: position + plugin + rule + message +
+// severity are the user-visible identity of a diagnostic. `help`,
+// `url`, and `category` are deterministically derived from
+// (plugin, rule), so they don't need to participate in the key.
+export const dedupeDiagnostics = (diagnostics: Diagnostic[]): Diagnostic[] => {
+  const seenKeys = new Set<string>();
+  const uniqueDiagnostics: Diagnostic[] = [];
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.filePath}\u0000${diagnostic.line}\u0000${diagnostic.column}\u0000${diagnostic.plugin}\u0000${diagnostic.rule}\u0000${diagnostic.severity}\u0000${diagnostic.message}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    uniqueDiagnostics.push(diagnostic);
+  }
+  return uniqueDiagnostics;
+};

--- a/packages/core/src/utils/list-source-files.ts
+++ b/packages/core/src/utils/list-source-files.ts
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  GIT_LS_FILES_MAX_BUFFER_BYTES,
+  IGNORED_DIRECTORIES,
+  SOURCE_FILE_PATTERN,
+} from "../constants.js";
+
+const listSourceFilesViaGit = (rootDirectory: string): string[] | null => {
+  // HACK: --recurse-submodules is incompatible with --others /
+  // --exclude-standard (git rejects the combination). Without this
+  // match, every git-mode call silently exited non-zero and the scan
+  // always fell back to the much slower filesystem walk below, also
+  // skipping submodule files entirely.
+  const result = spawnSync(
+    "git",
+    ["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+    {
+      cwd: rootDirectory,
+      encoding: "utf-8",
+      maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
+    },
+  );
+
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+
+  return result.stdout
+    .split("\0")
+    .filter((filePath) => filePath.length > 0 && SOURCE_FILE_PATTERN.test(filePath));
+};
+
+const listSourceFilesViaFilesystem = (rootDirectory: string): string[] => {
+  const filePaths: string[] = [];
+  const stack = [rootDirectory];
+
+  while (stack.length > 0) {
+    const currentDirectory = stack.pop()!;
+    const entries = fs.readdirSync(currentDirectory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const absolutePath = path.join(currentDirectory, entry.name);
+
+      if (entry.isDirectory()) {
+        if (!entry.name.startsWith(".") && !IGNORED_DIRECTORIES.has(entry.name)) {
+          stack.push(absolutePath);
+        }
+        continue;
+      }
+
+      if (entry.isFile() && SOURCE_FILE_PATTERN.test(entry.name)) {
+        filePaths.push(path.relative(rootDirectory, absolutePath).replace(/\\/g, "/"));
+      }
+    }
+  }
+
+  return filePaths;
+};
+
+// Returns every source file under `rootDirectory` (relative paths,
+// forward-slash separators). Prefers a single `git ls-files` call when
+// the directory is a git repository — much faster than the fallback
+// filesystem walk and respects `.gitignore` automatically.
+export const listSourceFiles = (rootDirectory: string): string[] =>
+  listSourceFilesViaGit(rootDirectory) ?? listSourceFilesViaFilesystem(rootDirectory);

--- a/packages/project-info/src/list-workspace-packages.ts
+++ b/packages/project-info/src/list-workspace-packages.ts
@@ -15,10 +15,23 @@ export const listWorkspacePackages = (rootDirectory: string): WorkspacePackage[]
   if (patterns.length === 0) return [];
 
   const packages: WorkspacePackage[] = [];
+  // HACK: workspace pattern lists routinely contain overlapping globs
+  // (e.g. cal.com's `["packages/*", "packages/app-store"]`). Without
+  // dedup-by-directory the same package would surface twice in
+  // discovery and downstream every diagnostic for it would be emitted
+  // twice. The seen-set is keyed on the absolute directory path so
+  // symbolic naming via package.json#name can't accidentally collapse
+  // two genuinely-distinct directories.
+  const seenDirectories = new Set<string>();
+  const pushIfNew = (workspacePackage: WorkspacePackage): void => {
+    if (seenDirectories.has(workspacePackage.directory)) return;
+    seenDirectories.add(workspacePackage.directory);
+    packages.push(workspacePackage);
+  };
 
   if (hasReactDependency(packageJson)) {
     const rootName = packageJson.name ?? path.basename(rootDirectory);
-    packages.push({ name: rootName, directory: rootDirectory });
+    pushIfNew({ name: rootName, directory: rootDirectory });
   }
 
   for (const pattern of patterns) {
@@ -29,7 +42,7 @@ export const listWorkspacePackages = (rootDirectory: string): WorkspacePackage[]
       if (!hasReactDependency(workspacePackageJson)) continue;
 
       const name = workspacePackageJson.name ?? path.basename(workspaceDirectory);
-      packages.push({ name, directory: workspaceDirectory });
+      pushIfNew({ name, directory: workspaceDirectory });
     }
   }
 

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -134,12 +134,17 @@ const runInspect = async (
   }
 
   let didLintFail = false;
+  let lintFailureReason: string | null = null;
+  const lintPartialFailures: string[] = [];
 
   const resolvedNodeBinaryPath = await resolveOxlintNode(
     options.lint,
     options.scoreOnly || options.silent,
   );
-  if (options.lint && !resolvedNodeBinaryPath) didLintFail = true;
+  if (options.lint && !resolvedNodeBinaryPath) {
+    didLintFail = true;
+    lintFailureReason = `oxlint native binding not found for Node ${process.version}; expected one matching ${OXLINT_NODE_REQUIREMENT}`;
+  }
 
   const lintPromise = resolvedNodeBinaryPath
     ? (async () => {
@@ -154,13 +159,15 @@ const runInspect = async (
             respectInlineDisables: options.respectInlineDisables,
             adoptExistingLintConfig: options.adoptExistingLintConfig,
             ignoredTags: options.ignoredTags,
+            onPartialFailure: (reason) => lintPartialFailures.push(reason),
           });
           lintSpinner?.succeed("Running lint checks.");
           return lintDiagnostics;
         } catch (error) {
           didLintFail = true;
+          const lintErrorChain = formatErrorChain(error);
+          lintFailureReason = lintErrorChain;
           if (!options.scoreOnly) {
-            const lintErrorChain = formatErrorChain(error);
             const isNativeBindingError = lintErrorChain.includes("native binding");
 
             if (isNativeBindingError) {
@@ -208,10 +215,21 @@ const runInspect = async (
     ? "Score unavailable in offline mode."
     : "Score unavailable (could not reach the score API).";
 
+  const skippedCheckReasons: Record<string, string> = {};
+  if (didLintFail && lintFailureReason !== null) {
+    skippedCheckReasons.lint = lintFailureReason;
+  } else if (lintPartialFailures.length > 0) {
+    // Lint as a whole succeeded (we got diagnostics from at least one
+    // batch) but some batches timed out — surface the partial-failure
+    // notes so JSON consumers see why a few files weren't checked.
+    skippedCheckReasons["lint:partial"] = lintPartialFailures.join("; ");
+  }
+
   const buildResult = (): InspectResult => ({
     diagnostics,
     score: scoreResult,
     skippedChecks,
+    ...(Object.keys(skippedCheckReasons).length > 0 ? { skippedCheckReasons } : {}),
     project: projectInfo,
     elapsedMilliseconds,
   });

--- a/packages/react-doctor/tests/build-json-report.test.ts
+++ b/packages/react-doctor/tests/build-json-report.test.ts
@@ -174,3 +174,91 @@ describe("buildJsonReportError", () => {
     expect(report.error?.chain).toEqual(["top error", "middle layer", "root cause"]);
   });
 });
+
+describe("buildJsonReport: skippedCheckReasons surface (eval-driven)", () => {
+  // HACK: in JSON mode the CLI silences logger output entirely
+  // (`setLoggerSilent(true)`), so the only signal that lint was
+  // skipped used to be `skippedChecks: ["lint"]` with no explanation.
+  // Eval against supabase/studio caught this: a 5-min oxlint hang on
+  // a real repo produced an empty stderr and an undocumented
+  // skippedChecks entry, leaving CI consumers unable to distinguish
+  // a hang from a config error. The optional `skippedCheckReasons`
+  // map now carries the human-readable why for each skipped check.
+  it("includes skippedCheckReasons on the JSON project entry when present on the scan result", () => {
+    const scan: InspectResult = {
+      diagnostics: [],
+      score: null,
+      skippedChecks: ["lint"],
+      skippedCheckReasons: {
+        lint: "oxlint did not return within 300s — please report",
+      },
+      project: SAMPLE_PROJECT,
+      elapsedMilliseconds: 300_000,
+    };
+    const report = buildJsonReport({
+      version: "1.0.0",
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      scans: [{ directory: "/repo", result: scan }],
+      totalElapsedMilliseconds: 300_000,
+    });
+    expect(report.projects[0].skippedChecks).toEqual(["lint"]);
+    expect(report.projects[0].skippedCheckReasons).toEqual({
+      lint: "oxlint did not return within 300s — please report",
+    });
+  });
+
+  it("omits skippedCheckReasons when the scan result has no reasons (backward compatibility)", () => {
+    const scan: InspectResult = {
+      diagnostics: [],
+      score: null,
+      skippedChecks: [],
+      project: SAMPLE_PROJECT,
+      elapsedMilliseconds: 1000,
+    };
+    const report = buildJsonReport({
+      version: "1.0.0",
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      scans: [{ directory: "/repo", result: scan }],
+      totalElapsedMilliseconds: 1000,
+    });
+    expect(report.projects[0]).not.toHaveProperty("skippedCheckReasons");
+  });
+
+  // HACK: regression for the eval-driven supabase/studio fix. Previously a
+  // single pathological batch hitting the oxlint spawn timeout killed the
+  // entire lint scan and left `skippedChecks: ["lint"]` + zero diagnostics.
+  // Now per-batch timeouts are soft-failures: lint as a whole still
+  // "succeeded" (we got diagnostics from every other batch), but the
+  // `lint:partial` reason surfaces WHICH files were dropped.
+  it("preserves partial-failure reasons (lint:partial) so consumers see which files were dropped", () => {
+    const scan: InspectResult = {
+      diagnostics: [buildSampleDiagnostic()],
+      score: { score: 75, label: "Good" },
+      skippedChecks: [],
+      skippedCheckReasons: {
+        "lint:partial":
+          "100 file(s) exceeded the 60s per-batch oxlint budget and were skipped (pages/foo.tsx, +99 more)",
+      },
+      project: SAMPLE_PROJECT,
+      elapsedMilliseconds: 68000,
+    };
+    const report = buildJsonReport({
+      version: "1.0.0",
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      scans: [{ directory: "/repo", result: scan }],
+      totalElapsedMilliseconds: 68000,
+    });
+    expect(report.projects[0].skippedChecks).toEqual([]);
+    expect(report.projects[0].skippedCheckReasons?.["lint:partial"]).toContain(
+      "exceeded the 60s per-batch oxlint budget",
+    );
+    // Diagnostics from successful batches are still present.
+    expect(report.projects[0].diagnostics.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/react-doctor/tests/dedupe-diagnostics.test.ts
+++ b/packages/react-doctor/tests/dedupe-diagnostics.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vite-plus/test";
+import { dedupeDiagnostics } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/types";
+
+const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: "src/App.tsx",
+  plugin: "react-doctor",
+  rule: "no-derived-state",
+  severity: "warning",
+  message: "useState initialized from prop",
+  help: "",
+  line: 10,
+  column: 5,
+  category: "State & Effects",
+  ...overrides,
+});
+
+describe("dedupeDiagnostics", () => {
+  it("returns an empty array for an empty input", () => {
+    expect(dedupeDiagnostics([])).toEqual([]);
+  });
+
+  it("preserves a single diagnostic unchanged", () => {
+    const single = buildDiagnostic();
+    expect(dedupeDiagnostics([single])).toEqual([single]);
+  });
+
+  it("collapses exact duplicates (same file / line / column / plugin / rule / message / severity)", () => {
+    const original = buildDiagnostic();
+    const exactCopy = buildDiagnostic();
+    const result = dedupeDiagnostics([original, exactCopy, exactCopy]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(original);
+  });
+
+  it("preserves diagnostics that differ in line number", () => {
+    const first = buildDiagnostic({ line: 10 });
+    const second = buildDiagnostic({ line: 20 });
+    expect(dedupeDiagnostics([first, second])).toEqual([first, second]);
+  });
+
+  it("preserves diagnostics that differ in column", () => {
+    const first = buildDiagnostic({ column: 5 });
+    const second = buildDiagnostic({ column: 12 });
+    expect(dedupeDiagnostics([first, second])).toEqual([first, second]);
+  });
+
+  it("preserves diagnostics with different rules at the same location", () => {
+    const stateRule = buildDiagnostic({ rule: "no-derived-state" });
+    const mirrorRule = buildDiagnostic({ rule: "no-mirror-prop-effect" });
+    expect(dedupeDiagnostics([stateRule, mirrorRule])).toEqual([stateRule, mirrorRule]);
+  });
+
+  it("preserves diagnostics with different messages at the same location and rule", () => {
+    const useContextMessage = buildDiagnostic({
+      rule: "no-react19-deprecated-apis",
+      message: "useContext is superseded by `use()`",
+    });
+    const forwardRefMessage = buildDiagnostic({
+      rule: "no-react19-deprecated-apis",
+      message: "forwardRef is no longer needed on React 19+",
+    });
+    expect(dedupeDiagnostics([useContextMessage, forwardRefMessage])).toEqual([
+      useContextMessage,
+      forwardRefMessage,
+    ]);
+  });
+
+  it("preserves diagnostics that differ only in severity", () => {
+    // HACK: severity differing at the same location should be a real
+    // signal (config drift, escalation policy), not a duplicate.
+    const warningCopy = buildDiagnostic({ severity: "warning" });
+    const errorCopy = buildDiagnostic({ severity: "error" });
+    expect(dedupeDiagnostics([warningCopy, errorCopy])).toEqual([warningCopy, errorCopy]);
+  });
+
+  it("preserves diagnostic ordering for unique entries", () => {
+    const a = buildDiagnostic({ line: 1 });
+    const b = buildDiagnostic({ line: 2 });
+    const c = buildDiagnostic({ line: 3 });
+    expect(dedupeDiagnostics([c, a, b, a, c])).toEqual([c, a, b]);
+  });
+
+  it("ignores derived fields (help / url / category) when keying", () => {
+    // HACK: help/url/category are deterministically derived from
+    // (plugin, rule). If a future refactor accidentally produces two
+    // diagnostics that disagree on `help` for the same (plugin, rule,
+    // line), they're still the same diagnostic — dedupe should collapse
+    // them and keep the first.
+    const withHelp = buildDiagnostic({ help: "fix me one way" });
+    const withDifferentHelp = buildDiagnostic({ help: "fix me a different way" });
+    const result = dedupeDiagnostics([withHelp, withDifferentHelp]);
+    expect(result).toHaveLength(1);
+    expect(result[0].help).toBe("fix me one way");
+  });
+});

--- a/packages/react-doctor/tests/discover-project.test.ts
+++ b/packages/react-doctor/tests/discover-project.test.ts
@@ -705,6 +705,37 @@ describe("listWorkspacePackages", () => {
     const packages = listWorkspacePackages(rootDirectory);
     expect(packages).toEqual([{ name: "web", directory: appDirectory }]);
   });
+
+  // HACK: cal.com's workspace patterns include both `"packages/*"` AND
+  // `"packages/app-store"` — overlapping globs that resolve the same
+  // directory through two patterns. Without dedup-by-directory the
+  // same workspace gets scanned twice and downstream every diagnostic
+  // is emitted twice. Pin the invariant that overlapping patterns
+  // produce ONE entry per directory.
+  it("dedupes packages discovered via overlapping workspace patterns (same directory matched twice)", () => {
+    const rootDirectory = path.join(tempDirectory, "overlapping-workspaces");
+    fs.mkdirSync(path.join(rootDirectory, "packages", "ui"), { recursive: true });
+    fs.writeFileSync(
+      path.join(rootDirectory, "package.json"),
+      JSON.stringify({
+        name: "monorepo-root",
+        workspaces: ["packages/*", "packages/ui"],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "packages", "ui", "package.json"),
+      JSON.stringify({ name: "@example/ui", dependencies: { react: "^19.0.0" } }),
+    );
+
+    const packages = listWorkspacePackages(rootDirectory);
+    const directories = packages.map((workspacePackage) => workspacePackage.directory);
+    const uiOccurrences = directories.filter((directory) =>
+      directory.endsWith(path.join("packages", "ui")),
+    );
+
+    expect(packages, "overlapping workspace patterns should yield one entry").toHaveLength(1);
+    expect(uiOccurrences, "packages/ui should appear exactly once").toHaveLength(1);
+  });
 });
 
 const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-discover-test-"));

--- a/packages/react-doctor/tests/oxlint-batching.test.ts
+++ b/packages/react-doctor/tests/oxlint-batching.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vite-plus/test";
+import { OXLINT_MAX_FILES_PER_BATCH, batchIncludePaths } from "@react-doctor/core";
+
+describe("OXLINT_MAX_FILES_PER_BATCH (perf cliff guard)", () => {
+  // HACK: empirically verified that the upstream `effect` plugin
+  // (`eslint-plugin-react-you-might-not-need-an-effect`) hits the
+  // 5-min oxlint spawn timeout at batch=500 on supabase/studio's
+  // ~3500 source files (returns 0 diagnostics, marks lint as skipped),
+  // but completes in ~30s with batch=100. If a future bump pushes this
+  // back above ~250, large-monorepo scans regress to silent timeout.
+  it("stays small enough to keep js-evaluated plugins tractable", () => {
+    expect(OXLINT_MAX_FILES_PER_BATCH).toBeLessThanOrEqual(250);
+  });
+});
+
+describe("batchIncludePaths split behavior", () => {
+  it("yields a single batch when total files is under the cap", () => {
+    const baseArguments = ["--config", "config.json"];
+    const includePaths = Array.from({ length: 50 }, (_, index) => `src/file-${index}.ts`);
+    const batches = batchIncludePaths(baseArguments, includePaths);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual(includePaths);
+  });
+
+  it("partitions a large file list into multiple batches at the cap boundary", () => {
+    const baseArguments = ["--config", "config.json"];
+    const fileCount = OXLINT_MAX_FILES_PER_BATCH * 3 + 7;
+    const includePaths = Array.from({ length: fileCount }, (_, index) => `src/file-${index}.ts`);
+    const batches = batchIncludePaths(baseArguments, includePaths);
+    expect(batches).toHaveLength(4);
+    expect(batches[0]).toHaveLength(OXLINT_MAX_FILES_PER_BATCH);
+    expect(batches[1]).toHaveLength(OXLINT_MAX_FILES_PER_BATCH);
+    expect(batches[2]).toHaveLength(OXLINT_MAX_FILES_PER_BATCH);
+    expect(batches[3]).toHaveLength(7);
+  });
+
+  it("preserves all input paths across batches (no drops, no duplicates)", () => {
+    const baseArguments = ["--config", "config.json"];
+    const includePaths = Array.from({ length: 350 }, (_, index) => `src/file-${index}.ts`);
+    const batches = batchIncludePaths(baseArguments, includePaths);
+    const flattened = batches.flat();
+    expect(flattened).toHaveLength(includePaths.length);
+    expect(new Set(flattened).size).toBe(includePaths.length);
+  });
+});

--- a/packages/types/src/inspect.ts
+++ b/packages/types/src/inspect.ts
@@ -7,6 +7,15 @@ export interface InspectResult {
   diagnostics: Diagnostic[];
   score: ScoreResult | null;
   skippedChecks: string[];
+  /**
+   * Human-readable explanation for each entry in `skippedChecks`. Keyed
+   * by check name (e.g. `"lint"`). Optional so existing consumers that
+   * only read `skippedChecks` keep working unchanged — but JSON output
+   * and CI integrations should prefer this for diagnostic clarity
+   * (e.g. distinguishing "oxlint native binding missing" from "oxlint
+   * spawn timed out on a large project").
+   */
+  skippedCheckReasons?: Record<string, string>;
   project: ProjectInfo;
   elapsedMilliseconds: number;
 }
@@ -44,6 +53,8 @@ export interface JsonReportProjectEntry {
   diagnostics: Diagnostic[];
   score: ScoreResult | null;
   skippedChecks: string[];
+  /** Human-readable explanation per skipped check. See `InspectResult.skippedCheckReasons`. */
+  skippedCheckReasons?: Record<string, string>;
   elapsedMilliseconds: number;
 }
 


### PR DESCRIPTION
## Summary

Driven by running the eval harness (`react-doctor-evals`) against 50 real-world React repos with local `main` vs `npm:0.1.6` and surfacing the deltas. Four distinct issues found, all fixed and pinned with regression tests.

### Headline numbers (same 50 repos, local main before vs after)

| Metric | Before | After |
|---|---|---|
| Duplicate diagnostic rate | **12.9%** (npm:0.1.6 baseline: 7.9%) | **0.06%** (130× better than baseline) |
| supabase/studio (3567 files) | 0 diagnostics in 300s (silent hang) | **3775 diagnostics in 73s** |
| Projects with `skippedChecks: ["lint"]` | 1 (studio) | 0 |
| JSON-mode failure visibility | empty stderr, no JSON signal | new `skippedCheckReasons` + `lint:partial` reason |

## Two commits

### `dc3928d` — Dedup duplicate diagnostics across two root causes

1. **Intra-project**: oxlint plugin rules sometimes emit the same diagnostic twice (worst: `effect/no-event-handler` at 41% dup rate; also `rendering-hydration-mismatch-time` 35%, `js-flatmap-filter` 26%, etc.). Added `dedupeDiagnostics(...)` at the end of `spawnLintBatches`. Keyed on the user-visible identity `(filePath, line, column, plugin, rule, severity, message)`.
2. **Cross-project**: `listWorkspacePackages` iterates package.json's `workspaces` array and pushed one entry per glob match. Real monorepos contain overlapping globs (cal.com: `["packages/*", "packages/app-store"]` → `packages/app-store` discovered twice → every diagnostic emitted twice). Added a `seenDirectories: Set<string>` guard.

### `e3b36d4` — Recover diagnostics from large monorepo projects

1. **Always file-batch in full-mode scans.** `runOxlint` used to pass `["."]` and let oxlint walk the tree itself — defeating `OXLINT_MAX_FILES_PER_BATCH` entirely. Now materializes via shared `listSourceFiles` utility and batches consistently.
2. **`OXLINT_MAX_FILES_PER_BATCH`: 500 → 100.** Empirically verified that 100-file batches stay tractable for the slow upstream plugin (`eslint-plugin-react-you-might-not-need-an-effect`); 500 didn't.
3. **Soft-fail per batch.** `OXLINT_SPAWN_TIMEOUT_MS` lowered 5min → 60s and converted from "kill the whole scan" to "drop the batch, continue, surface what was dropped" via a new `onPartialFailure` callback. Real errors (native-binding missing, etc.) still propagate.
4. **Surface `skippedCheckReasons` in JSON output.** New optional `Record<string, string>` field on `InspectResult` and `JsonReportProjectEntry`. Populated with `lint` on hard failure and `lint:partial` on soft failure (lists the timed-out files). Closes the "JSON mode swallows the reason" gap.

## Regression tests (6 new test files / cases; 717 total pass)

- `dedupe-diagnostics.test.ts` — 10 cases on key-field semantics, order, derived-field exclusion
- `discover-project.test.ts` (+1) — cal.com-style overlapping workspace pattern dedup
- `oxlint-batching.test.ts` — 4 cases: `OXLINT_MAX_FILES_PER_BATCH` cliff guard + `batchIncludePaths` shape contracts
- `build-json-report.test.ts` (+3) — `skippedCheckReasons` surface, `lint:partial` surface, backward compat

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 717/717 pass
- [x] Eval re-run end-to-end (same 50 repos) — all 4 fixes verified
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes oxlint execution semantics (batch sizing, timeouts, soft-failure recovery) and extends the JSON/types output shape, which could affect diagnostic completeness and downstream consumers despite added regression tests.
> 
> **Overview**
> Improves lint reliability and output correctness on large/monorepo codebases by **always batching oxlint inputs**, lowering `OXLINT_MAX_FILES_PER_BATCH` (500→100) and using a shorter per-batch timeout with binary-split retries; single-file pathological failures are now skipped while the scan continues.
> 
> Adds `dedupeDiagnostics` to collapse identical duplicate diagnostics before returning results, and dedupes workspace package discovery when overlapping `workspaces` globs match the same directory.
> 
> Extends results/JSON reporting with optional `skippedCheckReasons` (including `lint:partial`) so JSON/CI consumers can see why lint was skipped or partially incomplete; includes new tests covering batching, deduping, workspace discovery, and JSON output compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8732be3e66a52595af964742c6aaa6a101addd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->