### PR TITLE
fix(runtime): self-audit cleanup against AGENTS.md Effect v4 rules [8/8]

### DIFF
--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -20,7 +20,6 @@ import {
 import {
   AmbiguousProjectError,
   NoReactDependencyError,
-  PackageJsonNotFoundError,
   ProjectNotFoundError,
 } from "@react-doctor/project-info";
 import type { DiagnoseOptions, DiagnoseResult } from "@react-doctor/types";
@@ -82,14 +81,12 @@ export const diagnose = async (
   );
   const directoryAfterRedirect = redirectedDirectory ?? requestedDirectory;
 
-  let resolvedDirectory: string | null;
-  try {
-    resolvedDirectory = resolveDiagnoseTarget(directoryAfterRedirect);
-  } catch (cause) {
-    if (cause instanceof AmbiguousProjectError) throw cause;
-    if (cause instanceof PackageJsonNotFoundError) throw cause;
-    throw cause;
-  }
+  // resolveDiagnoseTarget throws AmbiguousProjectError when the
+  // requested directory has multiple React subprojects; let it
+  // propagate so the legacy public-API contract holds. A `null`
+  // return means "no React project here" — translate that to the
+  // ProjectNotFoundError the legacy diagnose() used.
+  const resolvedDirectory = resolveDiagnoseTarget(directoryAfterRedirect);
   if (!resolvedDirectory) {
     throw new ProjectNotFoundError(directoryAfterRedirect);
   }

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -169,6 +169,8 @@ export const runInspect = <HooksR = never>(
       ? []
       : checkReducedMotion(scanDirectory);
 
+    const emptyDiagnosticStream: Stream.Stream<Diagnostic, never> = Stream.empty;
+
     const rawLintStream = linterService
       .run({
         rootDirectory: scanDirectory,
@@ -190,7 +192,7 @@ export const runInspect = <HooksR = never>(
                 reason: error.message,
                 reasonTag: error.reason._tag,
               });
-              return Stream.empty as Stream.Stream<Diagnostic, never>;
+              return emptyDiagnosticStream;
             }),
           ),
         ),
@@ -208,12 +210,12 @@ export const runInspect = <HooksR = never>(
                     didFail: true,
                     reason: error.message,
                   });
-                  return Stream.empty as Stream.Stream<Diagnostic, never>;
+                  return emptyDiagnosticStream;
                 }),
               ),
             ),
           )
