### PR TITLE
fix(server-auth-actions): accept member-expression auth calls + config allowlist

### DIFF
--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -20,7 +20,13 @@ import reactDoctorPlugin, {
   ALL_REACT_DOCTOR_RULE_KEYS,
   FRAMEWORK_SPECIFIC_RULE_KEYS,
 } from "oxlint-plugin-react-doctor";
-import type { CleanedDiagnostic, Diagnostic, OxlintOutput, ProjectInfo } from "@react-doctor/types";
+import type {
+  CleanedDiagnostic,
+  Diagnostic,
+  OxlintOutput,
+  ProjectInfo,
+  ReactDoctorConfig,
+} from "@react-doctor/types";
 import { buildNoSecretsRecommendation } from "./utils/build-no-secrets-recommendation.js";
 import { neutralizeDisableDirectives } from "./neutralize-disable-directives.js";
 
@@ -343,6 +349,14 @@ interface RunOxlintOptions {
   adoptExistingLintConfig?: boolean;
   ignoredTags?: ReadonlySet<string>;
   /**
+   * Optional react-doctor user config (already-loaded
+   * `react-doctor.config.json` or `package.json#reactDoctor`). When
+   * provided, project-level knobs the rule surface honors — currently
+   * `serverAuthFunctionNames` — are forwarded to the generated oxlint
+   * settings so plugin rules can read them via `context.settings`.
+   */
+  userConfig?: ReactDoctorConfig | null;
+  /**
    * Called once per soft-fail event (e.g. a batch hit
    * `OXLINT_SPAWN_TIMEOUT_MS` and was skipped). The lint scan keeps
    * going on remaining batches; the caller is expected to surface the
@@ -401,8 +415,15 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     respectInlineDisables = true,
     adoptExistingLintConfig = true,
     ignoredTags = new Set<string>(),
+    userConfig,
     onPartialFailure,
   } = options;
+
+  const serverAuthFunctionNames = Array.isArray(userConfig?.serverAuthFunctionNames)
+    ? userConfig.serverAuthFunctionNames.filter(
+        (entry): entry is string => typeof entry === "string" && entry.length > 0,
+      )
+    : undefined;
 
   validateRuleRegistration();
 
@@ -439,6 +460,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     customRulesOnly,
     extendsPaths,
     ignoredTags,
+    serverAuthFunctionNames,
   });
   // HACK: only neutralize disable comments in audit mode. Default
   // behavior respects the user's existing `// eslint-disable*` /
@@ -571,6 +593,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         customRulesOnly,
         extendsPaths: [],
         ignoredTags,
+        serverAuthFunctionNames,
       });
       writeOxlintConfig(fallbackConfig);
       return await spawnLintBatches();

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -23,6 +23,7 @@ export interface OxlintConfigOptions {
   customRulesOnly?: boolean;
   extendsPaths?: string[];
   ignoredTags?: ReadonlySet<string>;
+  serverAuthFunctionNames?: ReadonlyArray<string>;
 }
 
 const resolveSettingsRootDirectory = (rootDirectory: string): string => {
@@ -36,6 +37,7 @@ export const createOxlintConfig = ({
   customRulesOnly = false,
   extendsPaths = [],
   ignoredTags = new Set<string>(),
+  serverAuthFunctionNames,
 }: OxlintConfigOptions) => {
   const reactHooksJsPlugin = resolveReactHooksJsPlugin(project.hasReactCompiler, customRulesOnly);
   const reactCompilerRules = reactHooksJsPlugin
@@ -89,6 +91,9 @@ export const createOxlintConfig = ({
       "react-doctor": {
         framework: project.framework,
         rootDirectory: resolveSettingsRootDirectory(project.rootDirectory),
+        ...(serverAuthFunctionNames && serverAuthFunctionNames.length > 0
+          ? { serverAuthFunctionNames: [...serverAuthFunctionNames] }
+          : {}),
       },
     },
     rules: {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
@@ -34,8 +34,15 @@ export const GENERIC_AUTH_METHOD_NAMES = new Set(["getUser"]);
 // purpose — we accept obvious auth providers (auth/clerk/session/jwt/
 // supabase…) and skip ambiguous nouns like "user" that show up in
 // non-auth namespaces (`userAnalytics`, `userStore`, …).
+//
+// Every alternative MUST be a substring that can actually appear in a
+// JavaScript identifier — i.e. no hyphens. `buildDottedReceiverSource`
+// only emits Identifier names joined by `.`, so any alternative with
+// `-` is dead code (it can never match). `auth` already covers most
+// "better-auth" and "iron-session" usage via the canonical `auth`
+// re-export those libraries ship.
 export const AUTH_OBJECT_PATTERN =
-  /(?:^|[._])(?:auth|authn|authz|clerk|session|jwt|firebase|supabase|nextauth|kinde|workos|stytch|descope|cognito|propelauth|lucia|iron-session|better-auth)/i;
+  /(?:^|[._])(?:auth|authn|authz|clerk|session|jwt|firebase|supabase|nextauth|kinde|workos|stytch|descope|cognito|propelauth|lucia)/i;
 
 export const SECRET_PATTERNS = [
   /^sk_live_/,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
@@ -17,6 +17,26 @@ export const AUTH_FUNCTION_NAMES = new Set([
   "validateSession",
 ]);
 
+// Auth function names that are too generic to recognize on their own
+// when called as a method (e.g. `analytics.getUser()` is not an auth
+// check). For these names a member call is only accepted when the
+// receiver expression looks auth-related per AUTH_OBJECT_PATTERN.
+// Bare identifier calls (`getUser()`) stay accepted because callers
+// who import `getUser` from an auth library normally do so as the
+// canonical name; renaming an analytics helper to bare `getUser`
+// would be unusual.
+export const GENERIC_AUTH_METHOD_NAMES = new Set(["getUser"]);
+
+// Receiver-expression substrings that signal an auth-related namespace
+// when paired with a generic method name like `.getUser()`. Matched
+// case-insensitively against the dotted source of the member-call
+// receiver (e.g. `ctx.auth`, `auth0`, `clerkClient`). Kept tight on
+// purpose — we accept obvious auth providers (auth/clerk/session/jwt/
+// supabase…) and skip ambiguous nouns like "user" that show up in
+// non-auth namespaces (`userAnalytics`, `userStore`, …).
+export const AUTH_OBJECT_PATTERN =
+  /(?:^|[._])(?:auth|authn|authz|clerk|session|jwt|firebase|supabase|nextauth|kinde|workos|stytch|descope|cognito|propelauth|lucia|iron-session|better-auth)/i;
+
 export const SECRET_PATTERNS = [
   /^sk_live_/,
   /^sk_test_/,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -7,29 +7,13 @@ import {
 import { defineRule } from "../../utils/define-rule.js";
 import { classifySecretFileExposure } from "../../utils/classify-secret-file-exposure.js";
 import { getIdentifierTrailingWord } from "../../utils/get-identifier-trailing-word.js";
+import { getReactDoctorStringSetting } from "../../utils/get-react-doctor-setting.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { isInsideServerOnlyScope } from "../../utils/is-inside-server-only-scope.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-
-const getReactDoctorStringSetting = (
-  settings: RuleContext["settings"],
-  settingName: string,
-): string | undefined => {
-  const reactDoctorSettings = settings?.["react-doctor"];
-  if (
-    typeof reactDoctorSettings !== "object" ||
-    reactDoctorSettings === null ||
-    Array.isArray(reactDoctorSettings)
-  ) {
-    return undefined;
-  }
-
-  const settingValue = Object.getOwnPropertyDescriptor(reactDoctorSettings, settingName)?.value;
-  return typeof settingValue === "string" ? settingValue : undefined;
-};
 
 export const noSecretsInClientCode = defineRule<Rule>({
   id: "no-secrets-in-client-code",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -5,6 +5,7 @@ import {
   GENERIC_AUTH_METHOD_NAMES,
 } from "../../constants/security.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { getReactDoctorStringArraySetting } from "../../utils/get-react-doctor-setting.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { hasUseServerDirective } from "../../utils/has-use-server-directive.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -14,14 +15,56 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+type AsyncFunctionLikeNode =
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"ArrowFunctionExpression">;
+
+const isAsyncFunctionLikeNode = (
+  node: EsTreeNode | null | undefined,
+): node is AsyncFunctionLikeNode => {
+  if (!node) return false;
+  if (
+    !isNodeOfType(node, "FunctionDeclaration") &&
+    !isNodeOfType(node, "FunctionExpression") &&
+    !isNodeOfType(node, "ArrowFunctionExpression")
+  ) {
+    return false;
+  }
+  return Boolean(node.async);
+};
+
+const unwrapTypeWrappedCallee = (node: EsTreeNode | null | undefined): EsTreeNode | null => {
+  let currentNode: EsTreeNode | null | undefined = node;
+  while (currentNode) {
+    if (
+      isNodeOfType(currentNode, "TSAsExpression") ||
+      isNodeOfType(currentNode, "TSNonNullExpression") ||
+      isNodeOfType(currentNode, "TSTypeAssertion") ||
+      isNodeOfType(currentNode, "TSSatisfiesExpression") ||
+      isNodeOfType(currentNode, "TSInstantiationExpression")
+    ) {
+      currentNode = currentNode.expression;
+      continue;
+    }
+    if (isNodeOfType(currentNode, "ChainExpression")) {
+      currentNode = currentNode.expression;
+      continue;
+    }
+    return currentNode;
+  }
+  return null;
+};
+
 const buildDottedReceiverSource = (receiverNode: EsTreeNode | null | undefined): string => {
-  if (!receiverNode) return "";
-  if (isNodeOfType(receiverNode, "Identifier")) return receiverNode.name;
-  if (isNodeOfType(receiverNode, "ThisExpression")) return "this";
-  if (isNodeOfType(receiverNode, "MemberExpression")) {
-    const objectSource = buildDottedReceiverSource(receiverNode.object);
-    const propertyName = isNodeOfType(receiverNode.property, "Identifier")
-      ? receiverNode.property.name
+  const unwrapped = unwrapTypeWrappedCallee(receiverNode);
+  if (!unwrapped) return "";
+  if (isNodeOfType(unwrapped, "Identifier")) return unwrapped.name;
+  if (isNodeOfType(unwrapped, "ThisExpression")) return "this";
+  if (isNodeOfType(unwrapped, "MemberExpression")) {
+    const objectSource = buildDottedReceiverSource(unwrapped.object);
+    const propertyName = isNodeOfType(unwrapped.property, "Identifier")
+      ? unwrapped.property.name
       : "";
     if (!propertyName) return objectSource;
     return objectSource ? `${objectSource}.${propertyName}` : propertyName;
@@ -44,7 +87,8 @@ const getAuthCallName = (
   allowedFunctionNames: ReadonlySet<string>,
   genericMethodNames: ReadonlySet<string>,
 ): string | null => {
-  const calleeNode = callExpression.callee;
+  const calleeNode = unwrapTypeWrappedCallee(callExpression.callee);
+  if (!calleeNode) return null;
   if (isNodeOfType(calleeNode, "Identifier")) {
     return allowedFunctionNames.has(calleeNode.name) ? calleeNode.name : null;
   }
@@ -60,26 +104,30 @@ const getAuthCallName = (
   return null;
 };
 
+const isFunctionLikeNode = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "FunctionDeclaration") ||
+  isNodeOfType(node, "FunctionExpression") ||
+  isNodeOfType(node, "ArrowFunctionExpression");
+
 const containsAuthCheck = (
-  statements: EsTreeNode[],
+  rootNodes: EsTreeNode[],
   allowedFunctionNames: ReadonlySet<string>,
   genericMethodNames: ReadonlySet<string>,
 ): boolean => {
   let foundAuthCall = false;
-  for (const statement of statements) {
-    walkAst(statement, (child: EsTreeNode) => {
+  for (const rootNode of rootNodes) {
+    walkAst(rootNode, (child: EsTreeNode) => {
       if (foundAuthCall) return;
-      let callNode: EsTreeNode | null = null;
-      if (isNodeOfType(child, "CallExpression")) {
-        callNode = child;
-      } else if (
-        isNodeOfType(child, "AwaitExpression") &&
-        isNodeOfType(child.argument, "CallExpression")
-      ) {
-        callNode = child.argument;
-      }
-      if (!isNodeOfType(callNode, "CallExpression")) return;
-      if (getAuthCallName(callNode, allowedFunctionNames, genericMethodNames)) {
+      // Prune at any function-like node. A call to `auth()` inside a
+      // helper that the action never invokes does not protect the
+      // action, so we restrict the search to expressions evaluated
+      // directly by the action's top-level statements. This also
+      // covers a hoisted-helper top-level statement (a
+      // FunctionDeclaration as a root) — we don't want its inner
+      // `auth()` to count either.
+      if (isFunctionLikeNode(child)) return false;
+      if (!isNodeOfType(child, "CallExpression")) return;
+      if (getAuthCallName(child, allowedFunctionNames, genericMethodNames)) {
         foundAuthCall = true;
       }
     });
@@ -87,21 +135,75 @@ const containsAuthCheck = (
   return foundAuthCall;
 };
 
-const getReactDoctorStringArraySetting = (
-  settings: RuleContext["settings"],
-  settingName: string,
-): ReadonlyArray<string> => {
-  const reactDoctorSettings = settings?.["react-doctor"];
-  if (
-    typeof reactDoctorSettings !== "object" ||
-    reactDoctorSettings === null ||
-    Array.isArray(reactDoctorSettings)
-  ) {
-    return [];
+const getAuthScanRoots = (functionNode: AsyncFunctionLikeNode): EsTreeNode[] => {
+  const bodyNode = functionNode.body;
+  if (!bodyNode) return [];
+  if (isNodeOfType(bodyNode, "BlockStatement")) {
+    return (bodyNode.body ?? []).slice(0, AUTH_CHECK_LOOKAHEAD_STATEMENTS);
   }
-  const settingValue = Object.getOwnPropertyDescriptor(reactDoctorSettings, settingName)?.value;
-  if (!Array.isArray(settingValue)) return [];
-  return settingValue.filter((entry): entry is string => typeof entry === "string" && entry !== "");
+  // Concise-body arrow (`async () => somethingExpr`): the body IS the
+  // (only) expression — treat it as the single root to scan.
+  return [bodyNode];
+};
+
+interface ServerActionCandidate {
+  functionNode: AsyncFunctionLikeNode;
+  displayName: string;
+  reportNode: EsTreeNode;
+}
+
+const inspectServerAction = (
+  candidate: ServerActionCandidate,
+  fileHasUseServerDirective: boolean,
+  allowedFunctionNames: ReadonlySet<string>,
+  context: RuleContext,
+): void => {
+  const isServerAction = fileHasUseServerDirective || hasUseServerDirective(candidate.functionNode);
+  if (!isServerAction) return;
+
+  const rootNodes = getAuthScanRoots(candidate.functionNode);
+  if (containsAuthCheck(rootNodes, allowedFunctionNames, GENERIC_AUTH_METHOD_NAMES)) return;
+
+  context.report({
+    node: candidate.reportNode,
+    message: `Server action "${candidate.displayName}" — add auth check (auth(), getSession(), etc.) at the top`,
+  });
+};
+
+const collectCandidatesFromVariableDeclaration = (
+  variableDeclaration: EsTreeNodeOfType<"VariableDeclaration">,
+): ServerActionCandidate[] => {
+  const candidates: ServerActionCandidate[] = [];
+  for (const declarator of variableDeclaration.declarations ?? []) {
+    if (!isAsyncFunctionLikeNode(declarator.init)) continue;
+    const bindingNode = isNodeOfType(declarator.id, "Identifier") ? declarator.id : null;
+    candidates.push({
+      functionNode: declarator.init,
+      displayName: bindingNode?.name ?? "anonymous",
+      reportNode: bindingNode ?? declarator,
+    });
+  }
+  return candidates;
+};
+
+const getCandidateFromDefaultDeclaration = (
+  node: EsTreeNodeOfType<"ExportDefaultDeclaration">,
+): ServerActionCandidate | null => {
+  const declaration = node.declaration;
+  if (!isAsyncFunctionLikeNode(declaration)) return null;
+  // Only FunctionDeclaration / FunctionExpression carry an `id`;
+  // arrow functions never do. Fall back to "default" when missing.
+  const functionId =
+    (isNodeOfType(declaration, "FunctionDeclaration") ||
+      isNodeOfType(declaration, "FunctionExpression")) &&
+    declaration.id
+      ? declaration.id
+      : null;
+  return {
+    functionNode: declaration,
+    displayName: functionId?.name ?? "default",
+    reportNode: functionId ?? node,
+  };
 };
 
 export const serverAuthActions = defineRule<Rule>({
@@ -123,28 +225,34 @@ export const serverAuthActions = defineRule<Rule>({
         ? new Set([...AUTH_FUNCTION_NAMES, ...customAuthFunctionNames])
         : AUTH_FUNCTION_NAMES;
 
+    const inspect = (candidate: ServerActionCandidate): void =>
+      inspectServerAction(candidate, fileHasUseServerDirective, allowedFunctionNames, context);
+
     return {
       Program(programNode: EsTreeNodeOfType<"Program">) {
         fileHasUseServerDirective = hasDirective(programNode, "use server");
       },
       ExportNamedDeclaration(node: EsTreeNodeOfType<"ExportNamedDeclaration">) {
         const declaration = node.declaration;
-        if (!isNodeOfType(declaration, "FunctionDeclaration") || !declaration?.async) return;
-
-        const isServerAction = fileHasUseServerDirective || hasUseServerDirective(declaration);
-        if (!isServerAction) return;
-
-        const firstStatements = (declaration.body?.body ?? []).slice(
-          0,
-          AUTH_CHECK_LOOKAHEAD_STATEMENTS,
-        );
-        if (!containsAuthCheck(firstStatements, allowedFunctionNames, GENERIC_AUTH_METHOD_NAMES)) {
-          const functionName = declaration.id?.name ?? "anonymous";
-          context.report({
-            node: declaration.id ?? node,
-            message: `Server action "${functionName}" — add auth check (auth(), getSession(), etc.) at the top`,
+        if (!declaration) return;
+        if (isAsyncFunctionLikeNode(declaration)) {
+          if (!isNodeOfType(declaration, "FunctionDeclaration")) return;
+          inspect({
+            functionNode: declaration,
+            displayName: declaration.id?.name ?? "anonymous",
+            reportNode: declaration.id ?? node,
           });
+          return;
         }
+        if (isNodeOfType(declaration, "VariableDeclaration")) {
+          for (const candidate of collectCandidatesFromVariableDeclaration(declaration)) {
+            inspect(candidate);
+          }
+        }
+      },
+      ExportDefaultDeclaration(node: EsTreeNodeOfType<"ExportDefaultDeclaration">) {
+        const candidate = getCandidateFromDefaultDeclaration(node);
+        if (candidate) inspect(candidate);
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -1,4 +1,9 @@
-import { AUTH_CHECK_LOOKAHEAD_STATEMENTS, AUTH_FUNCTION_NAMES } from "../../constants/security.js";
+import {
+  AUTH_CHECK_LOOKAHEAD_STATEMENTS,
+  AUTH_FUNCTION_NAMES,
+  AUTH_OBJECT_PATTERN,
+  GENERIC_AUTH_METHOD_NAMES,
+} from "../../constants/security.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { hasUseServerDirective } from "../../utils/has-use-server-directive.js";
@@ -9,7 +14,57 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
+const buildDottedReceiverSource = (receiverNode: EsTreeNode | null | undefined): string => {
+  if (!receiverNode) return "";
+  if (isNodeOfType(receiverNode, "Identifier")) return receiverNode.name;
+  if (isNodeOfType(receiverNode, "ThisExpression")) return "this";
+  if (isNodeOfType(receiverNode, "MemberExpression")) {
+    const objectSource = buildDottedReceiverSource(receiverNode.object);
+    const propertyName = isNodeOfType(receiverNode.property, "Identifier")
+      ? receiverNode.property.name
+      : "";
+    if (!propertyName) return objectSource;
+    return objectSource ? `${objectSource}.${propertyName}` : propertyName;
+  }
+  return "";
+};
+
+const isMemberCallAuthRelated = (
+  receiverNode: EsTreeNode | null | undefined,
+  methodName: string,
+  genericMethodNames: ReadonlySet<string>,
+): boolean => {
+  if (!genericMethodNames.has(methodName)) return true;
+  const receiverSource = buildDottedReceiverSource(receiverNode);
+  return AUTH_OBJECT_PATTERN.test(receiverSource);
+};
+
+const getAuthCallName = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  allowedFunctionNames: ReadonlySet<string>,
+  genericMethodNames: ReadonlySet<string>,
+): string | null => {
+  const calleeNode = callExpression.callee;
+  if (isNodeOfType(calleeNode, "Identifier")) {
+    return allowedFunctionNames.has(calleeNode.name) ? calleeNode.name : null;
+  }
+  if (
+    isNodeOfType(calleeNode, "MemberExpression") &&
+    isNodeOfType(calleeNode.property, "Identifier")
+  ) {
+    const methodName = calleeNode.property.name;
+    if (!allowedFunctionNames.has(methodName)) return null;
+    if (!isMemberCallAuthRelated(calleeNode.object, methodName, genericMethodNames)) return null;
+    return methodName;
+  }
+  return null;
+};
+
+const containsAuthCheck = (
+  statements: EsTreeNode[],
+  allowedFunctionNames: ReadonlySet<string>,
+  genericMethodNames: ReadonlySet<string>,
+): boolean => {
   let foundAuthCall = false;
   for (const statement of statements) {
     walkAst(statement, (child: EsTreeNode) => {
@@ -23,16 +78,30 @@ const containsAuthCheck = (statements: EsTreeNode[]): boolean => {
       ) {
         callNode = child.argument;
       }
-
-      if (
-        isNodeOfType(callNode?.callee, "Identifier") &&
-        AUTH_FUNCTION_NAMES.has(callNode.callee.name)
-      ) {
+      if (!isNodeOfType(callNode, "CallExpression")) return;
+      if (getAuthCallName(callNode, allowedFunctionNames, genericMethodNames)) {
         foundAuthCall = true;
       }
     });
   }
   return foundAuthCall;
+};
+
+const getReactDoctorStringArraySetting = (
+  settings: RuleContext["settings"],
+  settingName: string,
+): ReadonlyArray<string> => {
+  const reactDoctorSettings = settings?.["react-doctor"];
+  if (
+    typeof reactDoctorSettings !== "object" ||
+    reactDoctorSettings === null ||
+    Array.isArray(reactDoctorSettings)
+  ) {
+    return [];
+  }
+  const settingValue = Object.getOwnPropertyDescriptor(reactDoctorSettings, settingName)?.value;
+  if (!Array.isArray(settingValue)) return [];
+  return settingValue.filter((entry): entry is string => typeof entry === "string" && entry !== "");
 };
 
 export const serverAuthActions = defineRule<Rule>({
@@ -42,6 +111,17 @@ export const serverAuthActions = defineRule<Rule>({
     "Add `const session = await auth()` at the top and throw/redirect if unauthorized before any data access",
   create: (context: RuleContext) => {
     let fileHasUseServerDirective = false;
+    const customAuthFunctionNames = getReactDoctorStringArraySetting(
+      context.settings,
+      "serverAuthFunctionNames",
+    );
+    // Custom auth guards from project config are treated as distinctive
+    // (NOT generic) — when a project opts a name in, the user has
+    // already vouched that the name uniquely identifies an auth check.
+    const allowedFunctionNames: ReadonlySet<string> =
+      customAuthFunctionNames.length > 0
+        ? new Set([...AUTH_FUNCTION_NAMES, ...customAuthFunctionNames])
+        : AUTH_FUNCTION_NAMES;
 
     return {
       Program(programNode: EsTreeNodeOfType<"Program">) {
@@ -58,7 +138,7 @@ export const serverAuthActions = defineRule<Rule>({
           0,
           AUTH_CHECK_LOOKAHEAD_STATEMENTS,
         );
-        if (!containsAuthCheck(firstStatements)) {
+        if (!containsAuthCheck(firstStatements, allowedFunctionNames, GENERIC_AUTH_METHOD_NAMES)) {
           const functionName = declaration.id?.name ?? "anonymous";
           context.report({
             node: declaration.id ?? node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-react-doctor-setting.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-react-doctor-setting.ts
@@ -1,0 +1,50 @@
+import type { RuleContext } from "./rule-context.js";
+
+// Extracted helpers for reading typed entries out of the `react-doctor`
+// settings bag that core writes into the oxlint config (see
+// `createOxlintConfig` in `@react-doctor/core`). Both functions:
+//   - Guard against the settings bag being missing, an array, or `null`.
+//   - Use `Object.getOwnPropertyDescriptor` instead of bracket access
+//     so that prototype-pollution-style keys (`__proto__`, …) can't
+//     leak inherited values into rule logic.
+//   - Filter the returned value by its actual runtime type so a
+//     malformed payload (e.g. a `number` where a `string[]` belongs)
+//     falls back to a safe default rather than crashing the rule.
+
+const readReactDoctorSettingsBag = (settings: RuleContext["settings"]): object | null => {
+  const reactDoctorSettings = settings?.["react-doctor"];
+  if (
+    typeof reactDoctorSettings !== "object" ||
+    reactDoctorSettings === null ||
+    Array.isArray(reactDoctorSettings)
+  ) {
+    return null;
+  }
+  return reactDoctorSettings;
+};
+
+const readOwnPropertyValue = (bag: object, settingName: string): unknown =>
+  Object.getOwnPropertyDescriptor(bag, settingName)?.value;
+
+export const getReactDoctorStringSetting = (
+  settings: RuleContext["settings"],
+  settingName: string,
+): string | undefined => {
+  const bag = readReactDoctorSettingsBag(settings);
+  if (!bag) return undefined;
+  const settingValue = readOwnPropertyValue(bag, settingName);
+  return typeof settingValue === "string" ? settingValue : undefined;
+};
+
+export const getReactDoctorStringArraySetting = (
+  settings: RuleContext["settings"],
+  settingName: string,
+): ReadonlyArray<string> => {
+  const bag = readReactDoctorSettingsBag(settings);
+  if (!bag) return [];
+  const settingValue = readOwnPropertyValue(bag, settingName);
+  if (!Array.isArray(settingValue)) return [];
+  return settingValue.filter(
+    (entry): entry is string => typeof entry === "string" && entry.length > 0,
+  );
+};

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -235,6 +235,7 @@ When a suppression isn't working, `--explain <file:line>` (or its alias `--why <
 | `offline`                  | `boolean`                        | `false`  |
 | `textComponents`           | `string[]`                       | `[]`     |
 | `rawTextWrapperComponents` | `string[]`                       | `[]`     |
+| `serverAuthFunctionNames`  | `string[]`                       | `[]`     |
 | `respectInlineDisables`    | `boolean`                        | `true`   |
 | `adoptExistingLintConfig`  | `boolean`                        | `true`   |
 | `ignore.tags`              | `string[]`                       | `[]`     |
@@ -242,6 +243,8 @@ When a suppression isn't working, `--explain <file:line>` (or its alias `--why <
 `textComponents` is the broad escape hatch for `rn-no-raw-text` — list components that themselves behave like React Native's `<Text>` (custom `Typography`, `NativeTabs.Trigger.Label`, etc.) and the rule will treat them as text containers regardless of what their children look like.
 
 `rawTextWrapperComponents` is the narrower option for components that are not text elements but safely route string-only children through an internal `<Text>` (e.g. `heroui-native`'s `Button`, which stringifies its children and renders them through a `ButtonLabel`). Listed wrappers suppress `rn-no-raw-text` only when their children are entirely stringifiable. A wrapper with mixed children — e.g. `<Button>Save<Icon /></Button>` — still reports because the wrapper can't safely route raw text alongside a sibling JSX element.
+
+`serverAuthFunctionNames` teaches `server-auth-actions` about custom auth guards your codebase wraps around its auth library (e.g. `requireWorkspaceMember`, `ensureSignedIn`). Listed names are accepted as a valid top-of-action auth check whether called bare (`requireWorkspaceMember()`) or as a member (`guards.requireWorkspaceMember()`), and — unlike the built-in default list — are treated as distinctive so the receiver is not re-validated.
 
 `ignore.tags` suppresses entire categories of rules by tag. For example, `"tags": ["design"]` disables all opinionated design rules (gradient text, pure black backgrounds, side tab borders, default Tailwind palettes). Available tags: `"design"`.
 

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -159,6 +159,7 @@ export const diagnose = async (
         respectInlineDisables: effectiveRespectInlineDisables,
         adoptExistingLintConfig: userConfig?.adoptExistingLintConfig ?? true,
         ignoredTags,
+        userConfig,
       }).catch((error: unknown) => {
         console.error("Lint failed:", error);
         return EMPTY_DIAGNOSTICS;

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -159,6 +159,7 @@ const runInspect = async (
             respectInlineDisables: options.respectInlineDisables,
             adoptExistingLintConfig: options.adoptExistingLintConfig,
             ignoredTags: options.ignoredTags,
+            userConfig,
             onPartialFailure: (reason) => lintPartialFailures.push(reason),
           });
           lintSpinner?.succeed("Running lint checks.");

--- a/packages/react-doctor/tests/regressions/server-auth-actions.test.ts
+++ b/packages/react-doctor/tests/regressions/server-auth-actions.test.ts
@@ -225,4 +225,190 @@ export async function publishPost(postId: string) {
     });
     expect(issues).toHaveLength(1);
   });
+
+  it("flags `export default async function` missing an auth check", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "default-export-named-missing", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts":
+          buildServerActionFile(`export default async function deleteAccount(accountId: string) {
+  return { accountId, deleted: true };
+}`),
+      },
+    });
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("deleteAccount");
+  });
+
+  it("accepts `export default async function` when an auth check is present", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "default-export-named-ok", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth } from "@/lib/auth";
+
+export default async function deleteAccount(accountId: string) {
+  const session = await auth();
+  if (!session) throw new Error("unauthorized");
+  return { accountId, deleted: true };
+}`),
+      },
+    });
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("flags anonymous default-export async functions missing an auth check", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "default-export-anonymous-missing", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts":
+          buildServerActionFile(`export default async function (accountId: string) {
+  return { accountId, deleted: true };
+}`),
+      },
+    });
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("default");
+  });
+
+  it("flags `export const fn = async () => {}` missing an auth check", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "const-arrow-missing", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts":
+          buildServerActionFile(`export const deleteAccount = async (accountId: string) => {
+  return { accountId, deleted: true };
+};`),
+      },
+    });
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("deleteAccount");
+  });
+
+  it("accepts `export const fn = async () => {}` when an auth check is present", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "const-arrow-ok", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth } from "@/lib/auth";
+
+export const deleteAccount = async (accountId: string) => {
+  const session = await auth();
+  if (!session) throw new Error("unauthorized");
+  return { accountId, deleted: true };
+};`),
+      },
+    });
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("flags concise-body arrow exports without an auth call", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "const-arrow-concise-missing", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { performDelete } from "@/lib/delete";
+
+export const deleteAccount = async (accountId: string) => performDelete(accountId);`),
+      },
+    });
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("deleteAccount");
+  });
+
+  it("accepts concise-body arrow exports whose body IS the auth call", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "const-arrow-concise-ok", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth } from "@/lib/auth";
+
+export const refreshSession = async () => auth();`),
+      },
+    });
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("flags `export const fn = async function() {}` missing an auth check", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "const-function-expression-missing", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts":
+          buildServerActionFile(`export const deleteAccount = async function (accountId: string) {
+  return { accountId, deleted: true };
+};`),
+      },
+    });
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("deleteAccount");
+  });
+
+  it("does not count auth() inside a nested helper as protecting the action", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "nested-helper-not-counted", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth } from "@/lib/auth";
+
+export async function deleteAccount(accountId: string) {
+  async function unusedHelper() {
+    return await auth();
+  }
+  return { accountId, deleted: true };
+}`),
+      },
+    });
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("deleteAccount");
+  });
+
+  it("accepts optional-chained member auth calls (`auth0?.getSession()`)", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "optional-chain-member-call", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth0 } from "@/lib/auth0";
+
+export async function readProfile(profileId: string) {
+  const session = await auth0?.getSession();
+  if (!session) throw new Error("unauthorized");
+  return { profileId, sessionId: session.id };
+}`),
+      },
+    });
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("accepts auth calls hidden behind a non-null assertion (`auth!()`)", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "ts-non-null-assertion-callee", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth } from "@/lib/auth";
+
+export async function publishPost(postId: string) {
+  const session = await auth!();
+  if (!session) throw new Error("unauthorized");
+  return { postId, publishedBy: session.userId };
+}`),
+      },
+    });
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("accepts auth calls hidden behind an `as` cast (`(auth as AuthFn)()`)", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "ts-as-cast-callee", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth } from "@/lib/auth";
+type AuthFn = () => Promise<{ userId: string } | null>;
+
+export async function archiveProject(projectId: string) {
+  const session = await (auth as AuthFn)();
+  if (!session) throw new Error("unauthorized");
+  return { projectId, archivedBy: session.userId };
+}`),
+      },
+    });
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
 });

--- a/packages/react-doctor/tests/regressions/server-auth-actions.test.ts
+++ b/packages/react-doctor/tests/regressions/server-auth-actions.test.ts
@@ -1,0 +1,228 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import { runOxlint } from "@react-doctor/core";
+import type { Diagnostic, ReactDoctorConfig } from "@react-doctor/types";
+import { buildTestProject, setupReactProject } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-server-auth-actions-"));
+const RULE_ID = "server-auth-actions";
+
+const NEXTJS_PACKAGE_DEPENDENCIES = {
+  next: "^15.0.0",
+  react: "^19.0.0",
+  "react-dom": "^19.0.0",
+};
+
+interface CollectAuthIssuesOptions {
+  userConfig?: ReactDoctorConfig | null;
+}
+
+const collectAuthActionIssues = async (
+  projectDirectory: string,
+  options: CollectAuthIssuesOptions = {},
+): Promise<Diagnostic[]> => {
+  const diagnostics = await runOxlint({
+    rootDirectory: projectDirectory,
+    project: buildTestProject({
+      rootDirectory: projectDirectory,
+      framework: "nextjs",
+    }),
+    userConfig: options.userConfig ?? null,
+  });
+  return diagnostics.filter((diagnostic) => diagnostic.rule === RULE_ID);
+};
+
+const buildServerActionFile = (body: string): string => `"use server";
+
+${body}
+`;
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("server-auth-actions", () => {
+  it("accepts auth0.getSession() as a top-of-action auth check", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "auth0-get-session", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth0 } from "@/lib/auth0";
+
+export async function deleteAccount(accountId: string) {
+  const session = await auth0.getSession();
+  if (!session) throw new Error("unauthorized");
+  return { accountId, deleted: true };
+}`),
+      },
+    });
+
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("accepts ctx.auth.getUser() through a nested member receiver", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "ctx-auth-get-user", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { ctx } from "@/lib/context";
+
+export async function updateProfile(profile: { name: string }) {
+  const user = await ctx.auth.getUser();
+  if (!user) throw new Error("unauthorized");
+  return { ...profile, userId: user.id };
+}`),
+      },
+    });
+
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("accepts clerkClient.getUser() through an auth-related receiver", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "clerk-client-get-user", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts":
+          buildServerActionFile(`import { clerkClient } from "@clerk/nextjs/server";
+
+export async function rotateKey(keyId: string) {
+  const user = await clerkClient.getUser();
+  if (!user) throw new Error("unauthorized");
+  return { keyId, rotatedBy: user.id };
+}`),
+      },
+    });
+
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("accepts session.auth() as a member-call auth check", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "session-auth", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { session } from "@/lib/session";
+
+export async function archiveProject(projectId: string) {
+  const result = await session.auth();
+  if (!result.userId) throw new Error("unauthorized");
+  return { projectId, archived: true };
+}`),
+      },
+    });
+
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("still reports server actions with no auth call at all", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "missing-auth-check", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts":
+          buildServerActionFile(`export async function deleteAccount(accountId: string) {
+  return { accountId, deleted: true };
+}`),
+      },
+    });
+
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("deleteAccount");
+  });
+
+  it("does not flag analytics.getUser() as an auth check (false-positive guard)", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "analytics-get-user-not-auth", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { analytics } from "@/lib/analytics";
+
+export async function trackVisit(visitId: string) {
+  const profile = await analytics.getUser();
+  return { visitId, segment: profile.segment };
+}`),
+      },
+    });
+
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("trackVisit");
+  });
+
+  it("accepts a bare-identifier auth call (regression guard for the original behavior)", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "bare-identifier-auth", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { auth } from "@/lib/auth";
+
+export async function deleteAccount(accountId: string) {
+  const session = await auth();
+  if (!session) throw new Error("unauthorized");
+  return { accountId, deleted: true };
+}`),
+      },
+    });
+
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("accepts custom guards listed in `serverAuthFunctionNames`", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "custom-auth-guard", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts":
+          buildServerActionFile(`import { requireWorkspaceMember } from "@/lib/guards";
+
+export async function inviteMember(workspaceId: string) {
+  const member = await requireWorkspaceMember();
+  return { workspaceId, invitedBy: member.id };
+}`),
+      },
+    });
+
+    const withoutCustomAllowlist = await collectAuthActionIssues(projectDirectory);
+    expect(withoutCustomAllowlist).toHaveLength(1);
+
+    const withCustomAllowlist = await collectAuthActionIssues(projectDirectory, {
+      userConfig: { serverAuthFunctionNames: ["requireWorkspaceMember"] },
+    });
+    expect(withCustomAllowlist).toEqual([]);
+  });
+
+  it("accepts custom guards even when called through a member expression", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "custom-auth-guard-member-call", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { guards } from "@/lib/guards";
+
+export async function publishPost(postId: string) {
+  const member = await guards.requireWorkspaceMember();
+  return { postId, publishedBy: member.id };
+}`),
+      },
+    });
+
+    const withCustomAllowlist = await collectAuthActionIssues(projectDirectory, {
+      userConfig: { serverAuthFunctionNames: ["requireWorkspaceMember"] },
+    });
+    expect(withCustomAllowlist).toEqual([]);
+  });
+
+  it("ignores non-string entries in `serverAuthFunctionNames`", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "custom-auth-guard-bad-entries", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`export async function leakData() {
+  return { ok: true };
+}`),
+      },
+    });
+
+    const issues = await collectAuthActionIssues(projectDirectory, {
+      userConfig: {
+        // Cast required to test runtime filtering of malformed config payloads.
+        serverAuthFunctionNames: ["", 42 as unknown as string, null as unknown as string],
+      },
+    });
+    expect(issues).toHaveLength(1);
+  });
+});

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -58,6 +58,20 @@ export interface ReactDoctorConfig {
    */
   rawTextWrapperComponents?: string[];
   /**
+   * Project-level allowlist of function names that the
+   * `server-auth-actions` rule treats as an auth check at the top of
+   * a server action. Names are accepted whether called as a bare
+   * identifier (`myAuthGuard()`) or as the final property of a
+   * member call (`ctx.myAuthGuard()`); unlike the built-in default
+   * list, user-provided names are treated as distinctive and never
+   * subject to receiver-object disambiguation.
+   *
+   * Use this to teach react-doctor about custom auth guards in
+   * codebases that wrap their auth library — e.g. a project-local
+   * `requireWorkspaceMember` or `ensureSignedIn`.
+   */
+  serverAuthFunctionNames?: string[];
+  /**
    * Whether to respect inline `// eslint-disable*`, `// oxlint-disable*`,
    * and `// react-doctor-disable*` comments in source files. Default: `true`.
    *


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `server-auth-actions` rule only matched bare identifier calls like `auth()` or `getSession()`. Common patterns from real auth libraries were silently flagged as missing an auth check:

- `auth0.getSession()`
- `ctx.auth.getUser()`
- `clerkClient.getUser()`
- `session.auth()`

## Fix

- The rule now accepts a call whose final property is in `AUTH_FUNCTION_NAMES`, whether called as a bare identifier (`getSession()`) or the last member of a chain (`auth0.getSession()`, `ctx.auth.getUser()`).
- For names that are too generic to recognize on their own (currently only `getUser`), a member-call form is only accepted when the receiver expression looks auth-related per `AUTH_OBJECT_PATTERN` (`auth` / `clerk` / `session` / `jwt` / `firebase` / `supabase` / `nextauth` / `kinde` / `workos` / `stytch` / `descope` / `cognito` / `propelauth` / `lucia` / `iron-session` / `better-auth`). This keeps `analytics.getUser()` from suppressing the rule.
- Adds a project-level allowlist via `ReactDoctorConfig.serverAuthFunctionNames` so codebases that wrap their auth library (e.g. `requireWorkspaceMember`, `ensureSignedIn`) can teach react-doctor about the wrapper. User-provided names are treated as distinctive and accepted as both bare and member calls. The value is plumbed through `runOxlint` → `createOxlintConfig` into the `react-doctor` settings block on the generated oxlintrc, then read by the rule via `context.settings`.

## Files touched

- `packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts`: split distinctive vs generic auth method names and added `AUTH_OBJECT_PATTERN`.
- `packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts`: extended `getAuthCallName` to walk `MemberExpression` callees, added receiver-source disambiguation for generic names, added settings read for `serverAuthFunctionNames`.
- `packages/types/src/config.ts`: documented new `serverAuthFunctionNames` field on `ReactDoctorConfig`.
- `packages/core/src/run-oxlint.ts` + `packages/core/src/runners/oxlint/config.ts`: thread `userConfig.serverAuthFunctionNames` through to the oxlintrc `settings."react-doctor".serverAuthFunctionNames` payload, with empty/invalid entries filtered out.
- `packages/react-doctor/src/index.ts`, `packages/react-doctor/src/inspect.ts`: pass already-loaded `userConfig` into `runOxlint`.

## Tests

New regression suite `packages/react-doctor/tests/regressions/server-auth-actions.test.ts` (10 tests) covers:

- accept `auth0.getSession()`, `ctx.auth.getUser()`, `clerkClient.getUser()`, `session.auth()`
- still report server actions with no auth check at all
- still report `analytics.getUser()` (false-positive guard)
- accept the original bare-identifier shape (regression guard)
- accept custom guards listed in `serverAuthFunctionNames` as bare and member calls
- ignore malformed entries (`""`, non-strings) in the config knob

Full suite: 889/889 tests pass. Typecheck, lint, and format checks all clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94b55b90-20a0-4f3c-bc04-f304bd247b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94b55b90-20a0-4f3c-bc04-f304bd247b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

