### PR TITLE
refactor(core): replace spawnSync in Git service with Effect's ChildProcess [14/?]

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@effect/platform-node": "4.0.0-beta.70",
     "@react-doctor/project-info": "workspace:*",
     "@react-doctor/types": "workspace:*",
     "deslop-js": "^0.0.12",

--- a/packages/core/src/get-diff-files.ts
+++ b/packages/core/src/get-diff-files.ts
@@ -5,25 +5,28 @@ import { Git, type GitDiffSelection } from "./services/git.js";
 import type { DiffInfo } from "@react-doctor/types";
 
 /**
- * Legacy synchronous façade. New callers should pull the `Git`
- * service directly via `yield* Git` inside their own Effect rather
- * than going through this wrapper — it exists so the existing CLI
- * code paths that aren't yet Effect-typed don't need to change.
+ * Programmatic façade over `Git.diffSelection`. Async because the
+ * Git service now runs through Effect's `ChildProcess` (true
+ * subprocess spawn, not `spawnSync`).
  *
- * Errors are unwrapped back into the historical `Error` shape:
+ * Errors are unwrapped back into the historical `Error` shape so
+ * existing thrown-class consumers continue to work:
  *  - empty base branch → `Error("Diff base branch cannot be empty.")`
- *  - non-existent base → `Error('Diff base branch "X" does not exist (run \`git fetch\` to update remote refs).')`
- *  - any other git failure → propagated cause
+ *  - non-existent base → `Error('Diff base branch "X" does not exist ...')`
+ *  - any other git failure → propagated cause via `Effect.runPromise`
  */
