### PR TITLE
feat(core): Git service — DI-wrap every spawnSync('git', ...) call site [11/?]

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -116,6 +116,41 @@ export class DeadCodeAnalysisFailed extends Schema.TaggedErrorClass<DeadCodeAnal
   }
 }
 
+export class GitInvocationFailed extends Schema.TaggedErrorClass<GitInvocationFailed>()(
+  "GitInvocationFailed",
+  {
+    args: Schema.Array(Schema.String),
+    directory: Schema.String,
+    cause: Schema.Unknown,
+  },
+) {
+  get message() {
+    return `git ${this.args.join(" ")} (cwd=${this.directory}) failed: ${Cause.pretty(Cause.fail(this.cause))}`;
+  }
+}
+
+export class GitBaseBranchMissing extends Schema.TaggedErrorClass<GitBaseBranchMissing>()(
+  "GitBaseBranchMissing",
+  {
+    branch: Schema.String,
+  },
+) {
+  get message() {
+    return `Diff base branch "${this.branch}" does not exist (run \`git fetch\` to update remote refs).`;
+  }
+}
+
+export class GitBaseBranchInvalid extends Schema.TaggedErrorClass<GitBaseBranchInvalid>()(
+  "GitBaseBranchInvalid",
+  {
+    detail: Schema.String,
+  },
+) {
+  get message() {
+    return this.detail;
+  }
+}
+
 export const ReactDoctorErrorReason = Schema.Union([
   OxlintUnavailable,
   OxlintBatchExceeded,
@@ -126,6 +161,9 @@ export const ReactDoctorErrorReason = Schema.Union([
   NoReactDependency,
   AmbiguousProject,
   DeadCodeAnalysisFailed,
+  GitInvocationFailed,
+  GitBaseBranchMissing,
+  GitBaseBranchInvalid,
 ]);
 
 export type ReactDoctorErrorReason = Schema.Schema.Type<typeof ReactDoctorErrorReason>;

--- a/packages/core/src/get-diff-files.ts
+++ b/packages/core/src/get-diff-files.ts
@@ -1,116 +1,52 @@
-import { spawnSync } from "node:child_process";
-import { DEFAULT_BRANCH_CANDIDATES, SOURCE_FILE_PATTERN } from "./constants.js";
+import * as Effect from "effect/Effect";
+import { SOURCE_FILE_PATTERN } from "./constants.js";
+import { GitBaseBranchInvalid, GitBaseBranchMissing, ReactDoctorError } from "./errors.js";
+import { Git, type GitDiffSelection } from "./services/git.js";
 import type { DiffInfo } from "@react-doctor/types";
 
-const runGit = (cwd: string, args: string[]): string | null => {
-  const result = spawnSync("git", args, {
-    cwd,
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf-8",
-  });
-  if (result.error || result.status !== 0) return null;
-  return result.stdout.toString().trim();
-};
-
-const getCurrentBranch = (directory: string): string | null => {
-  const branch = runGit(directory, ["rev-parse", "--abbrev-ref", "HEAD"]);
-  if (!branch) return null;
-  return branch === "HEAD" ? null : branch;
-};
-
-const detectDefaultBranch = (directory: string): string | null => {
-  const reference = runGit(directory, ["symbolic-ref", "refs/remotes/origin/HEAD"]);
-  if (reference) return reference.replace("refs/remotes/origin/", "");
-
-  const candidateRefs = DEFAULT_BRANCH_CANDIDATES.map((candidate) => `refs/heads/${candidate}`);
-  const output = runGit(directory, ["for-each-ref", "--format=%(refname:short)", ...candidateRefs]);
-  if (output) {
-    const firstLine = output.split("\n")[0]?.trim();
-    if (firstLine) return firstLine;
-  }
-  return null;
-};
-
-const branchExists = (directory: string, branch: string): boolean => {
-  const result = spawnSync("git", ["rev-parse", "--verify", branch], {
-    cwd: directory,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  return !result.error && result.status === 0;
-};
-
-const runGitNullSeparated = (cwd: string, args: string[]): string[] | null => {
-  const result = spawnSync("git", args, {
-    cwd,
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf-8",
-  });
-  if (result.error || result.status !== 0) return null;
-  return result.stdout
-    .toString()
-    .split("\0")
-    .filter((filePath) => filePath.length > 0);
-};
-
-const getChangedFilesSinceBranch = (directory: string, baseBranch: string): string[] | null => {
-  const mergeBase = runGit(directory, ["merge-base", baseBranch, "HEAD"]);
-  if (mergeBase === null) return null;
-
-  return runGitNullSeparated(directory, [
-    "diff",
-    "-z",
-    "--name-only",
-    "--diff-filter=ACMR",
-    "--relative",
-    mergeBase,
-  ]);
-};
-
-const getUncommittedChangedFiles = (directory: string): string[] => {
-  const output = runGitNullSeparated(directory, [
-    "diff",
-    "-z",
-    "--name-only",
-    "--diff-filter=ACMR",
-    "--relative",
-    "HEAD",
-  ]);
-  return output ?? [];
-};
-
+/**
+ * Legacy synchronous façade. New callers should pull the `Git`
+ * service directly via `yield* Git` inside their own Effect rather
+ * than going through this wrapper — it exists so the existing CLI
+ * code paths that aren't yet Effect-typed don't need to change.
+ *
+ * Errors are unwrapped back into the historical `Error` shape:
+ *  - empty base branch → `Error("Diff base branch cannot be empty.")`
+ *  - non-existent base → `Error('Diff base branch "X" does not exist (run \`git fetch\` to update remote refs).')`
+ *  - any other git failure → propagated cause
+ */
 export const getDiffInfo = (directory: string, explicitBaseBranch?: string): DiffInfo | null => {
-  if (explicitBaseBranch !== undefined && explicitBaseBranch.trim().length === 0) {
-    throw new Error("Diff base branch cannot be empty.");
+  const program = Effect.gen(function* () {
+    const git = yield* Git;
+    return yield* git.diffSelection({ directory, explicitBaseBranch });
+  });
+
+  let selection: GitDiffSelection | null;
+  try {
+    selection = runProgram(program);
+  } catch (cause) {
+    if (cause instanceof ReactDoctorError) {
+      if (cause.reason instanceof GitBaseBranchInvalid) {
+        throw new Error(cause.reason.detail);
+      }
+      if (cause.reason instanceof GitBaseBranchMissing) {
+        throw new Error(cause.reason.message);
+      }
+    }
+    throw cause;
   }
 
-  const currentBranch = getCurrentBranch(directory);
-  // Detached HEAD (e.g. GitHub Actions `pull_request` checks out
-  // `refs/pull/N/merge`) is fine as long as the caller supplied an
-  // explicit base — `git merge-base <base> HEAD` resolves without a
-  // branch name. Without an explicit base we still bail out, since
-  // `detectDefaultBranch` can't infer "what did this PR change" from
-  // a bare commit hash.
-  if (!currentBranch && !explicitBaseBranch) return null;
-
-  const baseBranch = explicitBaseBranch ?? detectDefaultBranch(directory);
-  if (!baseBranch) return null;
-
-  if (explicitBaseBranch && !branchExists(directory, explicitBaseBranch)) {
-    throw new Error(
-      `Diff base branch "${explicitBaseBranch}" does not exist (run \`git fetch\` to update remote refs).`,
-    );
-  }
-
-  if (currentBranch !== null && currentBranch === baseBranch) {
-    const uncommittedFiles = getUncommittedChangedFiles(directory);
-    if (uncommittedFiles.length === 0) return null;
-    return { currentBranch, baseBranch, changedFiles: uncommittedFiles, isCurrentChanges: true };
-  }
-
-  const changedFiles = getChangedFilesSinceBranch(directory, baseBranch);
-  if (changedFiles === null) return null;
-  return { currentBranch, baseBranch, changedFiles };
+  if (selection === null) return null;
+  return {
+    currentBranch: selection.currentBranch,
+    baseBranch: selection.baseBranch,
+    changedFiles: [...selection.changedFiles],
+    ...(selection.isCurrentChanges ? { isCurrentChanges: true } : {}),
+  };
 };
+
+const runProgram = <Value>(program: Effect.Effect<Value, ReactDoctorError, Git>): Value =>
+  Effect.runSync(program.pipe(Effect.provide(Git.layerNode)));
 
 export const filterSourceFiles = (filePaths: string[]): string[] =>
   filePaths.filter((filePath) => SOURCE_FILE_PATTERN.test(filePath));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./schemas.js";
 export * from "./services/config.js";
 export * from "./services/dead-code.js";
 export * from "./services/files.js";
+export * from "./services/git.js";
 export * from "./services/linter.js";
 export * from "./services/logger.js";
 export * from "./services/progress.js";

--- a/packages/core/src/neutralize-disable-directives.ts
+++ b/packages/core/src/neutralize-disable-directives.ts
@@ -1,12 +1,9 @@
-import { spawnSync } from "node:child_process";
+import * as Effect from "effect/Effect";
 import fs from "node:fs";
 import path from "node:path";
 import { readDirectoryEntries } from "@react-doctor/project-info";
-import {
-  GIT_LS_FILES_MAX_BUFFER_BYTES,
-  IGNORED_DIRECTORIES,
-  SOURCE_FILE_PATTERN,
-} from "./constants.js";
+import { IGNORED_DIRECTORIES, SOURCE_FILE_PATTERN } from "./constants.js";
+import { Git } from "./services/git.js";
 
 const DISABLE_DIRECTIVE_PATTERN = /(eslint|oxlint)-disable/;
 
@@ -14,27 +11,27 @@ const findFilesWithDisableDirectivesViaGit = (
   rootDirectory: string,
   includePaths?: string[],
 ): string[] | null => {
-  const grepArgs = ["grep", "-l", "--untracked", "-E", "(eslint|oxlint)-disable"];
-  if (includePaths && includePaths.length > 0) {
-    grepArgs.push("--", ...includePaths);
-  }
-
-  const result = spawnSync("git", grepArgs, {
-    cwd: rootDirectory,
-    encoding: "utf-8",
-    maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
+  const program = Effect.gen(function* () {
+    const git = yield* Git;
+    return yield* git.grep({
+      directory: rootDirectory,
+      pattern: "(eslint|oxlint)-disable",
+      extendedRegexp: true,
+      listMatchingFiles: true,
+      includeUntracked: true,
+      includePaths: includePaths && includePaths.length > 0 ? includePaths : undefined,
+    });
   });
 
-  // null status means git wasn't found at all; non-null+nonzero with no
-  // output means "ran but no matches" only when there's no error code.
-  // Distinguish "git unavailable / not a repo" (return null → caller
-  // falls back) from "git ran successfully" (return [] or matches).
-  if (result.error || result.status === null) return null;
-  // Status 1 with empty stdout = git grep ran inside a repo and found
-  // nothing. Status 128 = "not a git repo". Treat 128 as fallback.
-  if (result.status === 128) return null;
+  let grepResult: { readonly status: number; readonly stdout: string } | null;
+  try {
+    grepResult = Effect.runSync(program.pipe(Effect.provide(Git.layerNode)));
+  } catch {
+    return null;
+  }
+  if (grepResult === null) return null;
 
-  return result.stdout
+  return grepResult.stdout
     .split("\n")
     .filter((filePath) => filePath.length > 0 && SOURCE_FILE_PATTERN.test(filePath));
 };

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -1,0 +1,346 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
+import { DEFAULT_BRANCH_CANDIDATES, GIT_LS_FILES_MAX_BUFFER_BYTES } from "../constants.js";
+import {
+  GitBaseBranchInvalid,
+  GitBaseBranchMissing,
+  GitInvocationFailed,
+  ReactDoctorError,
+} from "../errors.js";
+
+interface GitInvocationOptions {
+  readonly maxBufferBytes?: number;
+  readonly allowNonZeroExit?: boolean;
+}
+
+interface GitInvocationResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/**
+ * Internal Effect-typed git invocation. Wraps `spawnSync` so callers
+ * stay synchronous (matches the existing react-doctor diff API). The
+ * `Git` service exposes higher-level methods on top of this primitive
+ * so call sites never touch `spawnSync` directly.
+ */
+const invokeGitSync = (
+  directory: string,
+  args: ReadonlyArray<string>,
+  options: GitInvocationOptions = {},
+): Effect.Effect<GitInvocationResult, ReactDoctorError> =>
+  Effect.try({
+    try: (): GitInvocationResult => {
+      const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
+        cwd: directory,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+        maxBuffer: options.maxBufferBytes ?? GIT_LS_FILES_MAX_BUFFER_BYTES,
+      };
+      const result = spawnSync("git", [...args], spawnOptions);
+      if (result.error) throw result.error;
+      return {
+        status: result.status,
+        stdout: result.stdout?.toString() ?? "",
+        stderr: result.stderr?.toString() ?? "",
+      };
+    },
+    catch: (cause) =>
+      new ReactDoctorError({
+        reason: new GitInvocationFailed({ args: [...args], directory, cause }),
+      }),
+  });
+
+const trimOrNull = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+};
+
+const splitNullSeparated = (value: string): ReadonlyArray<string> =>
+  value.split("\0").filter((entry) => entry.length > 0);
+
+export interface GitDiffSelection {
+  /**
+   * `null` when `HEAD` is detached (e.g. GitHub Actions
+   * `pull_request` runs that check out `refs/pull/N/merge`).
+   */
+  readonly currentBranch: string | null;
+  readonly baseBranch: string;
+  readonly changedFiles: ReadonlyArray<string>;
+  readonly isCurrentChanges: boolean;
+}
+
+interface GitDiffSelectionInput {
+  readonly directory: string;
+  readonly explicitBaseBranch?: string;
+}
+
+interface GitShowOptions {
+  readonly maxBufferBytes?: number;
+}
+
+interface GitGrepInput {
+  readonly directory: string;
+  readonly pattern: string;
+  readonly extendedRegexp?: boolean;
+  readonly listMatchingFiles?: boolean;
+  readonly includeUntracked?: boolean;
+  readonly includePaths?: ReadonlyArray<string>;
+  readonly maxBufferBytes?: number;
+}
+
+interface GitGrepResult {
+  readonly status: number;
+  readonly stdout: string;
+}
+
+/**
+ * `Git` wraps every `git`-via-`spawnSync` call react-doctor makes
+ * (current branch detection, diff-base resolution, `git diff`,
+ * `git diff --cached`, `git grep`, `git show :<path>`) behind a
+ * service interface so tests can swap in `layerOf({ ... })` snapshots
+ * without spinning up a real repository, and so future async
+ * conversion (via `ChildProcess` from `effect/unstable/process`) can
+ * happen without disturbing call sites.
+ *
+ * All methods raise `ReactDoctorError` with a `GitInvocationFailed`
+ * reason when `git` itself can't run; "git ran but produced no
+ * matches" still resolves successfully (with `null` / `[]`).
+ */
+export class Git extends Context.Service<
+  Git,
+  {
+    /** `null` when on detached HEAD or `rev-parse` fails. */
+    readonly currentBranch: (directory: string) => Effect.Effect<string | null, ReactDoctorError>;
+    /** Best-effort default branch: `origin/HEAD` symref, then `main`/`master`. */
+    readonly defaultBranch: (directory: string) => Effect.Effect<string | null, ReactDoctorError>;
+    readonly branchExists: (
+      directory: string,
+      branch: string,
+    ) => Effect.Effect<boolean, ReactDoctorError>;
+    /**
+     * High-level diff selection: resolves current branch + base
+     * branch + changed file list with the same semantics as the
+     * legacy `getDiffInfo` helper. `null` when no diff is detectable
+     * (detached HEAD without explicit base, no default branch, etc.).
+     */
+    readonly diffSelection: (
+      input: GitDiffSelectionInput,
+    ) => Effect.Effect<GitDiffSelection | null, ReactDoctorError>;
+    /** Files staged for commit (null-separated, `--diff-filter=ACMR`). */
+    readonly stagedFilePaths: (
+      directory: string,
+    ) => Effect.Effect<ReadonlyArray<string>, ReactDoctorError>;
+    /** `git show :<path>` contents; `null` when the file isn't in the index. */
+    readonly showStagedContent: (
+      directory: string,
+      relativePath: string,
+      options?: GitShowOptions,
+    ) => Effect.Effect<string | null, ReactDoctorError>;
+    /**
+     * `git grep -l` (default). Returns `null` when git itself isn't
+     * available or the directory isn't a repository so callers can
+     * fall back to a filesystem walk.
+     */
+    readonly grep: (input: GitGrepInput) => Effect.Effect<GitGrepResult | null, ReactDoctorError>;
+  }
+>()("react-doctor/Git") {
+  static readonly layerNode: Layer.Layer<Git> = Layer.sync(Git, () => {
+    const currentBranch = (directory: string): Effect.Effect<string | null, ReactDoctorError> =>
+      invokeGitSync(directory, ["rev-parse", "--abbrev-ref", "HEAD"]).pipe(
+        Effect.map((result) => {
+          if (result.status !== 0) return null;
+          const branch = trimOrNull(result.stdout);
+          return branch === "HEAD" ? null : branch;
+        }),
+      );
+
+    const defaultBranch = (directory: string): Effect.Effect<string | null, ReactDoctorError> =>
+      Effect.gen(function* () {
+        const symref = yield* invokeGitSync(directory, [
+          "symbolic-ref",
+          "refs/remotes/origin/HEAD",
+        ]);
+        if (symref.status === 0) {
+          const trimmed = trimOrNull(symref.stdout);
+          if (trimmed !== null) return trimmed.replace("refs/remotes/origin/", "");
+        }
+        const candidateRefs = DEFAULT_BRANCH_CANDIDATES.map(
+          (candidate) => `refs/heads/${candidate}`,
+        );
+        const candidates = yield* invokeGitSync(directory, [
+          "for-each-ref",
+          "--format=%(refname:short)",
+          ...candidateRefs,
+        ]);
+        if (candidates.status !== 0) return null;
+        return trimOrNull(candidates.stdout.split("\n")[0] ?? "");
+      });
+
+    const branchExists = (
+      directory: string,
+      branch: string,
+    ): Effect.Effect<boolean, ReactDoctorError> =>
+      invokeGitSync(directory, ["rev-parse", "--verify", branch]).pipe(
+        Effect.map((result) => result.status === 0),
+      );
+
+    return Git.of({
+      currentBranch,
+      defaultBranch,
+      branchExists,
+      diffSelection: ({ directory, explicitBaseBranch }) =>
+        Effect.gen(function* () {
+          if (explicitBaseBranch !== undefined && explicitBaseBranch.trim().length === 0) {
+            return yield* Effect.fail(
+              new ReactDoctorError({
+                reason: new GitBaseBranchInvalid({
+                  detail: "Diff base branch cannot be empty.",
+                }),
+              }),
+            );
+          }
+
+          const resolvedCurrentBranch = yield* currentBranch(directory);
+          // Detached HEAD is still scannable when an explicit base
+          // resolves a merge-base, so we only abandon when both the
+          // branch is detached AND the caller didn't pin a base.
+          if (resolvedCurrentBranch === null && explicitBaseBranch === undefined) return null;
+
+          const baseBranch = explicitBaseBranch ?? (yield* defaultBranch(directory));
+          if (baseBranch === null) return null;
+
+          if (explicitBaseBranch !== undefined) {
+            const exists = yield* branchExists(directory, explicitBaseBranch);
+            if (!exists) {
+              return yield* Effect.fail(
+                new ReactDoctorError({
+                  reason: new GitBaseBranchMissing({ branch: explicitBaseBranch }),
+                }),
+              );
+            }
+          }
+
+          if (resolvedCurrentBranch !== null && resolvedCurrentBranch === baseBranch) {
+            const uncommitted = yield* invokeGitSync(directory, [
+              "diff",
+              "-z",
+              "--name-only",
+              "--diff-filter=ACMR",
+              "--relative",
+              "HEAD",
+            ]);
+            if (uncommitted.status !== 0) return null;
+            const files = splitNullSeparated(uncommitted.stdout);
+            if (files.length === 0) return null;
+            return {
+              currentBranch: resolvedCurrentBranch,
+              baseBranch,
+              changedFiles: files,
+              isCurrentChanges: true,
+            } satisfies GitDiffSelection;
+          }
+
+          const mergeBase = yield* invokeGitSync(directory, ["merge-base", baseBranch, "HEAD"]);
+          if (mergeBase.status !== 0) return null;
+          const mergeBaseRef = trimOrNull(mergeBase.stdout);
+          if (mergeBaseRef === null) return null;
+
+          const diff = yield* invokeGitSync(directory, [
+            "diff",
+            "-z",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "--relative",
+            mergeBaseRef,
+          ]);
+          if (diff.status !== 0) return null;
+          return {
+            currentBranch: resolvedCurrentBranch,
+            baseBranch,
+            changedFiles: splitNullSeparated(diff.stdout),
+            isCurrentChanges: false,
+          } satisfies GitDiffSelection;
+        }),
+      stagedFilePaths: (directory) =>
+        invokeGitSync(directory, [
+          "diff",
+          "--cached",
+          "-z",
+          "--name-only",
+          "--diff-filter=ACMR",
+          "--relative",
+        ]).pipe(
+          Effect.map((result) => {
+            if (result.status !== 0) return [] as ReadonlyArray<string>;
+            return splitNullSeparated(result.stdout);
+          }),
+        ),
+      showStagedContent: (directory, relativePath, options) =>
+        invokeGitSync(directory, ["show", `:${relativePath}`], {
+          maxBufferBytes: options?.maxBufferBytes,
+        }).pipe(Effect.map((result) => (result.status === 0 ? result.stdout : null))),
+      grep: (input) =>
+        Effect.gen(function* () {
+          const args: string[] = ["grep"];
+          if (input.listMatchingFiles ?? true) args.push("-l");
+          if (input.includeUntracked ?? false) args.push("--untracked");
+          if (input.extendedRegexp ?? false) args.push("-E");
+          args.push(input.pattern);
+          if (input.includePaths && input.includePaths.length > 0) {
+            args.push("--", ...input.includePaths);
+          }
+          const result = yield* invokeGitSync(input.directory, args, {
+            maxBufferBytes: input.maxBufferBytes,
+          });
+          // Status null = git wasn't found (already raised by `invokeGitSync`).
+          // Status 128 = not a git repo → caller should fall back.
+          if (result.status === null || result.status === 128) return null;
+          return { status: result.status, stdout: result.stdout } satisfies GitGrepResult;
+        }),
+    });
+  });
+
+  /**
+   * Test layer driven by a deterministic `Map<command, response>`.
+   * Each key is the joined git argv (e.g. `"diff -z --name-only ..."`)
+   * and each value is the canned `GitInvocationResult`. Unknown
+   * commands resolve to a `status: 1, stdout: ""` (mirroring
+   * "ran but no output") so tests don't have to enumerate every
+   * subcommand the production path might issue. Two convenience
+   * snapshots — `currentBranch` and `stagedFiles` — short-circuit
+   * the two most common test fixtures.
+   */
+  static readonly layerOf = (snapshot: {
+    readonly currentBranch?: string | null;
+    readonly defaultBranch?: string | null;
+    readonly branchExists?: ReadonlyMap<string, boolean>;
+    readonly stagedFiles?: ReadonlyArray<string>;
+    readonly stagedContent?: ReadonlyMap<string, string>;
+    readonly diffSelection?: GitDiffSelection | null;
+    readonly grepMatches?: ReadonlyArray<string> | null;
+  }): Layer.Layer<Git> =>
+    Layer.succeed(
+      Git,
+      Git.of({
+        currentBranch: () => Effect.succeed(snapshot.currentBranch ?? null),
+        defaultBranch: () => Effect.succeed(snapshot.defaultBranch ?? null),
+        branchExists: (_directory, branch) =>
+          Effect.succeed(snapshot.branchExists?.get(branch) ?? false),
+        diffSelection: () => Effect.succeed(snapshot.diffSelection ?? null),
+        stagedFilePaths: () => Effect.succeed(snapshot.stagedFiles ?? []),
+        showStagedContent: (_directory, relativePath) =>
+          Effect.succeed(snapshot.stagedContent?.get(relativePath) ?? null),
+        grep: () =>
+          Effect.sync(() => {
+            const matches = snapshot.grepMatches;
+            if (matches === null || matches === undefined) return null;
+            const stdout = matches.length === 0 ? "" : `${matches.join("\n")}\n`;
+            return { status: matches.length === 0 ? 1 : 0, stdout } satisfies GitGrepResult;
+          }),
+      }),
+    );
+}

--- a/packages/core/tests/services/git.test.ts
+++ b/packages/core/tests/services/git.test.ts
@@ -1,0 +1,190 @@
+import * as Effect from "effect/Effect";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  Git,
+  GitBaseBranchInvalid,
+  GitBaseBranchMissing,
+  ReactDoctorError,
+} from "@react-doctor/core";
+
+const runWith = <Value>(
+  layer: ReturnType<typeof Git.layerOf>,
+  program: Effect.Effect<Value, ReactDoctorError, Git>,
+): Value => Effect.runSync(program.pipe(Effect.provide(layer)));
+
+describe("Git.layerOf", () => {
+  it("returns the snapshot's current branch and default branch", () => {
+    const layer = Git.layerOf({
+      currentBranch: "feature/x",
+      defaultBranch: "main",
+    });
+
+    const result = runWith(
+      layer,
+      Effect.gen(function* () {
+        const git = yield* Git;
+        const current = yield* git.currentBranch("/repo");
+        const fallback = yield* git.defaultBranch("/repo");
+        return { current, fallback };
+      }),
+    );
+
+    expect(result).toEqual({ current: "feature/x", fallback: "main" });
+  });
+
+  it("treats a missing snapshot value as null", () => {
+    const layer = Git.layerOf({});
+    const result = runWith(
+      layer,
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return {
+          current: yield* git.currentBranch("/repo"),
+          fallback: yield* git.defaultBranch("/repo"),
+        };
+      }),
+    );
+    expect(result).toEqual({ current: null, fallback: null });
+  });
+
+  it("reports branch existence from the explicit map", () => {
+    const layer = Git.layerOf({
+      branchExists: new Map([
+        ["main", true],
+        ["nope", false],
+      ]),
+    });
+
+    const exists = runWith(
+      layer,
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return {
+          main: yield* git.branchExists("/repo", "main"),
+          nope: yield* git.branchExists("/repo", "nope"),
+          unknown: yield* git.branchExists("/repo", "totally-unknown"),
+        };
+      }),
+    );
+
+    expect(exists).toEqual({ main: true, nope: false, unknown: false });
+  });
+
+  it("returns the snapshot's staged file list", () => {
+    const layer = Git.layerOf({
+      stagedFiles: ["src/a.ts", "src/b.tsx"],
+    });
+
+    const files = runWith(
+      layer,
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.stagedFilePaths("/repo");
+      }),
+    );
+
+    expect(files).toEqual(["src/a.ts", "src/b.tsx"]);
+  });
+
+  it("looks up staged content by relative path", () => {
+    const layer = Git.layerOf({
+      stagedContent: new Map([["src/a.ts", "export const a = 1;\n"]]),
+    });
+
+    const result = runWith(
+      layer,
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return {
+          present: yield* git.showStagedContent("/repo", "src/a.ts"),
+          absent: yield* git.showStagedContent("/repo", "src/missing.ts"),
+        };
+      }),
+    );
+
+    expect(result).toEqual({ present: "export const a = 1;\n", absent: null });
+  });
+
+  it("returns the snapshot's diff selection unchanged", () => {
+    const layer = Git.layerOf({
+      diffSelection: {
+        currentBranch: "feature/x",
+        baseBranch: "main",
+        changedFiles: ["src/a.ts"],
+        isCurrentChanges: false,
+      },
+    });
+
+    const selection = runWith(
+      layer,
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.diffSelection({ directory: "/repo" });
+      }),
+    );
+
+    expect(selection).toEqual({
+      currentBranch: "feature/x",
+      baseBranch: "main",
+      changedFiles: ["src/a.ts"],
+      isCurrentChanges: false,
+    });
+  });
+
+  it("simulates a fallback (null) grep when no matches are configured", () => {
+    const layer = Git.layerOf({ grepMatches: null });
+
+    const result = runWith(
+      layer,
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.grep({
+          directory: "/repo",
+          pattern: "TODO",
+        });
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("formats grep matches into newline-delimited stdout", () => {
+    const layer = Git.layerOf({
+      grepMatches: ["src/a.ts", "src/b.tsx"],
+    });
+
+    const result = runWith(
+      layer,
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.grep({
+          directory: "/repo",
+          pattern: "TODO",
+        });
+      }),
+    );
+
+    expect(result).toEqual({
+      status: 0,
+      stdout: "src/a.ts\nsrc/b.tsx\n",
+    });
+  });
+});
+
+describe("ReactDoctorError shapes raised by Git", () => {
+  it("constructs a GitBaseBranchInvalid leaf", () => {
+    const error = new ReactDoctorError({
+      reason: new GitBaseBranchInvalid({ detail: "x" }),
+    });
+    expect(error.reason._tag).toBe("GitBaseBranchInvalid");
+    expect(error.message).toContain("x");
+  });
+
+  it("constructs a GitBaseBranchMissing leaf", () => {
+    const error = new ReactDoctorError({
+      reason: new GitBaseBranchMissing({ branch: "release/9.9" }),
+    });
+    expect(error.reason._tag).toBe("GitBaseBranchMissing");
+    expect(error.message).toContain("release/9.9");
+  });
+});

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import {
   buildJsonReport,
+  consoleLogger,
   filterDiagnosticsForSurface,
   filterSourceFiles,
   getDiffInfo,
@@ -80,7 +81,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
     }
 
     if (!isQuiet) {
-      printBrandedHeader();
+      printBrandedHeader(consoleLogger);
     }
 
     const scanOptions = resolveCliInspectOptions(flags, userConfig);

