### PR TITLE
Simplify npx usage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,9 +82,9 @@ runs:
           # so style cleanup doesn't dilute meaningful React findings
           # in the sticky PR comment. Configure overrides via
           # config.surfaces.{prComment,ciFailure} in react-doctor.config.json.
-          npx -y react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}" --pr-comment | tee "$OUTPUT_FILE"
+          npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}" --pr-comment | tee "$OUTPUT_FILE"
         else
-          npx -y react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}"
+          npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}"
         fi
 
     - id: score
@@ -101,7 +101,7 @@ runs:
         # don't fail the composite action under `set -e -o pipefail`.
         SCORE_ARGS=("$INPUT_DIRECTORY" "--score" "--fail-on" "none")
         if [ "$INPUT_OFFLINE" = "true" ]; then SCORE_ARGS+=("--offline"); fi
-        SCORE=$(npx -y react-doctor@latest "${SCORE_ARGS[@]}" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
+        SCORE=$(npx react-doctor@latest "${SCORE_ARGS[@]}" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
         if [[ -n "$SCORE" && "$SCORE" =~ ^[0-9]+$ ]]; then
           echo "score=$SCORE" >> "$GITHUB_OUTPUT"
         fi

--- a/packages/eslint-plugin-react-doctor/README.md
+++ b/packages/eslint-plugin-react-doctor/README.md
@@ -75,7 +75,7 @@ export default [
 This package only ships the ESLint plugin. To run React Doctor's full scan (with scoring, JSON reports, agent integration, etc.), use the main CLI:
 
 ```bash
-npx -y react-doctor@latest .
+npx react-doctor@latest
 ```
 
 See the [React Doctor README](https://github.com/millionco/react-doctor#readme) for the full feature set.

--- a/packages/oxlint-plugin-react-doctor/README.md
+++ b/packages/oxlint-plugin-react-doctor/README.md
@@ -61,7 +61,7 @@ Each rule can be set to `"error"`, `"warn"`, or `"off"`:
 This package only ships the oxlint plugin. To run React Doctor's full scan (with scoring, JSON reports, agent integration, etc.), use the main CLI:
 
 ```bash
-npx -y react-doctor@latest .
+npx react-doctor@latest
 ```
 
 See the [React Doctor README](https://github.com/millionco/react-doctor#readme) for the full feature set.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -20,7 +20,7 @@ Works with Next.js, Vite, and React Native.
 Run this at your project root:
 
 ```bash
-npx -y react-doctor@latest .
+npx react-doctor@latest
 ```
 
 You'll get a score (75+ Great, 50 to 74 Needs work, under 50 Critical) and a list of issues across state & effects, performance, architecture, security, accessibility, and dead code. Rules toggle automatically based on your framework and React version.
@@ -32,7 +32,7 @@ https://github.com/user-attachments/assets/07cc88d9-9589-44c3-aa73-5d603cb1c570
 Teach your coding agent React best practices so it stops writing the bad code in the first place.
 
 ```bash
-npx -y react-doctor@latest install
+npx react-doctor@latest install
 ```
 
 You'll be prompted to pick which detected agents to install for. Pass `--yes` to skip prompts.
@@ -75,7 +75,7 @@ When `github-token` is set on `pull_request` events, findings are posted (and up
 Prefer not to add a marketplace action? The bare `npx` form works too:
 
 ```yaml
-- run: npx -y react-doctor@latest --fail-on warning
+- run: npx react-doctor@latest --fail-on warning
 ```
 
 ## Configuration

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -33,7 +33,7 @@ describe("GitHub Action contract", () => {
 
     expect(scoreStep).toContain("--score");
     expect(scoreStep).toContain('"--fail-on" "none"');
-    expect(scoreStep).toContain("SCORE=$(npx -y react-doctor@latest");
+    expect(scoreStep).toContain("SCORE=$(npx react-doctor@latest");
     expect(scoreStep).toContain("|| true");
   });
 

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -7,67 +7,67 @@ Diagnose React codebase health. Scans for security, performance, correctness, an
 Run this at your project root:
 
 ```bash
-npx -y react-doctor@latest .
+npx react-doctor@latest
 ```
 
 Use `--verbose` to see affected files and line numbers:
 
 ```bash
-npx -y react-doctor@latest . --verbose
+npx react-doctor@latest --verbose
 ```
 
 Use `--diff [base]` to scan only files changed vs a base branch (default: auto-detected `main`/`master`). On the default branch, scans uncommitted working-tree changes; on a feature branch, scans changes vs the base.
 
 ```bash
-npx -y react-doctor@latest . --verbose --diff
+npx react-doctor@latest --verbose --diff
 ```
 
 Use `--score` to output only the numeric score:
 
 ```bash
-npx -y react-doctor@latest . --score
+npx react-doctor@latest --score
 ```
 
 Use `--json` for a single structured JSON report (suppresses other output):
 
 ```bash
-npx -y react-doctor@latest . --json | jq '.summary'
+npx react-doctor@latest --json | jq '.summary'
 ```
 
 Use `-y` to skip prompts (required for non-interactive environments like CI or coding agents):
 
 ```bash
-npx -y react-doctor@latest . -y
+npx react-doctor@latest -y
 ```
 
 Use `--staged` for pre-commit hooks (scans only staged files):
 
 ```bash
-npx -y react-doctor@latest --staged
+npx react-doctor@latest --staged
 ```
 
 Use `--annotations` to emit GitHub Actions annotations:
 
 ```bash
-npx -y react-doctor@latest . --annotations
+npx react-doctor@latest --annotations
 ```
 
 Use `--fail-on <level>` to control exit codes (`error`, `warning`, `none`):
 
 ```bash
-npx -y react-doctor@latest . --fail-on error
+npx react-doctor@latest --fail-on error
 ```
 
 Use `--offline` to skip the score API (computes score locally):
 
 ```bash
-npx -y react-doctor@latest . --offline
+npx react-doctor@latest --offline
 ```
 
 Install the skill into your coding agent (50+ agents supported via agent-install: Claude Code, Codex, Cursor, Factory Droid, Gemini CLI, GitHub Copilot, Goose, OpenCode, Pi, Windsurf, Roo Code, Cline, Kilo Code, Warp, Replit, OpenHands, Continue, and more):
 
 ```bash
-npx -y react-doctor@latest install
+npx react-doctor@latest install
 ```
 
 ## Options

--- a/packages/website/src/app/install-skill/route.ts
+++ b/packages/website/src/app/install-skill/route.ts
@@ -27,7 +27,7 @@ if ! command -v npx >/dev/null 2>&1; then
 fi
 
 printf "\${GREEN}→\${RESET} Installing react-doctor skill via npx react-doctor install...\\n"
-exec npx -y react-doctor@latest install --yes
+exec npx react-doctor@latest install --yes
 `;
 
 export const GET = (): Response =>

--- a/packages/website/src/app/leaderboard/page.tsx
+++ b/packages/website/src/app/leaderboard/page.tsx
@@ -7,7 +7,7 @@ import { getScoreColorClass } from "@/utils/get-score-color-class";
 
 const SCORE_BAR_WIDTH = 20;
 const REVALIDATE_SECONDS = 60 * 60;
-const COMMAND = "npx -y react-doctor@latest .";
+const COMMAND = "npx react-doctor@latest";
 const BENCHMARKS_REPO_URL = "https://github.com/millionco/react-doctor-benchmarks";
 const LEADERBOARD_URL =
   "https://raw.githubusercontent.com/millionco/react-doctor-benchmarks/main/results/leaderboard.json";

--- a/packages/website/src/app/share/page.tsx
+++ b/packages/website/src/app/share/page.tsx
@@ -8,7 +8,7 @@ import BadgeSnippet from "./badge-snippet";
 
 const MAX_PROJECT_NAME_LENGTH = 100;
 const MAX_DISPLAY_COUNT = 99_999;
-const COMMAND = "npx -y react-doctor@latest .";
+const COMMAND = "npx react-doctor@latest";
 const SHARE_BASE_URL = "https://www.react.doctor/share";
 const X_ICON_PATH =
   "M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z";

--- a/skills/react-doctor/SKILL.md
+++ b/skills/react-doctor/SKILL.md
@@ -10,18 +10,18 @@ Scans React codebases for security, performance, correctness, and architecture i
 
 ## After making React code changes:
 
-Run `npx -y react-doctor@latest . --verbose --diff` and check the score did not regress.
+Run `npx react-doctor@latest --verbose --diff` and check the score did not regress.
 
 If the score dropped, fix the regressions before committing.
 
 ## For general cleanup or code improvement:
 
-Run `npx -y react-doctor@latest . --verbose` (without `--diff`) to scan the full codebase. Fix issues by severity — errors first, then warnings.
+Run `npx react-doctor@latest --verbose` (without `--diff`) to scan the full codebase. Fix issues by severity — errors first, then warnings.
 
 ## Command
 
 ```bash
-npx -y react-doctor@latest . --verbose --diff
+npx react-doctor@latest --verbose --diff
 ```
 
 | Flag        | Purpose                                       |


### PR DESCRIPTION
## Summary
- Removes the `-y` and explicit `.` defaults from React Doctor `npx` examples where the CLI already handles defaults.
- Updates the composite GitHub Action command strings and matching contract test to use the simplified invocation.

## Test plan
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/command-string cleanup; the only behavioral touchpoint is the GitHub Action switching from `npx -y` to plain `npx`, which could matter if `npx`/CLI prompting behavior differs in some environments.
> 
> **Overview**
> Updates the composite GitHub Action to invoke `react-doctor` via `npx react-doctor@latest` (dropping `-y`) for both the scan and score-collection steps, and adjusts the contract test to match.
> 
> Refreshes README/website/skill documentation and UI command snippets to use the simplified `npx react-doctor@latest` form (removing the explicit `.` directory and `-y` in examples).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1537e61beb01d08ca51a43dfa279a0a54a34c798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->