### PR TITLE
chore: upgrade deslop-js to ^0.0.12

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@react-doctor/project-info": "workspace:*",
     "@react-doctor/types": "workspace:*",
-    "deslop-js": "^0.0.11",
+    "deslop-js": "^0.0.12",
     "effect": "4.0.0-beta.70",
     "oxlint": "^1.66.0",
     "oxlint-plugin-react-doctor": "workspace:*",

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "agent-install": "0.0.5",
-    "deslop-js": "^0.0.11",
+    "deslop-js": "^0.0.12",
     "effect": "4.0.0-beta.70",
     "oxlint": "^1.66.0",
     "oxlint-plugin-react-doctor": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       deslop-js:
-        specifier: ^0.0.11
-        version: 0.0.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.0.12
+        version: 0.0.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
@@ -141,8 +141,8 @@ importers:
         specifier: 0.0.5
         version: 0.0.5
       deslop-js:
-        specifier: ^0.0.11
-        version: 0.0.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.0.12
+        version: 0.0.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
@@ -2070,8 +2070,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deslop-js@0.0.11:
-    resolution: {integrity: sha512-WWlKBhKxqoar4Y2DcQHeltXgobiRAWLVNMdmDvIrW+vuLyIj24HJUo70nw06K6lRCHpFctJmivJX8Z7UCM3Yqw==}
+  deslop-js@0.0.12:
+    resolution: {integrity: sha512-DsoVhhrgdqjkHxD9zFFJS7r+wDkbbpbdYVfwTNo6s89xTDbZQ9xW0EOd17a45Cfo1z0KxJQkjtJi/fHZ/LpBPA==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -4497,7 +4497,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deslop-js@0.0.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  deslop-js@0.0.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps `deslop-js` from `^0.0.11` to `^0.0.12` in `packages/core` and `packages/react-doctor`.

## Changes in deslop-js 0.0.12

Reviewed the diff between 0.0.11 and 0.0.12:

- **No public API changes** — `dist/index.d.mts` is byte-identical between versions, so the `analyze` / `defineConfig` call surface used in `packages/core/src/check-dead-code.ts` is unchanged.
- **No dependency changes** — `package.json` only bumps the version field; `@oxc-project/types`, `oxc-parser`, `oxc-resolver`, `fast-glob`, `minimatch`, and `typescript` ranges are unchanged.
- Internal improvements only:
  - Better function-pattern detection (skips method-context, inline callbacks, and explicit `Promise<...>` return types when flagging `useless-async`).
  - Unwraps `ParenthesizedExpression` and skips `JSXElement` / `JSXFragment` in arrow-body detection.
  - Adds a Tailwind `@plugin` / `@reference` / `@config` reference pattern to the CSS import scanner.
  - New `referencedFilenames` capture surfaces filename-shaped string literals on JS/TS/CSS captures.
  - Refactors capture pipeline to compute walks before composing the file capture object.

Because none of these surface in the integration in `check-dead-code.ts` (we only consume `unusedFiles`, `unusedExports`, `unusedDependencies`, `circularDependencies`, all of which keep their existing shapes), this is a low-risk patch bump.

## Verification

- `pnpm install` — lockfile resolves `deslop-js@0.0.12` cleanly.
- `pnpm typecheck` — 12/12 tasks pass.
- `pnpm lint` — clean.
- `pnpm test` — 113 test files, 1442 passed (3 skipped, pre-existing).
- `pnpm format:check` — all files formatted.
- `pnpm smoke:json-report` — `Smoke OK: schemaVersion=1 mode=full projects=1 diagnostics=0`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c1cc083-f4fb-480e-ad73-5ce0f53124e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c1cc083-f4fb-480e-ad73-5ce0f53124e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

