### PR TITLE
docs: document PR blocking and `fail-on` semantics

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -608,20 +608,31 @@ Fix:
 - Document local-only report workflow.
 - Add SARIF or generic report path if needed for non-GitHub CI.
 
-### [ ] Make PR blocking and `fail-on` semantics explicit
+### [x] Make PR blocking and `fail-on` semantics explicit
 
-Status: partially addressed.
+Status: landed.
 
 Sources:
 
 - Users asked for simple "block merge if score < X" behavior.
 - Existing scoring/delta feedback shows absolute thresholds can be misleading.
 
-Fix:
+Done:
 
-- Document `fail-on`, score thresholds, annotations, and PR comments together.
-- Separate "fail on new regressions" from "fail because baseline score is below threshold."
-- Add examples for advisory mode, regression-only mode, and strict threshold mode.
+- Added a `## PR blocking and exit codes` README section that
+  separates diagnostic-level gating (`--fail-on`) from absolute-score
+  gating (the `score` action output + a follow-up step), and documents
+  annotations and PR comments alongside both.
+- Spelled out that combining `--fail-on` with `--diff` is the
+  built-in way to fail only on new regressions vs. failing on the
+  baseline (no separate `--fail-on-new` flag).
+- Added three worked recipes: advisory mode (`fail-on: none`),
+  regression-only mode (`diff: main` + `fail-on: warning`), and
+  strict threshold mode (`fail-on: error` + score-floor step
+  reading `steps.<id>.outputs.score`).
+- Tightened `action.yml`'s `fail-on` description so it states the
+  gate runs on diagnostics, not on the score, and points at the
+  composable patterns above.
 
 ## P2 - Platform and Product Expansion
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: "GitHub token for posting PR comments. When set on pull_request events, findings are posted as a PR comment."
     required: false
   fail-on:
-    description: "Exit with error code on diagnostics: error, warning, none"
+    description: "Exit non-zero when diagnostics fire (error, warning, none). Gates on individual diagnostics in the scanned files, not on the score. Combine with `diff` for regression-only gating, or read the `score` output in a follow-up step to enforce an absolute score floor."
     default: "error"
   offline:
     description: "Skip sending diagnostics to the react.doctor API and calculate score locally"

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -80,43 +80,18 @@ Prefer not to add a marketplace action? The bare `npx` form works too:
 
 ## PR blocking and exit codes
 
-Two completely separate things can block a PR. Decide which one (or both) you want before tuning anything else:
+Two independent gates can block a PR — pick one or both:
 
-| You're gating on                                | How it's gated                                                                                      | What it sees                                                                      |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **Individual diagnostics** (a rule fired)       | `--fail-on error` / `--fail-on warning` exit code                                                   | Whatever React Doctor scanned (`--diff` narrows it; default is the whole project) |
-| **Absolute score** (baseline health < a number) | A follow-up step that compares the action's `score` output to a threshold and `exit 1`s if it's low | The full project (the score step always runs a full scan)                         |
+- **`--fail-on <level>`** exits non-zero on diagnostics: `error` (default, any error-severity rule fires), `warning` (any diagnostic fires), or `none` (never). Runs against the `ciFailure` surface, so the default `design`-tag exclusion still applies.
+- **Score floor** — a follow-up step that reads the action's `score` output and `exit 1`s when it's below your threshold.
 
-These are independent. `--fail-on` knows nothing about the score; the score check knows nothing about `--fail-on`. Use one, the other, both, or neither.
+Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed files only — that's the built-in way to fail on **new** regressions without dragging in baseline backlog. There is no separate `--fail-on-new` flag.
 
