### PR TITLE
remove react review CTA from CLI summary

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -26,8 +26,6 @@ export const SCORE_API_URL = "https://www.react.doctor/api/score";
 
 export const SHARE_BASE_URL = "https://www.react.doctor/share";
 
-export const REACT_REVIEW_URL = "https://react.review";
-
 export const FETCH_TIMEOUT_MS = 10_000;
 
 // HACK: Windows CreateProcessW limits total command-line length to 32,767 chars.

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -1,6 +1,5 @@
 import {
   PERFECT_SCORE,
-  REACT_REVIEW_URL,
   SCORE_BAR_WIDTH_CHARS,
   SCORE_GOOD_THRESHOLD,
   SCORE_OK_THRESHOLD,
@@ -70,18 +69,5 @@ export const printBrandingOnlyHeader = (): void => {
 export const printNoScoreHeader = (noScoreMessage: string): void => {
   logger.log(`  ${BRANDING_LINE}`);
   logger.log(`  ${highlighter.gray(noScoreMessage)}`);
-  logger.break();
-};
-
-export const printReactReviewCta = (): void => {
-  logger.log(
-    `  ${highlighter.bold("→ Catch these issues on every PR:")} ${highlighter.info(REACT_REVIEW_URL)}`,
-  );
-  logger.log(
-    `  ${highlighter.dim("React Review is a GitHub App built on React Doctor, and it runs on each pull request,")}`,
-  );
-  logger.log(
-    `  ${highlighter.dim("posts new issues as inline review comments, and tracks your team's score over time.")}`,
-  );
   logger.break();
 };

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -1,11 +1,7 @@
 import { highlighter, logger, SHARE_BASE_URL } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/types";
 import { collectAffectedFiles, formatElapsedTime } from "./render-diagnostics.js";
-import {
-  printNoScoreHeader,
-  printReactReviewCta,
-  printScoreHeader,
-} from "./render-score-header.js";
+import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
 import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 
 const buildShareUrl = (
@@ -81,6 +77,5 @@ export const printSummary = (
     const shareUrl = buildShareUrl(diagnostics, scoreResult, projectName);
     logger.log(`  ${highlighter.bold("→ Share your results:")} ${highlighter.info(shareUrl)}`);
     logger.break();
-    printReactReviewCta();
   }
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the trailing "Catch these issues on every PR" React Review call-to-action block from the CLI summary output.

## Changes

- `packages/react-doctor/src/cli/utils/render-score-header.ts`: drop `printReactReviewCta` and its `REACT_REVIEW_URL` import.
- `packages/react-doctor/src/cli/utils/render-summary.ts`: stop calling the CTA and drop its import.
- `packages/core/src/constants.ts`: remove the now-unused `REACT_REVIEW_URL` constant.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e72deff-8136-4cb8-95c4-875733738e89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e72deff-8136-4cb8-95c4-875733738e89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