--- a/packages/react-doctor/src/cli/commands/install.ts
+++ b/packages/react-doctor/src/cli/commands/install.ts
@@ -1,3 +1,4 @@
+import { consoleLogger } from "@react-doctor/core";
 import { handleError } from "../utils/handle-error.js";
 import { runInstallSkill } from "../utils/install-skill.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
@@ -12,7 +13,7 @@ interface InstallCommandOptions {
 }
 
 export const installAction = async (options: InstallCommandOptions): Promise<void> => {
-  printBrandedHeader();
+  printBrandedHeader(consoleLogger);
   try {
     await runInstallSkill({
       yes: options.yes,

--- a/packages/react-doctor/src/cli/utils/get-staged-files.ts
+++ b/packages/react-doctor/src/cli/utils/get-staged-files.ts
@@ -1,30 +1,37 @@
-import { spawnSync } from "node:child_process";
+import * as Effect from "effect/Effect";
 import fs from "node:fs";
 import path from "node:path";
-import { GIT_SHOW_MAX_BUFFER_BYTES, SOURCE_FILE_PATTERN } from "@react-doctor/core";
+import { GIT_SHOW_MAX_BUFFER_BYTES, Git, SOURCE_FILE_PATTERN } from "@react-doctor/core";
 
 // HACK: --diff-filter=ACMR excludes Deleted (D) — staged-only scans cannot
 // lint files that no longer exist in the staging area.
 const getStagedFilePaths = (directory: string): string[] => {
-  const result = spawnSync(
-    "git",
-    ["diff", "--cached", "-z", "--name-only", "--diff-filter=ACMR", "--relative"],
-    { cwd: directory, stdio: "pipe", maxBuffer: GIT_SHOW_MAX_BUFFER_BYTES },
-  );
-  if (result.error || result.status !== 0) return [];
-  const output = result.stdout.toString();
-  if (!output) return [];
-  return output.split("\0").filter((filePath) => filePath.length > 0);
+  try {
+    const result = Effect.runSync(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.stagedFilePaths(directory);
+      }).pipe(Effect.provide(Git.layerNode)),
+    );
+    return [...result];
+  } catch {
+    return [];
+  }
 };
 
 const readStagedContent = (directory: string, relativePath: string): string | null => {
-  const result = spawnSync("git", ["show", `:${relativePath}`], {
-    cwd: directory,
-    stdio: "pipe",
-    maxBuffer: GIT_SHOW_MAX_BUFFER_BYTES,
-  });
-  if (result.error || result.status !== 0) return null;
-  return result.stdout.toString();
+  try {
+    return Effect.runSync(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.showStagedContent(directory, relativePath, {
+          maxBufferBytes: GIT_SHOW_MAX_BUFFER_BYTES,
+        });
+      }).pipe(Effect.provide(Git.layerNode)),
+    );
+  } catch {
+    return null;
+  }
 };
 
 interface StagedSnapshot {

--- a/packages/react-doctor/src/cli/utils/handle-error.ts
+++ b/packages/react-doctor/src/cli/utils/handle-error.ts
@@ -1,23 +1,31 @@
 import {
   CANONICAL_GITHUB_URL,
+  consoleLogger,
   formatErrorChain,
   formatReactDoctorError,
   isReactDoctorError,
-  logger,
+  type LoggerWriter,
 } from "@react-doctor/core";
 import type { HandleErrorOptions } from "@react-doctor/types";
 
+interface HandleErrorInput {
+  readonly logger?: LoggerWriter;
+  readonly shouldExit?: boolean;
+}
+
 export const handleError = (
   error: unknown,
-  options: HandleErrorOptions = { shouldExit: true },
+  options: HandleErrorOptions | HandleErrorInput = { shouldExit: true },
 ): void => {
+  const logger: LoggerWriter =
+    "logger" in options && options.logger !== undefined ? options.logger : consoleLogger;
   logger.break();
   logger.error("Something went wrong. Please check the error below for more details.");
   logger.error(`If the problem persists, please open an issue at ${CANONICAL_GITHUB_URL}/issues.`);
   logger.error("");
   logger.error(isReactDoctorError(error) ? formatReactDoctorError(error) : formatErrorChain(error));
   logger.break();
-  if (options.shouldExit) {
+  if (options.shouldExit !== false) {
     process.exit(1);
   }
   process.exitCode = 1;

--- a/packages/react-doctor/src/cli/utils/print-branded-header.ts
+++ b/packages/react-doctor/src/cli/utils/print-branded-header.ts
@@ -1,10 +1,10 @@
-import { highlighter, logger } from "@react-doctor/core";
+import { highlighter, type LoggerWriter } from "@react-doctor/core";
 import { VERSION } from "./version.js";
 
 // Single branded line every command prints first when not in JSON/score
 // mode. Keeps the visual signature consistent across `inspect`, `install`,
 // and any future subcommand.
-export const printBrandedHeader = (): void => {
+export const printBrandedHeader = (logger: LoggerWriter): void => {
   logger.log(`${highlighter.bold("react-doctor")} ${highlighter.dim(`v${VERSION}`)}`);
   logger.break();
 };

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -1,13 +1,16 @@
 import {
+  groupBy,
+  highlighter,
   MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE,
   MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
   MILLISECONDS_PER_SECOND,
   OUTPUT_DETAIL_WRAP_WIDTH_CHARS,
   RULE_NAME_COLUMN_WIDTH_CHARS,
+  toRelativePath,
+  type LoggerWriter,
 } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/types";
 import { buildHiddenDiagnosticsSummary } from "./build-hidden-diagnostics-summary.js";
-import { groupBy, highlighter, logger, toRelativePath } from "@react-doctor/core";
 import { indentMultilineText } from "./indent-multiline-text.js";
 import { wrapIndentedText } from "./wrap-indented-text.js";
 
@@ -79,18 +82,19 @@ const padRuleNameToColumn = (ruleName: string, columnWidth: number): string => {
   return ruleName + " ".repeat(columnWidth - ruleName.length);
 };
 
-const grayLine = (text: string): void => {
+const grayLine = (text: string, logger: LoggerWriter): void => {
   logger.log(highlighter.gray(text));
 };
 
-const grayWrappedLine = (text: string, linePrefix: string): void => {
-  grayLine(wrapIndentedText(text, linePrefix, OUTPUT_DETAIL_WRAP_WIDTH_CHARS));
+const grayWrappedLine = (text: string, linePrefix: string, logger: LoggerWriter): void => {
+  grayLine(wrapIndentedText(text, linePrefix, OUTPUT_DETAIL_WRAP_WIDTH_CHARS), logger);
 };
 
 const printCompactRuleGroupLine = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
   ruleNameColumnWidth: number,
+  logger: LoggerWriter,
 ): void => {
   const firstDiagnostic = ruleDiagnostics[0];
   const severitySymbol = firstDiagnostic.severity === "error" ? "✗" : "⚠";
@@ -140,6 +144,7 @@ const printDefaultRuleGroup = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
   rootDirectory: string,
+  logger: LoggerWriter,
 ): void => {
   const firstDiagnostic = ruleDiagnostics[0];
   const ruleTitle = toRuleTitle(firstDiagnostic.rule);
@@ -149,17 +154,17 @@ const printDefaultRuleGroup = (
   const trailingBadge = siteCountBadge.length > 0 ? ` ${highlighter.gray(siteCountBadge)}` : "";
 
   logger.log(`  ${icon} ${ruleTitle}${trailingBadge}`);
-  grayWrappedLine(firstDiagnostic.message, "    ");
+  grayWrappedLine(firstDiagnostic.message, "    ", logger);
   if (firstDiagnostic.help) {
-    grayWrappedLine(firstDiagnostic.help, "    ");
+    grayWrappedLine(firstDiagnostic.help, "    ", logger);
   }
   if (firstDiagnostic.url) {
-    grayLine(`    ${firstDiagnostic.url}`);
+    grayLine(`    ${firstDiagnostic.url}`, logger);
   }
   const firstLocation = ruleDiagnostics.find((diagnostic) => diagnostic.line > 0);
   if (firstLocation) {
     const locationPath = toRelativePath(firstLocation.filePath, rootDirectory);
-    grayLine(`    ${locationPath}:${firstLocation.line}`);
+    grayLine(`    ${locationPath}:${firstLocation.line}`, logger);
   }
 };
 
@@ -167,11 +172,12 @@ const printDefaultCategoryGroup = (
   categoryGroup: CategoryDiagnosticGroup,
   visibleRuleGroups: [string, Diagnostic[]][],
   rootDirectory: string,
+  logger: LoggerWriter,
 ): void => {
   const issueCount = formatIssueCount(categoryGroup.diagnostics.length);
   logger.log(`${highlighter.bold(categoryGroup.category)} ${highlighter.dim(issueCount)}`);
   for (const [ruleKey, ruleDiagnostics] of visibleRuleGroups) {
-    printDefaultRuleGroup(ruleKey, ruleDiagnostics, rootDirectory);
+    printDefaultRuleGroup(ruleKey, ruleDiagnostics, rootDirectory, logger);
   }
   logger.break();
 };
@@ -180,30 +186,34 @@ const printVerboseRuleGroup = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
   ruleNameColumnWidth: number,
+  logger: LoggerWriter,
 ): void => {
-  printCompactRuleGroupLine(ruleKey, ruleDiagnostics, ruleNameColumnWidth);
+  printCompactRuleGroupLine(ruleKey, ruleDiagnostics, ruleNameColumnWidth, logger);
   const firstDiagnostic = ruleDiagnostics[0];
-  grayLine(indentMultilineText(firstDiagnostic.message, "      "));
+  grayLine(indentMultilineText(firstDiagnostic.message, "      "), logger);
   if (firstDiagnostic.help) {
-    grayLine(indentMultilineText(`→ ${firstDiagnostic.help}`, "      "));
+    grayLine(indentMultilineText(`→ ${firstDiagnostic.help}`, "      "), logger);
   }
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);
   for (const [filePath, sites] of fileSites) {
     if (sites.length > 0) {
       for (const site of sites) {
-        grayLine(`      ${filePath}:${site.line}`);
+        grayLine(`      ${filePath}:${site.line}`, logger);
         if (site.suppressionHint) {
-          grayLine(`        ↳ ${site.suppressionHint}`);
+          grayLine(`        ↳ ${site.suppressionHint}`, logger);
         }
       }
     } else {
-      grayLine(`      ${filePath}`);
+      grayLine(`      ${filePath}`, logger);
     }
   }
   logger.break();
 };
 
-const printHiddenDiagnosticsSummary = (hiddenRuleGroups: [string, Diagnostic[]][]): void => {
+const printHiddenDiagnosticsSummary = (
+  hiddenRuleGroups: [string, Diagnostic[]][],
+  logger: LoggerWriter,
+): void => {
   const hiddenDiagnostics = hiddenRuleGroups.flatMap(([, ruleDiagnostics]) => ruleDiagnostics);
   const renderedParts = buildHiddenDiagnosticsSummary(hiddenDiagnostics).map((part) => {
     const [icon, ...labelParts] = part.text.split(" ");
@@ -211,11 +221,15 @@ const printHiddenDiagnosticsSummary = (hiddenRuleGroups: [string, Diagnostic[]][
   });
 
   logger.log(`  ${renderedParts.join("  ")}`);
-  grayLine("    Run `npx react-doctor@latest . --verbose` to get all details");
+  grayLine("    Run `npx react-doctor@latest . --verbose` to get all details", logger);
   logger.break();
 };
 
-const printDefaultDiagnostics = (diagnostics: Diagnostic[], rootDirectory: string): void => {
+const printDefaultDiagnostics = (
+  diagnostics: Diagnostic[],
+  rootDirectory: string,
+  logger: LoggerWriter,
+): void => {
   const categoryGroups = buildCategoryDiagnosticGroups(diagnostics);
   const hiddenRuleGroups: [string, Diagnostic[]][] = [];
   const visibleCategoryGroups = categoryGroups.slice(0, MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE);
@@ -229,7 +243,7 @@ const printDefaultDiagnostics = (diagnostics: Diagnostic[], rootDirectory: strin
     const remainingRuleGroups = categoryGroup.ruleGroups.slice(
       MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
     );
-    printDefaultCategoryGroup(categoryGroup, visibleRuleGroups, rootDirectory);
+    printDefaultCategoryGroup(categoryGroup, visibleRuleGroups, rootDirectory, logger);
     hiddenRuleGroups.push(...remainingRuleGroups);
   }
   hiddenRuleGroups.push(
@@ -237,7 +251,7 @@ const printDefaultDiagnostics = (diagnostics: Diagnostic[], rootDirectory: strin
   );
 
   if (hiddenRuleGroups.length > 0) {
-    printHiddenDiagnosticsSummary(hiddenRuleGroups);
+    printHiddenDiagnosticsSummary(hiddenRuleGroups, logger);
   }
 };
 
@@ -245,9 +259,10 @@ export const printDiagnostics = (
   diagnostics: Diagnostic[],
   isVerbose: boolean,
   rootDirectory: string,
+  logger: LoggerWriter,
 ): void => {
   if (!isVerbose) {
-    printDefaultDiagnostics(diagnostics, rootDirectory);
+    printDefaultDiagnostics(diagnostics, rootDirectory, logger);
     return;
   }
 
@@ -263,7 +278,7 @@ export const printDiagnostics = (
   );
 
   visibleRuleGroups.forEach(([ruleKey, ruleDiagnostics]) => {
-    printVerboseRuleGroup(ruleKey, ruleDiagnostics, ruleNameColumnWidth);
+    printVerboseRuleGroup(ruleKey, ruleDiagnostics, ruleNameColumnWidth, logger);
   });
 };
 

--- a/packages/react-doctor/src/cli/utils/render-project-detection.ts
+++ b/packages/react-doctor/src/cli/utils/render-project-detection.ts
@@ -1,6 +1,6 @@
 import type { ProjectInfo, ReactDoctorConfig } from "@react-doctor/types";
 import { formatFrameworkName } from "@react-doctor/project-info";
-import { highlighter, logger } from "@react-doctor/core";
+import { highlighter, type LoggerWriter } from "@react-doctor/core";
 import { spinner } from "./spinner.js";
 
 export const printProjectDetection = (
@@ -8,7 +8,8 @@ export const printProjectDetection = (
   userConfig: ReactDoctorConfig | null,
   isDiffMode: boolean,
   includePaths: string[],
-  lintSourceFileCount?: number,
+  lintSourceFileCount: number | undefined,
+  logger: LoggerWriter,
 ): void => {
   const frameworkLabel = formatFrameworkName(projectInfo.framework);
   const languageLabel = projectInfo.hasTypeScript ? "TypeScript" : "JavaScript";

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -1,12 +1,13 @@
 import {
+  highlighter,
   PERFECT_SCORE,
   SCORE_BAR_WIDTH_CHARS,
   SCORE_GOOD_THRESHOLD,
   SCORE_OK_THRESHOLD,
+  type LoggerWriter,
 } from "@react-doctor/core";
 import type { ScoreResult } from "@react-doctor/types";
 import { colorizeByScore } from "./colorize-by-score.js";
-import { highlighter, logger } from "@react-doctor/core";
 
 interface ScoreBarSegments {
   filledSegment: string;
@@ -42,7 +43,7 @@ const buildFaceRenderedLines = (score: number): string[] => {
   return ["┌─────┐", `│ ${eyes} │`, `│ ${mouth} │`, "└─────┘"].map(colorize);
 };
 
-export const printScoreHeader = (scoreResult: ScoreResult): void => {
+export const printScoreHeader = (scoreResult: ScoreResult, logger: LoggerWriter): void => {
   const renderedFaceLines = buildFaceRenderedLines(scoreResult.score);
 
   const scoreNumber = colorizeByScore(`${scoreResult.score}`, scoreResult.score);
@@ -61,12 +62,12 @@ export const printScoreHeader = (scoreResult: ScoreResult): void => {
   logger.break();
 };
 
-export const printBrandingOnlyHeader = (): void => {
+export const printBrandingOnlyHeader = (logger: LoggerWriter): void => {
   logger.log(`  ${BRANDING_LINE}`);
   logger.break();
 };
 
-export const printNoScoreHeader = (noScoreMessage: string): void => {
+export const printNoScoreHeader = (noScoreMessage: string, logger: LoggerWriter): void => {
   logger.log(`  ${BRANDING_LINE}`);
   logger.log(`  ${highlighter.gray(noScoreMessage)}`);
   logger.break();

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -1,4 +1,4 @@
-import { highlighter, logger, SHARE_BASE_URL } from "@react-doctor/core";
+import { highlighter, SHARE_BASE_URL, type LoggerWriter } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/types";
 import { collectAffectedFiles, formatElapsedTime } from "./render-diagnostics.js";
 import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
@@ -27,6 +27,7 @@ const printCountsSummaryLine = (
   diagnostics: Diagnostic[],
   totalSourceFileCount: number,
   elapsedMilliseconds: number,
+  logger: LoggerWriter,
 ): void => {
   const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
   const warningCount = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
@@ -56,14 +57,15 @@ export const printSummary = (
   totalSourceFileCount: number,
   noScoreMessage: string,
   isOffline: boolean,
+  logger: LoggerWriter,
 ): void => {
   if (scoreResult) {
-    printScoreHeader(scoreResult);
+    printScoreHeader(scoreResult, logger);
   } else {
-    printNoScoreHeader(noScoreMessage);
+    printNoScoreHeader(noScoreMessage, logger);
   }
 
-  printCountsSummaryLine(diagnostics, totalSourceFileCount, elapsedMilliseconds);
+  printCountsSummaryLine(diagnostics, totalSourceFileCount, elapsedMilliseconds, logger);
 
   try {
     const diagnosticsDirectory = writeDiagnosticsDirectory(diagnostics);

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -9,12 +9,11 @@ import {
   Files,
   filterDiagnosticsForSurface,
   highlighter,
-  isLoggerSilent,
   isReactDoctorError,
   Linter,
   LintPartialFailures,
   loadConfigWithSource,
-  logger,
+  Logger,
   OXLINT_NODE_REQUIREMENT,
   Project,
   ReactDoctorError,
@@ -22,8 +21,8 @@ import {
   resolveConfigRootDir,
   runInspect as runInspectEffect,
   Score,
-  setLoggerSilent,
   type InspectOutput,
+  type LoggerWriter,
   type ReactDoctorErrorReason,
 } from "@react-doctor/core";
 import {
@@ -138,12 +137,13 @@ export const inspect = async (
 
   const options = mergeInspectOptions(inputOptions, userConfig);
 
-  const wasLoggerSilent = isLoggerSilent();
+  // HACK: spinner.ts still has module-level silent state (used by
+  // printProjectDetection's internal spinner() calls). Mirror the
+  // silent flag here until that file moves to a Progress service in
+  // a follow-up PR. Logger-side silent is handled cleanly via
+  // Logger.layerSilent provided to the Effect program.
   const wasSpinnerSilent = isSpinnerSilent();
-  if (options.silent) {
-    setLoggerSilent(true);
-    setSpinnerSilent(true);
-  }
+  if (options.silent) setSpinnerSilent(true);
 
   try {
     return await runInspectWithRuntime(
@@ -154,10 +154,7 @@ export const inspect = async (
       startTime,
     );
   } finally {
-    if (options.silent) {
-      setLoggerSilent(wasLoggerSilent);
-      setSpinnerSilent(wasSpinnerSilent);
-    }
+    if (options.silent) setSpinnerSilent(wasSpinnerSilent);
   }
 };
 
@@ -191,14 +188,15 @@ const runInspectWithRuntime = async (
   const linterLayer = !options.lint || lintBindingMissing ? Linter.layerOf([]) : Linter.layerOxlint;
   const deadCodeLayer = options.deadCode ? DeadCode.layerNode : DeadCode.layerOf([]);
   // HACK: always provide layerOf(null) for Score — the orchestrator's
-  // Score.compute would otherwise see the FULL diagnostic list. The
-  // legacy contract is to filter for the "score" surface (strips
-  // design tags by default) before calculating the score. We do that
-  // here after runInspect returns instead of inside the orchestrator.
+  // Score.compute sees the per-element-filtered list, NOT the
+  // surface-filtered list this function needs. We compute the real
+  // score below with `filterDiagnosticsForSurface("score", ...)`
+  // applied first.
   const scoreLayer = Score.layerOf(null);
   const configLayer = hasConfigOverride
     ? Config.layerOf({ config: userConfig, resolvedDirectory: directory })
     : Config.layerNode;
+  const loggerLayer = options.silent ? Logger.layerSilent : Logger.layerConsole;
 
   const layers = Layer.mergeAll(
     Project.layerNode,
@@ -209,9 +207,11 @@ const runInspectWithRuntime = async (
     deadCodeLayer,
     Reporter.layerNoop,
     scoreLayer,
+    loggerLayer,
   );
 
   const program = Effect.gen(function* () {
+    const logger = yield* Logger;
     const spinnerRef = yield* Ref.make<SpinnerHandle | null>(null);
 
     const output = yield* runInspectEffect(
@@ -237,9 +237,10 @@ const runInspectWithRuntime = async (
                 isDiffMode,
                 options.includePaths,
                 lintSourceFileCount,
+                logger,
               );
             }
-            if (options.lint && resolvedNodeBinaryPath && !options.scoreOnly) {
+            if (options.lint && resolvedNodeBinaryPath && !options.scoreOnly && !options.silent) {
               const handle = spinner("Running lint checks...").start();
               yield* Ref.set(spinnerRef, {
                 succeed: (text) => handle.succeed(text),
@@ -256,15 +257,17 @@ const runInspectWithRuntime = async (
     );
 
     const finalHandle = yield* Ref.get(spinnerRef);
-    return { output, finalHandle };
+    return { output, finalHandle, logger };
   });
 
   let output: InspectOutput;
   let finalSpinnerHandle: SpinnerHandle | null;
+  let logger: LoggerWriter;
   try {
     const programResult = await Effect.runPromise(program.pipe(Effect.provide(layers)));
     output = programResult.output;
     finalSpinnerHandle = programResult.finalHandle;
+    logger = programResult.logger;
   } catch (cause) {
     if (isReactDoctorError(cause)) restoreLegacyThrow(cause);
     throw cause;
@@ -349,6 +352,7 @@ const runInspectWithRuntime = async (
     didDeadCodeFail: output.didDeadCodeFail,
     deadCodeFailureReason: output.deadCodeFailureReason,
     directory: output.resolvedDirectory,
+    logger,
   });
 };
 
@@ -365,6 +369,7 @@ interface FinalizeInput {
   didDeadCodeFail: boolean;
   deadCodeFailureReason: string | null;
   directory: string;
+  logger: LoggerWriter;
 }
 
 const finalizeAndRender = (input: FinalizeInput): InspectResult => {
@@ -381,6 +386,7 @@ const finalizeAndRender = (input: FinalizeInput): InspectResult => {
     didDeadCodeFail,
     deadCodeFailureReason,
     directory,
+    logger,
   } = input;
 
   const skippedChecks: string[] = [];
@@ -444,18 +450,18 @@ const finalizeAndRender = (input: FinalizeInput): InspectResult => {
     }
     logger.break();
     if (hasSkippedChecks) {
-      printBrandingOnlyHeader();
+      printBrandingOnlyHeader(logger);
       logger.log(highlighter.gray("  Score not shown — some checks could not complete."));
     } else if (score) {
-      printScoreHeader(score);
+      printScoreHeader(score, logger);
     } else {
-      printNoScoreHeader(noScoreMessage);
+      printNoScoreHeader(noScoreMessage, logger);
     }
     return buildResult();
   }
 
   logger.break();
-  printDiagnostics(surfaceDiagnostics, options.verbose, directory);
+  printDiagnostics(surfaceDiagnostics, options.verbose, directory, logger);
 
   if (demotedDiagnosticCount > 0) {
     logger.log(
@@ -475,6 +481,7 @@ const finalizeAndRender = (input: FinalizeInput): InspectResult => {
     lintSourceFileCount,
     noScoreMessage,
     !shouldShowShareLink,
+    logger,
   );
 
   if (hasSkippedChecks) {


### PR DESCRIPTION
## Summary

PR 11 in the Effect v4 stack: adds a **`Git` Context.Service** in `@react-doctor/core/services/git` so every `spawnSync('git', ...)` call in the codebase goes through a single, swappable seam — the production path is unchanged, but tests can now `Git.layerOf({ stagedFiles: [...] })` instead of provisioning a real repo.

### What moves behind the service

- **`get-diff-files.ts`** — `merge-base` + `diff --name-only` + branch detection logic moves into `Git.diffSelection`. The exported `getDiffInfo` becomes a thin sync façade that runs an Effect program with `Git.layerNode` and unwraps the result back into the historical shape.
- **`get-staged-files.ts`** — `git diff --cached` and `git show :path` calls go through `Git.stagedFilePaths` / `Git.showStagedContent`.
- **`neutralize-disable-directives.ts`** — the `git grep -l --untracked -E '(eslint|oxlint)-disable'` path goes through `Git.grep`.

### New tagged error leaves (in `errors.ts`)

- `GitInvocationFailed { args, directory, cause }` — raised when `git` itself can't run.
- `GitBaseBranchMissing { branch }` — raised when `--diff origin/foo` resolves to a non-existent branch (preserves the existing CLI message).
- `GitBaseBranchInvalid { detail }` — raised when the explicit base is empty.

The sync façade catches `ReactDoctorError` at the boundary and re-throws plain `Error`s with the historical messages so callers that aren't yet Effect-typed don't observe the change.

### Two layers

- `Git.layerNode` — production layer; routes through `spawnSync` (kept sync to preserve the current API contract).
- `Git.layerOf({ currentBranch, defaultBranch, branchExists, stagedFiles, stagedContent, diffSelection, grepMatches })` — test layer driven by a deterministic snapshot. Missing keys resolve to safe defaults so tests don't have to enumerate every subcommand.

### Why \`spawnSync\` and not \`ChildProcess\`?

Every call site that currently invokes `getDiffInfo` / `getStagedSourceFiles` / `neutralizeDisableDirectives` is synchronous. Swapping the internals for Effect's async `ChildProcess` here would cascade into rewriting every caller as `Effect.gen`, which is a much bigger PR. This change keeps the wrapper synchronous (`Effect.try` over `spawnSync`) so the DI seam lands first; a follow-up PR can swap `Git.layerNode` for a `ChildProcess`-backed implementation once the orchestrator is fully Effect-typed.

## Test plan

- [x] `pnpm typecheck` — all packages clean
- [x] `pnpm --filter @react-doctor/core test` — 10 files / 49 tests pass (9 new tests for `Git.layerOf`)
- [x] `pnpm test` — full suite (1442 tests across 113 files) green
- [x] `pnpm lint` clean
- [x] `pnpm smoke:json-report` — schema round-trip OK
- [x] No new runtime deps (the wrapper uses `effect/Effect` + `node:child_process`, both already in tree)

## Stack

- #421 — Logger service (\`layerConsole\` / \`layerSilent\` / \`layerCapture\`)
- #422 — wire Logger through inspect() + thread \`logger\` param through 6 renderers
- **this PR (PR 11)** — Git service
- PR 12 (next) — NodeResolver + StagedFiles services
- PR 13 — Decompose \`runOxlint\` into Stream combinators
- PR 14 — Collapse \`@react-doctor/types\` / \`@react-doctor/project-info\` into core; rename legacy \`ReactDoctorError\` to disambiguate

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes all `git` invocations behind a new service and updates diff/staged/grep paths to use it, which can affect diff-mode behavior and error handling across the CLI. Risk is mitigated by a legacy sync façade and added unit coverage, but regressions would surface in common workflows like `--diff` and `--staged`.
> 
> **Overview**
> Introduces a new `Git` `Context.Service` (`services/git.ts`) that wraps all synchronous `git` subprocess calls (branch detection, diff selection, staged file reads, grep) and provides both a production `Git.layerNode` and a snapshot-based `Git.layerOf` for tests.
> 
> Refactors core utilities to use the service: `getDiffInfo` becomes a legacy sync façade over `Git.diffSelection` with explicit error unwrapping for invalid/missing base branches, and `neutralize-disable-directives` switches `git grep` to `Git.grep` with the same filesystem fallback semantics. The CLI’s staged-file utilities now use `Git.stagedFilePaths`/`Git.showStagedContent` via Effect.
> 
> Extends `ReactDoctorErrorReason` with new git-specific tagged errors (`GitInvocationFailed`, `GitBaseBranchMissing`, `GitBaseBranchInvalid`), exports the new service from core, and adds unit tests covering `Git.layerOf` behavior and error leaf construction. Separately, CLI render/entrypoints are adjusted to pass an explicit `LoggerWriter` (via `consoleLogger`/`Logger` service) into header/diagnostic/summary rendering instead of relying on module-level `logger`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d08b1793f74d0706dcf23bb5d2110a0f8880664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->