### PR TITLE
triage: address #219 audit and #203 Husky/lint-staged recipe

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -74,6 +74,16 @@ When `github-token` is set on `pull_request` events, findings are posted (and up
 
 **Inputs:** `directory`, `verbose`, `project`, `diff`, `github-token`, `fail-on` (`error` / `warning` / `none`), `offline`, `annotations`, `node-version`. See [`action.yml`](https://github.com/millionco/react-doctor/blob/main/action.yml) for full descriptions.
 
+#### Pinning the action for hardened CI
+
+The examples above use `@main` for readability. Because `main` is a mutable branch, anything pushed to it runs in your workflow at the next trigger — combined with `pull-requests: write` (needed for sticky PR comments) that is real supply-chain surface. For production pipelines, pin to a specific commit SHA instead:
+
+```yaml
+- uses: millionco/react-doctor@<full-commit-sha> # e.g. 6543a86f9dfe86c894bd71361fc2c46d8d9c967d
+```
+
+Grab the SHA from the [Releases](https://github.com/millionco/react-doctor/releases) page or `git ls-remote https://github.com/millionco/react-doctor` and let [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) bump it. Tools like [`pin-github-action`](https://github.com/mheap/pin-github-action) can SHA-pin every action in a workflow at once.
+
 #### PR feedback modes
 
 Pick one or both; they're independent.
@@ -411,6 +421,52 @@ React Doctor can scan only changed files instead of the full project:
 When on a feature branch without explicit flags, you'll be prompted: "Only scan changed files?" This prompt is suppressed in CI, `--json` mode, and non-interactive environments.
 
 `--staged` and `--diff` cannot be combined.
+
+### Pre-commit hooks with Husky + lint-staged
+
+The most common setup is [Husky](https://typicode.github.io/husky/) for the git hook and [lint-staged](https://github.com/lint-staged/lint-staged) to filter which files run through each tool. React Doctor's `--staged` mode is built for this: it reads file contents from the git **index** (not the working tree) and materializes them into a temp directory, so partially-staged files are scanned exactly as they will be committed.
+
+Install both, then wire them up:
+
+```bash
+npx ni -D husky lint-staged
+npx husky init
+```
+
+`husky init` creates `.husky/pre-commit`. Replace its contents with:
+
+```bash
+npx lint-staged
+```
+
+Then add a `lint-staged` block to your `package.json`. Because React Doctor already filters to the staged set via `--staged`, **do not pass the lint-staged-injected file list** — invoke it with a single command and let it discover the index itself:
+
+```json
+{
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": "react-doctor --staged --fail-on warning"
+  }
+}
+```
+
+A few notes that bite people:
+
+- **Don't append `{staged-files}`** — lint-staged would otherwise pass the matched paths as positional arguments and you'd get the union (path filter + index scan) instead of the intent.
+- **Use the function form when you only want the hook to run if any matching file is staged** but still want a single project-wide scan:
+
+  ```js
+  // lint-staged.config.js
+  export default {
+    "*.{ts,tsx,js,jsx}": () => "react-doctor --staged --fail-on warning",
+  };
+  ```
+
+- **`--fail-on warning`** blocks the commit on any diagnostic. Use `--fail-on error` for a softer gate, or `--fail-on none` to lint advisory-only.
+- **Index vs. working tree:** `--staged` reflects `git diff --cached`, not your editor buffer. If you `git add` half a file and keep typing, only the added half is scanned — the unstaged tail is ignored.
+- **Skip in CI:** lint-staged is a pre-commit concern. In CI, use the GitHub Action (above) or `react-doctor --diff <base>` directly; running both does duplicate work.
+- **Other hook managers:** the same `react-doctor --staged --fail-on warning` command works under [Lefthook](https://lefthook.dev/), [pre-commit](https://pre-commit.com/), or a hand-written `.git/hooks/pre-commit` — `--staged` is hook-manager-agnostic.
+
+To bypass the hook for a one-off commit, use `git commit --no-verify`.
 
 ## Agent and CI integration
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -74,16 +74,6 @@ When `github-token` is set on `pull_request` events, findings are posted (and up
 
 **Inputs:** `directory`, `verbose`, `project`, `diff`, `github-token`, `fail-on` (`error` / `warning` / `none`), `offline`, `annotations`, `node-version`. See [`action.yml`](https://github.com/millionco/react-doctor/blob/main/action.yml) for full descriptions.
 
-#### Pinning the action for hardened CI
-
-The examples above use `@main` for readability. Because `main` is a mutable branch, anything pushed to it runs in your workflow at the next trigger — combined with `pull-requests: write` (needed for sticky PR comments) that is real supply-chain surface. For production pipelines, pin to a specific commit SHA instead:
-
-```yaml
-- uses: millionco/react-doctor@<full-commit-sha> # e.g. 6543a86f9dfe86c894bd71361fc2c46d8d9c967d
-```
-
-Grab the SHA from the [Releases](https://github.com/millionco/react-doctor/releases) page or `git ls-remote https://github.com/millionco/react-doctor` and let [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) bump it. Tools like [`pin-github-action`](https://github.com/mheap/pin-github-action) can SHA-pin every action in a workflow at once.
-
 #### PR feedback modes
 
 Pick one or both; they're independent.

--- a/packages/website/src/app/leaderboard/page.tsx
+++ b/packages/website/src/app/leaderboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
 import { PERFECT_SCORE } from "@/constants";
 import { clampScore } from "@/utils/clamp-score";
@@ -116,7 +117,7 @@ const LeaderboardPage = async () => {
           href="/"
           className="inline-flex items-center gap-2 text-neutral-500 transition-colors hover:text-neutral-300"
         >
-          <img src="/favicon.svg" alt="React Doctor" width={20} height={20} />
+          <Image src="/favicon.svg" alt="React Doctor" width={20} height={20} unoptimized />
           <span>react-doctor</span>
         </Link>
       </div>

--- a/packages/website/src/app/page.tsx
+++ b/packages/website/src/app/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import Terminal from "@/components/terminal";
+
+export const metadata: Metadata = {
+  title: "React Doctor",
+  description: "Your agent writes bad React, this catches it. Diagnose and fix React codebases.",
+};
 
 const Home = () => <Terminal />;
 

--- a/packages/website/src/app/share/animated-score.tsx
+++ b/packages/website/src/app/share/animated-score.tsx
@@ -28,19 +28,19 @@ const AnimatedScore = ({ targetScore }: { targetScore: number }) => {
   const [animatedScore, setAnimatedScore] = useState(0);
 
   useEffect(() => {
-    let cancelled = false;
     let frame = 0;
+    let pendingTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const animate = () => {
-      if (cancelled || frame > SCORE_FRAME_COUNT) return;
+      if (frame > SCORE_FRAME_COUNT) return;
       setAnimatedScore(Math.round(easeOutCubic(frame / SCORE_FRAME_COUNT) * targetScore));
       frame++;
-      setTimeout(animate, SCORE_FRAME_DELAY_MS);
+      pendingTimeoutId = setTimeout(animate, SCORE_FRAME_DELAY_MS);
     };
 
     animate();
     return () => {
-      cancelled = true;
+      if (pendingTimeoutId !== null) clearTimeout(pendingTimeoutId);
     };
   }, [targetScore]);
 

--- a/packages/website/src/app/share/animated-score.tsx
+++ b/packages/website/src/app/share/animated-score.tsx
@@ -30,9 +30,10 @@ const AnimatedScore = ({ targetScore }: { targetScore: number }) => {
   useEffect(() => {
     let frame = 0;
     let pendingTimeoutId: ReturnType<typeof setTimeout> | null = null;
+    let isCancelled = false;
 
     const animate = () => {
-      if (frame > SCORE_FRAME_COUNT) return;
+      if (isCancelled || frame > SCORE_FRAME_COUNT) return;
       setAnimatedScore(Math.round(easeOutCubic(frame / SCORE_FRAME_COUNT) * targetScore));
       frame++;
       pendingTimeoutId = setTimeout(animate, SCORE_FRAME_DELAY_MS);
@@ -40,6 +41,7 @@ const AnimatedScore = ({ targetScore }: { targetScore: number }) => {
 
     animate();
     return () => {
+      isCancelled = true;
       if (pendingTimeoutId !== null) clearTimeout(pendingTimeoutId);
     };
   }, [targetScore]);

--- a/packages/website/src/app/share/badge-snippet.tsx
+++ b/packages/website/src/app/share/badge-snippet.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 
 const COPY_FEEDBACK_DURATION_MS = 2000;
 const BADGE_BASE_URL = "https://www.react.doctor/share/badge";
 const SHARE_BASE_URL = "https://www.react.doctor/share";
+const BADGE_PREVIEW_HEIGHT_PX = 20;
+const BADGE_PREVIEW_INTRINSIC_WIDTH_PX = 160;
 
 interface BadgeSnippetProps {
   searchParamsString: string;
@@ -28,7 +31,14 @@ const BadgeSnippet = ({ searchParamsString }: BadgeSnippetProps) => {
     <div className="mt-8">
       <div className="text-neutral-500">Add a badge to your README:</div>
       <div className="mt-3 flex flex-wrap items-center gap-3">
-        <img src={badgePreviewPath} alt="React Doctor score badge" height={20} className="block" />
+        <Image
+          src={badgePreviewPath}
+          alt="React Doctor score badge"
+          width={BADGE_PREVIEW_INTRINSIC_WIDTH_PX}
+          height={BADGE_PREVIEW_HEIGHT_PX}
+          unoptimized
+          className="block h-5 w-auto"
+        />
         <a
           href={badgePreviewPath}
           target="_blank"

--- a/packages/website/src/app/share/og/route.tsx
+++ b/packages/website/src/app/share/og/route.tsx
@@ -20,6 +20,63 @@ const getScoreColor = (score: number): string => {
 
 const clampDisplayCount = (raw: number): number => Math.max(0, Math.min(MAX_DISPLAY_COUNT, raw));
 
+// HACK: next/og (Satori) renders via inline `style` only — CSS classes,
+// Tailwind utilities, and CSS modules are not supported, so style objects
+// are hoisted to module scope to keep render bodies compact and reusable.
+const OG_CONTAINER_STYLE = {
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  flexDirection: "column",
+  backgroundColor: "#0a0a0a",
+  fontFamily: "monospace",
+  padding: "60px 80px",
+  justifyContent: "center",
+} as const;
+
+const OG_HEADER_STYLE = {
+  display: "flex",
+  alignItems: "center",
+  gap: "24px",
+} as const;
+
+const OG_PROJECT_LABEL_STYLE = {
+  display: "flex",
+  marginLeft: "auto",
+  fontSize: "24px",
+  color: "#a3a3a3",
+} as const;
+
+const OG_SCORE_ROW_STYLE = {
+  display: "flex",
+  alignItems: "baseline",
+  gap: "16px",
+  marginTop: "48px",
+} as const;
+
+const OG_SCORE_LABEL_STYLE = {
+  fontSize: "40px",
+  color: "#525252",
+  lineHeight: 1,
+} as const;
+
+const OG_SCORE_BAR_TRACK_STYLE = {
+  display: "flex",
+  width: "100%",
+  height: "16px",
+  backgroundColor: "#1a1a1a",
+  borderRadius: "8px",
+  marginTop: "32px",
+  overflow: "hidden",
+} as const;
+
+const OG_COUNTS_ROW_STYLE = {
+  display: "flex",
+  gap: "24px",
+  marginTop: "36px",
+  fontSize: "24px",
+} as const;
+
 export const GET = (request: Request): ImageResponse => {
   const { searchParams } = new URL(request.url);
 
@@ -36,73 +93,39 @@ export const GET = (request: Request): ImageResponse => {
   const brandMarkUrl = new URL(OG_BRAND_MARK_PATH, request.url).toString();
   const scoreBarPercent = (score / PERFECT_SCORE) * 100;
 
+  const scoreValueStyle = { fontSize: "120px", color: scoreColor, fontWeight: 700, lineHeight: 1 };
+  const scoreOutcomeStyle = { ...OG_SCORE_LABEL_STYLE, color: scoreColor, marginLeft: "8px" };
+  const scoreBarFillStyle = {
+    width: `${scoreBarPercent}%`,
+    height: "100%",
+    backgroundColor: scoreColor,
+    borderRadius: "8px",
+  };
+
   return new ImageResponse(
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        backgroundColor: "#0a0a0a",
-        fontFamily: "monospace",
-        padding: "60px 80px",
-        justifyContent: "center",
-      }}
-    >
-      <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
+    <div style={OG_CONTAINER_STYLE}>
+      <div style={OG_HEADER_STYLE}>
         <img
           src={brandMarkUrl}
           alt="React Doctor"
           width={OG_BRAND_MARK_WIDTH_PX}
           height={OG_BRAND_MARK_HEIGHT_PX}
         />
-        {projectName && (
-          <div
-            style={{
-              display: "flex",
-              marginLeft: "auto",
-              fontSize: "24px",
-              color: "#a3a3a3",
-            }}
-          >
-            {projectName}
-          </div>
-        )}
+        {projectName && <div style={OG_PROJECT_LABEL_STYLE}>{projectName}</div>}
       </div>
 
-      <div style={{ display: "flex", alignItems: "baseline", gap: "16px", marginTop: "48px" }}>
-        <span style={{ fontSize: "120px", color: scoreColor, fontWeight: 700, lineHeight: 1 }}>
-          {score}
-        </span>
-        <span style={{ fontSize: "40px", color: "#525252", lineHeight: 1 }}>/ {PERFECT_SCORE}</span>
-        <span style={{ fontSize: "40px", color: scoreColor, lineHeight: 1, marginLeft: "8px" }}>
-          {getScoreLabel(score)}
-        </span>
+      <div style={OG_SCORE_ROW_STYLE}>
+        <span style={scoreValueStyle}>{score}</span>
+        <span style={OG_SCORE_LABEL_STYLE}>/ {PERFECT_SCORE}</span>
+        <span style={scoreOutcomeStyle}>{getScoreLabel(score)}</span>
       </div>
 
-      <div
-        style={{
-          display: "flex",
-          width: "100%",
-          height: "16px",
-          backgroundColor: "#1a1a1a",
-          borderRadius: "8px",
-          marginTop: "32px",
-          overflow: "hidden",
-        }}
-      >
-        <div
-          style={{
-            width: `${scoreBarPercent}%`,
-            height: "100%",
-            backgroundColor: scoreColor,
-            borderRadius: "8px",
-          }}
-        />
+      <div style={OG_SCORE_BAR_TRACK_STYLE}>
+        <div style={scoreBarFillStyle} />
       </div>
 
       {(errorCount > 0 || warningCount > 0 || fileCount > 0) && (
-        <div style={{ display: "flex", gap: "24px", marginTop: "36px", fontSize: "24px" }}>
+        <div style={OG_COUNTS_ROW_STYLE}>
           {errorCount > 0 && (
             <span style={{ color: "#f87171" }}>
               {errorCount} error{errorCount === 1 ? "" : "s"}

--- a/packages/website/src/components/terminal.tsx
+++ b/packages/website/src/components/terminal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Image from "next/image";
 import { Copy, Check, ChevronRight, RotateCcw } from "lucide-react";
 import { PERFECT_SCORE } from "@/constants";
 import { getDoctorFace } from "@/utils/get-doctor-face";
@@ -86,8 +87,25 @@ const DIAGNOSTICS: RuleDiagnostic[] = [
 
 const easeOutCubic = (progress: number) => 1 - Math.pow(1 - progress, 3);
 
-const sleep = (milliseconds: number) =>
-  new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+const sleep = (milliseconds: number, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener("abort", handleAbort);
+      resolve();
+    }, milliseconds);
+    const handleAbort = () => {
+      clearTimeout(timeoutId);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof DOMException && error.name === "AbortError";
 
 const Spacer = () => <div className="min-h-[1.4em]" />;
 
@@ -262,59 +280,56 @@ const Terminal = () => {
       return;
     }
 
-    let cancelled = false;
+    const abortController = new AbortController();
+    const { signal } = abortController;
 
     const update = (patch: Partial<AnimationState>) => {
-      if (!cancelled) setState((previous) => ({ ...previous, ...patch }));
+      if (signal.aborted) return;
+      setState((previous) => ({ ...previous, ...patch }));
     };
 
     const run = async () => {
-      await sleep(INITIAL_DELAY_MS);
+      await sleep(INITIAL_DELAY_MS, signal);
 
       for (let index = 0; index <= COMMAND.length; index++) {
-        if (cancelled) return;
         update({ typedCommand: COMMAND.slice(0, index) });
-        await sleep(TYPING_DELAY_MS);
+        await sleep(TYPING_DELAY_MS, signal);
       }
 
       update({ isTyping: false });
-      await sleep(POST_COMMAND_DELAY_MS);
-      if (cancelled) return;
+      await sleep(POST_COMMAND_DELAY_MS, signal);
 
       update({ showVersion: true });
-      await sleep(POST_VERSION_DELAY_MS);
+      await sleep(POST_VERSION_DELAY_MS, signal);
 
       for (let index = 0; index < DIAGNOSTICS.length; index++) {
-        if (cancelled) return;
         update({ visibleDiagnosticCount: index + 1 });
         const jitteredDelay =
           DIAGNOSTIC_MIN_DELAY_MS +
           Math.random() * (DIAGNOSTIC_MAX_DELAY_MS - DIAGNOSTIC_MIN_DELAY_MS);
-        await sleep(jitteredDelay);
+        await sleep(jitteredDelay, signal);
       }
 
-      await sleep(SCORE_REVEAL_DELAY_MS);
+      await sleep(SCORE_REVEAL_DELAY_MS, signal);
 
       for (let frame = 0; frame <= SCORE_FRAME_COUNT; frame++) {
-        if (cancelled) return;
         update({ score: Math.round(easeOutCubic(frame / SCORE_FRAME_COUNT) * TARGET_SCORE) });
-        await sleep(SCORE_FRAME_DELAY_MS);
+        await sleep(SCORE_FRAME_DELAY_MS, signal);
       }
 
-      await sleep(POST_SCORE_DELAY_MS);
-      if (cancelled) return;
+      await sleep(POST_SCORE_DELAY_MS, signal);
       update({ showCountsSummary: true });
 
-      await sleep(POST_SCORE_DELAY_MS);
-      if (cancelled) return;
+      await sleep(POST_SCORE_DELAY_MS, signal);
       update({ showCta: true });
       markAnimationCompleted();
     };
 
-    run();
-    return () => {
-      cancelled = true;
-    };
+    run().catch((error) => {
+      if (!isAbortError(error)) throw error;
+    });
+
+    return () => abortController.abort();
   }, []);
 
   return (
@@ -329,7 +344,7 @@ const Terminal = () => {
         <FadeIn>
           <Spacer />
           <div className="flex items-center gap-2">
-            <img src="/favicon.svg" alt="React Doctor" width={24} height={24} />
+            <Image src="/favicon.svg" alt="React Doctor" width={24} height={24} unoptimized />
             react-doctor
           </div>
           <div className="text-neutral-500">Your agent writes bad React, this catches it.</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this PR does

Triage pass over the 7 currently-open issues. Four of them (#311, #306, #314, #292) are already fixed on `main` and only waiting for the next `react-doctor` release on npm — no code change needed. Two need actual edits (the third, #299, was scoped out — no CI hardening guidance here).

### #219 — clear the React Review audit findings in `packages/website`

The audit posted on commit `6543a86f` flagged 1 error + 8 warnings. This commit clears all of them:

- **`effect-needs-cleanup` (error)** in `app/share/animated-score.tsx`. The recursive frame loop tracked a `cancelled` flag but never `clearTimeout`-ed the last scheduled timer. Switched to tracking `pendingTimeoutId` and clearing it in the effect cleanup.
- **`nextjs-missing-metadata`** in `app/page.tsx`. Added a page-level `metadata` export; the root layout still owns site-wide defaults, this just lets the home page override.
- **`nextjs-no-img-element`** in `components/terminal.tsx`, `app/leaderboard/page.tsx`, `app/share/badge-snippet.tsx`. Switched `/favicon.svg` and the dynamic `/share/badge` SVG to `next/image` with `unoptimized` (the optimizer doesn't help SVG). The badge preview keeps variable intrinsic width via `h-5 w-auto` so badges aren't forced to a fixed width.
- **`async-defer-await`** in `components/terminal.tsx`. Replaced the manual `cancelled` flag with an `AbortController`. `sleep` is now abortable, the post-await `if (cancelled) return` guards are gone, and cancellation propagates as an `AbortError` caught at the top of `run()`.
- **`no-inline-exhaustive-style`** in `app/share/og/route.tsx`. `next/og` (Satori) only supports inline `style`, so CSS classes aren't an option. Hoisted style objects to module-scope constants and pass them by reference, so the JSX no longer carries `ObjectExpression` literals with 8+ properties.

### #203 — Husky / lint-staged integration guide

Added a "Pre-commit hooks with Husky + lint-staged" subsection to the existing "Diff and staged modes" chapter. Covers:

- The right way to wire `react-doctor --staged` (don't append `{staged-files}` — it would union the path filter with the index scan).
- The function-form gate when you only want the hook to run if matching files are staged.
- `--fail-on` tradeoffs.
- The index-vs-working-tree gotcha.
- Why this stays off CI.
- A note that the same invocation drops into Lefthook / pre-commit unchanged.

The root `README.md` is a symlink to `packages/react-doctor/README.md`, so the npm package page picks up the update automatically.

## Triage status of the other open issues

| Issue | Verdict |
|------|---------|
| **#311** hoisted React in pnpm workspaces | Fixed in `main` by `6543a86f`. Currently published `react-doctor@0.2.1` still ships the old code — clears at next release. |
| **#306** false `effect-needs-cleanup` on `AbortController` | Fixed in `main` by `a6f16d42`. Same — clears at next release. |
| **#314** `--offline` auto-forced in CI | Fixed in `main` by `36f20e2b` (the `isCiEnvironment()` OR was removed from the offline default). Same — clears at next release. |
| **#292** action passes `--pr-comment` to `@latest` | npm `latest` is now `0.2.1` which understands `--pr-comment`. Effectively resolved; the maintainer already commented "should be fixed". |
| **#299** prefer release tag over `@main` in examples | Out of scope for this PR. |

If the npm dist-tag ships, the first four can be closed.

## Verification

- `pnpm typecheck` — passes
- `pnpm test` — 1413 passed / 3 skipped (existing skips)
- `pnpm lint` — clean
- `pnpm format` — clean
- Website `tsc --noEmit` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-875879a3-fa83-4635-a83f-d9abbe980333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-875879a3-fa83-4635-a83f-d9abbe980333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

