### PR TITLE
docs+refactor: adopt eval-canonical Effect v4 patterns; .specs + CONTEXT.md [16/?]

### DIFF
--- a/.specs/inspect-pipeline.md
+++ b/.specs/inspect-pipeline.md
@@ -1,0 +1,228 @@
+# Spec: `inspect()` pipeline
+
+The streaming Effect orchestrator that turns "a directory on disk" into a structured `InspectOutput`. Owns the entire scan side of react-doctor; the CLI and the programmatic `diagnose()` API are both thin shells around it.
+
+Lives in `packages/core/src/run-inspect.ts`. Wires 9 services (`Project`, `Config`, `Files`, `Linter`, `LintPartialFailures`, `DeadCode`, `Reporter`, `Score`, plus `Git` transitively via `StagedFiles` for the staged-mode façade) into a single `Stream<Diagnostic, ReactDoctorError>` and folds the result into `InspectOutput`.
+
+## Design constraints
+
+- **One Effect program**. No imperative `Promise.all` glue, no `async/await` inside the orchestration. The whole pipeline is a `Stream` so a future LSP host or watch-mode caller can swap `Stream.runCollect` for `Stream.runForEach(connection.sendDiagnostic)` without changing the orchestrator.
+- **Failures are tagged, never thrown**. Lint / dead-code stream failures fold into a `Ref` via `Stream.catchTag("ReactDoctorError", ...)`. They do NOT sink the scan — the renderer reports them as `skippedChecks: ["lint"]` / `["dead-code"]` and the rest of the diagnostics still flow.
+- **No "hidden" service dependencies**. Every service the orchestrator yields appears in the `Effect.Effect<…, ReactDoctorError, R>` requirement, so a caller that omits a Layer gets a compile error, not a runtime crash.
+- **Per-element transforms are pure**. The auto-suppress / severity-override / ignore / inline-disable pipeline (`build-diagnostic-pipeline.ts`) is a single `Filter.fromPredicateOption` over each diagnostic. No state, no IO inside the filter — the file-reads it needs are batched through the `Files` service ahead of time.
+- **Hooks vs services**. `InspectHooks` is for caller-side UI bookkeeping (CLI spinner lifecycle, project-detection block). Anything that needs to observe every diagnostic is a `Reporter` layer instead — that's the side-channel for future LSP / NDJSON / capture-for-test consumers.
+- **Surface filtering happens outside**. `runInspect` returns ALL surviving diagnostics; the renderer applies `filterDiagnosticsForSurface("cli" | "score" | "ciFailure", …)` per output target. Keeps the orchestrator agnostic to who's consuming it.
+
+## Service map
+
+| Service               | Purpose                                                                                                          | Live layer                                                               | Test surface                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------ |
+| `Project`             | Discover the React project at a directory (framework, react version, tailwind, etc.).                            | `layerNode` (wraps `@react-doctor/project-info`)                         | `layerOf(projectInfo)`                                 |
+| `Config`              | Resolve `react-doctor.config.json` + `rootDir` redirect; cached.                                                 | `layerNode` (`Cache.make`-backed)                                        | `layerOf({ config, resolvedDirectory })`               |
+| `Files`               | Read source-file lines + walk source files; abstracts `node:fs` for the per-element pipeline.                    | `layerNode`                                                              | `layerInMemory(Map<absolutePath, content>)`            |
+| `Linter`              | Produces `Stream<Diagnostic, ReactDoctorError, LintPartialFailures>` from oxlint.                                | `layerOxlint` (wraps `runOxlint`)                                        | `layerOf(diagnostics[])`, `layerComposite(backends[])` |
+| `LintPartialFailures` | `Ref<ReadonlyArray<string>>` for per-batch soft failures that surface to the renderer but don't fail the stream. | `layerLive`                                                              | n/a — service is just a `Ref` shape                    |
+| `DeadCode`            | Whole-project reachability analysis.                                                                             | `layerNode` (wraps `checkDeadCode`)                                      | `layerOf(diagnostics[])`                               |
+| `Reporter`            | Per-diagnostic side-channel (LSP push, NDJSON sink, capture for tests).                                          | `layerNoop` (production: scan returns the array via `Stream.runCollect`) | `layerCapture(ref)`, `layerNdjson(path)`               |
+| `Score`               | Compute the headline 0–100 score from a diagnostic list.                                                         | `layerHttp` (POSTs to the score API)                                     | `layerOf(scoreResult \| null)`                         |
+| `Git` (transitive)    | DI seam for every `spawnSync("git", ...)` call in the codebase. Used by `StagedFiles` + diff/staged façades.     | `layerNode` (uses Effect `ChildProcess` via `@effect/platform-node`)     | `layerOf({ stagedFiles, diffSelection, … })`           |
+
+## Module map
+
+```
+packages/core/src/
+  run-inspect.ts             # the orchestrator (this spec)
+  build-diagnostic-pipeline  # per-element filter (auto-suppress / severity / ignore / inline-disable)
+  errors.ts                  # 12 Schema.TaggedErrorClass leaves + ReactDoctorError union
+  schemas.ts                 # Diagnostic, Severity, JsonReport (Schema.Class wire types)
+  refs.ts                    # Context.Reference for ambient env / cache config
+  paths.ts                   # branded OxlintBinaryPath / NodeBinaryPath
+  services/
+    config.ts                # Cache.make-backed config resolver
+    dead-code.ts             # checkDeadCode wrapper as a Stream
+    files.ts                 # readLines / listSourceFiles / isFile / isDirectory
+    git.ts                   # Effect ChildProcess wrapper (spawnSync replaced PR 14)
+    linter.ts                # runOxlint wrapper + LintPartialFailures companion Ref
+    node-resolver.ts         # nvm / Node-version compatibility for the oxlint binding
+    progress.ts              # spinner / progress reporter (ora-backed in CLI)
+    project.ts               # @react-doctor/project-info wrapper
+    reporter.ts              # per-diagnostic side-channel
+    score.ts                 # score API client (HTTP)
+    staged-files.ts          # materialize git-staged files into temp tree
+```
+
+## Pipeline (Stream-shape)
+
+```
+Stream.fromIterable(checkReducedMotion env diagnostics)
+  ├─ Stream.concat(rawLintStream)
+  │   └─ rawLintStream = linterService.run({...}).pipe(
+  │        Stream.catchTag("ReactDoctorError", (e) => Stream.unwrap(
+  │          Ref.set(lintFailure, {didFail: true, reason: e.message, reasonTag: e.reason._tag})
+  │            .pipe(Effect.as(Stream.empty))
+  │        ))
+  │      )
+  ├─ Stream.concat(deadCodeStream)        // gated on `runDeadCode && !isDiffMode`, same catchTag shape
+  ├─ Stream.filterMap(perElementPipeline.apply)  // Filter.fromPredicateOption — pure, no IO
+  └─ Stream.tap(reporterService.emit)      // side-channel (noop in prod, NDJSON in eval, push in LSP)
+
+const survivingDiagnostics = yield* Stream.runCollect(transformedStream)
+yield* reporterService.finalize
+
+const score = lintFailureState.didFail
+  ? null                                    // skip the score API when lint didn't run
+  : yield* scoreService.compute({ diagnostics: surviving, isCi })
+```
+
+## Failure folding (the only place `catchTag` lives)
+
+Two Refs hold the soft-failure state on the orchestrator side:
+
+```ts
+const lintFailure = yield* Ref.make<{
+  didFail: boolean
+  reason: string | null
+  reasonTag: ReactDoctorErrorReason["_tag"] | null   // for renderer dispatch
+}>({ didFail: false, reason: null, reasonTag: null })
+
+const deadCodeFailure = yield* Ref.make<{ didFail: boolean; reason: string | null }>(...)
+```
+
+`Stream.catchTag("ReactDoctorError", ...)` on each producer drains the failure into the Ref and substitutes `Stream.empty`. The orchestrator continues; downstream `runCollect` sees only successful diagnostics.
+
+The `reasonTag` field lets renderers dispatch on `OxlintUnavailable.kind === "native-binding-missing"` (→ "upgrade Node" hint) vs the generic case without string-sniffing on `message`. See `inspect.ts → restoreLegacyThrow` for the parallel `Effect.catchReasons` pattern at the outer boundary.
+
+## Layers — production vs override
+
+`layerInspectLive` (default for CLI + `@react-doctor/api`'s `diagnose()`):
+
+```ts
+Layer.mergeAll(
+  Project.layerNode,
+  Config.layerNode,
+  DeadCode.layerNode,
+  Files.layerNode,
+  Linter.layerOxlint,
+  LintPartialFailures.layerLive,
+  Reporter.layerNoop,
+  Score.layerHttp,
+);
+```
+
+Common overrides:
+
+- `--offline` → swap `Score.layerHttp` for `Score.layerOf(null)`
+- `--no-lint` → swap `Linter.layerOxlint` for `Linter.layerOf([])`
+- `--no-dead-code` → swap `DeadCode.layerNode` for `DeadCode.layerOf([])`
+- programmatic caller with pre-loaded config → swap `Config.layerNode` for `Config.layerOf({ config, resolvedDirectory })`
+- LSP / watch-mode → swap `Reporter.layerNoop` for `Reporter.layerCapture(ref)` and consume via `Stream.runForEach` instead of `Stream.runCollect` (requires changing the orchestrator)
+
+## InspectInput / InspectOutput
+
+```ts
+interface InspectInput {
+  readonly directory: string;
+  readonly includePaths: ReadonlyArray<string>; // empty = full scan; non-empty = diff/staged
+  readonly customRulesOnly: boolean; // skip builtin react/jsx-a11y rules
+  readonly respectInlineDisables: boolean; // honor `// eslint-disable*` / `// oxlint-disable*`
+  readonly adoptExistingLintConfig: boolean; // extend user's oxlint.json / .oxlintrc.json
+  readonly ignoredTags: ReadonlySet<string>; // suppress diagnostics with `meta.tags` ∩ ignoredTags
+  readonly nodeBinaryPath?: string; // override the Node binary used to spawn oxlint
+  readonly runDeadCode: boolean; // also gated on `!isDiffMode`
+  readonly isCi: boolean; // marks the run for the Score API
+}
+
+interface InspectOutput {
+  readonly project: ProjectInfo;
+  readonly userConfig: ReactDoctorConfig | null;
+  readonly resolvedDirectory: string; // may differ from input.directory after `rootDir` redirect
+  readonly diagnostics: ReadonlyArray<Diagnostic>; // surviving (= not auto-suppressed / inline-disabled / etc.)
+  readonly score: ScoreResult | null; // null when lint failed or `--offline`
+  readonly didLintFail: boolean;
+  readonly lintFailureReason: string | null;
+  readonly lintFailureReasonTag: ReactDoctorErrorReason["_tag"] | null; // renderer dispatch
+  readonly lintPartialFailures: ReadonlyArray<string>; // per-batch soft failures (e.g. one batch timed out)
+  readonly didDeadCodeFail: boolean;
+  readonly deadCodeFailureReason: string | null;
+}
+```
+
+## InspectHooks (caller participation, NOT services)
+
+Hooks are for caller-side UI bookkeeping (spinner lifecycle, project-detection block). Anything observation-shaped should be a `Reporter` layer.
+
+```ts
+interface InspectHooks<HooksR = never> {
+  readonly beforeLint?: (
+    project: ProjectInfo,
+    lintIncludePaths: ReadonlyArray<string> | undefined,
+  ) => Effect.Effect<void, never, HooksR>;
+  readonly afterLint?: (didFail: boolean) => Effect.Effect<void, never, HooksR>;
+}
+```
+
+The CLI uses these to print "Detecting framework. Found React." spinner-checklist and to swap the lint spinner to ✓ / ✗ after the stream drains. Tests pass `NO_HOOKS = { beforeLint: Effect.void, afterLint: Effect.void }` (the default).
+
+## Concurrency / interruption
+
+- The pipeline is a single `Stream`, so `Effect.interrupt` propagating from the outer scope (e.g. SIGINT in the CLI) drops the in-flight oxlint spawn via `Effect.scoped` → `ChildProcess.spawn`'s scope finalizer.
+- `Linter.layerOxlint` collects per-batch partial failures into a closure-captured array and drains them into the `LintPartialFailures` Ref AFTER the oxlint Promise resolves — no `Effect.runSync` bridge inside the callback (was a HACK pre-PR 12).
+- `DeadCode.layerNode` wraps the legacy `checkDeadCode` Promise via `Effect.tryPromise`. Failures stream-catchTag into the `deadCodeFailure` Ref.
+- The pipeline runs sequentially across the three producers (env → lint → dead-code) by design — diagnostics surface in deterministic order for the renderer's sort. A future parallel-producer mode is `Stream.merge` instead of `Stream.concat`, no other changes.
+
+## Error model
+
+- Inside `runInspect`: every fallible service raises a `ReactDoctorError` (tagged, `reason: Schema.Union([…])`). `ReactDoctorError` is the only error type on the orchestrator's error channel.
+- At the public boundary: `inspect()` / `diagnose()` wrap `runInspect` with `Effect.catchReasons("ReactDoctorError", { NoReactDependency: …, ProjectNotFound: …, AmbiguousProject: …, orElse: e => Effect.die(new Error(e.message)) })` to preserve the legacy thrown-class contract for back-compat.
+- Inside per-batch lint failures: `runOxlint`'s `onPartialFailure` callback receives reason strings; the Linter layer accumulates them into `LintPartialFailures` (a `Ref<readonly string[]>`). The renderer reports them via `skippedCheckReasons["lint:partial"]`.
+
+## Surface filter (`filterDiagnosticsForSurface`)
+
+`runInspect` returns ALL surviving diagnostics. The renderer applies the surface filter PER consumer:
+
+- `"cli"` — what the user sees in the terminal output
+- `"score"` — what counts toward the headline 0–100 (e.g. design rules are demoted out of scoring by default)
+- `"ciFailure"` — what triggers `process.exitCode = 1` under `--fail-on`
+
+This means `score` is computed in `inspect.ts` AFTER `runInspect` returns, with the surface filter applied:
+
+```ts
+const scoreDiagnostics = filterDiagnosticsForSurface([...output.diagnostics], "score", userConfig);
+const score = didLintFail || offline ? null : await calculateScore([...scoreDiagnostics], { isCi });
+```
+
+The orchestrator's `Score` service runs with `layerOf(null)` from the CLI's `inspect.ts` and computes the score afterwards via `calculateScore` — the programmatic API (`@react-doctor/api`) uses `Score.layerHttp` directly because its caller doesn't need surface filtering. Both paths converge on the same score result for the same input.
+
+## Test strategy
+
+- Service-level: each service has a `layerOf(...)` (`layerInMemory` for `Files`) test layer in `packages/core/tests/services/*.test.ts`. The test layer takes a deterministic snapshot — no IO.
+- Orchestrator-level: `packages/core/tests/run-inspect.test.ts` provides every service via its test layer and asserts the `InspectOutput` shape for representative scenarios (lint-only diagnostics, lint failure + dead-code, dead-code-disabled, etc.).
+- End-to-end: `packages/react-doctor/tests/regressions/*.test.ts` exercise the CLI through `inspect()` with fixture directories.
+
+## Adding a new diagnostic source
+
+1. Make it a `Stream<Diagnostic, ReactDoctorError>`. If it's whole-project, mirror `DeadCode`; if it's per-file with batching, mirror `Linter`.
+2. Wrap behind a `Context.Service<Self, { run: (input) => Stream<…> }>()("react-doctor/Name")`.
+3. Add `Stream.concat(newSourceStream)` to the orchestrator after the existing `deadCodeStream`. Add a soft-failure `Ref` + `Stream.catchTag` if it can fail without sinking the scan.
+4. Expose `layerNode` + `layerOf([])` for tests.
+5. Add to `layerInspectLive`.
+
+No changes to `build-diagnostic-pipeline.ts` — the per-element transforms apply uniformly to every diagnostic regardless of source. No changes to renderers — they read `InspectOutput.diagnostics` and don't care which producer surfaced what.
+
+## Adding a new lint backend
+
+Mirror the `Linter` service. The orchestrator binds to `Linter` (singular), so the runtime picks one backend via `Linter.layerOxlint` / a future `Linter.layerEslintWorker` / `Linter.layerComposite([…])`. The composite layer is already in place (`Linter.layerComposite(backends)`) — a second backend is one new `Layer` that satisfies the interface, plus the composite arg.
+
+## Locked-in decisions
+
+1. **Streaming, not array passing**. Even though production calls `Stream.runCollect` at the end, every intermediate transform stays in `Stream` so LSP / watch mode is one swap away.
+2. **Failures via `Ref` + `catchTag`, not thrown**. The renderer needs the failure state alongside the surviving diagnostics; throwing would force `try/catch` around `runInspect` and lose the partial output.
+3. **Per-element pipeline is pure**. Every transform that needs file IO batches through the `Files` service before the stream starts. The filter itself never touches disk.
+4. **Reporter is a side-channel, not a sink**. Production uses `layerNoop` and reads the diagnostic array from `Stream.runCollect`. NDJSON / LSP / capture-for-test consumers swap the layer; the orchestrator's shape doesn't change.
+5. **Hooks are NOT services**. `InspectHooks` is the caller-side participation point for spinner / progress UI. Diagnostic observation is a Reporter layer instead.
+
+## Open follow-ups
+
+- **Surface-filter inside the orchestrator?** Currently the renderer applies `filterDiagnosticsForSurface` AFTER `runInspect`. Could push it inside as a `Stream.filter` so the Reporter side-channel sees the surface-correct set. Blocked on the score computation needing the unfiltered set to compute the headline 0–100; either the score moves out or we run `runInspect` twice with different surface filters.
+- **Per-file streaming for `DeadCode`**. Today `DeadCode.layerNode` returns the whole reachability analysis as one chunk. Converting to per-component streaming would let large monorepos surface dead components incrementally.
+- **`Effect.fn("name")` on every service method**. Adds OpenTelemetry-compatible span names with zero behavioral change. The eval (`react-doctor-evals`) does this consistently; we don't yet. A future observability PR can layer in `Otlp.layerJson` from `effect/unstable/observability/Otlp` for Axiom / Honeycomb / OTel-collector export.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,10 @@ for this codebase) for canonical examples.
   prefix in the identifier (matches react-doctor-evals' `rde/X` shape).
 - Service method bodies use `Effect.fnUntraced` for hot paths, `Effect.sync` for
   one-liners. Test layers + orchestration use `Effect.gen`.
+- **`Effect.fn("Service.method")`** for non-trivial methods so they surface as
+  named spans in OTel traces. Production cost is zero when no tracer layer is
+  provided; with `Otlp.layerJson(...)` users see one span per service call.
+  Canonical eval pattern (`react-doctor-evals/src/Runner.ts` → every method).
 - `Service.of({ ... })` everywhere inside `Layer.succeed` / `make:` — never
   `{ ... } as const`.
 - `Layer.effect` when the service has init work (e.g. `Cache.make`); `Layer.succeed`
@@ -148,6 +152,23 @@ for this codebase) for canonical examples.
 
 - Env-var reads + cache paths go through `Context.Reference<T>("react-doctor/X", { defaultValue })`.
   See `core/src/refs.ts`. Tests override via `Layer.succeed(MyRef, ...)`.
+- Secrets (API tokens, signing keys) should prefer `Config.redacted("ENV_NAME")` over
+  `Context.Reference` so they auto-redact in logs / traces. Group with `Config.all({ ... })`
+  at the service constructor when you need several. (Pattern from
+  `react-doctor-evals/src/GitHub.ts` — not yet used in this codebase; document
+  the convention so the first secret-shaped config does it right.)
+
+### Observability
+
+- Wrap the top-level entry of a multi-step operation in `Effect.withSpan("name", { attributes })`.
+  See `core/src/run-inspect.ts → runInspect` for the canonical shape. Attribute
+  keys use dotted namespacing (`inspect.directory`, `inspect.isCi`).
+- Per-service-method spans come from `Effect.fn("Service.method")` — see Services section
+  above. The two compose: `runInspect` is the parent span, every `Service.method` is a child.
+- Production observability layer (when wired): `Otlp.layerJson({ baseUrl, resource, headers })`
+  from `effect/unstable/observability/Otlp` + `NodeHttpClient.layerUndici`. Eval reference:
+  `react-doctor-evals/src/Observability.ts → layerAxiom`. Not currently wired in
+  react-doctor; the spans are in place so it's a one-liner when an end user opts in.
 
 ### Console / logging
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,174 @@
+# Context
+
+Domain glossary and conceptual map for react-doctor.
+
+Two views of the same codebase:
+
+1. **End-user view** — react-doctor is a CLI + npm package that scans a React project and prints diagnostics ("lint check failed in src/App.tsx:42" / "use `useEffect` here"), with a 0–100 score and a sharable URL. Optional: a GitHub Action that posts the same diagnostics inline on PRs.
+2. **Architecture view** — an Effect v4 runtime that orchestrates 9 services (Project / Config / Files / Linter / DeadCode / Score / Reporter / Progress / Git) into a single streaming pipeline. The CLI and the programmatic `diagnose()` API are both thin shells around `runInspect`.
+
+The end-user view is what the README and the website document. This file is the architecture view.
+
+## Glossary
+
+### Diagnostic
+
+One finding from a scan. Shape: `{ filePath, line, column, rule, plugin, severity, message, help?, url?, category?, suppressionHint? }`. Located by point (line, column), not range.
+
+Defined as a `Schema.Class<Diagnostic>("Diagnostic")(...)` in `packages/core/src/schemas.ts`. The schema is the source of truth — the JSON output (`--json`), the programmatic `diagnose()` return, and the inline-comment payload posted by the GitHub action all share this shape.
+
+### InspectOutput
+
+The structured result of one scan. Shape: `{ project, userConfig, resolvedDirectory, diagnostics, score, didLintFail, lintFailureReason, lintFailureReasonTag, lintPartialFailures, didDeadCodeFail, deadCodeFailureReason }`.
+
+Returned by `runInspect` (the orchestrator). Consumed by the CLI's renderer, the programmatic `diagnose()`, and the GitHub action's `runDiagnoseAcrossWorkspace`.
+
+### JsonReport
+
+The wire format of `react-doctor --json`. Top-level `Schema.Union([JsonReportV1])` (versioned for forward-compat). Carries the same diagnostics plus a `summary` block, `projects[]` for monorepos, and a `diff` snapshot when `--diff`/`--staged` ran.
+
+Round-trips through the schema with `Schema.encodeUnknownSync(JsonReport)` + `Schema.decodeUnknownSync(JsonReport)`. The smoke test (`scripts/smoke-json-report.ts`) validates every CI run.
+
+### Service
+
+A `Context.Service<Self, Shape>()("react-doctor/Name") {}` Effect v4 service. Used for every IO-shaped or environment-shaped dependency the orchestrator has: project discovery, config loading, file reads, lint backend, dead-code analysis, score API, reporter side-channel, progress spinner, git subprocess.
+
+Two layers per service:
+
+- `layerNode` — production implementation. Real IO.
+- `layerOf(snapshot)` / `layerInMemory(map)` — test layer. Deterministic snapshot, no IO.
+
+Some have additional variants: `Linter.layerComposite(backends[])`, `Linter.layerOxlint`, `Score.layerHttp`, `Reporter.layerNoop` / `layerCapture(ref)` / `layerNdjson(path)`.
+
+### Layer stack
+
+`layerInspectLive` in `run-inspect.ts` is the default production wiring. Callers override individual layers for `--offline` (swap `Score.layerHttp` → `Score.layerOf(null)`), `--no-lint` (`Linter.layerOxlint` → `Linter.layerOf([])`), etc.
+
+### Per-element pipeline
+
+The pure-function filter that runs over every diagnostic between the producer (Linter / DeadCode) and the renderer. Lives in `packages/core/src/build-diagnostic-pipeline.ts`. Applies in order:
+
+1. **Auto-suppress** — drop diagnostics where the source file isn't actually a React component (e.g. flagged by oxlint but the file is a Node script).
+2. **Severity controls** — apply `config.severityOverrides` so users can demote a rule to `warning` or upgrade to `error`.
+3. **Ignore patterns** — apply `config.ignore.{paths, rules, tags}` so users can mute noisy diagnostics.
+4. **Inline-disable** — honor `// eslint-disable-next-line` / `// oxlint-disable-next-line` comments in source.
+
+Result is a `Filter.Filter<Diagnostic, Diagnostic>` over the stream. The filter is pure — no IO — because file reads it needs are batched through the `Files` service before the stream starts.
+
+### Surface filter
+
+`filterDiagnosticsForSurface(diagnostics, surface, config)` runs AFTER `runInspect` returns, per output consumer:
+
+- `"cli"` — what the user sees in the terminal
+- `"score"` — what counts toward the headline 0–100 (e.g. `design` cleanup rules demoted out of scoring by default)
+- `"ciFailure"` — what triggers `process.exitCode = 1` under `--fail-on`
+
+A single scan produces one diagnostic list; the surface filter picks the subset for each consumer.
+
+### `inspect()` vs `diagnose()` vs `runInspect`
+
+Three layers from outside in:
+
+| Function                       | Package                        | Shape                                        | Caller                          |
+| ------------------------------ | ------------------------------ | -------------------------------------------- | ------------------------------- |
+| `inspect(directory, options)`  | `react-doctor`                 | `Promise<InspectResult>`                     | CLI commands                    |
+| `diagnose(directory, options)` | `@react-doctor/api` (internal) | `Promise<DiagnoseResult>`                    | programmatic Node API consumers |
+| `runInspect(input, hooks)`     | `@react-doctor/core`           | `Effect<InspectOutput, ReactDoctorError, …>` | both of the above               |
+
+All three end up calling `runInspect` with `Effect.runPromise(Effect.provide(layerInspectLive))`. The differences are the legacy-error translation (`inspect.ts` and `api/diagnose.ts` use `Effect.catchReasons` to map tagged reasons back to legacy thrown classes) and the rendering / spinner integration that `inspect()` adds for CLI use.
+
+### `ReactDoctorError` (tagged)
+
+The single error type on the orchestrator's error channel. Defined as `Schema.TaggedErrorClass<ReactDoctorError>()("ReactDoctorError", { reason: Schema.Union([…]) })` in `packages/core/src/errors.ts`.
+
+13 leaf reasons today: `OxlintUnavailable`, `OxlintBatchExceeded`, `OxlintSpawnFailed`, `OxlintOutputUnparseable`, `ConfigParseFailed`, `ProjectNotFound`, `NoReactDependency`, `AmbiguousProject`, `DeadCodeAnalysisFailed`, `GitInvocationFailed`, `GitBaseBranchMissing`, `GitBaseBranchInvalid`. Each leaf is itself a `Schema.TaggedErrorClass` with a `get message()` getter and (where applicable) a `cause: Schema.Unknown` for the underlying JS error.
+
+Renderers dispatch on `error.reason._tag` via `Effect.catchReasons("ReactDoctorError", { TagA: …, TagB: … })`. NEVER on `error.message.includes(...)`.
+
+### Legacy thrown errors (`@react-doctor/project-info`)
+
+Pre-Effect-runtime errors that the public `inspect()` / `diagnose()` API still throws for back-compat: `NoReactDependencyError`, `ProjectNotFoundError`, `AmbiguousProjectError`, `PackageJsonNotFoundError`. Translation from the tagged reason happens at the outer boundary via `Effect.catchReasons(...)` → `Effect.die(new LegacyError(...))`.
+
+### `Context.Reference` (ambient config)
+
+Effect's mechanism for fiber-local config with a default. Used in `packages/core/src/refs.ts` for: `OxlintSpawnTimeoutMs` (env-var overridable), `OxlintOutputMaxBytes`, `StagedFilesTempDirPrefix`. Tests override via `Layer.succeed(MyRef, value)`.
+
+### Branded paths
+
+`OxlintBinaryPath` and `NodeBinaryPath` in `packages/core/src/paths.ts`. `Schema.String.pipe(Schema.brand("Tag"))` so a `string` can't be passed where a binary path is expected without explicit construction. Defensive against `"./not-actually-a-binary"` slipping into the spawn argument.
+
+### Mode
+
+Three scan modes the CLI exposes:
+
+- `full` (default) — scan every source file under the project root.
+- `--diff [<base>]` — only scan files changed vs the diff base (default: best-effort `origin/HEAD` → `main` → `master`). Goes through `Git.diffSelection`.
+- `--staged` — only scan files staged for commit, materializing them into a temp tree first. Goes through `StagedFiles.materialize` (Zip-Slip defended).
+
+Affects which files the linter sees (`includePaths`) and gates whole-project analyses like dead-code that don't make sense on a slice.
+
+### Score
+
+The headline 0–100 react-doctor number. Computed by POSTing the diagnostic set to the score API (`Score.layerHttp`) which returns `{ score, label }`. `--offline` / `--no-share` swaps to `Score.layerOf(null)` so no network call happens.
+
+The score is computed AFTER `runInspect` returns with the surface filter applied (the `score` surface demotes weak-signal rule families like `design`), so the orchestrator's `Score` service runs with `layerOf(null)` from the CLI path. The programmatic `diagnose()` uses `Score.layerHttp` directly because its caller doesn't need surface filtering.
+
+### Composite action (`actions/review/`)
+
+The GitHub composite action lives in `actions/review/` (a separate workspace package, `@react-doctor/review-action`). On `pull_request` events it:
+
+1. Materializes a base worktree at `pull_request.base.sha` in `RUNNER_TEMP`.
+2. Runs `runDiagnoseAcrossWorkspace` against head + base.
+3. Diffs the two snapshots by `(relativePath, rule, message)` identity → `{ newDiagnostics, fixedDiagnostics }`.
+4. Posts a sticky summary comment + inline review comments on the `+` lines.
+5. Resolves prior threads when their underlying diagnostic disappears.
+
+`runDiagnoseAcrossWorkspace(scanDir, pathBaseDir)` takes both args so emitted `relativePath`s are repo-root-relative (the GitHub API key shape), even when `INPUT_DIRECTORY` scopes the scan to a subtree.
+
+### Eval harness (separate repo)
+
+`react-doctor-evals` (a sibling repo, NOT in this monorepo) runs react-doctor against a pinned corpus of OSS repos and:
+
+- **Parity**: diff two react-doctor versions to gate refactor PRs.
+- **Eval**: interactively score every diagnostic as TruePositive / FalsePositive / Skipped.
+- **Digest**: rule-frequency / per-diagnostic JSON dump.
+
+The architecture in this repo (Effect v4 services + tagged errors + streaming pipeline) is modeled on the eval's patterns. Cross-references between the two should go in commit messages, not in code.
+
+## File map
+
+```
+packages/
+  core/                          PRIVATE  the diagnostic engine
+    src/
+      run-inspect.ts             the streaming orchestrator (see .specs/inspect-pipeline.md)
+      build-diagnostic-pipeline  per-element pure filter
+      errors.ts                  tagged Schema.TaggedErrorClass leaves + ReactDoctorError union
+      schemas.ts                 Diagnostic, Severity, JsonReport (wire types)
+      refs.ts                    Context.Reference for ambient config
+      paths.ts                   branded path types
+      services/                  10 Context.Service classes — see Service section above
+      ...                        rest of the lint / score / suppression engine
+  api/                           PRIVATE  programmatic `diagnose()` (Effect.runPromise shell + legacy translation)
+  project-info/                  PRIVATE  legacy React project discovery + legacy thrown error classes
+  types/                         PRIVATE  shared cross-package type interfaces + RN dependency name constants
+  react-doctor/                  PUBLISHED  CLI + public `inspect()` + bin
+  oxlint-plugin-react-doctor/    PUBLISHED  the 100+ rules
+  eslint-plugin-react-doctor/    PUBLISHED  ESLint mirror of the oxlint plugin
+  website/                       PRIVATE  docs / leaderboard site
+
+actions/
+  review/                        PRIVATE  composite GitHub action (@react-doctor/review-action)
+
+.specs/                          design specs (see inspect-pipeline.md)
+CONTEXT.md                       this file — domain glossary
+AGENTS.md                        coding conventions + Effect v4 rules
+```
+
+## Reference reading
+
+- `.specs/inspect-pipeline.md` — design spec for the orchestrator.
+- `AGENTS.md` — Effect v4 conventions enforced across the codebase.
+- `~/Developer/react-doctor-evals/` — sister repo this codebase's runtime patterns are modeled on (`Schemas.ts`, `Runner.ts`, `WorkerPool.ts`, `errors.ts` shapes).
+- `tmp/effect/.patterns/effect.md` — canonical Effect v4 idioms (cloned reference, gitignored).
+- `tmp/effect/migration/*.md` — v3 → v4 migration guides (`error-handling.md`, `services.md`, `schema.md`, `yieldable.md`, etc.).

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -117,6 +117,13 @@ export const runInspect = <HooksR = never>(
   ReactDoctorError,
   Project | Config | DeadCode | Files | Linter | LintPartialFailures | Reporter | Score | HooksR
 > =>
+  // `Effect.withSpan("runInspect", { attributes })` turns the entire
+  // orchestrator into a single named OTel span; child service spans
+  // (`Project.discover`, `Linter.run`, `DeadCode.run`, `Score.compute`)
+  // hang off it. With no tracing layer provided, zero runtime cost.
+  // With `Otlp.layerJson(...)` provided, the user gets the whole
+  // scan as one trace — same shape as `react-doctor-evals`'
+  // `Runner.run` / `WorkerPool.invoke` instrumentation.
   Effect.gen(function* () {
     const projectService = yield* Project;
     const configService = yield* Config;
@@ -250,7 +257,16 @@ export const runInspect = <HooksR = never>(
       didDeadCodeFail: deadCodeFailureState.didFail,
       deadCodeFailureReason: deadCodeFailureState.reason,
     };
-  });
+  }).pipe(
+    Effect.withSpan("runInspect", {
+      attributes: {
+        "inspect.directory": input.directory,
+        "inspect.includePathCount": input.includePaths.length,
+        "inspect.runDeadCode": input.runDeadCode,
+        "inspect.isCi": input.isCi,
+      },
+    }),
+  );
 
 /**
  * Default layer stack for the production CLI / programmatic API:

--- a/packages/core/src/services/config.ts
+++ b/packages/core/src/services/config.ts
@@ -40,7 +40,11 @@ export class Config extends Context.Service<
           }),
       });
       return Config.of({
-        resolve: (directory) => Cache.get(cache, directory),
+        // `Effect.fn("Config.resolve")` adds an OTel-compatible span
+        // name; canonical eval pattern.
+        resolve: Effect.fn("Config.resolve")(function* (directory: string) {
+          return yield* Cache.get(cache, directory);
+        }),
       });
     }),
   );

--- a/packages/core/src/services/dead-code.ts
+++ b/packages/core/src/services/dead-code.ts
@@ -32,15 +32,20 @@ export class DeadCode extends Context.Service<
     DeadCode.of({
       run: (input) =>
         Stream.unwrap(
-          Effect.tryPromise({
-            try: () =>
-              checkDeadCode({
-                rootDirectory: input.rootDirectory,
-                userConfig: input.userConfig,
-              }),
-            catch: (cause) =>
-              new ReactDoctorError({ reason: new DeadCodeAnalysisFailed({ cause }) }),
-          }).pipe(Effect.map((diagnostics) => Stream.fromIterable(diagnostics))),
+          // `Effect.fn("DeadCode.run")` so the dead-code analysis
+          // surfaces as a single named span in OTel traces (parent
+          // of the per-call `Effect.tryPromise`).
+          Effect.fn("DeadCode.run")(function* () {
+            return yield* Effect.tryPromise({
+              try: () =>
+                checkDeadCode({
+                  rootDirectory: input.rootDirectory,
+                  userConfig: input.userConfig,
+                }),
+              catch: (cause) =>
+                new ReactDoctorError({ reason: new DeadCodeAnalysisFailed({ cause }) }),
+            }).pipe(Effect.map((diagnostics) => Stream.fromIterable(diagnostics)));
+          })(),
         ),
     }),
   );

--- a/packages/core/src/services/linter.ts
+++ b/packages/core/src/services/linter.ts
@@ -88,7 +88,13 @@ export class Linter extends Context.Service<
     Linter.of({
       run: (input) =>
         Stream.unwrap(
-          Effect.gen(function* () {
+          // `Effect.fn("Linter.run")` lights up the lint pass as a
+          // single named span in OTel traces. Wraps the inner
+          // `runOxlint` call + the partial-failure Ref drain so a
+          // user attaching `Otlp.layerJson` sees one parent span
+          // ("Linter.run") with `Effect.tryPromise` + `Ref.update`
+          // children.
+          Effect.fn("Linter.run")(function* () {
             const partialFailures = yield* LintPartialFailures;
             const collectedFailures: string[] = [];
             const diagnostics = yield* Effect.tryPromise({
@@ -113,7 +119,7 @@ export class Linter extends Context.Service<
               yield* Ref.update(partialFailures, (existing) => [...existing, ...collectedFailures]);
             }
             return Stream.fromIterable(diagnostics);
-          }),
+          })(),
         ),
     }),
   );

--- a/packages/core/src/services/project.ts
+++ b/packages/core/src/services/project.ts
@@ -46,11 +46,17 @@ export class Project extends Context.Service<
   static readonly layerNode = Layer.succeed(
     Project,
     Project.of({
-      discover: (directory) =>
-        Effect.try({
+      // `Effect.fn("Project.discover")` adds an OTel-compatible span
+      // name to every invocation. Canonical eval pattern from
+      // `react-doctor-evals/src/Runner.ts` / `ReactDoctorV2.ts` —
+      // free observability with zero runtime cost when no tracer
+      // layer is provided.
+      discover: Effect.fn("Project.discover")(function* (directory: string) {
+        return yield* Effect.try({
           try: () => discoverProjectSync(directory),
           catch: (cause) => translateProjectInfoError(cause, directory),
-        }),
+        });
+      }),
     }),
   );
 

--- a/packages/core/src/services/score.ts
+++ b/packages/core/src/services/score.ts
@@ -21,16 +21,23 @@ export class Score extends Context.Service<
    * for the linter contract, and the renderer distinguishes "user
    * opted out" from "we tried and failed" via a separate `noScoreMessage`
    * the caller picks based on `--offline`.
+   *
+   * `Effect.fn("Score.compute")` wraps the body so the effect carries
+   * an OpenTelemetry-compatible span name out of the box (canonical
+   * eval pattern from `react-doctor-evals/src/Runner.ts`). Zero runtime
+   * cost when no tracing layer is provided; surfaces in
+   * `Otlp.layerJson` traces when one is.
    */
   static readonly layerHttp = Layer.succeed(
     Score,
     Score.of({
-      compute: (input) =>
-        Effect.promise(() =>
+      compute: Effect.fn("Score.compute")(function* (input: ComputeInput) {
+        return yield* Effect.promise(() =>
           calculateScore([...input.diagnostics], { isCi: input.isCi }).catch(
             (): ScoreResult | null => null,
           ),
-        ),
+        );
+      }),
     }),
   );
 


