### PR TITLE
feat: first-class PR comment markdown via `--pr-comment-output`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -101,21 +101,27 @@ runs:
         esac
 
         OUTPUT_FILE="${RUNNER_TEMP:-/tmp}/react-doctor-output-${GITHUB_RUN_ID:-$$}.txt"
+        MARKDOWN_FILE="${RUNNER_TEMP:-/tmp}/react-doctor-comment-${GITHUB_RUN_ID:-$$}.md"
         echo "REACT_DOCTOR_OUTPUT_FILE=$OUTPUT_FILE" >> "$GITHUB_ENV"
+        echo "REACT_DOCTOR_MARKDOWN_FILE=$MARKDOWN_FILE" >> "$GITHUB_ENV"
 
         if [ -n "$INPUT_GITHUB_TOKEN" ]; then
-          # --pr-comment demotes weak-signal rule families (default:
-          # `design` tag) from the printed output and the fail-on gate
-          # so style cleanup doesn't dilute meaningful React findings
-          # in the sticky PR comment. Configure overrides via
-          # config.surfaces.{prComment,ciFailure} in react-doctor.config.json.
+          # Single scan, two outputs:
+          # - stdout: human-readable diagnostics for the build log
+          #   (piped through a sed that strips GitHub `::error`/`::warning`
+          #   workflow commands; the runner still parses those from the
+          #   live step log).
+          # - $MARKDOWN_FILE: structured sticky-comment markdown written
+          #   as a side effect via `--pr-comment-output`.
+          # `set +e`/PIPESTATUS preserves the scan's exit code through the
+          # `| tee` pipeline so a failing scan still fails the composite
+          # action - while letting the sticky-comment markdown land first.
           RAW_FILE="${RUNNER_TEMP:-/tmp}/react-doctor-raw-${GITHUB_RUN_ID:-$$}.txt"
           set +e
-          npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}" --pr-comment | tee "$RAW_FILE"
+          npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}" \
+            --pr-comment --pr-comment-output "$MARKDOWN_FILE" | tee "$RAW_FILE"
           PIPELINE_EXIT_CODES=("${PIPESTATUS[@]}")
           set -e
-          # Strip annotation workflow commands from the PR-comment body;
-          # the runner still parses them from the live step log.
           sed -E '/^::(error|warning) /d' "$RAW_FILE" > "$OUTPUT_FILE"
           if [ "${PIPELINE_EXIT_CODES[1]}" -ne 0 ]; then exit "${PIPELINE_EXIT_CODES[1]}"; fi
           exit "${PIPELINE_EXIT_CODES[0]}"
@@ -146,25 +152,41 @@ runs:
       uses: actions/github-script@v7
       env:
         REACT_DOCTOR_OUTPUT_FILE: ${{ env.REACT_DOCTOR_OUTPUT_FILE }}
