### PR TITLE
ci(release): restore release workflow with maintainer-only gating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    if: github.repository == 'millionco/react-doctor'
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Verify actor has write access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PERMISSION=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/collaborators/${GITHUB_ACTOR}/permission" \
+            --jq '.permission')
+          case "$PERMISSION" in
+            admin|maintain|write)
+              echo "Actor ${GITHUB_ACTOR} has '${PERMISSION}' permission, allowing release."
+              ;;
+            *)
+              echo "::error::Actor ${GITHUB_ACTOR} has '${PERMISSION}' permission; release is restricted to org maintainers."
+              exit 1
+              ;;
+          esac
+
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create Release PR or Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          title: "chore: version packages"
+          commit: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Releases and move action tags
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          REACT_DOCTOR_VERSION=""
+
+          while IFS= read -r encoded; do
+            NAME=$(echo "$encoded" | base64 -d | jq -r '.name')
+            VERSION=$(echo "$encoded" | base64 -d | jq -r '.version')
+            TAG="${NAME}@${VERSION}"
+            if [ "$NAME" = "react-doctor" ]; then
+              TAG="v${VERSION}"
+              REACT_DOCTOR_VERSION="$VERSION"
+            fi
+            PRERELEASE_FLAG=""
+            if [[ "$VERSION" == *-* ]]; then
+              PRERELEASE_FLAG="--prerelease"
+            fi
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes \
+              --target "$GITHUB_SHA" \
+              $PRERELEASE_FLAG || true
+          done < <(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | @base64')
+
+          if [ -z "$REACT_DOCTOR_VERSION" ] || [[ "$REACT_DOCTOR_VERSION" == *-* ]]; then
+            echo "Skipping floating action tag updates (no stable react-doctor release in this batch)."
+            exit 0
+          fi
+
+          MAJOR=$(echo "$REACT_DOCTOR_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$REACT_DOCTOR_VERSION" | cut -d. -f2)
+          for FLOATING in "v${MAJOR}" "v${MAJOR}.${MINOR}"; do
+            git tag -fa "$FLOATING" -m "Move ${FLOATING} to react-doctor v${REACT_DOCTOR_VERSION}"
+            git push origin "refs/tags/${FLOATING}" --force
+          done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Split out from #418 (release-workflow slice).

Re-introduces `.github/workflows/release.yml` (last seen pre-#228) with three changes over the historical version:

## Floating action tags

After changesets publishes `react-doctor`, the workflow force-moves the floating `vMAJOR` and `vMAJOR.MINOR` tags to the release commit so downstream consumers can pin `uses: millionco/react-doctor@v0`. Prereleases skip the floating-tag step so RCs never leak into the stable major ref. Per-package versioned `gh release create` (with prerelease flagging) is preserved.

## Least-privilege permissions

Drops the unused `id-token: write` permission. `pnpm release` does not enable npm provenance, so the OIDC grant was over-broad. The workflow only needs `contents: write` (tag push) and `pull-requests: write` (changesets release PR).

## Maintainer-only gating (three layers)

- **Fork guard**: `if: github.repository == 'millionco/react-doctor'` so a fork that pushes to its own `main` no-ops.
- **Required-reviewer environment**: `environment: release` pauses the job until a configured reviewer approves it. **One-time setup needed after merge**: repo Settings -> Environments -> create `release` and add org maintainers as required reviewers.
- **Preflight actor-permission check**: `gh api repos/.../collaborators/.../permission` fails fast unless the actor has `write` / `maintain` / `admin`, so the workflow never proceeds to npm publish or tag push if branch protection is later loosened.

## Notes for reviewers

- Assumes `NPM_TOKEN` is configured as a repo secret (same assumption as the historical workflow).
- The first run that publishes a stable `react-doctor@X.Y.Z` will create `vX`, `vX.Y`, and `vX.Y.Z` for the first time.
- This PR does **not** change the README's recommended action ref. `@main` remains the documented default; this workflow makes versioned tags available for consumers who want to opt in.

## Verification

- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass on the source branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6152c19-ec2c-4a6f-89b8-001b6fa8a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6152c19-ec2c-4a6f-89b8-001b6fa8a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

