### PR TITLE
ci(security): pin permissions and add fork guards on existing workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,6 +18,8 @@ jobs:
         node-version: [22, 24]
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update:
+    if: github.repository == 'millionco/react-doctor'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Split out from #418 (CI / leaderboard workflow hardening slice).

Two defense-in-depth changes that don't alter workflow behavior:

## `ci.yml`

- Pin `permissions: contents: read` at the workflow level. Fork PRs already default to a read-only `GITHUB_TOKEN`, but pinning here keeps that guarantee if the repo-wide default ever changes and stops same-repo branch pushes from inheriting a wider token.
- Set `actions/checkout@v5` to `persist-credentials: false` so later steps (or untrusted PR scripts) can't pick a token out of `.git/config`.

## `update-leaderboard.yml`

- Add `if: github.repository == 'millionco/react-doctor'` so a fork can't trigger a leaderboard commit through `workflow_dispatch`. Schedule-only triggers already wouldn't fire on a fork, but the manual-trigger path was open.

## Verification

- Workflow behavior unchanged. `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass on the source branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6152c19-ec2c-4a6f-89b8-001b6fa8a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6152c19-ec2c-4a6f-89b8-001b6fa8a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