+        REACT_DOCTOR_MARKDOWN_FILE: ${{ env.REACT_DOCTOR_MARKDOWN_FILE }}
         REACT_DOCTOR_SCORE: ${{ steps.score.outputs.score }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
           const fs = require("fs");
-          const path = process.env.REACT_DOCTOR_OUTPUT_FILE;
-          if (!path || !fs.existsSync(path)) return;
-          const output = fs.readFileSync(path, "utf8").trim();
-          if (!output) return;
-
-          const score = process.env.REACT_DOCTOR_SCORE;
-          const scoreLine =
-            score && /^[0-9]+$/.test(score)
-              ? `**Score:** \`${score}\` / 100\n\n`
-              : "";
-
           const marker = "<!-- react-doctor -->";
-          const fence = "````";
-          const body = `${marker}\n## React Doctor\n\n${scoreLine}${fence}\n${output}\n${fence}`;
+
+          // Prefer the CLI's first-class sticky-comment markdown when
+          // it produced a non-empty document - it ships per-rule
+          // <details>, per-package summaries, baseline framing, and
+          // suppression snippets straight out of the CLI. Fall back to
+          // the legacy plaintext-in-fence layout when the markdown
+          // capture wasn't generated (older react-doctor versions).
+          const markdownPath = process.env.REACT_DOCTOR_MARKDOWN_FILE;
+          let body = null;
+          if (markdownPath && fs.existsSync(markdownPath)) {
+            const markdown = fs.readFileSync(markdownPath, "utf8").trim();
+            if (markdown.startsWith(marker)) body = markdown;
+          }
+          if (!body) {
+            const outputPath = process.env.REACT_DOCTOR_OUTPUT_FILE;
+            if (!outputPath || !fs.existsSync(outputPath)) return;
+            const output = fs.readFileSync(outputPath, "utf8").trim();
+            if (!output) return;
+
+            const score = process.env.REACT_DOCTOR_SCORE;
+            const scoreLine =
+              score && /^[0-9]+$/.test(score)
+                ? `**Score:** \`${score}\` / 100\n\n`
+                : "";
+
+            const fence = "````";
+            body = `${marker}\n## React Doctor\n\n${scoreLine}${fence}\n${output}\n${fence}`;
+          }
 
           const { data: comments } = await github.rest.issues.listComments({
             ...context.repo,

--- a/packages/core/src/build-json-report.ts
+++ b/packages/core/src/build-json-report.ts
@@ -27,7 +27,7 @@ const toJsonDiff = (diff: DiffInfo | null): JsonReportDiffInfo | null => {
   };
 };
 
-const findWorstScoredProject = (
+export const findWorstScoredProject = (
   projects: JsonReportProjectEntry[],
 ): JsonReportProjectEntry | null => {
   let worst: JsonReportProjectEntry | null = null;

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs";
+import fs, { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
@@ -19,7 +19,8 @@ import {
 } from "@react-doctor/core";
 import type { TouchedLinesByFile } from "@react-doctor/core";
 import { inspect } from "../../inspect.js";
-import type { Diagnostic, DiffInfo, InspectResult } from "@react-doctor/types";
+import type { Diagnostic, DiffInfo, InspectResult, JsonReport } from "@react-doctor/types";
+import { buildPrCommentMarkdown } from "../utils/build-pr-comment-markdown.js";
 import { STAGED_FILES_TEMP_DIR_PREFIX } from "../utils/constants.js";
 import { getStagedSourceFiles, materializeStagedFiles } from "../utils/get-staged-files.js";
 import type { InspectFlags } from "../utils/inspect-flags.js";
@@ -44,8 +45,23 @@ import { runWithConcurrency } from "../utils/run-with-concurrency.js";
 import { selectProjects } from "../utils/select-projects.js";
 import { shouldFailForDiagnostics } from "../utils/should-fail-for-diagnostics.js";
 import { shouldSkipPrompts } from "../utils/should-skip-prompts.js";
+import { setSpinnerSilent } from "../utils/spinner.js";
 import { validateModeFlags } from "../utils/validate-mode-flags.js";
 import { VERSION } from "../utils/version.js";
+
+const writePrCommentMarkdownIfRequested = (
+  outputPath: string | undefined,
+  report: JsonReport,
+  baseDirectory: string,
+): void => {
+  if (!outputPath) return;
+  const markdown = buildPrCommentMarkdown(report, { baseDirectory });
+  const directory = path.dirname(outputPath);
+  if (directory && directory !== "." && !fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  fs.writeFileSync(outputPath, `${markdown}\n`);
+};
 
 const resolveTouchedLinesByFile = (
   projectDirectory: string,
@@ -64,6 +80,7 @@ const resolveTouchedLinesByFile = (
 export const inspectAction = async (directory: string, flags: InspectFlags): Promise<void> => {
   const isScoreOnly = Boolean(flags.score);
   const isJsonMode = Boolean(flags.json);
+  const prCommentOutput = flags.prCommentOutput;
   const isQuiet = isScoreOnly || isJsonMode;
   const requestedDirectory = path.resolve(directory);
   const startTime = performance.now();
@@ -71,6 +88,10 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
   if (isJsonMode) {
     enableJsonMode({ compact: Boolean(flags.jsonCompact), directory: requestedDirectory });
   }
+  // `--pr-comment-output` writes a side file; suppress the spinner
+  // so it doesn't intersperse with the CLI's stdout output. Logger
+  // is left alone - users still want to see the build-log summary.
+  if (prCommentOutput) setSpinnerSilent(true);
 
   try {
     validateModeFlags(flags);
@@ -117,18 +138,19 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       setJsonReportMode("staged");
       const stagedFiles = getStagedSourceFiles(resolvedDirectory);
       if (stagedFiles.length === 0) {
-        if (isJsonMode) {
-          writeJsonReport(
-            buildJsonReport({
-              version: VERSION,
-              directory: resolvedDirectory,
-              mode: "staged",
-              diff: null,
-              scans: [],
-              totalElapsedMilliseconds: performance.now() - startTime,
-            }),
-          );
-        } else if (!isScoreOnly) {
+        if (isJsonMode || prCommentOutput) {
+          const emptyReport = buildJsonReport({
+            version: VERSION,
+            directory: resolvedDirectory,
+            mode: "staged",
+            diff: null,
+            scans: [],
+            totalElapsedMilliseconds: performance.now() - startTime,
+          });
+          if (isJsonMode) writeJsonReport(emptyReport);
+          writePrCommentMarkdownIfRequested(prCommentOutput, emptyReport, resolvedDirectory);
+        }
+        if (!isQuiet && !isScoreOnly) {
           logger.dim("No staged source files found.");
         }
         return;
@@ -181,7 +203,8 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         const remappedDiagnostics = scanResult.diagnostics.map(remapDiagnostic);
         const remappedBaselineDiagnostics = scanResult.baselineDiagnostics?.map(remapDiagnostic);
 
-        if (isJsonMode) {
+        const needsStagedAggregatedReport = isJsonMode || prCommentOutput;
+        if (needsStagedAggregatedReport) {
           const remappedInspectResult: InspectResult = {
             ...scanResult,
             diagnostics: remappedDiagnostics,
@@ -190,16 +213,16 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
               ? { baselineDiagnostics: remappedBaselineDiagnostics }
               : {}),
           };
-          writeJsonReport(
-            buildJsonReport({
-              version: VERSION,
-              directory: resolvedDirectory,
-              mode: "staged",
-              diff: null,
-              scans: [{ directory: resolvedDirectory, result: remappedInspectResult }],
-              totalElapsedMilliseconds: performance.now() - startTime,
-            }),
-          );
+          const stagedReport = buildJsonReport({
+            version: VERSION,
+            directory: resolvedDirectory,
+            mode: "staged",
+            diff: null,
+            scans: [{ directory: resolvedDirectory, result: remappedInspectResult }],
+            totalElapsedMilliseconds: performance.now() - startTime,
+          });
+          if (isJsonMode) writeJsonReport(stagedReport);
+          writePrCommentMarkdownIfRequested(prCommentOutput, stagedReport, resolvedDirectory);
         }
 
         if (flags.updateBaseline) {
@@ -395,17 +418,18 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       }
     }
 
-    if (isJsonMode) {
-      writeJsonReport(
-        buildJsonReport({
-          version: VERSION,
-          directory: resolvedDirectory,
-          mode: isDiffMode ? "diff" : "full",
-          diff: isDiffMode ? diffInfo : null,
-          scans: completedScans,
-          totalElapsedMilliseconds: performance.now() - startTime,
-        }),
-      );
+    let aggregatedReport: JsonReport | null = null;
+    if (isJsonMode || prCommentOutput) {
+      aggregatedReport = buildJsonReport({
+        version: VERSION,
+        directory: resolvedDirectory,
+        mode: isDiffMode ? "diff" : "full",
+        diff: isDiffMode ? diffInfo : null,
+        scans: completedScans,
+        totalElapsedMilliseconds: performance.now() - startTime,
+      });
+      if (isJsonMode) writeJsonReport(aggregatedReport);
+      writePrCommentMarkdownIfRequested(prCommentOutput, aggregatedReport, resolvedDirectory);
     }
 
     if (flags.annotations) {

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -53,6 +53,10 @@ const program = new Command()
   )
   .option("--concurrency <n>", "scan up to N workspace projects in parallel (default: 1)")
   .option(
+    "--pr-comment-output <path>",
+    "write a sticky-PR-comment-ready markdown document to this file as a side effect of the scan (compose with --pr-comment for the build-log plaintext)",
+  )
+  .option(
     "--explain <file:line>",
     "diagnose why a rule fired or why a suppression didn't apply at a specific location",
   )

--- a/packages/react-doctor/src/cli/utils/build-pr-comment-markdown.ts
+++ b/packages/react-doctor/src/cli/utils/build-pr-comment-markdown.ts
@@ -1,0 +1,200 @@
+import path from "node:path";
+import { findWorstScoredProject } from "@react-doctor/core";
+import type { Diagnostic, JsonReport, JsonReportProjectEntry } from "@react-doctor/types";
+
+const PR_COMMENT_MARKER = "<!-- react-doctor -->";
+const MAX_INLINE_DIAGNOSTICS = 25;
+const MAX_PROJECTS_LISTED = 12;
+
+interface RuleGroup {
+  ruleKey: string;
+  diagnostics: Diagnostic[];
+}
+
+const groupDiagnosticsByRule = (diagnostics: Diagnostic[]): RuleGroup[] => {
+  const groupsByKey = new Map<string, Diagnostic[]>();
+  for (const diagnostic of diagnostics) {
+    const ruleKey = `${diagnostic.plugin}/${diagnostic.rule}`;
+    const collected = groupsByKey.get(ruleKey);
+    if (collected) {
+      collected.push(diagnostic);
+    } else {
+      groupsByKey.set(ruleKey, [diagnostic]);
+    }
+  }
+  return [...groupsByKey.entries()]
+    .map(([ruleKey, ruleDiagnostics]) => ({ ruleKey, diagnostics: ruleDiagnostics }))
+    .sort(
+      (firstGroup, secondGroup) => secondGroup.diagnostics.length - firstGroup.diagnostics.length,
+    );
+};
+
+const formatScoreLine = (project: JsonReportProjectEntry | null): string => {
+  if (!project?.score) return "";
+  return `**Score:** \`${project.score.score}\` / 100 (${project.score.label})\n\n`;
+};
+
+const formatHeader = (report: JsonReport): string => {
+  const newCount = report.summary.totalDiagnosticCount;
+  const baselineCount = report.summary.baselineDiagnosticCount;
+
+  if (newCount === 0 && baselineCount === 0) {
+    return `## React Doctor
+
+No issues found.`;
+  }
+
+  if (newCount === 0 && baselineCount > 0) {
+    return `## React Doctor
+
+${baselineCount} known baseline issue${baselineCount === 1 ? "" : "s"} - **no new violations introduced by this PR.**`;
+  }
+
+  const newLabel = `${newCount} new issue${newCount === 1 ? "" : "s"}`;
+  const baselineLabel = baselineCount > 0 ? ` (plus ${baselineCount} baseline)` : "";
+  return `## React Doctor
+
+${newLabel}${baselineLabel}.`;
+};
+
+const formatRelativeFilePath = (filePath: string, baseDirectory: string): string => {
+  if (!path.isAbsolute(filePath)) return filePath.split(path.sep).join("/");
+  return path.relative(baseDirectory, filePath).split(path.sep).join("/");
+};
+
+const formatDiagnosticBullet = (diagnostic: Diagnostic, baseDirectory: string): string => {
+  const filePathLabel = formatRelativeFilePath(diagnostic.filePath, baseDirectory);
+  const positionLabel = diagnostic.line > 0 ? `${filePathLabel}:${diagnostic.line}` : filePathLabel;
+  const severityIcon = diagnostic.severity === "error" ? "❌" : "⚠️";
+  const sanitizedMessage = diagnostic.message.replace(/\s+/g, " ").trim();
+  return `- ${severityIcon} \`${positionLabel}\` - ${sanitizedMessage}`;
+};
+
+const formatProjectSummary = (project: JsonReportProjectEntry, baseDirectory: string): string => {
+  const score = project.score ? `${project.score.score}/100` : "-";
+  const newCount = project.diagnostics.length;
+  const baselineCount = project.baselineDiagnostics?.length ?? 0;
+  const projectLabel =
+    project.project.projectName ||
+    formatRelativeFilePath(project.directory, baseDirectory) ||
+    "(root)";
+  const newPart = newCount === 0 ? "no new" : `${newCount} new`;
+  const baselinePart = baselineCount > 0 ? `, ${baselineCount} baseline` : "";
+  return `- **${projectLabel}** - score ${score}, ${newPart}${baselinePart}`;
+};
+
+const formatPerProjectSection = (report: JsonReport, baseDirectory: string): string => {
+  if (report.projects.length <= 1) return "";
+  const projectsToShow = report.projects.slice(0, MAX_PROJECTS_LISTED);
+  const overflowCount = Math.max(0, report.projects.length - projectsToShow.length);
+  const lines = projectsToShow.map((project) => formatProjectSummary(project, baseDirectory));
+  if (overflowCount > 0) {
+    lines.push(
+      `- _+${overflowCount} more workspace project${overflowCount === 1 ? "" : "s"} not shown_`,
+    );
+  }
+  return `\n\n### Per-package summary\n\n${lines.join("\n")}`;
+};
+
+const formatRiskyFixSuppressionHint = (diagnostic: Diagnostic): string => {
+  // HACK: per-rule suppression snippet for the diagnostic - keeps PR
+  // comments actionable without forcing every user to open the docs.
+  if (diagnostic.suppressionHint) return diagnostic.suppressionHint;
+  const ruleKey = `${diagnostic.plugin}/${diagnostic.rule}`;
+  return `// eslint-disable-next-line ${ruleKey} -- intentional`;
+};
+
+const formatDiagnosticsSection = (diagnostics: Diagnostic[], baseDirectory: string): string => {
+  if (diagnostics.length === 0) return "";
+  const groups = groupDiagnosticsByRule(diagnostics);
+  let renderedCount = 0;
+  let diagnosticsAccountedForCount = 0;
+  const sections: string[] = [];
+  for (const group of groups) {
+    const { ruleKey: ruleLabel, diagnostics: groupDiagnostics } = group;
+    const groupDiagnosticCount = groupDiagnostics.length;
+    const bullets: string[] = [];
+    for (const diagnostic of groupDiagnostics) {
+      if (renderedCount >= MAX_INLINE_DIAGNOSTICS) break;
+      bullets.push(formatDiagnosticBullet(diagnostic, baseDirectory));
+      renderedCount += 1;
+    }
+    if (bullets.length === 0) break;
+    const remainderCount = groupDiagnosticCount - bullets.length;
+    const remainderNote = remainderCount > 0 ? `\n- _+${remainderCount} more in this rule_` : "";
+    const suppressionHint = formatRiskyFixSuppressionHint(groupDiagnostics[0]);
+    sections.push(
+      `<details>
+<summary><b>${ruleLabel}</b> · ${groupDiagnosticCount} occurrence${groupDiagnosticCount === 1 ? "" : "s"}</summary>
+
+${bullets.join("\n")}${remainderNote}
+
+Suppress with: \`${suppressionHint}\`
+</details>`,
+    );
+    // The whole group is "accounted for" once its <summary> + remainder
+    // line surface its full diagnostic count, even when only the first
+    // few bullets are rendered. The footer's "N hidden" should count
+    // ONLY rule groups that didn't make it into `sections` at all -
+    // otherwise the same diagnostics show up twice (once in the
+    // group's "+N more in this rule" line, once in the footer).
+    diagnosticsAccountedForCount += groupDiagnosticCount;
+    if (renderedCount >= MAX_INLINE_DIAGNOSTICS) break;
+  }
+  const overflowCount = diagnostics.length - diagnosticsAccountedForCount;
+  const overflowNote =
+    overflowCount > 0
+      ? `\n\n> _${overflowCount} more finding${overflowCount === 1 ? "" : "s"} hidden - run \`npx react-doctor@latest .\` locally for the full list._`
+      : "";
+  return `\n\n### Findings\n\n${sections.join("\n\n")}${overflowNote}`;
+};
+
+const formatFooter = (report: JsonReport): string => {
+  const lines: string[] = [];
+  if (report.diff) {
+    const diffLabel = report.diff.isCurrentChanges
+      ? "uncommitted changes"
+      : `${report.diff.currentBranch} → ${report.diff.baseBranch}`;
+    lines.push(
+      `Scanned ${diffLabel} (${report.diff.changedFileCount} file${report.diff.changedFileCount === 1 ? "" : "s"}).`,
+    );
+  }
+  const touchedLinesHidden = report.projects.reduce(
+    (totalHidden, project) => totalHidden + (project.diagnosticsHiddenByTouchedLines ?? 0),
+    0,
+  );
+  if (touchedLinesHidden > 0) {
+    lines.push(
+      `${touchedLinesHidden} diagnostic${touchedLinesHidden === 1 ? "" : "s"} hidden by touched-line filtering.`,
+    );
+  }
+  if (lines.length === 0) return "";
+  return `\n\n<sub>${lines.join(" · ")}</sub>`;
+};
+
+/**
+ * Render a JSON report as sticky-comment-ready markdown. Emits a
+ * leading HTML marker (`<!-- react-doctor -->`) so a GitHub Action
+ * comment-updater can find and replace its previous post idempotently
+ * - the same marker `action.yml` looks for when locating the existing
+ * comment.
+ */
+export const buildPrCommentMarkdown = (
+  report: JsonReport,
+  options: { baseDirectory?: string } = {},
+): string => {
+  const baseDirectory = options.baseDirectory ?? report.directory;
+  const headlineProject = findWorstScoredProject(report.projects);
+  const sections: string[] = [PR_COMMENT_MARKER, formatHeader(report)];
+  const scoreLine = formatScoreLine(headlineProject);
+  if (scoreLine.length > 0) {
+    sections.push(scoreLine.trimEnd());
+  }
+  const perProjectSection = formatPerProjectSection(report, baseDirectory);
+  if (perProjectSection) sections.push(perProjectSection.trimStart());
+  const diagnosticsSection = formatDiagnosticsSection(report.diagnostics, baseDirectory);
+  if (diagnosticsSection) sections.push(diagnosticsSection.trimStart());
+  const footer = formatFooter(report);
+  if (footer) sections.push(footer.trimStart());
+  return sections.join("\n\n");
+};

--- a/packages/react-doctor/src/cli/utils/inspect-flags.ts
+++ b/packages/react-doctor/src/cli/utils/inspect-flags.ts
@@ -32,4 +32,15 @@ export interface InspectFlags {
   touchedLines?: boolean;
   /** Maximum number of workspace projects to scan in parallel. */
   concurrency?: string;
+  /**
+   * When set, write the sticky-PR-comment-ready markdown document
+   * (with the `<!-- react-doctor -->` marker, per-rule `<details>`
+   * groups, suppression snippets, per-package summary, and baseline
+   * framing) to this file as a side effect of the normal scan.
+   *
+   * The CLI's main stdout output is unaffected, so the same invocation
+   * can `| tee` the human-readable plaintext into a build log while
+   * the action posts the markdown file as a sticky comment.
+   */
+  prCommentOutput?: string;
 }

--- a/packages/react-doctor/tests/build-pr-comment-markdown.test.ts
+++ b/packages/react-doctor/tests/build-pr-comment-markdown.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vite-plus/test";
+import type {
+  Diagnostic,
+  JsonReport,
+  JsonReportProjectEntry,
+  ProjectInfo,
+} from "@react-doctor/types";
+import { buildPrCommentMarkdown } from "../src/cli/utils/build-pr-comment-markdown.js";
+
+const sampleProjectInfo: ProjectInfo = {
+  rootDirectory: "/repo/apps/web",
+  projectName: "apps/web",
+  reactVersion: "19.0.0",
+  reactMajorVersion: 19,
+  tailwindVersion: null,
+  framework: "nextjs",
+  hasTypeScript: true,
+  hasReactCompiler: false,
+  hasTanStackQuery: false,
+  hasReactNativeWorkspace: false,
+  sourceFileCount: 200,
+};
+
+const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: "/repo/apps/web/src/App.tsx",
+  plugin: "react-doctor",
+  rule: "no-array-index-as-key",
+  severity: "error",
+  message: "Array index used as React key",
+  help: "",
+  line: 12,
+  column: 4,
+  category: "Correctness",
+  ...overrides,
+});
+
+const buildProjectEntry = (
+  overrides: Partial<JsonReportProjectEntry> = {},
+): JsonReportProjectEntry => ({
+  directory: "/repo/apps/web",
+  project: sampleProjectInfo,
+  diagnostics: [],
+  score: { score: 86, label: "Great" },
+  skippedChecks: [],
+  elapsedMilliseconds: 1234,
+  ...overrides,
+});
+
+const buildJsonReport = (overrides: Partial<JsonReport>): JsonReport => ({
+  schemaVersion: 1,
+  version: "0.0.0",
+  ok: true,
+  directory: "/repo",
+  mode: "full",
+  diff: null,
+  projects: [],
+  diagnostics: [],
+  summary: {
+    errorCount: 0,
+    warningCount: 0,
+    affectedFileCount: 0,
+    totalDiagnosticCount: 0,
+    score: null,
+    scoreLabel: null,
+    baselineDiagnosticCount: 0,
+  },
+  elapsedMilliseconds: 1000,
+  error: null,
+  ...overrides,
+});
+
+describe("buildPrCommentMarkdown", () => {
+  it("emits a sticky-comment marker on the first line", () => {
+    const markdown = buildPrCommentMarkdown(buildJsonReport({}));
+    expect(markdown.startsWith("<!-- react-doctor -->")).toBe(true);
+  });
+
+  it("renders a celebratory message when there are no diagnostics", () => {
+    const markdown = buildPrCommentMarkdown(buildJsonReport({}));
+    expect(markdown).toContain("No issues found.");
+  });
+
+  it("frames the comment as no-new-violations when only baseline issues remain", () => {
+    const markdown = buildPrCommentMarkdown(
+      buildJsonReport({
+        summary: {
+          errorCount: 0,
+          warningCount: 0,
+          affectedFileCount: 0,
+          totalDiagnosticCount: 0,
+          score: 70,
+          scoreLabel: "Needs work",
+          baselineDiagnosticCount: 9,
+        },
+      }),
+    );
+    expect(markdown).toContain("no new violations introduced by this PR");
+  });
+
+  it("groups diagnostics by rule and includes a suppression snippet", () => {
+    const errorDiagnostic = buildDiagnostic();
+    const warningDiagnostic = buildDiagnostic({
+      severity: "warning",
+      rule: "no-direct-state-mutation",
+      message: "Direct state mutation",
+      filePath: "/repo/apps/web/src/Other.tsx",
+      line: 4,
+    });
+    const project = buildProjectEntry({ diagnostics: [errorDiagnostic, warningDiagnostic] });
+    const markdown = buildPrCommentMarkdown(
+      buildJsonReport({
+        projects: [project],
+        diagnostics: [errorDiagnostic, warningDiagnostic],
+        summary: {
+          errorCount: 1,
+          warningCount: 1,
+          affectedFileCount: 2,
+          totalDiagnosticCount: 2,
+          score: 86,
+          scoreLabel: "Great",
+          baselineDiagnosticCount: 0,
+        },
+      }),
+      { baseDirectory: "/repo" },
+    );
+    expect(markdown).toContain("react-doctor/no-array-index-as-key");
+    expect(markdown).toContain("react-doctor/no-direct-state-mutation");
+    expect(markdown).toContain("`apps/web/src/App.tsx:12`");
+    expect(markdown).toContain("Suppress with:");
+  });
+
+  it("does not double-count partially-rendered groups in the overflow footer", () => {
+    // 30 diagnostics under one rule: the bullet list caps at
+    // MAX_INLINE_DIAGNOSTICS (25), so the group's <summary> claims
+    // "30 occurrences" with an inline "+5 more in this rule" line.
+    // The footer must NOT then claim "5 more findings hidden" - that
+    // would double-count the same 5 diagnostics.
+    const manyDiagnostics: Diagnostic[] = Array.from({ length: 30 }, (_, index) =>
+      buildDiagnostic({ line: index + 1 }),
+    );
+    const markdown = buildPrCommentMarkdown(
+      buildJsonReport({
+        projects: [buildProjectEntry({ diagnostics: manyDiagnostics })],
+        diagnostics: manyDiagnostics,
+        summary: {
+          errorCount: 30,
+          warningCount: 0,
+          affectedFileCount: 1,
+          totalDiagnosticCount: 30,
+          score: 70,
+          scoreLabel: "Needs work",
+          baselineDiagnosticCount: 0,
+        },
+      }),
+    );
+    expect(markdown).toContain("+5 more in this rule");
+    expect(markdown).not.toContain("findings hidden");
+  });
+
+  it("renders a per-package section for monorepos with multiple projects", () => {
+    const projectA = buildProjectEntry({
+      directory: "/repo/apps/web",
+      project: { ...sampleProjectInfo, projectName: "apps/web" },
+      diagnostics: [buildDiagnostic()],
+      score: { score: 72, label: "Needs work" },
+    });
+    const projectB = buildProjectEntry({
+      directory: "/repo/packages/ui",
+      project: {
+        ...sampleProjectInfo,
+        projectName: "packages/ui",
+        rootDirectory: "/repo/packages/ui",
+      },
+      diagnostics: [],
+      score: { score: 95, label: "Excellent" },
+    });
+    const markdown = buildPrCommentMarkdown(
+      buildJsonReport({
+        projects: [projectA, projectB],
+        diagnostics: [buildDiagnostic()],
+        summary: {
+          errorCount: 1,
+          warningCount: 0,
+          affectedFileCount: 1,
+          totalDiagnosticCount: 1,
+          score: 72,
+          scoreLabel: "Needs work",
+          baselineDiagnosticCount: 0,
+        },
+      }),
+      { baseDirectory: "/repo" },
+    );
+    expect(markdown).toContain("Per-package summary");
+    expect(markdown).toContain("apps/web");
+    expect(markdown).toContain("packages/ui");
+  });
+
+  it("notes when touched-line filtering hid diagnostics", () => {
+    const project = buildProjectEntry({
+      diagnostics: [],
+      diagnosticsHiddenByTouchedLines: 5,
+    });
+    const markdown = buildPrCommentMarkdown(
+      buildJsonReport({
+        projects: [project],
+        diagnostics: [],
+      }),
+    );
+    expect(markdown).toContain("hidden by touched-line filtering");
+  });
+});

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -66,7 +66,9 @@ describe("GitHub Action contract", () => {
     );
 
     expect(scanStep).toContain('if [ -n "$INPUT_GITHUB_TOKEN" ]; then');
-    expect(scanStep).toContain('"${FLAGS[@]}" --pr-comment | tee "$RAW_FILE"');
+    expect(scanStep).toContain(
+      '"${FLAGS[@]}" \\ --pr-comment --pr-comment-output "$MARKDOWN_FILE" | tee "$RAW_FILE"',
+    );
     expect(scanStep).toContain('PIPELINE_EXIT_CODES=("${PIPESTATUS[@]}")');
     expect(scanStep).toContain('sed -E \'/^::(error|warning) /d\' "$RAW_FILE" > "$OUTPUT_FILE"');
     expect(scanStep).toContain('exit "${PIPELINE_EXIT_CODES[0]}"');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Third and final PR of the #286 split. **Stacked on #288 (`cursor/baseline-and-touched-lines-675b`)**, which is itself stacked on #287. Merge order: #287 → #288 → this PR.

## What's new

### `--pr-comment-output <path>`

```bash
react-doctor . --pr-comment --pr-comment-output ./comment.md | tee ./build-log.txt
```

One scan, two outputs:

- **stdout** — the legacy `--pr-comment` plaintext for the build log.
- **file** — a sticky-PR-comment-ready markdown document written as a side effect.

The action.yml previously had to invoke `npx react-doctor@latest` *twice* (once for plaintext, once for markdown). Now it's a single invocation.

### `buildPrCommentMarkdown(report)` — structured rendering

- Leading `<!-- react-doctor -->` marker so a GitHub Action comment-updater can idempotently replace its previous post.
- Per-rule `<details>` groups with severity icons, file:line references, and copy-pasteable `// eslint-disable-next-line …` suppression snippets.
- Per-package summary block for monorepos (worst-scored project drives the headline).
- Baseline-aware framing — `"no new violations introduced by this PR"` when only baseline issues remain, taken from #288's `JsonReportSummary.baselineDiagnosticCount`.
- Touched-lines footnote when filtering removed diagnostics (consumes #288's `diagnosticsHiddenByTouchedLines`).

### `action.yml` integration

```bash
RAW_FILE="${RUNNER_TEMP:-/tmp}/react-doctor-raw-${GITHUB_RUN_ID:-$$}.txt"
set +e
npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}" \
  --pr-comment --pr-comment-output "$MARKDOWN_FILE" | tee "$RAW_FILE"
PIPELINE_EXIT_CODES=("${PIPESTATUS[@]}")
set -e
sed -E '/^::(error|warning) /d' "$RAW_FILE" > "$OUTPUT_FILE"
if [ "${PIPELINE_EXIT_CODES[1]}" -ne 0 ]; then exit "${PIPELINE_EXIT_CODES[1]}"; fi
exit "${PIPELINE_EXIT_CODES[0]}"
```

The github-script step prefers the markdown file when available; it falls back to the legacy plaintext-in-fence layout when running against older `react-doctor` versions that don't ship `--pr-comment-output`.

## Stats

- 6 new tests in `build-pr-comment-markdown`.
- Updated `github-action` contract tests for the single-scan + `PIPESTATUS` preservation.
- All 1223 tests passing; lint / typecheck / format clean.

Originally landed as part of #286.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8eecf781-816d-46db-a233-a077ad28675b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8eecf781-816d-46db-a233-a077ad28675b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

