### PR TITLE
docs: remove stale dead-code claims after Knip removal (#246)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -274,9 +274,9 @@ Fix:
 - Implement local score calculation or update `action.yml` and marketplace docs.
 - Add tests for `--offline`, `--score --offline`, Action offline score output, and CI auto-offline.
 
-### [ ] Remove stale dead-code claims after Knip removal
+### [x] Remove stale dead-code claims after Knip removal
 
-Status: confirmed current.
+Status: resolved by docs updates after #246.
 
 Link: https://github.com/millionco/react-doctor/pull/246
 
@@ -793,7 +793,7 @@ Decision:
 - [x] #135 Knip plugin failure recovery.
 - [x] #149 empty pattern crash.
 - [x] #246 removed Knip/dead-code integration.
-- [ ] Remove remaining stale dead-code docs.
+- [x] Remove remaining stale dead-code docs.
 
 ### Dependency detection
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -23,7 +23,9 @@ Run this at your project root:
 npx -y react-doctor@latest .
 ```
 
-You'll get a score (75+ Great, 50 to 74 Needs work, under 50 Critical) and a list of issues across state & effects, performance, architecture, security, accessibility, and dead code. Rules toggle automatically based on your framework and React version.
+You'll get a score (75+ Great, 50 to 74 Needs work, under 50 Critical) and a list of issues across state & effects, performance, architecture, security, and accessibility. Rules toggle automatically based on your framework and React version.
+
+> **Migration note:** React Doctor used to bundle [knip](https://knip.dev/) for dead-code detection. That integration was removed in v0.2 — if you want dead-code analysis, run `npx knip` directly as part of your own pre-commit or CI pipeline.
 
 https://github.com/user-attachments/assets/07cc88d9-9589-44c3-aa73-5d603cb1c570
 

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -2,6 +2,8 @@
 
 Diagnose React codebase health. Scans for security, performance, correctness, and architecture issues, then outputs a 0–100 score with actionable diagnostics.
 
+Note: dead-code detection was removed in v0.2 (previously powered by knip). For dead-code analysis, run `npx knip` directly.
+
 ## Usage
 
 Run this at your project root:
@@ -79,8 +81,6 @@ Options:
   -v, --version      display the version number
   --lint             enable linting (default: on)
   --no-lint          skip linting
-  --dead-code        enable dead code detection (default: on)
-  --no-dead-code     skip dead code detection
   --verbose          show file details per rule
   --score            output only the score
   --json             output a single structured JSON report (suppresses other output)

--- a/skills/react-doctor/SKILL.md
+++ b/skills/react-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-doctor
-description: Use when finishing a feature, fixing a bug, before committing React code, or when the user wants to improve code quality or clean up a codebase. Checks for score regression. Covers lint, dead code, accessibility, bundle size, architecture diagnostics.
+description: Use when finishing a feature, fixing a bug, before committing React code, or when the user wants to improve code quality or clean up a codebase. Checks for score regression. Covers lint, accessibility, bundle size, architecture diagnostics.
 version: "1.0.0"
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[PR #246](https://github.com/millionco/react-doctor/pull/246) removed the bundled knip integration end-to-end (subprocess runner, config loading, filter caching, result merging, the `--dead-code` / `--no-dead-code` CLI flags, and the `deadCode` / `entryFiles` config keys). Several user-facing docs were missed in that pass and still advertised dead-code coverage:

| File | Stale claim |
| --- | --- |
| `packages/react-doctor/README.md` | "…issues across state & effects, performance, architecture, security, accessibility, **and dead code**." |
| `skills/react-doctor/SKILL.md` (description frontmatter, shipped to every installed agent via `react-doctor install`) | "Covers lint, **dead code**, accessibility, bundle size, architecture diagnostics." |
| `packages/website/public/llms.txt` (the hosted LLM-facing copy at react.doctor/llms.txt) | Documented `--dead-code` / `--no-dead-code` flags that no longer exist on the CLI. |

## Changes

- Strip the "dead code" / `--dead-code` references from all three surfaces.
- Add a short migration note in the README and in `llms.txt` directing users to run `npx knip` directly for dead-code analysis (this is the same recommendation given in the PR #246 description).
- Mark the corresponding TODO entry as resolved.

The marketplace `action.yml` and the website source under `packages/website/src` were checked and don't contain any stale references — only the three files above did.

## Out of scope

- `packages/react-doctor/CHANGELOG.md` references to knip / dead-code are historical changelog entries (versions 0.0.1 through 0.1.x) and are intentionally left untouched.

## Verification

- `pnpm format:check` — clean (684 files)
- `pnpm lint` — 0 warnings, 0 errors (560 files, 90 rules)
- `pnpm typecheck` — 0 errors across 10 packages
- `pnpm test` — 91/91 test files, 1136/1136 tests pass

No code paths were modified, so there's no behavioral regression risk; the change is purely documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a4a5b98-6bd7-434f-8225-f4306b0dd6f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a4a5b98-6bd7-434f-8225-f4306b0dd6f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

