### PR TITLE
feat(core): Logger service — layerConsole / layerSilent / layerCapture [9/?]

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from "./services/config.js";
 export * from "./services/dead-code.js";
 export * from "./services/files.js";
 export * from "./services/linter.js";
+export * from "./services/logger.js";
 export * from "./services/progress.js";
 export * from "./services/project.js";
 export * from "./services/reporter.js";

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,40 +1,73 @@
 import { highlighter } from "./highlighter.js";
 
-let isSilent = false;
+/**
+ * Logger contract. Side-effect functions that print to the host
+ * terminal (or test capture, or LSP output channel). Methods take
+ * varargs joined by " " to match the legacy module-level helper
+ * `logger` exported by this file before the Logger service landed.
+ *
+ * Use `consoleLogger` for production; `silentLogger` for `--silent`;
+ * inside Effect code, yield the `Logger` service instead so the
+ * caller's layer choice decides the implementation. Plain functions
+ * that take a logger parameter type it as `LoggerWriter`.
+ */
+export interface LoggerWriter {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  success: (...args: unknown[]) => void;
+  dim: (...args: unknown[]) => void;
+  break: () => void;
+}
 
+export const consoleLogger: LoggerWriter = {
+  log: (...args) => console.log(args.join(" ")),
+  error: (...args) => console.error(highlighter.error(args.join(" "))),
+  warn: (...args) => console.warn(highlighter.warn(args.join(" "))),
+  info: (...args) => console.log(highlighter.info(args.join(" "))),
+  success: (...args) => console.log(highlighter.success(args.join(" "))),
+  dim: (...args) => console.log(highlighter.dim(args.join(" "))),
+  break: () => console.log(""),
+};
+
+export const silentLogger: LoggerWriter = {
+  log: () => {},
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+  success: () => {},
+  dim: () => {},
+  break: () => {},
+};
+
+/**
+ * Registry-pattern facade for callers that haven't been converted to
+ * accept a Logger parameter or yield the Logger service yet. Swaps
+ * between consoleLogger (default) and silentLogger via the legacy
+ * `setLoggerSilent` helper. Effect-aware code should yield the Logger
+ * service instead — the registry is for non-Effect callers only.
+ *
+ * @deprecated Prefer passing a Logger parameter or yielding the
+ * Logger service. The registry will be removed once every caller is
+ * Logger-aware.
+ */
+let currentLogger: LoggerWriter = consoleLogger;
+
+export const logger: LoggerWriter = {
+  log: (...args) => currentLogger.log(...args),
+  error: (...args) => currentLogger.error(...args),
+  warn: (...args) => currentLogger.warn(...args),
+  info: (...args) => currentLogger.info(...args),
+  success: (...args) => currentLogger.success(...args),
+  dim: (...args) => currentLogger.dim(...args),
+  break: () => currentLogger.break(),
+};
+
+/** @deprecated use Logger service via Effect or pass a Logger parameter */
 export const setLoggerSilent = (silent: boolean): void => {
-  isSilent = silent;
+  currentLogger = silent ? silentLogger : consoleLogger;
 };
 
-export const isLoggerSilent = (): boolean => isSilent;
-
-export const logger = {
-  error(...args: unknown[]) {
-    if (isSilent) return;
-    console.error(highlighter.error(args.join(" ")));
-  },
-  warn(...args: unknown[]) {
-    if (isSilent) return;
-    console.warn(highlighter.warn(args.join(" ")));
-  },
-  info(...args: unknown[]) {
-    if (isSilent) return;
-    console.log(highlighter.info(args.join(" ")));
-  },
-  success(...args: unknown[]) {
-    if (isSilent) return;
-    console.log(highlighter.success(args.join(" ")));
-  },
-  dim(...args: unknown[]) {
-    if (isSilent) return;
-    console.log(highlighter.dim(args.join(" ")));
-  },
-  log(...args: unknown[]) {
-    if (isSilent) return;
-    console.log(args.join(" "));
-  },
-  break() {
-    if (isSilent) return;
-    console.log("");
-  },
-};
+/** @deprecated use Logger service */
+export const isLoggerSilent = (): boolean => currentLogger === silentLogger;

