### PR TITLE
fix(security): four pre-existing findings from a deep audit

### DIFF
--- a/packages/core/src/get-diff-files.ts
+++ b/packages/core/src/get-diff-files.ts
@@ -78,9 +78,24 @@ const getUncommittedChangedFiles = (directory: string): string[] => {
   return output ?? [];
 };
 
+const SAFE_BRANCH_NAME_PATTERN = /^[A-Za-z0-9_./-]+$/;
+
+const isSafeGitRevision = (candidate: string): boolean => {
+  if (candidate.length === 0) return false;
+  if (candidate.startsWith("-")) return false;
+  if (candidate.startsWith(".") || candidate.endsWith(".")) return false;
+  if (candidate.includes("..") || candidate.includes("@{")) return false;
+  return SAFE_BRANCH_NAME_PATTERN.test(candidate);
+};
+
 export const getDiffInfo = (directory: string, explicitBaseBranch?: string): DiffInfo | null => {
   if (explicitBaseBranch !== undefined && explicitBaseBranch.trim().length === 0) {
     throw new Error("Diff base branch cannot be empty.");
+  }
+  if (explicitBaseBranch !== undefined && !isSafeGitRevision(explicitBaseBranch)) {
+    throw new Error(
+      `Diff base branch "${explicitBaseBranch}" is not a valid git ref name (must match [A-Za-z0-9_./-] without leading '-', '..', or '@{').`,
+    );
   }
 
   const currentBranch = getCurrentBranch(directory);

--- a/packages/react-doctor/src/cli/utils/get-staged-files.ts
+++ b/packages/react-doctor/src/cli/utils/get-staged-files.ts
@@ -45,20 +45,29 @@ const PROJECT_CONFIG_FILENAMES = [
   ".oxlintrc.json",
 ];
 
+const isPathInsideDirectory = (childAbsolutePath: string, parentAbsolutePath: string): boolean => {
+  const relative = path.relative(parentAbsolutePath, childAbsolutePath);
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+};
+
 export const materializeStagedFiles = (
   directory: string,
   stagedFiles: string[],
   tempDirectory: string,
 ): StagedSnapshot => {
   const materializedFiles: string[] = [];
+  const resolvedTempDirectory = path.resolve(tempDirectory);
 
   for (const relativePath of stagedFiles) {
     const content = readStagedContent(directory, relativePath);
     if (content === null) continue;
 
-    const targetPath = path.join(tempDirectory, relativePath);
-    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    fs.writeFileSync(targetPath, content);
+    const candidateTargetPath = path.resolve(resolvedTempDirectory, relativePath);
+    if (!isPathInsideDirectory(candidateTargetPath, resolvedTempDirectory)) {
+      continue;
+    }
+    fs.mkdirSync(path.dirname(candidateTargetPath), { recursive: true });
+    fs.writeFileSync(candidateTargetPath, content);
     materializedFiles.push(relativePath);
   }
 

--- a/packages/website/src/app/leaderboard/page.tsx
+++ b/packages/website/src/app/leaderboard/page.tsx
@@ -48,11 +48,26 @@ const formatGeneratedAt = (isoTimestamp: string): string => {
   return `${parsedDate.toISOString().replace("T", " ").slice(0, 16)} UTC`;
 };
 
+const isSafeGithubUrl = (candidate: unknown): candidate is string => {
+  if (typeof candidate !== "string") return false;
+  try {
+    const parsed = new URL(candidate);
+    return parsed.protocol === "https:" && parsed.host === "github.com";
+  } catch {
+    return false;
+  }
+};
+
+const sanitizeLeaderboardEntries = (entries: LeaderboardEntry[]): LeaderboardEntry[] =>
+  entries.filter((entry) => isSafeGithubUrl(entry.githubUrl));
+
 const fetchLeaderboard = async (): Promise<LeaderboardFile | null> => {
   try {
     const response = await fetch(LEADERBOARD_URL, { next: { revalidate: REVALIDATE_SECONDS } });
     if (!response.ok) return null;
-    return (await response.json()) as LeaderboardFile;
+    const payload = (await response.json()) as LeaderboardFile;
+    if (!payload || !Array.isArray(payload.entries)) return null;
+    return { ...payload, entries: sanitizeLeaderboardEntries(payload.entries) };
   } catch {
     return null;
   }

--- a/scripts/update-leaderboard.ts
+++ b/scripts/update-leaderboard.ts
@@ -37,12 +37,38 @@ const fetchLeaderboard = async (): Promise<LeaderboardFile> => {
   return (await response.json()) as LeaderboardFile;
 };
 
+const isSafeGithubUrl = (candidate: unknown): candidate is string => {
+  if (typeof candidate !== "string") return false;
+  try {
+    const parsed = new URL(candidate);
+    return parsed.protocol === "https:" && parsed.host === "github.com";
+  } catch {
+    return false;
+  }
+};
+
+const escapeMarkdownTableCell = (text: string): string =>
+  text
+    .replaceAll("\\", "\\\\")
+    .replaceAll("|", "\\|")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]")
+    .replaceAll("`", "\\`")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll(/[\r\n]+/g, " ");
+
 const renderLeaderboardTable = (entries: LeaderboardEntry[]): string => {
   const header = ["| #  | Repo | Score |", "| -- | ---- | ----: |"];
-  const rows = entries.slice(0, LEADERBOARD_TOP_COUNT).map((entry, innerIndex) => {
-    const rank = String(innerIndex + 1).padEnd(2, " ");
-    return `| ${rank} | [${entry.name}](${entry.githubUrl}) | ${entry.score} |`;
-  });
+  const rows = entries
+    .filter((entry) => isSafeGithubUrl(entry.githubUrl) && Number.isFinite(entry.score))
+    .slice(0, LEADERBOARD_TOP_COUNT)
+    .map((entry, innerIndex) => {
+      const rank = String(innerIndex + 1).padEnd(2, " ");
+      const safeName = escapeMarkdownTableCell(entry.name);
+      const safeUrl = encodeURI(entry.githubUrl);
+      return `| ${rank} | [${safeName}](${safeUrl}) | ${entry.score} |`;
+    });
   return [...header, ...rows].join("\n");
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Split out from #418 (security audit slice). Four independent fixes from a deep audit of the workflows, the composite action, the helper scripts, and the CLI source surface. Each fix is its own commit so they can be reverted or backported individually.

## 1. `fix(staged): block path traversal when materializing staged files`

`git diff --cached --name-only` is the source of `relativePath`. Git normalizes paths during ordinary `git add`, but a deliberately crafted index entry (via `git update-index --add`, a malicious pack, or a symlinked working tree) can include `..` segments. The previous `path.join(tempDirectory, relativePath)` then escapes the temp dir and `writeFileSync` would write attacker-chosen paths anywhere the running user can write.

`SOURCE_FILE_PATTERN` (`/\.(tsx?|jsx?)$/`) only matches the file extension and doesn't block `../`.

**Fix**: resolve the candidate path against the resolved temp directory and skip the entry when the result falls outside (Zip-Slip defense).

## 2. `fix(core): validate --diff base branch name to block git flag injection`

`getDiffInfo(directory, explicitBaseBranch)` passed `explicitBaseBranch` straight to `git rev-parse --verify <branch>` and `git merge-base <branch> HEAD`. A value starting with `-` (such as `--upload-pack=evil`) would be interpreted by git as an option instead of a refname — the CVE-2018-17456 shape.

In the canonical CI path the GitHub composite action guards with `case "$DIFF_BASE" in -* )` before the CLI is even invoked, so the exposure today is limited to local CLI runs. Hardening the library boundary anyway.

**Fix**: reject empty refs, leading `-`, leading/trailing `.`, embedded `..`, `@{` reflog suffix, and any character outside `[A-Za-z0-9_./-]`.

## 3. `fix(website): validate leaderboard github URLs to prevent XSS via href`

The hosted leaderboard rendered `<a href={entry.githubUrl}>` with no protocol check. `entry.githubUrl` is read from `react-doctor-benchmarks` (a separate repo), so a compromise of that repo could land a `javascript:` href on react.doctor. React 18+ no longer blocks `javascript:` URLs in href, so this was a live XSS path.

**Fix**: parse each URL through the WHATWG URL constructor and only keep entries whose protocol is `https:` and whose host is exactly `github.com`. Filter happens at fetch time so every downstream render uses the sanitized list.

## 4. `fix(scripts): escape leaderboard entries before writing them into README`

`update-leaderboard.ts` interpolated `entry.name` and `entry.githubUrl` directly into a markdown table that the workflow later commits to the canonical README. A compromise of the upstream benchmarks repo could land arbitrary markdown (or HTML that GitHub's renderer accepts, like `<img>`) into the README and from there onto npm via the published `react-doctor` package's README field.

**Fix**: escape repo names against the markdown table grammar (`\`, `|`, `[`, `]`, `` ` ``, `<`, `>`, newlines), reject entries whose `githubUrl` doesn't parse as `https://github.com/...`, and `encodeURI` the URL before substituting so a stray space or paren can't terminate the markdown link target.

## Audited and confirmed safe (no change needed)

- All workflows pass user-controlled values through `env:` and reference them as `$VAR` in shell — no `${{ }}` interpolation inside `run:` blocks (the canonical script-injection vector).
- `action.yml` defends `DIFF_BASE` / `HEAD_REF` against flag injection with `case "$X" in -*`.
- `action.yml`'s `actions/github-script@v7` body wraps CLI output in a 6-backtick fence; CLI-rendered diagnostics never start at column 0 with `::xxx` (`render-diagnostics.ts` always indents at least 2 spaces), so the runner's workflow-command parser cannot be tricked by echoed user content. Annotation lines from `print-annotations.ts` are URL-encoded.
- No `pull_request_target` anywhere; `ci.yml` uses plain `pull_request` and runs no secrets in jobs.
- `pnpm.onlyBuiltDependencies` allow-lists only `@parcel/watcher`, `esbuild`, `unrs-resolver` for postinstall scripts.
- `actions/setup-node@v4` `cache: pnpm` is keyed per-branch; fork PRs can't poison `main`'s cache.
- Config loading (`load-config.ts` -> `validate-config-types.ts`) uses `JSON.parse` + whitelist validation; no prototype-pollution surface. **No `eval` or `new Function`** anywhere in shipped code.
- `run-oxlint.ts` strips `NODE_OPTIONS`, `NODE_DEBUG`, and `npm_config_*` from the child env before spawning oxlint.
- `resolve-compatible-node.ts` validates `nvm.sh` with `existsSync` before sourcing and uses `env:` (not shell interpolation) for `NVM_SCRIPT` / `NODE_MAJOR`.

## Known follow-ups (deliberately out of scope)

- `pnpm audit` reports 24 advisories. All sit in dev tooling or in the `packages/website` Next.js tree. **None touch the published `react-doctor` / `eslint-plugin-react-doctor` / `oxlint-plugin-react-doctor` runtime trees.** Worth a dedicated dep-bump pass.
- Third-party actions are tag-pinned, not SHA-pinned. Worth a repo-wide policy change.
- Score-API response in `calculate-score.ts` is unbounded. Mitigated by `FETCH_TIMEOUT_MS` and `--offline` opt-out.
- `action.yml` runs `npx react-doctor@latest` regardless of action ref. The maintainer-only release gate (in #423) is the proximate mitigation.

## Verification

- `pnpm format:check` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (1442 passed, 3 skipped, no regressions)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6152c19-ec2c-4a6f-89b8-001b6fa8a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6152c19-ec2c-4a6f-89b8-001b6fa8a5ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