-### What `--fail-on` actually gates on
-
-| Level             | Exits non-zero when…                                 | Common use                                                            |
-| ----------------- | ---------------------------------------------------- | --------------------------------------------------------------------- |
-| `error` (default) | Any error-severity diagnostic fires in scanned files | Block merge on rules React Doctor classifies as breaking              |
-| `warning`         | Any error- or warning-severity diagnostic fires      | Strictest mode — PRs must be diagnostic-clean before merging          |
-| `none`            | Never (always exit 0)                                | Advisory mode — combine with `github-token` for a comment-only signal |
-
-The gate runs against the `ciFailure` surface, not every diagnostic. By default the `design` tag is excluded from `ciFailure` (and from the score and the PR comment) so Tailwind cleanup hints can't block merges. Override per tag, category, or rule id under `surfaces.ciFailure` in `react-doctor.config.json` (see [Surface controls](#surface-controls-cli-pr-comments-score-ci-failure)).
-
-### What scope `--fail-on` sees: new regressions vs. baseline
-
-Combine `--fail-on` with `--diff` to control what gets gated:
-
-- **Full scan** (no `--diff`) → `--fail-on` blocks on **any** matching diagnostic anywhere in the repo, including pre-existing baseline issues. A new contributor inherits the full backlog and can't merge until everything is clean.
-- **`--diff <base>`** → React Doctor only scans files changed vs the base branch. `--fail-on` then only sees diagnostics on the PR's changed files, so the gate effectively becomes "fail on **new** regressions introduced by this PR." Existing baseline issues in untouched files don't gate the merge.
-
-This is the only built-in way to separate "fail on new regressions in this PR" from "fail because the baseline score is below a threshold." There is no `--fail-on-new` flag — `--diff` is how you scope the failure surface.
-
-### Annotations and PR comments are independent of the gate
-
-- **`--annotations`** emits `::error` / `::warning` lines so GitHub renders inline annotations on the PR's Files Changed tab. Annotations don't change the exit code — they're a visualization layer. Currently exposed through the bare `npx` form; the composite action does not pass it through automatically.
-- **`github-token`** (composite action only) posts a sticky PR comment with the report and the score. The comment uses the `prComment` surface (which also drops the `design` tag by default), so what's visible in the comment can legitimately differ from what's gated by `--fail-on` if you've tuned the surfaces separately.
-- The action also exposes a **`score`** output (`steps.<id>.outputs.score`), populated by an internal `--score` step. Read it in a separate workflow step if you want to gate on an absolute number.
+`--annotations` (bare `npx` only) and `github-token` (sticky PR comment) are visualization layers and never change the exit code.
 
 ### Examples
 
-#### Advisory mode — never blocks, always comments
+**Advisory mode** — never blocks, always comments:
 
 ```yaml
 - uses: millionco/react-doctor@main
@@ -125,9 +100,7 @@ This is the only built-in way to separate "fail on new regressions in this PR" f
     fail-on: none
 ```
 
-Posts the sticky PR comment so reviewers see the report, but no React Doctor finding can ever fail the job. Useful when adopting React Doctor in a mature codebase without immediately enforcing it.
-
-#### Regression-only mode — fail only when this PR introduces new diagnostics
+**Regression-only mode** — fail only on new diagnostics introduced by the PR:
 
 ```yaml
 - uses: actions/checkout@v5
@@ -140,9 +113,7 @@ Posts the sticky PR comment so reviewers see the report, but no React Doctor fin
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-`diff: main` restricts the scan to files changed vs `main`. `fail-on: warning` then only sees diagnostics on those changed files, so the merge is blocked when the PR adds a new warning or error — but pre-existing issues in untouched files are ignored. Recommended default when onboarding an existing repository: it stops new regressions without forcing a backlog cleanup first.
-
-#### Strict threshold mode — fail when the baseline score drops below a floor
+**Strict threshold mode** — fail when the baseline score drops below a floor:
 
 ```yaml
 - id: doctor
@@ -150,22 +121,17 @@ Posts the sticky PR comment so reviewers see the report, but no React Doctor fin
   with:
     fail-on: error
     github-token: ${{ secrets.GITHUB_TOKEN }}
-- name: Enforce score floor
-  env:
+- env:
     SCORE: ${{ steps.doctor.outputs.score }}
     FLOOR: "80"
   run: |
-    if [ -z "$SCORE" ]; then
-      echo "::warning::no score reported; skipping floor check"
-      exit 0
-    fi
-    if [ "$SCORE" -lt "$FLOOR" ]; then
+    if [ -n "$SCORE" ] && [ "$SCORE" -lt "$FLOOR" ]; then
       echo "::error::React Doctor score $SCORE is below floor $FLOOR"
       exit 1
     fi
 ```
 
-`fail-on: error` keeps the per-rule gate on. The follow-up step enforces an absolute score floor by reading the `score` output. Tune `FLOOR` to your codebase — and pin to a specific `react-doctor` version, because new rule releases can lower the score even when your code hasn't changed (see [Scoring](#scoring)).
+Pin a specific `react-doctor` version when using a score floor — new rule releases can lower the score even when your code hasn't changed (see [Scoring](#scoring)).
 
 ## Configuration
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -78,6 +78,95 @@ Prefer not to add a marketplace action? The bare `npx` form works too:
 - run: npx -y react-doctor@latest --fail-on warning
 ```
 