--- a/packages/core/src/services/logger.ts
+++ b/packages/core/src/services/logger.ts
@@ -1,0 +1,61 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+import { consoleLogger, silentLogger, type LoggerWriter } from "../logger.js";
+
+/**
+ * Captured Logger events backing `Logger.layerCapture`. One entry per
+ * `log/error/warn/info/success/dim/break` call. Tests `yield*
+ * LoggerCapture` to read the recorded events and assert on what the
+ * pipeline would have printed.
+ */
+export interface LoggerEvent {
+  readonly level: "log" | "error" | "warn" | "info" | "success" | "dim" | "break";
+  readonly message: string;
+}
+
+export class LoggerCapture extends Context.Service<
+  LoggerCapture,
+  Ref.Ref<ReadonlyArray<LoggerEvent>>
+>()("react-doctor/LoggerCapture") {
+  static readonly layer = Layer.effect(LoggerCapture, Ref.make<ReadonlyArray<LoggerEvent>>([]));
+}
+
+const recordCapture =
+  (events: Ref.Ref<ReadonlyArray<LoggerEvent>>, level: LoggerEvent["level"]) =>
+  (...args: unknown[]): void => {
+    Effect.runSync(
+      Ref.update(events, (existing) => [...existing, { level, message: args.join(" ") }]),
+    );
+  };
+
+/**
+ * `Logger` is the terminal-output service. Production picks
+ * `layerConsole` or `layerSilent` based on `--silent`; tests use
+ * `layerCapture` to record events into a `Ref` without touching
+ * stdout/stderr. An LSP host would provide a fourth layer that
+ * routes through `connection.window.showMessage` instead of
+ * console.
+ */
+export class Logger extends Context.Service<Logger, LoggerWriter>()("react-doctor/Logger") {
+  static readonly layerConsole: Layer.Layer<Logger> = Layer.succeed(Logger, consoleLogger);
+
+  static readonly layerSilent: Layer.Layer<Logger> = Layer.succeed(Logger, silentLogger);
+
+  static readonly layerCapture: Layer.Layer<Logger | LoggerCapture> = Layer.effect(
+    Logger,
+    Effect.map(
+      LoggerCapture,
+      (events): LoggerWriter => ({
+        log: recordCapture(events, "log"),
+        error: recordCapture(events, "error"),
+        warn: recordCapture(events, "warn"),
+        info: recordCapture(events, "info"),
+        success: recordCapture(events, "success"),
+        dim: recordCapture(events, "dim"),
+        break: () => recordCapture(events, "break")(),
+      }),
+    ),
+  ).pipe(Layer.provideMerge(LoggerCapture.layer));
+}

