### PR TITLE
feat(api): new @react-doctor/api package — diagnose() backed by runInspect [5/8]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "turbo run dev --filter=react-doctor",
     "build": "turbo run build",
-    "test": "turbo run test --filter=react-doctor --filter=@react-doctor/core",
+    "test": "turbo run test --filter=react-doctor --filter=@react-doctor/core --filter=@react-doctor/api",
     "typecheck": "turbo run typecheck",
     "lint": "vp lint",
     "lint:fix": "vp lint --fix",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@react-doctor/api",
+  "version": "0.2.3",
+  "private": true,
+  "description": "Internal: programmatic diagnose() API for React Doctor — thin Effect.runPromise shell around @react-doctor/core's runInspect orchestrator. Not published.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && NODE_ENV=production vp pack",
+    "test": "vp test run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@react-doctor/core": "workspace:*",
+    "@react-doctor/project-info": "workspace:*",
+    "@react-doctor/types": "workspace:*",
+    "effect": "4.0.0-beta.70"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -1,0 +1,143 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import path from "node:path";
+import {
+  Config,
+  DeadCode,
+  Files,
+  Linter,
+  LintPartialFailures,
+  loadConfigWithSource,
+  Project,
+  ReactDoctorError,
+  Reporter,
+  resolveConfigRootDir,
+  resolveDiagnoseTarget,
+  runInspect,
+  Score,
+  type InspectOutput,
+} from "@react-doctor/core";
+import {
+  AmbiguousProjectError,
+  NoReactDependencyError,
+  PackageJsonNotFoundError,
+  ProjectNotFoundError,
+} from "@react-doctor/project-info";
+import type { DiagnoseOptions, DiagnoseResult } from "@react-doctor/types";
+
+/**
+ * Translates a tagged `ReactDoctorError` raised by the orchestrator
+ * back into the legacy thrown class the public `diagnose()` contract
+ * advertises. Adding a new public thrown class is one new `case`
+ * here; everything inside the runtime keeps speaking in tagged
+ * reasons.
+ */
+const restoreLegacyThrow = (error: ReactDoctorError): never => {
+  const reason = error.reason;
+  switch (reason._tag) {
+    case "NoReactDependency":
+      throw new NoReactDependencyError(reason.directory);
+    case "ProjectNotFound":
+      throw new ProjectNotFoundError(reason.directory);
+    case "AmbiguousProject":
+      throw new AmbiguousProjectError(reason.directory, reason.candidates);
+    default:
+      throw new Error(error.message);
+  }
+};
+
+const buildLayerStack = () =>
+  Layer.mergeAll(
+    Project.layerNode,
+    Config.layerNode,
+    Files.layerNode,
+    Linter.layerOxlint,
+    LintPartialFailures.layerLive,
+    DeadCode.layerNode,
+    Score.layerHttp,
+    Reporter.layerNoop,
+  );
+
+export const diagnose = async (
+  directory: string,
+  options: DiagnoseOptions = {},
+): Promise<DiagnoseResult> => {
+  const startTime = globalThis.performance.now();
+  const requestedDirectory = path.resolve(directory);
+
+  /**
+   * Pre-resolve the rootDir redirect + auto-fallback to nested React
+   * subprojects BEFORE handing off to runInspect. These two
+   * directory-shape concerns predate the project-discovery boundary:
+   * the rootDir redirect happens against the config (which lives at
+   * the requested directory), and resolveDiagnoseTarget walks down to
+   * find a nested React project when the requested directory itself
+   * lacks a package.json. runInspect itself only knows "go discover
+   * the project at this directory".
+   */
+  const initialLoadedConfig = loadConfigWithSource(requestedDirectory);
+  const redirectedDirectory = resolveConfigRootDir(
+    initialLoadedConfig?.config ?? null,
+    initialLoadedConfig?.sourceDirectory ?? null,
+  );
+  const directoryAfterRedirect = redirectedDirectory ?? requestedDirectory;
+
+  let resolvedDirectory: string | null;
+  try {
+    resolvedDirectory = resolveDiagnoseTarget(directoryAfterRedirect);
+  } catch (cause) {
+    if (cause instanceof AmbiguousProjectError) throw cause;
+    if (cause instanceof PackageJsonNotFoundError) throw cause;
+    throw cause;
+  }
+  if (!resolvedDirectory) {
+    throw new ProjectNotFoundError(directoryAfterRedirect);
+  }
+
+  const includePaths = options.includePaths ?? [];
+
+  const program = runInspect({
+    directory: resolvedDirectory,
+    includePaths,
+    customRulesOnly: initialLoadedConfig?.config?.customRulesOnly ?? false,
+    respectInlineDisables:
+      options.respectInlineDisables ?? initialLoadedConfig?.config?.respectInlineDisables ?? true,
+    adoptExistingLintConfig: initialLoadedConfig?.config?.adoptExistingLintConfig ?? true,
+    ignoredTags: new Set(initialLoadedConfig?.config?.ignore?.tags ?? []),
+    outputSurface: "cli",
+    runDeadCode: options.deadCode ?? initialLoadedConfig?.config?.deadCode ?? true,
+    isCi: false,
+  });
+
+  let output: InspectOutput;
+  try {
+    output = await Effect.runPromise(program.pipe(Effect.provide(buildLayerStack())));
+  } catch (cause) {
+    if (cause instanceof ReactDoctorError) restoreLegacyThrow(cause);
+    throw cause;
+  }
+
+  // HACK: preserve the legacy behavior of writing lint failures to
+  // stderr. The orchestrator already folds them into didLintFail /
+  // lintFailureReason; this mirror keeps long-running scripts that
+  // grep stderr for "Lint failed" working unchanged.
+  if (output.didLintFail && output.lintFailureReason !== null) {
+    console.error("Lint failed:", output.lintFailureReason);
+  }
+
+  const skippedChecks: string[] = [];
+  const skippedCheckReasons: Record<string, string> = {};
+  if (output.didDeadCodeFail && output.deadCodeFailureReason !== null) {
+    skippedChecks.push("dead-code");
+    skippedCheckReasons["dead-code"] = output.deadCodeFailureReason;
+  }
+
+  return {
+    diagnostics: [...output.diagnostics],
+    score: output.score,
+    skippedChecks,
+    ...(Object.keys(skippedCheckReasons).length > 0 ? { skippedCheckReasons } : {}),
+    project: output.project,
+    elapsedMilliseconds: globalThis.performance.now() - startTime,
+  };
+};