+## PR blocking and exit codes
+
+Two completely separate things can block a PR. Decide which one (or both) you want before tuning anything else:
+
+| You're gating on                                | How it's gated                                                                                      | What it sees                                                                      |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Individual diagnostics** (a rule fired)       | `--fail-on error` / `--fail-on warning` exit code                                                   | Whatever React Doctor scanned (`--diff` narrows it; default is the whole project) |
+| **Absolute score** (baseline health < a number) | A follow-up step that compares the action's `score` output to a threshold and `exit 1`s if it's low | The full project (the score step always runs a full scan)                         |
+
+These are independent. `--fail-on` knows nothing about the score; the score check knows nothing about `--fail-on`. Use one, the other, both, or neither.
+
+### What `--fail-on` actually gates on
+
+| Level             | Exits non-zero when…                                 | Common use                                                            |
+| ----------------- | ---------------------------------------------------- | --------------------------------------------------------------------- |
+| `error` (default) | Any error-severity diagnostic fires in scanned files | Block merge on rules React Doctor classifies as breaking              |
+| `warning`         | Any error- or warning-severity diagnostic fires      | Strictest mode — PRs must be diagnostic-clean before merging          |
+| `none`            | Never (always exit 0)                                | Advisory mode — combine with `github-token` for a comment-only signal |
+
+The gate runs against the `ciFailure` surface, not every diagnostic. By default the `design` tag is excluded from `ciFailure` (and from the score and the PR comment) so Tailwind cleanup hints can't block merges. Override per tag, category, or rule id under `surfaces.ciFailure` in `react-doctor.config.json` (see [Surface controls](#surface-controls-cli-pr-comments-score-ci-failure)).
+
+### What scope `--fail-on` sees: new regressions vs. baseline
+
+Combine `--fail-on` with `--diff` to control what gets gated:
+
+- **Full scan** (no `--diff`) → `--fail-on` blocks on **any** matching diagnostic anywhere in the repo, including pre-existing baseline issues. A new contributor inherits the full backlog and can't merge until everything is clean.
+- **`--diff <base>`** → React Doctor only scans files changed vs the base branch. `--fail-on` then only sees diagnostics on the PR's changed files, so the gate effectively becomes "fail on **new** regressions introduced by this PR." Existing baseline issues in untouched files don't gate the merge.
+
+This is the only built-in way to separate "fail on new regressions in this PR" from "fail because the baseline score is below a threshold." There is no `--fail-on-new` flag — `--diff` is how you scope the failure surface.
+
+### Annotations and PR comments are independent of the gate
+
+- **`--annotations`** emits `::error` / `::warning` lines so GitHub renders inline annotations on the PR's Files Changed tab. Annotations don't change the exit code — they're a visualization layer. Currently exposed through the bare `npx` form; the composite action does not pass it through automatically.
+- **`github-token`** (composite action only) posts a sticky PR comment with the report and the score. The comment uses the `prComment` surface (which also drops the `design` tag by default), so what's visible in the comment can legitimately differ from what's gated by `--fail-on` if you've tuned the surfaces separately.
+- The action also exposes a **`score`** output (`steps.<id>.outputs.score`), populated by an internal `--score` step. Read it in a separate workflow step if you want to gate on an absolute number.
+
+### Examples
+
+#### Advisory mode — never blocks, always comments
+
+```yaml
+- uses: millionco/react-doctor@main
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    fail-on: none
+```
+
+Posts the sticky PR comment so reviewers see the report, but no React Doctor finding can ever fail the job. Useful when adopting React Doctor in a mature codebase without immediately enforcing it.
+
+#### Regression-only mode — fail only when this PR introduces new diagnostics
+
+```yaml
+- uses: actions/checkout@v5
+  with:
+    fetch-depth: 0 # required for `diff`
+- uses: millionco/react-doctor@main
+  with:
+    diff: main
+    fail-on: warning
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+`diff: main` restricts the scan to files changed vs `main`. `fail-on: warning` then only sees diagnostics on those changed files, so the merge is blocked when the PR adds a new warning or error — but pre-existing issues in untouched files are ignored. Recommended default when onboarding an existing repository: it stops new regressions without forcing a backlog cleanup first.
+
+#### Strict threshold mode — fail when the baseline score drops below a floor
+
+```yaml
+- id: doctor
+  uses: millionco/react-doctor@main
+  with:
+    fail-on: error
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+- name: Enforce score floor
+  env:
+    SCORE: ${{ steps.doctor.outputs.score }}
+    FLOOR: "80"
+  run: |
+    if [ -z "$SCORE" ]; then
+      echo "::warning::no score reported; skipping floor check"
+      exit 0
+    fi
+    if [ "$SCORE" -lt "$FLOOR" ]; then
+      echo "::error::React Doctor score $SCORE is below floor $FLOOR"
+      exit 1
+    fi
+```
+
+`fail-on: error` keeps the per-rule gate on. The follow-up step enforces an absolute score floor by reading the `score` output. Tune `FLOOR` to your codebase — and pin to a specific `react-doctor` version, because new rule releases can lower the score even when your code hasn't changed (see [Scoring](#scoring)).
+
 ## Configuration
 
 Create a `react-doctor.config.json` in your project root:
@@ -326,8 +415,8 @@ React Doctor detects 50+ coding agents (Claude Code, Cursor, Codex, OpenCode, Wi
 - **Install for agents**: `npx react-doctor@latest install` writes agent-specific rule files (SKILL.md, AGENTS.md, .cursorrules) into your project so agents learn React best practices.
 - **JSON output**: `--json` produces a structured `JsonReport` on stdout. Errors still produce a valid JSON document with `ok: false`. Use `--json-compact` for minimal whitespace.
 - **Score-only output**: `--score` outputs just the numeric score (0-100), useful for threshold checks in agent loops.
-- **GitHub Actions annotations**: `--annotations` emits `::error` / `::warning` format for inline PR annotations.
-- **Exit codes**: `--fail-on error` (default) exits non-zero when error-severity diagnostics are found. Use `--fail-on warning` or `--fail-on none` to tune CI gating.
+- **GitHub Actions annotations**: `--annotations` emits `::error` / `::warning` format for inline PR annotations. Annotations don't change the exit code.
+- **Exit codes**: `--fail-on error` (default) exits non-zero when error-severity diagnostics are found. Use `--fail-on warning` or `--fail-on none` to tune CI gating. See [PR blocking and exit codes](#pr-blocking-and-exit-codes) for the full model — including how to fail only on new regressions vs. fail on the baseline score.
 - **Programmatic API**: `import { diagnose } from "react-doctor/api"` for direct integration in scripts and automation.
 
 In CI environments, prompts are automatically skipped and `--offline` is implied (no network round-trip; score is omitted from the output).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the `Make PR blocking and \`fail-on\` semantics explicit` TODO under P1.

