### PR TITLE
docs: codify Effect v4 patterns + package layout + defer the consolidation work [7/7]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,122 @@
 - MUST: Use Boolean over !!.
 - MUST: Never write changesets (`.changeset/*.md`) or edit `CHANGELOG.md`. Changesets and changelog entries are authored by humans at release time, not by agents.
 
+## Package Layout
+
+```
+packages/
+  core/                          PRIVATE  the diagnostic engine
+    src/
+      errors.ts                  tagged Schema.TaggedErrorClass leaves + ReactDoctorError union
+      schemas.ts                 Diagnostic / Severity / JsonReport / buildDiagnosticIdentity
+      refs.ts                    Context.Reference for ambient env config
+      paths.ts                   Schema.brand for OxlintBinaryPath / NodeBinaryPath
+      run-inspect.ts             streaming orchestrator (the heart)
+      build-diagnostic-pipeline  per-element filter pipeline (single source of truth)
+      services/                  8 Context.Service classes (Files, Project, Config,
+                                 Linter, DeadCode, Score, Reporter, Progress)
+                                 + LintPartialFailures
+      ...                        rest of the lint / score / suppression engine
+  api/                           PRIVATE  programmatic diagnose() (Effect.runPromise shell)
+  project-info/                  PRIVATE  legacy React project discovery (still separate
+                                 from core to avoid a circular dep with oxlint-plugin
+                                 over the shared isReactNativeDependencyName helper —
+                                 see TODOS.md for the planned consolidation)
+  types/                         PRIVATE  shared cross-package type interfaces +
+                                 React Native dependency name constants
+  react-doctor/                  PUBLISHED  CLI + public inspect() + bin
+  oxlint-plugin-react-doctor/    PUBLISHED  the 100+ rules
+  eslint-plugin-react-doctor/    PUBLISHED  ESLint mirror of the oxlint plugin
+  website/                       PRIVATE   docs site
+```
+
+## Effect v4 Conventions
+
+Built on `effect@4.0.0-beta.70`. See `tmp/effect/.patterns/effect.md` (cloned reference)
+and `~/Developer/react-doctor-evals/src/` (the application that pioneered these patterns
+for this codebase) for canonical examples.
+
+### Imports
+
+- ALWAYS: `import * as Schema from "effect/Schema"`, `import * as Effect from "effect/Effect"`,
+  `import * as Cause from "effect/Cause"`, etc. — one module per import line.
+- NEVER: `import { Schema, Effect } from "effect"` — the umbrella import inflates the
+  type-resolution graph and contradicts what every other Effect codebase does.
+
+### Errors
+
+- Every fallible service fails with `ReactDoctorError` (`reason: Schema.Union([...])`)
+- Each leaf is a `Schema.TaggedErrorClass<Self>()("Tag", { fields })` with a
+  `get message()` getter (NOT `message =`) returning a human string.
+- Opaque causes use `Cause.pretty(Cause.fail(this.cause))` in the message body.
+- Renderers dispatch on `error.reason._tag`, NEVER on `error.message.includes(...)`.
+- `formatReactDoctorError(error)` / `isReactDoctorError(error)` / `isSplittableReactDoctorError(error)`
+  live in `core/src/errors.ts`. Use them; don't add new error-shape helpers.
+
+### Services
+
+- `Context.Service<Self, Interface>()("react-doctor/Name", { make: ... })` — short
+  prefix in the identifier (matches react-doctor-evals' `rde/X` shape).
+- Service method bodies use `Effect.fnUntraced` for hot paths, `Effect.sync` for
+  one-liners. Test layers + orchestration use `Effect.gen`.
+- `Service.of({ ... })` everywhere inside `Layer.succeed` / `make:` — never
+  `{ ... } as const`.
+- `Layer.effect` when the service has init work (e.g. `Cache.make`); `Layer.succeed`
+  when stateless.
+- Method takes a single object arg when there are >1 parameters
+  (e.g. `Files.readLines({ filePath, rootDirectory })`).
+
+### Layer naming
+
+- `layerNode` for the production Node.js implementation.
+- `layerOf(value)` for the test layer that returns a pre-supplied value.
+- `layerInMemory(Map)` for filesystem-shaped services backed by an in-memory tree.
+- `layerCapture` for the test layer that records calls into a `Ref` exposed via a
+  sibling `*Capture` service (e.g. `ReporterCapture`, `ProgressCapture`).
+- `layerNoop` for the production layer that has void-return / discard semantics
+  (Reporter, Progress). Analyzers (Linter, DeadCode) use `layerOf([])` instead.
+- `layerComposite(backends)` for the slot a future second backend plugs into.
+- Implementation-specific names: `layerOxlint`, `layerHttp`, `layerNdjson(path)`,
+  `layerOra(factory)`.
+
+### Schemas
+
+- Use `Schema.Class<Self>("Name")({ fields })` for wire records.
+- Use `Schema.Literals(["a", "b"])` for unions of literals (plural), `Schema.Literal(1)`
+  for single literals.
+- `Schema.NullOr(X)` for `X | null`; `Schema.optional(X)` for `X?`.
+- `Schema.brand("X")` via `.pipe()` for branded primitives.
+- Schema for wire types (Diagnostic, JsonReport); interfaces for arg types
+  (InspectInput, LintInput) — avoid runtime encode/decode cost on hot paths.
+
+### Ambient config
+
+- Env-var reads + cache paths go through `Context.Reference<T>("react-doctor/X", { defaultValue })`.
+  See `core/src/refs.ts`. Tests override via `Layer.succeed(MyRef, ...)`.
+
 ## Testing
+
+Tests live alongside source in each package's `tests/` directory:
+
+- `packages/core/tests/` — service tests + run-inspect orchestration tests
+- `packages/api/tests/` — api shell tests
+- `packages/react-doctor/tests/` — CLI + end-to-end fixture tests
+
+Test framework is `vite-plus/test` (the existing vitest wrapper).
 
 Run checks always before committing with:
 
 ```bash
-pnpm test # runs e2e tests
+pnpm test         # all packages
 pnpm lint
-pnpm typecheck # runs type checking
-pnpm format
+pnpm typecheck
+pnpm format       # use `format:check` to verify only
+pnpm smoke:json-report   # validates the built CLI's JSON output against the schema
 ```
+
+## Reference reading
+
+- `tmp/effect/.patterns/effect.md` — canonical Effect v4 idioms (cloned for reference,
+  gitignored)
+- `~/Developer/react-doctor-evals/src/` — sister application this codebase's runtime
+  patterns are modeled on (Schemas.ts, Runner.ts, Worker.ts, errors.ts shapes)

--- a/TODOS.md
+++ b/TODOS.md
@@ -354,6 +354,55 @@ Decision:
 - Keep React Doctor React-only, or create separate rule packs / products.
 - If broadening, separate branding and diagnostics so React-specific quality is not diluted.
 
+## Effect v4 runtime follow-ups
+
+The Effect v4 rewrite (#405, #410, #411, #412, #414, #417) landed the
+runtime; the items below are the deliberately-deferred consolidation
+work flagged in the per-PR descriptions.
+
+- [ ] **Collapse `@react-doctor/project-info` into `@react-doctor/core`.**
+      Naming collision blocks the move: `project-info/src/errors.ts` exports
+      `ReactDoctorError` as the legacy `Error` base class for thrown
+      `ProjectNotFoundError` / `NoReactDependencyError` / `AmbiguousProjectError`;
+      `core/src/errors.ts` exports `ReactDoctorError` as the new
+      `Schema.TaggedErrorClass` runtime wrapper. Both names ship via
+      `react-doctor`'s public re-exports. Resolve by either renaming the
+      tagged class (large rename across the runtime) or by re-exporting
+      with `as Legacy*` aliases (uglier surface). Defer until we decide
+      the public-API direction for v1.0.
+
+- [ ] **Collapse `@react-doctor/types` into `@react-doctor/core`.**
+      Blocked by the same `ReactDoctorError` collision plus a circular-dep
+      risk: `oxlint-plugin-react-doctor` imports
+      `isReactNativeDependencyName` from `@react-doctor/types`. If types
+      moves into core, oxlint-plugin would have to depend on core (which
+      already depends on oxlint-plugin) — cycle. Resolve by hoisting the
+      RN dependency constants into oxlint-plugin (it's the only direct
+      consumer; project-info reads them transitively).
+
+- [ ] **Extract `@react-doctor/cli` workspace package.**
+      Currently `packages/react-doctor/src/cli/` holds ~40 commander +
+      rendering files. Moving them into a dedicated `@react-doctor/cli`
+      package would let `react-doctor` shrink to a published front-door
+      (one-liner `index.ts` + bin shim). Mechanical but tedious — every
+      caller of `cli/utils/*` needs its import updated. No correctness
+      benefit; purely organizational.
+
+- [ ] **Decompose `core/src/run-oxlint.ts` into Effect Stream combinators.**
+      Today `Linter.layerOxlint` calls `Effect.runSync(Ref.update(...))`
+      inside `runOxlint`'s `onPartialFailure` callback because `runOxlint`
+      is callback-shaped. If `runOxlint` returned a `Stream<Diagnostic,
+ReactDoctorError>` natively, the sync bridge disappears. Documented
+      as a HACK in `core/src/services/linter.ts`.
+
+- [ ] **`Reporter.layerCapture` for production.** Today production
+      uses `Reporter.layerNoop` — the orchestrator returns the full
+      diagnostic array via `Stream.runCollect`, so the reporter has no
+      consumer. The eval harness uses `Reporter.layerNdjson(path)`. A
+      future LSP / watch mode would need either `layerCapture` exposed at
+      the api layer or a `Reporter.layerLsp` that pushes
+      `connection.sendDiagnostics`. Slot exists; integration is downstream.
+
 ## Historical Regression Ledger
 
 GitHub issues referenced below are all CLOSED; the entries kept here


### PR DESCRIPTION
Final PR of the Effect v4 rewrite stack. **Scope reduced from the original plan** — see "Scope reduction" below.

## What ships

**[AGENTS.md](AGENTS.md)** — codifies the patterns that landed across #405–#417 so subsequent agents (and humans) write code matching the runtime:

- **Package Layout** — enumerates each workspace package's role
- **Effect v4 Conventions** covering:
  - Imports (\`import * as X from "effect/X"\`, never the umbrella)
  - Errors: tagged \`Schema.TaggedErrorClass\`, \`get message()\` getters, \`Cause.pretty\` for opaque causes, \`_tag\`-based dispatch
  - Services: \`Context.Service<Self, Interface>()("react-doctor/Name", { make })\`; \`Effect.fnUntraced\` for hot paths; \`Service.of(...)\`; \`Layer.effect\` vs \`Layer.succeed\`; object args when >1 parameter
  - Layer naming (\`layerNode\` / \`layerOf\` / \`layerInMemory\` / \`layerCapture\` / \`layerNoop\` / \`layerComposite\` / implementation-specific \`layerOxlint\` / \`layerHttp\` / etc.)
  - Schemas: \`Schema.Class\` for wire types, \`Schema.Literals\` plural for unions, \`Schema.brand\` via \`.pipe()\`, interfaces for arg types
  - Ambient config via \`Context.Reference\`
- **Testing** — \`vite-plus/test\` per-package
- **Reference reading** — pointers at \`tmp/effect/.patterns/\` (the cloned Effect-TS smol patterns doc) and \`~/Developer/react-doctor-evals/src/\` (the sister codebase whose patterns this codebase mirrors)

**[TODOS.md](TODOS.md)** — new "Effect v4 runtime follow-ups" section captures the deferred consolidation:

- Collapse \`@react-doctor/project-info\` into core (**blocked by name collision**: \`project-info/errors.ts\` exports \`ReactDoctorError\` as the legacy thrown base class; \`core/errors.ts\` exports \`ReactDoctorError\` as the new \`Schema.TaggedErrorClass\` runtime wrapper. Resolve at v1.0 by either renaming the tagged class or by re-exporting with \`as Legacy*\` aliases)
- Collapse \`@react-doctor/types\` into core (same collision + a circular dep risk via \`oxlint-plugin-react-doctor\`'s import of \`isReactNativeDependencyName\` from types)
- Extract \`@react-doctor/cli\` workspace package (mechanical ~40-file move — purely organizational, no correctness benefit)
- Decompose \`run-oxlint.ts\` into Stream combinators (kills the \`Effect.runSync\` HACK inside \`Linter.layerOxlint\`)
- Production \`Reporter\` layer choice (currently \`layerNoop\` because the orchestrator returns the array via \`Stream.runCollect\`; future LSP / watch mode would need different)

## Scope reduction

Original plan PR 7 was "collapse \`@react-doctor/types\` + \`@react-doctor/project-info\` into core." I started the consolidation, discovered the \`ReactDoctorError\` naming collision (real semantic conflict between two distinct classes that ship via the same public name), and reverted. Documented as a TODO; resolution is a v1.0 design decision, not a refactor.

Original plan PR 8 was the cli package extraction + react-doctor as front door. The architectural win (the runtime rewire) is already in main from #417. The remaining file moves are organizational; documented as a TODO.

This PR is the **smallest mergeable closure** of the stack — codifies what landed, files what didn't, leaves the repo cleanly mergeable for unrelated work.

## Validation

- \`pnpm format:check\` — clean
- No code changes, no test impact (1485 tests pass on main as of #417)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only updates documentation (no runtime, build, or test code changes), but it may influence future implementation decisions by codifying conventions and deferred work items.
> 
> **Overview**
> Codifies the **Effect v4 rewrite conventions** in `AGENTS.md`, including package layout, import/error/service/layer/schema patterns, ambient config guidance, and updated test/run command expectations.
> 
> Adds an **“Effect v4 runtime follow-ups”** section to `TODOS.md` that records the intentionally deferred consolidation/refactor work (notably the `ReactDoctorError` naming collision blocking package merges, plus potential CLI/package and stream refactors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75f98bde52f146be7dbaa911babad6279ac6349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->