### PR TITLE
fix(score): gzip score payload to avoid 413 on large projects

### DIFF
--- a/packages/core/src/calculate-score.ts
+++ b/packages/core/src/calculate-score.ts
@@ -1,3 +1,4 @@
+import { gzipSync } from "node:zlib";
 import { FETCH_TIMEOUT_MS, SCORE_API_URL } from "./constants.js";
 import type { Diagnostic, ScoreResult } from "@react-doctor/types";
 
@@ -27,10 +28,16 @@ export const calculateScore = async (diagnostics: Diagnostic[]): Promise<ScoreRe
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
   try {
+    const requestBody = JSON.stringify({ diagnostics: stripFilePaths(diagnostics) });
+    const compressedBody = gzipSync(requestBody);
+
     const response = await fetch(SCORE_API_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ diagnostics: stripFilePaths(diagnostics) }),
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Encoding": "gzip",
+      },
+      body: compressedBody,
       signal: controller.signal,
     });
 

--- a/packages/react-doctor/tests/calculate-score.test.ts
+++ b/packages/react-doctor/tests/calculate-score.test.ts
@@ -1,3 +1,4 @@
+import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { calculateScore } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/types";
@@ -53,9 +54,11 @@ describe("calculateScore", () => {
   });
 
   it("parses a well-formed API response and strips file paths from the request body", async () => {
-    let capturedBody: string | undefined;
+    let capturedBody: BodyInit | null | undefined;
+    let capturedHeaders: HeadersInit | undefined;
     stubFetch(async (_url, init) => {
-      capturedBody = init?.body as string;
+      capturedBody = init?.body;
+      capturedHeaders = init?.headers;
       return new Response(JSON.stringify(apiScoreResponse), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -65,9 +68,13 @@ describe("calculateScore", () => {
     const result = await calculateScore(sampleDiagnostics);
 
     expect(result).toEqual(apiScoreResponse);
-    const parsedBody: { diagnostics: Array<Record<string, unknown>> } = JSON.parse(
-      capturedBody ?? "{}",
-    );
+    const headerRecord = capturedHeaders as Record<string, string> | undefined;
+    expect(headerRecord?.["Content-Encoding"]).toBe("gzip");
+    const compressedBytes = capturedBody as Uint8Array;
+    expect(compressedBytes).toBeInstanceOf(Uint8Array);
+    const decompressedJson = gunzipSync(compressedBytes).toString("utf8");
+    const parsedBody: { diagnostics: Array<Record<string, unknown>> } =
+      JSON.parse(decompressedJson);
     expect(parsedBody.diagnostics).toHaveLength(1);
     expect(parsedBody.diagnostics[0]).not.toHaveProperty("filePath");
     expect(parsedBody.diagnostics[0]).toMatchObject({

--- a/packages/react-doctor/tests/inspect-surface-filter.test.ts
+++ b/packages/react-doctor/tests/inspect-surface-filter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { inspect } from "../src/inspect.js";
 import path from "node:path";
+import { gunzipSync } from "node:zlib";
 import reactDoctorPlugin from "oxlint-plugin-react-doctor";
 
 vi.mock("ora", () => ({
@@ -24,12 +25,24 @@ interface CapturedFetchCall {
   body: string;
 }
 
+const decodeRequestBody = (init: RequestInit | undefined): string => {
+  const rawBody = init?.body;
+  if (!rawBody) return "";
+  const encoding = new Headers(init?.headers ?? {}).get("content-encoding")?.toLowerCase() ?? "";
+  if (rawBody instanceof Uint8Array) {
+    return encoding === "gzip"
+      ? gunzipSync(rawBody).toString("utf8")
+      : Buffer.from(rawBody).toString("utf8");
+  }
+  return String(rawBody);
+};
+
 const stubScoreFetchAndCapture = (): { captured: CapturedFetchCall[] } => {
   const captured: CapturedFetchCall[] = [];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (url: string, init?: RequestInit) => {
-      captured.push({ url, body: String(init?.body ?? "") });
+      captured.push({ url, body: decodeRequestBody(init) });
       return new Response(JSON.stringify({ score: 90, label: "Great" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },

--- a/packages/website/src/app/api/score/route.ts
+++ b/packages/website/src/app/api/score/route.ts
@@ -1,9 +1,11 @@
+import { gunzipSync } from "node:zlib";
 import { PERFECT_SCORE } from "@/constants";
 import { getScoreLabel } from "@/utils/get-score-label";
 
 const ERROR_RULE_PENALTY = 1.5;
 const WARNING_RULE_PENALTY = 0.75;
-const MAX_REQUEST_BODY_BYTES = 1_000_000;
+const MAX_REQUEST_BODY_BYTES = 2_000_000;
+const MAX_DECOMPRESSED_BODY_BYTES = 25_000_000;
 const MAX_DIAGNOSTICS_PER_REQUEST = 50_000;
 
 interface DiagnosticInput {
@@ -55,7 +57,7 @@ const isValidDiagnostic = (value: unknown): value is DiagnosticInput => {
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Headers": "Content-Type, Content-Encoding",
 };
 
 export const OPTIONS = (): Response => new Response(null, { status: 204, headers: CORS_HEADERS });
@@ -63,17 +65,27 @@ export const OPTIONS = (): Response => new Response(null, { status: 204, headers
 const respondError = (status: number, message: string): Response =>
   Response.json({ error: message }, { status, headers: CORS_HEADERS });
 
+const decodeRequestBody = async (request: Request): Promise<unknown> => {
+  const contentEncoding = request.headers.get("content-encoding")?.toLowerCase() ?? "";
+  if (contentEncoding === "gzip") {
+    const rawBody = Buffer.from(await request.arrayBuffer());
+    const decompressed = gunzipSync(rawBody, { maxOutputLength: MAX_DECOMPRESSED_BODY_BYTES });
+    return JSON.parse(decompressed.toString("utf8"));
+  }
+  return request.json();
+};
+
 export const POST = async (request: Request): Promise<Response> => {
   // used for rate limiting bad actors
   const ip = (request as any).ip || request.headers.get("x-forwarded-for") || "unknown";
   const contentLength = Number(request.headers.get("content-length") ?? "0");
   if (contentLength > MAX_REQUEST_BODY_BYTES) {
-    return respondError(413, "Request body exceeds 1MB");
+    return respondError(413, "Request body exceeds 2MB");
   }
 
   let body: unknown;
   try {
-    body = await request.json();
+    body = await decodeRequestBody(request);
   } catch {
     body = null;
   }

--- a/packages/website/src/app/api/score/route.ts
+++ b/packages/website/src/app/api/score/route.ts
@@ -65,11 +65,27 @@ export const OPTIONS = (): Response => new Response(null, { status: 204, headers
 const respondError = (status: number, message: string): Response =>
   Response.json({ error: message }, { status, headers: CORS_HEADERS });
 
+class DecompressedBodyTooLargeError extends Error {
+  constructor() {
+    super("decompressed body exceeds limit");
+    this.name = "DecompressedBodyTooLargeError";
+  }
+}
+
+const isBufferTooLargeError = (error: unknown): boolean =>
+  error instanceof Error && (error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE";
+
 const decodeRequestBody = async (request: Request): Promise<unknown> => {
   const contentEncoding = request.headers.get("content-encoding")?.toLowerCase() ?? "";
   if (contentEncoding === "gzip") {
     const rawBody = Buffer.from(await request.arrayBuffer());
-    const decompressed = gunzipSync(rawBody, { maxOutputLength: MAX_DECOMPRESSED_BODY_BYTES });
+    let decompressed: Buffer;
+    try {
+      decompressed = gunzipSync(rawBody, { maxOutputLength: MAX_DECOMPRESSED_BODY_BYTES });
+    } catch (error) {
+      if (isBufferTooLargeError(error)) throw new DecompressedBodyTooLargeError();
+      throw error;
+    }
     return JSON.parse(decompressed.toString("utf8"));
   }
   return request.json();
@@ -86,7 +102,10 @@ export const POST = async (request: Request): Promise<Response> => {
   let body: unknown;
   try {
     body = await decodeRequestBody(request);
-  } catch {
+  } catch (error) {
+    if (error instanceof DecompressedBodyTooLargeError) {
+      return respondError(413, "Decompressed request body exceeds 25MB");
+    }
     body = null;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #300.

## Problem

`npx react-doctor@latest --score` fails with `413 Request Entity Too Large` on large monorepos. The score API route caps incoming request bodies at 1MB, and the raw JSON payload of diagnostics exceeds that cap on large projects.

## Approach

Per the task, no local fallback is restored — instead the payload is gzip-compressed so the request stays well under the body cap. Both ends are updated together:

- **CLI (`packages/core/src/calculate-score.ts`)**: `JSON.stringify(...)` is piped through `gzipSync` from `node:zlib`, and the request is sent with `Content-Encoding: gzip` plus the compressed `Uint8Array` as the body. Gzip on this shape of data compresses ~50–75× in practice (verified: ~1.3MB raw → ~17KB gzipped on 5k diagnostics), so even the largest realistic scans now fit comfortably under the 2MB raw-body cap.
- **API route (`packages/website/src/app/api/score/route.ts`)**: when `Content-Encoding: gzip` is present, the route reads the raw `arrayBuffer()` and decompresses with `gunzipSync`, bounded by `maxOutputLength: MAX_DECOMPRESSED_BODY_BYTES` (25MB) as a zip-bomb guard. Plain JSON requests are still accepted, so older CLI versions keep working. The raw-body cap is bumped from 1MB to 2MB (compressed) and the preflight `Access-Control-Allow-Headers` now includes `Content-Encoding`.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test` — full suite (1202 tests) passes, including the two existing tests that capture fetch bodies, which were updated to decode the gzipped request payload.

Roundtrip sanity check on a representative payload (5k diagnostics, ~1.33MB JSON) gzips to ~17.8KB (ratio 0.013) and roundtrips identically.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77faa7dd-11e4-4ae6-90ca-51bf5ab9e3b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77faa7dd-11e4-4ae6-90ca-51bf5ab9e3b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