User feedback has consistently conflated two completely different CI gates: "block merge if a rule fires" (what `--fail-on` actually does) and "block merge if the score < X" (which has to be wired up through the action's `score` output and a follow-up step). The previous docs only mentioned `fail-on` in passing and never said anything about how to separate "fail on the PR's new regressions" from "fail because the baseline is bad."

## What this PR changes

### New `## PR blocking and exit codes` README section

Placed right after the GitHub Actions section so it's discoverable next to where users set up CI. A short bulleted summary names the two independent gates, calls out that combining `--fail-on` with `--diff` is the built-in way to fail on **new** regressions only (no separate `--fail-on-new` flag), and notes that `--annotations` and the sticky PR comment are visualization layers that never change the exit code. Then three minimal worked recipes:

- **Advisory mode** — `fail-on: none` + `github-token`. Never blocks; always comments.
- **Regression-only mode** — `diff: main` + `fail-on: warning`. Fail only on new diagnostics.
- **Strict threshold mode** — `fail-on: error` plus a follow-up step that reads `steps.<id>.outputs.score` and `exit 1`s if it's below a `FLOOR`.

### Cross-link from "Agent and CI integration"

The existing one-line "Exit codes:" bullet now also points at the new section so people who land there first can find the full model.

### Tightened `action.yml` `fail-on` description

Old: `Exit with error code on diagnostics: error, warning, none`. New text states the gate runs on diagnostics (not on the score), and mentions composing with `diff` for regression-only gating and reading the `score` output for absolute-score gating. This is what surfaces on the Marketplace input docs.

### TODO bookkeeping

Marked the matching `Make PR blocking and \`fail-on\` semantics explicit` item under P1 as landed.

## What this PR intentionally does NOT do

- **No code changes / no new flags.** The TODO scope is documentation only — the `--diff` + `--fail-on` composition and the `score` action output are already supported. Adding a first-class `--fail-on-score` or `--fail-on-new` flag would be a separate product change (and likely interacts with the open "Separate PR regressions from baseline health in React Review" P0 item).
- **Did not expose `--annotations` through `action.yml`** — that's tracked separately under "Expose `--annotations` through `action.yml`" (P1) and is called out in the new section as a current limitation so the docs stay honest until that input lands.

## Validation

- `pnpm format`, `pnpm lint`, `pnpm typecheck` — all clean.
- Re-read the new section against `packages/react-doctor/src/cli/utils/{resolve-fail-on-level,should-fail-for-diagnostics}.ts`, `packages/types/src/config.ts`, and `action.yml` to confirm the documented levels, default, and `score`-output wiring match the actual implementation.

The root `README.md` is a symlink to `packages/react-doctor/README.md`, so the npm package README and the GitHub repo README pick up the new section automatically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e4c903-4f6d-4f91-9308-0b633ba0cbfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e4c903-4f6d-4f91-9308-0b633ba0cbfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

