### PR TITLE
feat(react-doctor): wire Logger service through inspect() + thread logger through 6 renderers [10/?]

### DIFF
--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import {
   buildJsonReport,
+  consoleLogger,
   filterDiagnosticsForSurface,
   filterSourceFiles,
   getDiffInfo,
@@ -80,7 +81,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
     }
 
     if (!isQuiet) {
-      printBrandedHeader();
+      printBrandedHeader(consoleLogger);
     }
 
     const scanOptions = resolveCliInspectOptions(flags, userConfig);

--- a/packages/react-doctor/src/cli/commands/install.ts
+++ b/packages/react-doctor/src/cli/commands/install.ts
@@ -1,3 +1,4 @@
+import { consoleLogger } from "@react-doctor/core";
 import { handleError } from "../utils/handle-error.js";
 import { runInstallSkill } from "../utils/install-skill.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
@@ -12,7 +13,7 @@ interface InstallCommandOptions {
 }
 
 export const installAction = async (options: InstallCommandOptions): Promise<void> => {
-  printBrandedHeader();
+  printBrandedHeader(consoleLogger);
   try {
     await runInstallSkill({
       yes: options.yes,

--- a/packages/react-doctor/src/cli/utils/handle-error.ts
+++ b/packages/react-doctor/src/cli/utils/handle-error.ts
@@ -1,23 +1,31 @@
 import {
   CANONICAL_GITHUB_URL,
+  consoleLogger,
   formatErrorChain,
   formatReactDoctorError,
   isReactDoctorError,
-  logger,
+  type LoggerWriter,
 } from "@react-doctor/core";
 import type { HandleErrorOptions } from "@react-doctor/types";
 
+interface HandleErrorInput {
+  readonly logger?: LoggerWriter;
+  readonly shouldExit?: boolean;
+}
+
 export const handleError = (
   error: unknown,
-  options: HandleErrorOptions = { shouldExit: true },
+  options: HandleErrorOptions | HandleErrorInput = { shouldExit: true },
 ): void => {
+  const logger: LoggerWriter =
+    "logger" in options && options.logger !== undefined ? options.logger : consoleLogger;
   logger.break();
   logger.error("Something went wrong. Please check the error below for more details.");
   logger.error(`If the problem persists, please open an issue at ${CANONICAL_GITHUB_URL}/issues.`);
   logger.error("");
   logger.error(isReactDoctorError(error) ? formatReactDoctorError(error) : formatErrorChain(error));
   logger.break();
-  if (options.shouldExit) {
+  if (options.shouldExit !== false) {
     process.exit(1);
   }
   process.exitCode = 1;

--- a/packages/react-doctor/src/cli/utils/print-branded-header.ts
+++ b/packages/react-doctor/src/cli/utils/print-branded-header.ts
@@ -1,10 +1,10 @@
-import { highlighter, logger } from "@react-doctor/core";
+import { highlighter, type LoggerWriter } from "@react-doctor/core";
 import { VERSION } from "./version.js";
 
 // Single branded line every command prints first when not in JSON/score
 // mode. Keeps the visual signature consistent across `inspect`, `install`,
 // and any future subcommand.
-export const printBrandedHeader = (): void => {
+export const printBrandedHeader = (logger: LoggerWriter): void => {
   logger.log(`${highlighter.bold("react-doctor")} ${highlighter.dim(`v${VERSION}`)}`);
   logger.break();
 };

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -1,13 +1,16 @@
 import {
+  groupBy,
+  highlighter,
   MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE,
   MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
   MILLISECONDS_PER_SECOND,
   OUTPUT_DETAIL_WRAP_WIDTH_CHARS,
   RULE_NAME_COLUMN_WIDTH_CHARS,
+  toRelativePath,
+  type LoggerWriter,
 } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/types";
 import { buildHiddenDiagnosticsSummary } from "./build-hidden-diagnostics-summary.js";
-import { groupBy, highlighter, logger, toRelativePath } from "@react-doctor/core";
 import { indentMultilineText } from "./indent-multiline-text.js";
 import { wrapIndentedText } from "./wrap-indented-text.js";
 
@@ -79,18 +82,19 @@ const padRuleNameToColumn = (ruleName: string, columnWidth: number): string => {
   return ruleName + " ".repeat(columnWidth - ruleName.length);
 };
 
-const grayLine = (text: string): void => {
+const grayLine = (text: string, logger: LoggerWriter): void => {
   logger.log(highlighter.gray(text));
 };
 
-const grayWrappedLine = (text: string, linePrefix: string): void => {
-  grayLine(wrapIndentedText(text, linePrefix, OUTPUT_DETAIL_WRAP_WIDTH_CHARS));
+const grayWrappedLine = (text: string, linePrefix: string, logger: LoggerWriter): void => {
+  grayLine(wrapIndentedText(text, linePrefix, OUTPUT_DETAIL_WRAP_WIDTH_CHARS), logger);
 };
 
 const printCompactRuleGroupLine = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
   ruleNameColumnWidth: number,
+  logger: LoggerWriter,
 ): void => {
   const firstDiagnostic = ruleDiagnostics[0];
   const severitySymbol = firstDiagnostic.severity === "error" ? "✗" : "⚠";
@@ -140,6 +144,7 @@ const printDefaultRuleGroup = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
   rootDirectory: string,
+  logger: LoggerWriter,
 ): void => {
   const firstDiagnostic = ruleDiagnostics[0];
   const ruleTitle = toRuleTitle(firstDiagnostic.rule);
@@ -149,17 +154,17 @@ const printDefaultRuleGroup = (
   const trailingBadge = siteCountBadge.length > 0 ? ` ${highlighter.gray(siteCountBadge)}` : "";
 
   logger.log(`  ${icon} ${ruleTitle}${trailingBadge}`);
-  grayWrappedLine(firstDiagnostic.message, "    ");
+  grayWrappedLine(firstDiagnostic.message, "    ", logger);
   if (firstDiagnostic.help) {
-    grayWrappedLine(firstDiagnostic.help, "    ");
+    grayWrappedLine(firstDiagnostic.help, "    ", logger);
   }
   if (firstDiagnostic.url) {
-    grayLine(`    ${firstDiagnostic.url}`);
+    grayLine(`    ${firstDiagnostic.url}`, logger);
   }
   const firstLocation = ruleDiagnostics.find((diagnostic) => diagnostic.line > 0);
   if (firstLocation) {
     const locationPath = toRelativePath(firstLocation.filePath, rootDirectory);
-    grayLine(`    ${locationPath}:${firstLocation.line}`);
+    grayLine(`    ${locationPath}:${firstLocation.line}`, logger);
   }
 };
 
@@ -167,11 +172,12 @@ const printDefaultCategoryGroup = (
   categoryGroup: CategoryDiagnosticGroup,
   visibleRuleGroups: [string, Diagnostic[]][],
   rootDirectory: string,
+  logger: LoggerWriter,
 ): void => {
   const issueCount = formatIssueCount(categoryGroup.diagnostics.length);
   logger.log(`${highlighter.bold(categoryGroup.category)} ${highlighter.dim(issueCount)}`);
   for (const [ruleKey, ruleDiagnostics] of visibleRuleGroups) {
-    printDefaultRuleGroup(ruleKey, ruleDiagnostics, rootDirectory);
+    printDefaultRuleGroup(ruleKey, ruleDiagnostics, rootDirectory, logger);
   }
   logger.break();
 };
@@ -180,30 +186,34 @@ const printVerboseRuleGroup = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
   ruleNameColumnWidth: number,
+  logger: LoggerWriter,
 ): void => {
-  printCompactRuleGroupLine(ruleKey, ruleDiagnostics, ruleNameColumnWidth);
+  printCompactRuleGroupLine(ruleKey, ruleDiagnostics, ruleNameColumnWidth, logger);
   const firstDiagnostic = ruleDiagnostics[0];
-  grayLine(indentMultilineText(firstDiagnostic.message, "      "));
+  grayLine(indentMultilineText(firstDiagnostic.message, "      "), logger);
   if (firstDiagnostic.help) {
-    grayLine(indentMultilineText(`→ ${firstDiagnostic.help}`, "      "));
+    grayLine(indentMultilineText(`→ ${firstDiagnostic.help}`, "      "), logger);
   }
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);
   for (const [filePath, sites] of fileSites) {
     if (sites.length > 0) {
       for (const site of sites) {
-        grayLine(`      ${filePath}:${site.line}`);
+        grayLine(`      ${filePath}:${site.line}`, logger);
         if (site.suppressionHint) {
-          grayLine(`        ↳ ${site.suppressionHint}`);
+          grayLine(`        ↳ ${site.suppressionHint}`, logger);
         }
       }
     } else {
-      grayLine(`      ${filePath}`);
+      grayLine(`      ${filePath}`, logger);
     }
   }
   logger.break();
 };
 
-const printHiddenDiagnosticsSummary = (hiddenRuleGroups: [string, Diagnostic[]][]): void => {
+const printHiddenDiagnosticsSummary = (
+  hiddenRuleGroups: [string, Diagnostic[]][],
+  logger: LoggerWriter,
+): void => {
   const hiddenDiagnostics = hiddenRuleGroups.flatMap(([, ruleDiagnostics]) => ruleDiagnostics);
   const renderedParts = buildHiddenDiagnosticsSummary(hiddenDiagnostics).map((part) => {
     const [icon, ...labelParts] = part.text.split(" ");
@@ -211,11 +221,15 @@ const printHiddenDiagnosticsSummary = (hiddenRuleGroups: [string, Diagnostic[]][
   });
 
   logger.log(`  ${renderedParts.join("  ")}`);
-  grayLine("    Run `npx react-doctor@latest . --verbose` to get all details");
+  grayLine("    Run `npx react-doctor@latest . --verbose` to get all details", logger);
   logger.break();
 };
 
-const printDefaultDiagnostics = (diagnostics: Diagnostic[], rootDirectory: string): void => {
+const printDefaultDiagnostics = (
+  diagnostics: Diagnostic[],
+  rootDirectory: string,
+  logger: LoggerWriter,
+): void => {
   const categoryGroups = buildCategoryDiagnosticGroups(diagnostics);
   const hiddenRuleGroups: [string, Diagnostic[]][] = [];
   const visibleCategoryGroups = categoryGroups.slice(0, MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE);
@@ -229,7 +243,7 @@ const printDefaultDiagnostics = (diagnostics: Diagnostic[], rootDirectory: strin
     const remainingRuleGroups = categoryGroup.ruleGroups.slice(
       MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
     );
-    printDefaultCategoryGroup(categoryGroup, visibleRuleGroups, rootDirectory);
+    printDefaultCategoryGroup(categoryGroup, visibleRuleGroups, rootDirectory, logger);
     hiddenRuleGroups.push(...remainingRuleGroups);
   }
   hiddenRuleGroups.push(
@@ -237,7 +251,7 @@ const printDefaultDiagnostics = (diagnostics: Diagnostic[], rootDirectory: strin
   );
 
   if (hiddenRuleGroups.length > 0) {
-    printHiddenDiagnosticsSummary(hiddenRuleGroups);
+    printHiddenDiagnosticsSummary(hiddenRuleGroups, logger);
   }
 };
 
@@ -245,9 +259,10 @@ export const printDiagnostics = (
   diagnostics: Diagnostic[],
   isVerbose: boolean,
   rootDirectory: string,
+  logger: LoggerWriter,
 ): void => {
   if (!isVerbose) {
-    printDefaultDiagnostics(diagnostics, rootDirectory);
+    printDefaultDiagnostics(diagnostics, rootDirectory, logger);
     return;
   }
 
@@ -263,7 +278,7 @@ export const printDiagnostics = (
   );
 
   visibleRuleGroups.forEach(([ruleKey, ruleDiagnostics]) => {
-    printVerboseRuleGroup(ruleKey, ruleDiagnostics, ruleNameColumnWidth);
+    printVerboseRuleGroup(ruleKey, ruleDiagnostics, ruleNameColumnWidth, logger);
   });
 };
 

--- a/packages/react-doctor/src/cli/utils/render-project-detection.ts
+++ b/packages/react-doctor/src/cli/utils/render-project-detection.ts
@@ -1,6 +1,6 @@
 import type { ProjectInfo, ReactDoctorConfig } from "@react-doctor/types";
 import { formatFrameworkName } from "@react-doctor/project-info";
-import { highlighter, logger } from "@react-doctor/core";
+import { highlighter, type LoggerWriter } from "@react-doctor/core";
 import { spinner } from "./spinner.js";
 
 export const printProjectDetection = (
@@ -8,7 +8,8 @@ export const printProjectDetection = (
   userConfig: ReactDoctorConfig | null,
   isDiffMode: boolean,
   includePaths: string[],
-  lintSourceFileCount?: number,
+  lintSourceFileCount: number | undefined,
+  logger: LoggerWriter,
 ): void => {
   const frameworkLabel = formatFrameworkName(projectInfo.framework);
   const languageLabel = projectInfo.hasTypeScript ? "TypeScript" : "JavaScript";

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -1,12 +1,13 @@
 import {
+  highlighter,
   PERFECT_SCORE,
   SCORE_BAR_WIDTH_CHARS,
   SCORE_GOOD_THRESHOLD,
   SCORE_OK_THRESHOLD,
+  type LoggerWriter,
 } from "@react-doctor/core";
 import type { ScoreResult } from "@react-doctor/types";
 import { colorizeByScore } from "./colorize-by-score.js";
-import { highlighter, logger } from "@react-doctor/core";
 
 interface ScoreBarSegments {
   filledSegment: string;
@@ -42,7 +43,7 @@ const buildFaceRenderedLines = (score: number): string[] => {
   return ["┌─────┐", `│ ${eyes} │`, `│ ${mouth} │`, "└─────┘"].map(colorize);
 };
 
-export const printScoreHeader = (scoreResult: ScoreResult): void => {
+export const printScoreHeader = (scoreResult: ScoreResult, logger: LoggerWriter): void => {
   const renderedFaceLines = buildFaceRenderedLines(scoreResult.score);
 
   const scoreNumber = colorizeByScore(`${scoreResult.score}`, scoreResult.score);
@@ -61,12 +62,12 @@ export const printScoreHeader = (scoreResult: ScoreResult): void => {
   logger.break();
 };
 
-export const printBrandingOnlyHeader = (): void => {
+export const printBrandingOnlyHeader = (logger: LoggerWriter): void => {
   logger.log(`  ${BRANDING_LINE}`);
   logger.break();
 };
 
-export const printNoScoreHeader = (noScoreMessage: string): void => {
+export const printNoScoreHeader = (noScoreMessage: string, logger: LoggerWriter): void => {
   logger.log(`  ${BRANDING_LINE}`);
   logger.log(`  ${highlighter.gray(noScoreMessage)}`);
   logger.break();

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -1,4 +1,4 @@
-import { highlighter, logger, SHARE_BASE_URL } from "@react-doctor/core";
+import { highlighter, SHARE_BASE_URL, type LoggerWriter } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/types";
 import { collectAffectedFiles, formatElapsedTime } from "./render-diagnostics.js";
 import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
@@ -27,6 +27,7 @@ const printCountsSummaryLine = (
   diagnostics: Diagnostic[],
   totalSourceFileCount: number,
   elapsedMilliseconds: number,
+  logger: LoggerWriter,
 ): void => {
   const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
   const warningCount = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
@@ -56,14 +57,15 @@ export const printSummary = (
   totalSourceFileCount: number,
   noScoreMessage: string,
   isOffline: boolean,
+  logger: LoggerWriter,
 ): void => {
   if (scoreResult) {
-    printScoreHeader(scoreResult);
+    printScoreHeader(scoreResult, logger);
   } else {
-    printNoScoreHeader(noScoreMessage);
+    printNoScoreHeader(noScoreMessage, logger);
   }
 
-  printCountsSummaryLine(diagnostics, totalSourceFileCount, elapsedMilliseconds);
+  printCountsSummaryLine(diagnostics, totalSourceFileCount, elapsedMilliseconds, logger);
 
   try {
     const diagnosticsDirectory = writeDiagnosticsDirectory(diagnostics);

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -9,12 +9,11 @@ import {
   Files,
   filterDiagnosticsForSurface,
   highlighter,
-  isLoggerSilent,
   isReactDoctorError,
   Linter,
   LintPartialFailures,
   loadConfigWithSource,
-  logger,
+  Logger,
   OXLINT_NODE_REQUIREMENT,
   Project,
   ReactDoctorError,
@@ -22,8 +21,8 @@ import {
   resolveConfigRootDir,
   runInspect as runInspectEffect,
   Score,
-  setLoggerSilent,
   type InspectOutput,
+  type LoggerWriter,
   type ReactDoctorErrorReason,
 } from "@react-doctor/core";
 import {
@@ -138,12 +137,13 @@ export const inspect = async (
 
   const options = mergeInspectOptions(inputOptions, userConfig);
 
-  const wasLoggerSilent = isLoggerSilent();
+  // HACK: spinner.ts still has module-level silent state (used by
+  // printProjectDetection's internal spinner() calls). Mirror the
+  // silent flag here until that file moves to a Progress service in
+  // a follow-up PR. Logger-side silent is handled cleanly via
+  // Logger.layerSilent provided to the Effect program.
   const wasSpinnerSilent = isSpinnerSilent();
-  if (options.silent) {
-    setLoggerSilent(true);
-    setSpinnerSilent(true);
-  }
+  if (options.silent) setSpinnerSilent(true);
 
   try {
     return await runInspectWithRuntime(
@@ -154,10 +154,7 @@ export const inspect = async (
       startTime,
     );
   } finally {
-    if (options.silent) {
-      setLoggerSilent(wasLoggerSilent);
-      setSpinnerSilent(wasSpinnerSilent);
-    }
+    if (options.silent) setSpinnerSilent(wasSpinnerSilent);
   }
 };
 
@@ -191,14 +188,15 @@ const runInspectWithRuntime = async (
   const linterLayer = !options.lint || lintBindingMissing ? Linter.layerOf([]) : Linter.layerOxlint;
   const deadCodeLayer = options.deadCode ? DeadCode.layerNode : DeadCode.layerOf([]);
   // HACK: always provide layerOf(null) for Score — the orchestrator's
-  // Score.compute would otherwise see the FULL diagnostic list. The
-  // legacy contract is to filter for the "score" surface (strips
-  // design tags by default) before calculating the score. We do that
-  // here after runInspect returns instead of inside the orchestrator.
+  // Score.compute sees the per-element-filtered list, NOT the
+  // surface-filtered list this function needs. We compute the real
+  // score below with `filterDiagnosticsForSurface("score", ...)`
+  // applied first.
   const scoreLayer = Score.layerOf(null);
   const configLayer = hasConfigOverride
     ? Config.layerOf({ config: userConfig, resolvedDirectory: directory })
     : Config.layerNode;
+  const loggerLayer = options.silent ? Logger.layerSilent : Logger.layerConsole;
 
   const layers = Layer.mergeAll(
     Project.layerNode,
@@ -209,9 +207,11 @@ const runInspectWithRuntime = async (
     deadCodeLayer,
     Reporter.layerNoop,
     scoreLayer,
+    loggerLayer,
   );
 
   const program = Effect.gen(function* () {
+    const logger = yield* Logger;
     const spinnerRef = yield* Ref.make<SpinnerHandle | null>(null);
 
     const output = yield* runInspectEffect(
@@ -237,9 +237,10 @@ const runInspectWithRuntime = async (
                 isDiffMode,
                 options.includePaths,
                 lintSourceFileCount,
+                logger,
               );
             }
-            if (options.lint && resolvedNodeBinaryPath && !options.scoreOnly) {
+            if (options.lint && resolvedNodeBinaryPath && !options.scoreOnly && !options.silent) {
               const handle = spinner("Running lint checks...").start();
               yield* Ref.set(spinnerRef, {
                 succeed: (text) => handle.succeed(text),
@@ -256,15 +257,17 @@ const runInspectWithRuntime = async (
     );
 
     const finalHandle = yield* Ref.get(spinnerRef);
-    return { output, finalHandle };
+    return { output, finalHandle, logger };
   });
 
   let output: InspectOutput;
   let finalSpinnerHandle: SpinnerHandle | null;
+  let logger: LoggerWriter;
   try {
     const programResult = await Effect.runPromise(program.pipe(Effect.provide(layers)));
     output = programResult.output;
     finalSpinnerHandle = programResult.finalHandle;
+    logger = programResult.logger;
   } catch (cause) {
     if (isReactDoctorError(cause)) restoreLegacyThrow(cause);
     throw cause;
@@ -349,6 +352,7 @@ const runInspectWithRuntime = async (
     didDeadCodeFail: output.didDeadCodeFail,
     deadCodeFailureReason: output.deadCodeFailureReason,
     directory: output.resolvedDirectory,
+    logger,
   });
 };
 
@@ -365,6 +369,7 @@ interface FinalizeInput {
   didDeadCodeFail: boolean;
   deadCodeFailureReason: string | null;
   directory: string;
+  logger: LoggerWriter;
 }
 
 const finalizeAndRender = (input: FinalizeInput): InspectResult => {
@@ -381,6 +386,7 @@ const finalizeAndRender = (input: FinalizeInput): InspectResult => {
     didDeadCodeFail,
     deadCodeFailureReason,
     directory,
+    logger,
   } = input;
 
   const skippedChecks: string[] = [];
@@ -444,18 +450,18 @@ const finalizeAndRender = (input: FinalizeInput): InspectResult => {
     }
     logger.break();
     if (hasSkippedChecks) {
-      printBrandingOnlyHeader();
+      printBrandingOnlyHeader(logger);
       logger.log(highlighter.gray("  Score not shown — some checks could not complete."));
     } else if (score) {
-      printScoreHeader(score);
+      printScoreHeader(score, logger);
     } else {
-      printNoScoreHeader(noScoreMessage);
+      printNoScoreHeader(noScoreMessage, logger);
     }
     return buildResult();
   }
 
   logger.break();
-  printDiagnostics(surfaceDiagnostics, options.verbose, directory);
+  printDiagnostics(surfaceDiagnostics, options.verbose, directory, logger);
 
   if (demotedDiagnosticCount > 0) {
     logger.log(
@@ -475,6 +481,7 @@ const finalizeAndRender = (input: FinalizeInput): InspectResult => {
     lintSourceFileCount,
     noScoreMessage,
     !shouldShowShareLink,
+    logger,
   );
 
   if (hasSkippedChecks) {


### PR DESCRIPTION
**Base:** [#421](https://github.com/millionco/react-doctor/pull/421) (Logger service infra).

Wires the Logger service from #421 into inspect(). Threads an explicit \`LoggerWriter\` parameter through every renderer so silent mode no longer needs the \`setLoggerSilent\` save/restore dance — \`Logger.layerSilent\` provides the silent writer cleanly via Effect's layer mechanism.

## Renderers converted (take \`LoggerWriter\` parameter)

| File | Functions |
|---|---|
| [print-branded-header.ts](packages/react-doctor/src/cli/utils/print-branded-header.ts) | \`printBrandedHeader\` |
| [handle-error.ts](packages/react-doctor/src/cli/utils/handle-error.ts) | \`handleError\` (HandleErrorOptions extended with optional logger field for backwards compat) |
| [render-project-detection.ts](packages/react-doctor/src/cli/utils/render-project-detection.ts) | \`printProjectDetection\` |
| [render-score-header.ts](packages/react-doctor/src/cli/utils/render-score-header.ts) | \`printScoreHeader\` / \`printNoScoreHeader\` / \`printBrandingOnlyHeader\` |
| [render-summary.ts](packages/react-doctor/src/cli/utils/render-summary.ts) | \`printSummary\` + \`printCountsSummaryLine\` |
| [render-diagnostics.ts](packages/react-doctor/src/cli/utils/render-diagnostics.ts) | \`printDiagnostics\` + 8 internal helpers (grayLine, printDefaultRuleGroup, printVerboseRuleGroup, etc.) |

## inspect.ts wiring

\`inspect()\` no longer mutates the module-level \`isSilent\` flag for logger. Instead:

\`\`\`ts
const loggerLayer = options.silent ? Logger.layerSilent : Logger.layerConsole;
// ... inside Effect.gen
const logger = yield* Logger;
// ... passed to renderers in finalizeAndRender
\`\`\`

The \`setLoggerSilent\` / \`isLoggerSilent\` save/restore dance is gone from inspect().

## What still has module-level state (transition residue — flagged)

- \`cli/utils/spinner.ts\` module-level \`isSilent\` boolean — \`printProjectDetection\` internally calls \`spinner()\` for each detection step, so silent mode for those lines is still gated by \`setSpinnerSilent(true)\` in inspect()'s top-level (mirroring previous behavior). **PR 11** routes spinner through the Progress service to eliminate.
- Other cli/utils files (run-explain, install-skill, prompts, select-projects, resolve-diff-mode, resolve-fail-on-level, exit-gracefully) still import module-level \`logger\`. Not in inspect()'s hot path; converted as separate PRs.

## Validation

- \`pnpm typecheck\` — 12/12
- \`pnpm test\` — **124 files / 1489 pass / 3 skipped** (unchanged from PR 9)
- \`pnpm lint\`, \`pnpm format:check\` (1146 files)
- \`pnpm smoke:json-report\` — schema-valid v1

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `inspect()` and multiple CLI renderers obtain and use logging, which can affect all CLI output and silent/CI behavior; functional scope is mostly plumbing but touches core user-facing reporting paths.
> 
> **Overview**
> **Refactors CLI output to use an injected `LoggerWriter` instead of module-level `logger`.** `printBrandedHeader`, `printDiagnostics`, `printProjectDetection`, `printScoreHeader`/`printNoScoreHeader`/`printBrandingOnlyHeader`, and `printSummary` now take an explicit logger parameter, and commands like `inspect`/`install` pass `consoleLogger`.
> 
> **Wires the Effect `Logger` service through `inspect()` and removes logger silent-state mutation.** `inspect.ts` now provides `Logger.layerConsole` vs `Logger.layerSilent` based on `options.silent`, retrieves the logger from the Effect environment, and threads it into all rendering/finalization helpers; spinner silence remains handled via the existing module-level `spinner.ts` flag.
> 
> **Makes error handling logger-aware.** `handleError` now accepts an optional logger (defaulting to `consoleLogger`) and treats `shouldExit` as opt-out (`!== false`) so callers can suppress exiting while still emitting errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c972f266aefbefdef2177e6ba9fbf389f07dee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->