### PR TITLE
feat(action): expose `--annotations` through `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "Skip sending diagnostics to the react.doctor API and calculate score locally"
     default: "false"
   annotations:
-    description: "Emit diagnostics as GitHub Actions annotations (`::error` / `::warning`) so findings show inline in the PR's Files changed view. Combine with `github-token` to get both inline annotations and a sticky PR comment, or leave `github-token` unset for annotations-only."
+    description: "Emit diagnostics as GitHub Actions annotations so findings show inline in the PR's Files changed view. Combine with `github-token` for both annotations and a sticky comment."
     default: "false"
   node-version:
     description: "Node.js version to use"
@@ -89,10 +89,8 @@ runs:
           # config.surfaces.{prComment,ciFailure} in react-doctor.config.json.
           RAW_FILE="${RUNNER_TEMP:-/tmp}/react-doctor-raw-${GITHUB_RUN_ID:-$$}.txt"
           npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}" --pr-comment | tee "$RAW_FILE"
-          # Strip GitHub Actions workflow commands (emitted by
-          # --annotations) from the captured PR-comment body — the runner
-          # still parses them as inline annotations from the live step
-          # log, but the sticky comment stays human-readable.
+          # Strip annotation workflow commands from the PR-comment body;
+          # the runner still parses them from the live step log.
           sed -E '/^::(error|warning) /d' "$RAW_FILE" > "$OUTPUT_FILE"
         else
           npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}"

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
   offline:
     description: "Skip sending diagnostics to the react.doctor API and calculate score locally"
     default: "false"
+  annotations:
+    description: "Emit diagnostics as GitHub Actions annotations (`::error` / `::warning`) so findings show inline in the PR's Files changed view. Combine with `github-token` to get both inline annotations and a sticky PR comment, or leave `github-token` unset for annotations-only."
+    default: "false"
   node-version:
     description: "Node.js version to use"
     default: "22"
@@ -64,6 +67,7 @@ runs:
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_FAIL_ON: ${{ inputs.fail-on }}
         INPUT_OFFLINE: ${{ inputs.offline }}
+        INPUT_ANNOTATIONS: ${{ inputs.annotations }}
         RUNNER_TEMP: ${{ runner.temp }}
         GITHUB_RUN_ID: ${{ github.run_id }}
       run: |
@@ -72,6 +76,7 @@ runs:
         if [ -n "$INPUT_PROJECT" ]; then FLAGS+=("--project" "$INPUT_PROJECT"); fi
         if [ -n "$INPUT_DIFF" ]; then FLAGS+=("--diff" "$INPUT_DIFF"); fi
         if [ "$INPUT_OFFLINE" = "true" ]; then FLAGS+=("--offline"); fi
+        if [ "$INPUT_ANNOTATIONS" = "true" ]; then FLAGS+=("--annotations"); fi
 
         OUTPUT_FILE="${RUNNER_TEMP:-/tmp}/react-doctor-output-${GITHUB_RUN_ID:-$$}.txt"
         echo "REACT_DOCTOR_OUTPUT_FILE=$OUTPUT_FILE" >> "$GITHUB_ENV"
@@ -82,7 +87,13 @@ runs:
           # so style cleanup doesn't dilute meaningful React findings
           # in the sticky PR comment. Configure overrides via
           # config.surfaces.{prComment,ciFailure} in react-doctor.config.json.
-          npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}" --pr-comment | tee "$OUTPUT_FILE"
+          RAW_FILE="${RUNNER_TEMP:-/tmp}/react-doctor-raw-${GITHUB_RUN_ID:-$$}.txt"
+          npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}" --pr-comment | tee "$RAW_FILE"
+          # Strip GitHub Actions workflow commands (emitted by
+          # --annotations) from the captured PR-comment body — the runner
+          # still parses them as inline annotations from the live step
+          # log, but the sticky comment stays human-readable.
+          sed -E '/^::(error|warning) /d' "$RAW_FILE" > "$OUTPUT_FILE"
         else
           npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}"
         fi

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -76,27 +76,11 @@ When `github-token` is set on `pull_request` events, findings are posted (and up
 
 #### PR feedback modes
 
-The action can surface findings on a PR in three ways. Pick whichever fits — they're independent and the workflow command output is always parsed by GitHub Actions regardless of where it appears.
+Pick one or both; they're independent.
 
-**Sticky comment only (default).** Set `github-token`, leave `annotations` unset. One updating comment lands on the PR with the full report and score:
-
-```yaml
-- uses: millionco/react-doctor@main
-  with:
-    diff: main
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-```
-
-**Inline annotations only.** Set `annotations: true`, omit `github-token`. Each finding appears as a `::error` / `::warning` annotation pinned to its file and line in the PR's Files changed view, with no comment posted:
-
-```yaml
-- uses: millionco/react-doctor@main
-  with:
-    diff: main
-    annotations: true
-```
-
-**Both.** Enable both inputs to get inline annotations and a sticky summary comment on the same run. Annotation lines are stripped from the comment body so it stays readable:
+- **Comments only** (default): set `github-token`.
+- **Annotations only**: set `annotations: true`.
+- **Both**: set `github-token` and `annotations: true`. Annotation lines are stripped from the comment body.
 
 ```yaml
 - uses: millionco/react-doctor@main

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -70,9 +70,41 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-When `github-token` is set on `pull_request` events, findings are posted (and updated) as a PR comment. The action also exposes a `score` output (0–100) you can use in subsequent steps.
+When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can use in subsequent steps.
 
