### PR TITLE
[superseded] Land docs + release-workflow + security audit batch from TODOS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Defense-in-depth: pin the auto-issued GITHUB_TOKEN to read-only for
+# every step in this workflow. Fork PRs already default to read-only,
+# but pinning here keeps that guarantee if the repo-wide default ever
+# widens (and protects same-repo branch pushes too).
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,6 +22,11 @@ jobs:
         node-version: [22, 24]
     steps:
       - uses: actions/checkout@v5
+        with:
+          # CI only reads the working tree; don't leave a credential
+          # behind in .git/config that later steps (or untrusted PR
+          # scripts) could pick up.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-# Defense-in-depth: pin the auto-issued GITHUB_TOKEN to read-only for
-# every step in this workflow. Fork PRs already default to read-only,
-# but pinning here keeps that guarantee if the repo-wide default ever
-# widens (and protects same-repo branch pushes too).
 permissions:
   contents: read
 
@@ -23,9 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # CI only reads the working tree; don't leave a credential
-          # behind in .git/config that later steps (or untrusted PR
-          # scripts) could pick up.
           persist-credentials: false
 
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,40 @@ permissions:
 
 jobs:
   release:
+    # Only run on the canonical repo. Forks that push to their own
+    # `main` should never trigger a publish from this workflow file.
+    if: github.repository == 'millionco/react-doctor'
     runs-on: ubuntu-latest
+    # Required-reviewer gate. The `release` environment must be
+    # configured in repo settings -> Environments with the org
+    # maintainers listed as required reviewers; this pauses the job
+    # for an explicit human approval before any npm publish or
+    # tag push happens, even when the push to main was scripted
+    # or by a non-maintainer with bypass rights.
+    environment: release
     steps:
