### PR TITLE
fix: keep score API on in CI with ?ci=1 marker (issue #302)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,10 @@ inputs:
     description: "GitHub token for posting PR comments. When set on pull_request events, findings are posted as a PR comment."
     required: false
   fail-on:
-    description: "Exit non-zero when diagnostics fire (error, warning, none). Gates on individual diagnostics in the scanned files, not on the score (the score API is skipped in CI — see the `offline` input). Combine with `diff` for regression-only gating."
+    description: "Exit non-zero when diagnostics fire (error, warning, none). Gates on individual diagnostics in the scanned files, not on the score. Combine with `diff` for regression-only gating, or read the `score` output in a follow-up step to enforce an absolute score floor."
     default: "error"
   offline:
-    description: "Skip sending diagnostics to the react.doctor API. The score is computed by that API, so offline runs print no score. CI environments imply `--offline` automatically — see the README's Scoring section."
+    description: "Skip sending diagnostics to the react.doctor score API. The score is computed by that API, so offline runs print no score and the action's `score` output stays empty. CI runs are NOT offline by default — they tag the score request with `ci=1` so the server can separate CI traffic, and only the share URL is suppressed."
     default: "false"
   annotations:
     description: "Emit diagnostics as GitHub Actions annotations so findings show inline in the PR's Files changed view. Combine with `github-token` for both annotations and a sticky comment."
@@ -32,6 +32,11 @@ inputs:
   node-version:
     description: "Node.js version to use"
     default: "22"
+
+outputs:
+  score:
+    description: "Health score (0-100). Empty when the `offline` input is true (the score API is skipped) or when the score API was unreachable."
+    value: ${{ steps.score.outputs.score }}
 
 runs:
   using: "composite"
@@ -96,10 +101,30 @@ runs:
           npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}"
         fi
 
