### PR TITLE
feat: config foundation — extends, zod validation, concurrency, barrelAllowlist

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,8 @@
     "oxlint": "^1.63.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "picomatch": "^4.0.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export * from "./jsx-include-paths.js";
 export * from "./load-config.js";
 export * from "./logger.js";
 export * from "./merge-and-filter-diagnostics.js";
+export * from "./merge-configs.js";
 export * from "./neutralize-disable-directives.js";
 export * from "./parse-gitattributes-linguist.js";
 export * from "./read-file-lines-node.js";

--- a/packages/core/src/load-config.ts
+++ b/packages/core/src/load-config.ts
@@ -3,10 +3,19 @@ import path from "node:path";
 import type { ReactDoctorConfig } from "@react-doctor/types";
 import { isFile, isMonorepoRoot, isPlainObject } from "@react-doctor/project-info";
 import { logger } from "./logger.js";
+import { mergeReactDoctorConfigs } from "./merge-configs.js";
 import { validateConfigTypes } from "./validate-config-types.js";
 
 const CONFIG_FILENAME = "react-doctor.config.json";
 const PACKAGE_JSON_CONFIG_KEY = "reactDoctor";
+
+// HACK: extends chains are flattened depth-first; a cycle guard caps
+// recursion at this depth in case `validate-config-types` accidentally
+// passes through a self-referential `extends`. Picked high enough to
+// cover the deepest realistic monorepo layout
+// (`packages/<x>/configs/<y>/react-doctor.config.json` extending two
+// or three ancestors) while still catching pathological loops.
+const MAX_EXTENDS_DEPTH = 16;
 
 interface LoadedReactDoctorConfig {
   config: ReactDoctorConfig;
@@ -19,24 +28,133 @@ interface LoadedReactDoctorConfig {
   sourceDirectory: string;
 }
 
+const readParsedJson = (filePath: string): unknown | null => {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch (error) {
+    logger.warn(
+      `Failed to parse ${path.basename(filePath)}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+};
+
+/**
+ * Resolve path-valued fields against the config file that DECLARED
+ * them, before that config is merged into a child. Without this,
+ * inherited `rootDir: "../apps/web"` from a parent at
+ * `/repo/shared/base.json` would later be resolved against the child's
+ * directory (e.g. `/repo/packages/lib/`) and point at the wrong tree.
+ */
+const absolutizeRelativePaths = (
+  config: ReactDoctorConfig,
+  sourceDirectory: string,
+): ReactDoctorConfig => {
+  if (typeof config.rootDir !== "string") return config;
+  const trimmed = config.rootDir.trim();
+  if (trimmed.length === 0 || path.isAbsolute(trimmed)) return config;
+  return { ...config, rootDir: path.resolve(sourceDirectory, trimmed) };
+};
+
+const loadConfigFile = (
+  configFilePath: string,
+  visited: Set<string>,
+  depth: number,
+): ReactDoctorConfig | null => {
+  if (depth >= MAX_EXTENDS_DEPTH) {
+    logger.warn(
+      `react-doctor config "extends" chain at ${configFilePath} exceeded depth ${MAX_EXTENDS_DEPTH}; ignoring deeper parents.`,
+    );
+    return null;
+  }
+  const absoluteConfigPath = resolveVisitedKey(configFilePath);
+  if (visited.has(absoluteConfigPath)) {
+    logger.warn(
+      `react-doctor config "extends" cycle detected at ${configFilePath}; ignoring this branch.`,
+    );
+    return null;
+  }
+  visited.add(absoluteConfigPath);
+
+  const parsed = readParsedJson(configFilePath);
+  if (!isPlainObject(parsed)) return null;
+  const validated = validateConfigTypes(parsed as ReactDoctorConfig);
+  const configDirectory = path.dirname(configFilePath);
+  const resolved = resolveExtendsChain(validated, configDirectory, visited, depth);
+  return absolutizeRelativePaths(resolved, configDirectory);
+};
+
+const resolveExtendsChain = (
+  config: ReactDoctorConfig,
+  configDirectory: string,
+  visited: Set<string>,
+  depth: number,
+): ReactDoctorConfig => {
+  const extendsValue = config.extends;
+  if (extendsValue === undefined) return config;
+  const extendsEntries = Array.isArray(extendsValue) ? extendsValue : [extendsValue];
+
+  let resolvedConfig: ReactDoctorConfig = {};
+  for (const entry of extendsEntries) {
+    if (typeof entry !== "string" || entry.length === 0) continue;
+    const candidatePath = path.isAbsolute(entry) ? entry : path.resolve(configDirectory, entry);
+    if (!isFile(candidatePath)) {
+      logger.warn(
+        `react-doctor config "extends" target "${entry}" not found at ${candidatePath}; ignoring this parent.`,
+      );
+      continue;
+    }
+    // Clone the visited set per branch so diamond inheritance works -
+    // if Root extends [A, B] and both A and B extend a common Shared
+    // parent, sharing one visited set across the loop would make B
+    // skip Shared as a "cycle" after A loaded it. The clone gives
+    // each top-level extends entry its own cycle window while still
+    // catching true cycles within a single chain.
+    const branchVisited = new Set(visited);
+    const parentConfig = loadConfigFile(candidatePath, branchVisited, depth + 1);
+    if (!parentConfig) continue;
+    // Documented semantics: later entries override earlier ones for
+    // scalar fields (consistent with tsconfig / eslint `extends`),
+    // and arrays concat in declaration order. The final
+    // `mergeReactDoctorConfigs` call below then layers the current
+    // config on top so its values always win over anything it extends.
+    resolvedConfig = mergeReactDoctorConfigs(resolvedConfig, parentConfig);
+  }
+
+  return mergeReactDoctorConfigs(resolvedConfig, config);
+};
+
+// Resolve a config path through the same lens `loadConfigFile` uses
+// when deduping the `extends` chain, so the visited set is keyed by
+// the realpath when symlinks are involved and the raw path otherwise.
+// Without this, a self-referencing `extends` from a symlinked root
+// would bypass cycle detection on the first re-entry and only be
+// caught by the depth guard.
+const resolveVisitedKey = (configFilePath: string): string => {
+  try {
+    return fs.realpathSync(configFilePath);
+  } catch {
+    return path.resolve(configFilePath);
+  }
+};
+
 const loadConfigFromDirectory = (directory: string): LoadedReactDoctorConfig | null => {
   const configFilePath = path.join(directory, CONFIG_FILENAME);
 
   if (isFile(configFilePath)) {
-    try {
-      const fileContent = fs.readFileSync(configFilePath, "utf-8");
-      const parsed: unknown = JSON.parse(fileContent);
-      if (isPlainObject(parsed)) {
-        return {
-          config: validateConfigTypes(parsed as ReactDoctorConfig),
-          sourceDirectory: directory,
-        };
-      }
-      logger.warn(`${CONFIG_FILENAME} must be a JSON object, ignoring.`);
-    } catch (error) {
-      logger.warn(
-        `Failed to parse ${CONFIG_FILENAME}: ${error instanceof Error ? error.message : String(error)}`,
+    const parsed = readParsedJson(configFilePath);
+    if (isPlainObject(parsed)) {
+      const validated = validateConfigTypes(parsed as ReactDoctorConfig);
+      const resolved = resolveExtendsChain(
+        validated,
+        directory,
+        new Set([resolveVisitedKey(configFilePath)]),
+        0,
       );
+      return { config: resolved, sourceDirectory: directory };
+    }
+    if (parsed !== null) {
+      logger.warn(`${CONFIG_FILENAME} must be a JSON object, ignoring.`);
     }
   }
 
@@ -48,10 +166,18 @@ const loadConfigFromDirectory = (directory: string): LoadedReactDoctorConfig | n
       if (isPlainObject(packageJson)) {
         const embeddedConfig = packageJson[PACKAGE_JSON_CONFIG_KEY];
         if (isPlainObject(embeddedConfig)) {
-          return {
-            config: validateConfigTypes(embeddedConfig as ReactDoctorConfig),
-            sourceDirectory: directory,
-          };
+          const validated = validateConfigTypes(embeddedConfig as ReactDoctorConfig);
+          const resolved = resolveExtendsChain(
+            validated,
+            directory,
+            // Seed the visited set with the host package.json so a
+            // child `extends` chain that eventually points back here
+            // is caught by cycle detection on the first re-entry, not
+            // only by the depth guard.
+            new Set([resolveVisitedKey(packageJsonPath)]),
+            0,
+          );
+          return { config: resolved, sourceDirectory: directory };
         }
       }
     } catch {

--- a/packages/core/src/merge-configs.ts
+++ b/packages/core/src/merge-configs.ts
@@ -1,0 +1,124 @@
+import type { ReactDoctorConfig, SurfaceControls } from "@react-doctor/types";
+
+const dedupeStringArray = (input: string[]): string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const entry of input) {
+    if (typeof entry !== "string" || entry.length === 0) continue;
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    result.push(entry);
+  }
+  return result;
+};
+
+const concatDedupedArrays = (
+  parentArray: string[] | undefined,
+  childArray: string[] | undefined,
+): string[] | undefined => {
+  if (parentArray === undefined && childArray === undefined) return undefined;
+  return dedupeStringArray([...(parentArray ?? []), ...(childArray ?? [])]);
+};
+
+const mergeSurfaceControls = (
+  parentControls: SurfaceControls | undefined,
+  childControls: SurfaceControls | undefined,
+): SurfaceControls | undefined => {
+  if (!parentControls && !childControls) return undefined;
+  const merged: SurfaceControls = {};
+  const includeTags = concatDedupedArrays(parentControls?.includeTags, childControls?.includeTags);
+  if (includeTags) merged.includeTags = includeTags;
+  const excludeTags = concatDedupedArrays(parentControls?.excludeTags, childControls?.excludeTags);
+  if (excludeTags) merged.excludeTags = excludeTags;
+  const includeCategories = concatDedupedArrays(
+    parentControls?.includeCategories,
+    childControls?.includeCategories,
+  );
+  if (includeCategories) merged.includeCategories = includeCategories;
+  const excludeCategories = concatDedupedArrays(
+    parentControls?.excludeCategories,
+    childControls?.excludeCategories,
+  );
+  if (excludeCategories) merged.excludeCategories = excludeCategories;
+  const includeRules = concatDedupedArrays(
+    parentControls?.includeRules,
+    childControls?.includeRules,
+  );
+  if (includeRules) merged.includeRules = includeRules;
+  const excludeRules = concatDedupedArrays(
+    parentControls?.excludeRules,
+    childControls?.excludeRules,
+  );
+  if (excludeRules) merged.excludeRules = excludeRules;
+  return merged;
+};
+
+/**
+ * Merge a child react-doctor config on top of an already-resolved
+ * parent config. Child values always win; arrays concatenate +
+ * deduplicate so a parent's `ignore.files` is not lost when a child
+ * adds its own entries. Used by `loadConfigWithSource` to flatten an
+ * `extends` chain into a single `ReactDoctorConfig` the rest of the
+ * pipeline consumes unchanged.
+ */
+export const mergeReactDoctorConfigs = (
+  parent: ReactDoctorConfig,
+  child: ReactDoctorConfig,
+): ReactDoctorConfig => {
+  const merged: ReactDoctorConfig = { ...parent, ...child };
+
+  if (parent.ignore || child.ignore) {
+    merged.ignore = {
+      ...parent.ignore,
+      ...child.ignore,
+      files: concatDedupedArrays(parent.ignore?.files, child.ignore?.files),
+      rules: concatDedupedArrays(parent.ignore?.rules, child.ignore?.rules),
+      tags: concatDedupedArrays(parent.ignore?.tags, child.ignore?.tags),
+      overrides: [...(parent.ignore?.overrides ?? []), ...(child.ignore?.overrides ?? [])],
+    };
+  }
+
+  const mergedTextComponents = concatDedupedArrays(parent.textComponents, child.textComponents);
+  if (mergedTextComponents) merged.textComponents = mergedTextComponents;
+
+  const mergedRawWrappers = concatDedupedArrays(
+    parent.rawTextWrapperComponents,
+    child.rawTextWrapperComponents,
+  );
+  if (mergedRawWrappers) merged.rawTextWrapperComponents = mergedRawWrappers;
+
+  const mergedAuth = concatDedupedArrays(
+    parent.serverAuthFunctionNames,
+    child.serverAuthFunctionNames,
+  );
+  if (mergedAuth) merged.serverAuthFunctionNames = mergedAuth;
+
+  const mergedBarrel = concatDedupedArrays(parent.barrelAllowlist, child.barrelAllowlist);
+  if (mergedBarrel) merged.barrelAllowlist = mergedBarrel;
+
+  if (parent.surfaces || child.surfaces) {
+    const mergedSurfaces: NonNullable<ReactDoctorConfig["surfaces"]> = { ...parent.surfaces };
+    for (const [surfaceName, childControls] of Object.entries(child.surfaces ?? {})) {
+      if (!childControls) continue;
+      const mergedControls = mergeSurfaceControls(
+        parent.surfaces?.[surfaceName as keyof typeof mergedSurfaces],
+        childControls,
+      );
+      if (mergedControls)
+        mergedSurfaces[surfaceName as keyof typeof mergedSurfaces] = mergedControls;
+    }
+    merged.surfaces = mergedSurfaces;
+  }
+
+  // Severity maps (`rules` / `categories`) merge field-by-field with
+  // child wins, the same convention as scalar field overrides.
+  if (parent.rules || child.rules) {
+    merged.rules = { ...parent.rules, ...child.rules };
+  }
+  if (parent.categories || child.categories) {
+    merged.categories = { ...parent.categories, ...child.categories };
+  }
+
+  delete (merged as Record<string, unknown>).extends;
+  return merged;
+};

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -427,6 +427,12 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     : undefined;
   const severityControls = buildRuleSeverityControls(userConfig);
 
+  const barrelAllowlist = Array.isArray(userConfig?.barrelAllowlist)
+    ? userConfig.barrelAllowlist.filter(
+        (entry): entry is string => typeof entry === "string" && entry.length > 0,
+      )
+    : undefined;
+
   validateRuleRegistration();
 
   if (includePaths !== undefined && includePaths.length === 0) {
@@ -464,6 +470,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     ignoredTags,
     serverAuthFunctionNames,
     severityControls,
+    barrelAllowlist,
   });
   // HACK: only neutralize disable comments in audit mode. Default
   // behavior respects the user's existing `// eslint-disable*` /
@@ -598,6 +605,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         ignoredTags,
         serverAuthFunctionNames,
         severityControls,
+        barrelAllowlist,
       });
       writeOxlintConfig(fallbackConfig);
       return await spawnLintBatches();

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -25,6 +25,7 @@ export interface OxlintConfigOptions {
   ignoredTags?: ReadonlySet<string>;
   serverAuthFunctionNames?: ReadonlyArray<string>;
   severityControls?: RuleSeverityControls;
+  barrelAllowlist?: ReadonlyArray<string>;
 }
 
 const resolveSettingsRootDirectory = (rootDirectory: string): string => {
@@ -40,6 +41,7 @@ export const createOxlintConfig = ({
   ignoredTags = new Set<string>(),
   serverAuthFunctionNames,
   severityControls,
+  barrelAllowlist,
 }: OxlintConfigOptions) => {
   const reactHooksJsPlugin = resolveReactHooksJsPlugin(project.hasReactCompiler, customRulesOnly);
   const reactCompilerRules = reactHooksJsPlugin
@@ -104,6 +106,9 @@ export const createOxlintConfig = ({
         rootDirectory: resolveSettingsRootDirectory(project.rootDirectory),
         ...(serverAuthFunctionNames && serverAuthFunctionNames.length > 0
           ? { serverAuthFunctionNames: [...serverAuthFunctionNames] }
+          : {}),
+        ...(barrelAllowlist && barrelAllowlist.length > 0
+          ? { barrelAllowlist: [...barrelAllowlist] }
           : {}),
       },
     },

--- a/packages/core/src/validate-config-types.ts
+++ b/packages/core/src/validate-config-types.ts
@@ -1,17 +1,174 @@
-import type {
-  DiagnosticSurface,
-  ReactDoctorConfig,
-  RuleSeverityOverride,
-  SurfaceControls,
-} from "@react-doctor/types";
-import { DIAGNOSTIC_SURFACES, isDiagnosticSurface } from "./diagnostic-surface.js";
+import { z } from "zod";
+import type { DiagnosticSurface, ReactDoctorConfig } from "@react-doctor/types";
+import { DIAGNOSTIC_SURFACES } from "./diagnostic-surface.js";
 
-const VALID_RULE_SEVERITIES: ReadonlyArray<RuleSeverityOverride> = ["error", "warn", "off"];
+// HACK: write to stderr directly so the warning is visible even in
+// `--json` mode (where the logger is silenced to keep stdout a single
+// valid JSON document). Same pattern as `coerceDiffValue` in cli.ts.
+const warnConfigField = (message: string): void => {
+  process.stderr.write(`[react-doctor] ${message}\n`);
+};
 
-// Boolean fields where the user might write `"true"` / `"false"` strings
-// in JSON by mistake. We coerce-and-warn rather than silently accept the
-// string (which JS treats as truthy and bypasses the negation path).
-const BOOLEAN_FIELD_NAMES = [
+const formatType = (value: unknown): string => {
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "string") return `"${value}"`;
+  if (value === null) return "null";
+  return typeof value;
+};
+
+/**
+ * Boolean fields where the user might write `"true"` / `"false"` strings
+ * in JSON by mistake. Coerce-and-warn rather than silently accept the
+ * string (which JS treats as truthy and bypasses the negation path).
+ * The warning fires from the preprocess so it sees the original string
+ * even after coercion.
+ */
+const stringyBooleanSchema = (fieldName: string) =>
+  z.preprocess((value) => {
+    if (value !== "true" && value !== "false") return value;
+    const coerced = value === "true";
+    warnConfigField(
+      `config field "${fieldName}" is the string "${value}"; treating as boolean ${coerced}.`,
+    );
+    return coerced;
+  }, z.boolean());
+
+const RULE_SEVERITY_VALUES = ["error", "warn", "off"] as const;
+const ruleSeveritySchema = z.enum(RULE_SEVERITY_VALUES);
+
+/**
+ * Drop-and-warn array transform: keeps every entry that passes
+ * `predicate`, logs `warnMessage(entry)` on every dropped entry, and
+ * returns the filtered array. Used by the per-field array validators
+ * so a single bad entry never invalidates the whole list.
+ */
+const filteringArrayTransform =
+  <Out>(predicate: (value: unknown) => value is Out, warnMessage: (value: unknown) => string) =>
+  (entries: ReadonlyArray<unknown>): Out[] => {
+    const collected: Out[] = [];
+    for (const entry of entries) {
+      if (predicate(entry)) {
+        collected.push(entry);
+        continue;
+      }
+      warnConfigField(warnMessage(entry));
+    }
+    return collected;
+  };
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0;
+
+const filteringStringArraySchema = (fieldName: string) =>
+  z.array(z.unknown()).transform(
+    filteringArrayTransform(
+      (entry): entry is string => typeof entry === "string",
+      (entry) =>
+        `config field "${fieldName}" contains a non-string entry (${formatType(entry)}); ignoring the entry.`,
+    ),
+  );
+
+/**
+ * Filtering record schema for the severity maps (`rules` / `categories`).
+ * Records preserve every key whose value is a valid `RuleSeverityOverride`;
+ * entries with invalid keys (empty string) or invalid values are dropped
+ * with a stderr warning that names the offending path.
+ */
+const severityMapSchema = (fieldName: string) =>
+  z.record(z.string(), z.unknown()).transform((rawMap) => {
+    const validated: Record<string, (typeof RULE_SEVERITY_VALUES)[number]> = {};
+    for (const [key, value] of Object.entries(rawMap)) {
+      if (key.length === 0) {
+        warnConfigField(`config field "${fieldName}" has an empty key; ignoring the entry.`);
+        continue;
+      }
+      const parsed = ruleSeveritySchema.safeParse(value);
+      if (!parsed.success) {
+        warnConfigField(
+          `config field "${fieldName}.${key}" must be one of: ${RULE_SEVERITY_VALUES.join(", ")} (got ${formatType(value)}); ignoring the entry.`,
+        );
+        continue;
+      }
+      validated[key] = parsed.data;
+    }
+    return validated;
+  });
+
+const SURFACE_CONTROL_FIELDS = [
+  "includeTags",
+  "excludeTags",
+  "includeCategories",
+  "excludeCategories",
+  "includeRules",
+  "excludeRules",
+] as const;
+
+/**
+ * Validates each surface control field independently and drops invalid
+ * siblings without invalidating the rest of the surface. Using a single
+ * `z.object({...})` here would fail the whole surface on one malformed
+ * field; this transform mirrors the per-field-safeParse pattern the
+ * old hand-rolled validator used.
+ */
+const surfaceControlsSchema = (surface: DiagnosticSurface) =>
+  z.record(z.string(), z.unknown()).transform((rawControls) => {
+    const validated: Record<string, string[]> = {};
+    for (const controlField of SURFACE_CONTROL_FIELDS) {
+      const rawValue = rawControls[controlField];
+      if (rawValue === undefined) continue;
+      const fieldSchema = filteringStringArraySchema(`surfaces.${surface}.${controlField}`);
+      const parsed = fieldSchema.safeParse(rawValue);
+      if (parsed.success) {
+        validated[controlField] = parsed.data;
+        continue;
+      }
+      warnConfigField(
+        `config field "surfaces.${surface}.${controlField}" must be an array of strings (got ${formatType(rawValue)}); ignoring this field.`,
+      );
+    }
+    return validated;
+  });
+
+const KNOWN_DIAGNOSTIC_SURFACES = new Set<string>(DIAGNOSTIC_SURFACES);
+
+const surfacesSchema = z.record(z.string(), z.unknown()).transform((rawSurfaces) => {
+  const validated: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(rawSurfaces)) {
+    if (!KNOWN_DIAGNOSTIC_SURFACES.has(key)) {
+      warnConfigField(
+        `config field "surfaces.${key}" is not a known surface (expected one of: ${DIAGNOSTIC_SURFACES.join(", ")}); ignoring.`,
+      );
+      continue;
+    }
+    const surfaceKey = key as DiagnosticSurface;
+    const parsed = surfaceControlsSchema(surfaceKey).safeParse(value);
+    if (!parsed.success) {
+      warnConfigField(
+        `config field "surfaces.${surfaceKey}" must be an object (got ${formatType(value)}); ignoring this surface.`,
+      );
+      continue;
+    }
+    validated[surfaceKey] = parsed.data;
+  }
+  return validated;
+});
+
+const extendsSchema = z.union([
+  z.string().min(1),
+  z
+    .array(z.unknown())
+    .transform(
+      filteringArrayTransform(isNonEmptyString, (entry) =>
+        typeof entry === "string"
+          ? `config field "extends" contains an empty string; ignoring the entry.`
+          : `config field "extends" contains a non-string entry (${formatType(entry)}); ignoring the entry.`,
+      ),
+    ),
+]);
+
+const concurrencySchema = z.number().int().min(1);
+
+const BOOLEAN_CONFIG_FIELDS = [
   "lint",
   "verbose",
   "customRulesOnly",
@@ -21,190 +178,61 @@ const BOOLEAN_FIELD_NAMES = [
   "offline",
 ] as const satisfies ReadonlyArray<keyof ReactDoctorConfig>;
 
-const STRING_FIELD_NAMES = ["rootDir"] as const satisfies ReadonlyArray<keyof ReactDoctorConfig>;
+interface FieldDescriptor {
+  expectedDescription: string;
+  schema: z.ZodType;
+}
 
-const SURFACE_CONTROL_FIELD_NAMES = [
-  "includeTags",
-  "excludeTags",
-  "includeCategories",
-  "excludeCategories",
-  "includeRules",
-  "excludeRules",
-] as const satisfies ReadonlyArray<keyof SurfaceControls>;
-
-const SEVERITY_FIELD_NAMES = ["rules", "categories"] as const satisfies ReadonlyArray<
-  keyof ReactDoctorConfig
->;
-
-// HACK: write to stderr directly so the warning is visible even in
-// `--json` mode (where the logger is silenced to keep stdout a single
-// valid JSON document). Same pattern as `coerceDiffValue` in cli.ts.
-const warnConfigField = (message: string): void => {
-  process.stderr.write(`[react-doctor] ${message}\n`);
-};
-
-const isPlainObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const formatType = (value: unknown): string =>
-  typeof value === "string" ? `"${value}"` : typeof value;
-
-const isRuleSeverity = (value: unknown): value is RuleSeverityOverride =>
-  typeof value === "string" && (VALID_RULE_SEVERITIES as ReadonlyArray<string>).includes(value);
-
-const coerceMaybeBooleanString = (fieldName: string, value: unknown): boolean | undefined => {
-  if (typeof value === "boolean") return value;
-  if (value === "true" || value === "false") {
-    const coerced = value === "true";
-    warnConfigField(
-      `config field "${fieldName}" is the string "${value}"; treating as boolean ${coerced}.`,
-    );
-    return coerced;
-  }
-  warnConfigField(
-    `config field "${fieldName}" must be a boolean (got ${typeof value}); ignoring this field.`,
+const buildBooleanDescriptors = (): Record<string, FieldDescriptor> =>
+  Object.fromEntries(
+    BOOLEAN_CONFIG_FIELDS.map((fieldName) => [
+      fieldName,
+      { expectedDescription: "a boolean", schema: stringyBooleanSchema(fieldName) },
+    ]),
   );
-  return undefined;
-};
 
-const validateString = (fieldName: string, value: unknown): string | undefined => {
-  if (typeof value === "string") return value;
-  warnConfigField(
-    `config field "${fieldName}" must be a string (got ${typeof value}); ignoring this field.`,
-  );
-  return undefined;
-};
+/**
+ * Per-field schema map. Fields are checked in iteration order; missing
+ * entries fall through unchanged - consumers still do their own runtime
+ * checks for those.
+ */
+const fieldDescriptors = {
+  ...buildBooleanDescriptors(),
+  rootDir: { expectedDescription: "a string", schema: z.string() },
+  barrelAllowlist: {
+    expectedDescription: "an array of strings",
+    schema: filteringStringArraySchema("barrelAllowlist"),
+  },
+  surfaces: { expectedDescription: "an object", schema: surfacesSchema },
+  rules: { expectedDescription: "an object", schema: severityMapSchema("rules") },
+  categories: { expectedDescription: "an object", schema: severityMapSchema("categories") },
+  extends: {
+    expectedDescription: "a non-empty string or array of strings",
+    schema: extendsSchema,
+  },
+  concurrency: { expectedDescription: "a positive integer", schema: concurrencySchema },
+} satisfies Record<string, FieldDescriptor>;
 
-const validateStringArrayField = (fieldName: string, value: unknown): string[] | undefined => {
-  if (!Array.isArray(value)) {
-    warnConfigField(
-      `config field "${fieldName}" must be an array of strings (got ${typeof value}); ignoring this field.`,
-    );
-    return undefined;
-  }
-  return value.filter((entry): entry is string => {
-    if (typeof entry === "string") return true;
-    warnConfigField(
-      `config field "${fieldName}" contains a non-string entry (${typeof entry}); ignoring the entry.`,
-    );
-    return false;
-  });
-};
-
-const validateSurfaceControls = (
-  surface: DiagnosticSurface,
-  rawControls: unknown,
-): SurfaceControls | undefined => {
-  if (!isPlainObject(rawControls)) {
-    warnConfigField(
-      `config field "surfaces.${surface}" must be an object (got ${typeof rawControls}); ignoring this surface.`,
-    );
-    return undefined;
-  }
-  const validated: SurfaceControls = {};
-  for (const fieldName of SURFACE_CONTROL_FIELD_NAMES) {
-    if (rawControls[fieldName] === undefined) continue;
-    const result = validateStringArrayField(
-      `surfaces.${surface}.${fieldName}`,
-      rawControls[fieldName],
-    );
-    if (result !== undefined) validated[fieldName] = result;
-  }
-  return validated;
-};
-
-const validateSurfacesField = (
-  rawSurfaces: unknown,
-): Partial<Record<DiagnosticSurface, SurfaceControls>> | undefined => {
-  if (!isPlainObject(rawSurfaces)) {
-    warnConfigField(
-      `config field "surfaces" must be an object (got ${typeof rawSurfaces}); ignoring this field.`,
-    );
-    return undefined;
-  }
-  const validated: Partial<Record<DiagnosticSurface, SurfaceControls>> = {};
-  for (const [key, value] of Object.entries(rawSurfaces)) {
-    if (!isDiagnosticSurface(key)) {
-      warnConfigField(
-        `config field "surfaces.${key}" is not a known surface (expected one of: ${DIAGNOSTIC_SURFACES.join(", ")}); ignoring.`,
-      );
-      continue;
-    }
-    const controls = validateSurfaceControls(key, value);
-    if (controls !== undefined) validated[key] = controls;
-  }
-  return validated;
-};
-
-// Validates one of the three top-level severity maps (`rules` /
-// `categories` / `tags`) — ESLint / oxlint-shaped severity surface.
-// Returns the validated map, dropping invalid entries with a warning.
-const validateSeverityMap = (
-  fieldName: string,
-  rawMap: unknown,
-): Record<string, RuleSeverityOverride> | undefined => {
-  if (!isPlainObject(rawMap)) {
-    warnConfigField(
-      `config field "${fieldName}" must be an object (got ${typeof rawMap}); ignoring this field.`,
-    );
-    return undefined;
-  }
-  const validated: Record<string, RuleSeverityOverride> = {};
-  for (const [key, value] of Object.entries(rawMap)) {
-    if (key.length === 0) {
-      warnConfigField(`config field "${fieldName}" has an empty key; ignoring the entry.`);
-      continue;
-    }
-    if (!isRuleSeverity(value)) {
-      warnConfigField(
-        `config field "${fieldName}.${key}" must be one of: ${VALID_RULE_SEVERITIES.join(", ")} (got ${formatType(value)}); ignoring the entry.`,
-      );
-      continue;
-    }
-    validated[key] = value;
-  }
-  return validated;
-};
-
-// Applies a validator to one config field: undefined skips, an `undefined`
-// return strips the field, anything else replaces it. Keeps the main
-// loop free of the repeating "if (raw === undefined) continue; result =
-// validator(...); if (result === undefined) delete; else assign" dance.
-const applyFieldValidator = <Key extends keyof ReactDoctorConfig>(
-  config: ReactDoctorConfig,
-  validated: ReactDoctorConfig,
-  fieldName: Key,
-  validator: (value: unknown) => ReactDoctorConfig[Key] | undefined,
-): void => {
-  const raw = (config as Record<string, unknown>)[fieldName];
-  if (raw === undefined) return;
-  const result = validator(raw);
-  if (result === undefined) {
-    delete (validated as Record<string, unknown>)[fieldName];
-  } else {
-    (validated as Record<string, unknown>)[fieldName] = result;
-  }
-};
-
-// Returns a config with boolean fields coerced from common JSON-typing
-// mistakes (string "true"/"false") and other invalid types stripped.
-// Non-validated fields pass through untouched — consumers still do their
-// own runtime checks for those.
+/**
+ * Returns a config with boolean fields coerced from common JSON-typing
+ * mistakes (string "true"/"false") and other invalid types stripped.
+ * Non-validated fields pass through untouched - consumers still do their
+ * own runtime checks for those.
+ */
 export const validateConfigTypes = (config: ReactDoctorConfig): ReactDoctorConfig => {
   const validated: ReactDoctorConfig = { ...config };
-  for (const fieldName of BOOLEAN_FIELD_NAMES) {
-    applyFieldValidator(config, validated, fieldName, (value) =>
-      coerceMaybeBooleanString(fieldName, value),
+  for (const [fieldName, descriptor] of Object.entries(fieldDescriptors)) {
+    const raw = (config as Record<string, unknown>)[fieldName];
+    if (raw === undefined) continue;
+    const parsed = descriptor.schema.safeParse(raw);
+    if (parsed.success) {
+      (validated as Record<string, unknown>)[fieldName] = parsed.data;
+      continue;
+    }
+    warnConfigField(
+      `config field "${fieldName}" must be ${descriptor.expectedDescription} (got ${formatType(raw)}); ignoring this field.`,
     );
-  }
-  for (const fieldName of STRING_FIELD_NAMES) {
-    applyFieldValidator(config, validated, fieldName, (value) => validateString(fieldName, value));
-  }
-  applyFieldValidator(config, validated, "surfaces", validateSurfacesField);
-  for (const fieldName of SEVERITY_FIELD_NAMES) {
-    applyFieldValidator(config, validated, fieldName, (value) =>
-      validateSeverityMap(fieldName, value),
-    );
+    delete (validated as Record<string, unknown>)[fieldName];
   }
   return validated;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-barrel-import.ts
@@ -1,6 +1,11 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { createRelativeImportSource } from "../../utils/create-relative-import-source.js";
+import {
+  getReactDoctorStringArraySetting,
+  getReactDoctorStringSetting,
+} from "../../utils/get-react-doctor-setting.js";
 import { isBarrelIndexModule } from "../../utils/is-barrel-index-module.js";
+import { matchesBarrelAllowlist } from "../../utils/matches-barrel-allowlist.js";
 import { resolveBarrelExportFilePath } from "../../utils/resolve-barrel-export-file-path.js";
 import { resolveRelativeImportPath } from "../../utils/resolve-relative-import-path.js";
 import type { Rule } from "../../utils/rule.js";
@@ -81,6 +86,20 @@ export const noBarrelImport = defineRule<Rule>({
 
         const resolvedImportPath = resolveRelativeImportPath(filename, source);
         if (resolvedImportPath && isBarrelIndexModule(resolvedImportPath)) {
+          const allowlistPatterns = getReactDoctorStringArraySetting(
+            context.settings,
+            "barrelAllowlist",
+          );
+          const settingsRootDirectory = getReactDoctorStringSetting(
+            context.settings,
+            "rootDirectory",
+          );
+          if (
+            allowlistPatterns.length > 0 &&
+            matchesBarrelAllowlist(resolvedImportPath, allowlistPatterns, settingsRootDirectory)
+          ) {
+            return;
+          }
           didReportForFile = true;
           context.report({
             node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/matches-barrel-allowlist.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/matches-barrel-allowlist.ts
@@ -1,0 +1,100 @@
+import path from "node:path";
+
+const REGEX_SPECIAL_CHARACTERS = /[.+^${}()|[\]\\]/g;
+
+// HACK: a deliberately minimal glob compiler mirroring `compileGlobPattern`
+// in `@react-doctor/core`. We don't reach across the package boundary
+// because oxlint loads this plugin as a self-contained module - pulling
+// a core helper in would force the plugin bundle to bloat with every
+// transitive core dependency. The supported syntax is identical
+// (`*`, `**`, `?`) so user-facing semantics stay consistent.
+const compileBarrelAllowlistPattern = (pattern: string, caseInsensitive: boolean): RegExp => {
+  // Preserve a leading `/` on the pattern - the matcher tries both
+  // relative- and absolute-path candidates, and stripping the leading
+  // slash would make `/repo/src/index.ts` (an explicitly-absolute
+  // pattern) compile to a regex that can only match the relative form
+  // `repo/src/index.ts`. Backslashes are normalized to forward slashes
+  // so a single config works on Windows + POSIX.
+  const normalized = pattern.replace(/\\/g, "/");
+  let regexSource = "^";
+  let characterIndex = 0;
+  while (characterIndex < normalized.length) {
+    if (normalized[characterIndex] === "*" && normalized[characterIndex + 1] === "*") {
+      if (normalized[characterIndex + 2] === "/") {
+        regexSource += "(?:.+/)?";
+        characterIndex += 3;
+      } else {
+        regexSource += ".*";
+        characterIndex += 2;
+      }
+    } else if (normalized[characterIndex] === "*") {
+      regexSource += "[^/]*";
+      characterIndex += 1;
+    } else if (normalized[characterIndex] === "?") {
+      regexSource += "[^/]";
+      characterIndex += 1;
+    } else {
+      regexSource += normalized[characterIndex].replace(REGEX_SPECIAL_CHARACTERS, "\\$&");
+      characterIndex += 1;
+    }
+  }
+  regexSource += "$";
+  return new RegExp(regexSource, caseInsensitive ? "i" : "");
+};
+
+// Filesystem case sensitivity follows the host platform. POSIX file
+// systems are case-sensitive; Windows and macOS's default HFS+ / APFS
+// volumes are case-insensitive. Without this flag a user's allowlist
+// pattern `src/index.ts` would miss a resolved path of `Src/index.ts`
+// on Windows even though the import resolved to the same file.
+const isCaseInsensitiveFilesystem = (): boolean =>
+  process.platform === "win32" || process.platform === "darwin";
+
+const normalizeForwardSlashes = (filePath: string): string => filePath.split(path.sep).join("/");
+
+const toRelativeForwardSlashes = (filePath: string, rootDirectory: string | undefined): string => {
+  if (!rootDirectory || !path.isAbsolute(filePath)) {
+    return normalizeForwardSlashes(filePath);
+  }
+  return normalizeForwardSlashes(path.relative(rootDirectory, filePath));
+};
+
+interface MatchesBarrelAllowlistOptions {
+  /**
+   * Force case-insensitive (or case-sensitive) matching irrespective
+   * of platform. Defaults to `process.platform === "win32" || "darwin"`,
+   * matching the typical filesystem case sensitivity of the host. The
+   * override is primarily for tests that need deterministic behavior
+   * across CI environments.
+   */
+  caseInsensitive?: boolean;
+}
+
+/**
+ * Whether the resolved barrel index file is on the user's intentional
+ * "public-API barrel" allowlist. Patterns match against the barrel
+ * file's path relative to the configured project root (forward-slash
+ * normalized so a single config works on Windows and POSIX).
+ *
+ * Case sensitivity follows the host filesystem by default: POSIX
+ * (Linux) is case-sensitive; Windows and the default macOS volume
+ * formats are case-insensitive.
+ */
+export const matchesBarrelAllowlist = (
+  barrelFilePath: string,
+  allowlistPatterns: ReadonlyArray<string>,
+  rootDirectory: string | undefined,
+  options: MatchesBarrelAllowlistOptions = {},
+): boolean => {
+  if (allowlistPatterns.length === 0) return false;
+  const caseInsensitive = options.caseInsensitive ?? isCaseInsensitiveFilesystem();
+  const relativePath = toRelativeForwardSlashes(barrelFilePath, rootDirectory);
+  const absolutePath = normalizeForwardSlashes(barrelFilePath);
+  for (const pattern of allowlistPatterns) {
+    if (!pattern || typeof pattern !== "string") continue;
+    const compiledPattern = compileBarrelAllowlistPattern(pattern, caseInsensitive);
+    if (compiledPattern.test(relativePath)) return true;
+    if (pattern.startsWith("/") && compiledPattern.test(absolutePath)) return true;
+  }
+  return false;
+};

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -30,10 +30,12 @@ import {
 import { printAnnotations } from "../utils/print-annotations.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
 import { resolveCliInspectOptions } from "../utils/resolve-cli-inspect-options.js";
+import { resolveConcurrency } from "../utils/resolve-concurrency.js";
 import { resolveDiffMode } from "../utils/resolve-diff-mode.js";
 import { resolveEffectiveDiff } from "../utils/resolve-effective-diff.js";
 import { resolveFailOnLevel } from "../utils/resolve-fail-on-level.js";
 import { runExplain } from "../utils/run-explain.js";
+import { runWithConcurrency } from "../utils/run-with-concurrency.js";
 import { selectProjects } from "../utils/select-projects.js";
 import { shouldFailForDiagnostics } from "../utils/should-fail-for-diagnostics.js";
 import { shouldSkipPrompts } from "../utils/should-skip-prompts.js";
@@ -203,48 +205,85 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       logger.break();
     }
 
-    const allDiagnostics: Diagnostic[] = [];
-    const completedScans: Array<{ directory: string; result: InspectResult }> = [];
+    const concurrency = resolveConcurrency(flags.concurrency, userConfig);
+    if (concurrency > 1 && !isQuiet) {
+      logger.dim(`Scanning up to ${concurrency} projects in parallel`);
+      logger.break();
+    }
 
-    for (const projectDirectory of projectDirectories) {
-      let includePaths: string[] | undefined;
-      if (isDiffMode) {
-        const projectDiffInfo =
-          projectDirectory === resolvedDirectory
-            ? diffInfo
-            : getDiffInfo(projectDirectory, explicitBaseBranch);
-        if (projectDiffInfo) {
-          const changedSourceFiles = filterSourceFiles(projectDiffInfo.changedFiles);
-          if (changedSourceFiles.length === 0) {
-            if (!isQuiet) {
-              logger.dim(`No changed source files in ${projectDirectory}, skipping.`);
-              logger.break();
-            }
-            continue;
-          }
-          includePaths = changedSourceFiles;
-        } else if (!isQuiet) {
-          logger.dim(
-            `Cannot detect diff for ${projectDirectory} (not a git repository?) — scanning all files.`,
-          );
+    interface PlannedProjectScan {
+      directory: string;
+      includePaths: string[] | undefined;
+      skipReason: string | null;
+    }
+
+    const plannedScans: PlannedProjectScan[] = projectDirectories.map((projectDirectory) => {
+      if (!isDiffMode) {
+        return { directory: projectDirectory, includePaths: undefined, skipReason: null };
+      }
+      const projectDiffInfo =
+        projectDirectory === resolvedDirectory
+          ? diffInfo
+          : getDiffInfo(projectDirectory, explicitBaseBranch);
+      if (!projectDiffInfo) {
+        return { directory: projectDirectory, includePaths: undefined, skipReason: "no-diff-info" };
+      }
+      const changedSourceFiles = filterSourceFiles(projectDiffInfo.changedFiles);
+      if (changedSourceFiles.length === 0) {
+        return {
+          directory: projectDirectory,
+          includePaths: changedSourceFiles,
+          skipReason: "no-changed-files",
+        };
+      }
+      return {
+        directory: projectDirectory,
+        includePaths: changedSourceFiles,
+        skipReason: null,
+      };
+    });
+
+    for (const plannedScan of plannedScans) {
+      if (plannedScan.skipReason === "no-changed-files" && !isQuiet) {
+        logger.dim(`No changed source files in ${plannedScan.directory}, skipping.`);
+        logger.break();
+      } else if (plannedScan.skipReason === "no-diff-info" && !isQuiet) {
+        logger.dim(
+          `Cannot detect diff for ${plannedScan.directory} (not a git repository?) - scanning all files.`,
+        );
+        logger.break();
+      }
+    }
+
+    const runnableScans = plannedScans.filter(
+      (plannedScan) => plannedScan.skipReason !== "no-changed-files",
+    );
+
+    const scanOutputs = await runWithConcurrency(
+      runnableScans,
+      concurrency,
+      async (plannedScan) => {
+        if (!isQuiet && concurrency <= 1) {
+          logger.dim(`Scanning ${plannedScan.directory}...`);
           logger.break();
         }
-      }
+        const scanResult = await inspect(plannedScan.directory, {
+          ...scanOptions,
+          includePaths: plannedScan.includePaths,
+          configOverride: userConfig,
+        });
+        if (!isQuiet && concurrency <= 1) {
+          logger.break();
+        }
+        return { directory: plannedScan.directory, result: scanResult };
+      },
+    );
 
-      if (!isQuiet) {
-        logger.dim(`Scanning ${projectDirectory}...`);
-        logger.break();
-      }
-      const scanResult = await inspect(projectDirectory, {
-        ...scanOptions,
-        includePaths,
-        configOverride: userConfig,
-      });
-      allDiagnostics.push(...scanResult.diagnostics);
-      completedScans.push({ directory: projectDirectory, result: scanResult });
-      if (!isQuiet) {
-        logger.break();
-      }
+    const allDiagnostics: Diagnostic[] = [];
+    const completedScans: Array<{ directory: string; result: InspectResult }> = [];
+    for (const scanOutput of scanOutputs) {
+      allDiagnostics.push(...scanOutput.result.diagnostics);
+      completedScans.push(scanOutput);
     }
 
     if (isJsonMode) {

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -39,6 +39,7 @@ const program = new Command()
     "--pr-comment",
     "tune CLI output for sticky PR comments (drops weak-signal rule families like `design` from the printed list and the fail-on gate; configure via config.surfaces)",
   )
+  .option("--concurrency <n>", "scan up to N workspace projects in parallel (default: 1)")
   .option(
     "--explain <file:line>",
     "diagnose why a rule fired or why a suppression didn't apply at a specific location",

--- a/packages/react-doctor/src/cli/utils/inspect-flags.ts
+++ b/packages/react-doctor/src/cli/utils/inspect-flags.ts
@@ -20,4 +20,6 @@ export interface InspectFlags {
   explain?: string;
   why?: string;
   failOn?: string;
+  /** Maximum number of workspace projects to scan in parallel. */
+  concurrency?: string;
 }

--- a/packages/react-doctor/src/cli/utils/resolve-concurrency.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-concurrency.ts
@@ -1,0 +1,36 @@
+import { highlighter, logger } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "@react-doctor/types";
+
+const MIN_CONCURRENCY = 1;
+const MAX_CONCURRENCY = 32;
+
+const parseConcurrencyFlag = (rawValue: string | undefined): number | null => {
+  if (rawValue === undefined) return null;
+  const parsedValue = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsedValue) || parsedValue < MIN_CONCURRENCY) {
+    logger.warn(
+      `--concurrency ${highlighter.info(rawValue)} is not a positive integer; falling back to 1.`,
+    );
+    return null;
+  }
+  if (parsedValue > MAX_CONCURRENCY) {
+    logger.warn(
+      `--concurrency ${parsedValue} clamped to ${MAX_CONCURRENCY} (over-parallelism slows large monorepo scans).`,
+    );
+    return MAX_CONCURRENCY;
+  }
+  return parsedValue;
+};
+
+export const resolveConcurrency = (
+  flagValue: string | undefined,
+  userConfig: ReactDoctorConfig | null,
+): number => {
+  const fromFlag = parseConcurrencyFlag(flagValue);
+  if (fromFlag !== null) return fromFlag;
+  const fromConfig = userConfig?.concurrency;
+  if (fromConfig !== undefined && fromConfig >= MIN_CONCURRENCY) {
+    return Math.min(fromConfig, MAX_CONCURRENCY);
+  }
+  return MIN_CONCURRENCY;
+};

--- a/packages/react-doctor/src/cli/utils/run-with-concurrency.ts
+++ b/packages/react-doctor/src/cli/utils/run-with-concurrency.ts
@@ -1,0 +1,51 @@
+/**
+ * Run async tasks with a fixed concurrency limit, preserving input
+ * order in the result array. Each task is invoked lazily - the
+ * `concurrency`+1th task is only awaited once one of the in-flight
+ * tasks resolves, so we never over-commit even when one project's
+ * scan is many times slower than its siblings.
+ */
+export const runWithConcurrency = async <Input, Output>(
+  inputs: ReadonlyArray<Input>,
+  concurrency: number,
+  taskFactory: (input: Input, index: number) => Promise<Output>,
+): Promise<Output[]> => {
+  if (inputs.length === 0) return [];
+  if (concurrency <= 1 || inputs.length === 1) {
+    const serialOutputs: Output[] = [];
+    for (let inputIndex = 0; inputIndex < inputs.length; inputIndex++) {
+      // HACK: intentional sequential await — concurrency<=1 means the
+      // caller explicitly opted into one-at-a-time execution (default
+      // for monorepo scans). `Promise.all` would defeat the back-pressure
+      // every scan is sized around.
+      // eslint-disable-next-line react-doctor/async-await-in-loop
+      serialOutputs.push(await taskFactory(inputs[inputIndex], inputIndex));
+    }
+    return serialOutputs;
+  }
+
+  const outputs: Output[] = new Array(inputs.length);
+  let nextIndexToDispatch = 0;
+  const workerCount = Math.min(concurrency, inputs.length);
+
+  const dispatchNext = async (): Promise<void> => {
+    // HACK: each worker pulls the next task only after the previous one
+    // finishes — that's how the concurrency limit is enforced. The pool
+    // of `workerCount` workers runs in parallel via `Promise.all` below;
+    // the per-worker loop must stay sequential.
+    while (true) {
+      const dispatchIndex = nextIndexToDispatch;
+      if (dispatchIndex >= inputs.length) return;
+      nextIndexToDispatch += 1;
+      // eslint-disable-next-line react-doctor/async-await-in-loop
+      outputs[dispatchIndex] = await taskFactory(inputs[dispatchIndex], dispatchIndex);
+    }
+  };
+
+  const workerPromises: Promise<void>[] = [];
+  for (let workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+    workerPromises.push(dispatchNext());
+  }
+  await Promise.all(workerPromises);
+  return outputs;
+};

--- a/packages/react-doctor/src/cli/utils/select-projects.ts
+++ b/packages/react-doctor/src/cli/utils/select-projects.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import type { WorkspacePackage } from "@react-doctor/types";
 import { discoverReactSubprojects, listWorkspacePackages } from "@react-doctor/project-info";
-import { highlighter, logger } from "@react-doctor/core";
+import { highlighter, isLoggerSilent, logger } from "@react-doctor/core";
 import { prompts } from "./prompts.js";
 
 export const selectProjects = async (
@@ -16,9 +16,11 @@ export const selectProjects = async (
 
   if (packages.length === 0) return [rootDirectory];
   if (packages.length === 1) {
-    logger.log(
-      `${highlighter.success("✔")} Select projects to scan ${highlighter.dim("›")} ${packages[0].name}`,
-    );
+    if (!isLoggerSilent()) {
+      logger.log(
+        `${highlighter.success("✔")} Select projects to scan ${highlighter.dim("›")} ${packages[0].name}`,
+      );
+    }
     return [packages[0].directory];
   }
 

--- a/packages/react-doctor/tests/extends-config.test.ts
+++ b/packages/react-doctor/tests/extends-config.test.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { clearConfigCache, loadConfigWithSource } from "@react-doctor/core";
+
+const writeJson = (filePath: string, contents: unknown): void => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(contents));
+};
+
+describe("loadConfigWithSource - extends", () => {
+  let rootDirectory: string;
+
+  beforeEach(() => {
+    rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-extends-"));
+    clearConfigCache();
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDirectory, { recursive: true, force: true });
+    clearConfigCache();
+  });
+
+  it("resolves a single string parent and lets the child override", () => {
+    const parentPath = path.join(rootDirectory, "react-doctor.base.json");
+    const childPath = path.join(rootDirectory, "packages/web/react-doctor.config.json");
+    writeJson(parentPath, { failOn: "warning", verbose: true });
+    writeJson(childPath, { extends: "../../react-doctor.base.json", failOn: "error" });
+
+    const loaded = loadConfigWithSource(path.dirname(childPath));
+    expect(loaded?.config.failOn).toBe("error");
+    expect(loaded?.config.verbose).toBe(true);
+  });
+
+  it("supports array extends and merges array fields", () => {
+    const sharedPath = path.join(rootDirectory, "react-doctor.shared.json");
+    const securityPath = path.join(rootDirectory, "react-doctor.security.json");
+    const childPath = path.join(rootDirectory, "packages/web/react-doctor.config.json");
+    writeJson(sharedPath, { ignore: { files: ["dist/**"] } });
+    writeJson(securityPath, { ignore: { files: ["coverage/**"] } });
+    writeJson(childPath, {
+      extends: ["../../react-doctor.shared.json", "../../react-doctor.security.json"],
+      ignore: { files: ["build/**"] },
+    });
+
+    const loaded = loadConfigWithSource(path.dirname(childPath));
+    expect(loaded?.config.ignore?.files).toEqual(["dist/**", "coverage/**", "build/**"]);
+  });
+
+  it("handles deep extends chains", () => {
+    const grandparentPath = path.join(rootDirectory, "react-doctor.grandparent.json");
+    const parentPath = path.join(rootDirectory, "react-doctor.parent.json");
+    const childPath = path.join(rootDirectory, "packages/web/react-doctor.config.json");
+    writeJson(grandparentPath, { lint: true, failOn: "warning" });
+    writeJson(parentPath, {
+      extends: "./react-doctor.grandparent.json",
+      verbose: true,
+    });
+    writeJson(childPath, {
+      extends: "../../react-doctor.parent.json",
+      failOn: "error",
+    });
+
+    const loaded = loadConfigWithSource(path.dirname(childPath));
+    expect(loaded?.config.lint).toBe(true);
+    expect(loaded?.config.verbose).toBe(true);
+    expect(loaded?.config.failOn).toBe("error");
+  });
+
+  it("ignores missing parent files but still loads the child", () => {
+    const childPath = path.join(rootDirectory, "react-doctor.config.json");
+    writeJson(childPath, {
+      extends: "./does-not-exist.json",
+      failOn: "error",
+    });
+
+    const loaded = loadConfigWithSource(rootDirectory);
+    expect(loaded?.config.failOn).toBe("error");
+  });
+
+  it("lets later entries in `extends` array override earlier ones on scalar conflicts", () => {
+    const earlierPath = path.join(rootDirectory, "earlier.json");
+    const laterPath = path.join(rootDirectory, "later.json");
+    const childPath = path.join(rootDirectory, "react-doctor.config.json");
+    writeJson(earlierPath, { failOn: "warning" });
+    writeJson(laterPath, { failOn: "none" });
+    writeJson(childPath, {
+      extends: ["./earlier.json", "./later.json"],
+    });
+
+    const loaded = loadConfigWithSource(rootDirectory);
+    expect(loaded?.config.failOn).toBe("none");
+  });
+
+  it("breaks cycles between parent and child configs", () => {
+    const parentPath = path.join(rootDirectory, "parent.json");
+    const childPath = path.join(rootDirectory, "react-doctor.config.json");
+    writeJson(parentPath, { extends: "./react-doctor.config.json", verbose: true });
+    writeJson(childPath, { extends: "./parent.json", failOn: "error" });
+
+    const loaded = loadConfigWithSource(rootDirectory);
+    expect(loaded?.config.failOn).toBe("error");
+    expect(loaded?.config.verbose).toBe(true);
+  });
+
+  it("loads shared parents through diamond inheritance (Root -> [A, B] -> Shared)", () => {
+    const sharedPath = path.join(rootDirectory, "shared.json");
+    const aPath = path.join(rootDirectory, "a.json");
+    const bPath = path.join(rootDirectory, "b.json");
+    const childPath = path.join(rootDirectory, "react-doctor.config.json");
+    writeJson(sharedPath, { failOn: "warning", lint: true });
+    writeJson(aPath, { extends: "./shared.json", verbose: true });
+    // B extends shared too; with a per-branch visited set both A and B
+    // see Shared without one branch silently skipping it as a cycle.
+    writeJson(bPath, { extends: "./shared.json" });
+    writeJson(childPath, { extends: ["./a.json", "./b.json"] });
+
+    const loaded = loadConfigWithSource(rootDirectory);
+    expect(loaded?.config.failOn).toBe("warning");
+    expect(loaded?.config.lint).toBe(true);
+    expect(loaded?.config.verbose).toBe(true);
+  });
+
+  it("resolves an inherited relative rootDir against the parent's directory, not the child's", () => {
+    // Parent at `<root>/shared/base.json` declares `rootDir: "../apps/web"`,
+    // which should resolve to `<root>/apps/web` regardless of where the
+    // child config lives. Without the fix, the child at
+    // `<root>/packages/lib/react-doctor.config.json` would resolve the
+    // inherited string against its own dir and point at
+    // `<root>/packages/apps/web`.
+    const appsWebDir = path.join(rootDirectory, "apps", "web");
+    fs.mkdirSync(appsWebDir, { recursive: true });
+    const parentPath = path.join(rootDirectory, "shared", "base.json");
+    const childPath = path.join(rootDirectory, "packages", "lib", "react-doctor.config.json");
+    writeJson(parentPath, { rootDir: "../apps/web", failOn: "error" });
+    writeJson(childPath, { extends: "../../shared/base.json" });
+
+    const loaded = loadConfigWithSource(path.dirname(childPath));
+    expect(loaded?.config.rootDir).toBe(appsWebDir);
+    expect(loaded?.config.failOn).toBe("error");
+  });
+
+  it("breaks cycles even when the entry config is loaded through a symlinked directory", () => {
+    // The root config self-references; cycle detection should catch
+    // it on the first re-entry regardless of whether the entry path
+    // came through a symlink or its realpath. The visited set is
+    // keyed by realpath so both lenses converge on the same key.
+    const realDirectory = path.join(rootDirectory, "real");
+    const linkDirectory = path.join(rootDirectory, "link");
+    fs.mkdirSync(realDirectory);
+    fs.symlinkSync(realDirectory, linkDirectory, "dir");
+    const realConfigPath = path.join(realDirectory, "react-doctor.config.json");
+    writeJson(realConfigPath, {
+      extends: "./react-doctor.config.json",
+      failOn: "error",
+    });
+
+    const loaded = loadConfigWithSource(linkDirectory);
+    expect(loaded?.config.failOn).toBe("error");
+  });
+});

--- a/packages/react-doctor/tests/matches-barrel-allowlist.test.ts
+++ b/packages/react-doctor/tests/matches-barrel-allowlist.test.ts
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { matchesBarrelAllowlist } from "../../oxlint-plugin-react-doctor/src/plugin/utils/matches-barrel-allowlist.js";
+
+const projectRoot = "/repo";
+
+describe("matchesBarrelAllowlist", () => {
+  it("returns false when the allowlist is empty", () => {
+    const barrelPath = path.join(projectRoot, "src/components/ui/index.ts");
+    expect(matchesBarrelAllowlist(barrelPath, [], projectRoot)).toBe(false);
+  });
+
+  it("matches a relative single-pattern allowlist", () => {
+    const barrelPath = path.join(projectRoot, "src/index.ts");
+    expect(matchesBarrelAllowlist(barrelPath, ["src/index.ts"], projectRoot)).toBe(true);
+  });
+
+  it("supports `**` for arbitrary depth (e.g. monorepo package public barrels)", () => {
+    const barrelPath = path.join(projectRoot, "packages/ui/src/index.ts");
+    expect(matchesBarrelAllowlist(barrelPath, ["packages/**/src/index.ts"], projectRoot)).toBe(
+      true,
+    );
+  });
+
+  it("rejects barrels that do not match any allowlist pattern", () => {
+    const barrelPath = path.join(projectRoot, "src/utils/index.ts");
+    expect(matchesBarrelAllowlist(barrelPath, ["src/components/index.ts"], projectRoot)).toBe(
+      false,
+    );
+  });
+
+  it("supports `*` as a single path-segment wildcard", () => {
+    const barrelPath = path.join(projectRoot, "src/components/ui/index.ts");
+    expect(matchesBarrelAllowlist(barrelPath, ["src/components/*/index.ts"], projectRoot)).toBe(
+      true,
+    );
+    expect(matchesBarrelAllowlist(barrelPath, ["src/components/*.ts"], projectRoot)).toBe(false);
+  });
+
+  it("matches absolute-path patterns against the absolute barrel path", () => {
+    const barrelPath = path.join(projectRoot, "src/index.ts");
+    expect(matchesBarrelAllowlist(barrelPath, [`${projectRoot}/src/index.ts`], projectRoot)).toBe(
+      true,
+    );
+    expect(matchesBarrelAllowlist(barrelPath, [`${projectRoot}/src/other.ts`], projectRoot)).toBe(
+      false,
+    );
+  });
+
+  it("honors the caseInsensitive option override regardless of platform", () => {
+    const barrelPath = path.join(projectRoot, "Src/Index.ts");
+    expect(
+      matchesBarrelAllowlist(barrelPath, ["src/index.ts"], projectRoot, {
+        caseInsensitive: true,
+      }),
+    ).toBe(true);
+    expect(
+      matchesBarrelAllowlist(barrelPath, ["src/index.ts"], projectRoot, {
+        caseInsensitive: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/merge-configs.test.ts
+++ b/packages/react-doctor/tests/merge-configs.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mergeReactDoctorConfigs } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "@react-doctor/types";
+
+describe("mergeReactDoctorConfigs", () => {
+  it("returns child values when there's no overlap", () => {
+    const parent: ReactDoctorConfig = { lint: true, verbose: false };
+    const child: ReactDoctorConfig = { failOn: "error" };
+    expect(mergeReactDoctorConfigs(parent, child)).toEqual({
+      lint: true,
+      verbose: false,
+      failOn: "error",
+    });
+  });
+
+  it("lets the child override scalar parent values", () => {
+    const parent: ReactDoctorConfig = { failOn: "warning", verbose: true };
+    const child: ReactDoctorConfig = { failOn: "error" };
+    const merged = mergeReactDoctorConfigs(parent, child);
+    expect(merged.failOn).toBe("error");
+    expect(merged.verbose).toBe(true);
+  });
+
+  it("concatenates and dedupes array fields", () => {
+    const parent: ReactDoctorConfig = {
+      ignore: { files: ["dist/**", "build/**"], rules: ["react/no-danger"] },
+      barrelAllowlist: ["src/index.ts"],
+    };
+    const child: ReactDoctorConfig = {
+      ignore: { files: ["build/**", ".next/**"], rules: ["react-doctor/no-effect-chain"] },
+      barrelAllowlist: ["packages/*/src/index.ts"],
+    };
+    const merged = mergeReactDoctorConfigs(parent, child);
+    expect(merged.ignore?.files).toEqual(["dist/**", "build/**", ".next/**"]);
+    expect(merged.ignore?.rules).toEqual(["react/no-danger", "react-doctor/no-effect-chain"]);
+    expect(merged.barrelAllowlist).toEqual(["src/index.ts", "packages/*/src/index.ts"]);
+  });
+
+  it("merges surface controls and dedupes tag lists", () => {
+    const parent: ReactDoctorConfig = {
+      surfaces: {
+        prComment: { excludeTags: ["design"] },
+        ciFailure: { excludeRules: ["react-doctor/no-prevent-default"] },
+      },
+    };
+    const child: ReactDoctorConfig = {
+      surfaces: {
+        prComment: { excludeTags: ["design", "test-noise"] },
+        score: { excludeTags: ["design"] },
+      },
+    };
+    const merged = mergeReactDoctorConfigs(parent, child);
+    expect(merged.surfaces?.prComment?.excludeTags).toEqual(["design", "test-noise"]);
+    expect(merged.surfaces?.score?.excludeTags).toEqual(["design"]);
+    expect(merged.surfaces?.ciFailure?.excludeRules).toEqual(["react-doctor/no-prevent-default"]);
+  });
+
+  it("strips the `extends` field from the merged output", () => {
+    const parent: ReactDoctorConfig = { extends: "./grandparent.json", lint: true };
+    const child: ReactDoctorConfig = { extends: "./parent.json", verbose: true };
+    const merged = mergeReactDoctorConfigs(parent, child);
+    expect((merged as Record<string, unknown>).extends).toBeUndefined();
+  });
+});

--- a/packages/react-doctor/tests/run-with-concurrency.test.ts
+++ b/packages/react-doctor/tests/run-with-concurrency.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runWithConcurrency } from "../src/cli/utils/run-with-concurrency.js";
+
+const sleep = (durationMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, durationMs));
+
+describe("runWithConcurrency", () => {
+  it("returns results in input order regardless of completion order", async () => {
+    const inputs = [60, 10, 40, 20];
+    const outputs = await runWithConcurrency(inputs, 3, async (durationMs) => {
+      await sleep(durationMs);
+      return durationMs;
+    });
+    expect(outputs).toEqual(inputs);
+  });
+
+  it("processes serially when concurrency <= 1", async () => {
+    let activeCount = 0;
+    let maxActiveCount = 0;
+    await runWithConcurrency([1, 1, 1, 1], 1, async () => {
+      activeCount += 1;
+      maxActiveCount = Math.max(maxActiveCount, activeCount);
+      await sleep(2);
+      activeCount -= 1;
+    });
+    expect(maxActiveCount).toBe(1);
+  });
+
+  it("never exceeds the requested concurrency window", async () => {
+    let activeCount = 0;
+    let maxActiveCount = 0;
+    await runWithConcurrency([1, 2, 3, 4, 5, 6, 7, 8], 3, async () => {
+      activeCount += 1;
+      maxActiveCount = Math.max(maxActiveCount, activeCount);
+      await sleep(5);
+      activeCount -= 1;
+    });
+    expect(maxActiveCount).toBeLessThanOrEqual(3);
+  });
+
+  it("returns an empty array for an empty input list", async () => {
+    const outputs = await runWithConcurrency([], 4, async () => "never called");
+    expect(outputs).toEqual([]);
+  });
+});

--- a/packages/react-doctor/tests/validate-config-types.test.ts
+++ b/packages/react-doctor/tests/validate-config-types.test.ts
@@ -95,6 +95,26 @@ describe("validateConfigTypes", () => {
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("dashboard"));
     });
 
+    it("keeps valid sibling fields on a surface when one field is malformed", () => {
+      // Regression: a string passed where an array of strings is expected
+      // for `includeTags` must NOT take down the rest of the surface
+      // (the sibling `excludeRules` is well-formed and should survive).
+      const result = validateConfigTypes({
+        surfaces: {
+          prComment: {
+            includeTags: "design" as unknown as string[],
+            excludeRules: ["react-doctor/no-vague-button-label"],
+          },
+        },
+      });
+      expect(result.surfaces?.prComment).toEqual({
+        excludeRules: ["react-doctor/no-vague-button-label"],
+      });
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining("surfaces.prComment.includeTags"),
+      );
+    });
+
     it("strips non-string entries from include/exclude arrays", () => {
       const result = validateConfigTypes({
         surfaces: {
@@ -113,6 +133,25 @@ describe("validateConfigTypes", () => {
       });
       expect(result.surfaces).toBeUndefined();
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("surfaces"));
+    });
+  });
+
+  describe("extends", () => {
+    it("rejects an empty string with a warning that mentions non-empty strings", () => {
+      const result = validateConfigTypes({
+        extends: "" as unknown as string,
+      });
+      expect((result as Record<string, unknown>).extends).toBeUndefined();
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("non-empty string"));
+    });
+
+    it("filters empty strings out of the array form with an accurate per-entry warning", () => {
+      const result = validateConfigTypes({
+        extends: ["./real.json", "", 42] as unknown as string[],
+      });
+      expect(result.extends).toEqual(["./real.json"]);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("empty string"));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("non-string entry"));
     });
   });
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -85,6 +85,28 @@ export interface SurfaceControls {
 }
 
 export interface ReactDoctorConfig {
+  /**
+   * One or more parent config files to inherit from. Paths are
+   * resolved relative to the config file that declares `extends`
+   * (NOT relative to the CWD). Each entry is loaded the same way the
+   * top-level config is - so a parent can itself extend further.
+   *
+   * Inheritance semantics (consistent with tsconfig / eslint `extends`):
+   *
+   * - Later entries override earlier entries on scalar conflicts.
+   * - The CURRENT config always wins over anything it extends.
+   * - Scalar fields (e.g. `lint`, `failOn`) replace.
+   * - Array fields (e.g. `ignore.files`, `surfaces.*.excludeTags`)
+   *   concatenate in declaration order, then deduplicate.
+   * - Nested objects merge field-by-field.
+   *
+   * Typical use: a monorepo keeps its shared "house" rules in
+   * `react-doctor.base.json` at the root, and each package's
+   * `react-doctor.config.json` extends it before adding package-local
+   * overrides (e.g. `customRulesOnly: true` in legacy packages still
+   * adopting react-doctor).
+   */
+  extends?: string | string[];
   ignore?: ReactDoctorIgnoreConfig;
   lint?: boolean;
   verbose?: boolean;
@@ -93,6 +115,37 @@ export interface ReactDoctorConfig {
   customRulesOnly?: boolean;
   share?: boolean;
   offline?: boolean;
+  /**
+   * Maximum number of workspace projects to scan in parallel when
+   * react-doctor is invoked against a monorepo. `1` runs every project
+   * serially - the historical default and the only safe value when
+   * each project might saturate CPU on its own (e.g. very large
+   * standalone Next.js apps). Override with the `--concurrency <n>`
+   * CLI flag.
+   */
+  concurrency?: number;
+  /**
+   * Per-glob allowlist for the `no-barrel-import` rule.
+   *
+   * Note: matches the resolved barrel index file path, not the
+   * importer's path - so a single entry exempts every importer of
+   * that barrel, where `ignore.overrides` would require listing
+   * every importer. Re-exports
+   * from index modules matching any pattern here are treated as
+   * intentional public APIs and the rule does NOT fire. Patterns are
+   * matched against the resolved on-disk path of the imported file
+   * relative to the package root.
+   *
+   * Use this when your project ships barrel files on purpose - for
+   * example a published component library's `src/index.ts`, or a
+   * shared `apps/web/src/components/ui/index.ts` whose ordering /
+   * grouping is part of the team contract.
+   *
+   * Globs accept `*`, `**`, and `?`. Case sensitivity follows the
+   * host filesystem - case-sensitive on POSIX (Linux) and
+   * case-insensitive on Windows and the default macOS volume formats.
+   */
+  barrelAllowlist?: string[];
   /**
    * Redirect react-doctor at a different project directory than the one
    * it was invoked against. Resolved relative to the location of the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -2634,8 +2637,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3834,8 +3837,8 @@ snapshots:
       '@babel/parser': 7.29.0
       eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4705,8 +4708,8 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
First of a three-PR split of #286 ("Support mature-codebase adoption workflows natively"). This one lands the foundational config surface; the next two stack on top of it.

## Why this PR exists

Three independent config knobs grouped on a shared zod-based validator. None of these change the scan execution path — they affect config loading, project orchestration, and one rule's allowlist.

## What's in it

### `extends` — config inheritance

```json
{
  "extends": ["../../react-doctor.base.json"],
  "customRulesOnly": true
}
```

- One or more parent configs, string or string array. Each parent can itself extend further.
- Cycle and depth guards (max 16) keep pathological configs from hanging the loader.
- Semantics match `tsconfig` / `eslint`: later entries override earlier ones on scalar conflicts; arrays concat + dedupe; nested objects merge field-by-field; the current config always wins over anything it extends.
- Tests cover deep chains, missing parents, array concat, and cycle breakage through symlinked directories.

### zod-based validation framework

Replaces ~280 lines of hand-rolled `typeof === "..."` / `Array.isArray` / `isPlainObject` checks in `validate-config-types.ts` with a declarative zod schema map.

- One `FieldDescriptor` entry per `ReactDoctorConfig` field (`{ expectedDescription, schema }`).
- One `parseFieldOrWarn` helper preserves the exact stderr message shape the existing `--json` mode and the 14 `validate-config-types` tests rely on (`config field "X" must be …; ignoring this field`).
- `filteringArrayTransform` higher-order helper unifies the drop-and-warn-but-keep-valid-siblings semantics across `extends`, `barrelAllowlist`, and the surface include/exclude lists.
- 8 boolean fields generated from a single array instead of being hand-spelled three times each.
- `zod ^4` added as a dependency of `@react-doctor/core`.

### `concurrency` — parallel runner

```bash
react-doctor . --concurrency 4
```

- `--concurrency <n>` CLI flag + top-level `concurrency` config field.
- Workspace projects scan in parallel via `runWithConcurrency` (output ordering preserved).
- Default `1`; clamped to `[1, 32]`.

### `barrelAllowlist` — `no-barrel-import` allowlist

```json
{
  "barrelAllowlist": ["packages/*/src/index.ts", "src/components/ui/index.ts"]
}
```

- Globs matched against the resolved barrel index file's project-relative path.
- The rule reads the list from plugin settings and skips reports against any matching barrel.
- Differs from `ignore.overrides[].rules`: this keys on the *imported barrel* path (one entry exempts every importer), whereas the override system keys on the *importer* (one entry per importer file).

## Stats

- 20 new tests across `extends-config`, `merge-configs`, `validate-config-types`, `matches-barrel-allowlist`, and `run-with-concurrency`.
- All 1192 tests passing; lint / typecheck / format clean.

## What's NOT in this PR

- Baseline mode — in stacked PR 2.
- Touched-line enforcement — in stacked PR 2.
- PR comment markdown / sticky comment integration — in stacked PR 3.
- `action.yml` knob additions for the new inputs — in stacked PRs 2/3.

Originally landed as part of #286; that PR is being closed in favor of this 3-way split.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8eecf781-816d-46db-a233-a077ad28675b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8eecf781-816d-46db-a233-a077ad28675b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

