### PR TITLE
fix(project-info): make filesystem walks tolerate EPERM/EACCES (macOS Library)

### DIFF
--- a/packages/core/src/neutralize-disable-directives.ts
+++ b/packages/core/src/neutralize-disable-directives.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { readDirectoryEntries } from "@react-doctor/project-info";
 import {
   GIT_LS_FILES_MAX_BUFFER_BYTES,
   IGNORED_DIRECTORIES,
@@ -69,12 +70,7 @@ const findFilesWithDisableDirectivesViaFilesystem = (
   while (stack.length > 0) {
     const current = stack.pop();
     if (current === undefined) continue;
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(current, { withFileTypes: true });
-    } catch {
-      continue;
-    }
+    const entries = readDirectoryEntries(current);
     for (const entry of entries) {
       if (entry.isDirectory()) {
         if (entry.name.startsWith(".") || IGNORED_DIRECTORIES.has(entry.name)) continue;

--- a/packages/core/src/resolve-config-root-dir.ts
+++ b/packages/core/src/resolve-config-root-dir.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs";
 import path from "node:path";
+import { isDirectory } from "@react-doctor/project-info";
 import type { ReactDoctorConfig } from "@react-doctor/types";
 import { logger } from "./logger.js";
 
@@ -21,7 +21,7 @@ export const resolveConfigRootDir = (
 
   if (resolvedRootDir === configSourceDirectory) return null;
 
-  if (!fs.existsSync(resolvedRootDir) || !fs.statSync(resolvedRootDir).isDirectory()) {
+  if (!isDirectory(resolvedRootDir)) {
     logger.warn(
       `react-doctor config "rootDir" points to "${rawRootDir}" (resolved to ${resolvedRootDir}), which is not a directory. Ignoring.`,
     );

--- a/packages/core/src/utils/list-source-files.ts
+++ b/packages/core/src/utils/list-source-files.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { readDirectoryEntries } from "@react-doctor/project-info";
 import {
   GIT_LS_FILES_MAX_BUFFER_BYTES,
   IGNORED_DIRECTORIES,
@@ -38,7 +38,7 @@ const listSourceFilesViaFilesystem = (rootDirectory: string): string[] => {
 
   while (stack.length > 0) {
     const currentDirectory = stack.pop()!;
-    const entries = fs.readdirSync(currentDirectory, { withFileTypes: true });
+    const entries = readDirectoryEntries(currentDirectory);
 
     for (const entry of entries) {
       const absolutePath = path.join(currentDirectory, entry.name);

--- a/packages/project-info/src/count-source-files.ts
+++ b/packages/project-info/src/count-source-files.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import {
@@ -6,6 +5,7 @@ import {
   IGNORED_DIRECTORIES,
   SOURCE_FILE_PATTERN,
 } from "./constants.js";
+import { readDirectoryEntries } from "./utils/read-directory-entries.js";
 
 const countSourceFilesViaFilesystem = (rootDirectory: string): number => {
   let count = 0;
@@ -13,7 +13,7 @@ const countSourceFilesViaFilesystem = (rootDirectory: string): number => {
 
   while (stack.length > 0) {
     const currentDirectory = stack.pop()!;
-    const entries = fs.readdirSync(currentDirectory, { withFileTypes: true });
+    const entries = readDirectoryEntries(currentDirectory);
 
     for (const entry of entries) {
       if (entry.isDirectory()) {

--- a/packages/project-info/src/discover-react-subprojects.ts
+++ b/packages/project-info/src/discover-react-subprojects.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
 import path from "node:path";
 import { IGNORED_DIRECTORIES } from "./constants.js";
 import type { PackageJson, WorkspacePackage } from "@react-doctor/types";
+import { isDirectory } from "./utils/is-directory.js";
 import { isFile } from "./utils/is-file.js";
 import { readDirectoryEntries } from "./utils/read-directory-entries.js";
 import { getNxWorkspaceDirectories } from "./get-nx-workspace-directories.js";
@@ -85,7 +85,7 @@ const discoverReactSubprojectsByFilesystem = (rootDirectory: string): WorkspaceP
 };
 
 export const discoverReactSubprojects = (rootDirectory: string): WorkspacePackage[] => {
-  if (!fs.existsSync(rootDirectory) || !fs.statSync(rootDirectory).isDirectory()) return [];
+  if (!isDirectory(rootDirectory)) return [];
 
   const manifestPackages = listManifestWorkspacePackages(rootDirectory);
   if (manifestPackages.length > 0) return manifestPackages;

--- a/packages/project-info/src/discover-react-subprojects.ts
+++ b/packages/project-info/src/discover-react-subprojects.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { IGNORED_DIRECTORIES } from "./constants.js";
 import type { PackageJson, WorkspacePackage } from "@react-doctor/types";
 import { isFile } from "./utils/is-file.js";
+import { readDirectoryEntries } from "./utils/read-directory-entries.js";
 import { getNxWorkspaceDirectories } from "./get-nx-workspace-directories.js";
 import { hasReactDependency } from "./has-react-dependency.js";
 import { listWorkspacePackages } from "./list-workspace-packages.js";
@@ -63,9 +64,9 @@ const discoverReactSubprojectsByFilesystem = (rootDirectory: string): WorkspaceP
       }
     }
 
-    const entries = fs
-      .readdirSync(currentDirectory, { withFileTypes: true })
-      .toSorted((firstEntry, secondEntry) => firstEntry.name.localeCompare(secondEntry.name));
+    const entries = readDirectoryEntries(currentDirectory).toSorted((firstEntry, secondEntry) =>
+      firstEntry.name.localeCompare(secondEntry.name),
+    );
 
     for (const entry of entries) {
       if (

--- a/packages/project-info/src/get-nx-workspace-directories.ts
+++ b/packages/project-info/src/get-nx-workspace-directories.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { isFile } from "./utils/is-file.js";
+import { readDirectoryEntries } from "./utils/read-directory-entries.js";
 
 const NX_PROJECT_DISCOVERY_DIRS = ["apps", "libs", "packages"];
 
@@ -11,7 +12,7 @@ export const getNxWorkspaceDirectories = (rootDirectory: string): string[] => {
   for (const candidate of NX_PROJECT_DISCOVERY_DIRS) {
     const candidatePath = path.join(rootDirectory, candidate);
     if (!fs.existsSync(candidatePath) || !fs.statSync(candidatePath).isDirectory()) continue;
-    for (const entry of fs.readdirSync(candidatePath, { withFileTypes: true })) {
+    for (const entry of readDirectoryEntries(candidatePath)) {
       if (!entry.isDirectory()) continue;
       const projectDirectory = path.join(candidatePath, entry.name);
       if (

--- a/packages/project-info/src/get-nx-workspace-directories.ts
+++ b/packages/project-info/src/get-nx-workspace-directories.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs";
 import path from "node:path";
+import { isDirectory } from "./utils/is-directory.js";
 import { isFile } from "./utils/is-file.js";
 import { readDirectoryEntries } from "./utils/read-directory-entries.js";
 
@@ -11,7 +11,7 @@ export const getNxWorkspaceDirectories = (rootDirectory: string): string[] => {
   const collected: string[] = [];
   for (const candidate of NX_PROJECT_DISCOVERY_DIRS) {
     const candidatePath = path.join(rootDirectory, candidate);
-    if (!fs.existsSync(candidatePath) || !fs.statSync(candidatePath).isDirectory()) continue;
+    if (!isDirectory(candidatePath)) continue;
     for (const entry of readDirectoryEntries(candidatePath)) {
       if (!entry.isDirectory()) continue;
       const projectDirectory = path.join(candidatePath, entry.name);

--- a/packages/project-info/src/index.ts
+++ b/packages/project-info/src/index.ts
@@ -21,6 +21,7 @@ export {
 } from "./errors.js";
 export { isFile } from "./utils/is-file.js";
 export { isPlainObject } from "./utils/is-plain-object.js";
+export { readDirectoryEntries } from "./utils/read-directory-entries.js";
 export {
   GIT_LS_FILES_MAX_BUFFER_BYTES,
   IGNORED_DIRECTORIES,

--- a/packages/project-info/src/index.ts
+++ b/packages/project-info/src/index.ts
@@ -19,6 +19,7 @@ export {
   AmbiguousProjectError,
   isReactDoctorError,
 } from "./errors.js";
+export { isDirectory } from "./utils/is-directory.js";
 export { isFile } from "./utils/is-file.js";
 export { isPlainObject } from "./utils/is-plain-object.js";
 export { readDirectoryEntries } from "./utils/read-directory-entries.js";

--- a/packages/project-info/src/read-package-json.ts
+++ b/packages/project-info/src/read-package-json.ts
@@ -19,7 +19,12 @@ const readPackageJsonUncached = (packageJsonPath: string): PackageJson => {
     }
     if (error instanceof Error && "code" in error) {
       const { code } = error as { code: string };
-      if (code === "EISDIR" || code === "EACCES") {
+      // EISDIR — packageJsonPath unexpectedly pointed at a directory.
+      // EACCES / EPERM — POSIX denial and macOS TCC denial respectively
+      // (e.g., a package.json inside ~/Library/Accounts when the scan
+      // root is $HOME). ENOENT — file disappeared between the isFile()
+      // probe upstream and this read (race during long walks).
+      if (code === "EISDIR" || code === "EACCES" || code === "EPERM" || code === "ENOENT") {
         return {};
       }
     }

--- a/packages/project-info/src/resolve-workspace-directories.ts
+++ b/packages/project-info/src/resolve-workspace-directories.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs";
 import path from "node:path";
+import { isDirectory } from "./utils/is-directory.js";
 import { isFile } from "./utils/is-file.js";
 import { readDirectoryEntries } from "./utils/read-directory-entries.js";
 
@@ -8,7 +8,7 @@ export const resolveWorkspaceDirectories = (rootDirectory: string, pattern: stri
 
   if (!cleanPattern.includes("*")) {
     const directoryPath = path.join(rootDirectory, cleanPattern);
-    if (fs.existsSync(directoryPath) && isFile(path.join(directoryPath, "package.json"))) {
+    if (isDirectory(directoryPath) && isFile(path.join(directoryPath, "package.json"))) {
       return [directoryPath];
     }
     return [];
@@ -18,18 +18,14 @@ export const resolveWorkspaceDirectories = (rootDirectory: string, pattern: stri
   const baseDirectory = path.join(rootDirectory, cleanPattern.slice(0, wildcardIndex));
   const suffixAfterWildcard = cleanPattern.slice(wildcardIndex + 1);
 
-  if (!fs.existsSync(baseDirectory) || !fs.statSync(baseDirectory).isDirectory()) {
+  if (!isDirectory(baseDirectory)) {
     return [];
   }
 
   const resolved: string[] = [];
   for (const entry of readDirectoryEntries(baseDirectory)) {
     const entryPath = path.join(baseDirectory, entry.name, suffixAfterWildcard);
-    if (
-      fs.existsSync(entryPath) &&
-      fs.statSync(entryPath).isDirectory() &&
-      isFile(path.join(entryPath, "package.json"))
-    ) {
+    if (isDirectory(entryPath) && isFile(path.join(entryPath, "package.json"))) {
       resolved.push(entryPath);
     }
   }

--- a/packages/project-info/src/resolve-workspace-directories.ts
+++ b/packages/project-info/src/resolve-workspace-directories.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { isFile } from "./utils/is-file.js";
+import { readDirectoryEntries } from "./utils/read-directory-entries.js";
 
 export const resolveWorkspaceDirectories = (rootDirectory: string, pattern: string): string[] => {
   const cleanPattern = pattern.replace(/["']/g, "").replace(/\/\*\*$/, "/*");
@@ -22,8 +23,8 @@ export const resolveWorkspaceDirectories = (rootDirectory: string, pattern: stri
   }
 
   const resolved: string[] = [];
-  for (const entry of fs.readdirSync(baseDirectory)) {
-    const entryPath = path.join(baseDirectory, entry, suffixAfterWildcard);
+  for (const entry of readDirectoryEntries(baseDirectory)) {
+    const entryPath = path.join(baseDirectory, entry.name, suffixAfterWildcard);
     if (
       fs.existsSync(entryPath) &&
       fs.statSync(entryPath).isDirectory() &&

--- a/packages/project-info/src/utils/is-directory.ts
+++ b/packages/project-info/src/utils/is-directory.ts
@@ -1,0 +1,9 @@
+import fs from "node:fs";
+
+export const isDirectory = (directoryPath: string): boolean => {
+  try {
+    return fs.statSync(directoryPath).isDirectory();
+  } catch {
+    return false;
+  }
+};

--- a/packages/project-info/src/utils/read-directory-entries.ts
+++ b/packages/project-info/src/utils/read-directory-entries.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+
+const IGNORABLE_READDIR_ERROR_CODES = new Set(["EACCES", "EPERM", "ENOENT", "ENOTDIR"]);
+
+const isIgnorableReaddirError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) return false;
+  const errorCode = (error as NodeJS.ErrnoException).code;
+  return typeof errorCode === "string" && IGNORABLE_READDIR_ERROR_CODES.has(errorCode);
+};
+
+export const readDirectoryEntries = (directoryPath: string): fs.Dirent[] => {
+  try {
+    return fs.readdirSync(directoryPath, { withFileTypes: true });
+  } catch (error) {
+    if (isIgnorableReaddirError(error)) return [];
+    throw error;
+  }
+};

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -34,9 +34,12 @@ import {
   SPAWN_ARGS_MAX_LENGTH_CHARS,
 } from "@react-doctor/core";
 import {
+  clearPackageJsonCache,
   discoverProject,
   discoverReactSubprojects,
+  isDirectory,
   readDirectoryEntries,
+  readPackageJson,
 } from "@react-doctor/project-info";
 import {
   getStagedSourceFiles,
@@ -215,6 +218,54 @@ describe("issue #275 + #290: filesystem walks tolerate EPERM/EACCES (macOS Libra
       expect(subprojectNames).toContain("accessible-app");
     } finally {
       fs.chmodSync(unreadableSibling, 0o755);
+    }
+  });
+
+  // Same root cause as the readdir crash, one level deeper: when the
+  // walk reaches a package.json under a TCC-protected directory, the
+  // subsequent fs.readFileSync would throw EPERM and bring down the
+  // whole scan. Mirror EISDIR/EACCES handling for EPERM (macOS TCC)
+  // and ENOENT (race during long walks) so the unreadable manifest
+  // gets treated as an empty package.json instead of a fatal error.
+  it("readPackageJson returns {} for an unreadable manifest (EPERM/EACCES) on posix", () => {
+    if (process.platform === "win32") return;
+    if (process.getuid?.() === 0) return;
+
+    const projectDir = path.join(tempRoot, "issue-275-unreadable-manifest");
+    fs.mkdirSync(projectDir, { recursive: true });
+    const manifestPath = path.join(projectDir, "package.json");
+    writeJson(manifestPath, { name: "hidden", dependencies: { react: "^19.0.0" } });
+    clearPackageJsonCache();
+    fs.chmodSync(manifestPath, 0o000);
+    try {
+      expect(readPackageJson(manifestPath)).toEqual({});
+    } finally {
+      fs.chmodSync(manifestPath, 0o644);
+      clearPackageJsonCache();
+    }
+  });
+
+  it("readPackageJson returns {} when the manifest no longer exists (ENOENT)", () => {
+    const missingPath = path.join(tempRoot, "issue-275-missing-manifest", "package.json");
+    clearPackageJsonCache();
+    expect(readPackageJson(missingPath)).toEqual({});
+  });
+
+  // Resolves the unsafe `fs.existsSync && fs.statSync().isDirectory()`
+  // pattern that throws on EPERM if existsSync somehow returned true
+  // but statSync was denied (narrow race / TCC interaction).
+  it("isDirectory returns false rather than throwing for an inaccessible path", () => {
+    if (process.platform === "win32") return;
+    if (process.getuid?.() === 0) return;
+
+    const outerDirectory = path.join(tempRoot, "issue-275-isdir-outer");
+    const childDirectory = path.join(outerDirectory, "child");
+    fs.mkdirSync(childDirectory, { recursive: true });
+    fs.chmodSync(outerDirectory, 0o000);
+    try {
+      expect(isDirectory(childDirectory)).toBe(false);
+    } finally {
+      fs.chmodSync(outerDirectory, 0o755);
     }
   });
 });

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -33,7 +33,11 @@ import {
   OXLINT_MAX_FILES_PER_BATCH,
   SPAWN_ARGS_MAX_LENGTH_CHARS,
 } from "@react-doctor/core";
-import { discoverProject } from "@react-doctor/project-info";
+import {
+  discoverProject,
+  discoverReactSubprojects,
+  readDirectoryEntries,
+} from "@react-doctor/project-info";
 import {
   getStagedSourceFiles,
   materializeStagedFiles,
@@ -149,6 +153,69 @@ describe("issue #53: source file count fallback for non-git directories", () => 
 
     const projectInfo = discoverProject(projectDir);
     expect(projectInfo.sourceFileCount).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("issue #275 + #290: filesystem walks tolerate EPERM/EACCES (macOS Library/Accounts)", () => {
+  // On macOS, certain directories like ~/Library/Accounts are protected
+  // by TCC and throw EPERM on readdir even for the owning user. If the
+  // CLI is run from a parent directory (e.g. $HOME), the recursive
+  // discovery walk would crash the entire scan with:
+  //   EPERM: operation not permitted, scandir '/Users/<user>/Library/Accounts'
+  // The fix swallows ignorable readdir errors (EPERM, EACCES, ENOENT,
+  // ENOTDIR) and continues the walk so a single unreadable directory
+  // can't take down the whole run.
+  it("readDirectoryEntries returns [] for a non-existent path", () => {
+    const missingDirectory = path.join(tempRoot, "issue-275-missing-directory");
+    expect(readDirectoryEntries(missingDirectory)).toEqual([]);
+  });
+
+  it("readDirectoryEntries returns [] for a path that points at a file (ENOTDIR)", () => {
+    const filePath = path.join(tempRoot, "issue-275-not-a-directory.txt");
+    writeFile(filePath, "not a directory\n");
+    expect(readDirectoryEntries(filePath)).toEqual([]);
+  });
+
+  // Posix permission bits behave the way we expect on linux + macOS in CI.
+  // Skipped on Windows where chmod 0 doesn't deny readdir to the owner.
+  it("readDirectoryEntries returns [] for an unreadable directory (EACCES) on posix", () => {
+    if (process.platform === "win32") return;
+    if (process.getuid?.() === 0) return;
+
+    const unreadableDirectory = path.join(tempRoot, "issue-275-unreadable");
+    fs.mkdirSync(unreadableDirectory, { recursive: true });
+    fs.writeFileSync(path.join(unreadableDirectory, "child.txt"), "hidden\n");
+    fs.chmodSync(unreadableDirectory, 0o000);
+    try {
+      expect(readDirectoryEntries(unreadableDirectory)).toEqual([]);
+    } finally {
+      fs.chmodSync(unreadableDirectory, 0o755);
+    }
+  });
+
+  it("discoverReactSubprojects skips unreadable nested directories and keeps walking", () => {
+    if (process.platform === "win32") return;
+    if (process.getuid?.() === 0) return;
+
+    const walkRoot = path.join(tempRoot, "issue-275-walk-root");
+    fs.mkdirSync(walkRoot, { recursive: true });
+
+    writeJson(path.join(walkRoot, "accessible-app", "package.json"), {
+      name: "accessible-app",
+      dependencies: { react: "^19.0.0" },
+    });
+
+    const unreadableSibling = path.join(walkRoot, "Library", "Accounts");
+    fs.mkdirSync(unreadableSibling, { recursive: true });
+    fs.chmodSync(unreadableSibling, 0o000);
+
+    try {
+      const subprojects = discoverReactSubprojects(walkRoot);
+      const subprojectNames = subprojects.map((subproject) => subproject.name);
+      expect(subprojectNames).toContain("accessible-app");
+    } finally {
+      fs.chmodSync(unreadableSibling, 0o755);
+    }
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #275, #290.

Running `react-doctor` from a directory that contains TCC-protected paths (e.g. `$HOME` on macOS) crashed the entire scan:

```
Something went wrong. Please check the error below for more details.
If the problem persists, please open an issue at https://github.com/millionco/react-doctor/issues.

EPERM: operation not permitted, scandir '/Users/dario/Library/Accounts'
```

Recursive directory walks and adjacent filesystem probes called `fs.readdirSync` / `fs.readFileSync` / `fs.statSync` unguarded. macOS denies access to certain `~/Library/...` subdirectories even for the owning user, so a single unreadable sibling would surface as a hard crash and abort every scan started above it.

## Fix

The crash had several adjacent failure modes that all stem from the same root cause. This PR fixes them in two commits:

### 1. `readDirectoryEntries` helper (`@react-doctor/project-info`)

Wraps `fs.readdirSync(path, { withFileTypes: true })` and returns `[]` when the error code is one of:

- `EPERM` — macOS TCC denial (the reported case)
- `EACCES` — generic POSIX permission denial
- `ENOENT` — directory disappeared during the walk
- `ENOTDIR` — path resolved to a file

Anything else still rethrows. Every recursive walk now goes through this helper:

- `packages/project-info/src/discover-react-subprojects.ts`
- `packages/project-info/src/count-source-files.ts`
- `packages/project-info/src/get-nx-workspace-directories.ts`
- `packages/project-info/src/resolve-workspace-directories.ts`
- `packages/core/src/utils/list-source-files.ts`
- `packages/core/src/neutralize-disable-directives.ts` (replaces an overly-broad `catch {}` with the precise helper)

### 2. Adjacent EPERM gaps

After the readdir fix landed locally, deep edge-case review surfaced two follow-on holes that would re-crash one step further in the same scan:

- **Manifest reads** — `readPackageJsonUncached` already caught `EISDIR` and `EACCES` but not `EPERM` (macOS TCC) or `ENOENT` (race during long walks). A `package.json` under a TCC-protected directory would still take down the scan one step after our readdir fix. Added both codes to the recovery list.
- **Stat guards** — every callsite paired `fs.existsSync(p) && fs.statSync(p).isDirectory()`. `existsSync` returns `false` on most denials, but if it ever returns `true` while `statSync` is denied (narrow race / TCC interaction) the whole call throws. Introduced a new `isDirectory()` helper paralleling the existing `isFile()` helper, and routed every guard through it in `discoverReactSubprojects`, `resolveWorkspaceDirectories`, `getNxWorkspaceDirectories`, and `resolveConfigRootDir`.

### Symlink-loop safety

Verified that `Dirent.isDirectory()` (from `readdirSync({ withFileTypes: true })`) returns `false` for symlinks even when the target is a directory, so the walks still don't follow symlinks and can't enter a loop.

## Tests

7 new regression tests in `packages/react-doctor/tests/regressions/scan-resilience.test.ts` under `issue #275 + #290`:

- `readDirectoryEntries` returns `[]` for a missing path (`ENOENT`)
- `readDirectoryEntries` returns `[]` when the path is a file (`ENOTDIR`)
- `readDirectoryEntries` returns `[]` for a `chmod 0` directory (`EACCES`) — skipped on Windows / when running as root
- `discoverReactSubprojects` skips an unreadable nested `Library/Accounts` sibling and still discovers a sibling React app under the same walk root
- `readPackageJson` returns `{}` for a `chmod 0` manifest (`EPERM` / `EACCES`)
- `readPackageJson` returns `{}` when the manifest no longer exists (`ENOENT`)
- `isDirectory` returns `false` rather than throwing when the parent is `chmod 0`

```
pnpm typecheck   # 10/10 successful
pnpm lint        # 0 warnings, 0 errors
pnpm format
pnpm test        # 1174 / 1174 passed (95 files)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa087ae8-13d7-4f0c-a9f7-f712449f2018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa087ae8-13d7-4f0c-a9f7-f712449f2018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