+      - name: Verify actor has write access (defense in depth)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # `github.actor` on a push event is the user who triggered
+          # the push (or merged the PR). Require write/maintain/admin
+          # so a compromised contributor cannot start a release even
+          # if branch protection is later loosened.
+          PERMISSION=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/collaborators/${GITHUB_ACTOR}/permission" \
+            --jq '.permission')
+          case "$PERMISSION" in
+            admin|maintain|write)
+              echo "Actor ${GITHUB_ACTOR} has '${PERMISSION}' permission, allowing release."
+              ;;
+            *)
+              echo "::error::Actor ${GITHUB_ACTOR} has '${PERMISSION}' permission; release is restricted to org maintainers."
+              exit 1
+              ;;
+          esac
+
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create Release PR or Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          title: "chore: version packages"
+          commit: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Releases and move action tags
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          REACT_DOCTOR_VERSION=""
+
+          while IFS= read -r encoded; do
+            NAME=$(echo "$encoded" | base64 -d | jq -r '.name')
+            VERSION=$(echo "$encoded" | base64 -d | jq -r '.version')
+            TAG="${NAME}@${VERSION}"
+            if [ "$NAME" = "react-doctor" ]; then
+              TAG="v${VERSION}"
+              REACT_DOCTOR_VERSION="$VERSION"
+            fi
+            PRERELEASE_FLAG=""
+            if [[ "$VERSION" == *-* ]]; then
+              PRERELEASE_FLAG="--prerelease"
+            fi
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes \
+              --target "$GITHUB_SHA" \
+              $PRERELEASE_FLAG || true
+          done < <(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | @base64')
+
+          # Move the floating action tags (vMAJOR and vMAJOR.MINOR) to this
+          # commit so `uses: millionco/react-doctor@v0` keeps resolving to the
+          # latest release of the v0.x line. Stable tags are mandatory for
+          # GitHub Action consumers (TODOS: stop recommending `@main`).
+          if [ -z "$REACT_DOCTOR_VERSION" ] || [[ "$REACT_DOCTOR_VERSION" == *-* ]]; then
+            echo "Skipping floating action tag updates (no stable react-doctor release in this batch)."
+            exit 0
+          fi
+
+          MAJOR=$(echo "$REACT_DOCTOR_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$REACT_DOCTOR_VERSION" | cut -d. -f2)
+          for FLOATING in "v${MAJOR}" "v${MAJOR}.${MINOR}"; do
+            git tag -fa "$FLOATING" -m "Move ${FLOATING} to react-doctor v${REACT_DOCTOR_VERSION}"
+            git push origin "refs/tags/${FLOATING}" --force
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,27 +12,15 @@ permissions:
 
 jobs:
   release:
-    # Only run on the canonical repo. Forks that push to their own
-    # `main` should never trigger a publish from this workflow file.
     if: github.repository == 'millionco/react-doctor'
     runs-on: ubuntu-latest
-    # Required-reviewer gate. The `release` environment must be
-    # configured in repo settings -> Environments with the org
-    # maintainers listed as required reviewers; this pauses the job
-    # for an explicit human approval before any npm publish or
-    # tag push happens, even when the push to main was scripted
-    # or by a non-maintainer with bypass rights.
     environment: release
     steps:
-      - name: Verify actor has write access (defense in depth)
+      - name: Verify actor has write access
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # `github.actor` on a push event is the user who triggered
-          # the push (or merged the PR). Require write/maintain/admin
-          # so a compromised contributor cannot start a release even
-          # if branch protection is later loosened.
           PERMISSION=$(gh api \
             "repos/${GITHUB_REPOSITORY}/collaborators/${GITHUB_ACTOR}/permission" \
             --jq '.permission')
@@ -102,10 +90,6 @@ jobs:
               $PRERELEASE_FLAG || true
           done < <(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | @base64')
 
-          # Move the floating action tags (vMAJOR and vMAJOR.MINOR) to this
-          # commit so `uses: millionco/react-doctor@v0` keeps resolving to the
-          # latest release of the v0.x line. Stable tags are mandatory for
-          # GitHub Action consumers (TODOS: stop recommending `@main`).
           if [ -z "$REACT_DOCTOR_VERSION" ] || [[ "$REACT_DOCTOR_VERSION" == *-* ]]; then
             echo "Skipping floating action tag updates (no stable react-doctor release in this batch)."
             exit 0

--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -11,8 +11,6 @@ permissions:
 
 jobs:
   update:
-    # Only run on the canonical repo so a fork can't trigger a
-    # leaderboard commit through `workflow_dispatch`.
     if: github.repository == 'millionco/react-doctor'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   update:
+    # Only run on the canonical repo so a fork can't trigger a
+    # leaderboard commit through `workflow_dispatch`.
+    if: github.repository == 'millionco/react-doctor'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/TODOS.md
+++ b/TODOS.md
@@ -24,18 +24,18 @@ Fix:
 
 ## P1 - CI, Docs, Config, Product Semantics
 
-### [x] Stop recommending `millionco/react-doctor@main`
+### [~] Stop recommending `millionco/react-doctor@main`
 
-Status: shipped. README now recommends `@v0`, `.github/workflows/release.yml` republishes the floating major/minor action tags after every `changesets` publish, and the new "Release versioning" section in the README documents the npm / action / marketing version mapping.
+Status: partial. README continues to recommend `@main` per maintainer preference; the versioned-tag path is documented as an opt-in alternative in the new "Release versioning" section. `.github/workflows/release.yml` republishes the floating major/minor action tags after every `changesets` publish so consumers who want `@v0` / `@v0.2` / `@v0.2.3` pinning can.
 
 Links:
 
 - https://github.com/millionco/react-doctor/issues/75
 - https://github.com/millionco/react-doctor/issues/79
 
-Follow-ups (still open):
+Remaining:
 
-- After the first release runs, double-check that `@v0`, `@v0.2`, and `@v0.2.3` all resolve and that downstream consumers receive the expected action inputs.
+- Maintainer decision: keep `@main` as the recommended default (current stance) or eventually flip the README to a pinned-tag recommendation.
 
 ### [ ] Support mature-codebase adoption workflows natively
 
@@ -338,7 +338,7 @@ are the ones whose code follow-up is still real.
 
 ### GitHub Action and CI
 
-- [x] #75 / #79: README recommends `@v0` and `.github/workflows/release.yml` republishes floating action tags after each changesets publish.
+- [~] #75 / #79: README still recommends `@main` per maintainer preference; `.github/workflows/release.yml` republishes floating action tags so `@v0` / `@v0.2` / `@v0.2.3` is available as an opt-in.
 
 ### CLI and agent workflow
 
@@ -354,7 +354,7 @@ are the ones whose code follow-up is still real.
 
 ### Product and docs
 
-- [~] #188 / #97 Action docs and PR blocking: stable tags shipped (`@v0`); delta semantics for the hosted PR comment still outstanding.
+- [~] #188 / #97 Action docs and PR blocking: stable tags available as an opt-in (`@v0` / `@v0.2` / `@v0.2.3`), README still recommends `@main`; delta semantics for the hosted PR comment still outstanding.
 - [ ] #189 Simplified Chinese README — closed PR; decide whether to ship docs.
 - [x] #65 / #21 / #64 RN support: README now publishes the full RN support matrix.
 
@@ -364,7 +364,7 @@ are the ones whose code follow-up is still real.
 
 ## Immediate Order
 
-1. [x] Update the README to recommend stable action tags and add a release workflow.
+1. [~] Update the README to recommend stable action tags and add a release workflow. Release workflow shipped; README keeps `@main` as the recommended ref per maintainer preference, versioned tags documented as an opt-in.
 2. [ ] Change React Review PR comment semantics to delta-first.
 3. [ ] Decide and ship a stable `--package-json` (or equivalent) API.
 4. [ ] Ship baseline mode for mature-codebase adoption.

--- a/TODOS.md
+++ b/TODOS.md
@@ -26,7 +26,7 @@ Fix:
 
 ### [x] Stop recommending `millionco/react-doctor@main`
 
-Status: shipped — README now recommends `@v0`, `.github/workflows/release.yml` republishes the floating major/minor action tags after every `changesets` publish, and the new "Release versioning" section in the README documents the npm / action / marketing version mapping.
+Status: shipped. README now recommends `@v0`, `.github/workflows/release.yml` republishes the floating major/minor action tags after every `changesets` publish, and the new "Release versioning" section in the README documents the npm / action / marketing version mapping.
 
 Links:
 
@@ -122,7 +122,7 @@ Fix:
 
 ### [x] Clarify React Doctor vs React Review
 
-Status: docs shipped — README now opens with an explicit "React Doctor vs React Review" callout that names the CLI vs hosted split, and points out that the hosted product augments (rather than replaces) CLI users. Hosted-side onboarding / migration path remains a product task.
+Status: docs shipped. README now opens with an explicit "React Doctor vs React Review" callout that names the CLI vs hosted split, and points out that the hosted product augments (rather than replaces) CLI users. Hosted-side onboarding / migration path remains a product task.
 
 ### [ ] Fix hosted private-repo / repo-not-found failures
 
@@ -167,15 +167,15 @@ Fix:
 
 ### [x] Make local and hosted privacy/data behavior explicit
 
-Status: shipped — README has a dedicated "Privacy and data" section
+Status: shipped. README has a dedicated "Privacy and data" section
 that itemizes the score and share-URL network calls, what each request
-actually carries (and what it doesn't — no source code, no file
+actually carries (and what it doesn't: no source code, no file
 paths), what `--offline` / `"share": false` disable, and how hosted
 React Review's GitHub App scope differs.
 
 ### [~] Improve score-change communication
 
-Status: docs partially shipped — the Scoring section now spells out
+Status: docs partially shipped. The Scoring section now spells out
 how to debug a score change (release changelog, unique-rules diff,
 `--explain`/`--why`), tells users not to chase 100/100, and points at
 the new "Release versioning" pin recipe for score-floor automation.
@@ -188,7 +188,7 @@ Remaining:
 
 ### [x] Add clear release/version mapping
 
-Status: shipped — README "Release versioning" section publishes the
+Status: shipped. README "Release versioning" section publishes the
 mapping table (CLI npm, plugin npm, composite action git tags,
 hosted Review) and documents the `@v0` / `@v0.2` / `@v0.2.3` floating
 vs exact-pin recommendations. Release workflow keeps the floating
@@ -202,7 +202,7 @@ Remaining:
 
 ### [~] Verify local report / export support and docs
 
-Status: docs partially shipped — README now has a "Non-GitHub CI"
+Status: docs partially shipped. README now has a "Non-GitHub CI"
 section that walks through the JSON-report flow for GitLab /
 CircleCI / Jenkins / Buildkite consumers and pins the
 `JsonReport` / `JsonReportSummary` API surface as the stable
@@ -285,7 +285,7 @@ Fix:
 
 ### [x] Clarify React Native coverage
 
-Status: shipped — README has a new "React Native support matrix"
+Status: shipped. README has a new "React Native support matrix"
 table (CLI / tvOS / Expo / Windows / macOS / out-of-tree, plus the
 file-extension overrides) directly above the existing mixed-monorepo
 section, and the `rawTextWrapperComponents` / `textComponents`
@@ -338,7 +338,7 @@ are the ones whose code follow-up is still real.
 
 ### GitHub Action and CI
 
-- [x] #75 / #79 — README recommends `@v0` and `.github/workflows/release.yml` republishes floating action tags after each changesets publish.
+- [x] #75 / #79: README recommends `@v0` and `.github/workflows/release.yml` republishes floating action tags after each changesets publish.
 
 ### CLI and agent workflow
 
@@ -354,9 +354,9 @@ are the ones whose code follow-up is still real.
 
 ### Product and docs
 
-- [~] #188 / #97 Action docs and PR blocking — stable tags shipped (`@v0`); delta semantics for the hosted PR comment still outstanding.
+- [~] #188 / #97 Action docs and PR blocking: stable tags shipped (`@v0`); delta semantics for the hosted PR comment still outstanding.
 - [ ] #189 Simplified Chinese README — closed PR; decide whether to ship docs.
-- [x] #65 / #21 / #64 RN support — README now publishes the full RN support matrix.
+- [x] #65 / #21 / #64 RN support: README now publishes the full RN support matrix.
 
 ### Shipped enhancements
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,6 +1,6 @@
 # React Doctor / React Review TODOs
 
-Last refreshed against `main` (commit `77b49650`). Items that have
+Last refreshed against `main` (commit `2cc0a603`). Items that have
 landed in code or whose tracking issues/PRs were resolved on GitHub
 have been removed; everything below is still genuinely open.
 
@@ -24,27 +24,18 @@ Fix:
 
 ## P1 - CI, Docs, Config, Product Semantics
 
-### [ ] Stop recommending `millionco/react-doctor@main`
+### [x] Stop recommending `millionco/react-doctor@main`
 
-Status: still open in code.
+Status: shipped — README now recommends `@v0`, `.github/workflows/release.yml` republishes the floating major/minor action tags after every `changesets` publish, and the new "Release versioning" section in the README documents the npm / action / marketing version mapping.
 
 Links:
 
 - https://github.com/millionco/react-doctor/issues/75
 - https://github.com/millionco/react-doctor/issues/79
 
-Current problem:
+Follow-ups (still open):
 
-- README still uses `uses: millionco/react-doctor@main` (README lines 67, 86, 115, 127, 138).
-- `.github/workflows/` contains only `ci.yml` and `update-leaderboard.yml`; no `release.yml`.
-- `@main` was explicitly reported as a supply-chain risk.
-
-Fix:
-
-- Recommend stable action tags in the README.
-- Add a release workflow that publishes a versioned action tag.
-- Ensure released action inputs match docs.
-- Document npm / action / marketing version mapping.
+- After the first release runs, double-check that `@v0`, `@v0.2`, and `@v0.2.3` all resolve and that downstream consumers receive the expected action inputs.
 
 ### [ ] Support mature-codebase adoption workflows natively
 
@@ -129,21 +120,9 @@ Fix:
 - Document memory expectations and large-repo mitigations.
 - Re-check Windows / path-length behavior outside dead-code scanning.
 
-### [ ] Clarify React Doctor vs React Review
+### [x] Clarify React Doctor vs React Review
 
-Status: hosted/product.
-
-User confusion:
-
-- "Should we use react doctor or react review?"
-- "Is there additional benefit if already using react-doctor?"
-- "So a react-doctor clone?"
-
-Fix:
-
-- React Doctor: local CLI, packages, CI command, offline / local workflows.
-- React Review: hosted dashboard, GitHub App, PR comments, baseline / delta, team workflow.
-- Add an "Already using React Doctor?" migration path.
+Status: docs shipped — README now opens with an explicit "React Doctor vs React Review" callout that names the CLI vs hosted split, and points out that the hosted product augments (rather than replaces) CLI users. Hosted-side onboarding / migration path remains a product task.
 
 ### [ ] Fix hosted private-repo / repo-not-found failures
 
@@ -186,49 +165,48 @@ Fix:
 - Add states for waiting, queued, running, no issues, comment failed, repo access failed, unsupported project, backend error.
 - Alert internally when install succeeds but no analysis / comment appears.
 
-### [ ] Make local and hosted privacy/data behavior explicit
+### [x] Make local and hosted privacy/data behavior explicit
 
-Status: partially addressed. README documents `--offline` and the
-share-URL behavior, but no dedicated privacy / data section exists.
-Underlying issues #35 / #89 / #92 are closed on GitHub.
+Status: shipped — README has a dedicated "Privacy and data" section
+that itemizes the score and share-URL network calls, what each request
+actually carries (and what it doesn't — no source code, no file
+paths), what `--offline` / `"share": false` disable, and how hosted
+React Review's GitHub App scope differs.
 
-Fix:
+### [~] Improve score-change communication
 
-- Explain what the CLI sends to score / share APIs.
-- Explain exactly what `--offline` disables.
-- Explain hosted Review repo / code access.
-- Explain local CLI-only mode and the share-link opt-out.
+Status: docs partially shipped — the Scoring section now spells out
+how to debug a score change (release changelog, unique-rules diff,
+`--explain`/`--why`), tells users not to chase 100/100, and points at
+the new "Release versioning" pin recipe for score-floor automation.
 
-### [ ] Improve score-change communication
+Remaining:
 
-Status: partially addressed. README warns "Scores may decrease across
-releases" but there is no per-release rule-diff / score-impact path.
+- Auto-generate the "what rules moved between X and Y" diff in the
+  changelog tooling so the docs link points to concrete content per
+  release.
 
-Sources:
+### [x] Add clear release/version mapping
 
-- 89 -> 49.
-- 93 -> 68.
-- 44/100 with hundreds of warnings.
+Status: shipped — README "Release versioning" section publishes the
+mapping table (CLI npm, plugin npm, composite action git tags,
+hosted Review) and documents the `@v0` / `@v0.2` / `@v0.2.3` floating
+vs exact-pin recommendations. Release workflow keeps the floating
+action tags in sync with each npm publish.
 
-Fix:
+Remaining:
 
-- Add release notes for material rule changes.
-- Show why scores changed: new rules, changed severities, formula, unique error/warning rules.
-- Avoid encouraging blind 100/100 chasing.
+- Bake a "rules added / removed since previous release" section into
+  the auto-generated changelog so the per-release score impact is
+  visible at a glance.
 
-### [ ] Add clear release/version mapping
+### [~] Verify local report / export support and docs
 
-Status: open.
-
-Fix:
-
-- Publish a mapping for marketing version, npm version, action tag, and hosted Review version.
-- Include rule diff and expected score impact in releases.
-
-### [ ] Verify local report / export support and docs
-
-Status: partially addressed. `--json`, `--score`, and the Node API
-(`react-doctor/api`) are documented; SARIF is not.
+Status: docs partially shipped — README now has a "Non-GitHub CI"
+section that walks through the JSON-report flow for GitLab /
+CircleCI / Jenkins / Buildkite consumers and pins the
+`JsonReport` / `JsonReportSummary` API surface as the stable
+integration contract.
 
 Links:
 
@@ -236,11 +214,11 @@ Links:
 - #60
 - #88
 
-Fix:
+Remaining:
 
-- Confirm current JSON / report / share outputs.
-- Document the local-only report workflow.
-- Add a SARIF or generic report path if needed for non-GitHub CI.
+- Decide whether to ship a first-class SARIF output (or a
+  GitLab Code Quality report adapter) instead of relying on
+  caller-side translation.
 
 ## P2 - Platform and Product Expansion
 
@@ -305,18 +283,17 @@ Fix:
 - Detect `preact`, `preact/compat`, and `@preact/signals`.
 - Document unsupported React-specific rules.
 
-### [ ] Clarify React Native coverage
+### [x] Clarify React Native coverage
 
-Status: partially addressed.
+Status: shipped — README has a new "React Native support matrix"
+table (CLI / tvOS / Expo / Windows / macOS / out-of-tree, plus the
+file-extension overrides) directly above the existing mixed-monorepo
+section, and the `rawTextWrapperComponents` / `textComponents`
+escape hatches are now called out next to the matrix.
 
 Links:
 
 - Support: #21, #65, #64
-
-Fix:
-
-- Publish RN support matrix.
-- Document `rawTextWrapperComponents`.
 
 ### [ ] Decide HIR precision work priority
 
@@ -361,7 +338,7 @@ are the ones whose code follow-up is still real.
 
 ### GitHub Action and CI
 
-- [ ] #75 / #79 — README still uses `@main`; no release workflow exists.
+- [x] #75 / #79 — README recommends `@v0` and `.github/workflows/release.yml` republishes floating action tags after each changesets publish.
 
 ### CLI and agent workflow
 
@@ -377,9 +354,9 @@ are the ones whose code follow-up is still real.
 
 ### Product and docs
 
-- [ ] #188 / #97 Action docs and PR blocking — stable tags and delta semantics still outstanding.
+- [~] #188 / #97 Action docs and PR blocking — stable tags shipped (`@v0`); delta semantics for the hosted PR comment still outstanding.
 - [ ] #189 Simplified Chinese README — closed PR; decide whether to ship docs.
-- [ ] #65 / #21 / #64 RN support exists; support matrix / docs remain open.
+- [x] #65 / #21 / #64 RN support — README now publishes the full RN support matrix.
 
 ### Shipped enhancements
 
@@ -387,7 +364,7 @@ are the ones whose code follow-up is still real.
 
 ## Immediate Order
 
-1. [ ] Update the README to recommend stable action tags and add a release workflow.
+1. [x] Update the README to recommend stable action tags and add a release workflow.
 2. [ ] Change React Review PR comment semantics to delta-first.
 3. [ ] Decide and ship a stable `--package-json` (or equivalent) API.
 4. [ ] Ship baseline mode for mature-codebase adoption.

--- a/packages/core/src/get-diff-files.ts
+++ b/packages/core/src/get-diff-files.ts
@@ -78,9 +78,24 @@ const getUncommittedChangedFiles = (directory: string): string[] => {
   return output ?? [];
 };
 
+const SAFE_BRANCH_NAME_PATTERN = /^[A-Za-z0-9_./-]+$/;
+
+const isSafeGitRevision = (candidate: string): boolean => {
+  if (candidate.length === 0) return false;
+  if (candidate.startsWith("-")) return false;
+  if (candidate.startsWith(".") || candidate.endsWith(".")) return false;
+  if (candidate.includes("..") || candidate.includes("@{")) return false;
+  return SAFE_BRANCH_NAME_PATTERN.test(candidate);
+};
+
 export const getDiffInfo = (directory: string, explicitBaseBranch?: string): DiffInfo | null => {
   if (explicitBaseBranch !== undefined && explicitBaseBranch.trim().length === 0) {
     throw new Error("Diff base branch cannot be empty.");
+  }
+  if (explicitBaseBranch !== undefined && !isSafeGitRevision(explicitBaseBranch)) {
+    throw new Error(
+      `Diff base branch "${explicitBaseBranch}" is not a valid git ref name (must match [A-Za-z0-9_./-] without leading '-', '..', or '@{').`,
+    );
   }
 
   const currentBranch = getCurrentBranch(directory);

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -66,13 +66,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # required for `diff`
-      - uses: millionco/react-doctor@v0
+      - uses: millionco/react-doctor@main
         with:
           diff: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-> **Pin the action ref.** Always use a released tag. Use `@v0` (floating major) for automatic patch updates, or `@v0.2.3` to pin exactly. Avoid `@main`: it ships unreleased work and is a supply-chain risk. See [Release versioning](#release-versioning) for the version-mapping table.
 
 When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can read in subsequent steps — see [PR blocking and exit codes](#pr-blocking-and-exit-codes) for a score-floor recipe.
 
@@ -87,7 +85,7 @@ Pick one or both; they're independent.
 - **Both**: set `github-token` and `annotations: true`. Annotation lines are stripped from the comment body.
 
 ```yaml
-- uses: millionco/react-doctor@v0
+- uses: millionco/react-doctor@main
   with:
     diff: main
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -108,18 +106,12 @@ React Doctor ships a few related artifacts. Each one has its own version, and th
 | ----------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------- |
 | `react-doctor` npm package (the CLI and Node API)           | [npm](https://npmjs.com/package/react-doctor)               | `npx react-doctor@0.2.3`                 |
 | `oxlint-plugin-react-doctor` / `eslint-plugin-react-doctor` | [npm](https://npmjs.com/package/oxlint-plugin-react-doctor) | `"oxlint-plugin-react-doctor": "^0.2.3"` |
-| `millionco/react-doctor` GitHub composite action            | git tags on this repo                                       | `uses: millionco/react-doctor@v0`        |
+| `millionco/react-doctor` GitHub composite action            | git refs on this repo (`@main` or version tag)              | `uses: millionco/react-doctor@main`      |
 | `react.doctor` hosted Review                                | the hosted dashboard auto-updates; no pin is required       | n/a                                      |
 
-Stable action tags follow npm: every published `react-doctor@X.Y.Z` release pushes a matching `vX.Y.Z` tag, then moves the floating `vX` and `vX.Y` tags to that commit. Pick a granularity:
+The composite action is referenced as `@main` by default, which tracks the latest commit on the canonical branch. If you want a pinned action ref instead, every published `react-doctor@X.Y.Z` release also pushes a matching `vX.Y.Z` tag and moves the floating `vX` / `vX.Y` tags to that commit, so `@v0`, `@v0.2`, and `@v0.2.3` all resolve. Pin tighter when you need reproducible scores across releases (see [Scoring](#scoring)).
 
-- `@v0`: floating major; picks up patch and minor releases automatically. **Recommended default.**
-- `@v0.2`: pins the minor; only patch fixes auto-update.
-- `@v0.2.3`: exact pin; needed when you also enforce a score floor (new rule releases can change the score even when your code hasn't, see [Scoring](#scoring)).
-
-Avoid `@main`: it ships unreleased work and is a documented supply-chain risk. Floating tags are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml) immediately after each changesets publish.
-
-> **One caveat to pin granularity.** The composite action invokes `npx react-doctor@latest` internally, so the action ref pins the **workflow shape** (inputs, comment plumbing, score collection), not the **CLI version** running underneath. For genuinely deterministic scores in CI, also pin the CLI side: either run `npx react-doctor@0.2.3 ...` in a bare `- run:` step, or add `"react-doctor": "0.2.3"` to your project's dev deps and invoke it through `pnpm exec` / `npm exec`.
+> **Pinning the action ref doesn't pin the CLI version.** The composite action invokes `npx react-doctor@latest` internally, so the action ref pins the **workflow shape** (inputs, comment plumbing, score collection), not the **CLI version** running underneath. For genuinely deterministic scores in CI, also pin the CLI side: either run `npx react-doctor@0.2.3 ...` in a bare `- run:` step, or add `"react-doctor": "0.2.3"` to your project's dev deps and invoke it through `pnpm exec` / `npm exec`.
 
 Each release ships with the changeset-generated changelog. Material rule additions, severity changes, or score-formula tweaks are called out there so you can read the expected score impact before bumping a pin.
 
@@ -139,7 +131,7 @@ Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed f
 **Advisory mode** — never blocks, always comments:
 
 ```yaml
-- uses: millionco/react-doctor@v0
+- uses: millionco/react-doctor@main
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     fail-on: none
@@ -151,7 +143,7 @@ Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed f
 - uses: actions/checkout@v5
   with:
     fetch-depth: 0 # required for `diff`
-- uses: millionco/react-doctor@v0
+- uses: millionco/react-doctor@main
   with:
     diff: main
     fail-on: warning
@@ -162,7 +154,7 @@ Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed f
 
 ```yaml
 - id: doctor
-  uses: millionco/react-doctor@v0
+  uses: millionco/react-doctor@main
   with:
     fail-on: error
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -449,7 +441,7 @@ When a release moves your score noticeably:
 
 - Check the per-release changelog for added rules, severity changes, or formula tweaks. Each release ships with the changeset-generated notes.
 - Compare the `unique rules triggered` list against the previous run. A single new rule firing once can subtract 1.5 points.
-- Pin to a specific `react-doctor` version in CI (see [Release versioning](#release-versioning)) if you need stable scores across upgrades. `@v0.2.3` is the right pin shape for score-floor automation; `@v0` is fine for everything else.
+- Pin to a specific `react-doctor` version in CI (see [Release versioning](#release-versioning)) if you need stable scores across upgrades. Pinning the action ref alone is not enough; pin the CLI side too.
 - If a newly fired rule looks noisy in your codebase, `--explain <file:line>` (or `--why`) prints exactly which rule it is and the suppression snippet to silence it. See [Inline suppressions](#inline-suppressions) and [Configuration](#configuration).
 
 ## Diff and staged modes

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -15,6 +15,8 @@ Works with Next.js, Vite, and React Native.
 
 ### [See it in action →](https://react.doctor)
 
+> **React Doctor vs React Review** — React Doctor is the local-first **CLI and lint plugins** in this repo: offline-friendly, scriptable, runs anywhere. React Review is the hosted product on [react.doctor](https://react.doctor) (GitHub App, dashboard, PR comments, baseline / delta tracking). They share the same rule set; pick the CLI when you want a one-shot scan or self-hosted CI, and add React Review when you also want a hosted dashboard and review team workflow. Already using the CLI? React Review augments it — no replacement required.
+
 ## Install
 
 Run this at your project root:
@@ -64,11 +66,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # required for `diff`
-      - uses: millionco/react-doctor@main
+      - uses: millionco/react-doctor@v0
         with:
           diff: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+> **Pin the action ref.** Always use a released tag — `@v0` (floating major) for automatic patch updates, or `@v0.2.3` to pin exactly. Avoid `@main`: it ships unreleased work and is a supply-chain risk. See [Release versioning](#release-versioning) for the version-mapping table.
 
 When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can read in subsequent steps — see [PR blocking and exit codes](#pr-blocking-and-exit-codes) for a score-floor recipe.
 
@@ -83,7 +87,7 @@ Pick one or both; they're independent.
 - **Both**: set `github-token` and `annotations: true`. Annotation lines are stripped from the comment body.
 
 ```yaml
-- uses: millionco/react-doctor@main
+- uses: millionco/react-doctor@v0
   with:
     diff: main
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +99,27 @@ Prefer not to add a marketplace action? The bare `npx` form works too:
 ```yaml
 - run: npx react-doctor@latest --fail-on warning
 ```
+
+## Release versioning
+
+React Doctor ships a few related artifacts. Each one has its own version, and the table below is the mapping you should refer to when pinning.
+
+| Artifact                                                    | Where to find the version                                   | Example pin                              |
+| ----------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------- |
+| `react-doctor` npm package (the CLI and Node API)           | [npm](https://npmjs.com/package/react-doctor)               | `npx react-doctor@0.2.3`                 |
+| `oxlint-plugin-react-doctor` / `eslint-plugin-react-doctor` | [npm](https://npmjs.com/package/oxlint-plugin-react-doctor) | `"oxlint-plugin-react-doctor": "^0.2.3"` |
+| `millionco/react-doctor` GitHub composite action            | git tags on this repo                                       | `uses: millionco/react-doctor@v0`        |
+| `react.doctor` hosted Review                                | the hosted dashboard auto-updates; no pin is required       | n/a                                      |
+
+Stable action tags follow npm: every published `react-doctor@X.Y.Z` release pushes a matching `vX.Y.Z` tag, then moves the floating `vX` and `vX.Y` tags to that commit. Pick a granularity:
+
+- `@v0` — floating major; picks up patch and minor releases automatically. **Recommended default.**
+- `@v0.2` — pins the minor; only patch fixes auto-update.
+- `@v0.2.3` — exact pin; needed when you also enforce a score floor (new rule releases can change the score even when your code hasn't, see [Scoring](#scoring)).
+
+Avoid `@main` — it ships unreleased work and is a documented supply-chain risk. Floating tags are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml) immediately after each changesets publish.
+
+Each release ships with the changeset-generated changelog. Material rule additions, severity changes, or score-formula tweaks are called out there so you can read the expected score impact before bumping a pin.
 
 ## PR blocking and exit codes
 
@@ -112,7 +137,7 @@ Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed f
 **Advisory mode** — never blocks, always comments:
 
 ```yaml
-- uses: millionco/react-doctor@main
+- uses: millionco/react-doctor@v0
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     fail-on: none
@@ -124,7 +149,7 @@ Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed f
 - uses: actions/checkout@v5
   with:
     fetch-depth: 0 # required for `diff`
-- uses: millionco/react-doctor@main
+- uses: millionco/react-doctor@v0
   with:
     diff: main
     fail-on: warning
@@ -135,7 +160,7 @@ Combine `--fail-on` with `--diff <base>` to scope the gate to the PR's changed f
 
 ```yaml
 - id: doctor
-  uses: millionco/react-doctor@main
+  uses: millionco/react-doctor@v0
   with:
     fail-on: error
     github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -364,6 +389,24 @@ When a suppression isn't working, `--explain <file:line>` (or its alias `--why <
 
 `offline` skips the score API entirely — no score is shown and no share URL is generated. CI runs (GitHub Actions, GitLab CI, CircleCI) are not offline by default; only the share URL is suppressed. Set `offline: true` (or `--offline`) explicitly when you want zero network.
 
+### React Native support matrix
+
+`rn-*` rules cover the React Native ecosystem in addition to React DOM. Detection keys off `package.json` dependencies (or their hoisted equivalents) plus file-extension hints:
+
+| Stack / runtime                                                                              | Detection signal (in `package.json` or workspace)                                                                                   | `rn-*` rules |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | :----------: |
+| React Native CLI                                                                             | `react-native` dependency                                                                                                           |      ON      |
+| React Native tvOS                                                                            | `react-native-tvos`                                                                                                                 |      ON      |
+| Expo (managed and bare)                                                                      | `expo`, `expo-router`, any `@expo/*`                                                                                                |      ON      |
+| React Native for Windows / macOS                                                             | `react-native-windows`, `react-native-macos`                                                                                        |      ON      |
+| Out-of-tree React Native targets                                                             | Any `@react-native/*` or `@react-native-*` package (e.g. `@react-native-firebase/app`, `@react-native-async-storage/async-storage`) |      ON      |
+| Metro-based projects without an `expo` / `react-native` dep                                  | Top-level `"react-native"` resolution field in `package.json`                                                                       |      ON      |
+| Web-only React (Next.js, Vite, CRA, Gatsby, Remix, Docusaurus, Storybook, plain `react-dom`) | `next`, `vite`, `react-scripts`, `gatsby`, `@remix-run/*`, `@docusaurus/*`, `@storybook/*`, `react-dom` (without an RN sibling)     |     OFF      |
+| `*.web.tsx` / `*.web.jsx` files in an RN package                                             | File extension                                                                                                                      |  OFF (file)  |
+| `*.ios.tsx` / `*.android.tsx` / `*.native.tsx` files                                         | File extension                                                                                                                      |  ON (file)   |
+
+Mixed monorepos work both ways: a web-rooted workspace with even one RN package gets the `rn-*` rules loaded, then file-level boundaries keep them silent on the web workspaces. The configuration knob `rawTextWrapperComponents` lets you teach `rn-no-raw-text` about library components that safely route string children through an internal `<Text>` (e.g. `heroui-native`'s `Button`); `textComponents` is the broader escape hatch for components that behave like `<Text>` themselves.
+
 ### React Native rules in mixed monorepos
 
 `rn-*` rules respect per-package boundaries automatically. In a mixed React Native + web monorepo (`apps/mobile` alongside `apps/web` / `apps/vite-app` / `packages/storybook` / `apps/docs`), every `rn-*` rule walks up to the file's nearest `package.json` before running:
@@ -398,7 +441,14 @@ Scoring runs on react.doctor's API and is **network-dependent**: without a succe
 
 Score labels: 75+ is **Great**, 50 to 74 is **Needs work**, under 50 is **Critical**.
 
-Scores may decrease across releases as new rules are added. Each new rule that fires in your codebase introduces an additional penalty. This is expected — it means the tool is catching more issues, not that your code got worse. Pin to a specific react-doctor version in CI if you need stable scores across upgrades.
+Scores may decrease across releases as new rules are added. Each new rule that fires in your codebase introduces an additional penalty. This is expected — it means the tool is catching more issues, not that your code got worse. Don't chase 100/100 blindly; the score is a signal to investigate, not a target.
+
+When a release moves your score noticeably:
+
+- Check the per-release changelog for added rules, severity changes, or formula tweaks. Each release ships with the changeset-generated notes.
+- Compare the `unique rules triggered` list against the previous run — a single new rule firing once can subtract 1.5 points.
+- Pin to a specific `react-doctor` version in CI (see [Release versioning](#release-versioning)) if you need stable scores across upgrades. `@v0.2.3` is the right pin shape for score-floor automation; `@v0` is fine for everything else.
+- If a newly fired rule looks noisy in your codebase, `--explain <file:line>` (or `--why`) prints exactly which rule it is and the suppression snippet to silence it — see [Inline suppressions](#inline-suppressions) and [Configuration](#configuration).
 
 ## Diff and staged modes
 
@@ -471,6 +521,22 @@ React Doctor detects 50+ coding agents (Claude Code, Cursor, Codex, OpenCode, Wi
 
 In CI environments, prompts are automatically skipped. Pass `--offline` explicitly when you need zero network.
 
+### Non-GitHub CI (GitLab, Bitbucket, CircleCI, Jenkins, …)
+
+The composite action is GitHub-specific, but everything it does is built on top of the CLI — there's nothing GitHub-only about React Doctor itself. For other providers, run the CLI directly and consume the JSON report from your existing tooling:
+
+```bash
+npx react-doctor@latest --diff "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --fail-on warning --json > react-doctor.json
+```
+
+The JSON document is the same one the action consumes — `{ ok, score, diagnostics[], summary, project }`. Any CI dashboard that accepts a parsed report can read it. Three common patterns:
+
+- **GitLab CI** — invoke the CLI in a `merge_request` job and surface `react-doctor.json` as a [Code Quality report artifact](https://docs.gitlab.com/ci/testing/code_quality.html) by translating diagnostics into the GitLab Code Quality JSON shape. Until a first-class GitLab integration ships, this is the recommended path.
+- **CircleCI / Jenkins / Buildkite** — fail the step on a non-zero exit (`--fail-on warning`) and upload `react-doctor.json` as an artifact. Read `summary.errorCount` / `summary.warningCount` in a follow-up step for thresholding.
+- **Pre-merge gates without a dashboard** — `--diff <base> --fail-on warning` is enough; the build log carries the diagnostics.
+
+SARIF and a hosted GitLab integration are tracked separately — see `TODOS.md` if you'd like to follow along. In the meantime, the JSON output is intentionally stable: `JsonReport`, `JsonReportSummary`, and friends are exported from [`react-doctor/api`](packages/react-doctor/src/api.ts) for type-safe consumption.
+
 ## Node.js API
 
 ```js
@@ -491,6 +557,28 @@ const counts = summarizeDiagnostics(result.diagnostics);
 ```
 
 `react-doctor/api` re-exports `JsonReport`, `JsonReportSummary`, `JsonReportProjectEntry`, `JsonReportMode`, plus the lower-level `buildJsonReport` and `buildJsonReportError` builders. See [`packages/react-doctor/src/api.ts`](https://github.com/millionco/react-doctor/blob/main/packages/react-doctor/src/api.ts) for the full types.
+
+## Privacy and data
+
+React Doctor runs entirely on your machine. The only network traffic is the optional score lookup and an opt-out share URL — both can be disabled.
+
+| Network call        | URL                                       | Sent                                                                                                                                                          | Disabled by                                  |
+| ------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| Score API           | `https://www.react.doctor/api/score`      | Gzipped JSON of the diagnostic list with **file paths stripped** (rule id, severity, message, position only). No source code, no file paths, no project name. | `--offline` / `"offline": true`              |
+| Share URL (printed) | `https://www.react.doctor/share?p=…&s=……` | Query parameters only: detected project name, score, error count, warning count, affected file count. Nothing is uploaded — the link is rendered locally.     | `--offline`, `"share": false`, or any CI run |
+
+What `--offline` disables, exactly:
+
+- The score API call. No score is computed and the `score` action output / `--score` value is empty.
+- The share URL line in the local CLI summary.
+
+What `--offline` does **not** affect:
+
+- Local rule execution, diagnostics, exit codes, JSON / annotation output, and the GitHub Actions sticky PR comment (the comment is constructed locally from the printed report).
+
+Source code never leaves your machine. There is no telemetry pipeline, no file upload, and no usage analytics in the CLI.
+
+For the hosted React Review product on [react.doctor](https://react.doctor), the GitHub App reads repository contents through GitHub's standard installation-scoped access in order to compute the same diagnostics server-side; review the App permissions screen before installing.
 
 ## Leaderboard
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -15,7 +15,7 @@ Works with Next.js, Vite, and React Native.
 
 ### [See it in action →](https://react.doctor)
 
-> **React Doctor vs React Review** — React Doctor is the local-first **CLI and lint plugins** in this repo: offline-friendly, scriptable, runs anywhere. React Review is the hosted product on [react.doctor](https://react.doctor) (GitHub App, dashboard, PR comments, baseline / delta tracking). They share the same rule set; pick the CLI when you want a one-shot scan or self-hosted CI, and add React Review when you also want a hosted dashboard and review team workflow. Already using the CLI? React Review augments it — no replacement required.
+> **React Doctor vs React Review.** React Doctor is the local-first **CLI and lint plugins** in this repo: offline-friendly, scriptable, runs anywhere. React Review is the hosted product on [react.doctor](https://react.doctor) (GitHub App, dashboard, PR comments, baseline / delta tracking). They share the same rule set; pick the CLI when you want a one-shot scan or self-hosted CI, and add React Review when you also want a hosted dashboard and review team workflow. Already using the CLI? React Review augments it without replacing it.
 
 ## Install
 
@@ -72,7 +72,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-> **Pin the action ref.** Always use a released tag — `@v0` (floating major) for automatic patch updates, or `@v0.2.3` to pin exactly. Avoid `@main`: it ships unreleased work and is a supply-chain risk. See [Release versioning](#release-versioning) for the version-mapping table.
+> **Pin the action ref.** Always use a released tag. Use `@v0` (floating major) for automatic patch updates, or `@v0.2.3` to pin exactly. Avoid `@main`: it ships unreleased work and is a supply-chain risk. See [Release versioning](#release-versioning) for the version-mapping table.
 
 When `github-token` is set on `pull_request` events, findings are posted (and updated) as a sticky PR comment. The action also exposes a `score` output (0–100) you can read in subsequent steps — see [PR blocking and exit codes](#pr-blocking-and-exit-codes) for a score-floor recipe.
 
@@ -113,13 +113,13 @@ React Doctor ships a few related artifacts. Each one has its own version, and th
 
 Stable action tags follow npm: every published `react-doctor@X.Y.Z` release pushes a matching `vX.Y.Z` tag, then moves the floating `vX` and `vX.Y` tags to that commit. Pick a granularity:
 
-- `@v0` — floating major; picks up patch and minor releases automatically. **Recommended default.**
-- `@v0.2` — pins the minor; only patch fixes auto-update.
-- `@v0.2.3` — exact pin; needed when you also enforce a score floor (new rule releases can change the score even when your code hasn't, see [Scoring](#scoring)).
+- `@v0`: floating major; picks up patch and minor releases automatically. **Recommended default.**
+- `@v0.2`: pins the minor; only patch fixes auto-update.
+- `@v0.2.3`: exact pin; needed when you also enforce a score floor (new rule releases can change the score even when your code hasn't, see [Scoring](#scoring)).
 
-Avoid `@main` — it ships unreleased work and is a documented supply-chain risk. Floating tags are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml) immediately after each changesets publish.
+Avoid `@main`: it ships unreleased work and is a documented supply-chain risk. Floating tags are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml) immediately after each changesets publish.
 
-> **One caveat to pin granularity.** The composite action invokes `npx react-doctor@latest` internally, so the action ref pins the **workflow shape** (inputs, comment plumbing, score collection), not the **CLI version** running underneath. For genuinely deterministic scores in CI, also pin the CLI side: either run `npx react-doctor@0.2.3 …` in a bare `- run:` step, or add `"react-doctor": "0.2.3"` to your project's dev deps and invoke it through `pnpm exec` / `npm exec`.
+> **One caveat to pin granularity.** The composite action invokes `npx react-doctor@latest` internally, so the action ref pins the **workflow shape** (inputs, comment plumbing, score collection), not the **CLI version** running underneath. For genuinely deterministic scores in CI, also pin the CLI side: either run `npx react-doctor@0.2.3 ...` in a bare `- run:` step, or add `"react-doctor": "0.2.3"` to your project's dev deps and invoke it through `pnpm exec` / `npm exec`.
 
 Each release ships with the changeset-generated changelog. Material rule additions, severity changes, or score-formula tweaks are called out there so you can read the expected score impact before bumping a pin.
 
@@ -443,14 +443,14 @@ Scoring runs on react.doctor's API and is **network-dependent**: without a succe
 
 Score labels: 75+ is **Great**, 50 to 74 is **Needs work**, under 50 is **Critical**.
 
-Scores may decrease across releases as new rules are added. Each new rule that fires in your codebase introduces an additional penalty. This is expected — it means the tool is catching more issues, not that your code got worse. Don't chase 100/100 blindly; the score is a signal to investigate, not a target.
+Scores may decrease across releases as new rules are added. Each new rule that fires in your codebase introduces an additional penalty. This is expected: it means the tool is catching more issues, not that your code got worse. Don't chase 100/100 blindly; the score is a signal to investigate, not a target.
 
 When a release moves your score noticeably:
 
 - Check the per-release changelog for added rules, severity changes, or formula tweaks. Each release ships with the changeset-generated notes.
-- Compare the `unique rules triggered` list against the previous run — a single new rule firing once can subtract 1.5 points.
+- Compare the `unique rules triggered` list against the previous run. A single new rule firing once can subtract 1.5 points.
 - Pin to a specific `react-doctor` version in CI (see [Release versioning](#release-versioning)) if you need stable scores across upgrades. `@v0.2.3` is the right pin shape for score-floor automation; `@v0` is fine for everything else.
-- If a newly fired rule looks noisy in your codebase, `--explain <file:line>` (or `--why`) prints exactly which rule it is and the suppression snippet to silence it — see [Inline suppressions](#inline-suppressions) and [Configuration](#configuration).
+- If a newly fired rule looks noisy in your codebase, `--explain <file:line>` (or `--why`) prints exactly which rule it is and the suppression snippet to silence it. See [Inline suppressions](#inline-suppressions) and [Configuration](#configuration).
 
 ## Diff and staged modes
 
@@ -525,19 +525,19 @@ In CI environments, prompts are automatically skipped. Pass `--offline` explicit
 
 ### Non-GitHub CI (GitLab, Bitbucket, CircleCI, Jenkins, …)
 
-The composite action is GitHub-specific, but everything it does is built on top of the CLI — there's nothing GitHub-only about React Doctor itself. For other providers, run the CLI directly and consume the JSON report from your existing tooling:
+The composite action is GitHub-specific, but everything it does is built on top of the CLI; there's nothing GitHub-only about React Doctor itself. For other providers, run the CLI directly and consume the JSON report from your existing tooling:
 
 ```bash
 npx react-doctor@latest --diff "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --fail-on warning --json > react-doctor.json
 ```
 
-The JSON document is the same one the action consumes — `{ ok, score, diagnostics[], summary, project }`. Any CI dashboard that accepts a parsed report can read it. Three common patterns:
+The JSON document is the same one the action consumes (`{ ok, score, diagnostics[], summary, project }`). Any CI dashboard that accepts a parsed report can read it. Three common patterns:
 
-- **GitLab CI** — invoke the CLI in a `merge_request` job and surface `react-doctor.json` as a [Code Quality report artifact](https://docs.gitlab.com/ci/testing/code_quality.html) by translating diagnostics into the GitLab Code Quality JSON shape. Until a first-class GitLab integration ships, this is the recommended path.
-- **CircleCI / Jenkins / Buildkite** — fail the step on a non-zero exit (`--fail-on warning`) and upload `react-doctor.json` as an artifact. Read `summary.errorCount` / `summary.warningCount` in a follow-up step for thresholding.
-- **Pre-merge gates without a dashboard** — `--diff <base> --fail-on warning` is enough; the build log carries the diagnostics.
+- **GitLab CI**: invoke the CLI in a `merge_request` job and surface `react-doctor.json` as a [Code Quality report artifact](https://docs.gitlab.com/ci/testing/code_quality.html) by translating diagnostics into the GitLab Code Quality JSON shape. Until a first-class GitLab integration ships, this is the recommended path.
+- **CircleCI / Jenkins / Buildkite**: fail the step on a non-zero exit (`--fail-on warning`) and upload `react-doctor.json` as an artifact. Read `summary.errorCount` / `summary.warningCount` in a follow-up step for thresholding.
+- **Pre-merge gates without a dashboard**: `--diff <base> --fail-on warning` is enough; the build log carries the diagnostics.
 
-SARIF and a hosted GitLab integration are tracked separately — see `TODOS.md` if you'd like to follow along. In the meantime, the JSON output is intentionally stable: `JsonReport`, `JsonReportSummary`, and friends are exported from [`react-doctor/api`](packages/react-doctor/src/api.ts) for type-safe consumption.
+SARIF and a hosted GitLab integration are tracked separately; see `TODOS.md` if you'd like to follow along. In the meantime, the JSON output is intentionally stable: `JsonReport`, `JsonReportSummary`, and friends are exported from [`react-doctor/api`](packages/react-doctor/src/api.ts) for type-safe consumption.
 
 ## Node.js API
 
@@ -562,12 +562,12 @@ const counts = summarizeDiagnostics(result.diagnostics);
 
 ## Privacy and data
 
-React Doctor runs entirely on your machine. The only network traffic is the optional score lookup and an opt-out share URL — both can be disabled.
+React Doctor runs entirely on your machine. The only network traffic is the optional score lookup and an opt-out share URL, and both can be disabled.
 
-| Network call        | URL                                       | Sent                                                                                                                                                          | Disabled by                                  |
-| ------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| Score API           | `https://www.react.doctor/api/score`      | Gzipped JSON of the diagnostic list with **file paths stripped** (rule id, severity, message, position only). No source code, no file paths, no project name. | `--offline` / `"offline": true`              |
-| Share URL (printed) | `https://www.react.doctor/share?p=…&s=……` | Query parameters only: detected project name, score, error count, warning count, affected file count. Nothing is uploaded — the link is rendered locally.     | `--offline`, `"share": false`, or any CI run |
+| Network call        | URL                                          | Sent                                                                                                                                                          | Disabled by                                  |
+| ------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| Score API           | `https://www.react.doctor/api/score`         | Gzipped JSON of the diagnostic list with **file paths stripped** (rule id, severity, message, position only). No source code, no file paths, no project name. | `--offline` / `"offline": true`              |
+| Share URL (printed) | `https://www.react.doctor/share?p=...&s=...` | Query parameters only: detected project name, score, error count, warning count, affected file count. Nothing is uploaded; the link is rendered locally.      | `--offline`, `"share": false`, or any CI run |
 
 What `--offline` disables, exactly:
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -119,6 +119,8 @@ Stable action tags follow npm: every published `react-doctor@X.Y.Z` release push
 
 Avoid `@main` — it ships unreleased work and is a documented supply-chain risk. Floating tags are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml) immediately after each changesets publish.
 
+> **One caveat to pin granularity.** The composite action invokes `npx react-doctor@latest` internally, so the action ref pins the **workflow shape** (inputs, comment plumbing, score collection), not the **CLI version** running underneath. For genuinely deterministic scores in CI, also pin the CLI side: either run `npx react-doctor@0.2.3 …` in a bare `- run:` step, or add `"react-doctor": "0.2.3"` to your project's dev deps and invoke it through `pnpm exec` / `npm exec`.
+
 Each release ships with the changeset-generated changelog. Material rule additions, severity changes, or score-formula tweaks are called out there so you can read the expected score impact before bumping a pin.
 
 ## PR blocking and exit codes

--- a/packages/react-doctor/src/cli/utils/get-staged-files.ts
+++ b/packages/react-doctor/src/cli/utils/get-staged-files.ts
@@ -45,20 +45,29 @@ const PROJECT_CONFIG_FILENAMES = [
   ".oxlintrc.json",
 ];
 
+const isPathInsideDirectory = (childAbsolutePath: string, parentAbsolutePath: string): boolean => {
+  const relative = path.relative(parentAbsolutePath, childAbsolutePath);
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+};
+
 export const materializeStagedFiles = (
   directory: string,
   stagedFiles: string[],
   tempDirectory: string,
 ): StagedSnapshot => {
   const materializedFiles: string[] = [];
+  const resolvedTempDirectory = path.resolve(tempDirectory);
 
   for (const relativePath of stagedFiles) {
     const content = readStagedContent(directory, relativePath);
     if (content === null) continue;
 
-    const targetPath = path.join(tempDirectory, relativePath);
-    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    fs.writeFileSync(targetPath, content);
+    const candidateTargetPath = path.resolve(resolvedTempDirectory, relativePath);
+    if (!isPathInsideDirectory(candidateTargetPath, resolvedTempDirectory)) {
+      continue;
+    }
+    fs.mkdirSync(path.dirname(candidateTargetPath), { recursive: true });
+    fs.writeFileSync(candidateTargetPath, content);
     materializedFiles.push(relativePath);
   }
 

--- a/packages/website/src/app/leaderboard/page.tsx
+++ b/packages/website/src/app/leaderboard/page.tsx
@@ -48,11 +48,26 @@ const formatGeneratedAt = (isoTimestamp: string): string => {
   return `${parsedDate.toISOString().replace("T", " ").slice(0, 16)} UTC`;
 };
 
+const isSafeGithubUrl = (candidate: unknown): candidate is string => {
+  if (typeof candidate !== "string") return false;
+  try {
+    const parsed = new URL(candidate);
+    return parsed.protocol === "https:" && parsed.host === "github.com";
+  } catch {
+    return false;
+  }
+};
+
+const sanitizeLeaderboardEntries = (entries: LeaderboardEntry[]): LeaderboardEntry[] =>
+  entries.filter((entry) => isSafeGithubUrl(entry.githubUrl));
+
 const fetchLeaderboard = async (): Promise<LeaderboardFile | null> => {
   try {
     const response = await fetch(LEADERBOARD_URL, { next: { revalidate: REVALIDATE_SECONDS } });
     if (!response.ok) return null;
-    return (await response.json()) as LeaderboardFile;
+    const payload = (await response.json()) as LeaderboardFile;
+    if (!payload || !Array.isArray(payload.entries)) return null;
+    return { ...payload, entries: sanitizeLeaderboardEntries(payload.entries) };
   } catch {
     return null;
   }

--- a/scripts/update-leaderboard.ts
+++ b/scripts/update-leaderboard.ts
@@ -37,12 +37,38 @@ const fetchLeaderboard = async (): Promise<LeaderboardFile> => {
   return (await response.json()) as LeaderboardFile;
 };
 
+const isSafeGithubUrl = (candidate: unknown): candidate is string => {
+  if (typeof candidate !== "string") return false;
+  try {
+    const parsed = new URL(candidate);
+    return parsed.protocol === "https:" && parsed.host === "github.com";
+  } catch {
+    return false;
+  }
+};
+
+const escapeMarkdownTableCell = (text: string): string =>
+  text
+    .replaceAll("\\", "\\\\")
+    .replaceAll("|", "\\|")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]")
+    .replaceAll("`", "\\`")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll(/[\r\n]+/g, " ");
+
 const renderLeaderboardTable = (entries: LeaderboardEntry[]): string => {
   const header = ["| #  | Repo | Score |", "| -- | ---- | ----: |"];
-  const rows = entries.slice(0, LEADERBOARD_TOP_COUNT).map((entry, innerIndex) => {
-    const rank = String(innerIndex + 1).padEnd(2, " ");
-    return `| ${rank} | [${entry.name}](${entry.githubUrl}) | ${entry.score} |`;
-  });
+  const rows = entries
+    .filter((entry) => isSafeGithubUrl(entry.githubUrl) && Number.isFinite(entry.score))
+    .slice(0, LEADERBOARD_TOP_COUNT)
+    .map((entry, innerIndex) => {
+      const rank = String(innerIndex + 1).padEnd(2, " ");
+      const safeName = escapeMarkdownTableCell(entry.name);
+      const safeUrl = encodeURI(entry.githubUrl);
+      return `| ${rank} | [${safeName}](${safeUrl}) | ${entry.score} |`;
+    });
   return [...header, ...rows].join("\n");
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Superseded — split into four focused PRs. Please close this one and review the splits instead.**

| Slice                                   | PR                                                                 | Branch                                |
| --------------------------------------- | ------------------------------------------------------------------ | ------------------------------------- |
| Release workflow + maintainer gating    | [#423](https://github.com/millionco/react-doctor/pull/423)         | `cursor/release-workflow-a5ef`        |
| CI + leaderboard workflow hardening     | [#424](https://github.com/millionco/react-doctor/pull/424)         | `cursor/workflow-hardening-a5ef`      |
| README integration coverage + TODOS     | [#425](https://github.com/millionco/react-doctor/pull/425)         | `cursor/docs-readme-todos-a5ef`       |
| Security audit fixes (4 independent)    | [#428](https://github.com/millionco/react-doctor/pull/428)         | `cursor/security-audit-a5ef`          |

Each PR is independent — no ordering dependency between them. The README in #425 deliberately keeps `@main` as the recommended action ref; #423 publishes the floating tags so consumers who want `@v0` / `@v0.2` / `@v0.2.3` can opt in.

The full history of how this was assembled lives on the original `cursor/todos-docs-release-a5ef` branch (12 commits). The four split branches were rebased onto `main` and only carry the final state.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6152c19-ec2c-4a6f-89b8-001b6fa8a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6152c19-ec2c-4a6f-89b8-001b6fa8a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

