### PR TITLE
fix(oxlint-plugin-react-doctor): drop deprecated `@types/eslint-scope` and `@types/eslint-visitor-keys` stubs

### DIFF
--- a/packages/oxlint-plugin-react-doctor/package.json
+++ b/packages/oxlint-plugin-react-doctor/package.json
@@ -52,8 +52,6 @@
     "test": "pnpm gen && vp test run"
   },
   "dependencies": {
-    "@types/eslint-scope": "^9.1.0",
-    "@types/eslint-visitor-keys": "^3.3.2",
     "@typescript-eslint/types": "^8.59.3",
     "eslint-scope": "^9.1.2",
     "eslint-visitor-keys": "^5.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,12 +86,6 @@ importers:
 
   packages/oxlint-plugin-react-doctor:
     dependencies:
-      '@types/eslint-scope':
-        specifier: ^9.1.0
-        version: 9.1.0
-      '@types/eslint-visitor-keys':
-        specifier: ^3.3.2
-        version: 3.3.2
       '@typescript-eslint/types':
         specifier: ^8.59.3
         version: 8.59.3
@@ -1663,14 +1657,6 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
-
-  '@types/eslint-scope@9.1.0':
-    resolution: {integrity: sha512-ZdRd/C3bTObl4fZ6d7iXN2AVv20waMU2tPy1W24e6ECLbB8T9fBxtONKZUpIpYHShMVk6cDNP9QMVw7Qdqsd/w==}
-    deprecated: This is a stub types definition. eslint-scope provides its own type definitions, so you do not need this installed.
-
-  '@types/eslint-visitor-keys@3.3.2':
-    resolution: {integrity: sha512-Jv7Ga0rieI+HtsG18BwW7FJZbxtm5XZxPRbQN9mSyek6Dt29YEkeWGxnUvwwzQ76j8BrS5nhfLF2tch+9vesuQ==}
-    deprecated: This is a stub types definition. eslint-visitor-keys provides its own type definitions, so you do not need this installed.
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -4205,14 +4191,6 @@ snapshots:
       assertion-error: 2.0.1
 
   '@types/deep-eql@4.0.2': {}
-
-  '@types/eslint-scope@9.1.0':
-    dependencies:
-      eslint-scope: 9.1.2
-
-  '@types/eslint-visitor-keys@3.3.2':
-    dependencies:
-      eslint-visitor-keys: 5.0.1
 
   '@types/esrecurse@4.3.1': {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Running `npx react-doctor@latest` prints two deprecation warnings during install:

```
npm warn deprecated @types/eslint-visitor-keys@3.3.2: This is a stub types definition. eslint-visitor-keys provides its own type definitions, so you do not need this installed.
npm warn deprecated @types/eslint-scope@9.1.0: This is a stub types definition. eslint-scope provides its own type definitions, so you do not need this installed.
```

Both warnings come from `oxlint-plugin-react-doctor`, which declares `@types/eslint-scope` and `@types/eslint-visitor-keys` as runtime `dependencies`. As npm itself notes, both packages now ship their own type definitions, so the `@types/*` stubs are unnecessary and have been deprecated.

## Change

Remove both stub `@types/*` packages from the `dependencies` field of `packages/oxlint-plugin-react-doctor/package.json`.

The source already imports types directly from the real packages (`eslint-scope`, `eslint-visitor-keys`) rather than from `@types/*`, so no code changes are required:

- `src/plugin/rules/state-and-effects/no-derived-state.ts`
- `src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts`
- `src/plugin/rules/state-and-effects/utils/effect/ast.ts`
- `src/plugin/rules/state-and-effects/utils/effect/constants.ts`
- `src/plugin/rules/state-and-effects/utils/effect/get-program-analysis.ts`
- `src/plugin/rules/state-and-effects/utils/effect/react.ts`

## Verification

- `pnpm install` succeeds with no deprecation warnings for these two packages.
- `pnpm --filter oxlint-plugin-react-doctor typecheck` passes.
- `pnpm --filter oxlint-plugin-react-doctor build` produces the same output (1.22 MB bundle, 416 kB d.ts).
- `pnpm --filter oxlint-plugin-react-doctor test` shows the exact same 38 pre-existing test failures as `main` (all in `no-multi-comp` and similar rule fixtures, unrelated to types).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c37c4c1c-d84f-4d4b-b5b8-584663cf7444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c37c4c1c-d84f-4d4b-b5b8-584663cf7444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