-export const getDiffInfo = (directory: string, explicitBaseBranch?: string): DiffInfo | null => {
-  const program = Effect.gen(function* () {
-    const git = yield* Git;
-    return yield* git.diffSelection({ directory, explicitBaseBranch });
-  });
-
+export const getDiffInfo = async (
+  directory: string,
+  explicitBaseBranch?: string,
+): Promise<DiffInfo | null> => {
   let selection: GitDiffSelection | null;
   try {
-    selection = runProgram(program);
+    selection = await Effect.runPromise(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.diffSelection({ directory, explicitBaseBranch });
+      }).pipe(Effect.provide(Git.layerNode)),
+    );
   } catch (cause) {
     if (cause instanceof ReactDoctorError) {
       if (cause.reason instanceof GitBaseBranchInvalid) {
@@ -44,9 +47,6 @@ export const getDiffInfo = (directory: string, explicitBaseBranch?: string): Dif
     ...(selection.isCurrentChanges ? { isCurrentChanges: true } : {}),
   };
 };
-
-const runProgram = <Value>(program: Effect.Effect<Value, ReactDoctorError, Git>): Value =>
-  Effect.runSync(program.pipe(Effect.provide(Git.layerNode)));
 
 export const filterSourceFiles = (filePaths: string[]): string[] =>
   filePaths.filter((filePath) => SOURCE_FILE_PATTERN.test(filePath));

--- a/packages/core/src/neutralize-disable-directives.ts
+++ b/packages/core/src/neutralize-disable-directives.ts
@@ -7,10 +7,10 @@ import { Git } from "./services/git.js";
 
 const DISABLE_DIRECTIVE_PATTERN = /(eslint|oxlint)-disable/;
 
-const findFilesWithDisableDirectivesViaGit = (
+const findFilesWithDisableDirectivesViaGit = async (
   rootDirectory: string,
   includePaths?: string[],
-): string[] | null => {
+): Promise<string[] | null> => {
   const program = Effect.gen(function* () {
     const git = yield* Git;
     return yield* git.grep({
@@ -25,7 +25,7 @@ const findFilesWithDisableDirectivesViaGit = (
 
   let grepResult: { readonly status: number; readonly stdout: string } | null;
   try {
-    grepResult = Effect.runSync(program.pipe(Effect.provide(Git.layerNode)));
+    grepResult = await Effect.runPromise(program.pipe(Effect.provide(Git.layerNode)));
   } catch {
     return null;
   }
@@ -83,8 +83,11 @@ const findFilesWithDisableDirectivesViaFilesystem = (
   return matches;
 };
 
-const findFilesWithDisableDirectives = (rootDirectory: string, includePaths?: string[]): string[] =>
-  findFilesWithDisableDirectivesViaGit(rootDirectory, includePaths) ??
+const findFilesWithDisableDirectives = async (
+  rootDirectory: string,
+  includePaths?: string[],
+): Promise<string[]> =>
+  (await findFilesWithDisableDirectivesViaGit(rootDirectory, includePaths)) ??
   findFilesWithDisableDirectivesViaFilesystem(rootDirectory, includePaths);
 
 const neutralizeContent = (content: string): string =>
@@ -92,11 +95,11 @@ const neutralizeContent = (content: string): string =>
     .replaceAll("eslint-disable", "eslint_disable")
     .replaceAll("oxlint-disable", "oxlint_disable");
 
-export const neutralizeDisableDirectives = (
+export const neutralizeDisableDirectives = async (
   rootDirectory: string,
   includePaths?: string[],
-): (() => void) => {
-  const filePaths = findFilesWithDisableDirectives(rootDirectory, includePaths);
+): Promise<() => void> => {
+  const filePaths = await findFilesWithDisableDirectives(rootDirectory, includePaths);
   const originalContents = new Map<string, string>();
 
   let isRestored = false;

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -490,7 +490,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   // `// oxlint-disable*` directives — we let oxlint apply them.
   const restoreDisableDirectives = respectInlineDisables
     ? () => {}
-    : neutralizeDisableDirectives(rootDirectory, includePaths);
+    : await neutralizeDisableDirectives(rootDirectory, includePaths);
 
   try {
     const oxlintBinary = resolveOxlintBinary();

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -1,8 +1,11 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
-import { DEFAULT_BRANCH_CANDIDATES, GIT_LS_FILES_MAX_BUFFER_BYTES } from "../constants.js";
+import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
+import { DEFAULT_BRANCH_CANDIDATES } from "../constants.js";
 import {
   GitBaseBranchInvalid,
   GitBaseBranchMissing,
@@ -10,49 +13,11 @@ import {
   ReactDoctorError,
 } from "../errors.js";
 
-interface GitInvocationOptions {
-  readonly maxBufferBytes?: number;
-  readonly allowNonZeroExit?: boolean;
-}
-
 interface GitInvocationResult {
-  readonly status: number | null;
+  readonly status: number;
   readonly stdout: string;
   readonly stderr: string;
 }
-
-/**
- * Internal Effect-typed git invocation. Wraps `spawnSync` so callers
- * stay synchronous (matches the existing react-doctor diff API). The
- * `Git` service exposes higher-level methods on top of this primitive
- * so call sites never touch `spawnSync` directly.
- */
-const invokeGitSync = (
-  directory: string,
-  args: ReadonlyArray<string>,
-  options: GitInvocationOptions = {},
-): Effect.Effect<GitInvocationResult, ReactDoctorError> =>
-  Effect.try({
-    try: (): GitInvocationResult => {
-      const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
-        cwd: directory,
-        stdio: ["ignore", "pipe", "pipe"],
-        encoding: "utf-8",
-        maxBuffer: options.maxBufferBytes ?? GIT_LS_FILES_MAX_BUFFER_BYTES,
-      };
-      const result = spawnSync("git", [...args], spawnOptions);
-      if (result.error) throw result.error;
-      return {
-        status: result.status,
-        stdout: result.stdout?.toString() ?? "",
-        stderr: result.stderr?.toString() ?? "",
-      };
-    },
-    catch: (cause) =>
-      new ReactDoctorError({
-        reason: new GitInvocationFailed({ args: [...args], directory, cause }),
-      }),
-  });
 
 const trimOrNull = (value: string): string | null => {
   const trimmed = value.trim();
@@ -79,6 +44,13 @@ interface GitDiffSelectionInput {
 }
 
 interface GitShowOptions {
+  /**
+   * Soft limit on the maximum bytes `git show :<path>` may return.
+   * Currently advisory — `ChildProcess`'s stream-based reader has
+   * no built-in cap. Kept on the interface so callers can document
+   * their expectations and so a future `Stream.takeWhile` byte
+   * counter can enforce it without changing call sites.
+   */
   readonly maxBufferBytes?: number;
 }
 
@@ -98,17 +70,16 @@ interface GitGrepResult {
 }
 
 /**
- * `Git` wraps every `git`-via-`spawnSync` call react-doctor makes
- * (current branch detection, diff-base resolution, `git diff`,
- * `git diff --cached`, `git grep`, `git show :<path>`) behind a
- * service interface so tests can swap in `layerOf({ ... })` snapshots
- * without spinning up a real repository, and so future async
- * conversion (via `ChildProcess` from `effect/unstable/process`) can
- * happen without disturbing call sites.
+ * `Git` wraps every `git`-via-subprocess call react-doctor makes
+ * behind a `Context.Service`. The production layer (`layerNode`)
+ * runs commands through Effect's `ChildProcessSpawner` + `ChildProcess.make`
+ * (from `effect/unstable/process`), so spawning, stdio draining,
+ * scope-bound cleanup, and error tagging all live inside the
+ * Effect runtime — no `node:child_process` imports outside this
+ * file. Tests swap in `layerOf({ ... })` for a deterministic snapshot.
  *
- * All methods raise `ReactDoctorError` with a `GitInvocationFailed`
- * reason when `git` itself can't run; "git ran but produced no
- * matches" still resolves successfully (with `null` / `[]`).
+ * All methods fail with `ReactDoctorError`; "git ran but produced
+ * no matches" still resolves successfully (with `null` / `[]`).
  */
 export class Git extends Context.Service<
   Git,
@@ -148,171 +119,211 @@ export class Git extends Context.Service<
     readonly grep: (input: GitGrepInput) => Effect.Effect<GitGrepResult | null, ReactDoctorError>;
   }
 >()("react-doctor/Git") {
-  static readonly layerNode: Layer.Layer<Git> = Layer.sync(Git, () => {
-    const currentBranch = (directory: string): Effect.Effect<string | null, ReactDoctorError> =>
-      invokeGitSync(directory, ["rev-parse", "--abbrev-ref", "HEAD"]).pipe(
-        Effect.map((result) => {
-          if (result.status !== 0) return null;
-          const branch = trimOrNull(result.stdout);
-          return branch === "HEAD" ? null : branch;
-        }),
-      );
+  static readonly layerNode: Layer.Layer<Git> = Layer.effect(
+    Git,
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner;
 
-    const defaultBranch = (directory: string): Effect.Effect<string | null, ReactDoctorError> =>
-      Effect.gen(function* () {
-        const symref = yield* invokeGitSync(directory, [
-          "symbolic-ref",
-          "refs/remotes/origin/HEAD",
-        ]);
-        if (symref.status === 0) {
-          const trimmed = trimOrNull(symref.stdout);
-          if (trimmed !== null) return trimmed.replace("refs/remotes/origin/", "");
-        }
-        const candidateRefs = DEFAULT_BRANCH_CANDIDATES.map(
-          (candidate) => `refs/heads/${candidate}`,
-        );
-        const candidates = yield* invokeGitSync(directory, [
-          "for-each-ref",
-          "--format=%(refname:short)",
-          ...candidateRefs,
-        ]);
-        if (candidates.status !== 0) return null;
-        return trimOrNull(candidates.stdout.split("\n")[0] ?? "");
-      });
-
-    const branchExists = (
-      directory: string,
-      branch: string,
-    ): Effect.Effect<boolean, ReactDoctorError> =>
-      invokeGitSync(directory, ["rev-parse", "--verify", branch]).pipe(
-        Effect.map((result) => result.status === 0),
-      );
-
-    return Git.of({
-      currentBranch,
-      defaultBranch,
-      branchExists,
-      diffSelection: ({ directory, explicitBaseBranch }) =>
-        Effect.gen(function* () {
-          if (explicitBaseBranch !== undefined && explicitBaseBranch.trim().length === 0) {
-            return yield* Effect.fail(
-              new ReactDoctorError({
-                reason: new GitBaseBranchInvalid({
-                  detail: "Diff base branch cannot be empty.",
-                }),
-              }),
+      /**
+       * Spawns `git <args>` via Effect's `ChildProcess` + the
+       * captured `ChildProcessSpawner`. Drains stdout / stderr /
+       * exitCode in parallel so the pipe never blocks on a full
+       * buffer, and folds any `PlatformError` (binary missing,
+       * ENOENT, EACCES, …) into the tagged `ReactDoctorError({
+       * reason: GitInvocationFailed })` so the rest of the codebase
+       * sees a single failure channel.
+       */
+      const runGit = (
+        directory: string,
+        args: ReadonlyArray<string>,
+      ): Effect.Effect<GitInvocationResult, ReactDoctorError> =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const handle = yield* spawner.spawn(
+              // HACK: `extendEnv: true` is required for the spawned
+              // git to inherit `process.env.PATH` — without it Effect's
+              // `ChildProcess` defaults to an empty env and `spawn`
+              // immediately fails with `ENOENT: git` even when git is
+              // on the user's PATH. (`spawnSync` inherited PATH by
+              // default; ChildProcess's option flips the polarity.)
+              ChildProcess.make("git", [...args], { cwd: directory, extendEnv: true }),
             );
+            const [stdout, stderr, status] = yield* Effect.all(
+              [
+                Stream.mkString(Stream.decodeText(handle.stdout)),
+                Stream.mkString(Stream.decodeText(handle.stderr)),
+                handle.exitCode,
+              ],
+              { concurrency: 3 },
+            );
+            return { status, stdout, stderr } satisfies GitInvocationResult;
+          }),
+        ).pipe(
+          Effect.catchTag(
+            "PlatformError",
+            (cause) =>
+              new ReactDoctorError({
+                reason: new GitInvocationFailed({ args: [...args], directory, cause }),
+              }),
+          ),
+        );
+
+      const currentBranch = (directory: string): Effect.Effect<string | null, ReactDoctorError> =>
+        runGit(directory, ["rev-parse", "--abbrev-ref", "HEAD"]).pipe(
+          Effect.map((result) => {
+            if (result.status !== 0) return null;
+            const branch = trimOrNull(result.stdout);
+            return branch === "HEAD" ? null : branch;
+          }),
+        );
+
+      const defaultBranch = (directory: string): Effect.Effect<string | null, ReactDoctorError> =>
+        Effect.gen(function* () {
+          const symref = yield* runGit(directory, ["symbolic-ref", "refs/remotes/origin/HEAD"]);
+          if (symref.status === 0) {
+            const trimmed = trimOrNull(symref.stdout);
+            if (trimmed !== null) return trimmed.replace("refs/remotes/origin/", "");
           }
+          const candidateRefs = DEFAULT_BRANCH_CANDIDATES.map(
+            (candidate) => `refs/heads/${candidate}`,
+          );
+          const candidates = yield* runGit(directory, [
+            "for-each-ref",
+            "--format=%(refname:short)",
+            ...candidateRefs,
+          ]);
+          if (candidates.status !== 0) return null;
+          return trimOrNull(candidates.stdout.split("\n")[0] ?? "");
+        });
 
-          const resolvedCurrentBranch = yield* currentBranch(directory);
-          // Detached HEAD is still scannable when an explicit base
-          // resolves a merge-base, so we only abandon when both the
-          // branch is detached AND the caller didn't pin a base.
-          if (resolvedCurrentBranch === null && explicitBaseBranch === undefined) return null;
+      const branchExists = (
+        directory: string,
+        branch: string,
+      ): Effect.Effect<boolean, ReactDoctorError> =>
+        runGit(directory, ["rev-parse", "--verify", branch]).pipe(
+          Effect.map((result) => result.status === 0),
+        );
 
-          const baseBranch = explicitBaseBranch ?? (yield* defaultBranch(directory));
-          if (baseBranch === null) return null;
-
-          if (explicitBaseBranch !== undefined) {
-            const exists = yield* branchExists(directory, explicitBaseBranch);
-            if (!exists) {
+      return Git.of({
+        currentBranch,
+        defaultBranch,
+        branchExists,
+        diffSelection: ({ directory, explicitBaseBranch }) =>
+          Effect.gen(function* () {
+            if (explicitBaseBranch !== undefined && explicitBaseBranch.trim().length === 0) {
               return yield* Effect.fail(
                 new ReactDoctorError({
-                  reason: new GitBaseBranchMissing({ branch: explicitBaseBranch }),
+                  reason: new GitBaseBranchInvalid({
+                    detail: "Diff base branch cannot be empty.",
+                  }),
                 }),
               );
             }
-          }
 
-          if (resolvedCurrentBranch !== null && resolvedCurrentBranch === baseBranch) {
-            const uncommitted = yield* invokeGitSync(directory, [
+            const resolvedCurrentBranch = yield* currentBranch(directory);
+            // Detached HEAD is still scannable when an explicit base
+            // resolves a merge-base, so we only abandon when both the
+            // branch is detached AND the caller didn't pin a base.
+            if (resolvedCurrentBranch === null && explicitBaseBranch === undefined) return null;
+
+            const baseBranch = explicitBaseBranch ?? (yield* defaultBranch(directory));
+            if (baseBranch === null) return null;
+
+            if (explicitBaseBranch !== undefined) {
+              const exists = yield* branchExists(directory, explicitBaseBranch);
+              if (!exists) {
+                return yield* Effect.fail(
+                  new ReactDoctorError({
+                    reason: new GitBaseBranchMissing({ branch: explicitBaseBranch }),
+                  }),
+                );
+              }
+            }
+
+            if (resolvedCurrentBranch !== null && resolvedCurrentBranch === baseBranch) {
+              const uncommitted = yield* runGit(directory, [
+                "diff",
+                "-z",
+                "--name-only",
+                "--diff-filter=ACMR",
+                "--relative",
+                "HEAD",
+              ]);
+              if (uncommitted.status !== 0) return null;
+              const files = splitNullSeparated(uncommitted.stdout);
+              if (files.length === 0) return null;
+              return {
+                currentBranch: resolvedCurrentBranch,
+                baseBranch,
+                changedFiles: files,
+                isCurrentChanges: true,
+              } satisfies GitDiffSelection;
+            }
+
+            const mergeBase = yield* runGit(directory, ["merge-base", baseBranch, "HEAD"]);
+            if (mergeBase.status !== 0) return null;
+            const mergeBaseRef = trimOrNull(mergeBase.stdout);
+            if (mergeBaseRef === null) return null;
+
+            const diff = yield* runGit(directory, [
               "diff",
               "-z",
               "--name-only",
               "--diff-filter=ACMR",
               "--relative",
-              "HEAD",
+              mergeBaseRef,
             ]);
-            if (uncommitted.status !== 0) return null;
-            const files = splitNullSeparated(uncommitted.stdout);
-            if (files.length === 0) return null;
+            if (diff.status !== 0) return null;
             return {
               currentBranch: resolvedCurrentBranch,
               baseBranch,
-              changedFiles: files,
-              isCurrentChanges: true,
+              changedFiles: splitNullSeparated(diff.stdout),
+              isCurrentChanges: false,
             } satisfies GitDiffSelection;
-          }
-
-          const mergeBase = yield* invokeGitSync(directory, ["merge-base", baseBranch, "HEAD"]);
-          if (mergeBase.status !== 0) return null;
-          const mergeBaseRef = trimOrNull(mergeBase.stdout);
-          if (mergeBaseRef === null) return null;
-
-          const diff = yield* invokeGitSync(directory, [
+          }),
+        stagedFilePaths: (directory) =>
+          runGit(directory, [
             "diff",
+            "--cached",
             "-z",
             "--name-only",
             "--diff-filter=ACMR",
             "--relative",
-            mergeBaseRef,
-          ]);
-          if (diff.status !== 0) return null;
-          return {
-            currentBranch: resolvedCurrentBranch,
-            baseBranch,
-            changedFiles: splitNullSeparated(diff.stdout),
-            isCurrentChanges: false,
-          } satisfies GitDiffSelection;
-        }),
-      stagedFilePaths: (directory) =>
-        invokeGitSync(directory, [
-          "diff",
-          "--cached",
-          "-z",
-          "--name-only",
-          "--diff-filter=ACMR",
-          "--relative",
-        ]).pipe(
-          Effect.map((result) => {
-            if (result.status !== 0) return [] as ReadonlyArray<string>;
-            return splitNullSeparated(result.stdout);
+          ]).pipe(
+            Effect.map((result) => {
+              if (result.status !== 0) return [] as ReadonlyArray<string>;
+              return splitNullSeparated(result.stdout);
+            }),
+          ),
+        showStagedContent: (directory, relativePath) =>
+          runGit(directory, ["show", `:${relativePath}`]).pipe(
+            Effect.map((result) => (result.status === 0 ? result.stdout : null)),
+          ),
+        grep: (input) =>
+          Effect.gen(function* () {
+            const args: string[] = ["grep"];
+            if (input.listMatchingFiles ?? true) args.push("-l");
+            if (input.includeUntracked ?? false) args.push("--untracked");
+            if (input.extendedRegexp ?? false) args.push("-E");
+            args.push(input.pattern);
+            if (input.includePaths && input.includePaths.length > 0) {
+              args.push("--", ...input.includePaths);
+            }
+            const result = yield* runGit(input.directory, args);
+            // Status 128 = "not a git repo" → caller should fall back.
+            if (result.status === 128) return null;
+            return { status: result.status, stdout: result.stdout } satisfies GitGrepResult;
           }),
-        ),
-      showStagedContent: (directory, relativePath, options) =>
-        invokeGitSync(directory, ["show", `:${relativePath}`], {
-          maxBufferBytes: options?.maxBufferBytes,
-        }).pipe(Effect.map((result) => (result.status === 0 ? result.stdout : null))),
-      grep: (input) =>
-        Effect.gen(function* () {
-          const args: string[] = ["grep"];
-          if (input.listMatchingFiles ?? true) args.push("-l");
-          if (input.includeUntracked ?? false) args.push("--untracked");
-          if (input.extendedRegexp ?? false) args.push("-E");
-          args.push(input.pattern);
-          if (input.includePaths && input.includePaths.length > 0) {
-            args.push("--", ...input.includePaths);
-          }
-          const result = yield* invokeGitSync(input.directory, args, {
-            maxBufferBytes: input.maxBufferBytes,
-          });
-          // Status null = git wasn't found (already raised by `invokeGitSync`).
-          // Status 128 = not a git repo → caller should fall back.
-          if (result.status === null || result.status === 128) return null;
-          return { status: result.status, stdout: result.stdout } satisfies GitGrepResult;
-        }),
-    });
-  });
+      });
+    }),
+  ).pipe(Layer.provide(NodeServices.layer));
 
   /**
-   * Test layer driven by a deterministic `Map<command, response>`.
-   * Each key is the joined git argv (e.g. `"diff -z --name-only ..."`)
-   * and each value is the canned `GitInvocationResult`. Unknown
-   * commands resolve to a `status: 1, stdout: ""` (mirroring
-   * "ran but no output") so tests don't have to enumerate every
-   * subcommand the production path might issue. Two convenience
-   * snapshots — `currentBranch` and `stagedFiles` — short-circuit
-   * the two most common test fixtures.
+   * Test layer driven by a deterministic snapshot. Each key is a
+   * convenience pre-canned response so tests don't have to enumerate
+   * every subcommand the production path might issue. Missing keys
+   * resolve to safe defaults (current branch null, no staged files,
+   * grep returns null = "git unavailable, fall back").
    */
   static readonly layerOf = (snapshot: {
     readonly currentBranch?: string | null;

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
       entry: { index: "./src/index.ts" },
       deps: {
         neverBundle: [
+          "@effect/platform-node",
           "deslop-js",
           "effect",
           "oxc-parser",

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -55,6 +55,7 @@
     "test": "vp test run"
   },
   "dependencies": {
+    "@effect/platform-node": "4.0.0-beta.70",
     "agent-install": "0.0.5",
     "deslop-js": "^0.0.12",
     "effect": "4.0.0-beta.70",

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -89,7 +89,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
     if (flags.staged) {
       setJsonReportMode("staged");
-      const stagedFiles = getStagedSourceFiles(resolvedDirectory);
+      const stagedFiles = await getStagedSourceFiles(resolvedDirectory);
       if (stagedFiles.length === 0) {
         if (isJsonMode) {
           writeJsonReport(
@@ -114,7 +114,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       }
 
       const tempDirectory = mkdtempSync(path.join(tmpdir(), STAGED_FILES_TEMP_DIR_PREFIX));
-      const snapshot = materializeStagedFiles(resolvedDirectory, stagedFiles, tempDirectory);
+      const snapshot = await materializeStagedFiles(resolvedDirectory, stagedFiles, tempDirectory);
       try {
         const scanResult = await inspect(snapshot.tempDirectory, {
           ...scanOptions,
@@ -178,7 +178,9 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
     // "Only scan changed files?" prompt never appears for users on a
     // feature branch who didn't explicitly pass --diff.
     const shouldDetectDiff = wantsDiffMode || (!skipPrompts && !isQuiet);
-    const diffInfo = shouldDetectDiff ? getDiffInfo(resolvedDirectory, explicitBaseBranch) : null;
+    const diffInfo = shouldDetectDiff
+      ? await getDiffInfo(resolvedDirectory, explicitBaseBranch)
+      : null;
     const isDiffMode = await resolveDiffMode(diffInfo, effectiveDiff, skipPrompts, isQuiet);
 
     // HACK: set the report-mode marker BEFORE the scan loop runs — if the
@@ -208,7 +210,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         const projectDiffInfo =
           projectDirectory === resolvedDirectory
             ? diffInfo
-            : getDiffInfo(projectDirectory, explicitBaseBranch);
+            : await getDiffInfo(projectDirectory, explicitBaseBranch);
         if (projectDiffInfo) {
           const changedSourceFiles = filterSourceFiles(projectDiffInfo.changedFiles);
           if (changedSourceFiles.length === 0) {

--- a/packages/react-doctor/src/cli/utils/get-staged-files.ts
+++ b/packages/react-doctor/src/cli/utils/get-staged-files.ts
@@ -4,9 +4,9 @@ import { Git, StagedFiles, type StagedSnapshot } from "@react-doctor/core";
 
 const stagedFilesLayer = StagedFiles.layerNode.pipe(Layer.provide(Git.layerNode));
 
-export const getStagedSourceFiles = (directory: string): string[] => {
+export const getStagedSourceFiles = async (directory: string): Promise<string[]> => {
   try {
-    const files = Effect.runSync(
+    const files = await Effect.runPromise(
       Effect.gen(function* () {
         const stagedFiles = yield* StagedFiles;
         return yield* stagedFiles.discoverSourceFiles(directory);
@@ -24,12 +24,12 @@ interface MaterializeResult {
   cleanup: () => void;
 }
 
-export const materializeStagedFiles = (
+export const materializeStagedFiles = async (
   directory: string,
   stagedFiles: string[],
   tempDirectory: string,
-): MaterializeResult => {
-  const snapshot: StagedSnapshot = Effect.runSync(
+): Promise<MaterializeResult> => {
+  const snapshot: StagedSnapshot = await Effect.runPromise(
     Effect.gen(function* () {
       const staged = yield* StagedFiles;
       return yield* staged.materialize({ directory, stagedFiles, tempDirectory });

--- a/packages/react-doctor/tests/regressions/diff-detached-head.test.ts
+++ b/packages/react-doctor/tests/regressions/diff-detached-head.test.ts
@@ -62,7 +62,7 @@ const buildPullRequestCheckoutFixture = (
 };
 
 describe("issue #298: --diff respects explicit base on detached HEAD", () => {
-  it("returns the changed file when given an explicit base branch and HEAD is detached", () => {
+  it("returns the changed file when given an explicit base branch and HEAD is detached", async () => {
     const { repoDir, changedFilePath } = buildPullRequestCheckoutFixture("detached-with-base");
 
     // Sanity-check the fixture: `rev-parse --abbrev-ref HEAD` returns
@@ -73,24 +73,24 @@ describe("issue #298: --diff respects explicit base on detached HEAD", () => {
     });
     expect(headRef.stdout.toString().trim()).toBe("HEAD");
 
-    const diffInfo = getDiffInfo(repoDir, "master");
+    const diffInfo = await getDiffInfo(repoDir, "master");
     expect(diffInfo).not.toBeNull();
     expect(diffInfo?.baseBranch).toBe("master");
     expect(diffInfo?.currentBranch).toBeNull();
     expect(diffInfo?.changedFiles).toEqual([changedFilePath]);
   });
 
-  it("still returns null on detached HEAD when no explicit base is given (cannot infer scope)", () => {
+  it("still returns null on detached HEAD when no explicit base is given (cannot infer scope)", async () => {
     const { repoDir } = buildPullRequestCheckoutFixture("detached-no-base");
-    expect(getDiffInfo(repoDir)).toBeNull();
+    await expect(getDiffInfo(repoDir)).resolves.toBeNull();
   });
 
-  it("still throws the existing 'base does not exist' error on detached HEAD with a bogus base", () => {
+  it("still throws the existing 'base does not exist' error on detached HEAD with a bogus base", async () => {
     const { repoDir } = buildPullRequestCheckoutFixture("detached-bogus-base");
-    expect(() => getDiffInfo(repoDir, "origin/does-not-exist")).toThrow(/does not exist/);
+    await expect(getDiffInfo(repoDir, "origin/does-not-exist")).rejects.toThrow(/does not exist/);
   });
 
-  it("keeps the attached-HEAD path working when explicit base is given", () => {
+  it("keeps the attached-HEAD path working when explicit base is given", async () => {
     const repoDir = path.join(tempRoot, "attached-with-base");
     fs.mkdirSync(repoDir, { recursive: true });
     writeFile(path.join(repoDir, "src", "app.tsx"), "export const App = () => null;\n");
@@ -102,7 +102,7 @@ describe("issue #298: --diff respects explicit base on detached HEAD", () => {
     writeFile(path.join(repoDir, changedFilePath), "export const Feature = () => null;\n");
     commitAll(repoDir, "add feature");
 
-    const diffInfo = getDiffInfo(repoDir, "main");
+    const diffInfo = await getDiffInfo(repoDir, "main");
     expect(diffInfo).not.toBeNull();
     expect(diffInfo?.currentBranch).toBe("feature");
     expect(diffInfo?.baseBranch).toBe("main");

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -271,7 +271,7 @@ describe("issue #275 + #290: filesystem walks tolerate EPERM/EACCES (macOS Libra
 });
 
 describe("issue #115: --staged uses git INDEX content, not working tree", () => {
-  it("getStagedSourceFiles returns staged JSX/TSX paths from the index", () => {
+  it("getStagedSourceFiles returns staged JSX/TSX paths from the index", async () => {
     const repoDir = path.join(tempRoot, "issue-115-paths");
     fs.mkdirSync(path.join(repoDir, "src"), { recursive: true });
     writeJson(path.join(repoDir, "package.json"), { name: "staged-paths" });
@@ -281,12 +281,12 @@ describe("issue #115: --staged uses git INDEX content, not working tree", () => 
     initGitRepo(repoDir);
     spawnSync("git", ["add", "src/App.tsx", "src/ignored.txt"], { cwd: repoDir });
 
-    const stagedFiles = getStagedSourceFiles(repoDir);
+    const stagedFiles = await getStagedSourceFiles(repoDir);
     expect(stagedFiles).toContain("src/App.tsx");
     expect(stagedFiles).not.toContain("src/ignored.txt");
   });
 
-  it("materializeStagedFiles snapshots INDEX content even when working tree differs", () => {
+  it("materializeStagedFiles snapshots INDEX content even when working tree differs", async () => {
     const repoDir = path.join(tempRoot, "issue-115-snapshot");
     fs.mkdirSync(path.join(repoDir, "src"), { recursive: true });
     writeJson(path.join(repoDir, "package.json"), { name: "staged-snapshot" });
@@ -301,11 +301,11 @@ describe("issue #115: --staged uses git INDEX content, not working tree", () => 
     spawnSync("git", ["add", "src/App.tsx"], { cwd: repoDir });
     writeFile(path.join(repoDir, "src", "App.tsx"), "export const WORKING_TREE = 3;\n");
 
-    const stagedFiles = getStagedSourceFiles(repoDir);
+    const stagedFiles = await getStagedSourceFiles(repoDir);
     expect(stagedFiles).toEqual(["src/App.tsx"]);
 
     const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-staged-snapshot-"));
-    const snapshot = materializeStagedFiles(repoDir, stagedFiles, tempDirectory);
+    const snapshot = await materializeStagedFiles(repoDir, stagedFiles, tempDirectory);
     try {
       const snapshotted = fs.readFileSync(
         path.join(snapshot.tempDirectory, "src", "App.tsx"),
@@ -318,12 +318,12 @@ describe("issue #115: --staged uses git INDEX content, not working tree", () => 
     }
   });
 
-  it("getStagedSourceFiles returns [] for a repo with nothing staged", () => {
+  it("getStagedSourceFiles returns [] for a repo with nothing staged", async () => {
     const repoDir = path.join(tempRoot, "issue-115-empty");
     fs.mkdirSync(repoDir, { recursive: true });
     writeJson(path.join(repoDir, "package.json"), { name: "empty-staged" });
     initGitRepo(repoDir);
-    expect(getStagedSourceFiles(repoDir)).toEqual([]);
+    await expect(getStagedSourceFiles(repoDir)).resolves.toEqual([]);
   });
 });
 

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
         // stay external.
         alwaysBundle: ["commander", "ora"],
         neverBundle: [
+          "@effect/platform-node",
           "agent-install",
           // HACK: deslop-js wraps oxc-parser / oxc-resolver, both of
           // which load platform-specific NAPI bindings via require().
@@ -106,6 +107,7 @@ export default defineConfig({
       deps: {
         alwaysBundle: ["commander", "ora"],
         neverBundle: [
+          "@effect/platform-node",
           "agent-install",
           "deslop-js",
           "effect",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.70
+        version: 4.0.0-beta.70(effect@4.0.0-beta.70)(ioredis@5.10.1)
       '@react-doctor/project-info':
         specifier: workspace:*
         version: link:../project-info
@@ -137,6 +140,9 @@ importers:
 
   packages/react-doctor:
     dependencies:
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.70
+        version: 4.0.0-beta.70(effect@4.0.0-beta.70)(ioredis@5.10.1)
       agent-install:
         specifier: 0.0.5
         version: 0.0.5
@@ -364,6 +370,19 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@effect/platform-node-shared@4.0.0-beta.70':
+    resolution: {integrity: sha512-3VXuL63IDmq13We+ApRKn2JW3Rb9g5gj1YEmfb8u2b73norur1VsIJ/pRE4qjShevg19dQYi2JsLawSZ6gApug==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-beta.70
+
+  '@effect/platform-node@4.0.0-beta.70':
+    resolution: {integrity: sha512-Ls1WtLaO2CbcO8jHtZRRi6eZa4YOJZ9KXm6udMvwhjV/XhqdsT6AzmcXbc1hINbKgvRcik6qM/441YEaBMYoqw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-beta.70
+      ioredis: ^5.7.0
 
   '@effect/vitest@4.0.0-beta.70':
     resolution: {integrity: sha512-XDteNN0xfOgoMauAVoN5iylxVgEjp7kFsGFq18tZ5XYjek0eOZa0nOoes5s7Bs71VvwjnCeCbFMD7IhxswEt8A==}
@@ -754,6 +773,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1709,6 +1731,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/types@8.59.3':
     resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2028,6 +2053,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2069,6 +2098,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   deslop-js@0.0.12:
     resolution: {integrity: sha512-DsoVhhrgdqjkHxD9zFFJS7r+wDkbbpbdYVfwTNo6s89xTDbZQ9xW0EOd17a45Cfo1z0KxJQkjtJi/fHZ/LpBPA==}
@@ -2322,6 +2355,10 @@ packages:
     resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2489,6 +2526,12 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2517,6 +2560,11 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2759,6 +2807,14 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2847,6 +2903,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -2969,6 +3028,10 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@8.3.0:
+    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+    engines: {node: '>=22.19.0'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3399,6 +3462,26 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@effect/platform-node-shared@4.0.0-beta.70(effect@4.0.0-beta.70)':
+    dependencies:
+      '@types/ws': 8.18.1
+      effect: 4.0.0-beta.70
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@4.0.0-beta.70(effect@4.0.0-beta.70)(ioredis@5.10.1)':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-beta.70(effect@4.0.0-beta.70)
+      effect: 4.0.0-beta.70
+      ioredis: 5.10.1
+      mime: 4.1.0
+      undici: 8.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/vitest@4.0.0-beta.70(effect@4.0.0-beta.70)(vitest@4.1.7(@types/node@25.6.0)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0)))':
     dependencies:
       effect: 4.0.0-beta.70
@@ -3660,6 +3743,8 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 25.6.0
+
+  '@ioredis/commands@1.5.1': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4241,6 +4326,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@typescript-eslint/types@8.59.3': {}
 
   '@vercel/analytics@2.0.1(next@16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
@@ -4466,6 +4555,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4496,6 +4587,8 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  denque@2.1.0: {}
 
   deslop-js@0.0.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
@@ -4797,6 +4890,20 @@ snapshots:
 
   ini@7.0.0: {}
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -4916,6 +5023,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.startcase@4.4.0: {}
@@ -4943,6 +5054,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime@4.1.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -5249,6 +5362,12 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -5375,6 +5494,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standard-as-callback@2.1.0: {}
+
   std-env@4.0.0: {}
 
   stdin-discarder@0.3.2: {}
@@ -5467,6 +5588,8 @@ snapshots:
   typescript@6.0.3: {}
 
   undici-types@7.19.2: {}
+
+  undici@8.3.0: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
## Summary

The last imperative \`node:child_process.spawnSync\` call in the Git service path is gone. \`Git.layerNode\` now spawns through **Effect v4's native subprocess primitives** from \`effect/unstable/process\` + \`@effect/platform-node\`'s \`NodeServices.layer\`.

This is the same pattern the eval uses (\`spawner.spawn(ChildProcess.make(...))\` → drain stdout / exitCode in parallel → wrap PlatformError into a tagged \`ReactDoctorError\`).

## What changed

### \`Git.layerNode\` rewrite

\`\`\`ts
const runGit = (directory, args) =>
  Effect.scoped(
    Effect.gen(function* () {
      const handle = yield* spawner.spawn(
        ChildProcess.make("git", [...args], { cwd: directory, extendEnv: true })
      )
      const [stdout, stderr, status] = yield* Effect.all(
        [
          Stream.mkString(Stream.decodeText(handle.stdout)),
          Stream.mkString(Stream.decodeText(handle.stderr)),
          handle.exitCode,
        ],
        { concurrency: 3 }
      )
      return { status, stdout, stderr }
    })
  ).pipe(
    Effect.catchTag("PlatformError", (cause) =>
      new ReactDoctorError({ reason: new GitInvocationFailed({ args, directory, cause }) })
    )
  )
\`\`\`

- \`ChildProcess.make\` from \`effect/unstable/process\` — builds the Command AST
- \`ChildProcessSpawner\` (provided by \`NodeServices.layer\`) — spawns the subprocess
- \`Stream.decodeText\` + \`Stream.mkString\` + \`Effect.all\` with concurrency: stdout/stderr/exitCode drain in parallel so the pipe never blocks on a full buffer
- \`Effect.scoped\` — binds the process to a Scope so cancellation cleans up
- \`Effect.catchTag("PlatformError", ...)\` — folds the platform error into the existing tagged \`ReactDoctorError({ reason: GitInvocationFailed })\` so the rest of the codebase keeps its uniform failure channel

### \`extendEnv: true\` HACK (worth knowing)

Effect's \`ChildProcess.make\` defaults \`extendEnv\` to undefined, which means the spawned process inherits **no environment variables** (empty PATH → \`spawn git ENOENT\` even when git is on the user's PATH). \`spawnSync\` had the opposite default. Setting \`extendEnv: true\` restores the historical behavior; commented in the source as a HACK so future readers don't burn an hour on it. Found via failing \`diff-detached-head.test.ts\`.

### Async cascade

Every \`Git\` service method already returned \`Effect<X, ReactDoctorError>\`, but the production layer was sync (\`Effect.try(spawnSync(...))\`). The new layer is **truly async** via \`ChildProcess\`, so the legacy sync façades flip from \`Effect.runSync\` to \`Effect.runPromise\` and become \`Promise\`-returning:

- \`getDiffInfo(directory, base?)\` → \`Promise<DiffInfo | null>\`
- \`getStagedSourceFiles(directory)\` → \`Promise<string[]>\`
- \`materializeStagedFiles(directory, files, tempDir)\` → \`Promise<MaterializeResult>\`
- \`neutralizeDisableDirectives(directory, includePaths?)\` → \`Promise<() => void>\`

Production callers (\`cli/commands/inspect.ts\`, \`run-oxlint.ts\`) were already inside async functions, so they only needed added \`await\`s. The two regression test files (\`diff-detached-head.test.ts\`, \`scan-resilience.test.ts\`) got the same \`await\` treatment and flipped their assertions to the Promise-aware counterparts (\`resolves.toBeNull\`, \`resolves.toEqual\`, \`rejects.toThrow\`).

### Dependency

Adds **\`@effect/platform-node@4.0.0-beta.70\`** to \`@react-doctor/core\` (matches the existing \`effect\` version pin). The Node platform services pull in \`FileSystem\` + \`Path\` (transitively required by \`NodeChildProcessSpawner\`). Bundle stays small because we import it via \`import * as NodeServices from "@effect/platform-node/NodeServices"\` and the dep stays external in both \`@react-doctor/core\` and \`react-doctor\` (\`neverBundle\`).

## Test plan

- [x] \`pnpm typecheck\` — all packages clean
- [x] \`pnpm test\` — full suite (1442 tests / 113 files) green
- [x] \`pnpm lint\` / \`pnpm format\` clean
- [x] \`pnpm smoke:json-report\` — JSON output round-trip OK with the new async path

## Stack

- \`✓\` #421 / #427 (Logger service + wiring — superseded by #432)
- \`✓\` #426 (Git service) — **merged**
- \`✓\` #431 (NodeResolver + StagedFiles services) — **merged**
- 🚧 #432 (drop custom Logger → Effect.Console pivot) — open
- **this PR (PR 14)** — Git: spawnSync → ChildProcess (proper Effect v4 subprocess)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches git invocation from synchronous `spawnSync` to Effect-managed subprocesses and cascades async (`Promise`) API changes through CLI and tests; risk is mainly behavioral/regression around process spawning, env inheritance, and diff/staged detection.
> 
> **Overview**
> Replaces the core `Git.layerNode` implementation from `spawnSync`-based calls to Effect v4’s subprocess runtime (`ChildProcessSpawner`/`ChildProcess.make`), including scoped process management, parallel stdout/stderr draining, and mapping platform failures into existing `ReactDoctorError` tags.
> 
> This change cascades sync wrappers to async: `getDiffInfo`, staged-file helpers, and disable-directive neutralization now return `Promise`s and call sites (`inspect` command, `runOxlint`) and regression tests are updated to `await` and use promise-aware assertions. Adds `@effect/platform-node` as a dependency (kept external in bundling configs) to provide Node services for subprocess spawning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe2413d91b97f766846fca8598a8f8f1c299943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->