--- a/packages/core/tests/services/logger.test.ts
+++ b/packages/core/tests/services/logger.test.ts
@@ -1,0 +1,73 @@
+import * as Effect from "effect/Effect";
+import * as Ref from "effect/Ref";
+import { describe, expect, it } from "vite-plus/test";
+import { Logger, LoggerCapture } from "../../src/services/logger.js";
+
+describe("Logger.layerSilent", () => {
+  it("every method is a void no-op", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const logger = yield* Logger;
+        logger.log("nothing");
+        logger.error("nothing");
+        logger.warn("nothing");
+        logger.info("nothing");
+        logger.success("nothing");
+        logger.dim("nothing");
+        logger.break();
+        return "ok";
+      }).pipe(Effect.provide(Logger.layerSilent)),
+    );
+    expect(result).toBe("ok");
+  });
+});
+
+describe("Logger.layerCapture", () => {
+  it("records every method call into LoggerCapture Ref with the right level + joined args", async () => {
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        const logger = yield* Logger;
+        logger.log("hello", "world");
+        logger.error("boom");
+        logger.warn("careful");
+        logger.info("fyi");
+        logger.success("done");
+        logger.dim("muted");
+        logger.break();
+        const ref = yield* LoggerCapture;
+        return yield* Ref.get(ref);
+      }).pipe(Effect.provide(Logger.layerCapture)),
+    );
+    expect(events).toEqual([
+      { level: "log", message: "hello world" },
+      { level: "error", message: "boom" },
+      { level: "warn", message: "careful" },
+      { level: "info", message: "fyi" },
+      { level: "success", message: "done" },
+      { level: "dim", message: "muted" },
+      { level: "break", message: "" },
+    ]);
+  });
+
+  it("LoggerCapture starts empty", async () => {
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        const ref = yield* LoggerCapture;
+        return yield* Ref.get(ref);
+      }).pipe(Effect.provide(Logger.layerCapture)),
+    );
+    expect(events).toEqual([]);
+  });
+});
+
+describe("Logger.layerConsole", () => {
+  it("provides the consoleLogger instance (writes to console; verified by spy in cli tests)", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const logger = yield* Logger;
+        return typeof logger.log === "function";
+      }).pipe(Effect.provide(Logger.layerConsole)),
+    );
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
Effect v4 \`Context.Service\` for terminal output. First step toward eliminating react-doctor's module-level mutable state.

## What ships

- **[core/src/services/logger.ts](packages/core/src/services/logger.ts)** — Logger service + LoggerCapture Ref-backed sibling
- **[core/src/logger.ts](packages/core/src/logger.ts) refactor** — renamed the interface to \`LoggerWriter\` (avoids colliding with the Logger service class name); exports \`consoleLogger\` + \`silentLogger\` instances; \`setLoggerSilent\` now SWAPS \`currentLogger\` between those two instances instead of mutating an \`isSilent\` boolean (cleaner shape, identical behavior)
- **[core/tests/services/logger.test.ts](packages/core/tests/services/logger.test.ts)** — 4 new tests: layerSilent no-op, layerCapture records w/ correct level + joined args, capture starts empty, layerConsole exposes consoleLogger

## Layers

| Layer | Use | What it does |
|---|---|---|
| \`layerConsole\` | production (default) | wraps \`consoleLogger\` — writes through \`highlighter\` + \`console.X\` |
| \`layerSilent\` | \`--silent\` mode | every method is a void no-op |
| \`layerCapture\` | tests | records every call into \`LoggerCapture\` \`Ref<LoggerEvent[]>\` for assertion |

## Migration strategy (next PRs)

This PR adds the service infrastructure. PR 10+ wires it into the actual callers:

- inspect.ts + api/diagnose.ts use \`Logger\` service via \`Effect.gen\`
- Hot-path renderers (printDiagnostics, printSummary, printProjectDetection, printScoreHeader, etc.) convert to take a \`LoggerWriter\` parameter
- \`setLoggerSilent\` / \`isLoggerSilent\` save/restore dance disappears (replaced by layer choice)
- The module-level \`logger\` registry stays \`@deprecated\` until every renderer migrates

## Validation

- \`pnpm typecheck\` — 12/12
- \`pnpm test\` — **124 files / 1489 pass / 3 skipped** (was 123/1485; +1 file, +4 tests)
- \`pnpm lint\`, \`pnpm format:check\` (1146 files)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes core logging plumbing (including `--silent` behavior via a new registry swap) and introduces new Effect layers that will be depended on by future wiring; output formatting/silencing regressions are possible but scope is limited to logging.
> 
> **Overview**
> Adds an Effect `Logger` service (`services/logger.ts`) with production `layerConsole`, `--silent` `layerSilent`, and test-focused `layerCapture` that records `LoggerEvent`s into a `Ref`.
> 
> Refactors `logger.ts` to formalize the `LoggerWriter` contract and to expose `consoleLogger`/`silentLogger`; the legacy module-level `logger` now delegates through a swappable `currentLogger`, and `setLoggerSilent`/`isLoggerSilent` are deprecated but preserved.
> 
> Exports the new service from `core`’s public `index.ts` and adds tests covering silent no-ops, capture recording semantics, and console layer provisioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53c10bd3f866b6423f1f04afc93161659074ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->