-      : Stream.empty;
+      : emptyDiagnosticStream;
 
     const transformedStream = Stream.fromIterable(environmentDiagnostics).pipe(
       Stream.concat(rawLintStream),

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -1,5 +1,7 @@
 import { performance } from "node:perf_hooks";
-import { Effect, Layer, Ref } from "effect";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
 import {
   calculateScore,
   Config,
@@ -264,7 +266,6 @@ const runInspectWithRuntime = async (
     output = programResult.output;
     finalSpinnerHandle = programResult.finalHandle;
   } catch (cause) {
-    if (cause instanceof ReactDoctorError) restoreLegacyThrow(cause);
     if (isReactDoctorError(cause)) restoreLegacyThrow(cause);
     throw cause;
   }
@@ -319,10 +320,13 @@ const runInspectWithRuntime = async (
 
   // Pre-filter diagnostics through the `score` surface so weak-signal
   // rule families (e.g. `design`) stay out of scoring by default and
-  // don't dilute the headline number. Surface-included diagnostics
-  // still flow through `result.diagnostics` for CLI/JSON consumers.
+  // don't dilute the headline number. The orchestrator's Score
+  // service ran with `layerOf(null)` for exactly this reason — it
+  // only sees the per-element-filtered list, not the surface-filtered
+  // list this function needs. We compute the real score here.
+  const inspectDiagnostics: ReadonlyArray<Diagnostic> = output.diagnostics;
   const scoreDiagnostics = filterDiagnosticsForSurface(
-    [...output.diagnostics] as Diagnostic[],
+    [...inspectDiagnostics],
     "score",
     output.userConfig,
   );
@@ -335,13 +339,13 @@ const runInspectWithRuntime = async (
   return finalizeAndRender({
     options,
     elapsedMilliseconds,
-    diagnostics: [...output.diagnostics],
+    diagnostics: inspectDiagnostics,
     score,
     project: output.project,
     userConfig: output.userConfig,
     didLintFail,
     lintFailureReason,
-    lintPartialFailures: [...output.lintPartialFailures],
+    lintPartialFailures: output.lintPartialFailures,
     didDeadCodeFail: output.didDeadCodeFail,
     deadCodeFailureReason: output.deadCodeFailureReason,
     directory: output.resolvedDirectory,
@@ -351,7 +355,7 @@ const runInspectWithRuntime = async (
 interface FinalizeInput {
   options: ResolvedInspectOptions;
   elapsedMilliseconds: number;
-  diagnostics: ReadonlyArray<InspectResult["diagnostics"][number]>;
+  diagnostics: ReadonlyArray<Diagnostic>;
   score: ScoreResult | null;
   project: InspectResult["project"];
   userConfig: ReactDoctorConfig | null;
@@ -399,7 +403,7 @@ const finalizeAndRender = (input: FinalizeInput): InspectResult => {
   }
 
   const buildResult = (): InspectResult => ({
-    diagnostics: [...diagnostics] as Diagnostic[],
+    diagnostics: [...diagnostics],
     score,
     skippedChecks,
     ...(Object.keys(skippedCheckReasons).length > 0 ? { skippedCheckReasons } : {}),
@@ -417,7 +421,7 @@ const finalizeAndRender = (input: FinalizeInput): InspectResult => {
   }
 
   const surfaceDiagnostics = filterDiagnosticsForSurface(
-    [...diagnostics] as Diagnostic[],
+    [...diagnostics],
     options.outputSurface,
     userConfig,
   );


### PR DESCRIPTION
Self-audit after [#419](https://github.com/millionco/react-doctor/pull/419) documented the patterns. Caught and fixed **6 issues I introduced** across [#414](https://github.com/millionco/react-doctor/pull/414) and [#417](https://github.com/millionco/react-doctor/pull/417) that contradict the rules the AGENTS.md update codified.

## P0 — AGENTS.md violations

**(1)** [packages/react-doctor/src/inspect.ts:2](packages/react-doctor/src/inspect.ts#L2) used the umbrella import \`from "effect"\` — replaced with individual \`import * as Effect / Layer / Ref from "effect/X"\` lines. AGENTS.md "ALWAYS: \`import * as X from 'effect/X'\`" rule.

**(2)** inspect.ts had three \`[...output.diagnostics] as Diagnostic[]\` casts that aren't needed — spreading a \`ReadonlyArray<Diagnostic>\` already gives \`Diagnostic[]\`. AGENTS.md "MUST: Do not type cast 'as' unless absolutely necessary" rule.

**(3)** inspect.ts catch had two consecutive identical predicates:

\`\`\`ts
if (cause instanceof ReactDoctorError) restoreLegacyThrow(cause);
if (isReactDoctorError(cause)) restoreLegacyThrow(cause);
\`\`\`

\`isReactDoctorError\` IS \`instanceof ReactDoctorError\`; the second is dead code (\`restoreLegacyThrow\` always throws so the first match exits). Dropped the duplicate.

## P1 — dead code / unnecessary casts

**(4)** [packages/api/src/diagnose.ts](packages/api/src/diagnose.ts) had a try/catch around \`resolveDiagnoseTarget\` where every branch re-threw cause unchanged:

\`\`\`ts
try { ... } catch (cause) {
  if (cause instanceof AmbiguousProjectError) throw cause;
  if (cause instanceof PackageJsonNotFoundError) throw cause;
  throw cause;
}
\`\`\`

The if-statements were no-ops. Dropped the wrapper + the unused \`PackageJsonNotFoundError\` import.

**(5)** [packages/core/src/run-inspect.ts](packages/core/src/run-inspect.ts) had two \`Stream.empty as Stream.Stream<Diagnostic, never>\` casts. \`Stream.empty\` is \`Stream<never>\` which IS assignable to \`Stream<Diagnostic, never>\` via subtyping; the casts were a TS-inference workaround. Replaced with a single typed local \`const emptyDiagnosticStream: Stream.Stream<Diagnostic, never> = Stream.empty\` shared across both call sites.

## Other

**(6)** inspect.ts Score HACK comment was misleading — claimed the orchestrator's Score would see the "FULL diagnostic list", but it actually sees the per-element-filtered list (just not score-surface-filtered). Updated the comment to match reality. Also dropped the redundant spread in \`lintPartialFailures: [...output.lintPartialFailures]\` (input is already \`ReadonlyArray<string>\`).

## What was checked but not changed

- \`_tag: "Started" as const\` in [progress.ts](packages/core/src/services/progress.ts) — \`as const\` is a const assertion, not a type cast; valid per AGENTS.md.
- \`Effect.runSync(Ref.update(...))\` inside [linter.ts](packages/core/src/services/linter.ts) — documented HACK, filed in [TODOS.md](TODOS.md) Effect v4 follow-ups.
- Score computed twice in inspect.ts flow (runInspect with Score.layerOf(null), then calculateScore) — documented HACK in the same comment.

## Audit residue (zero hits)

\`\`\`
$ rg "as Diagnostic|as Stream\\.|from \"effect\"" packages/{core,api,react-doctor}/src
(no matches)
\`\`\`

## Validation

- \`pnpm typecheck\` — 12/12
- \`pnpm test\` — **123 files / 1485 pass / 3 skipped** (unchanged from #419)
- \`pnpm lint\`, \`pnpm format:check\` (1144 files)
- \`pnpm build\` — 8/8
- \`pnpm smoke:json-report\` — schema-valid v1

## Test plan

- [x] All 1485 tests still pass
- [x] No public API change
- [x] CLI smoke test still produces schema-valid v1 JsonReport
- [x] Zero remaining umbrella \`from "effect"\` imports
- [x] Zero remaining \`as Diagnostic[]\` / \`as Stream.Stream<...>\` casts in the new code

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that removes redundant try/catch and TypeScript casts, plus standardizes Effect imports; behavior should be unchanged aside from clearer error propagation when no project is found.
> 
> **Overview**
> Cleans up runtime/CLI inspection and API diagnose code to align with Effect v4 and internal style rules, removing redundant error handling and unnecessary TypeScript casts.
> 
> `diagnose()` now relies on `resolveDiagnoseTarget()`’s `null` return to throw `ProjectNotFoundError`, while still letting `AmbiguousProjectError` propagate, and drops the unused `PackageJsonNotFoundError` import. `runInspect` replaces repeated `Stream.empty as ...` casts with a single typed `emptyDiagnosticStream` constant.
> 
> The CLI `inspect()` switches away from the umbrella `effect` import, removes duplicate ReactDoctorError checks in the catch path, avoids redundant array spreads/casts in result assembly, and updates the score-filtering comment/flow to reflect that score is computed after applying the `score` surface filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05a7afd2646c91d6aa67e6f6fedb360832c7ea26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->