### PR TITLE
feat(core): Effect v4 foundation — tagged errors, schemas, refs, paths [1/8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,6 @@ jobs:
             echo "Built CLI version is missing or 0.0.0; build env did not inject VERSION"
             exit 1
           fi
+
+      - name: Smoke test JSON report shape
+        run: pnpm smoke:json-report

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 *.log
 .DS_Store
 .cursor
+tmp/
 review-report.md
 review-*.md
 *.review.md

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "changeset": "changeset",
     "version": "changeset version",
     "release": "pnpm build && changeset publish",
-    "leaderboard:update": "node --experimental-strip-types --no-warnings scripts/update-leaderboard.ts"
+    "leaderboard:update": "node --experimental-strip-types --no-warnings scripts/update-leaderboard.ts",
+    "smoke:json-report": "node --experimental-strip-types --no-warnings scripts/smoke-json-report.ts"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,12 +20,14 @@
     "@react-doctor/project-info": "workspace:*",
     "@react-doctor/types": "workspace:*",
     "deslop-js": "^0.0.11",
+    "effect": "4.0.0-beta.70",
     "oxlint": "^1.66.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "picomatch": "^4.0.4",
     "typescript": "^6.0.3"
   },
   "devDependencies": {
+    "@effect/vitest": "4.0.0-beta.70",
     "@types/node": "^25.6.0",
     "@types/picomatch": "^4.0.3",
     "eslint-plugin-react-hooks": "^7.1.1"

--- a/packages/core/src/build-json-report-error.ts
+++ b/packages/core/src/build-json-report-error.ts
@@ -1,4 +1,5 @@
 import type { JsonReport, JsonReportMode } from "@react-doctor/types";
+import { formatReactDoctorError, isReactDoctorError } from "./errors.js";
 import { getErrorChainMessages } from "./format-error-chain.js";
 
 interface BuildJsonReportErrorInput {
@@ -27,8 +28,13 @@ const safeGetErrorChain = (error: unknown): string[] => {
 
 export const buildJsonReportError = (input: BuildJsonReportErrorInput): JsonReport => {
   const chain = safeGetErrorChain(input.error);
-  const errorPayload =
-    input.error instanceof Error
+  const errorPayload = isReactDoctorError(input.error)
+    ? {
+        message: formatReactDoctorError(input.error),
+        name: `ReactDoctorError(${input.error.reason._tag})`,
+        chain,
+      }
+    : input.error instanceof Error
       ? {
           message: input.error.message || input.error.name || "Error",
           name: input.error.name || "Error",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -64,7 +64,26 @@ export const CANONICAL_GITHUB_URL = "https://github.com/millionco/react-doctor";
 
 export const SKILL_NAME = "react-doctor";
 
+// HACK: cap on combined stdout+stderr bytes per oxlint batch. Above
+// this we kill the process (SIGKILL) and ask the user to narrow the
+// scan with --diff. Pinned to 50 MiB because oxlint emits ~1 KB of
+// JSON per diagnostic and the largest real-world batches in the eval
+// corpus (supabase/studio at 3,567 source files) produce ~3 MiB
+// total — 50 MiB leaves an order of magnitude of headroom for
+// pathological JS-plugin rules that emit one diagnostic per AST node.
 export const OXLINT_OUTPUT_MAX_BYTES = 50 * 1024 * 1024;
+
+// HACK: per-batch wall-clock budget for an oxlint spawn. Each batch
+// is at most OXLINT_MAX_FILES_PER_BATCH (= 100) files and a healthy
+// batch finishes in well under a second; 60 s leaves a large safety
+// margin while still firing fast enough that the binary-split
+// recovery in spawnLintBatches narrows a pathological batch to the
+// single offending file rather than killing the whole scan as the
+// previous 5-min budget did on supabase/studio. The eval harness
+// overrides this via the OxlintSpawnTimeoutMs Context.Reference when
+// running under Vercel Sandbox microVMs where the oxlint native
+// binding is markedly slower than on a developer laptop.
+export const OXLINT_SPAWN_TIMEOUT_MS = 60_000;
 
 // HACK: lookahead cap for JSX opener-span scanning; bounds worst-case
 // work on pathological files. Real openers stay well under this.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,150 @@
+import * as Cause from "effect/Cause";
+import * as Schema from "effect/Schema";
+
+const OxlintUnavailableKind = Schema.Literals(["binary-not-found", "native-binding-missing"]);
+
+export class OxlintUnavailable extends Schema.TaggedErrorClass<OxlintUnavailable>()(
+  "OxlintUnavailable",
+  {
+    kind: OxlintUnavailableKind,
+    detail: Schema.String,
+  },
+) {
+  get message() {
+    return this.kind === "binary-not-found"
+      ? `oxlint binary not found: ${this.detail}`
+      : `oxlint native binding missing: ${this.detail}`;
+  }
+}
+
+const OxlintBatchExceededKind = Schema.Literals(["timeout", "output-too-large", "oom", "killed"]);
+
+export class OxlintBatchExceeded extends Schema.TaggedErrorClass<OxlintBatchExceeded>()(
+  "OxlintBatchExceeded",
+  {
+    kind: OxlintBatchExceededKind,
+    detail: Schema.String,
+  },
+) {
+  get message() {
+    switch (this.kind) {
+      case "timeout":
+        return `oxlint batch timed out: ${this.detail}`;
+      case "output-too-large":
+        return `oxlint batch output exceeded limit: ${this.detail}`;
+      case "oom":
+        return `oxlint batch ran out of memory: ${this.detail}`;
+      case "killed":
+        return `oxlint batch was killed: ${this.detail}`;
+    }
+  }
+}
+
+export class OxlintSpawnFailed extends Schema.TaggedErrorClass<OxlintSpawnFailed>()(
+  "OxlintSpawnFailed",
+  {
+    cause: Schema.Unknown,
+  },
+) {
+  get message() {
+    return `Failed to run oxlint: ${Cause.pretty(Cause.fail(this.cause))}`;
+  }
+}
+
+export class OxlintOutputUnparseable extends Schema.TaggedErrorClass<OxlintOutputUnparseable>()(
+  "OxlintOutputUnparseable",
+  {
+    preview: Schema.String,
+  },
+) {
+  get message() {
+    return `Failed to parse oxlint output: ${this.preview}`;
+  }
+}
+
+export class ConfigParseFailed extends Schema.TaggedErrorClass<ConfigParseFailed>()(
+  "ConfigParseFailed",
+  {
+    path: Schema.String,
+    cause: Schema.Unknown,
+  },
+) {
+  get message() {
+    return `Failed to parse react-doctor config at ${this.path}: ${Cause.pretty(Cause.fail(this.cause))}`;
+  }
+}
+
+export class ProjectNotFound extends Schema.TaggedErrorClass<ProjectNotFound>()("ProjectNotFound", {
+  directory: Schema.String,
+}) {
+  get message() {
+    return `Could not find a React project at ${this.directory}`;
+  }
+}
+
+export class NoReactDependency extends Schema.TaggedErrorClass<NoReactDependency>()(
+  "NoReactDependency",
+  {
+    directory: Schema.String,
+  },
+) {
+  get message() {
+    return `No React dependency found in ${this.directory}`;
+  }
+}
+
+export class AmbiguousProject extends Schema.TaggedErrorClass<AmbiguousProject>()(
+  "AmbiguousProject",
+  {
+    directory: Schema.String,
+    candidates: Schema.Array(Schema.String),
+  },
+) {
+  get message() {
+    return `Ambiguous project at ${this.directory}: found ${this.candidates.length} candidates (${this.candidates.join(", ")})`;
+  }
+}
+
+export class DeadCodeAnalysisFailed extends Schema.TaggedErrorClass<DeadCodeAnalysisFailed>()(
+  "DeadCodeAnalysisFailed",
+  {
+    cause: Schema.Unknown,
+  },
+) {
+  get message() {
+    return `Dead-code analysis failed: ${Cause.pretty(Cause.fail(this.cause))}`;
+  }
+}
+
+export const ReactDoctorErrorReason = Schema.Union([
+  OxlintUnavailable,
+  OxlintBatchExceeded,
+  OxlintSpawnFailed,
+  OxlintOutputUnparseable,
+  ConfigParseFailed,
+  ProjectNotFound,
+  NoReactDependency,
+  AmbiguousProject,
+  DeadCodeAnalysisFailed,
+]);
+
+export type ReactDoctorErrorReason = Schema.Schema.Type<typeof ReactDoctorErrorReason>;
+
+export class ReactDoctorError extends Schema.TaggedErrorClass<ReactDoctorError>()(
+  "ReactDoctorError",
+  {
+    reason: ReactDoctorErrorReason,
+  },
+) {
+  get message() {
+    return this.reason.message;
+  }
+}
+
+export const formatReactDoctorError = (error: ReactDoctorError): string => error.reason.message;
+
+export const isSplittableReactDoctorError = (error: unknown): error is ReactDoctorError =>
+  error instanceof ReactDoctorError && error.reason._tag === "OxlintBatchExceeded";
+
+export const isReactDoctorError = (error: unknown): error is ReactDoctorError =>
+  error instanceof ReactDoctorError;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,7 @@
+export * from "./errors.js";
+export * from "./paths.js";
+export * from "./refs.js";
+export * from "./schemas.js";
 export * from "./apply-ignore-overrides.js";
 export * from "./apply-severity-controls.js";
 export * from "./build-rule-severity-controls.js";

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,0 +1,20 @@
+import * as Schema from "effect/Schema";
+
+/**
+ * Absolute filesystem path to the oxlint binary loaded by the lint
+ * runner. Branded so it doesn't get confused with `NodeBinaryPath` at
+ * a call site: both are `string` but pass them in the wrong order
+ * (e.g. `spawn(oxlintBinary, [nodeBinary, ...])`) and the lint scan
+ * silently fails. The brand lets the typechecker catch the swap.
+ */
+export const OxlintBinaryPath = Schema.String.pipe(Schema.brand("OxlintBinaryPath"));
+export type OxlintBinaryPath = Schema.Schema.Type<typeof OxlintBinaryPath>;
+
+/**
+ * Absolute filesystem path to a Node binary whose native bindings
+ * are loadable by the oxlint native module. Resolved by
+ * `resolveOxlintNode` on the host; the brand pairs with
+ * `OxlintBinaryPath` to keep the two from being swapped.
+ */
+export const NodeBinaryPath = Schema.String.pipe(Schema.brand("NodeBinaryPath"));
+export type NodeBinaryPath = Schema.Schema.Type<typeof NodeBinaryPath>;

--- a/packages/core/src/refs.ts
+++ b/packages/core/src/refs.ts
@@ -1,0 +1,47 @@
+import * as Context from "effect/Context";
+import { OXLINT_OUTPUT_MAX_BYTES, OXLINT_SPAWN_TIMEOUT_MS } from "./constants.js";
+
+/**
+ * Per-batch oxlint wall-clock budget. Reads from the env var on
+ * startup so the eval harness can raise the budget under sandbox
+ * microVMs without recompiling react-doctor. Tests override via
+ * `Layer.succeed(OxlintSpawnTimeoutMs, ...)`.
+ */
+export class OxlintSpawnTimeoutMs extends Context.Reference<number>(
+  "react-doctor/OxlintSpawnTimeoutMs",
+  {
+    defaultValue: () => {
+      const raw = process.env["REACT_DOCTOR_OXLINT_SPAWN_TIMEOUT_MS"];
+      if (raw === undefined) return OXLINT_SPAWN_TIMEOUT_MS;
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0) return OXLINT_SPAWN_TIMEOUT_MS;
+      return parsed;
+    },
+  },
+) {}
+
+/**
+ * Hard cap on combined stdout+stderr bytes per oxlint batch. The
+ * subprocess gets SIGKILL'd if it produces more; the recovery path
+ * suggests narrowing the scan with --diff. Override via Layer in
+ * tests that exercise the cap behavior.
+ */
+export class OxlintOutputMaxBytes extends Context.Reference<number>(
+  "react-doctor/OxlintOutputMaxBytes",
+  {
+    defaultValue: () => OXLINT_OUTPUT_MAX_BYTES,
+  },
+) {}
+
+/**
+ * Prefix for mkdtemp directories created when materializing
+ * staged-file snapshots for pre-commit hook scans. Override in tests
+ * that want a deterministic prefix; production uses
+ * `react-doctor-staged-` and the OS provides the random suffix.
+ */
+export class StagedFilesTempDirPrefix extends Context.Reference<string>(
+  "react-doctor/StagedFilesTempDirPrefix",
+  {
+    defaultValue: () => "react-doctor-staged-",
+  },
+) {}

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,0 +1,99 @@
+import * as Schema from "effect/Schema";
+
+export const Severity = Schema.Literals(["error", "warning"]);
+export type Severity = Schema.Schema.Type<typeof Severity>;
+
+export class Diagnostic extends Schema.Class<Diagnostic>("Diagnostic")({
+  filePath: Schema.String,
+  plugin: Schema.String,
+  rule: Schema.String,
+  severity: Severity,
+  message: Schema.String,
+  help: Schema.String,
+  url: Schema.optional(Schema.String),
+  line: Schema.Number,
+  column: Schema.Number,
+  category: Schema.String,
+  suppressionHint: Schema.optional(Schema.String),
+}) {}
+
+/**
+ * Deterministic identity string for a diagnostic. Same diagnostic
+ * across two scans yields the same identity; lets baselines,
+ * suppression files, content-hash caches, and IDE "ignore this"
+ * actions all key off one shared shape.
+ */
+export const buildDiagnosticIdentity = (input: {
+  readonly filePath: string;
+  readonly line: number;
+  readonly column: number;
+  readonly plugin: string;
+  readonly rule: string;
+}): string => `${input.filePath}::${input.line}:${input.column}::${input.plugin}/${input.rule}`;
+
+export const JsonReportMode = Schema.Literals(["full", "diff", "staged"]);
+export type JsonReportMode = Schema.Schema.Type<typeof JsonReportMode>;
+
+export class JsonReportSummary extends Schema.Class<JsonReportSummary>("JsonReportSummary")({
+  errorCount: Schema.Number,
+  warningCount: Schema.Number,
+  affectedFileCount: Schema.Number,
+  totalDiagnosticCount: Schema.Number,
+  score: Schema.NullOr(Schema.Number),
+  scoreLabel: Schema.NullOr(Schema.String),
+}) {}
+
+export class JsonReportDiffInfo extends Schema.Class<JsonReportDiffInfo>("JsonReportDiffInfo")({
+  baseBranch: Schema.String,
+  currentBranch: Schema.NullOr(Schema.String),
+  changedFileCount: Schema.Number,
+  isCurrentChanges: Schema.Boolean,
+}) {}
+
+export class JsonReportError extends Schema.Class<JsonReportError>("JsonReportError")({
+  message: Schema.String,
+  name: Schema.String,
+  chain: Schema.Array(Schema.String),
+}) {}
+
+/**
+ * Schema for a single project entry within a JsonReport. `project` is
+ * `Schema.Unknown` for now because `ProjectInfo` is still a hand-written
+ * interface in `@react-doctor/types`; it gets a real schema when the
+ * `Project` service lands and at that point this field tightens.
+ */
+export class JsonReportProjectEntry extends Schema.Class<JsonReportProjectEntry>(
+  "JsonReportProjectEntry",
+)({
+  directory: Schema.String,
+  project: Schema.Unknown,
+  diagnostics: Schema.Array(Diagnostic),
+  score: Schema.Unknown,
+  skippedChecks: Schema.Array(Schema.String),
+  skippedCheckReasons: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  elapsedMilliseconds: Schema.Number,
+}) {}
+
+/**
+ * Versioned JsonReport schema. `JsonReport` is a `Schema.Union` so we
+ * can add `schemaVersion: 2` later as one new union member without
+ * breaking existing v1 consumers (the GitHub Action keys off the
+ * version literal). Today's union is single-arm; the shape is
+ * intentional.
+ */
+export class JsonReportV1 extends Schema.Class<JsonReportV1>("JsonReportV1")({
+  schemaVersion: Schema.Literal(1),
+  version: Schema.String,
+  ok: Schema.Boolean,
+  directory: Schema.String,
+  mode: JsonReportMode,
+  diff: Schema.NullOr(JsonReportDiffInfo),
+  projects: Schema.Array(JsonReportProjectEntry),
+  diagnostics: Schema.Array(Diagnostic),
+  summary: JsonReportSummary,
+  elapsedMilliseconds: Schema.Number,
+  error: Schema.NullOr(JsonReportError),
+}) {}
+
+export const JsonReport = Schema.Union([JsonReportV1]);
+export type JsonReport = Schema.Schema.Type<typeof JsonReport>;

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "agent-install": "0.0.5",
     "deslop-js": "^0.0.11",
+    "effect": "4.0.0-beta.70",
     "oxlint": "^1.66.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "prompts": "^2.4.2",

--- a/packages/react-doctor/src/cli/utils/handle-error.ts
+++ b/packages/react-doctor/src/cli/utils/handle-error.ts
@@ -1,4 +1,10 @@
-import { CANONICAL_GITHUB_URL, formatErrorChain, logger } from "@react-doctor/core";
+import {
+  CANONICAL_GITHUB_URL,
+  formatErrorChain,
+  formatReactDoctorError,
+  isReactDoctorError,
+  logger,
+} from "@react-doctor/core";
 import type { HandleErrorOptions } from "@react-doctor/types";
 
 export const handleError = (
@@ -9,7 +15,7 @@ export const handleError = (
   logger.error("Something went wrong. Please check the error below for more details.");
   logger.error(`If the problem persists, please open an issue at ${CANONICAL_GITHUB_URL}/issues.`);
   logger.error("");
-  logger.error(formatErrorChain(error));
+  logger.error(isReactDoctorError(error) ? formatReactDoctorError(error) : formatErrorChain(error));
   logger.break();
   if (options.shouldExit) {
     process.exit(1);

--- a/packages/react-doctor/tests/errors.test.ts
+++ b/packages/react-doctor/tests/errors.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  AmbiguousProject,
+  ConfigParseFailed,
+  DeadCodeAnalysisFailed,
+  formatReactDoctorError,
+  isReactDoctorError,
+  isSplittableReactDoctorError,
+  NoReactDependency,
+  OxlintBatchExceeded,
+  OxlintOutputUnparseable,
+  OxlintSpawnFailed,
+  OxlintUnavailable,
+  ProjectNotFound,
+  ReactDoctorError,
+} from "@react-doctor/core";
+
+describe("ReactDoctorError leaves", () => {
+  it("OxlintUnavailable renders binary-not-found", () => {
+    const error = new ReactDoctorError({
+      reason: new OxlintUnavailable({
+        kind: "binary-not-found",
+        detail: "/path/to/oxlint",
+      }),
+    });
+    expect(error.reason._tag).toBe("OxlintUnavailable");
+    expect(formatReactDoctorError(error)).toBe("oxlint binary not found: /path/to/oxlint");
+  });
+
+  it("OxlintUnavailable renders native-binding-missing", () => {
+    const error = new ReactDoctorError({
+      reason: new OxlintUnavailable({
+        kind: "native-binding-missing",
+        detail: "no @oxlint/linux-x64 in node_modules",
+      }),
+    });
+    expect(formatReactDoctorError(error)).toBe(
+      "oxlint native binding missing: no @oxlint/linux-x64 in node_modules",
+    );
+  });
+
+  it("OxlintBatchExceeded renders each kind", () => {
+    const cases: Array<{
+      kind: "timeout" | "output-too-large" | "oom" | "killed";
+      expected: string;
+    }> = [
+      { kind: "timeout", expected: "oxlint batch timed out: 60s budget exceeded" },
+      { kind: "output-too-large", expected: "oxlint batch output exceeded limit: 50 MiB cap" },
+      { kind: "oom", expected: "oxlint batch ran out of memory: SIGABRT" },
+      { kind: "killed", expected: "oxlint batch was killed: SIGKILL" },
+    ];
+    const details: Record<string, string> = {
+      timeout: "60s budget exceeded",
+      "output-too-large": "50 MiB cap",
+      oom: "SIGABRT",
+      killed: "SIGKILL",
+    };
+    for (const { kind, expected } of cases) {
+      const error = new ReactDoctorError({
+        reason: new OxlintBatchExceeded({ kind, detail: details[kind] ?? "" }),
+      });
+      expect(formatReactDoctorError(error)).toBe(expected);
+    }
+  });
+
+  it("OxlintSpawnFailed wraps an underlying cause", () => {
+    const inner = new Error("ENOENT: spawn oxlint");
+    const error = new ReactDoctorError({
+      reason: new OxlintSpawnFailed({ cause: inner }),
+    });
+    expect(formatReactDoctorError(error)).toContain("Failed to run oxlint");
+    expect(formatReactDoctorError(error)).toContain("ENOENT: spawn oxlint");
+  });
+
+  it("OxlintOutputUnparseable surfaces the preview", () => {
+    const error = new ReactDoctorError({
+      reason: new OxlintOutputUnparseable({ preview: "<html>500 internal</html>" }),
+    });
+    expect(formatReactDoctorError(error)).toBe(
+      "Failed to parse oxlint output: <html>500 internal</html>",
+    );
+  });
+
+  it("ConfigParseFailed names the path + cause", () => {
+    const error = new ReactDoctorError({
+      reason: new ConfigParseFailed({
+        path: "/repo/react-doctor.config.json",
+        cause: new SyntaxError("Unexpected token }"),
+      }),
+    });
+    expect(formatReactDoctorError(error)).toContain("/repo/react-doctor.config.json");
+    expect(formatReactDoctorError(error)).toContain("Unexpected token }");
+  });
+
+  it("ProjectNotFound names the directory", () => {
+    const error = new ReactDoctorError({
+      reason: new ProjectNotFound({ directory: "/repo/apps/web" }),
+    });
+    expect(formatReactDoctorError(error)).toBe("Could not find a React project at /repo/apps/web");
+  });
+
+  it("NoReactDependency names the directory", () => {
+    const error = new ReactDoctorError({
+      reason: new NoReactDependency({ directory: "/repo/packages/utils" }),
+    });
+    expect(formatReactDoctorError(error)).toBe("No React dependency found in /repo/packages/utils");
+  });
+
+  it("AmbiguousProject lists the candidates", () => {
+    const error = new ReactDoctorError({
+      reason: new AmbiguousProject({
+        directory: "/repo",
+        candidates: ["apps/web", "apps/admin"],
+      }),
+    });
+    expect(formatReactDoctorError(error)).toBe(
+      "Ambiguous project at /repo: found 2 candidates (apps/web, apps/admin)",
+    );
+  });
+
+  it("DeadCodeAnalysisFailed wraps the cause", () => {
+    const error = new ReactDoctorError({
+      reason: new DeadCodeAnalysisFailed({ cause: "SIGABRT from native binding" }),
+    });
+    expect(formatReactDoctorError(error)).toContain("Dead-code analysis failed");
+    expect(formatReactDoctorError(error)).toContain("SIGABRT from native binding");
+  });
+});
+
+describe("isReactDoctorError", () => {
+  it("returns true for a wrapped tagged error", () => {
+    const error = new ReactDoctorError({
+      reason: new ProjectNotFound({ directory: "/repo" }),
+    });
+    expect(isReactDoctorError(error)).toBe(true);
+  });
+
+  it("returns false for plain Errors", () => {
+    expect(isReactDoctorError(new Error("not tagged"))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isReactDoctorError("string")).toBe(false);
+    expect(isReactDoctorError(null)).toBe(false);
+    expect(isReactDoctorError(undefined)).toBe(false);
+    expect(isReactDoctorError({ _tag: "ReactDoctorError" })).toBe(false);
+  });
+});
+
+describe("isSplittableReactDoctorError", () => {
+  it("returns true only for OxlintBatchExceeded", () => {
+    const splittable = new ReactDoctorError({
+      reason: new OxlintBatchExceeded({ kind: "timeout", detail: "60s" }),
+    });
+    expect(isSplittableReactDoctorError(splittable)).toBe(true);
+  });
+
+  it("returns false for other reasons", () => {
+    const cases = [
+      new OxlintUnavailable({ kind: "binary-not-found", detail: "x" }),
+      new OxlintSpawnFailed({ cause: new Error("boom") }),
+      new OxlintOutputUnparseable({ preview: "x" }),
+      new ConfigParseFailed({ path: "x", cause: "x" }),
+      new ProjectNotFound({ directory: "x" }),
+      new NoReactDependency({ directory: "x" }),
+      new AmbiguousProject({ directory: "x", candidates: [] }),
+      new DeadCodeAnalysisFailed({ cause: "x" }),
+    ] as const;
+    for (const reason of cases) {
+      const error = new ReactDoctorError({ reason });
+      expect(isSplittableReactDoctorError(error)).toBe(false);
+    }
+  });
+
+  it("returns false for non-ReactDoctorError values", () => {
+    expect(isSplittableReactDoctorError(new Error("plain"))).toBe(false);
+    expect(isSplittableReactDoctorError("string")).toBe(false);
+    expect(isSplittableReactDoctorError(null)).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/schemas.test.ts
+++ b/packages/react-doctor/tests/schemas.test.ts
@@ -1,0 +1,226 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  buildDiagnosticIdentity,
+  Diagnostic,
+  JsonReport,
+  JsonReportV1,
+  NodeBinaryPath,
+  OxlintBinaryPath,
+  Severity,
+} from "@react-doctor/core";
+
+describe("Diagnostic schema", () => {
+  it("decodes the minimal shape (required fields only)", () => {
+    const decoded = Schema.decodeUnknownSync(Diagnostic)({
+      filePath: "/repo/src/App.tsx",
+      plugin: "react-doctor",
+      rule: "no-derived-state",
+      severity: "error",
+      message: "Avoid useState(propX)",
+      help: "Use propX directly",
+      line: 12,
+      column: 4,
+      category: "Correctness",
+    });
+    expect(decoded.filePath).toBe("/repo/src/App.tsx");
+    expect(decoded.severity).toBe("error");
+    expect(decoded.url).toBeUndefined();
+    expect(decoded.suppressionHint).toBeUndefined();
+  });
+
+  it("decodes optional fields when present", () => {
+    const decoded = Schema.decodeUnknownSync(Diagnostic)({
+      filePath: "/repo/src/Button.tsx",
+      plugin: "react-doctor",
+      rule: "no-barrel-import",
+      severity: "warning",
+      message: "Barrel import",
+      help: "Import directly",
+      url: "https://www.react.doctor/rules/no-barrel-import",
+      line: 1,
+      column: 1,
+      category: "Bundle Size",
+      suppressionHint: "// react-doctor-disable-next-line no-barrel-import",
+    });
+    expect(decoded.url).toBe("https://www.react.doctor/rules/no-barrel-import");
+    expect(decoded.suppressionHint).toBe("// react-doctor-disable-next-line no-barrel-import");
+  });
+
+  it("rejects an unknown severity value", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(Diagnostic)({
+        filePath: "/repo/src/App.tsx",
+        plugin: "react-doctor",
+        rule: "x",
+        severity: "info",
+        message: "x",
+        help: "x",
+        line: 1,
+        column: 1,
+        category: "x",
+      }),
+    ).toThrow();
+  });
+
+  it("round-trips via encode / decode", () => {
+    const original = new Diagnostic({
+      filePath: "/repo/src/App.tsx",
+      plugin: "react",
+      rule: "no-danger",
+      severity: "warning",
+      message: "Avoid dangerouslySetInnerHTML",
+      help: "Use safer alternatives",
+      line: 10,
+      column: 1,
+      category: "Security",
+    });
+    const encoded = Schema.encodeUnknownSync(Diagnostic)(original);
+    const decoded = Schema.decodeUnknownSync(Diagnostic)(encoded);
+    expect(decoded.filePath).toBe(original.filePath);
+    expect(decoded.rule).toBe(original.rule);
+    expect(decoded.line).toBe(original.line);
+  });
+});
+
+describe("Severity schema", () => {
+  it("accepts the two literal values", () => {
+    expect(Schema.decodeUnknownSync(Severity)("error")).toBe("error");
+    expect(Schema.decodeUnknownSync(Severity)("warning")).toBe("warning");
+  });
+
+  it("rejects anything else", () => {
+    expect(() => Schema.decodeUnknownSync(Severity)("info")).toThrow();
+    expect(() => Schema.decodeUnknownSync(Severity)(undefined)).toThrow();
+  });
+});
+
+describe("buildDiagnosticIdentity", () => {
+  it("produces the documented shape", () => {
+    expect(
+      buildDiagnosticIdentity({
+        filePath: "/repo/src/App.tsx",
+        line: 12,
+        column: 4,
+        plugin: "react-doctor",
+        rule: "no-derived-state",
+      }),
+    ).toBe("/repo/src/App.tsx::12:4::react-doctor/no-derived-state");
+  });
+
+  it("is deterministic across calls with the same input", () => {
+    const inputs = {
+      filePath: "/a/b/c.tsx",
+      line: 1,
+      column: 1,
+      plugin: "p",
+      rule: "r",
+    } as const;
+    expect(buildDiagnosticIdentity(inputs)).toBe(buildDiagnosticIdentity(inputs));
+  });
+
+  it("changes when any field changes", () => {
+    const base = {
+      filePath: "/a/b/c.tsx",
+      line: 1,
+      column: 1,
+      plugin: "p",
+      rule: "r",
+    } as const;
+    const seen = new Set<string>();
+    seen.add(buildDiagnosticIdentity(base));
+    seen.add(buildDiagnosticIdentity({ ...base, filePath: "/a/b/d.tsx" }));
+    seen.add(buildDiagnosticIdentity({ ...base, line: 2 }));
+    seen.add(buildDiagnosticIdentity({ ...base, column: 2 }));
+    seen.add(buildDiagnosticIdentity({ ...base, plugin: "q" }));
+    seen.add(buildDiagnosticIdentity({ ...base, rule: "s" }));
+    expect(seen.size).toBe(6);
+  });
+});
+
+describe("JsonReport (v1)", () => {
+  it("decodes a minimal v1 report", () => {
+    const decoded = Schema.decodeUnknownSync(JsonReport)({
+      schemaVersion: 1,
+      version: "0.2.3",
+      ok: true,
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      projects: [],
+      diagnostics: [],
+      summary: {
+        errorCount: 0,
+        warningCount: 0,
+        affectedFileCount: 0,
+        totalDiagnosticCount: 0,
+        score: 100,
+        scoreLabel: "Excellent",
+      },
+      elapsedMilliseconds: 42,
+      error: null,
+    });
+    expect(decoded.schemaVersion).toBe(1);
+    expect(decoded instanceof JsonReportV1).toBe(true);
+  });
+
+  it("rejects a report missing the schemaVersion discriminator", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(JsonReport)({
+        version: "0.2.3",
+        ok: true,
+        directory: "/repo",
+        mode: "full",
+        diff: null,
+        projects: [],
+        diagnostics: [],
+        summary: {
+          errorCount: 0,
+          warningCount: 0,
+          affectedFileCount: 0,
+          totalDiagnosticCount: 0,
+          score: null,
+          scoreLabel: null,
+        },
+        elapsedMilliseconds: 0,
+        error: null,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown mode", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(JsonReportV1)({
+        schemaVersion: 1,
+        version: "0.2.3",
+        ok: true,
+        directory: "/repo",
+        mode: "incremental",
+        diff: null,
+        projects: [],
+        diagnostics: [],
+        summary: {
+          errorCount: 0,
+          warningCount: 0,
+          affectedFileCount: 0,
+          totalDiagnosticCount: 0,
+          score: null,
+          scoreLabel: null,
+        },
+        elapsedMilliseconds: 0,
+        error: null,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("Branded paths", () => {
+  it("OxlintBinaryPath and NodeBinaryPath decode raw strings", () => {
+    expect(Schema.decodeUnknownSync(OxlintBinaryPath)("/usr/local/bin/oxlint")).toBe(
+      "/usr/local/bin/oxlint",
+    );
+    expect(Schema.decodeUnknownSync(NodeBinaryPath)("/usr/local/bin/node")).toBe(
+      "/usr/local/bin/node",
+    );
+  });
+});

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -69,6 +69,10 @@ export default defineConfig({
           // resolves the bindings from the deslop-js node_modules
           // tree on install — see issue #404.
           "deslop-js",
+          // Effect ships as ~1MB+ of tree-shakable TypeScript; bundling
+          // it would balloon the published tarball. Match react-doctor-evals
+          // and let installers pull it as a regular dependency.
+          "effect",
           "oxc-parser",
           "oxc-resolver",
           "oxlint",
@@ -104,6 +108,7 @@ export default defineConfig({
         neverBundle: [
           "agent-install",
           "deslop-js",
+          "effect",
           "oxc-parser",
           "oxc-resolver",
           "oxlint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 25.6.0
       '@voidzero-dev/vite-plus-core':
         specifier: ^0.1.15
-        version: 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3)
+        version: 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(yaml@2.9.0)
       turbo:
         specifier: ^2.9.7
         version: 2.9.7
@@ -32,7 +32,7 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: ^0.1.15
-        version: 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))(yaml@2.9.0)
 
   packages/core:
     dependencies:
@@ -45,6 +45,9 @@ importers:
       deslop-js:
         specifier: ^0.0.11
         version: 0.0.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      effect:
+        specifier: 4.0.0-beta.70
+        version: 4.0.0-beta.70
       oxlint:
         specifier: ^1.66.0
         version: 1.66.0(oxlint-tsgolint@0.23.0)
@@ -58,6 +61,9 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
     devDependencies:
+      '@effect/vitest':
+        specifier: 4.0.0-beta.70
+        version: 4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.1.7(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0)))
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -124,6 +130,9 @@ importers:
       deslop-js:
         specifier: ^0.0.11
         version: 0.0.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      effect:
+        specifier: 4.0.0-beta.70
+        version: 4.0.0-beta.70
       oxlint:
         specifier: ^1.66.0
         version: 1.66.0(oxlint-tsgolint@0.23.0)
@@ -339,6 +348,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@effect/vitest@4.0.0-beta.70':
+    resolution: {integrity: sha512-XDteNN0xfOgoMauAVoN5iylxVgEjp7kFsGFq18tZ5XYjek0eOZa0nOoes5s7Bs71VvwjnCeCbFMD7IhxswEt8A==}
+    peerDependencies:
+      effect: ^4.0.0-beta.70
+      vitest: ^3.0.0 || ^4.0.0
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -748,6 +763,36 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1689,6 +1734,35 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
   '@voidzero-dev/vite-plus-core@0.1.20':
     resolution: {integrity: sha512-4KmzRfzwTeG3JuvDijrdqWusSgRvLMKDPrVsDdtbDVVjEMq0VnM8lSH+Nvepd6Pg+SuSVUP212OIfH/3Yn1bfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1920,6 +1994,10 @@ packages:
   caniuse-lite@1.0.30001769:
     resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2003,6 +2081,9 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
+  effect@4.0.0-beta.70:
+    resolution: {integrity: sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==}
+
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
@@ -2016,6 +2097,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -2087,12 +2171,23 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2126,6 +2221,9 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2212,6 +2310,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2289,6 +2391,9 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  kubernetes-types@1.30.0:
+    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2427,6 +2532,16 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@2.0.1:
+    resolution: {integrity: sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==}
+
+  multipasta@0.2.7:
+    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2464,6 +2579,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -2559,6 +2678,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2606,6 +2728,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -2677,6 +2802,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2708,6 +2836,9 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -2788,9 +2919,17 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toml@4.1.1:
+    resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
+    engines: {node: '>=20'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -2835,6 +2974,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   vite-plus@0.1.20:
     resolution: {integrity: sha512-hxJqXTxiiFhszwAeD0MvKlztVuXE4TztTdJ64BPxGqgY67F0PDa5eZkUsrN91Ae8aYUMfweW6V/J57OUO9/0zw==}
@@ -2881,6 +3024,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2890,6 +3074,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2913,6 +3102,11 @@ packages:
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -3196,6 +3390,11 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@effect/vitest@4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.1.7(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0)))':
+    dependencies:
+      effect: 4.0.0-beta.70
+      vitest: 4.1.7(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -3494,6 +3693,24 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -4031,7 +4248,48 @@ snapshots:
       next: 16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3)':
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.127.0
       '@oxc-project/types': 0.127.0
@@ -4044,7 +4302,7 @@ snapshots:
       jiti: 2.6.1
       terser: 5.46.0
       typescript: 6.0.3
-      yaml: 2.8.3
+      yaml: 2.9.0
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.20':
     optional: true
@@ -4064,11 +4322,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(yaml@2.9.0)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.2.0
@@ -4078,7 +4336,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0)
       ws: 8.20.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -4189,6 +4447,8 @@ snapshots:
 
   caniuse-lite@1.0.30001769: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4259,6 +4519,19 @@ snapshots:
 
   dotenv@8.6.0: {}
 
+  effect@4.0.0-beta.70:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.8.0
+      find-my-way-ts: 0.1.6
+      ini: 7.0.0
+      kubernetes-types: 1.30.0
+      msgpackr: 2.0.1
+      multipasta: 0.2.7
+      toml: 4.1.1
+      uuid: 14.0.0
+      yaml: 2.9.0
+
   electron-to-chromium@1.5.286: {}
 
   enhanced-resolve@5.19.0:
@@ -4272,6 +4545,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -4394,9 +4669,19 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
+  expect-type@1.3.0: {}
+
   extendable-error@0.1.7: {}
+
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -4427,6 +4712,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-my-way-ts@0.1.6: {}
 
   find-up@4.1.0:
     dependencies:
@@ -4508,6 +4795,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  ini@7.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -4562,6 +4851,8 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@3.0.3: {}
+
+  kubernetes-types@1.30.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -4669,6 +4960,24 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@2.0.1:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
+  multipasta@0.2.7: {}
+
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
@@ -4700,6 +5009,11 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.27: {}
 
@@ -4876,6 +5190,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -4912,6 +5228,8 @@ snapshots:
       sisteransi: 1.0.5
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.0: {}
 
   quansync@0.2.11: {}
 
@@ -5023,6 +5341,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sirv@3.0.2:
@@ -5052,6 +5372,8 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -5113,9 +5435,13 @@ snapshots:
 
   tinypool@2.1.0: {}
 
+  tinyrainbow@3.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toml@4.1.1: {}
 
   totalist@3.0.1: {}
 
@@ -5154,11 +5480,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-plus@0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3):
+  uuid@14.0.0: {}
+
+  vite-plus@0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.127.0
-      '@voidzero-dev/vite-plus-core': 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.3))(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))(yaml@2.9.0)
       oxfmt: 0.46.0
       oxlint: 1.66.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint: 0.23.0
@@ -5201,7 +5529,7 @@ snapshots:
       - vite
       - yaml
 
-  vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.8.3):
+  vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5215,7 +5543,34 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       terser: 5.46.0
-      yaml: 2.8.3
+      yaml: 2.9.0
+
+  vitest@4.1.7(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
 
   webidl-conversions@3.0.1: {}
 
@@ -5228,6 +5583,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   ws@8.20.0: {}
@@ -5235,6 +5595,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/scripts/smoke-json-report.ts
+++ b/scripts/smoke-json-report.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as Schema from "effect/Schema";
+import { JsonReport } from "@react-doctor/core";
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = resolve(SCRIPT_DIRECTORY, "..");
+const CLI_BINARY_PATH = resolve(REPOSITORY_ROOT, "packages/react-doctor/dist/cli.js");
+const FIXTURE_DIRECTORY = resolve(
+  REPOSITORY_ROOT,
+  "packages/react-doctor/tests/fixtures/basic-react",
+);
+
+if (!existsSync(CLI_BINARY_PATH)) {
+  console.error(`Built CLI missing at ${CLI_BINARY_PATH}. Run \`pnpm build\` first.`);
+  process.exit(1);
+}
+
+if (!existsSync(FIXTURE_DIRECTORY)) {
+  console.error(`Fixture missing at ${FIXTURE_DIRECTORY}.`);
+  process.exit(1);
+}
+
+// `--offline --no-lint --no-dead-code` keeps the run fast and
+// deterministic — we're checking that the CLI plumbing produces a
+// schema-valid v1 JsonReport, not that any particular rule fires.
+// The eval harness (react-doctor-evals parity check) is the right
+// tool for diagnostic-set comparison; this smoke catches structural
+// regressions to the JSON output across refactor PRs.
+const result = spawnSync(
+  process.execPath,
+  [CLI_BINARY_PATH, FIXTURE_DIRECTORY, "--offline", "--no-lint", "--no-dead-code", "--json"],
+  { encoding: "utf-8", maxBuffer: 50 * 1024 * 1024 },
+);
+
+if (result.status !== 0 && result.status !== 1) {
+  console.error(`CLI exited with unexpected status ${result.status}`);
+  console.error("stderr:", result.stderr);
+  process.exit(1);
+}
+
+let parsed: unknown;
+try {
+  parsed = JSON.parse(result.stdout);
+} catch (cause) {
+  console.error("CLI did not produce parseable JSON on stdout.");
+  console.error("stdout:", result.stdout.slice(0, 2_000));
+  console.error("cause:", cause);
+  process.exit(1);
+}
+
+let decoded: ReturnType<typeof Schema.decodeUnknownSync<typeof JsonReport>>;
+try {
+  decoded = Schema.decodeUnknownSync(JsonReport)(parsed);
+} catch (cause) {
+  console.error("CLI output did not validate against the JsonReport schema.");
+  console.error("cause:", cause);
+  process.exit(1);
+}
+
+if (decoded.schemaVersion !== 1) {
+  console.error(`Expected schemaVersion 1, got ${decoded.schemaVersion}`);
+  process.exit(1);
+}
+
+if (decoded.mode !== "full") {
+  console.error(`Expected mode "full", got "${decoded.mode}"`);
+  process.exit(1);
+}
+
+if (decoded.summary.totalDiagnosticCount !== decoded.diagnostics.length) {
+  console.error(
+    `summary.totalDiagnosticCount (${decoded.summary.totalDiagnosticCount}) does not match diagnostics.length (${decoded.diagnostics.length})`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Smoke OK: schemaVersion=${decoded.schemaVersion} mode=${decoded.mode} projects=${decoded.projects.length} diagnostics=${decoded.diagnostics.length}`,
+);


### PR DESCRIPTION
First PR of an 8-PR stack rewriting react-doctor's orchestration on Effect v4. Lands the architectural primitives subsequent PRs build on, preserving every public contract (`inspect()`, `diagnose()`, CLI flags, JSON `schemaVersion: 1`, GitHub Action).

The plan (in `.cursor/plans/`) was authored before any code, fully aligned with `react-doctor-evals`' Effect v4 patterns. See [react-doctor-evals/src/errors.ts](https://github.com/millionco/react-doctor-evals/blob/main/src/errors.ts) for the canonical reference this PR mirrors.

## Stack

- **1/8 (this PR)** — Foundation: tagged errors, schemas, refs, paths
- 2/8 — Convert `run-oxlint.ts` to raise tagged errors
- 3/8 — Stand up 8 services (`Files`, `Project`, `Config`, `Linter`, `DeadCode`, `Score`, `Reporter`, `Progress`)
- 4/8 — `runInspect` streaming orchestrator
- 5/8 — `@react-doctor/api` package
- 6/8 — `@react-doctor/cli` package
- 7/8 — Collapse `@react-doctor/types` + `@react-doctor/project-info` into core
- 8/8 — `react-doctor` becomes the published npm front door

## What lands in this PR

**New files** ([packages/core/src/](packages/core/src/)):

- [errors.ts](packages/core/src/errors.ts) — 9 leaf `Schema.TaggedErrorClass` composed into `ReactDoctorError { reason: Schema.Union([...]) }`. Helpers `formatReactDoctorError` / `isReactDoctorError` / `isSplittableReactDoctorError` (all `_tag`-based, zero string-grepping).
- [schemas.ts](packages/core/src/schemas.ts) — `Diagnostic`, `Severity`, `JsonReport = Schema.Union([JsonReportV1])`, `buildDiagnosticIdentity`. Forward-compatible: adding `schemaVersion: 2` is one new union member.
- [refs.ts](packages/core/src/refs.ts) — `Context.Reference` for env-derived ambient config (`OxlintSpawnTimeoutMs`, `OxlintOutputMaxBytes`, `StagedFilesTempDirPrefix`). Tests override via `Layer.succeed`.
- [paths.ts](packages/core/src/paths.ts) — `Schema.brand` for `OxlintBinaryPath` and `NodeBinaryPath`. Catches the binary-swap bug at compile time.

**Wiring**:

- [handle-error.ts](packages/react-doctor/src/cli/utils/handle-error.ts) and [build-json-report-error.ts](packages/core/src/build-json-report-error.ts) dispatch to the tagged-error message getter when `isReactDoctorError(error)`, else fall back to the existing `formatErrorChain`. `run-oxlint.ts` still throws plain `Error`s — PR 2 converts those.
- [scripts/smoke-json-report.ts](scripts/smoke-json-report.ts) runs the built CLI against `tests/fixtures/basic-react` and `Schema.decodeUnknownSync`s the stdout against the new `JsonReport` schema. New CI step (`pnpm smoke:json-report`) must stay green through PR 8. Verified locally that a full lint run with 263 real diagnostics decodes cleanly.

**Constants**:

- Hoisted \`OXLINT_SPAWN_TIMEOUT_MS\` from the inline IIFE in [run-oxlint.ts](packages/core/src/run-oxlint.ts) into [constants.ts](packages/core/src/constants.ts) with explanatory docstring (per \`AGENTS.md\`).

## Effect v4 deps

- `effect@4.0.0-beta.70` in `packages/core/dependencies` and `packages/react-doctor/dependencies`. Marked `neverBundle` in [vite.config.ts](packages/react-doctor/vite.config.ts) (~1MB+ of tree-shakable source; installers pull it as a regular dep — matches `react-doctor-evals`' approach).
- `@effect/vitest@4.0.0-beta.70` as a devDependency of core, used by PR 3+.

## Patterns

Every new file matches the canonical Effect v4 / `react-doctor-evals` conventions exactly:

- `import * as X from "effect/X"` (never the umbrella import) — verified zero remaining `from "effect"` lines
- `Schema.TaggedErrorClass<Self>()("Tag", { fields })` extension syntax
- `Schema.Class<Self>("Name")({ fields })` extension syntax
- `Cause.pretty(Cause.fail(this.cause))` in `get message()` for opaque causes
- `Context.Reference<T>("react-doctor/X", { defaultValue })` with env-var reads in `defaultValue`
- `Schema.brand("X")` via `.pipe()`
- `Schema.Literals([...])` for unions, `Schema.Literal(x)` for single
- `Schema.NullOr` for nullable (\`x | null\`), `Schema.optional` for absent-OK (\`x?\`)
- Service / Reference identifiers use the short prefix \`react-doctor/X\` (matches eval's \`rde/X\`)
- kebab-case file names (per AGENTS.md)

## Validation

- \`pnpm typecheck\` — 10/10 tasks green
- \`pnpm test\` — 113 files, 1442 pass / 3 skipped (up from 1198; +244 new tests in [errors.test.ts](packages/react-doctor/tests/errors.test.ts) and [schemas.test.ts](packages/react-doctor/tests/schemas.test.ts))
- \`pnpm lint\` — clean
- \`pnpm format:check\` — clean across 1119 files
- \`pnpm build\` — all 7 packages produce dist/
- \`pnpm smoke:json-report\` — schema-valid v1 JsonReport from built CLI

## Test plan

- [x] All existing tests still pass (1198 → 1442 incl. new)
- [x] Built CLI produces schema-valid JSON output
- [x] Built CLI version flag still works
- [x] No public API change (\`inspect\`, \`diagnose\`, CLI flags, JSON shape all unchanged)
- [x] Effect v4 dep installs cleanly across the workspace

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new runtime dependency (`effect`) and new core error/schema plumbing that changes how failures are formatted/serialized, which could affect CLI and JSON-report consumers if mismatched.
> 
> **Overview**
> Adds an Effect v4-based foundation in `@react-doctor/core`: new tagged error types wrapped by `ReactDoctorError`, versioned `effect/Schema` definitions for `Diagnostic`/`JsonReport` (plus `buildDiagnosticIdentity`), branded path types, and `Context.Reference` knobs for oxlint spawn timeout/output caps.
> 
> Updates CLI and JSON error reporting to prefer the new tagged-error messages (including embedding `ReactDoctorError(<tag>)` into JSON error payloads) while preserving `schemaVersion: 1`. CI now runs a new `pnpm smoke:json-report` script that executes the built CLI against a fixture and validates stdout against the `JsonReport` schema, and `effect` is added as a dependency (kept external in the CLI bundle).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3fc5682d1c28eaede9b1e25f5736eda7ee8a951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->