### PR TITLE
perf(react-doctor): cut install graph from 32 to 15 packages

### DIFF
--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -56,11 +56,8 @@
   },
   "dependencies": {
     "agent-install": "0.0.5",
-    "commander": "^14.0.3",
-    "ora": "^9.4.0",
     "oxlint": "^1.63.0",
     "oxlint-plugin-react-doctor": "workspace:*",
-    "picocolors": "^1.1.1",
     "prompts": "^2.4.2",
     "typescript": ">=5.0.4 <7"
   },
@@ -69,8 +66,10 @@
     "@react-doctor/project-info": "workspace:*",
     "@react-doctor/types": "workspace:*",
     "@types/prompts": "^2.4.9",
+    "commander": "^14.0.3",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.1"
+    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.1",
+    "ora": "^9.4.0"
   },
   "peerDependencies": {
     "eslint-plugin-react-hooks": "^6 || ^7",

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -46,7 +46,24 @@ export default defineConfig({
   pack: [
     {
       entry: { cli: "./src/cli/index.ts" },
-      deps: { neverBundle: ["oxlint", "oxlint-plugin-react-doctor", "typescript"] },
+      deps: {
+        // Inline pure-JS CLI deps so `npm i react-doctor` skips
+        // ~15 transitive installs (commander, ora, and ora's spinner
+        // / cursor / log-symbols / string-width chain). Native
+        // (oxlint), the lint plugin, prompts (we monkey-patch it via
+        // require so the runtime copy must be on disk), agent-install
+        // (its jsonc-parser/yaml/toml transitives ship as UMD that
+        // doesn't bundle cleanly), and the typescript compiler all
+        // stay external.
+        alwaysBundle: ["commander", "ora"],
+        neverBundle: [
+          "agent-install",
+          "oxlint",
+          "oxlint-plugin-react-doctor",
+          "prompts",
+          "typescript",
+        ],
+      },
       dts: true,
       target: "node22",
       platform: "node",
@@ -69,7 +86,16 @@ export default defineConfig({
     },
     {
       entry: { index: "./src/index.ts" },
-      deps: { neverBundle: ["oxlint", "oxlint-plugin-react-doctor", "typescript"] },
+      deps: {
+        alwaysBundle: ["commander", "ora"],
+        neverBundle: [
+          "agent-install",
+          "oxlint",
+          "oxlint-plugin-react-doctor",
+          "prompts",
+          "typescript",
+        ],
+      },
       dts: true,
       target: "node22",
       platform: "node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,21 +109,12 @@ importers:
       agent-install:
         specifier: 0.0.5
         version: 0.0.5
-      commander:
-        specifier: ^14.0.3
-        version: 14.0.3
-      ora:
-        specifier: ^9.4.0
-        version: 9.4.0
       oxlint:
         specifier: ^1.63.0
         version: 1.63.0(oxlint-tsgolint@0.22.1)
       oxlint-plugin-react-doctor:
         specifier: workspace:*
         version: link:../oxlint-plugin-react-doctor
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -143,12 +134,18 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-you-might-not-need-an-effect:
         specifier: ^0.10.1
         version: 0.10.1(eslint@9.39.2(jiti@2.6.1))
+      ora:
+        specifier: ^9.4.0
+        version: 9.4.0
 
   packages/types:
     devDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`npm i react-doctor` previously pulled in 32 packages. After this change it pulls 15 — a 17-package (53%) reduction in the transitive install graph, with no functional change.

| | Before | After |
| --- | ---: | ---: |
| Direct deps | 8 | 5 |
| Total packages installed | 32 | 15 |
| `npm install` (warm cache, local) | 2.34s | 0.86s |
| `dist/cli.js` size | 260 KB | 445 KB |
| `dist/cli.js` gzip | ~62 KB | ~106 KB |

Total `node_modules` size is unchanged (~45 MB), because the heavy hitters — `typescript` (~24 MB) and `oxlint`'s native binding (~14 MB) — must stay external. The win is purely in the number of tarballs the package manager has to fetch, extract, and link.

## What changed

1. **`commander` and `ora` are now inlined into `dist/cli.js`.**
   They're pure-ESM leaf packages that bundle cleanly via tsdown's `deps.alwaysBundle`. Moved from `dependencies` to `devDependencies`. This kills the entire `ora` transitive chain (`cli-cursor`, `cli-spinners`, `log-symbols`, `signal-exit`, `stdin-discarder`, `string-width`, `strip-ansi`, `is-interactive`, `is-unicode-supported`, `chalk`, …).

2. **`picocolors` removed from `dependencies` entirely.**
   It was already inlined into `dist/cli.js` and `dist/index.js` via `@react-doctor/core` (which is a workspace `devDependency` and gets bundled into the published artifact). The runtime install was a duplicate.

3. **`prompts` stays external on purpose.**
   `src/cli/utils/prompts.ts` monkey-patches `prompts/lib/elements/multiselect` through `createRequire`. That patch needs to run against the same constructor instance that `basePrompts(…)` uses internally, which means we need a copy on disk to `require()`.

4. **`agent-install` stays external on purpose.**
   Its `mcp` helper (re-exported from the root entry) pulls in `jsonc-parser`, which ships its main entry as a UMD bundle whose `require("./impl/format")` calls don't survive Rolldown's CJS handler. Bundling it produced a runtime `Cannot find module './impl/format'` crash. Leaving `agent-install` external sidesteps the issue.

## Files

- `packages/react-doctor/vite.config.ts` — set `deps.alwaysBundle: ["commander", "ora"]` and explicitly list the externals (`agent-install`, `oxlint`, `oxlint-plugin-react-doctor`, `prompts`, `typescript`).
- `packages/react-doctor/package.json` — moved `commander` and `ora` to `devDependencies`; removed `picocolors`.
- `pnpm-lock.yaml` — regenerated.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (1204 tests across 100 files) all green.
- Smoke test: `node packages/react-doctor/bin/react-doctor.js .` against a small React project still produces the expected diagnostics.
- Smoke test: `react-doctor install --dry-run -y` still detects agents and would install — exercises the `agent-install` external path.
- Verified the externals in `dist/cli.js` exactly match the new `dependencies`: `typescript`, `prompts`, `oxlint-plugin-react-doctor`, `agent-install` (plus `oxlint` invoked via `child_process`).
- Verified the externals in `dist/index.js` (the `react-doctor/api` entry) are just `typescript` and `oxlint-plugin-react-doctor` — programmatic API consumers no longer pull `commander`/`ora`/`picocolors` into their own dep graphs either.

## Not in scope

- `typescript` (~24 MB) is the single biggest install cost. It's used in one place (`resolveUseCallBinding` for the `react-hooks(rules-of-hooks)` `use()` suppression heuristic). Demoting it to an optional peer dep with a fallback is a bigger, behavior-changing refactor and is left for a follow-up.
- `oxlint`'s native binding is also large but unavoidable — it's the linter we shell out to.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7343d50b-4a54-448c-8f26-ee9885bd2d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7343d50b-4a54-448c-8f26-ee9885bd2d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