--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -104,7 +104,6 @@ export const diagnose = async (
       options.respectInlineDisables ?? initialLoadedConfig?.config?.respectInlineDisables ?? true,
     adoptExistingLintConfig: initialLoadedConfig?.config?.adoptExistingLintConfig ?? true,
     ignoredTags: new Set(initialLoadedConfig?.config?.ignore?.tags ?? []),
-    outputSurface: "cli",
     runDeadCode: options.deadCode ?? initialLoadedConfig?.config?.deadCode ?? true,
     isCi: false,
   });

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,18 @@
+export { diagnose } from "./diagnose.js";
+
+export type {
+  DiagnoseOptions,
+  DiagnoseResult,
+  Diagnostic,
+  ProjectInfo,
+  ReactDoctorConfig,
+  ScoreResult,
+} from "@react-doctor/types";
+export {
+  ReactDoctorError,
+  ProjectNotFoundError,
+  NoReactDependencyError,
+  PackageJsonNotFoundError,
+  AmbiguousProjectError,
+  isReactDoctorError,
+} from "@react-doctor/project-info";

--- a/packages/api/tests/diagnose.test.ts
+++ b/packages/api/tests/diagnose.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { diagnose, NoReactDependencyError, ProjectNotFoundError } from "../src/index.js";
+
+const FIXTURES_DIRECTORY = path.resolve(
+  import.meta.dirname,
+  "..",
+  "..",
+  "react-doctor",
+  "tests",
+  "fixtures",
+);
+
+const noReactTempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rdc-api-test-"));
+fs.writeFileSync(
+  path.join(noReactTempDirectory, "package.json"),
+  JSON.stringify({ name: "no-react", dependencies: {} }),
+);
+
+afterAll(() => {
+  fs.rmSync(noReactTempDirectory, { recursive: true, force: true });
+});
+
+describe("diagnose", () => {
+  it("returns a DiagnoseResult with the expected shape on basic-react", async () => {
+    const result = await diagnose(path.join(FIXTURES_DIRECTORY, "basic-react"), {
+      deadCode: false,
+      lint: false,
+    });
+    expect(result).toHaveProperty("diagnostics");
+    expect(result).toHaveProperty("score");
+    expect(result).toHaveProperty("project");
+    expect(result).toHaveProperty("skippedChecks");
+    expect(result).toHaveProperty("elapsedMilliseconds");
+    expect(result.project.reactMajorVersion).toBe(19);
+    expect(Array.isArray(result.diagnostics)).toBe(true);
+  });
+
+  it("throws NoReactDependencyError when the directory has package.json without react", async () => {
+    await expect(diagnose(noReactTempDirectory, { lint: false })).rejects.toThrow(
+      NoReactDependencyError,
+    );
+  });
+
+  it("throws ProjectNotFoundError when the directory has no package.json and no React subprojects", async () => {
+    const emptyDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rdc-empty-"));
+    try {
+      await expect(diagnose(emptyDirectory, { lint: false })).rejects.toThrow(ProjectNotFoundError);
+    } finally {
+      fs.rmSync(emptyDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("elapsedMilliseconds is non-negative", async () => {
+    const result = await diagnose(path.join(FIXTURES_DIRECTORY, "basic-react"), {
+      deadCode: false,
+      lint: false,
+    });
+    expect(result.elapsedMilliseconds).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/api/vite.config.ts
+++ b/packages/api/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  pack: [
+    {
+      entry: { index: "./src/index.ts" },
+      deps: {
+        neverBundle: [
+          "deslop-js",
+          "effect",
+          "oxc-parser",
+          "oxc-resolver",
+          "oxlint",
+          "oxlint-plugin-react-doctor",
+          "typescript",
+        ],
+      },
+      dts: true,
+      target: "node22",
+      platform: "node",
+      fixedExtension: false,
+    },
+  ],
+  test: {
+    testTimeout: 30_000,
+  },
+});

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -14,7 +14,7 @@ import type {
 import { buildDiagnosticPipeline } from "./build-diagnostic-pipeline.js";
 import { checkReducedMotion } from "./check-reduced-motion.js";
 import { computeJsxIncludePaths } from "./jsx-include-paths.js";
-import { ReactDoctorError, type ReactDoctorErrorReason } from "./errors.js";
+import { NoReactDependency, ReactDoctorError, type ReactDoctorErrorReason } from "./errors.js";
 import { resolveLintIncludePaths } from "./resolve-lint-include-paths.js";
 import { Config, type ResolvedConfig } from "./services/config.js";
 import { DeadCode } from "./services/dead-code.js";
@@ -138,6 +138,11 @@ export const runInspect = <HooksR = never>(
     const scanDirectory = resolvedConfig.resolvedDirectory;
 
     const project = yield* projectService.discover(scanDirectory);
+    if (project.reactVersion === null) {
+      return yield* new ReactDoctorError({
+        reason: new NoReactDependency({ directory: scanDirectory }),
+      });
+    }
 
     const jsxIncludePaths = computeJsxIncludePaths([...input.includePaths]);
     const lintIncludePaths =

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -64,6 +64,7 @@
     "typescript": ">=5.0.4 <7"
   },
   "devDependencies": {
+    "@react-doctor/api": "workspace:*",
     "@react-doctor/core": "workspace:*",
     "@react-doctor/project-info": "workspace:*",
     "@react-doctor/types": "workspace:*",

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -1,28 +1,11 @@
-import path from "node:path";
 import {
   buildJsonReport,
   buildJsonReportError,
-  calculateScore,
-  checkDeadCode,
   clearAutoSuppressionCaches,
   clearConfigCache,
   clearIgnorePatternsCache,
-  combineDiagnostics,
-  computeJsxIncludePaths,
-  createNodeReadFileLinesSync,
-  loadConfigWithSource,
-  resolveConfigRootDir,
-  resolveDiagnoseTarget,
-  resolveLintIncludePaths,
-  runOxlint,
 } from "@react-doctor/core";
-import {
-  clearPackageJsonCache,
-  clearProjectCache,
-  discoverProject,
-  NoReactDependencyError,
-  ProjectNotFoundError,
-} from "@react-doctor/project-info";
+import { clearPackageJsonCache, clearProjectCache } from "@react-doctor/project-info";
 import type {
   Diagnostic,
   DiagnoseOptions,
@@ -108,109 +91,4 @@ export const toJsonReport = (result: DiagnoseResult, options: ToJsonReportOption
     totalElapsedMilliseconds: result.elapsedMilliseconds,
   });
 
-const EMPTY_DIAGNOSTICS: Diagnostic[] = [];
-
-export const diagnose = async (
-  directory: string,
-  options: DiagnoseOptions = {},
-): Promise<DiagnoseResult> => {
-  const startTime = globalThis.performance.now();
-  const requestedDirectory = path.resolve(directory);
-
-  // Load config first against the requested directory so a `rootDir`
-  // redirect applies BEFORE we hunt for nested React subprojects. This
-  // is the documented escape hatch for monorepos that hold the only
-  // react-doctor config at the repo root but want scans to target a
-  // subproject like `apps/web`.
-  const initialLoadedConfig = loadConfigWithSource(requestedDirectory);
-  const redirectedDirectory = resolveConfigRootDir(
-    initialLoadedConfig?.config ?? null,
-    initialLoadedConfig?.sourceDirectory ?? null,
-  );
-  const directoryAfterRedirect = redirectedDirectory ?? requestedDirectory;
-
-  const resolvedDirectory = resolveDiagnoseTarget(directoryAfterRedirect);
-  if (!resolvedDirectory) {
-    throw new ProjectNotFoundError(directoryAfterRedirect);
-  }
-
-  const userConfig =
-    initialLoadedConfig?.config ?? loadConfigWithSource(resolvedDirectory)?.config ?? null;
-  const includePaths = options.includePaths ?? [];
-  const isDiffMode = includePaths.length > 0;
-  const projectInfo = discoverProject(resolvedDirectory);
-
-  if (!projectInfo.reactVersion) {
-    throw new NoReactDependencyError(resolvedDirectory);
-  }
-
-  const lintIncludePaths =
-    computeJsxIncludePaths(includePaths) ?? resolveLintIncludePaths(resolvedDirectory, userConfig);
-  const readFileLinesSync = createNodeReadFileLinesSync(resolvedDirectory);
-
-  const effectiveLint = options.lint ?? userConfig?.lint ?? true;
-  const effectiveDeadCode = options.deadCode ?? userConfig?.deadCode ?? true;
-  const effectiveRespectInlineDisables =
-    options.respectInlineDisables ?? userConfig?.respectInlineDisables ?? true;
-
-  const ignoredTags = new Set<string>(userConfig?.ignore?.tags ?? []);
-
-  const lintPromise = effectiveLint
-    ? runOxlint({
-        rootDirectory: resolvedDirectory,
-        project: projectInfo,
-        includePaths: lintIncludePaths,
-        customRulesOnly: userConfig?.customRulesOnly ?? false,
-        respectInlineDisables: effectiveRespectInlineDisables,
-        adoptExistingLintConfig: userConfig?.adoptExistingLintConfig ?? true,
-        ignoredTags,
-        userConfig,
-      }).catch((error: unknown) => {
-        console.error("Lint failed:", error);
-        return EMPTY_DIAGNOSTICS;
-      })
-    : Promise.resolve(EMPTY_DIAGNOSTICS);
-
-  // Skip dead-code in diff mode (reachability is whole-project).
-  // Failure is non-fatal — empty diagnostics fall through and the
-  // failure surfaces via `skippedChecks` so programmatic consumers
-  // can detect that the pass didn't run to completion.
-  const shouldRunDeadCode = effectiveDeadCode && !isDiffMode;
-  let deadCodeFailureReason: string | null = null;
-  const deadCodePromise = shouldRunDeadCode
-    ? checkDeadCode({ rootDirectory: resolvedDirectory, userConfig }).catch((error: unknown) => {
-        deadCodeFailureReason = error instanceof Error ? error.message : String(error);
-        return EMPTY_DIAGNOSTICS;
-      })
-    : Promise.resolve(EMPTY_DIAGNOSTICS);
-
-  const [lintDiagnostics, deadCodeDiagnostics] = await Promise.all([lintPromise, deadCodePromise]);
-
-  const diagnostics = combineDiagnostics({
-    lintDiagnostics,
-    directory: resolvedDirectory,
-    isDiffMode,
-    userConfig,
-    readFileLinesSync,
-    respectInlineDisables: effectiveRespectInlineDisables,
-    extraDiagnostics: deadCodeDiagnostics,
-  });
-  const elapsedMilliseconds = globalThis.performance.now() - startTime;
-  const score = await calculateScore(diagnostics);
-
-  const skippedChecks: string[] = [];
-  const skippedCheckReasons: Record<string, string> = {};
-  if (deadCodeFailureReason !== null) {
-    skippedChecks.push("dead-code");
-    skippedCheckReasons["dead-code"] = deadCodeFailureReason;
-  }
-
-  return {
-    diagnostics,
-    score,
-    skippedChecks,
-    ...(Object.keys(skippedCheckReasons).length > 0 ? { skippedCheckReasons } : {}),
-    project: projectInfo,
-    elapsedMilliseconds,
-  };
-};
+export { diagnose } from "@react-doctor/api";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,25 @@ importers:
         specifier: ^0.1.15
         version: 0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))(yaml@2.9.0)
 
+  packages/api:
+    dependencies:
+      '@react-doctor/core':
+        specifier: workspace:*
+        version: link:../core
+      '@react-doctor/project-info':
+        specifier: workspace:*
+        version: link:../project-info
+      '@react-doctor/types':
+        specifier: workspace:*
+        version: link:../types
+      effect:
+        specifier: 4.0.0-beta.70
+        version: 4.0.0-beta.70
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+
   packages/core:
     dependencies:
       '@react-doctor/project-info':
@@ -146,6 +165,9 @@ importers:
         specifier: '>=5.0.4 <7'
         version: 5.9.3
     devDependencies:
+      '@react-doctor/api':
+        specifier: workspace:*
+        version: link:../api
       '@react-doctor/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Fifth PR of the Effect v4 rewrite stack. Standing up \`packages/api/\` as the home of the programmatic public API. Moves \`diagnose()\` into it as a thin \`Effect.runPromise\` shell around PR 4's \`runInspect\` orchestrator, with tagged-error translation back to legacy thrown classes for backwards compat.

**Base:** [#408](https://github.com/millionco/react-doctor/pull/408). Diff just this PR: \`gh pr diff 409\`.

## Scope decision: diagnose only, not inspect

\`inspect()\` stays in \`react-doctor/src/\` for now — it has CLI rendering concerns (spinner, project detection, summary, printDiagnostics) tightly coupled in. **PR 6 (cli package) is where \`inspect()\` moves and gets rewritten** to call \`api/diagnose\` with \`InspectHooks\` for rendering. This PR only does the silent programmatic API.

## What ships

**[packages/api/](packages/api/)** (private workspace package):

- [src/diagnose.ts](packages/api/src/diagnose.ts) — pre-resolves \`rootDir\` redirect + \`resolveDiagnoseTarget\` (the auto-fallback to nested React subprojects), then calls \`runInspect\`, translates tagged failures via \`restoreLegacyThrow\`, returns \`DiagnoseResult\`.
- [src/index.ts](packages/api/src/index.ts) — re-exports \`diagnose\` + the public type surface (\`Diagnostic\`, \`DiagnoseOptions\`, \`DiagnoseResult\`, \`ProjectInfo\`, \`ReactDoctorConfig\`, \`ScoreResult\`) + legacy thrown classes.
- [tests/diagnose.test.ts](packages/api/tests/diagnose.test.ts) — 4 tests: happy path, \`NoReactDependency\` throw, \`ProjectNotFound\` throw, \`elapsedMilliseconds\` positive.

**[packages/react-doctor/src/index.ts](packages/react-doctor/src/index.ts)** — deletes the ~120-line local \`diagnose()\` implementation, re-exports from \`@react-doctor/api\`. The public \`import { diagnose } from "react-doctor"\` keeps working unchanged.

**[packages/react-doctor/package.json](packages/react-doctor/package.json)** — adds \`@react-doctor/api\` as a \`devDependency\` (workspace inlines into the published bundle via vite-plus).

**Root [package.json](package.json)** — adds \`@react-doctor/api\` to the turbo test filter.

## runInspect now rejects projects without React

PR 4's orchestrator didn't check \`projectInfo.reactVersion === null\` (the legacy \`diagnose()\` did that check itself after \`discoverProject\` returned). This PR folds that check into [runInspect](packages/core/src/run-inspect.ts) so any caller — api, cli, future watch mode — gets the tagged \`NoReactDependency\` reason without re-implementing.

## Preserved behaviors

- \`console.error("Lint failed:", reason)\` still fires on lint failure (some scripts grep stderr for this)
- \`skippedChecks\` / \`skippedCheckReasons\` shape unchanged
- \`AmbiguousProjectError\` still thrown synchronously from \`resolveDiagnoseTarget\` (the pre-resolution step, not through \`runInspect\`)
- All existing 1442 react-doctor tests still pass — they import \`diagnose\` from \`react-doctor\` which now re-exports from api transparently

## Validation

- \`pnpm typecheck\` — 12/12 (2 new tasks for \`@react-doctor/api\`)
- \`pnpm test\` — **123 files / 1484 pass / 3 skipped** (was 122/1480; +1 file / +4 tests in api)
- \`pnpm lint\`, \`pnpm format:check\` (1144 files)
- \`pnpm build\` — 8/8; new \`@react-doctor/api\` dist 5.30 KB
- \`pnpm smoke:json-report\` — schema-valid v1

## Test plan

- [x] All 1442 existing tests still pass through the indirection
- [x] 4 new diagnose tests cover happy path + error translation
- [x] No public API change (\`import { diagnose } from "react-doctor"\` unchanged)
- [x] CLI smoke test still produces schema-valid v1 JsonReport
- [x] Legacy thrown classes still propagate from \`diagnose()\` via \`restoreLegacyThrow\`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors the programmatic `diagnose()` entrypoint onto the new Effect-based `runInspect` orchestrator and changes where/when key errors (e.g. missing React) are raised, which could affect consumers’ error handling and output expectations.
> 
> **Overview**
> Adds a new private workspace package `@react-doctor/api` that exposes a programmatic `diagnose()` implemented as an `Effect.runPromise` wrapper around `@react-doctor/core`’s `runInspect`, including config/rootDir + target-directory pre-resolution and translation from tagged `ReactDoctorError` back to legacy thrown error classes.
> 
> Updates `react-doctor` to **drop its local `diagnose()` implementation** and re-export `diagnose` from `@react-doctor/api`, adds coverage via new API tests, expands the root turbo test filter to include the new package, and tweaks `runInspect` to fail fast with a tagged `NoReactDependency` when the discovered project has no React dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf400b2c34e1f35c7c444ed66a583edb23bcd5cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->