+    - id: score
+      if: always()
+      shell: bash
+      env:
+        INPUT_DIRECTORY: ${{ inputs.directory }}
+        INPUT_OFFLINE: ${{ inputs.offline }}
+      run: |
+        # HACK: --score is an output-collection step, not a gate. Force
+        # --fail-on none so older react-doctor releases (which exit
+        # non-zero when the score lands in the "Needs work" band, even
+        # though the value itself is the only meaningful signal here)
+        # don't fail the composite action under `set -e -o pipefail`.
+        SCORE_ARGS=("$INPUT_DIRECTORY" "--score" "--fail-on" "none")
+        if [ "$INPUT_OFFLINE" = "true" ]; then SCORE_ARGS+=("--offline"); fi
+        SCORE=$(npx react-doctor@latest "${SCORE_ARGS[@]}" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
+        if [[ -n "$SCORE" && "$SCORE" =~ ^[0-9]+$ ]]; then
+          echo "score=$SCORE" >> "$GITHUB_OUTPUT"
+        fi
+
     - if: ${{ inputs.github-token != '' && github.event_name == 'pull_request' }}
       uses: actions/github-script@v7
       env:
         REACT_DOCTOR_OUTPUT_FILE: ${{ env.REACT_DOCTOR_OUTPUT_FILE }}
+        REACT_DOCTOR_SCORE: ${{ steps.score.outputs.score }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -109,9 +134,15 @@ runs:
           const output = fs.readFileSync(path, "utf8").trim();
           if (!output) return;
 
+          const score = process.env.REACT_DOCTOR_SCORE;
+          const scoreLine =
+            score && /^[0-9]+$/.test(score)
+              ? `**Score:** \`${score}\` / 100\n\n`
+              : "";
+
           const marker = "<!-- react-doctor -->";
           const fence = "````";
-          const body = `${marker}\n## React Doctor\n\n${fence}\n${output}\n${fence}`;
+          const body = `${marker}\n## React Doctor\n\n${scoreLine}${fence}\n${output}\n${fence}`;
 
           const { data: comments } = await github.rest.issues.listComments({
             ...context.repo,

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: "Exit non-zero when diagnostics fire (error, warning, none). Gates on individual diagnostics in the scanned files, not on the score. Combine with `diff` for regression-only gating, or read the `score` output in a follow-up step to enforce an absolute score floor."
     default: "error"
   offline:
-    description: "Skip the score API. The score is computed server-side, so offline runs print no score and the `score` output stays empty. CI runs are not offline by default; the score still appears."
+    description: "Skip the score API. Offline runs print no score and leave the `score` output empty."
     default: "false"
   annotations:
     description: "Emit diagnostics as GitHub Actions annotations so findings show inline in the PR's Files changed view. Combine with `github-token` for both annotations and a sticky comment."
@@ -35,7 +35,7 @@ inputs:
 
 outputs:
   score:
-    description: "Health score (0-100). Empty when the `offline` input is true (the score API is skipped) or when the score API was unreachable."
+    description: "Health score (0-100). Empty in offline mode or when the score API was unreachable."
     value: ${{ steps.score.outputs.score }}
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: "Exit non-zero when diagnostics fire (error, warning, none). Gates on individual diagnostics in the scanned files, not on the score. Combine with `diff` for regression-only gating, or read the `score` output in a follow-up step to enforce an absolute score floor."
     default: "error"
   offline:
-    description: "Skip sending diagnostics to the react.doctor score API. The score is computed by that API, so offline runs print no score and the action's `score` output stays empty. CI runs are NOT offline by default — they tag the score request with `ci=1` so the server can separate CI traffic, and only the share URL is suppressed."
+    description: "Skip the score API. The score is computed server-side, so offline runs print no score and the `score` output stays empty. CI runs are not offline by default; the score still appears."
     default: "false"
   annotations:
     description: "Emit diagnostics as GitHub Actions annotations so findings show inline in the PR's Files changed view. Combine with `github-token` for both annotations and a sticky comment."

--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,10 @@ inputs:
     description: "GitHub token for posting PR comments. When set on pull_request events, findings are posted as a PR comment."
     required: false
   fail-on:
-    description: "Exit non-zero when diagnostics fire (error, warning, none). Gates on individual diagnostics in the scanned files, not on the score. Combine with `diff` for regression-only gating, or read the `score` output in a follow-up step to enforce an absolute score floor."
+    description: "Exit non-zero when diagnostics fire (error, warning, none). Gates on individual diagnostics in the scanned files, not on the score (the score API is skipped in CI — see the `offline` input). Combine with `diff` for regression-only gating."
     default: "error"
   offline:
-    description: "Skip sending diagnostics to the react.doctor API and calculate score locally"
+    description: "Skip sending diagnostics to the react.doctor API. The score is computed by that API, so offline runs print no score. CI environments imply `--offline` automatically — see the README's Scoring section."
     default: "false"
   annotations:
     description: "Emit diagnostics as GitHub Actions annotations so findings show inline in the PR's Files changed view. Combine with `github-token` for both annotations and a sticky comment."
@@ -32,11 +32,6 @@ inputs:
   node-version:
     description: "Node.js version to use"
     default: "22"
-
-outputs:
-  score:
-    description: "Health score (0-100)"
-    value: ${{ steps.score.outputs.score }}
 
 runs:
   using: "composite"
@@ -101,30 +96,10 @@ runs:
           npx react-doctor@latest "$INPUT_DIRECTORY" "${FLAGS[@]}"
         fi
 
-    - id: score
-      if: always()
-      shell: bash
-      env:
-        INPUT_DIRECTORY: ${{ inputs.directory }}
-        INPUT_OFFLINE: ${{ inputs.offline }}
-      run: |
-        # HACK: --score is an output-collection step, not a gate. Force
-        # --fail-on none so older react-doctor releases (which exit
-        # non-zero when the score lands in the "Needs work" band, even
-        # though the value itself is the only meaningful signal here)
-        # don't fail the composite action under `set -e -o pipefail`.
-        SCORE_ARGS=("$INPUT_DIRECTORY" "--score" "--fail-on" "none")
-        if [ "$INPUT_OFFLINE" = "true" ]; then SCORE_ARGS+=("--offline"); fi
-        SCORE=$(npx react-doctor@latest "${SCORE_ARGS[@]}" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
-        if [[ -n "$SCORE" && "$SCORE" =~ ^[0-9]+$ ]]; then
-          echo "score=$SCORE" >> "$GITHUB_OUTPUT"
-        fi
-
     - if: ${{ inputs.github-token != '' && github.event_name == 'pull_request' }}
       uses: actions/github-script@v7
       env:
         REACT_DOCTOR_OUTPUT_FILE: ${{ env.REACT_DOCTOR_OUTPUT_FILE }}
-        REACT_DOCTOR_SCORE: ${{ steps.score.outputs.score }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -134,15 +109,9 @@ runs:
           const output = fs.readFileSync(path, "utf8").trim();
           if (!output) return;
 
-          const score = process.env.REACT_DOCTOR_SCORE;
-          const scoreLine =
-            score && /^[0-9]+$/.test(score)
-              ? `**Score:** \`${score}\` / 100\n\n`
-              : "";
-
           const marker = "<!-- react-doctor -->";
           const fence = "````";
-          const body = `${marker}\n## React Doctor\n\n${scoreLine}${fence}\n${output}\n${fence}`;
+          const body = `${marker}\n## React Doctor\n\n${fence}\n${output}\n${fence}`;
 
           const { data: comments } = await github.rest.issues.listComments({
             ...context.repo,

--- a/packages/core/src/calculate-score.ts
+++ b/packages/core/src/calculate-score.ts
@@ -24,10 +24,7 @@ const describeFailure = (error: unknown): string => {
 };
 
 export interface CalculateScoreOptions {
-  /**
-   * Marks the run as CI-originated. The CLI sets this when running
-   * under `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI` / `CI=true`.
-   */
+  /** Marks the run as CI-originated. */
   isCi?: boolean;
 }
 

--- a/packages/core/src/calculate-score.ts
+++ b/packages/core/src/calculate-score.ts
@@ -23,15 +23,31 @@ const describeFailure = (error: unknown): string => {
   return String(error);
 };
 
-export const calculateScore = async (diagnostics: Diagnostic[]): Promise<ScoreResult | null> => {
+export interface CalculateScoreOptions {
+  /**
+   * Tags the request as originating from a CI run by appending `?ci=1`
+   * to the score API URL. The CLI sets this when running under
+   * `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI` / `CI=true` so the
+   * server can distinguish CI traffic from interactive local runs
+   * (rate-limit envelope, billing attribution, share-link generation,
+   * …) without changing the request body shape.
+   */
+  isCi?: boolean;
+}
+
+export const calculateScore = async (
+  diagnostics: Diagnostic[],
+  options: CalculateScoreOptions = {},
+): Promise<ScoreResult | null> => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  const requestUrl = options.isCi ? `${SCORE_API_URL}?ci=1` : SCORE_API_URL;
 
   try {
     const requestBody = JSON.stringify({ diagnostics: stripFilePaths(diagnostics) });
     const compressedBody = gzipSync(requestBody);
 
-    const response = await fetch(SCORE_API_URL, {
+    const response = await fetch(requestUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/packages/core/src/calculate-score.ts
+++ b/packages/core/src/calculate-score.ts
@@ -25,12 +25,8 @@ const describeFailure = (error: unknown): string => {
 
 export interface CalculateScoreOptions {
   /**
-   * Tags the request as originating from a CI run by appending `?ci=1`
-   * to the score API URL. The CLI sets this when running under
-   * `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI` / `CI=true` so the
-   * server can distinguish CI traffic from interactive local runs
-   * (rate-limit envelope, billing attribution, share-link generation,
-   * …) without changing the request body shape.
+   * Marks the run as CI-originated. The CLI sets this when running
+   * under `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI` / `CI=true`.
    */
   isCi?: boolean;
 }

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -70,9 +70,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment.
-
-The composite action does **not** expose a `score` output. CI runs imply `--offline` (see [Scoring](#scoring)), and offline mode skips the score API entirely — there is no score to read in a follow-up step. Diagnostic-level gating via `--fail-on` (optionally combined with `--diff`) is the supported way to block PRs from CI; see [PR blocking and exit codes](#pr-blocking-and-exit-codes).
+When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can read in subsequent steps — see [PR blocking and exit codes](#pr-blocking-and-exit-codes) for a working score-floor recipe. The score API is reached even on CI runs (the request is tagged with `?ci=1` so server-side metrics can separate CI traffic from interactive local runs); pass `offline: true` to opt out and leave `score` empty.
 
 **Inputs:** `directory`, `verbose`, `project`, `diff`, `github-token`, `fail-on` (`error` / `warning` / `none`), `offline`, `annotations`, `node-version`. See [`action.yml`](https://github.com/millionco/react-doctor/blob/main/action.yml) for full descriptions.
 
@@ -100,13 +98,14 @@ Prefer not to add a marketplace action? The bare `npx` form works too:
 
 ## PR blocking and exit codes
 
-PRs are gated on individual diagnostics, not on the score. Use **`--fail-on <level>`** to control the exit code: `error` (default, any error-severity rule fires), `warning` (any diagnostic fires), or `none` (never). It runs against the `ciFailure` surface, so the default `design`-tag exclusion still applies.
+Two independent gates can block a PR — pick one or both:
+
+- **`--fail-on <level>`** exits non-zero on diagnostics: `error` (default, any error-severity rule fires), `warning` (any diagnostic fires), or `none` (never). Runs against the `ciFailure` surface, so the default `design`-tag exclusion still applies.
+- **Score floor** — a follow-up step that reads the action's `score` output and `exit 1`s when it's below your threshold.
 
 Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed files only — that's the built-in way to fail on **new** regressions without dragging in baseline backlog. There is no separate `--fail-on-new` flag.
 
 `--annotations` (bare `npx` only) and `github-token` (sticky PR comment) are visualization layers and never change the exit code.
-
-Score-floor gating (failing when the absolute health score drops below a threshold) is **not supported in the GitHub Action**: CI runs imply `--offline`, which skips the score API entirely (see [Scoring](#scoring)). Track the score from a non-CI run instead — for example, with `npx react-doctor --score` in a local pre-push hook or on a developer machine.
 
 ### Examples
 
@@ -131,6 +130,34 @@ Score-floor gating (failing when the absolute health score drops below a thresho
     fail-on: warning
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+**Strict threshold mode** — fail when the baseline score drops below a floor:
+
+```yaml
+- id: doctor
+  uses: millionco/react-doctor@main
+  with:
+    fail-on: error
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+- env:
+    SCORE: ${{ steps.doctor.outputs.score }}
+    FLOOR: "80"
+  run: |
+    # The `score` output is best-effort: it stays empty when the score
+    # API is unreachable, returns a non-2xx, or `offline: true` is set.
+    # Skip the floor when it's empty so a transient API hiccup doesn't
+    # block unrelated PRs.
+    if [ -z "$SCORE" ]; then
+      echo "::notice::React Doctor score unavailable — skipping floor check"
+      exit 0
+    fi
+    if [ "$SCORE" -lt "$FLOOR" ]; then
+      echo "::error::React Doctor score $SCORE is below floor $FLOOR"
+      exit 1
+    fi
+```
+
+Pin a specific `react-doctor` version when using a score floor — new rule releases can lower the score even when your code hasn't changed (see [Scoring](#scoring)).
 
 ## Configuration
 
@@ -336,7 +363,7 @@ When a suppression isn't working, `--explain <file:line>` (or its alias `--why <
 
 `ignore.tags` suppresses entire categories of rules by tag. For example, `"tags": ["design"]` disables all opinionated design rules (gradient text, pure black backgrounds, side tab borders, default Tailwind palettes). Available tags: `"design"`.
 
-`offline` skips the score API entirely — no score is shown and no share URL is generated. Automatically enabled in CI environments (GitHub Actions, GitLab CI, CircleCI) so CI runs don't depend on the network.
+`offline` skips the score API entirely — no score is shown and no share URL is generated. CI runs (GitHub Actions, GitLab CI, CircleCI, or any environment that sets `CI=true`) are NOT auto-offline: the score request is sent with a `?ci=1` marker so server-side metrics can separate CI traffic from interactive runs, and only the share URL is suppressed in the printed summary. Set `offline: true` (or `--offline`) explicitly when you want zero network from CI.
 
 ### React Native rules in mixed monorepos
 
@@ -364,7 +391,7 @@ The walker stops at function and `Program` boundaries — JSX defined inside a c
 
 The health score formula: `100 - (unique_error_rules x 1.5) - (unique_warning_rules x 0.75)`.
 
-Scoring runs on react.doctor's API and is **network-dependent**: without a successful API round-trip (or under `--offline`) the score is omitted and the rest of the report still renders normally. Because `--offline` is automatically enabled in CI environments (GitHub Actions, GitLab CI, CircleCI, or any environment that sets `CI=true`), the score is **not available from the GitHub Action** — score-based gating has to run outside CI. Key details:
+Scoring runs on react.doctor's API and is **network-dependent**: without a successful API round-trip (or under `--offline`) the score is omitted and the rest of the report still renders normally. CI runs reach the score API too — the request is tagged with `?ci=1` so server-side metrics can separate CI traffic — but the score is always best-effort: any score-based automation must treat an empty value as a no-op (see the strict-threshold example above). Key details:
 
 - The score counts **unique rules triggered**, not total instances. Fixing 49 of 50 `no-barrel-import` violations does not change the score; fixing all 50 removes the 0.75 penalty for that rule.
 - Error-severity rules cost 1.5 points each. Warning-severity rules cost 0.75 points each.
@@ -397,7 +424,7 @@ React Doctor detects 50+ coding agents (Claude Code, Cursor, Codex, OpenCode, Wi
 - **Exit codes**: `--fail-on error` (default) exits non-zero when error-severity diagnostics are found. Use `--fail-on warning` or `--fail-on none` to tune CI gating. See [PR blocking and exit codes](#pr-blocking-and-exit-codes) for the full model — including how to fail only on new regressions vs. fail on the baseline score.
 - **Programmatic API**: `import { diagnose } from "react-doctor/api"` for direct integration in scripts and automation.
 
-In CI environments, prompts are automatically skipped and `--offline` is implied (no network round-trip; score is omitted from the output).
+In CI environments, prompts are automatically skipped. The score API still runs (the request is tagged with `?ci=1` so server-side metrics can separate CI traffic from interactive runs); pass `--offline` explicitly when you need zero network.
 
 ## Node.js API
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -70,7 +70,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can use in subsequent steps.
+When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment.
+
+The composite action does **not** expose a `score` output. CI runs imply `--offline` (see [Scoring](#scoring)), and offline mode skips the score API entirely — there is no score to read in a follow-up step. Diagnostic-level gating via `--fail-on` (optionally combined with `--diff`) is the supported way to block PRs from CI; see [PR blocking and exit codes](#pr-blocking-and-exit-codes).
 
 **Inputs:** `directory`, `verbose`, `project`, `diff`, `github-token`, `fail-on` (`error` / `warning` / `none`), `offline`, `annotations`, `node-version`. See [`action.yml`](https://github.com/millionco/react-doctor/blob/main/action.yml) for full descriptions.
 
@@ -98,14 +100,13 @@ Prefer not to add a marketplace action? The bare `npx` form works too:
 
 ## PR blocking and exit codes
 
-Two independent gates can block a PR — pick one or both:
-
-- **`--fail-on <level>`** exits non-zero on diagnostics: `error` (default, any error-severity rule fires), `warning` (any diagnostic fires), or `none` (never). Runs against the `ciFailure` surface, so the default `design`-tag exclusion still applies.
-- **Score floor** — a follow-up step that reads the action's `score` output and `exit 1`s when it's below your threshold.
+PRs are gated on individual diagnostics, not on the score. Use **`--fail-on <level>`** to control the exit code: `error` (default, any error-severity rule fires), `warning` (any diagnostic fires), or `none` (never). It runs against the `ciFailure` surface, so the default `design`-tag exclusion still applies.
 
 Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed files only — that's the built-in way to fail on **new** regressions without dragging in baseline backlog. There is no separate `--fail-on-new` flag.
 
 `--annotations` (bare `npx` only) and `github-token` (sticky PR comment) are visualization layers and never change the exit code.
+
+Score-floor gating (failing when the absolute health score drops below a threshold) is **not supported in the GitHub Action**: CI runs imply `--offline`, which skips the score API entirely (see [Scoring](#scoring)). Track the score from a non-CI run instead — for example, with `npx react-doctor --score` in a local pre-push hook or on a developer machine.
 
 ### Examples
 
@@ -130,26 +131,6 @@ Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed f
     fail-on: warning
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-**Strict threshold mode** — fail when the baseline score drops below a floor:
-
-```yaml
-- id: doctor
-  uses: millionco/react-doctor@main
-  with:
-    fail-on: error
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-- env:
-    SCORE: ${{ steps.doctor.outputs.score }}
-    FLOOR: "80"
-  run: |
-    if [ -n "$SCORE" ] && [ "$SCORE" -lt "$FLOOR" ]; then
-      echo "::error::React Doctor score $SCORE is below floor $FLOOR"
-      exit 1
-    fi
-```
-
-Pin a specific `react-doctor` version when using a score floor — new rule releases can lower the score even when your code hasn't changed (see [Scoring](#scoring)).
 
 ## Configuration
 
@@ -383,7 +364,7 @@ The walker stops at function and `Program` boundaries — JSX defined inside a c
 
 The health score formula: `100 - (unique_error_rules x 1.5) - (unique_warning_rules x 0.75)`.
 
-Scoring runs on react.doctor's API and is **network-dependent**: without a successful API round-trip (or under `--offline`) the score is omitted and the rest of the report still renders normally. Key details:
+Scoring runs on react.doctor's API and is **network-dependent**: without a successful API round-trip (or under `--offline`) the score is omitted and the rest of the report still renders normally. Because `--offline` is automatically enabled in CI environments (GitHub Actions, GitLab CI, CircleCI, or any environment that sets `CI=true`), the score is **not available from the GitHub Action** — score-based gating has to run outside CI. Key details:
 
 - The score counts **unique rules triggered**, not total instances. Fixing 49 of 50 `no-barrel-import` violations does not change the score; fixing all 50 removes the 0.75 penalty for that rule.
 - Error-severity rules cost 1.5 points each. Warning-severity rules cost 0.75 points each.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -70,7 +70,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can read in subsequent steps — see [PR blocking and exit codes](#pr-blocking-and-exit-codes) for a working score-floor recipe. The score API is reached even on CI runs (the request is tagged with `?ci=1` so server-side metrics can separate CI traffic from interactive local runs); pass `offline: true` to opt out and leave `score` empty.
+When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can read in subsequent steps — see [PR blocking and exit codes](#pr-blocking-and-exit-codes) for a working score-floor recipe. Pass `offline: true` to opt out of scoring and leave the `score` output empty.
 
 **Inputs:** `directory`, `verbose`, `project`, `diff`, `github-token`, `fail-on` (`error` / `warning` / `none`), `offline`, `annotations`, `node-version`. See [`action.yml`](https://github.com/millionco/react-doctor/blob/main/action.yml) for full descriptions.
 
@@ -143,10 +143,8 @@ Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed f
     SCORE: ${{ steps.doctor.outputs.score }}
     FLOOR: "80"
   run: |
-    # The `score` output is best-effort: it stays empty when the score
-    # API is unreachable, returns a non-2xx, or `offline: true` is set.
-    # Skip the floor when it's empty so a transient API hiccup doesn't
-    # block unrelated PRs.
+    # `score` is best-effort and may be empty (e.g. when offline is on).
+    # Skip the floor when it's empty so unrelated PRs aren't blocked.
     if [ -z "$SCORE" ]; then
       echo "::notice::React Doctor score unavailable — skipping floor check"
       exit 0
@@ -363,7 +361,7 @@ When a suppression isn't working, `--explain <file:line>` (or its alias `--why <
 
 `ignore.tags` suppresses entire categories of rules by tag. For example, `"tags": ["design"]` disables all opinionated design rules (gradient text, pure black backgrounds, side tab borders, default Tailwind palettes). Available tags: `"design"`.
 
-`offline` skips the score API entirely — no score is shown and no share URL is generated. CI runs (GitHub Actions, GitLab CI, CircleCI, or any environment that sets `CI=true`) are NOT auto-offline: the score request is sent with a `?ci=1` marker so server-side metrics can separate CI traffic from interactive runs, and only the share URL is suppressed in the printed summary. Set `offline: true` (or `--offline`) explicitly when you want zero network from CI.
+`offline` skips the score API entirely — no score is shown and no share URL is generated. CI runs (GitHub Actions, GitLab CI, CircleCI) are not offline by default — the score still appears and only the share URL is suppressed in the printed summary. Set `offline: true` (or `--offline`) explicitly when you want zero network from CI.
 
 ### React Native rules in mixed monorepos
 
@@ -391,7 +389,7 @@ The walker stops at function and `Program` boundaries — JSX defined inside a c
 
 The health score formula: `100 - (unique_error_rules x 1.5) - (unique_warning_rules x 0.75)`.
 
-Scoring runs on react.doctor's API and is **network-dependent**: without a successful API round-trip (or under `--offline`) the score is omitted and the rest of the report still renders normally. CI runs reach the score API too — the request is tagged with `?ci=1` so server-side metrics can separate CI traffic — but the score is always best-effort: any score-based automation must treat an empty value as a no-op (see the strict-threshold example above). Key details:
+Scoring runs on react.doctor's API and is **network-dependent**: without a successful API round-trip (or under `--offline`) the score is omitted and the rest of the report still renders normally. The score is always best-effort, so any score-based automation must treat an empty value as a no-op (see the strict-threshold example above). Key details:
 
 - The score counts **unique rules triggered**, not total instances. Fixing 49 of 50 `no-barrel-import` violations does not change the score; fixing all 50 removes the 0.75 penalty for that rule.
 - Error-severity rules cost 1.5 points each. Warning-severity rules cost 0.75 points each.
@@ -424,7 +422,7 @@ React Doctor detects 50+ coding agents (Claude Code, Cursor, Codex, OpenCode, Wi
 - **Exit codes**: `--fail-on error` (default) exits non-zero when error-severity diagnostics are found. Use `--fail-on warning` or `--fail-on none` to tune CI gating. See [PR blocking and exit codes](#pr-blocking-and-exit-codes) for the full model — including how to fail only on new regressions vs. fail on the baseline score.
 - **Programmatic API**: `import { diagnose } from "react-doctor/api"` for direct integration in scripts and automation.
 
-In CI environments, prompts are automatically skipped. The score API still runs (the request is tagged with `?ci=1` so server-side metrics can separate CI traffic from interactive runs); pass `--offline` explicitly when you need zero network.
+In CI environments, prompts are automatically skipped and the score still appears in the output. Pass `--offline` explicitly when you need zero network.
 
 ## Node.js API
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -70,7 +70,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can read in subsequent steps — see [PR blocking and exit codes](#pr-blocking-and-exit-codes) for a working score-floor recipe. Pass `offline: true` to opt out of scoring and leave the `score` output empty.
+When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can read in subsequent steps — see [PR blocking and exit codes](#pr-blocking-and-exit-codes) for a score-floor recipe.
 
 **Inputs:** `directory`, `verbose`, `project`, `diff`, `github-token`, `fail-on` (`error` / `warning` / `none`), `offline`, `annotations`, `node-version`. See [`action.yml`](https://github.com/millionco/react-doctor/blob/main/action.yml) for full descriptions.
 
@@ -361,7 +361,7 @@ When a suppression isn't working, `--explain <file:line>` (or its alias `--why <
 
 `ignore.tags` suppresses entire categories of rules by tag. For example, `"tags": ["design"]` disables all opinionated design rules (gradient text, pure black backgrounds, side tab borders, default Tailwind palettes). Available tags: `"design"`.
 
-`offline` skips the score API entirely — no score is shown and no share URL is generated. CI runs (GitHub Actions, GitLab CI, CircleCI) are not offline by default — the score still appears and only the share URL is suppressed in the printed summary. Set `offline: true` (or `--offline`) explicitly when you want zero network from CI.
+`offline` skips the score API entirely — no score is shown and no share URL is generated. CI runs (GitHub Actions, GitLab CI, CircleCI) are not offline by default; only the share URL is suppressed. Set `offline: true` (or `--offline`) explicitly when you want zero network.
 
 ### React Native rules in mixed monorepos
 
@@ -389,7 +389,7 @@ The walker stops at function and `Program` boundaries — JSX defined inside a c
 
 The health score formula: `100 - (unique_error_rules x 1.5) - (unique_warning_rules x 0.75)`.
 
-Scoring runs on react.doctor's API and is **network-dependent**: without a successful API round-trip (or under `--offline`) the score is omitted and the rest of the report still renders normally. The score is always best-effort, so any score-based automation must treat an empty value as a no-op (see the strict-threshold example above). Key details:
+Scoring runs on react.doctor's API and is **network-dependent**: without a successful API round-trip (or under `--offline`) the score is omitted and the rest of the report still renders normally. Score-based automation must treat an empty value as a no-op (see the strict-threshold example above). Key details:
 
 - The score counts **unique rules triggered**, not total instances. Fixing 49 of 50 `no-barrel-import` violations does not change the score; fixing all 50 removes the 0.75 penalty for that rule.
 - Error-severity rules cost 1.5 points each. Warning-severity rules cost 0.75 points each.
@@ -422,7 +422,7 @@ React Doctor detects 50+ coding agents (Claude Code, Cursor, Codex, OpenCode, Wi
 - **Exit codes**: `--fail-on error` (default) exits non-zero when error-severity diagnostics are found. Use `--fail-on warning` or `--fail-on none` to tune CI gating. See [PR blocking and exit codes](#pr-blocking-and-exit-codes) for the full model — including how to fail only on new regressions vs. fail on the baseline score.
 - **Programmatic API**: `import { diagnose } from "react-doctor/api"` for direct integration in scripts and automation.
 
-In CI environments, prompts are automatically skipped and the score still appears in the output. Pass `--offline` explicitly when you need zero network.
+In CI environments, prompts are automatically skipped. Pass `--offline` explicitly when you need zero network.
 
 ## Node.js API
 

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -19,7 +19,6 @@ import { STAGED_FILES_TEMP_DIR_PREFIX } from "../utils/constants.js";
 import { getStagedSourceFiles, materializeStagedFiles } from "../utils/get-staged-files.js";
 import type { InspectFlags } from "../utils/inspect-flags.js";
 import { handleError } from "../utils/handle-error.js";
-import { isCiEnvironment } from "../utils/is-ci-environment.js";
 import {
   enableJsonMode,
   setJsonReportDirectory,
@@ -86,11 +85,6 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
     const scanOptions = resolveCliInspectOptions(flags, userConfig);
     const skipPrompts = shouldSkipPrompts({ yes: flags.yes, full: flags.full, json: flags.json });
-
-    if (!flags.offline && isCiEnvironment() && !isQuiet) {
-      logger.dim("CI detected — scoring locally.");
-      logger.break();
-    }
 
     if (flags.staged) {
       setJsonReportMode("staged");

--- a/packages/react-doctor/src/cli/utils/is-ci-environment.ts
+++ b/packages/react-doctor/src/cli/utils/is-ci-environment.ts
@@ -1,14 +1,12 @@
-// Stay narrow: only the canonical CI signals where we're confident the
-// run is automated. The detection drives two things:
-//   1. The score request is tagged with `?ci=1` so the server can
-//      separate CI traffic from interactive local runs.
-//   2. The share URL is suppressed in the printed summary (it's just
-//      noise in CI logs).
+// Stay narrow: only the canonical CI signals where we're confident
+// the run is automated. The detection is used to suppress the share
+// URL in the printed summary (it's just noise in CI logs) and to
+// mark the run as CI-originated for the score path.
 // CI no longer auto-implies `--offline` — users who want zero network
 // in CI keep passing `--offline` (or set `offline: true` in config).
-// Other tools that set non-interactive env vars (Jenkins agents, Azure
-// DevOps tasks running interactively, agentic coding sessions) are
-// deliberately excluded so they don't get the CI marker either.
+// Other tools that set non-interactive env vars (Jenkins agents,
+// Azure DevOps tasks running interactively, agentic coding sessions)
+// are deliberately excluded.
 const CI_ENVIRONMENT_VARIABLES = ["GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"];
 
 export const isCiEnvironment = (): boolean =>

--- a/packages/react-doctor/src/cli/utils/is-ci-environment.ts
+++ b/packages/react-doctor/src/cli/utils/is-ci-environment.ts
@@ -1,12 +1,6 @@
-// Stay narrow: only the canonical CI signals where we're confident
-// the run is automated. The detection is used to suppress the share
-// URL in the printed summary (it's just noise in CI logs) and to
-// mark the run as CI-originated for the score path.
-// CI no longer auto-implies `--offline` — users who want zero network
-// in CI keep passing `--offline` (or set `offline: true` in config).
-// Other tools that set non-interactive env vars (Jenkins agents,
-// Azure DevOps tasks running interactively, agentic coding sessions)
-// are deliberately excluded.
+// Narrow on canonical CI signals only. Used to suppress the share
+// URL (noise in CI logs) and to mark the run as CI-originated for
+// the score path. Does not imply `--offline`.
 const CI_ENVIRONMENT_VARIABLES = ["GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"];
 
 export const isCiEnvironment = (): boolean =>

--- a/packages/react-doctor/src/cli/utils/is-ci-environment.ts
+++ b/packages/react-doctor/src/cli/utils/is-ci-environment.ts
@@ -1,8 +1,14 @@
-// HACK: only flip --offline by default for the narrowest set of CI signals
-// where we're confident the run is automated and a share URL would be
-// useless. Other tools that set non-interactive env vars (Jenkins agents,
-// Azure DevOps tasks running interactively, agentic coding sessions) still
-// get telemetry-on-by-default; users can pass --offline explicitly.
+// Stay narrow: only the canonical CI signals where we're confident the
+// run is automated. The detection drives two things:
+//   1. The score request is tagged with `?ci=1` so the server can
+//      separate CI traffic from interactive local runs.
+//   2. The share URL is suppressed in the printed summary (it's just
+//      noise in CI logs).
+// CI no longer auto-implies `--offline` — users who want zero network
+// in CI keep passing `--offline` (or set `offline: true` in config).
+// Other tools that set non-interactive env vars (Jenkins agents, Azure
+// DevOps tasks running interactively, agentic coding sessions) are
+// deliberately excluded so they don't get the CI marker either.
 const CI_ENVIRONMENT_VARIABLES = ["GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"];
 
 export const isCiEnvironment = (): boolean =>

--- a/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
@@ -10,10 +10,6 @@ export const resolveCliInspectOptions = (
   deadCode: flags.deadCode ?? userConfig?.deadCode ?? true,
   verbose: flags.verbose ?? userConfig?.verbose ?? false,
   scoreOnly: Boolean(flags.score),
-  // CI no longer auto-implies `--offline`. The score still runs and
-  // only the share URL is suppressed in CI output. Users who want
-  // zero network in CI keep passing `--offline` (or set
-  // `offline: true` in config).
   offline: Boolean(flags.offline) || (userConfig?.offline ?? false),
   isCi: isCiEnvironment(),
   silent: Boolean(flags.json),

--- a/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
@@ -10,11 +10,10 @@ export const resolveCliInspectOptions = (
   deadCode: flags.deadCode ?? userConfig?.deadCode ?? true,
   verbose: flags.verbose ?? userConfig?.verbose ?? false,
   scoreOnly: Boolean(flags.score),
-  // CI no longer auto-implies `--offline`. The score API still runs —
-  // tagged with `?ci=1` via `options.isCi` so the server can
-  // distinguish CI traffic — and only the share URL is suppressed in
-  // CI output. Users who want zero network in CI keep passing
-  // `--offline` (or set `offline: true` in config).
+  // CI no longer auto-implies `--offline`. The score still runs and
+  // only the share URL is suppressed in CI output. Users who want
+  // zero network in CI keep passing `--offline` (or set
+  // `offline: true` in config).
   offline: Boolean(flags.offline) || (userConfig?.offline ?? false),
   isCi: isCiEnvironment(),
   silent: Boolean(flags.json),

--- a/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
@@ -10,7 +10,13 @@ export const resolveCliInspectOptions = (
   deadCode: flags.deadCode ?? userConfig?.deadCode ?? true,
   verbose: flags.verbose ?? userConfig?.verbose ?? false,
   scoreOnly: Boolean(flags.score),
-  offline: Boolean(flags.offline) || (userConfig?.offline ?? false) || isCiEnvironment(),
+  // CI no longer auto-implies `--offline`. The score API still runs —
+  // tagged with `?ci=1` via `options.isCi` so the server can
+  // distinguish CI traffic — and only the share URL is suppressed in
+  // CI output. Users who want zero network in CI keep passing
+  // `--offline` (or set `offline: true` in config).
+  offline: Boolean(flags.offline) || (userConfig?.offline ?? false),
+  isCi: isCiEnvironment(),
   silent: Boolean(flags.json),
   respectInlineDisables: flags.respectInlineDisables ?? userConfig?.respectInlineDisables ?? true,
   outputSurface: flags.prComment ? "prComment" : "cli",

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -41,6 +41,7 @@ interface ResolvedInspectOptions {
   verbose: boolean;
   scoreOnly: boolean;
   offline: boolean;
+  isCi: boolean;
   silent: boolean;
   includePaths: string[];
   customRulesOnly: boolean;
@@ -68,6 +69,7 @@ const mergeInspectOptions = (
   verbose: inputOptions.verbose ?? userConfig?.verbose ?? false,
   scoreOnly: inputOptions.scoreOnly ?? false,
   offline: inputOptions.offline ?? false,
+  isCi: inputOptions.isCi ?? false,
   silent: inputOptions.silent ?? false,
   includePaths: inputOptions.includePaths ?? [],
   customRulesOnly: userConfig?.customRulesOnly ?? false,
@@ -259,14 +261,19 @@ const runInspect = async (
   // null sources — `--offline` (user-requested) vs API failure (the
   // network round-trip didn't return a usable score) — so the
   // renderer doesn't claim offline mode when the user is online but
-  // the API was unreachable.
+  // the API was unreachable. CI runs are NOT auto-offline: they reach
+  // the score API with a `?ci=1` marker (see `options.isCi`) so the
+  // GitHub Action's `score` output stays populated, and only the share
+  // URL is suppressed downstream.
   //
   // Pre-filter diagnostics through the `score` surface so weak-signal
   // rule families (e.g. `design`) stay out of scoring by default and
   // don't dilute the headline number. Surface-included diagnostics
   // still flow through `result.diagnostics` for CLI/JSON consumers.
   const scoreDiagnostics = filterDiagnosticsForSurface(diagnostics, "score", userConfig);
-  const scoreResult = options.offline ? null : await calculateScore(scoreDiagnostics);
+  const scoreResult = options.offline
+    ? null
+    : await calculateScore(scoreDiagnostics, { isCi: options.isCi });
   const noScoreMessage = options.offline
     ? "Score unavailable in offline mode."
     : "Score unavailable (could not reach the score API).";
@@ -356,7 +363,10 @@ const runInspect = async (
 
   const displayedSourceFileCount = isDiffMode ? includePaths.length : lintSourceFileCount;
 
-  const shouldShowShareLink = !options.offline && options.share;
+  // Share links are noise in CI logs (the score itself is what useful
+  // there — see the GitHub Action's `score` output). Suppress the
+  // share URL on CI runs even though the score API still runs.
+  const shouldShowShareLink = !options.offline && options.share && !options.isCi;
   printSummary(
     surfaceDiagnostics,
     elapsedMilliseconds,

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -254,17 +254,14 @@ const runInspect = async (
   if (didDeadCodeFail) skippedChecks.push("dead-code");
   const hasSkippedChecks = skippedChecks.length > 0;
 
-  // HACK: --offline opts out of the score API entirely; without a
-  // local fallback (intentional — scoring lives on the server) we
-  // simply skip the score in offline mode and the renderer shows the
-  // "score unavailable" branch. The message distinguishes the two
-  // null sources — `--offline` (user-requested) vs API failure (the
-  // network round-trip didn't return a usable score) — so the
+  // HACK: --offline opts out of the score entirely; without a local
+  // fallback (intentional — scoring lives on the server) we simply
+  // skip the score in offline mode and the renderer shows the "score
+  // unavailable" branch. The message distinguishes the two null
+  // sources — `--offline` (user-requested) vs API failure — so the
   // renderer doesn't claim offline mode when the user is online but
-  // the API was unreachable. CI runs are NOT auto-offline: they reach
-  // the score API with a `?ci=1` marker (see `options.isCi`) so the
-  // GitHub Action's `score` output stays populated, and only the share
-  // URL is suppressed downstream.
+  // the API was unreachable. CI runs are NOT auto-offline (the score
+  // still appears); only the share URL is suppressed downstream.
   //
   // Pre-filter diagnostics through the `score` surface so weak-signal
   // rule families (e.g. `design`) stay out of scoring by default and

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -254,19 +254,13 @@ const runInspect = async (
   if (didDeadCodeFail) skippedChecks.push("dead-code");
   const hasSkippedChecks = skippedChecks.length > 0;
 
-  // HACK: --offline opts out of the score entirely; without a local
-  // fallback (intentional — scoring lives on the server) we simply
-  // skip the score in offline mode and the renderer shows the "score
-  // unavailable" branch. The message distinguishes the two null
-  // sources — `--offline` (user-requested) vs API failure — so the
-  // renderer doesn't claim offline mode when the user is online but
-  // the API was unreachable. CI runs are NOT auto-offline (the score
-  // still appears); only the share URL is suppressed downstream.
-  //
   // Pre-filter diagnostics through the `score` surface so weak-signal
   // rule families (e.g. `design`) stay out of scoring by default and
   // don't dilute the headline number. Surface-included diagnostics
   // still flow through `result.diagnostics` for CLI/JSON consumers.
+  // The two null branches (offline vs unreachable API) are
+  // distinguished in `noScoreMessage` so the renderer doesn't claim
+  // offline mode when the user is online but the API failed.
   const scoreDiagnostics = filterDiagnosticsForSurface(diagnostics, "score", userConfig);
   const scoreResult = options.offline
     ? null
@@ -360,9 +354,6 @@ const runInspect = async (
 
   const displayedSourceFileCount = isDiffMode ? includePaths.length : lintSourceFileCount;
 
-  // Share links are noise in CI logs (the score itself is what useful
-  // there — see the GitHub Action's `score` output). Suppress the
-  // share URL on CI runs even though the score API still runs.
   const shouldShowShareLink = !options.offline && options.share && !options.isCi;
   printSummary(
     surfaceDiagnostics,

--- a/packages/react-doctor/tests/calculate-score.test.ts
+++ b/packages/react-doctor/tests/calculate-score.test.ts
@@ -84,10 +84,10 @@ describe("calculateScore", () => {
     });
   });
 
-  it("hits the bare score API URL when isCi is not set", async () => {
-    const capturedUrls: Array<string | URL | Request> = [];
+  it("issue #302: tags the score request with ?ci=1 when isCi is true", async () => {
+    let capturedUrl: string | URL | Request | undefined;
     stubFetch(async (url) => {
-      capturedUrls.push(url);
+      capturedUrl = url;
       return new Response(JSON.stringify(apiScoreResponse), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -95,28 +95,10 @@ describe("calculateScore", () => {
     });
 
     await calculateScore(sampleDiagnostics);
-
-    expect(capturedUrls).toHaveLength(1);
-    const requestUrl = String(capturedUrls[0]);
-    expect(requestUrl).toMatch(/\/api\/score$/);
-    expect(requestUrl).not.toContain("ci=1");
-  });
-
-  it("issue #302: tags the score request with ?ci=1 when isCi is true", async () => {
-    const capturedUrls: Array<string | URL | Request> = [];
-    stubFetch(async (url) => {
-      capturedUrls.push(url);
-      return new Response(JSON.stringify(apiScoreResponse), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    });
+    expect(String(capturedUrl)).not.toContain("ci=1");
 
     await calculateScore(sampleDiagnostics, { isCi: true });
-
-    expect(capturedUrls).toHaveLength(1);
-    const requestUrl = String(capturedUrls[0]);
-    expect(requestUrl).toContain("?ci=1");
+    expect(String(capturedUrl)).toContain("?ci=1");
   });
 
   it("returns null when the API response shape is invalid", async () => {

--- a/packages/react-doctor/tests/calculate-score.test.ts
+++ b/packages/react-doctor/tests/calculate-score.test.ts
@@ -84,6 +84,41 @@ describe("calculateScore", () => {
     });
   });
 
+  it("hits the bare score API URL when isCi is not set", async () => {
+    const capturedUrls: Array<string | URL | Request> = [];
+    stubFetch(async (url) => {
+      capturedUrls.push(url);
+      return new Response(JSON.stringify(apiScoreResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await calculateScore(sampleDiagnostics);
+
+    expect(capturedUrls).toHaveLength(1);
+    const requestUrl = String(capturedUrls[0]);
+    expect(requestUrl).toMatch(/\/api\/score$/);
+    expect(requestUrl).not.toContain("ci=1");
+  });
+
+  it("issue #302: tags the score request with ?ci=1 when isCi is true", async () => {
+    const capturedUrls: Array<string | URL | Request> = [];
+    stubFetch(async (url) => {
+      capturedUrls.push(url);
+      return new Response(JSON.stringify(apiScoreResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    await calculateScore(sampleDiagnostics, { isCi: true });
+
+    expect(capturedUrls).toHaveLength(1);
+    const requestUrl = String(capturedUrls[0]);
+    expect(requestUrl).toContain("?ci=1");
+  });
+
   it("returns null when the API response shape is invalid", async () => {
     stubFetch(
       async () =>

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -37,12 +37,11 @@ describe("GitHub Action contract", () => {
     expect(scoreStep).toContain("|| true");
   });
 
-  it("issue #302: action exposes a `score` output and threads the offline input into the score step", () => {
+  it("issue #302: exposes a `score` output and threads `offline` into the score step", () => {
     const actionYaml = readActionYaml();
     const outputsBlock = extractBlock(actionYaml, "outputs:", "\nruns:");
     const scoreStep = normalizeWhitespace(extractStep(actionYaml, "- id: score"));
 
-    expect(outputsBlock).toContain("  score:");
     expect(outputsBlock).toContain("${{ steps.score.outputs.score }}");
     expect(scoreStep).toContain("INPUT_OFFLINE: ${{ inputs.offline }}");
     expect(scoreStep).toContain(

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -28,17 +28,31 @@ const extractStep = (actionYaml: string, marker: string): string => {
 };
 
 describe("GitHub Action contract", () => {
-  it("issue #302: does not advertise a score output (CI implies --offline, score API is skipped)", () => {
-    const actionYaml = readActionYaml();
+  it("issue #190: score collection cannot fail the job on Needs work scores", () => {
+    const scoreStep = normalizeWhitespace(extractStep(readActionYaml(), "- id: score"));
 
-    expect(actionYaml).not.toMatch(/^outputs:/m);
-    expect(actionYaml).not.toContain("- id: score");
-    expect(actionYaml).not.toContain("REACT_DOCTOR_SCORE");
+    expect(scoreStep).toContain("--score");
+    expect(scoreStep).toContain('"--fail-on" "none"');
+    expect(scoreStep).toContain("SCORE=$(npx react-doctor@latest");
+    expect(scoreStep).toContain("|| true");
+  });
+
+  it("issue #302: action exposes a `score` output and threads the offline input into the score step", () => {
+    const actionYaml = readActionYaml();
+    const outputsBlock = extractBlock(actionYaml, "outputs:", "\nruns:");
+    const scoreStep = normalizeWhitespace(extractStep(actionYaml, "- id: score"));
+
+    expect(outputsBlock).toContain("  score:");
+    expect(outputsBlock).toContain("${{ steps.score.outputs.score }}");
+    expect(scoreStep).toContain("INPUT_OFFLINE: ${{ inputs.offline }}");
+    expect(scoreStep).toContain(
+      'if [ "$INPUT_OFFLINE" = "true" ]; then SCORE_ARGS+=("--offline"); fi',
+    );
   });
 
   it("issue #188 + #61: action exposes CI inputs used by the scan step", () => {
     const actionYaml = readActionYaml();
-    const inputsBlock = extractBlock(actionYaml, "inputs:", "\nruns:");
+    const inputsBlock = extractBlock(actionYaml, "inputs:", "\noutputs:");
     const scanStep = normalizeWhitespace(
       extractStep(actionYaml, "INPUT_FAIL_ON: ${{ inputs.fail-on }}"),
     );
@@ -93,7 +107,7 @@ describe("GitHub Action contract", () => {
 
   it("forwards --annotations to the CLI when the annotations input is true", () => {
     const actionYaml = readActionYaml();
-    const inputsBlock = extractBlock(actionYaml, "inputs:", "\nruns:");
+    const inputsBlock = extractBlock(actionYaml, "inputs:", "\noutputs:");
     const scanStep = normalizeWhitespace(
       extractStep(actionYaml, "INPUT_FAIL_ON: ${{ inputs.fail-on }}"),
     );

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -28,18 +28,17 @@ const extractStep = (actionYaml: string, marker: string): string => {
 };
 
 describe("GitHub Action contract", () => {
-  it("issue #190: score collection cannot fail the job on Needs work scores", () => {
-    const scoreStep = normalizeWhitespace(extractStep(readActionYaml(), "- id: score"));
+  it("issue #302: does not advertise a score output (CI implies --offline, score API is skipped)", () => {
+    const actionYaml = readActionYaml();
 
-    expect(scoreStep).toContain("--score");
-    expect(scoreStep).toContain('"--fail-on" "none"');
-    expect(scoreStep).toContain("SCORE=$(npx react-doctor@latest");
-    expect(scoreStep).toContain("|| true");
+    expect(actionYaml).not.toMatch(/^outputs:/m);
+    expect(actionYaml).not.toContain("- id: score");
+    expect(actionYaml).not.toContain("REACT_DOCTOR_SCORE");
   });
 
   it("issue #188 + #61: action exposes CI inputs used by the scan step", () => {
     const actionYaml = readActionYaml();
-    const inputsBlock = extractBlock(actionYaml, "inputs:", "\noutputs:");
+    const inputsBlock = extractBlock(actionYaml, "inputs:", "\nruns:");
     const scanStep = normalizeWhitespace(
       extractStep(actionYaml, "INPUT_FAIL_ON: ${{ inputs.fail-on }}"),
     );
@@ -94,7 +93,7 @@ describe("GitHub Action contract", () => {
 
   it("forwards --annotations to the CLI when the annotations input is true", () => {
     const actionYaml = readActionYaml();
-    const inputsBlock = extractBlock(actionYaml, "inputs:", "\noutputs:");
+    const inputsBlock = extractBlock(actionYaml, "inputs:", "\nruns:");
     const scanStep = normalizeWhitespace(
       extractStep(actionYaml, "INPUT_FAIL_ON: ${{ inputs.fail-on }}"),
     );

--- a/packages/react-doctor/tests/resolve-cli-inspect-options.test.ts
+++ b/packages/react-doctor/tests/resolve-cli-inspect-options.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { resolveCliInspectOptions } from "../src/cli/utils/resolve-cli-inspect-options.js";
+
+const CI_ENVIRONMENT_VARIABLES = ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"] as const;
+
+describe("resolveCliInspectOptions: CI behavior (issue #302)", () => {
+  let savedEnvironment: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnvironment = {};
+    for (const envVariable of CI_ENVIRONMENT_VARIABLES) {
+      savedEnvironment[envVariable] = process.env[envVariable];
+      delete process.env[envVariable];
+    }
+  });
+
+  afterEach(() => {
+    for (const envVariable of CI_ENVIRONMENT_VARIABLES) {
+      const previousValue = savedEnvironment[envVariable];
+      if (previousValue === undefined) {
+        delete process.env[envVariable];
+      } else {
+        process.env[envVariable] = previousValue;
+      }
+    }
+  });
+
+  it("does NOT auto-flip offline in CI — the score API still runs so `outputs.score` works", () => {
+    process.env.GITHUB_ACTIONS = "true";
+
+    const resolved = resolveCliInspectOptions({}, null);
+
+    expect(resolved.offline).toBe(false);
+    expect(resolved.isCi).toBe(true);
+  });
+
+  it("respects an explicit user `--offline` flag in CI (zero-network opt-out is preserved)", () => {
+    process.env.GITHUB_ACTIONS = "true";
+
+    const resolved = resolveCliInspectOptions({ offline: true }, null);
+
+    expect(resolved.offline).toBe(true);
+    expect(resolved.isCi).toBe(true);
+  });
+
+  it("respects `offline: true` from user config in CI", () => {
+    process.env.GITHUB_ACTIONS = "true";
+
+    const resolved = resolveCliInspectOptions({}, { offline: true });
+
+    expect(resolved.offline).toBe(true);
+    expect(resolved.isCi).toBe(true);
+  });
+
+  it("leaves isCi false outside CI environments", () => {
+    const resolved = resolveCliInspectOptions({}, null);
+
+    expect(resolved.offline).toBe(false);
+    expect(resolved.isCi).toBe(false);
+  });
+
+  it("flags GITLAB_CI and CIRCLECI as CI runs", () => {
+    process.env.GITLAB_CI = "true";
+    expect(resolveCliInspectOptions({}, null).isCi).toBe(true);
+    delete process.env.GITLAB_CI;
+
+    process.env.CIRCLECI = "true";
+    expect(resolveCliInspectOptions({}, null).isCi).toBe(true);
+  });
+});

--- a/packages/react-doctor/tests/resolve-cli-inspect-options.test.ts
+++ b/packages/react-doctor/tests/resolve-cli-inspect-options.test.ts
@@ -25,7 +25,7 @@ describe("resolveCliInspectOptions: CI behavior (issue #302)", () => {
     }
   });
 
-  it("does NOT auto-flip offline in CI — the score API still runs so `outputs.score` works", () => {
+  it("does not auto-flip offline in CI; the score path still runs", () => {
     process.env.GITHUB_ACTIONS = "true";
 
     const resolved = resolveCliInspectOptions({}, null);
@@ -34,37 +34,22 @@ describe("resolveCliInspectOptions: CI behavior (issue #302)", () => {
     expect(resolved.isCi).toBe(true);
   });
 
-  it("respects an explicit user `--offline` flag in CI (zero-network opt-out is preserved)", () => {
+  it("respects an explicit user opt-out (CLI flag or config) in CI", () => {
     process.env.GITHUB_ACTIONS = "true";
 
-    const resolved = resolveCliInspectOptions({ offline: true }, null);
-
-    expect(resolved.offline).toBe(true);
-    expect(resolved.isCi).toBe(true);
+    expect(resolveCliInspectOptions({ offline: true }, null).offline).toBe(true);
+    expect(resolveCliInspectOptions({}, { offline: true }).offline).toBe(true);
   });
 
-  it("respects `offline: true` from user config in CI", () => {
-    process.env.GITHUB_ACTIONS = "true";
-
-    const resolved = resolveCliInspectOptions({}, { offline: true });
-
-    expect(resolved.offline).toBe(true);
-    expect(resolved.isCi).toBe(true);
+  it("leaves isCi false outside CI", () => {
+    expect(resolveCliInspectOptions({}, null).isCi).toBe(false);
   });
 
-  it("leaves isCi false outside CI environments", () => {
-    const resolved = resolveCliInspectOptions({}, null);
-
-    expect(resolved.offline).toBe(false);
-    expect(resolved.isCi).toBe(false);
-  });
-
-  it("flags GITLAB_CI and CIRCLECI as CI runs", () => {
-    process.env.GITLAB_CI = "true";
-    expect(resolveCliInspectOptions({}, null).isCi).toBe(true);
-    delete process.env.GITLAB_CI;
-
-    process.env.CIRCLECI = "true";
-    expect(resolveCliInspectOptions({}, null).isCi).toBe(true);
+  it("detects GITHUB_ACTIONS, GITLAB_CI, and CIRCLECI", () => {
+    for (const envVariable of ["GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"] as const) {
+      process.env[envVariable] = "true";
+      expect(resolveCliInspectOptions({}, null).isCi).toBe(true);
+      delete process.env[envVariable];
+    }
   });
 });

--- a/packages/types/src/inspect.ts
+++ b/packages/types/src/inspect.ts
@@ -30,11 +30,9 @@ export interface InspectOptions {
   /**
    * Marks the run as originating from a CI environment. Set by the CLI
    * when one of `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI` / `CI=true`
-   * is present. Forwarded to the score API as `?ci=1` so the server can
-   * tag CI traffic separately, and used to suppress the share URL in
-   * the printed summary (share links are noise in CI logs). It does
-   * NOT imply `--offline`; the score API still runs unless the user
-   * explicitly opts out.
+   * is present. Used to suppress the share URL in the printed summary
+   * (share links are noise in CI logs). Does NOT imply `--offline` —
+   * the score still runs unless the user explicitly opts out.
    */
   isCi?: boolean;
   silent?: boolean;

--- a/packages/types/src/inspect.ts
+++ b/packages/types/src/inspect.ts
@@ -27,6 +27,16 @@ export interface InspectOptions {
   verbose?: boolean;
   scoreOnly?: boolean;
   offline?: boolean;
+  /**
+   * Marks the run as originating from a CI environment. Set by the CLI
+   * when one of `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI` / `CI=true`
+   * is present. Forwarded to the score API as `?ci=1` so the server can
+   * tag CI traffic separately, and used to suppress the share URL in
+   * the printed summary (share links are noise in CI logs). It does
+   * NOT imply `--offline`; the score API still runs unless the user
+   * explicitly opts out.
+   */
+  isCi?: boolean;
   silent?: boolean;
   includePaths?: string[];
   configOverride?: ReactDoctorConfig | null;

--- a/packages/types/src/inspect.ts
+++ b/packages/types/src/inspect.ts
@@ -28,11 +28,8 @@ export interface InspectOptions {
   scoreOnly?: boolean;
   offline?: boolean;
   /**
-   * Marks the run as originating from a CI environment. Set by the CLI
-   * when one of `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI` / `CI=true`
-   * is present. Used to suppress the share URL in the printed summary
-   * (share links are noise in CI logs). Does NOT imply `--offline` —
-   * the score still runs unless the user explicitly opts out.
+   * Marks the run as CI-originated. Suppresses the share URL in the
+   * printed summary; does not imply `--offline`.
    */
   isCi?: boolean;
   silent?: boolean;

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -60,7 +60,7 @@ Use `--fail-on <level>` to control exit codes (`error`, `warning`, `none`):
 npx react-doctor@latest --fail-on error
 ```
 
-Use `--offline` to skip the score API (computes score locally):
+Use `--offline` to skip the score API and the share URL. Scoring runs on the react.doctor API, so offline runs print no score and the rest of the report still renders normally. Automatically enabled in CI (GitHub Actions, GitLab CI, CircleCI, or any environment that sets `CI=true`):
 
 ```bash
 npx react-doctor@latest --offline
@@ -88,7 +88,7 @@ Options:
   --full             skip prompts, always run a full scan (decline diff-only)
   --project <name>   select workspace project (comma-separated for multiple)
   --diff [base]      scan only files changed vs base branch or uncommitted changes
-  --offline          skip telemetry (anonymous, not stored, only used to calculate score)
+  --offline          skip the score API and share URL (no score is shown; auto-enabled in CI)
   --staged           scan only staged (git index) files for pre-commit hooks
   --fail-on <level>  exit with error code on diagnostics: error, warning, none
   --annotations      output diagnostics as GitHub Actions annotations

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -60,7 +60,7 @@ Use `--fail-on <level>` to control exit codes (`error`, `warning`, `none`):
 npx react-doctor@latest --fail-on error
 ```
 
-Use `--offline` to skip the score API and the share URL. Scoring runs on the react.doctor API, so offline runs print no score and the rest of the report still renders normally. CI runs (GitHub Actions, GitLab CI, CircleCI) are NOT auto-offline — the score request is tagged with `?ci=1` instead, and only the share URL is suppressed:
+Use `--offline` to skip the score API and the share URL. Scoring runs on the react.doctor API, so offline runs print no score and the rest of the report still renders normally. CI runs are not offline by default — only the share URL is suppressed:
 
 ```bash
 npx react-doctor@latest --offline
@@ -88,7 +88,7 @@ Options:
   --full             skip prompts, always run a full scan (decline diff-only)
   --project <name>   select workspace project (comma-separated for multiple)
   --diff [base]      scan only files changed vs base branch or uncommitted changes
-  --offline          skip the score API and share URL (no score is shown; CI runs reach the API by default with a ci=1 marker)
+  --offline          skip the score API and share URL (no score is shown)
   --staged           scan only staged (git index) files for pre-commit hooks
   --fail-on <level>  exit with error code on diagnostics: error, warning, none
   --annotations      output diagnostics as GitHub Actions annotations

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -60,7 +60,7 @@ Use `--fail-on <level>` to control exit codes (`error`, `warning`, `none`):
 npx react-doctor@latest --fail-on error
 ```
 
-Use `--offline` to skip the score API and the share URL. Scoring runs on the react.doctor API, so offline runs print no score and the rest of the report still renders normally. Automatically enabled in CI (GitHub Actions, GitLab CI, CircleCI, or any environment that sets `CI=true`):
+Use `--offline` to skip the score API and the share URL. Scoring runs on the react.doctor API, so offline runs print no score and the rest of the report still renders normally. CI runs (GitHub Actions, GitLab CI, CircleCI) are NOT auto-offline — the score request is tagged with `?ci=1` instead, and only the share URL is suppressed:
 
 ```bash
 npx react-doctor@latest --offline
@@ -88,7 +88,7 @@ Options:
   --full             skip prompts, always run a full scan (decline diff-only)
   --project <name>   select workspace project (comma-separated for multiple)
   --diff [base]      scan only files changed vs base branch or uncommitted changes
-  --offline          skip the score API and share URL (no score is shown; auto-enabled in CI)
+  --offline          skip the score API and share URL (no score is shown; CI runs reach the API by default with a ci=1 marker)
   --staged           scan only staged (git index) files for pre-commit hooks
   --fail-on <level>  exit with error code on diagnostics: error, warning, none
   --annotations      output diagnostics as GitHub Actions annotations

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -60,7 +60,7 @@ Use `--fail-on <level>` to control exit codes (`error`, `warning`, `none`):
 npx react-doctor@latest --fail-on error
 ```
 
-Use `--offline` to skip the score API and the share URL. Scoring runs on the react.doctor API, so offline runs print no score and the rest of the report still renders normally. CI runs are not offline by default — only the share URL is suppressed:
+Use `--offline` to skip the score API and the share URL. Offline runs print no score; the rest of the report renders normally:
 
 ```bash
 npx react-doctor@latest --offline


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #302.

## Context

The GitHub Action's `steps.doctor.outputs.score` was documented as a way to enforce a score floor in CI, but the CLI auto-implied `--offline` whenever `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI` / `CI=true` was set, and `--offline` skips the score API entirely (the score is computed server-side; there's no local fallback as of v0.2.x). The composite action's `score` step therefore always emitted an empty value, the documented "Strict threshold mode" recipe never worked from CI, and the sticky PR comment occasionally rendered an empty Score line.

The original justification for auto-offline-in-CI conflated two unrelated concerns: (a) share URLs are noise in CI logs, (b) score requests should be skipped. (a) is the real reason; (b) was an accidental side effect that broke the documented `score` output contract.

## Approach

Decouple the two. CI runs reach the score API by default — the URL is tagged so server-side metrics can separate CI traffic from interactive runs without changing the request body shape. Only the share URL is suppressed on CI. Users who want zero network in CI keep passing `--offline` (or `offline: true` in config).

The documented score-floor recipe is hardened — if the API is unreachable, returns a non-2xx, or the response shape changes, `outputs.score` stays empty and the floor step soft-skips with a `::notice::` instead of failing the build, so a transient API hiccup can't block unrelated PRs.

User-facing docs intentionally describe only the observable behavior (score works in CI, `offline: true` opts out). Internal type doc-comments and the test suite still pin the wire-level contract.

## Changes

- **`@react-doctor/core/calculate-score`**: accept `{ isCi?: boolean }` and add a CI marker to the score-API URL when set.
- **`@react-doctor/types/InspectOptions`**: add an `isCi` flag (doc-commented at the type level) so the CLI can mark a run as CI-originated without conflating it with `--offline`.
- **`packages/react-doctor/src/inspect.ts`**: thread `isCi` into `calculateScore`; suppress the share link (not the score) when `isCi` is true.
- **`packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts`**: stop OR-ing `isCiEnvironment()` into `offline`; pass `isCi: isCiEnvironment()` instead. Explicit `--offline` and `offline: true` config still win in CI.
- **`packages/react-doctor/src/cli/commands/inspect.ts`**: drop the stale "CI detected — scoring locally" log line (the score now comes from the API in CI too).
- **`packages/react-doctor/src/cli/utils/is-ci-environment.ts`**: refresh the HACK comment for the new role.
- **`action.yml`**: restore the `score` output, the `- id: score` step, and the score line in the sticky PR comment. Tighten the `offline` / `fail-on` input descriptions and the `score` output description.
- **`packages/react-doctor/README.md`**: restore the strict-threshold recipe; harden the example so the floor step is a no-op when `score` is empty. Update the Scoring + agent integration paragraphs to reflect the new CI behavior.
- **`packages/website/public/llms.txt`**: align the `--offline` description with the new model.
- **Tests**:
  - `tests/calculate-score.test.ts` — assert the request URL is bare by default and tagged when `isCi: true`.
  - `tests/resolve-cli-inspect-options.test.ts` — new regression file for issue #302 covering: CI does not auto-flip `offline`; explicit `--offline` and `offline: true` config still win in CI; CI is correctly detected for `GITHUB_ACTIONS` / `GITLAB_CI` / `CIRCLECI`.
  - `tests/github-action.test.ts` — restore the issue-#190 score-collection contract test and add an issue-#302 contract test that asserts `outputs.score` and the `- id: score` step are wired through.

## Verification

```
pnpm format    # 694 files, clean
pnpm lint      # 0 warnings, 0 errors
pnpm typecheck # 10 tasks successful
pnpm test      # 101 files, 1210 tests passing (8 new)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16c4b906-5655-4e55-b63a-8d7b2c125e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16c4b906-5655-4e55-b63a-8d7b2c125e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