### PR DESCRIPTION
Deep study of [\`~/Developer/react-doctor-evals\`](https://github.com/millionco/react-doctor-evals) against our current architecture. The eval pioneered the Effect v4 patterns this repo is modeled on; this PR brings over the lasting structural and observability wins.

## Lasting docs (the main deliverable)

### \`.specs/inspect-pipeline.md\`

Full spec for \`runInspect\`, the streaming orchestrator. Documents:

- **9-service wiring** with the layer-stack override knobs (\`--offline\` / \`--no-lint\` / etc.)
- **Stream shape** with the failure-folding pattern (Ref + \`Stream.catchTag\`)
- **Per-element pipeline** — auto-suppress / severity / ignore / inline-disable as a pure \`Filter.fromPredicateOption\`
- **Surface filtering** — why it lives outside the orchestrator (score needs unfiltered, renderer needs surface-filtered)
- **Hooks vs services** — \`InspectHooks\` for caller-side UI bookkeeping, \`Reporter\` layer for diagnostic observation
- **Three-layer call story** — \`inspect()\` → \`diagnose()\` → \`runInspect\`
- **Playbook** for adding a new diagnostic source or a new lint backend
- **Locked-in decisions** + **open follow-ups**

Mirrors the eval's \`.specs/github-app.md\` format (design constraints → module map → numbered sections → tests → locked decisions → open questions).

### \`CONTEXT.md\`

Domain glossary. Diagnostic, InspectOutput, Service, Layer stack, per-element pipeline, surface filter, mode, score, composite action, ReactDoctorError vs legacy thrown errors, Context.Reference, branded paths, three-layer call story. Pairs with AGENTS.md (conventions) and \`.specs/inspect-pipeline.md\` (deepest dive). Mirrors the eval's \`CONTEXT.md\`.

## \`Effect.fn(\"Service.method\")\` for free observability

Every non-trivial service-method body is now wrapped in \`Effect.fn(\"Service.method\")\` — the canonical eval pattern from \`react-doctor-evals/src/Runner.ts\` and \`WorkerPool.ts\`. Production cost is zero when no tracer layer is provided. With \`Otlp.layerJson(...)\` from \`effect/unstable/observability/Otlp\` (eval ref: \`Observability.ts → layerAxiom\`), users see one named span per service call.

Wrapped today:
- \`Project.discover\`
- \`Config.resolve\`
- \`DeadCode.run\`
- \`Linter.run\`
- \`Score.compute\`
- \`runInspect\` itself, via \`Effect.withSpan(\"runInspect\", { attributes: { \"inspect.directory\", \"inspect.includePathCount\", \"inspect.runDeadCode\", \"inspect.isCi\" } })\` so the orchestrator is the parent of the per-service-method spans.

## AGENTS.md updates

- New \`Effect.fn(\"Service.method\")\` rule in the Services section
- New \`Config.redacted\` guidance for secret-shaped env vars (will land with the first secret-shaped config; documented now so it lands correctly)
- New \`Observability\` subsection documenting \`Effect.withSpan\` + \`Effect.fn\` composition, attribute-key naming convention, and the \`Otlp.layerJson\` opt-in path

## Not in this PR (tracked for follow-up)

- **Migrate services to canonical \`make:\` pattern**: the eval uses \`Context.Service<Self>()(\"name\", { make: Effect.gen(...) }) { static readonly layer = Layer.effect(this, this.make) }\` while we use the shape-in-type-param form. Both are valid v4; the eval's form is more idiomatic for services with init work. Defer the wholesale conversion — current shape works and the refactor would churn every service file.
- **Adopt \`Layer.mock(Service, { method })\` in tests**: cleaner test layers. Eval pattern from \`Runner.ts → layerTest\`.
- **\`Effect.Command\` from \`effect/unstable/cli\`** to replace commander. Bigger refactor; tracked for the v0.3 CLI overhaul.
- **\`Otlp.layerJson\` end-to-end**: the spans are now in place, but no actual exporter is wired in production. End users that want traces add \`Otlp.layerJson({ baseUrl, resource, headers })\` + \`NodeHttpClient.layerUndici\` themselves. Document the snippet in the README when there's demand.

## Test plan

- [x] \`pnpm typecheck\` — all packages clean
- [x] \`pnpm test\` — full suite (1442 tests across 113 files) green
- [x] \`pnpm lint\` / \`pnpm format\` clean
- [x] \`pnpm smoke:json-report\` schema-valid (the smoke is end-to-end through \`runInspect\` so the new spans are exercised)

## Files

- 📄 \`.specs/inspect-pipeline.md\` (new, 230 lines)
- 📄 \`CONTEXT.md\` (new, 170 lines)
- 📝 \`AGENTS.md\` (Services + Ambient config + Observability sections)
- ✏️ \`packages/core/src/run-inspect.ts\` (Effect.withSpan)
- ✏️ \`packages/core/src/services/{project,config,dead-code,linter,score}.ts\` (Effect.fn)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily documentation plus observability wrappers (`Effect.withSpan`/`Effect.fn`) that should not change functional behavior, though it touches the core `runInspect` and service entrypoints.
> 
> **Overview**
> Adds two new high-level docs: `.specs/inspect-pipeline.md` (full `runInspect` streaming/pipeline spec) and `CONTEXT.md` (domain glossary/architecture map), and updates `AGENTS.md` with new conventions for tracing (`Effect.fn`, `Effect.withSpan`) and secret handling guidance.
> 
> In `@react-doctor/core`, wraps `runInspect` in `Effect.withSpan` with inspect-run attributes and wraps key service methods (`Project.discover`, `Config.resolve`, `Linter.run`, `DeadCode.run`, `Score.compute`) in `Effect.fn("Service.method")` to emit named spans for optional OpenTelemetry tracing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fad85bcfc73bb6fa4f0369f074d33750720f987b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->