### PR TITLE
fix(effect-needs-cleanup): recognize AbortController.abort() as a valid cleanup

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -75,6 +75,12 @@ export const SUBSCRIPTION_METHOD_NAMES = new Set([
 // counterparts. Used to recognize a valid `return () => removeEventListener(...)`
 // cleanup form even when the subscribe call is `addEventListener` rather
 // than a `subscribe()` whose return value gets re-bound.
+//
+// `abort` covers the AbortController pattern, which is the recommended
+// modern shape for tearing down `addEventListener` registrations bound
+// via `{ signal }`: a single `controller.abort()` removes every
+// listener bound to that signal in one shot, so it IS the matching
+// "remove" call even when no literal `removeEventListener(...)` is present.
 export const UNSUBSCRIPTION_METHOD_NAMES = new Set([
   "unsubscribe",
   "removeEventListener",
@@ -83,6 +89,7 @@ export const UNSUBSCRIPTION_METHOD_NAMES = new Set([
   "unwatch",
   "unlisten",
   "unsub",
+  "abort",
 ]);
 
 // Identifier names recognized as "this is a release/teardown call"

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -353,6 +353,66 @@ export const Subscribe = () => {
     expect(hits).toHaveLength(0);
   });
 
+  // Regression for #310: AbortController is the modern, idiomatic way to
+  // tear down many `addEventListener` registrations in one call. A single
+  // `controller.abort()` removes every listener that was bound via
+  // `{ signal: controller.signal }`, so the cleanup return IS valid even
+  // though no literal `removeEventListener(...)` appears.
+  it("does NOT flag `addEventListener({ signal })` cleaned up via `controller.abort()`", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-abort-controller", {
+      files: {
+        "src/FileDrop.tsx": `import { useEffect } from "react";
+
+declare const handleDragEnter: (event: DragEvent) => void;
+declare const handleDragLeave: (event: DragEvent) => void;
+declare const handleDragOver: (event: DragEvent) => void;
+declare const handleDrop: (event: DragEvent) => void;
+
+export const FileDrop = () => {
+  useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    window.addEventListener("dragenter", handleDragEnter, { signal });
+    window.addEventListener("dragleave", handleDragLeave, { signal });
+    window.addEventListener("dragover", handleDragOver, { signal });
+    window.addEventListener("drop", handleDrop, { signal });
+    return () => controller.abort();
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag `addEventListener({ signal })` cleaned up via a block calling `controller.abort()`", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-abort-controller-block", {
+      files: {
+        "src/FileDrop.tsx": `import { useEffect } from "react";
+
+declare const onResize: () => void;
+
+export const FileDrop = () => {
+  useEffect(() => {
+    const controller = new AbortController();
+    window.addEventListener("resize", onResize, { signal: controller.signal });
+    return () => {
+      controller.abort();
+    };
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
   // HACK: ensure the broader walk does NOT credit cleanup returns from a
   // *nested* function expression (e.g. an inner callback) as the effect's
   // own cleanup. The walker stops at function boundaries; this protects


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`effect-needs-cleanup` flags this perfectly valid pattern as needing cleanup:

```tsx
useEffect(() => {
  const controller = new AbortController();
  const signal = controller.signal;

  window.addEventListener("dragenter", handleDragEnter, { signal });
  window.addEventListener("dragleave", handleDragLeave, { signal });
  window.addEventListener("dragover", handleDragOver, { signal });
  window.addEventListener("drop", handleDrop, { signal });

  return () => controller.abort();
}, [handleDragEnter, handleDragLeave, handleDragOver, handleDrop]);
```

Reported error:

```
✗ Effect needs cleanup
  useEffect subscribes via `addEventListener(...)` but never returns a cleanup —
  leaks the registration on every re-run and on unmount. Return a cleanup function
  that calls the matching remove/unsubscribe call
```

The detector only recognized literal `removeEventListener` (and the other
named unsubscribe shapes) as the matching teardown — it did not know that
`controller.abort()` removes every listener bound via
`{ signal: controller.signal }` in one shot.

## Fix

Add `abort` to `UNSUBSCRIPTION_METHOD_NAMES` in
`packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts`. This is
the single source of truth that:

- `is-cleanup-return.ts` consults for `MemberExpression` cleanup callees
  (`controller.abort()`)
- propagates into `CLEANUP_LIKE_RELEASE_CALLEE_NAMES` for the
  bare-callee case as well

So `() => controller.abort()` and `() => { controller.abort(); }` are now
both accepted as valid cleanup, matching the modern recommended pattern for
batched `addEventListener` teardown.

## Tests

Two new regressions in
`packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts`:

1. Multiple `addEventListener({ signal })` calls cleaned up via
   `return () => controller.abort()` (the exact shape from the issue).
2. The same shape with a block-form cleanup
   (`return () => { controller.abort(); }`).

Both expect zero diagnostics.

## Verification

- `pnpm test` — 1204 / 1204 passing (17 / 17 in `effect-needs-cleanup.test.ts`).
- `pnpm lint` — 0 warnings, 0 errors.
- `pnpm typecheck` — clean.
- `pnpm format` — clean.

Closes #310.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fa23402-6939-45d6-b945-b32dd03a7c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fa23402-6939-45d6-b945-b32dd03a7c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

