### PR TITLE
fix: avoid async defer await destructuring false positives

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -2,19 +2,19 @@ import { defineRule } from "../../utils/define-rule.js";
 import { collectPatternDefaultReferenceNames } from "../../utils/collect-pattern-default-reference-names.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { collectReferenceIdentifierNames } from "../../utils/collect-reference-identifier-names.js";
+import { containsDirectAwait } from "../../utils/contains-direct-await.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isBareAwaitExpressionStatement } from "../../utils/is-bare-await-expression-statement.js";
+import { isEarlyExitIfStatement } from "../../utils/is-early-exit-if-statement.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { walkAst } from "../../utils/walk-ast.js";
 
-const collectDeclaratorDependencyIdentifierNames = (
-  declarator: EsTreeNode,
-  into: Set<string>,
-): void => {
-  if (!isNodeOfType(declarator, "VariableDeclarator")) return;
-  collectReferenceIdentifierNames(declarator.init, into);
-  collectPatternDefaultReferenceNames(declarator.id, into);
-};
+interface DeclarationProcessResult {
+  didIntroduceAwait: boolean;
+  didGrowBindings: boolean;
+}
 
 const hasAnyIdentifierName = (
   identifierNames: ReadonlySet<string>,
@@ -26,16 +26,92 @@ const hasAnyIdentifierName = (
   return false;
 };
 
-const isEarlyReturnIfStatement = (statement: EsTreeNode): boolean => {
-  if (!isNodeOfType(statement, "IfStatement")) return false;
-  const consequent = statement.consequent;
-  if (!consequent) return false;
-  if (isNodeOfType(consequent, "ReturnStatement")) return true;
-  if (!isNodeOfType(consequent, "BlockStatement")) return false;
-  for (const inner of consequent.body ?? []) {
-    if (isNodeOfType(inner, "ReturnStatement")) return true;
+const collectDeclaratorDependencyIdentifierNames = (
+  declarator: EsTreeNode,
+  into: Set<string>,
+): void => {
+  if (!isNodeOfType(declarator, "VariableDeclarator")) return;
+  collectReferenceIdentifierNames(declarator.init, into);
+  collectPatternDefaultReferenceNames(declarator.id, into);
+};
+
+// Iterates declarators to a fixed point so backward-referenced derivations
+// (`const isMissing = !flowRow, flowRow = await select();`) still propagate
+// `flowRow` and its dependents into `awaitedBindingNames` regardless of the
+// authored order.
+const processVariableDeclaration = (
+  declaration: EsTreeNode,
+  awaitedBindingNames: Set<string>,
+): DeclarationProcessResult => {
+  if (!isNodeOfType(declaration, "VariableDeclaration"))
+    return { didIntroduceAwait: false, didGrowBindings: false };
+  let didIntroduceAwait = false;
+  const sizeBeforeAll = awaitedBindingNames.size;
+  let hasChanged = true;
+  while (hasChanged) {
+    hasChanged = false;
+    for (const declarator of declaration.declarations ?? []) {
+      if (!isNodeOfType(declarator, "VariableDeclarator")) continue;
+      const declaratorHasAwait =
+        containsDirectAwait(declarator.init) || containsDirectAwait(declarator.id);
+      if (declaratorHasAwait) {
+        didIntroduceAwait = true;
+        const sizeBefore = awaitedBindingNames.size;
+        collectPatternNames(declarator.id, awaitedBindingNames);
+        if (awaitedBindingNames.size > sizeBefore) hasChanged = true;
+        continue;
+      }
+      const dependencyIdentifiers = new Set<string>();
+      collectDeclaratorDependencyIdentifierNames(declarator, dependencyIdentifiers);
+      if (!hasAnyIdentifierName(dependencyIdentifiers, awaitedBindingNames)) continue;
+      const sizeBefore = awaitedBindingNames.size;
+      collectPatternNames(declarator.id, awaitedBindingNames);
+      if (awaitedBindingNames.size > sizeBefore) hasChanged = true;
+    }
   }
-  return false;
+  const didGrowBindings = awaitedBindingNames.size > sizeBeforeAll;
+  return { didIntroduceAwait, didGrowBindings };
+};
+
+interface AwaitWindow {
+  firstAwaitStatement: EsTreeNode;
+  awaitedBindingNames: Set<string>;
+  // Index of the first statement past the preamble (where the guard, if any,
+  // must live).
+  guardCandidateIndex: number;
+}
+
+// Walks forward from `startIndex` collecting an "await preamble" — the
+// originating awaited statement plus any contiguous bare-await statements
+// or VariableDeclarations whose declarators introduce their own await OR
+// derive from the running `awaitedBindingNames`. Returns `null` when the
+// statement at `startIndex` is not itself an awaiting statement.
+const collectAwaitWindow = (statements: EsTreeNode[], startIndex: number): AwaitWindow | null => {
+  const firstStatement = statements[startIndex];
+  const awaitedBindingNames = new Set<string>();
+  let isAwaitingStatement = false;
+  if (isNodeOfType(firstStatement, "VariableDeclaration")) {
+    const result = processVariableDeclaration(firstStatement, awaitedBindingNames);
+    if (result.didIntroduceAwait) isAwaitingStatement = true;
+  } else if (isBareAwaitExpressionStatement(firstStatement)) {
+    isAwaitingStatement = true;
+  }
+  if (!isAwaitingStatement) return null;
+
+  let cursor = startIndex + 1;
+  while (cursor < statements.length) {
+    const candidate = statements[cursor];
+    if (isBareAwaitExpressionStatement(candidate)) {
+      cursor++;
+      continue;
+    }
+    if (!isNodeOfType(candidate, "VariableDeclaration")) break;
+    const result = processVariableDeclaration(candidate, awaitedBindingNames);
+    if (!result.didIntroduceAwait && !result.didGrowBindings) break;
+    cursor++;
+  }
+
+  return { firstAwaitStatement: firstStatement, awaitedBindingNames, guardCandidateIndex: cursor };
 };
 
 // HACK: `const x = await something(); if (skip) return defaultValue;` —
@@ -44,11 +120,13 @@ const isEarlyReturnIfStatement = (statement: EsTreeNode): boolean => {
 // after the cheap synchronous guard so we only pay the latency when we
 // actually need the data.
 //
-// Heuristic: an awaited VariableDeclaration immediately followed by an
-// IfStatement whose test references no identifiers from the awaited
-// declaration. We require the if to be the very next statement to
-// stay precise (intervening statements would imply the awaited binding
-// is being prepared for use).
+// Heuristic: an awaiting preamble (a `VariableDeclaration` containing
+// `await`, or a bare `await expr;` statement, optionally followed by
+// further bare awaits and binding-only declarations that derive from the
+// awaited values) immediately followed by an early-exit `IfStatement`
+// whose test references no identifiers bound by the preamble. Any
+// non-binding statement between the await and the if implies the awaited
+// value is being prepared for use, so we conservatively skip.
 export const asyncDeferAwait = defineRule<Rule>({
   id: "async-defer-await",
   severity: "warn",
@@ -57,48 +135,52 @@ export const asyncDeferAwait = defineRule<Rule>({
   create: (context: RuleContext) => {
     const inspectStatements = (statements: EsTreeNode[]): void => {
       for (let statementIndex = 0; statementIndex < statements.length - 1; statementIndex++) {
-        const currentStatement = statements[statementIndex];
-        if (!isNodeOfType(currentStatement, "VariableDeclaration")) continue;
+        const window = collectAwaitWindow(statements, statementIndex);
+        if (!window) continue;
+        if (window.guardCandidateIndex >= statements.length) continue;
+        const guardStatement = statements[window.guardCandidateIndex];
+        if (!isEarlyExitIfStatement(guardStatement)) continue;
+        if (!isNodeOfType(guardStatement, "IfStatement")) continue;
 
-        const awaitedBindingNames = new Set<string>();
-        let didAwait = false;
-        for (const declarator of currentStatement.declarations ?? []) {
-          if (isNodeOfType(declarator.init, "AwaitExpression")) {
-            didAwait = true;
-            collectPatternNames(declarator.id, awaitedBindingNames);
-            continue;
-          }
-          const dependencyIdentifiers = new Set<string>();
-          collectDeclaratorDependencyIdentifierNames(declarator, dependencyIdentifiers);
-          if (hasAnyIdentifierName(dependencyIdentifiers, awaitedBindingNames)) {
-            collectPatternNames(declarator.id, awaitedBindingNames);
-          }
+        const testIdentifierNames = new Set<string>();
+        collectReferenceIdentifierNames(guardStatement.test, testIdentifierNames);
+        if (hasAnyIdentifierName(testIdentifierNames, window.awaitedBindingNames)) {
+          statementIndex = window.guardCandidateIndex - 1;
+          continue;
         }
-        if (!didAwait) continue;
 
-        const nextStatement = statements[statementIndex + 1];
-        if (!isEarlyReturnIfStatement(nextStatement)) continue;
-        if (!isNodeOfType(nextStatement, "IfStatement")) continue;
-
-        const testIdentifiers = new Set<string>();
-        collectReferenceIdentifierNames(nextStatement.test, testIdentifiers);
-        const usesAwaitedBinding = hasAnyIdentifierName(testIdentifiers, awaitedBindingNames);
-        if (usesAwaitedBinding) continue;
-
-        const consequentIdentifiers = new Set<string>();
-        collectReferenceIdentifierNames(nextStatement.consequent, consequentIdentifiers);
-        const consequentUsesAwaited = hasAnyIdentifierName(
-          consequentIdentifiers,
-          awaitedBindingNames,
-        );
-        if (consequentUsesAwaited) continue;
+        const consequentIdentifierNames = new Set<string>();
+        collectReferenceIdentifierNames(guardStatement.consequent, consequentIdentifierNames);
+        if (hasAnyIdentifierName(consequentIdentifierNames, window.awaitedBindingNames)) {
+          statementIndex = window.guardCandidateIndex - 1;
+          continue;
+        }
 
         context.report({
-          node: currentStatement,
+          node: window.firstAwaitStatement,
           message:
             "await blocks the function before an early-return that doesn't use the awaited value — move the await after the synchronous guard so the skip path stays fast",
         });
+        statementIndex = window.guardCandidateIndex - 1;
       }
+    };
+
+    const inspectAllStatementBlocks = (functionBody: EsTreeNode | null | undefined): void => {
+      if (!functionBody) return;
+      walkAst(functionBody, (descendant: EsTreeNode) => {
+        if (
+          isNodeOfType(descendant, "FunctionDeclaration") ||
+          isNodeOfType(descendant, "FunctionExpression") ||
+          isNodeOfType(descendant, "ArrowFunctionExpression")
+        ) {
+          return false;
+        }
+        if (isNodeOfType(descendant, "BlockStatement")) {
+          inspectStatements(descendant.body ?? []);
+        } else if (isNodeOfType(descendant, "SwitchCase")) {
+          inspectStatements(descendant.consequent ?? []);
+        }
+      });
     };
 
     const enterFunction = (node: EsTreeNode): void => {
@@ -111,7 +193,7 @@ export const asyncDeferAwait = defineRule<Rule>({
       }
       if (!node.async) return;
       if (!isNodeOfType(node.body, "BlockStatement")) return;
-      inspectStatements(node.body.body ?? []);
+      inspectAllStatementBlocks(node.body);
     };
 
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -1,15 +1,29 @@
 import { defineRule } from "../../utils/define-rule.js";
-import { walkAst } from "../../utils/walk-ast.js";
+import { collectPatternDefaultReferenceNames } from "../../utils/collect-pattern-default-reference-names.js";
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
+import { collectReferenceIdentifierNames } from "../../utils/collect-reference-identifier-names.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
-const collectIdentifierNames = (node: EsTreeNode | null | undefined, into: Set<string>): void => {
-  if (!node) return;
-  walkAst(node, (child: EsTreeNode) => {
-    if (isNodeOfType(child, "Identifier")) into.add(child.name);
-  });
+const collectDeclaratorDependencyIdentifierNames = (
+  declarator: EsTreeNode,
+  into: Set<string>,
+): void => {
+  if (!isNodeOfType(declarator, "VariableDeclarator")) return;
+  collectReferenceIdentifierNames(declarator.init, into);
+  collectPatternDefaultReferenceNames(declarator.id, into);
+};
+
+const hasAnyIdentifierName = (
+  identifierNames: ReadonlySet<string>,
+  candidateNames: ReadonlySet<string>,
+): boolean => {
+  for (const candidateName of candidateNames) {
+    if (identifierNames.has(candidateName)) return true;
+  }
+  return false;
 };
 
 const isEarlyReturnIfStatement = (statement: EsTreeNode): boolean => {
@@ -51,18 +65,13 @@ export const asyncDeferAwait = defineRule<Rule>({
         for (const declarator of currentStatement.declarations ?? []) {
           if (isNodeOfType(declarator.init, "AwaitExpression")) {
             didAwait = true;
-            if (isNodeOfType(declarator.id, "Identifier")) {
-              awaitedBindingNames.add(declarator.id.name);
-            } else if (isNodeOfType(declarator.id, "ObjectPattern")) {
-              for (const property of declarator.id.properties ?? []) {
-                if (
-                  isNodeOfType(property, "Property") &&
-                  isNodeOfType(property.value, "Identifier")
-                ) {
-                  awaitedBindingNames.add(property.value.name);
-                }
-              }
-            }
+            collectPatternNames(declarator.id, awaitedBindingNames);
+            continue;
+          }
+          const dependencyIdentifiers = new Set<string>();
+          collectDeclaratorDependencyIdentifierNames(declarator, dependencyIdentifiers);
+          if (hasAnyIdentifierName(dependencyIdentifiers, awaitedBindingNames)) {
+            collectPatternNames(declarator.id, awaitedBindingNames);
           }
         }
         if (!didAwait) continue;
@@ -72,16 +81,15 @@ export const asyncDeferAwait = defineRule<Rule>({
         if (!isNodeOfType(nextStatement, "IfStatement")) continue;
 
         const testIdentifiers = new Set<string>();
-        collectIdentifierNames(nextStatement.test, testIdentifiers);
-        const usesAwaitedBinding = [...awaitedBindingNames].some((name) =>
-          testIdentifiers.has(name),
-        );
+        collectReferenceIdentifierNames(nextStatement.test, testIdentifiers);
+        const usesAwaitedBinding = hasAnyIdentifierName(testIdentifiers, awaitedBindingNames);
         if (usesAwaitedBinding) continue;
 
         const consequentIdentifiers = new Set<string>();
-        collectIdentifierNames(nextStatement.consequent, consequentIdentifiers);
-        const consequentUsesAwaited = [...awaitedBindingNames].some((name) =>
-          consequentIdentifiers.has(name),
+        collectReferenceIdentifierNames(nextStatement.consequent, consequentIdentifiers);
+        const consequentUsesAwaited = hasAnyIdentifierName(
+          consequentIdentifiers,
+          awaitedBindingNames,
         );
         if (consequentUsesAwaited) continue;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-pattern-default-reference-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-pattern-default-reference-names.ts
@@ -1,0 +1,34 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { collectReferenceIdentifierNames } from "./collect-reference-identifier-names.js";
+
+export const collectPatternDefaultReferenceNames = (
+  pattern: EsTreeNode | null | undefined,
+  into: Set<string>,
+): void => {
+  if (!pattern) return;
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    collectReferenceIdentifierNames(pattern.right, into);
+    collectPatternDefaultReferenceNames(pattern.left, into);
+    return;
+  }
+  if (isNodeOfType(pattern, "RestElement")) {
+    collectPatternDefaultReferenceNames(pattern.argument, into);
+    return;
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    for (const element of pattern.elements ?? [])
+      collectPatternDefaultReferenceNames(element, into);
+    return;
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    for (const property of pattern.properties ?? []) {
+      if (isNodeOfType(property, "RestElement")) {
+        collectPatternDefaultReferenceNames(property.argument, into);
+      } else if (isNodeOfType(property, "Property")) {
+        if (property.computed) collectReferenceIdentifierNames(property.key, into);
+        collectPatternDefaultReferenceNames(property.value, into);
+      }
+    }
+  }
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-reference-identifier-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-reference-identifier-names.ts
@@ -1,34 +1,127 @@
+import { collectPatternNames } from "./collect-pattern-names.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isAstNode } from "./is-ast-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
-export const collectReferenceIdentifierNames = (
-  node: EsTreeNode | null | undefined,
+const TYPE_POSITION_KEYS = new Set([
+  "typeAnnotation",
+  "typeParameters",
+  "typeArguments",
+  "returnType",
+  "superTypeArguments",
+  "superTypeParameters",
+]);
+
+const collectScopedReferencesInPattern = (
+  pattern: EsTreeNode | null | undefined,
   into: Set<string>,
+  shadowed: ReadonlySet<string>,
 ): void => {
-  if (!node) return;
-  if (isNodeOfType(node, "Identifier")) {
-    into.add(node.name);
+  if (!pattern) return;
+  if (isNodeOfType(pattern, "Identifier")) return;
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    collectScopedReferenceIdentifierNames(pattern.right, into, shadowed);
+    collectScopedReferencesInPattern(pattern.left, into, shadowed);
     return;
   }
-  if (isNodeOfType(node, "MemberExpression")) {
-    collectReferenceIdentifierNames(node.object, into);
-    if (node.computed) collectReferenceIdentifierNames(node.property, into);
+  if (isNodeOfType(pattern, "RestElement")) {
+    collectScopedReferencesInPattern(pattern.argument, into, shadowed);
     return;
   }
-  if (isNodeOfType(node, "Property")) {
-    if (node.computed) collectReferenceIdentifierNames(node.key, into);
-    collectReferenceIdentifierNames(node.value, into);
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    for (const element of pattern.elements ?? []) {
+      collectScopedReferencesInPattern(element, into, shadowed);
+    }
     return;
   }
-  for (const [key, child] of Object.entries(node)) {
-    if (key === "parent") continue;
-    if (Array.isArray(child)) {
-      for (const item of child) {
-        if (isAstNode(item)) collectReferenceIdentifierNames(item, into);
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    for (const property of pattern.properties ?? []) {
+      if (isNodeOfType(property, "RestElement")) {
+        collectScopedReferencesInPattern(property.argument, into, shadowed);
+        continue;
       }
-    } else if (isAstNode(child)) {
-      collectReferenceIdentifierNames(child, into);
+      if (!isNodeOfType(property, "Property")) continue;
+      if (property.computed) collectScopedReferenceIdentifierNames(property.key, into, shadowed);
+      collectScopedReferencesInPattern(property.value, into, shadowed);
     }
   }
 };
+
+const collectFromFunction = (
+  functionNode: EsTreeNode,
+  into: Set<string>,
+  shadowed: ReadonlySet<string>,
+): void => {
+  if (
+    !isNodeOfType(functionNode, "FunctionDeclaration") &&
+    !isNodeOfType(functionNode, "FunctionExpression") &&
+    !isNodeOfType(functionNode, "ArrowFunctionExpression")
+  ) {
+    return;
+  }
+  const innerShadowed = new Set(shadowed);
+  for (const param of functionNode.params ?? []) {
+    collectPatternNames(param, innerShadowed);
+  }
+  for (const param of functionNode.params ?? []) {
+    collectScopedReferencesInPattern(param, into, innerShadowed);
+  }
+  collectScopedReferenceIdentifierNames(functionNode.body, into, innerShadowed);
+};
+
+const collectScopedReferenceIdentifierNames = (
+  node: EsTreeNode | null | undefined,
+  into: Set<string>,
+  shadowed: ReadonlySet<string>,
+): void => {
+  if (!node) return;
+  if (isNodeOfType(node, "Identifier")) {
+    if (!shadowed.has(node.name)) into.add(node.name);
+    return;
+  }
+  if (isNodeOfType(node, "MemberExpression")) {
+    collectScopedReferenceIdentifierNames(node.object, into, shadowed);
+    if (node.computed) collectScopedReferenceIdentifierNames(node.property, into, shadowed);
+    return;
+  }
+  if (isNodeOfType(node, "Property")) {
+    if (node.computed) collectScopedReferenceIdentifierNames(node.key, into, shadowed);
+    collectScopedReferenceIdentifierNames(node.value, into, shadowed);
+    return;
+  }
+  if (
+    isNodeOfType(node, "FunctionDeclaration") ||
+    isNodeOfType(node, "FunctionExpression") ||
+    isNodeOfType(node, "ArrowFunctionExpression")
+  ) {
+    collectFromFunction(node, into, shadowed);
+    return;
+  }
+  if (
+    isNodeOfType(node, "TSAsExpression") ||
+    isNodeOfType(node, "TSSatisfiesExpression") ||
+    isNodeOfType(node, "TSTypeAssertion") ||
+    isNodeOfType(node, "TSNonNullExpression") ||
+    isNodeOfType(node, "TSInstantiationExpression")
+  ) {
+    collectScopedReferenceIdentifierNames(node.expression, into, shadowed);
+    return;
+  }
+  if (typeof node.type === "string" && node.type.startsWith("TS")) return;
+  for (const [key, child] of Object.entries(node)) {
+    if (key === "parent") continue;
+    if (TYPE_POSITION_KEYS.has(key)) continue;
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (isAstNode(item)) collectScopedReferenceIdentifierNames(item, into, shadowed);
+      }
+    } else if (isAstNode(child)) {
+      collectScopedReferenceIdentifierNames(child, into, shadowed);
+    }
+  }
+};
+
+export const collectReferenceIdentifierNames = (
+  node: EsTreeNode | null | undefined,
+  into: Set<string>,
+): void => collectScopedReferenceIdentifierNames(node, into, new Set());

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-reference-identifier-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-reference-identifier-names.ts
@@ -1,0 +1,34 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isAstNode } from "./is-ast-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const collectReferenceIdentifierNames = (
+  node: EsTreeNode | null | undefined,
+  into: Set<string>,
+): void => {
+  if (!node) return;
+  if (isNodeOfType(node, "Identifier")) {
+    into.add(node.name);
+    return;
+  }
+  if (isNodeOfType(node, "MemberExpression")) {
+    collectReferenceIdentifierNames(node.object, into);
+    if (node.computed) collectReferenceIdentifierNames(node.property, into);
+    return;
+  }
+  if (isNodeOfType(node, "Property")) {
+    if (node.computed) collectReferenceIdentifierNames(node.key, into);
+    collectReferenceIdentifierNames(node.value, into);
+    return;
+  }
+  for (const [key, child] of Object.entries(node)) {
+    if (key === "parent") continue;
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (isAstNode(item)) collectReferenceIdentifierNames(item, into);
+      }
+    } else if (isAstNode(child)) {
+      collectReferenceIdentifierNames(child, into);
+    }
+  }
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/contains-direct-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/contains-direct-await.ts
@@ -1,0 +1,26 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { walkAst } from "./walk-ast.js";
+
+// Returns true if `node` contains an `AwaitExpression` evaluated by the
+// enclosing async function — i.e. not inside a nested function (whose
+// `await` belongs to that function's own async context).
+export const containsDirectAwait = (node: EsTreeNode | null | undefined): boolean => {
+  if (!node) return false;
+  let foundAwait = false;
+  walkAst(node, (child: EsTreeNode) => {
+    if (foundAwait) return false;
+    if (
+      isNodeOfType(child, "FunctionDeclaration") ||
+      isNodeOfType(child, "FunctionExpression") ||
+      isNodeOfType(child, "ArrowFunctionExpression")
+    ) {
+      return false;
+    }
+    if (isNodeOfType(child, "AwaitExpression")) {
+      foundAwait = true;
+      return false;
+    }
+  });
+  return foundAwait;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-bare-await-expression-statement.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-bare-await-expression-statement.ts
@@ -1,0 +1,10 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+// A statement of the form `await expr;` — an `ExpressionStatement` whose
+// expression is directly an `AwaitExpression`. Used by `async-defer-await`
+// to recognise bare awaits (no binding) alongside `const x = await …;`.
+export const isBareAwaitExpressionStatement = (statement: EsTreeNode): boolean => {
+  if (!isNodeOfType(statement, "ExpressionStatement")) return false;
+  return isNodeOfType(statement.expression, "AwaitExpression");
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-early-exit-if-statement.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-early-exit-if-statement.ts
@@ -1,0 +1,24 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+const isEarlyExitStatement = (statement: EsTreeNode): boolean =>
+  isNodeOfType(statement, "ReturnStatement") ||
+  isNodeOfType(statement, "ThrowStatement") ||
+  isNodeOfType(statement, "ContinueStatement") ||
+  isNodeOfType(statement, "BreakStatement");
+
+// Recognises `if (cond) return …;`, `if (cond) throw …;`, and the loop
+// equivalents `continue` / `break`. The consequent may be the exit itself
+// or a block whose first statement is the exit (matching the original
+// rule's heuristic, ignoring any unreachable tail).
+export const isEarlyExitIfStatement = (statement: EsTreeNode): boolean => {
+  if (!isNodeOfType(statement, "IfStatement")) return false;
+  const consequent = statement.consequent;
+  if (!consequent) return false;
+  if (isEarlyExitStatement(consequent)) return true;
+  if (!isNodeOfType(consequent, "BlockStatement")) return false;
+  for (const inner of consequent.body ?? []) {
+    if (isEarlyExitStatement(inner)) return true;
+  }
+  return false;
+};

--- a/packages/react-doctor/tests/regressions/js-performance-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/js-performance-rules.test.ts
@@ -287,4 +287,260 @@ describe("async-defer-await", () => {
     const hits = await collectRuleHits(projectDir, "async-defer-await");
     expect(hits).toHaveLength(4);
   });
+
+  it("does not flag derived guards regardless of declarator order", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-backward-derived", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlow: (flowSeq: number) => Promise<FlowRow | null>;
+
+          export const loadFlowWithBackwardDerivedGuard = async (flowSeq: number) => {
+            const isMissingFlow = !flowRow, flowRow = await selectFlow(flowSeq);
+            if (isMissingFlow) return [];
+            return [flowRow!.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag guards derived through a chain of intervening declarations", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-intervening-derivation", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlow: (flowSeq: number) => Promise<FlowRow | null>;
+          declare const normalizeFlow: (row: FlowRow | null) => { id: string } | null;
+
+          export const loadFlowWithDerivationChain = async (flowSeq: number) => {
+            const flowRow = await selectFlow(flowSeq);
+            const normalized = normalizeFlow(flowRow);
+            const isMissing = !normalized;
+            if (isMissing) return [];
+            return [normalized!.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("flags awaits buried in wrapper expressions when the guard is unrelated", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-wrapped-init", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlow: (flowSeq: number) => Promise<{ row: FlowRow }>;
+          declare const selectMaybeFlow: (flowSeq: number) => Promise<FlowRow | null>;
+          declare const transform: <T>(value: T) => T;
+          declare const fallbackFlow: FlowRow;
+          declare const shouldSkip: boolean;
+
+          export const loadFlowFromMember = async (flowSeq: number) => {
+            const flowRow = (await selectFlow(flowSeq)).row;
+            if (shouldSkip) return [];
+            return [flowRow.id];
+          };
+
+          export const loadFlowFromCallArg = async (flowSeq: number) => {
+            const wrappedRow = transform(await selectFlow(flowSeq));
+            if (shouldSkip) return [];
+            return [wrappedRow.row.id];
+          };
+
+          export const loadFlowFromAwaitInPatternDefault = async (flowSeq: number) => {
+            const { value = await selectMaybeFlow(flowSeq) } = {} as { value?: FlowRow | null };
+            if (shouldSkip) return [];
+            return [value?.id ?? fallbackFlow.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(3);
+  });
+
+  it("flags bare-await statements when followed by an unrelated guard", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-bare-await", {
+      files: {
+        "src/flush.ts": `
+          declare const flushQueue: () => Promise<void>;
+          declare const shouldSkip: boolean;
+
+          export const drainQueue = async () => {
+            await flushQueue();
+            if (shouldSkip) return;
+            return;
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags the earliest of multiple consecutive awaits before an unrelated guard", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-multi-await", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlowA: () => Promise<FlowRow>;
+          declare const selectFlowB: () => Promise<FlowRow>;
+          declare const shouldSkip: boolean;
+
+          export const loadTwoFlows = async () => {
+            const flowA = await selectFlowA();
+            const flowB = await selectFlowB();
+            if (shouldSkip) return [];
+            return [flowA.id, flowB.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("await blocks the function");
+  });
+
+  it("flags awaits even when the early exit is a throw", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-throw-exit", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlow: (flowSeq: number) => Promise<FlowRow>;
+          declare const shouldSkip: boolean;
+
+          export const loadFlowOrThrow = async (flowSeq: number) => {
+            const flowRow = await selectFlow(flowSeq);
+            if (shouldSkip) throw new Error("skipped");
+            return [flowRow.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags awaits inside nested blocks (try / if-body / for-body)", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-nested-blocks", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlow: (flowSeq: number) => Promise<FlowRow>;
+          declare const shouldSkip: boolean;
+
+          export const loadFlowInsideTry = async (flowSeq: number) => {
+            try {
+              const flowRow = await selectFlow(flowSeq);
+              if (shouldSkip) return [];
+              return [flowRow.id];
+            } catch {
+              return [];
+            }
+          };
+
+          export const loadFlowInsideIfBody = async (flowSeq: number, enabled: boolean) => {
+            if (enabled) {
+              const flowRow = await selectFlow(flowSeq);
+              if (shouldSkip) return [];
+              return [flowRow.id];
+            }
+            return [];
+          };
+
+          export const loadFlowInsideForBody = async (flowSeqs: number[]) => {
+            const results: string[] = [];
+            for (const flowSeq of flowSeqs) {
+              const flowRow = await selectFlow(flowSeq);
+              if (shouldSkip) continue;
+              results.push(flowRow.id);
+            }
+            return results;
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(3);
+  });
+
+  it("flags awaits when a nested function in the guard merely shadows the awaited name", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-shadowed-name", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+            unrelated: boolean;
+          }
+
+          declare const selectFlow: () => Promise<FlowRow>;
+          declare const otherFlow: FlowRow;
+
+          export const loadFlowWithShadowingGuard = async () => {
+            const flowRow = await selectFlow();
+            if (((flowRow: FlowRow) => flowRow.unrelated)(otherFlow)) return [];
+            return [flowRow.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("flags awaits when the guard only mentions the awaited name in a type position", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-type-only-mention", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlow: () => Promise<FlowRow>;
+          declare const otherFlow: unknown;
+          declare const shouldSkip: boolean;
+
+          export const loadFlowWithAsAssertion = async () => {
+            const flowRow = await selectFlow();
+            if (shouldSkip && (otherFlow as typeof flowRow).id === "") return [];
+            return [flowRow.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(1);
+  });
 });

--- a/packages/react-doctor/tests/regressions/js-performance-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/js-performance-rules.test.ts
@@ -135,3 +135,156 @@ describe("async-await-in-loop", () => {
     expect(hits).toHaveLength(0);
   });
 });
+
+describe("async-defer-await", () => {
+  it("does not flag early returns that check destructured awaited values", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-destructured-guard", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const fallbackFlow: FlowRow | null;
+          declare const selectFlow: (flowSeq: number) => Promise<[FlowRow | null]>;
+          declare const selectTuple: (flowSeq: number) => Promise<[string, FlowRow | null]>;
+          declare const selectOptional: (flowSeq: number) => Promise<Array<FlowRow | null | undefined>>;
+          declare const selectRows: (flowSeq: number) => Promise<{ rows: [FlowRow | null] }>;
+          declare const selectPayload: (flowSeq: number) => Promise<{ data: { row: FlowRow | null } }>;
+          declare const selectManyFlows: (flowSeq: number) => Promise<FlowRow[]>;
+
+          export const loadFirstFlow = async (flowSeq: number) => {
+            const [flowRow] = await selectFlow(flowSeq);
+            if (!flowRow) return [];
+            return [flowRow.id];
+          };
+
+          export const loadTupleFlow = async (flowSeq: number) => {
+            const [, flowRow] = await selectTuple(flowSeq);
+            if (!flowRow) return [];
+            return [flowRow.id];
+          };
+
+          export const loadFlowWithDefault = async (flowSeq: number) => {
+            const [flowRow = fallbackFlow] = await selectOptional(flowSeq);
+            if (!flowRow) return [];
+            return [flowRow.id];
+          };
+
+          export const loadNestedFlow = async (flowSeq: number) => {
+            const { rows: [flowRow] } = await selectRows(flowSeq);
+            if (!flowRow) return [];
+            return [flowRow.id];
+          };
+
+          export const loadAliasedNestedFlow = async (flowSeq: number) => {
+            const { data: { row: flowRow } } = await selectPayload(flowSeq);
+            if (!flowRow) return [];
+            return [flowRow.id];
+          };
+
+          export const loadRemainingFlows = async (flowSeq: number) => {
+            const [firstFlowRow, ...remainingFlowRows] = await selectManyFlows(flowSeq);
+            if (remainingFlowRows.length === 0) return [];
+            return [firstFlowRow.id, ...remainingFlowRows.map((flowRow) => flowRow.id)];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag guards derived from awaited values in the same declaration", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-derived-same-declaration", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlow: (flowSeq: number) => Promise<FlowRow | null>;
+          declare const selectTuple: (flowSeq: number) => Promise<[FlowRow | null]>;
+          declare const selectRequiredFlow: (flowSeq: number) => Promise<FlowRow>;
+          declare const readCachedFlow: () => { id?: string };
+          declare const cacheById: Record<string, FlowRow | undefined>;
+
+          export const loadFlowWithDerivedGuard = async (flowSeq: number) => {
+            const flowRow = await selectFlow(flowSeq), isMissingFlow = !flowRow, shouldReturnEarly = isMissingFlow;
+            if (shouldReturnEarly) return [];
+            return [flowRow.id];
+          };
+
+          export const loadFlowWithDerivedDestructuredGuard = async (flowSeq: number) => {
+            const [flowRow] = await selectTuple(flowSeq), flowId = flowRow?.id;
+            if (!flowId) return [];
+            return [flowId];
+          };
+
+          export const loadFlowWithDefaultAliasGuard = async (flowSeq: number) => {
+            const flowRow = await selectFlow(flowSeq), { id: flowId = flowRow?.id } = readCachedFlow();
+            if (!flowId) return [];
+            return [flowId];
+          };
+
+          export const loadFlowFromAwaitedComputedKey = async (flowSeq: number) => {
+            const flowRow = await selectRequiredFlow(flowSeq), { [flowRow.id]: cachedFlow } = cacheById;
+            if (!cachedFlow) return [];
+            return [cachedFlow.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("still flags destructured awaited values when the early return is unrelated", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-await-destructured-unrelated", {
+      files: {
+        "src/load-flows.ts": `
+          interface FlowRow {
+            id: string;
+          }
+
+          declare const selectFlow: (flowSeq: number) => Promise<[FlowRow | null]>;
+          declare const selectData: (flowSeq: number) => Promise<FlowRow>;
+          declare const selectId: (flowSeq: number) => Promise<string>;
+          declare const readCachedFlow: () => { data?: FlowRow };
+          declare const cachedFlow: { id?: string };
+          declare const cacheById: Record<string, FlowRow | undefined>;
+          declare const cacheKey: string;
+
+          export const loadMaybeSkippedFlow = async (flowSeq: number, shouldSkip: boolean) => {
+            const [flowRow] = await selectFlow(flowSeq);
+            if (shouldSkip) return [];
+            return flowRow ? [flowRow.id] : [];
+          };
+
+          export const loadCachedFlow = async (flowSeq: number) => {
+            const data = await selectData(flowSeq), { data: cachedFlow } = readCachedFlow();
+            if (!cachedFlow) return [];
+            return [data.id, cachedFlow.id];
+          };
+
+          export const loadFlowAfterCachedIdCheck = async (flowSeq: number) => {
+            const id = await selectId(flowSeq);
+            if (!cachedFlow.id) return [];
+            return [id];
+          };
+
+          export const loadFlowAfterUnrelatedComputedKeyCheck = async (flowSeq: number) => {
+            const data = await selectData(flowSeq), { [cacheKey]: cachedFlow } = cacheById;
+            if (!cachedFlow) return [];
+            return [data.id];
+          };
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary
- Track awaited bindings through recursive binding patterns for `async-defer-await`.
- Avoid false positives when early-return guards depend on destructured, derived, defaulted, rest, or computed-key bindings from awaited values.
- Add focused regressions for dependent and unrelated guard cases.

## Test plan
- `nr test tests/regressions/js-performance-rules.test.ts`
- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`

## Parity eval
Optional wider diagnostic parity check against `main`:

```bash
# Configure these for your machine/sample size.
BASELINE_WORKTREE=/tmp/react-doctor-main
EVAL_REPOSITORIES=~/dev/react-doctor-evals/repos.json
TAKE=50

# One-time baseline worktree next to this branch.
git worktree add "$BASELINE_WORKTREE" main
(cd "$BASELINE_WORKTREE" && ni && nr build)

# Rebuild this branch too; rde uses the built CLI.
nr build

# Clear stale eval output, then evaluate both builds.
rm -rf .evals "$BASELINE_WORKTREE/.evals"
rde run path:. --take "$TAKE" --repositories "$EVAL_REPOSITORIES"
rde run path:"$BASELINE_WORKTREE" --take "$TAKE" --repositories "$EVAL_REPOSITORIES"

# Diff baseline first, comparison second.
rde parity path:"$BASELINE_WORKTREE" path:. --verbose

# Increase TAKE for a wider sample. Clean up when done:
git worktree remove "$BASELINE_WORKTREE"
```

`+` means this branch adds diagnostics; `-` means this branch drops diagnostics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates non-trivial AST analysis for a performance lint rule, which can change diagnostics (both false positives and false negatives) across codebases.
> 
> **Overview**
> Improves the `async-defer-await` rule to more accurately decide when an early-exit guard is *actually* independent of preceding `await`s.
> 
> The rule now tracks awaited bindings through complex destructuring patterns (including defaults, rest, and computed keys), propagates derived bindings across multi-declarator `const` statements (even with backward references), detects bare `await expr;` statements, and recognizes additional early-exit forms (`throw`/`break`/`continue`). It also inspects nested statement blocks (e.g. inside `try`, `if`, loops, `switch` cases) rather than only top-level function bodies.
> 
> Adds new AST utilities (`collectReferenceIdentifierNames`, `collectPatternDefaultReferenceNames`, `containsDirectAwait`, `isBareAwaitExpressionStatement`, `isEarlyExitIfStatement`) and extensive regression tests covering dependent vs unrelated guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437dbd492c4960d040dda5028bd6a0b59357fa8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->