-**Inputs:** `directory`, `verbose`, `project`, `diff`, `github-token`, `fail-on` (`error` / `warning` / `none`), `offline`, `node-version`. See [`action.yml`](https://github.com/millionco/react-doctor/blob/main/action.yml) for full descriptions.
+**Inputs:** `directory`, `verbose`, `project`, `diff`, `github-token`, `fail-on` (`error` / `warning` / `none`), `offline`, `annotations`, `node-version`. See [`action.yml`](https://github.com/millionco/react-doctor/blob/main/action.yml) for full descriptions.
+
+#### PR feedback modes
+
+The action can surface findings on a PR in three ways. Pick whichever fits — they're independent and the workflow command output is always parsed by GitHub Actions regardless of where it appears.
+
+**Sticky comment only (default).** Set `github-token`, leave `annotations` unset. One updating comment lands on the PR with the full report and score:
+
+```yaml
+- uses: millionco/react-doctor@main
+  with:
+    diff: main
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Inline annotations only.** Set `annotations: true`, omit `github-token`. Each finding appears as a `::error` / `::warning` annotation pinned to its file and line in the PR's Files changed view, with no comment posted:
+
+```yaml
+- uses: millionco/react-doctor@main
+  with:
+    diff: main
+    annotations: true
+```
+
+**Both.** Enable both inputs to get inline annotations and a sticky summary comment on the same run. Annotation lines are stripped from the comment body so it stays readable:
+
+```yaml
+- uses: millionco/react-doctor@main
+  with:
+    diff: main
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    annotations: true
+```
 
 Prefer not to add a marketplace action? The bare `npx` form works too:
 

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -66,7 +66,22 @@ describe("GitHub Action contract", () => {
     );
 
     expect(scanStep).toContain('if [ -n "$INPUT_GITHUB_TOKEN" ]; then');
-    expect(scanStep).toContain('"${FLAGS[@]}" --pr-comment | tee "$OUTPUT_FILE"');
+    expect(scanStep).toContain('"${FLAGS[@]}" --pr-comment | tee "$RAW_FILE"');
+    expect(scanStep).toContain('sed -E \'/^::(error|warning) /d\' "$RAW_FILE" > "$OUTPUT_FILE"');
     expect(scanStep).not.toContain('"${FLAGS[@]}" --pr-comment\n        else');
+  });
+
+  it("forwards --annotations to the CLI when the annotations input is true", () => {
+    const actionYaml = readActionYaml();
+    const inputsBlock = extractBlock(actionYaml, "inputs:", "\noutputs:");
+    const scanStep = normalizeWhitespace(
+      extractStep(actionYaml, "INPUT_FAIL_ON: ${{ inputs.fail-on }}"),
+    );
+
+    expect(inputsBlock).toContain("  annotations:");
+    expect(scanStep).toContain("INPUT_ANNOTATIONS: ${{ inputs.annotations }}");
+    expect(scanStep).toContain(
+      'if [ "$INPUT_ANNOTATIONS" = "true" ]; then FLAGS+=("--annotations"); fi',
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an opt-in `annotations` input to the composite action so users can surface diagnostics as inline GitHub Actions annotations on the PR's *Files changed* view, alongside (or instead of) the existing sticky comment.

## Changes

- **`action.yml`**: new `annotations` input (default `"false"`). When `true`, forwards `--annotations` to the CLI. When combined with `github-token`, annotation workflow-command lines are stripped from the captured comment body via `sed`; the runner still picks them up from the live step log.
- **`packages/react-doctor/README.md`**: documents the three modes (comments-only, annotations-only, both).

## Usage

```yaml
- uses: millionco/react-doctor@main
  with:
    diff: main
    github-token: ${{ secrets.GITHUB_TOKEN }}
    annotations: true
```

## Notes

- Default is `false`; existing workflows behave identically.
- `--annotations` is an existing CLI flag; no CLI changes required.
- No changeset added: `action.yml` ships via Git ref, not npm.

## Verification

- `pnpm format`, `pnpm lint`: clean.
- `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"`: OK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d60b3fd-83bc-457b-ab93-54e3a7cb113e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d60b3fd-83bc-457b-ab93-54e3a7cb113e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

