### PR TITLE
feat(core): user-plugin extension — `config.plugins: [...]` for custom rules

### DIFF
--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -189,6 +189,7 @@ export const runInspect = <HooksR = never>(
         adoptExistingLintConfig: input.adoptExistingLintConfig,
         ignoredTags: input.ignoredTags,
         userConfig: resolvedConfig.config ?? undefined,
+        configSourceDirectory: resolvedConfig.configSourceDirectory ?? undefined,
       })
       .pipe(
         Stream.catchTag("ReactDoctorError", (error: ReactDoctorError) =>

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -379,6 +379,19 @@ interface RunOxlintOptions {
    */
   userConfig?: ReactDoctorConfig | null;
   /**
+   * Directory of the `react-doctor.config.json` (or `package.json`)
+   * that supplied `userConfig`. Used as the resolution base for
+   * `userConfig.plugins` entries — relative paths resolve against
+   * this directory and npm package names resolve through its
+   * `node_modules`, matching how `rootDir` resolves. Diverges from
+   * `rootDirectory` whenever `userConfig.rootDir` redirects the
+   * scan to a subtree.
+   *
+   * Defaults to `rootDirectory` for direct callers that don't load
+   * a config file (e.g. tests that pass `userConfig` synthetically).
+   */
+  configSourceDirectory?: string;
+  /**
    * Called once per soft-fail event (e.g. a batch hit
    * `OXLINT_SPAWN_TIMEOUT_MS` and was skipped). The lint scan keeps
    * going on remaining batches; the caller is expected to surface the
@@ -438,6 +451,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     adoptExistingLintConfig = true,
     ignoredTags = new Set<string>(),
     userConfig,
+    configSourceDirectory = rootDirectory,
     onPartialFailure,
   } = options;
 
@@ -477,13 +491,16 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   // Drop them up front so the scan starts in the same state the fallback
   // would land in, with no stderr noise.
   const extendsPaths = detectedConfigPaths.filter(canOxlintExtendConfig);
-  // Resolve user-declared plugins (`config.plugins: [...]`) relative
-  // to the project root (the scan root, which is `react-doctor.config.json`'s
-  // own directory in the common case). Each resolved plugin
-  // contributes its rules + its specifier to the generated
-  // oxlintrc.json; failures are warned and skipped so a typo in
-  // one entry doesn't block the rest of the scan.
-  const userPlugins = resolveUserPlugins(userConfig?.plugins, rootDirectory);
+  // Resolve user-declared plugins (`config.plugins: [...]`) against
+  // the config file's source directory — NOT the scan root, since
+  // those diverge whenever `userConfig.rootDir` redirects the scan
+  // to a subtree (the canonical monorepo case: the config sits at
+  // the workspace root with `rootDir: "apps/web"`, the scan root is
+  // `apps/web/`, but `./lint/team.cjs` still resolves from the
+  // workspace root). Defaults to `rootDirectory` for direct callers
+  // that don't load a config file (e.g. tests passing `userConfig`
+  // synthetically without a corresponding `configSourceDirectory`).
+  const userPlugins = resolveUserPlugins(userConfig?.plugins, configSourceDirectory);
   const config = createOxlintConfig({
     pluginPath,
     project,

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -19,6 +19,7 @@ import {
 import { batchIncludePaths } from "./batch-include-paths.js";
 import { buildRuleSeverityControls } from "./build-rule-severity-controls.js";
 import { canOxlintExtendConfig } from "./can-oxlint-extend-config.js";
+import { resolveUserPlugins } from "./runners/oxlint/plugin-resolution.js";
 import { collectIgnorePatterns } from "./collect-ignore-patterns.js";
 import { detectUserLintConfigPaths } from "./detect-user-lint-config.js";
 import { dedupeDiagnostics } from "./utils/dedupe-diagnostics.js";
@@ -476,6 +477,13 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   // Drop them up front so the scan starts in the same state the fallback
   // would land in, with no stderr noise.
   const extendsPaths = detectedConfigPaths.filter(canOxlintExtendConfig);
+  // Resolve user-declared plugins (`config.plugins: [...]`) relative
+  // to the project root (the scan root, which is `react-doctor.config.json`'s
+  // own directory in the common case). Each resolved plugin
+  // contributes its rules + its specifier to the generated
+  // oxlintrc.json; failures are warned and skipped so a typo in
+  // one entry doesn't block the rest of the scan.
+  const userPlugins = resolveUserPlugins(userConfig?.plugins, rootDirectory);
   const config = createOxlintConfig({
     pluginPath,
     project,
@@ -484,6 +492,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     ignoredTags,
     serverAuthFunctionNames,
     severityControls,
+    userPlugins,
   });
   // HACK: only neutralize disable comments in audit mode. Default
   // behavior respects the user's existing `// eslint-disable*` /

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -649,6 +649,10 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       // as react-doctor itself crashing; the curated-rules scan is the
       // graceful path.
       if (extendsPaths.length === 0) throw error;
+      // Drop `extendsPaths` only — keep `userPlugins` (and every
+      // other option) so the retry still runs the user's custom
+      // rules. Forgetting one option here silently disappears those
+      // diagnostics from the successful retry without warning.
       const fallbackConfig = createOxlintConfig({
         pluginPath,
         project,
@@ -657,6 +661,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         ignoredTags,
         serverAuthFunctionNames,
         severityControls,
+        userPlugins,
       });
       writeOxlintConfig(fallbackConfig);
       return await spawnLintBatches();

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -8,7 +8,7 @@ import type { ProjectInfo, RuleSeverityControls } from "@react-doctor/types";
 import { resolveRuleSeverityOverride } from "../../resolve-rule-severity-override.js";
 import { buildCapabilities, shouldEnableRule } from "./capabilities.js";
 import { filterRulesToAvailable, resolveReactHooksJsPlugin } from "./plugin-resolution.js";
-import type { JsPluginEntry } from "./plugin-resolution.js";
+import type { JsPluginEntry, ResolvedUserPlugin } from "./plugin-resolution.js";
 
 export interface OxlintConfigOptions {
   pluginPath: string;
@@ -18,6 +18,14 @@ export interface OxlintConfigOptions {
   ignoredTags?: ReadonlySet<string>;
   serverAuthFunctionNames?: ReadonlyArray<string>;
   severityControls?: RuleSeverityControls;
+  /**
+   * User-declared plugins from `react-doctor.config.json`'s
+   * `plugins: [...]`, already resolved + introspected via
+   * `resolveUserPlugins`. Each plugin's rules are opt-in: they don't
+   * run unless `severityControls.rules["<plugin-name>/<rule>"]` is
+   * set to `"warn"` or `"error"`.
+   */
+  userPlugins?: ReadonlyArray<ResolvedUserPlugin>;
 }
 
 const resolveSettingsRootDirectory = (rootDirectory: string): string => {
@@ -38,6 +46,28 @@ const applyRuleSeverityControls = (
   return enabledRules;
 };
 
+/**
+ * Builds the `rules` entries for one user-declared plugin. Rules are
+ * opt-in: a rule never registers unless `severityControls.rules`
+ * explicitly sets it to `"warn"` or `"error"`. This mirrors the
+ * built-in plugin's `defaultEnabled: false` behavior so installing
+ * a third-party plugin doesn't surprise the user with a flood of
+ * new diagnostics on the first scan.
+ */
+const buildUserPluginRules = (
+  userPlugin: ResolvedUserPlugin,
+  severityControls: RuleSeverityControls | undefined,
+): Record<string, OxlintRuleSeverity> => {
+  const enabled: Record<string, OxlintRuleSeverity> = {};
+  for (const ruleName of userPlugin.availableRuleNames) {
+    const ruleKey = `${userPlugin.entry.name}/${ruleName}`;
+    const explicitSeverity = resolveRuleSeverityOverride({ ruleKey }, severityControls);
+    if (explicitSeverity === undefined || explicitSeverity === "off") continue;
+    enabled[ruleKey] = explicitSeverity;
+  }
+  return enabled;
+};
+
 export const createOxlintConfig = ({
   pluginPath,
   project,
@@ -46,6 +76,7 @@ export const createOxlintConfig = ({
   ignoredTags = new Set<string>(),
   serverAuthFunctionNames,
   severityControls,
+  userPlugins = [],
 }: OxlintConfigOptions) => {
   const reactHooksJsPlugin = resolveReactHooksJsPlugin(project.hasReactCompiler, customRulesOnly);
   const reactCompilerRules = reactHooksJsPlugin
@@ -89,6 +120,18 @@ export const createOxlintConfig = ({
     enabledReactDoctorRules[registryEntry.key] = severity;
   }
 
+  // Fold every user-declared plugin's enabled rules + add its
+  // resolved specifier to `jsPlugins` so oxlint loads it alongside
+  // the built-in react-doctor plugin. Order: react-hooks-js (when
+  // present) → user plugins → react-doctor itself. The react-doctor
+  // plugin stays last so its rules can reference earlier plugins'
+  // settings if a future composition pattern needs that hook.
+  const userPluginRules: Record<string, OxlintRuleSeverity> = {};
+  for (const userPlugin of userPlugins) {
+    Object.assign(userPluginRules, buildUserPluginRules(userPlugin, severityControls));
+    jsPlugins.push(userPlugin.entry);
+  }
+
   return {
     ...(extendsPaths.length > 0 ? { extends: extendsPaths } : {}),
     categories: {
@@ -104,7 +147,8 @@ export const createOxlintConfig = ({
     // and `jsx-a11y/*` rule has been ported into `react-doctor/*`. The
     // empty `plugins:` array is intentional; rules come exclusively
     // from our codegen-built registry plus configured npm-shipped
-    // plugins (react-hooks-js for the React Compiler frontend etc.).
+    // plugins (react-hooks-js for the React Compiler frontend etc.)
+    // and any user-declared plugins from `config.plugins`.
     plugins: [],
     jsPlugins: [...jsPlugins, pluginPath],
     settings: {
@@ -119,6 +163,7 @@ export const createOxlintConfig = ({
     rules: {
       ...reactCompilerRules,
       ...enabledReactDoctorRules,
+      ...userPluginRules,
     },
   };
 };

--- a/packages/core/src/runners/oxlint/plugin-resolution.ts
+++ b/packages/core/src/runners/oxlint/plugin-resolution.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import type { OxlintRuleSeverity } from "oxlint-plugin-react-doctor";
+import { warnConfigIssue } from "../../utils/warn-config-issue.js";
 
 const esmRequire = createRequire(import.meta.url);
 
@@ -10,46 +11,43 @@ export interface JsPluginEntry {
 }
 
 /**
- * A user-declared oxlint plugin (via `config.plugins: [...]`),
- * resolved to an absolute file path with introspected metadata.
- * `name` is the namespace rule keys are prefixed with — sourced from
- * the plugin's `meta.name` field, falling back to a slugified
- * specifier when the plugin doesn't declare one.
+ * Shape an oxlint plugin module is expected to export. Marked
+ * structurally permissive (`Record<string, unknown>` for rules,
+ * `unknown` for `meta.name`) because the module crosses our trust
+ * boundary — the introspection helper validates before we use the
+ * shape downstream.
  */
-export interface ResolvedUserPlugin {
-  readonly entry: JsPluginEntry;
-  /** Rule names exported by the plugin (e.g. `"no-bare-fetch"`). */
-  readonly availableRuleNames: ReadonlySet<string>;
-  /** The original spec from `config.plugins`, for diagnostics. */
-  readonly originalSpec: string;
-}
-
-type ReactHooksJsPluginEntry = JsPluginEntry;
-
-interface ResolvedReactHooksJsPlugin {
-  entry: ReactHooksJsPluginEntry;
-  /** Rule names exported by the loaded plugin (e.g. "void-use-memo"). */
-  availableRuleNames: ReadonlySet<string>;
-}
-
 interface MaybePluginModule {
   meta?: { name?: unknown };
   rules?: Record<string, unknown>;
-  default?: { meta?: { name?: unknown }; rules?: Record<string, unknown> };
+  default?: MaybePluginModule;
 }
 
-const readPluginModule = (pluginSpecifier: string): MaybePluginModule | null => {
-  try {
-    return esmRequire(pluginSpecifier) as MaybePluginModule;
-  } catch {
-    return null;
-  }
-};
+interface PluginShape {
+  /** Plugin's declared `meta.name` (the namespace for rule keys), or `null`. */
+  readonly name: string | null;
+  /** Rule names exported by the plugin (e.g. `"void-use-memo"`). */
+  readonly ruleNames: ReadonlySet<string>;
+}
 
+/**
+ * Loads a plugin module via the local require resolver and extracts
+ * `(name, ruleNames)` from either `module.exports.meta + rules` or
+ * the `module.exports.default.meta + rules` ESM shape. Returns a
+ * shape with empty `ruleNames` when the module can't be loaded or
+ * doesn't expose a `rules` field — callers check `ruleNames.size`
+ * to decide whether the plugin is usable.
+ */
 const readPluginShape = (
-  pluginModule: MaybePluginModule | null,
-): { name: string | null; ruleNames: ReadonlySet<string> } => {
-  if (pluginModule === null) return { name: null, ruleNames: new Set() };
+  pluginSpecifier: string,
+  loadModule: (specifier: string) => unknown,
+): PluginShape => {
+  let pluginModule: MaybePluginModule;
+  try {
+    pluginModule = loadModule(pluginSpecifier) as MaybePluginModule;
+  } catch {
+    return { name: null, ruleNames: new Set() };
+  }
   const moduleNamespace = pluginModule.default ?? pluginModule;
   const rules = moduleNamespace.rules ?? {};
   const rawName = moduleNamespace.meta?.name;
@@ -57,111 +55,11 @@ const readPluginShape = (
   return { name, ruleNames: new Set(Object.keys(rules)) };
 };
 
-const slugifyUserPluginSpec = (spec: string): string => {
-  const base = spec
-    .split(/[/\\]/)
-    .pop()!
-    .replace(/\.(js|cjs|mjs|ts|cts|mts)$/i, "");
-  const slug = base.replace(/[^A-Za-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
-  return slug.length > 0 ? slug : "user-plugin";
-};
-
-/**
- * Resolves a user plugin spec from `react-doctor.config.json`'s
- * `plugins: [...]` to an absolute file path. Two accepted spec
- * shapes:
- *
- * - **Relative path** (`./`, `../`, or any path with `/` not starting
- *   with a letter that npm would parse as a package): resolved
- *   relative to `configSourceDirectory` (the dir of the config file
- *   that declared it). Mirrors how `rootDir` is resolved.
- * - **npm package name**: resolved via Node module resolution from
- *   the config source directory's `node_modules`.
- *
- * Returns `null` when the spec can't be resolved or the resolved
- * module doesn't look like an oxlint plugin (no `rules` field).
- * A warning is logged in either case; the scan continues without
- * the user plugin so config typos don't block the rest of the run.
- */
-export const resolveUserPlugin = (
-  spec: string,
-  configSourceDirectory: string,
-): ResolvedUserPlugin | null => {
-  const isRelative = spec.startsWith("./") || spec.startsWith("../") || path.isAbsolute(spec);
-  const candidateRequire = createRequire(path.join(configSourceDirectory, "noop.js"));
-  let resolvedSpecifier: string;
-  try {
-    resolvedSpecifier = isRelative
-      ? path.resolve(configSourceDirectory, spec)
-      : candidateRequire.resolve(spec);
-  } catch (error) {
-    process.stderr.write(
-      `[react-doctor] config.plugins entry "${spec}" could not be resolved from ${configSourceDirectory}: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
-    return null;
-  }
-  const pluginModule = readPluginModule(resolvedSpecifier);
-  if (pluginModule === null) {
-    process.stderr.write(
-      `[react-doctor] config.plugins entry "${spec}" (resolved to ${resolvedSpecifier}) failed to load — skipping.\n`,
-    );
-    return null;
-  }
-  const { name, ruleNames } = readPluginShape(pluginModule);
-  if (ruleNames.size === 0) {
-    process.stderr.write(
-      `[react-doctor] config.plugins entry "${spec}" exports no rules (expected \`{ meta: { name }, rules: {...} }\` shape) — skipping.\n`,
-    );
-    return null;
-  }
-  const resolvedName = name ?? slugifyUserPluginSpec(spec);
-  return {
-    entry: { name: resolvedName, specifier: resolvedSpecifier },
-    availableRuleNames: ruleNames,
-    originalSpec: spec,
-  };
-};
-
-export const resolveUserPlugins = (
-  specs: ReadonlyArray<string> | undefined,
-  configSourceDirectory: string,
-): ReadonlyArray<ResolvedUserPlugin> => {
-  if (!specs || specs.length === 0) return [];
-  const resolved: ResolvedUserPlugin[] = [];
-  const seenNames = new Set<string>();
-  for (const spec of specs) {
-    const plugin = resolveUserPlugin(spec, configSourceDirectory);
-    if (plugin === null) continue;
-    if (seenNames.has(plugin.entry.name)) {
-      process.stderr.write(
-        `[react-doctor] config.plugins entry "${spec}" declares duplicate plugin name "${plugin.entry.name}" — skipping. Rename via the plugin's \`meta.name\` field to load multiple variants.\n`,
-      );
-      continue;
-    }
-    seenNames.add(plugin.entry.name);
-    resolved.push(plugin);
-  }
-  return resolved;
-};
-
-const readPluginRuleNames = (pluginSpecifier: string): ReadonlySet<string> => {
-  // HACK: oxlint resolves the plugin itself at scan time; we just need
-  // a fast rule-name listing to filter our config so we don't
-  // reference rules that don't exist in the user's installed version
-  // (e.g. older eslint-plugin-react-hooks releases do not expose every
-  // compiler rule). Failing to read the module is non-fatal - we fall
-  // back to enabling every rule we have
-  // configured for and let oxlint surface the mismatch (which preserves
-  // pre-fix behavior for unknown plugin shapes).
-  try {
-    const pluginModule: MaybePluginModule = esmRequire(pluginSpecifier);
-    const rules = pluginModule.rules ?? pluginModule.default?.rules;
-    if (rules === undefined) return new Set();
-    return new Set(Object.keys(rules));
-  } catch {
-    return new Set();
-  }
-};
+interface ResolvedReactHooksJsPlugin {
+  entry: JsPluginEntry;
+  /** Rule names exported by the loaded plugin (e.g. "void-use-memo"). */
+  availableRuleNames: ReadonlySet<string>;
+}
 
 export const resolveReactHooksJsPlugin = (
   hasReactCompiler: boolean,
@@ -174,9 +72,17 @@ export const resolveReactHooksJsPlugin = (
   } catch {
     return null;
   }
+  // HACK: oxlint resolves the plugin itself at scan time; we just
+  // need a fast rule-name listing to filter our config so we don't
+  // reference rules that don't exist in the user's installed version
+  // (e.g. older eslint-plugin-react-hooks releases do not expose
+  // every compiler rule). Failing to read the module is non-fatal —
+  // we fall back to enabling every configured rule and let oxlint
+  // surface any mismatch.
+  const { ruleNames } = readPluginShape(pluginSpecifier, (spec) => esmRequire(spec));
   return {
     entry: { name: "react-hooks-js", specifier: pluginSpecifier },
-    availableRuleNames: readPluginRuleNames(pluginSpecifier),
+    availableRuleNames: ruleNames,
   };
 };
 
@@ -202,4 +108,93 @@ export const filterRulesToAvailable = (
     }
   }
   return filtered;
+};
+
+/**
+ * A user-declared oxlint plugin (via `config.plugins: [...]`),
+ * resolved to an absolute file path with introspected metadata.
+ */
+export interface ResolvedUserPlugin {
+  readonly entry: JsPluginEntry;
+  readonly availableRuleNames: ReadonlySet<string>;
+  /** The original spec from `config.plugins`, for diagnostics. */
+  readonly originalSpec: string;
+}
+
+/**
+ * Resolves a user plugin spec from `react-doctor.config.json`'s
+ * `plugins: [...]` to an absolute file path. Two accepted spec
+ * shapes:
+ *
+ * - **Relative path** (`./`, `../`, or absolute): resolved relative
+ *   to `configSourceDirectory` (the dir of the config file that
+ *   declared it). Mirrors how `rootDir` is resolved.
+ * - **npm package name**: resolved via Node module resolution from
+ *   the config source directory's `node_modules`.
+ *
+ * Returns `null` (with a warning) when the spec can't be resolved,
+ * the module doesn't expose any rules, or `meta.name` is missing.
+ * `meta.name` is required — there's no slug fallback — so rule
+ * keys in `config.rules` can't silently change when a file gets
+ * renamed.
+ */
+export const resolveUserPlugin = (
+  spec: string,
+  configSourceDirectory: string,
+): ResolvedUserPlugin | null => {
+  const isRelative = spec.startsWith("./") || spec.startsWith("../") || path.isAbsolute(spec);
+  const candidateRequire = createRequire(path.join(configSourceDirectory, "noop.js"));
+  let resolvedSpecifier: string;
+  try {
+    resolvedSpecifier = isRelative
+      ? path.resolve(configSourceDirectory, spec)
+      : candidateRequire.resolve(spec);
+  } catch (error) {
+    warnConfigIssue(
+      `config.plugins entry "${spec}" could not be resolved from ${configSourceDirectory}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+  const { name, ruleNames } = readPluginShape(resolvedSpecifier, (target) =>
+    candidateRequire(target),
+  );
+  if (ruleNames.size === 0) {
+    warnConfigIssue(
+      `config.plugins entry "${spec}" (resolved to ${resolvedSpecifier}) exports no rules (expected \`{ meta: { name }, rules: {...} }\` shape) — skipping.`,
+    );
+    return null;
+  }
+  if (name === null) {
+    warnConfigIssue(
+      `config.plugins entry "${spec}" is missing \`meta.name\` — add \`module.exports = { meta: { name: "..." }, rules: {...} }\` so rule keys in \`config.rules\` resolve. Skipping.`,
+    );
+    return null;
+  }
+  return {
+    entry: { name, specifier: resolvedSpecifier },
+    availableRuleNames: ruleNames,
+    originalSpec: spec,
+  };
+};
+
+export const resolveUserPlugins = (
+  specs: ReadonlyArray<string> | undefined,
+  configSourceDirectory: string,
+): ReadonlyArray<ResolvedUserPlugin> => {
+  if (!specs || specs.length === 0) return [];
+  const resolved: ResolvedUserPlugin[] = [];
+  const seenNames = new Set<string>();
+  for (const spec of specs) {
+    const plugin = resolveUserPlugin(spec, configSourceDirectory);
+    if (plugin === null) continue;
+    if (seenNames.has(plugin.entry.name)) {
+      warnConfigIssue(
+        `config.plugins entry "${spec}" declares duplicate plugin name "${plugin.entry.name}" — skipping. Rename via \`meta.name\` to load multiple variants.`,
+      );
+      continue;
+    }
+    seenNames.add(plugin.entry.name);
+    resolved.push(plugin);
+  }
+  return resolved;
 };

--- a/packages/core/src/runners/oxlint/plugin-resolution.ts
+++ b/packages/core/src/runners/oxlint/plugin-resolution.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import path from "node:path";
 import type { OxlintRuleSeverity } from "oxlint-plugin-react-doctor";
 
 const esmRequire = createRequire(import.meta.url);
@@ -6,6 +7,21 @@ const esmRequire = createRequire(import.meta.url);
 export interface JsPluginEntry {
   name: string;
   specifier: string;
+}
+
+/**
+ * A user-declared oxlint plugin (via `config.plugins: [...]`),
+ * resolved to an absolute file path with introspected metadata.
+ * `name` is the namespace rule keys are prefixed with — sourced from
+ * the plugin's `meta.name` field, falling back to a slugified
+ * specifier when the plugin doesn't declare one.
+ */
+export interface ResolvedUserPlugin {
+  readonly entry: JsPluginEntry;
+  /** Rule names exported by the plugin (e.g. `"no-bare-fetch"`). */
+  readonly availableRuleNames: ReadonlySet<string>;
+  /** The original spec from `config.plugins`, for diagnostics. */
+  readonly originalSpec: string;
 }
 
 type ReactHooksJsPluginEntry = JsPluginEntry;
@@ -17,9 +33,116 @@ interface ResolvedReactHooksJsPlugin {
 }
 
 interface MaybePluginModule {
+  meta?: { name?: unknown };
   rules?: Record<string, unknown>;
-  default?: { rules?: Record<string, unknown> };
+  default?: { meta?: { name?: unknown }; rules?: Record<string, unknown> };
 }
+
+const readPluginModule = (pluginSpecifier: string): MaybePluginModule | null => {
+  try {
+    return esmRequire(pluginSpecifier) as MaybePluginModule;
+  } catch {
+    return null;
+  }
+};
+
+const readPluginShape = (
+  pluginModule: MaybePluginModule | null,
+): { name: string | null; ruleNames: ReadonlySet<string> } => {
+  if (pluginModule === null) return { name: null, ruleNames: new Set() };
+  const moduleNamespace = pluginModule.default ?? pluginModule;
+  const rules = moduleNamespace.rules ?? {};
+  const rawName = moduleNamespace.meta?.name;
+  const name = typeof rawName === "string" && rawName.length > 0 ? rawName : null;
+  return { name, ruleNames: new Set(Object.keys(rules)) };
+};
+
+const slugifyUserPluginSpec = (spec: string): string => {
+  const base = spec
+    .split(/[/\\]/)
+    .pop()!
+    .replace(/\.(js|cjs|mjs|ts|cts|mts)$/i, "");
+  const slug = base.replace(/[^A-Za-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug : "user-plugin";
+};
+
+/**
+ * Resolves a user plugin spec from `react-doctor.config.json`'s
+ * `plugins: [...]` to an absolute file path. Two accepted spec
+ * shapes:
+ *
+ * - **Relative path** (`./`, `../`, or any path with `/` not starting
+ *   with a letter that npm would parse as a package): resolved
+ *   relative to `configSourceDirectory` (the dir of the config file
+ *   that declared it). Mirrors how `rootDir` is resolved.
+ * - **npm package name**: resolved via Node module resolution from
+ *   the config source directory's `node_modules`.
+ *
+ * Returns `null` when the spec can't be resolved or the resolved
+ * module doesn't look like an oxlint plugin (no `rules` field).
+ * A warning is logged in either case; the scan continues without
+ * the user plugin so config typos don't block the rest of the run.
+ */
+export const resolveUserPlugin = (
+  spec: string,
+  configSourceDirectory: string,
+): ResolvedUserPlugin | null => {
+  const isRelative = spec.startsWith("./") || spec.startsWith("../") || path.isAbsolute(spec);
+  const candidateRequire = createRequire(path.join(configSourceDirectory, "noop.js"));
+  let resolvedSpecifier: string;
+  try {
+    resolvedSpecifier = isRelative
+      ? path.resolve(configSourceDirectory, spec)
+      : candidateRequire.resolve(spec);
+  } catch (error) {
+    process.stderr.write(
+      `[react-doctor] config.plugins entry "${spec}" could not be resolved from ${configSourceDirectory}: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    return null;
+  }
+  const pluginModule = readPluginModule(resolvedSpecifier);
+  if (pluginModule === null) {
+    process.stderr.write(
+      `[react-doctor] config.plugins entry "${spec}" (resolved to ${resolvedSpecifier}) failed to load — skipping.\n`,
+    );
+    return null;
+  }
+  const { name, ruleNames } = readPluginShape(pluginModule);
+  if (ruleNames.size === 0) {
+    process.stderr.write(
+      `[react-doctor] config.plugins entry "${spec}" exports no rules (expected \`{ meta: { name }, rules: {...} }\` shape) — skipping.\n`,
+    );
+    return null;
+  }
+  const resolvedName = name ?? slugifyUserPluginSpec(spec);
+  return {
+    entry: { name: resolvedName, specifier: resolvedSpecifier },
+    availableRuleNames: ruleNames,
+    originalSpec: spec,
+  };
+};
+
+export const resolveUserPlugins = (
+  specs: ReadonlyArray<string> | undefined,
+  configSourceDirectory: string,
+): ReadonlyArray<ResolvedUserPlugin> => {
+  if (!specs || specs.length === 0) return [];
+  const resolved: ResolvedUserPlugin[] = [];
+  const seenNames = new Set<string>();
+  for (const spec of specs) {
+    const plugin = resolveUserPlugin(spec, configSourceDirectory);
+    if (plugin === null) continue;
+    if (seenNames.has(plugin.entry.name)) {
+      process.stderr.write(
+        `[react-doctor] config.plugins entry "${spec}" declares duplicate plugin name "${plugin.entry.name}" — skipping. Rename via the plugin's \`meta.name\` field to load multiple variants.\n`,
+      );
+      continue;
+    }
+    seenNames.add(plugin.entry.name);
+    resolved.push(plugin);
+  }
+  return resolved;
+};
 
 const readPluginRuleNames = (pluginSpecifier: string): ReadonlySet<string> => {
   // HACK: oxlint resolves the plugin itself at scan time; we just need

--- a/packages/core/src/services/config.ts
+++ b/packages/core/src/services/config.ts
@@ -9,6 +9,14 @@ import { resolveConfigRootDir } from "../resolve-config-root-dir.js";
 export interface ResolvedConfig {
   readonly config: ReactDoctorConfig | null;
   readonly resolvedDirectory: string;
+  /**
+   * Directory of the `react-doctor.config.json` / `package.json`
+   * that supplied `config`. `null` when no config was found.
+   * Diverges from `resolvedDirectory` whenever `config.rootDir`
+   * redirects the scan — used as the resolution base for relative
+   * paths inside the config (e.g. `config.plugins: [...]`).
+   */
+  readonly configSourceDirectory: string | null;
 }
 
 const CONFIG_CACHE_CAPACITY = 16;
@@ -36,6 +44,7 @@ export class Config extends Context.Service<
             return {
               config: loaded?.config ?? null,
               resolvedDirectory: redirected ?? directory,
+              configSourceDirectory: loaded?.sourceDirectory ?? null,
             };
           }),
       });

--- a/packages/core/src/services/linter.ts
+++ b/packages/core/src/services/linter.ts
@@ -35,6 +35,12 @@ export interface LintInput {
   readonly adoptExistingLintConfig?: boolean;
   readonly ignoredTags?: ReadonlySet<string>;
   readonly userConfig?: ReactDoctorConfig | null;
+  /**
+   * Directory of the config file that declared `userConfig`.
+   * Used to resolve `userConfig.plugins` entries — diverges from
+   * `rootDirectory` after a `userConfig.rootDir` redirect.
+   */
+  readonly configSourceDirectory?: string;
   readonly nodeBinaryPath?: string;
 }
 
@@ -109,6 +115,7 @@ export class Linter extends Context.Service<
                   adoptExistingLintConfig: input.adoptExistingLintConfig,
                   ignoredTags: input.ignoredTags,
                   userConfig: input.userConfig ?? null,
+                  configSourceDirectory: input.configSourceDirectory,
                   onPartialFailure: (reason) => {
                     collectedFailures.push(reason);
                   },

--- a/packages/core/src/validate-config-types.ts
+++ b/packages/core/src/validate-config-types.ts
@@ -207,5 +207,8 @@ export const validateConfigTypes = (config: ReactDoctorConfig): ReactDoctorConfi
       validateSeverityMap(fieldName, value),
     );
   }
+  applyFieldValidator(config, validated, "plugins", (value) =>
+    validateStringArrayField("plugins", value),
+  );
   return validated;
 };

--- a/packages/core/src/validate-config-types.ts
+++ b/packages/core/src/validate-config-types.ts
@@ -5,6 +5,7 @@ import type {
   SurfaceControls,
 } from "@react-doctor/types";
 import { DIAGNOSTIC_SURFACES, isDiagnosticSurface } from "./diagnostic-surface.js";
+import { warnConfigIssue } from "./utils/warn-config-issue.js";
 
 const VALID_RULE_SEVERITIES: ReadonlyArray<RuleSeverityOverride> = ["error", "warn", "off"];
 
@@ -37,13 +38,6 @@ const SEVERITY_FIELD_NAMES = ["rules", "categories"] as const satisfies Readonly
   keyof ReactDoctorConfig
 >;
 
-// HACK: write to stderr directly so the warning is visible even in
-// `--json` mode (where the logger is silenced to keep stdout a single
-// valid JSON document). Same pattern as `coerceDiffValue` in cli.ts.
-const warnConfigField = (message: string): void => {
-  process.stderr.write(`[react-doctor] ${message}\n`);
-};
-
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -57,12 +51,12 @@ const coerceMaybeBooleanString = (fieldName: string, value: unknown): boolean | 
   if (typeof value === "boolean") return value;
   if (value === "true" || value === "false") {
     const coerced = value === "true";
-    warnConfigField(
+    warnConfigIssue(
       `config field "${fieldName}" is the string "${value}"; treating as boolean ${coerced}.`,
     );
     return coerced;
   }
-  warnConfigField(
+  warnConfigIssue(
     `config field "${fieldName}" must be a boolean (got ${typeof value}); ignoring this field.`,
   );
   return undefined;
@@ -70,7 +64,7 @@ const coerceMaybeBooleanString = (fieldName: string, value: unknown): boolean | 
 
 const validateString = (fieldName: string, value: unknown): string | undefined => {
   if (typeof value === "string") return value;
-  warnConfigField(
+  warnConfigIssue(
     `config field "${fieldName}" must be a string (got ${typeof value}); ignoring this field.`,
   );
   return undefined;
@@ -78,14 +72,14 @@ const validateString = (fieldName: string, value: unknown): string | undefined =
 
 const validateStringArrayField = (fieldName: string, value: unknown): string[] | undefined => {
   if (!Array.isArray(value)) {
-    warnConfigField(
+    warnConfigIssue(
       `config field "${fieldName}" must be an array of strings (got ${typeof value}); ignoring this field.`,
     );
     return undefined;
   }
   return value.filter((entry): entry is string => {
     if (typeof entry === "string") return true;
-    warnConfigField(
+    warnConfigIssue(
       `config field "${fieldName}" contains a non-string entry (${typeof entry}); ignoring the entry.`,
     );
     return false;
@@ -97,7 +91,7 @@ const validateSurfaceControls = (
   rawControls: unknown,
 ): SurfaceControls | undefined => {
   if (!isPlainObject(rawControls)) {
-    warnConfigField(
+    warnConfigIssue(
       `config field "surfaces.${surface}" must be an object (got ${typeof rawControls}); ignoring this surface.`,
     );
     return undefined;
@@ -118,7 +112,7 @@ const validateSurfacesField = (
   rawSurfaces: unknown,
 ): Partial<Record<DiagnosticSurface, SurfaceControls>> | undefined => {
   if (!isPlainObject(rawSurfaces)) {
-    warnConfigField(
+    warnConfigIssue(
       `config field "surfaces" must be an object (got ${typeof rawSurfaces}); ignoring this field.`,
     );
     return undefined;
@@ -126,7 +120,7 @@ const validateSurfacesField = (
   const validated: Partial<Record<DiagnosticSurface, SurfaceControls>> = {};
   for (const [key, value] of Object.entries(rawSurfaces)) {
     if (!isDiagnosticSurface(key)) {
-      warnConfigField(
+      warnConfigIssue(
         `config field "surfaces.${key}" is not a known surface (expected one of: ${DIAGNOSTIC_SURFACES.join(", ")}); ignoring.`,
       );
       continue;
@@ -145,7 +139,7 @@ const validateSeverityMap = (
   rawMap: unknown,
 ): Record<string, RuleSeverityOverride> | undefined => {
   if (!isPlainObject(rawMap)) {
-    warnConfigField(
+    warnConfigIssue(
       `config field "${fieldName}" must be an object (got ${typeof rawMap}); ignoring this field.`,
     );
     return undefined;
@@ -153,11 +147,11 @@ const validateSeverityMap = (
   const validated: Record<string, RuleSeverityOverride> = {};
   for (const [key, value] of Object.entries(rawMap)) {
     if (key.length === 0) {
-      warnConfigField(`config field "${fieldName}" has an empty key; ignoring the entry.`);
+      warnConfigIssue(`config field "${fieldName}" has an empty key; ignoring the entry.`);
       continue;
     }
     if (!isRuleSeverity(value)) {
-      warnConfigField(
+      warnConfigIssue(
         `config field "${fieldName}.${key}" must be one of: ${VALID_RULE_SEVERITIES.join(", ")} (got ${formatType(value)}); ignoring the entry.`,
       );
       continue;

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -75,7 +75,7 @@ const layersOf = (config: {
 }) =>
   Layer.mergeAll(
     Project.layerOf(sampleProject),
-    Config.layerOf({ config: null, resolvedDirectory: "/repo" }),
+    Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
     Files.layerInMemory(new Map()),
     Linter.layerOf(config.diagnostics ?? []),
     LintPartialFailures.layerLive,
@@ -128,7 +128,7 @@ describe("runInspect — missing React dependency", () => {
     const projectWithoutReact: ProjectInfo = { ...sampleProject, reactVersion: null };
     const layers = Layer.mergeAll(
       Project.layerOf(projectWithoutReact),
-      Config.layerOf({ config: null, resolvedDirectory: "/repo" }),
+      Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
       Files.layerInMemory(new Map()),
       Linter.layerOf([]),
       LintPartialFailures.layerLive,
@@ -149,7 +149,7 @@ describe("runInspect — missing React dependency", () => {
             new ReactDoctorError({ reason: new NoReactDependency({ directory: "/repo" }) }),
           ),
       }),
-      Config.layerOf({ config: null, resolvedDirectory: "/repo" }),
+      Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
       Files.layerInMemory(new Map()),
       Linter.layerOf([]),
       LintPartialFailures.layerLive,
@@ -188,7 +188,7 @@ describe("runInspect — mid-stream lint failure", () => {
     });
     const layers = Layer.mergeAll(
       Project.layerOf(sampleProject),
-      Config.layerOf({ config: null, resolvedDirectory: "/repo" }),
+      Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
       Files.layerInMemory(new Map()),
       failingLinter,
       LintPartialFailures.layerLive,
@@ -219,7 +219,7 @@ describe("runInspect — dead-code failure", () => {
     });
     const layers = Layer.mergeAll(
       Project.layerOf(sampleProject),
-      Config.layerOf({ config: null, resolvedDirectory: "/repo" }),
+      Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
       Files.layerInMemory(new Map()),
       Linter.layerOf([lintDiagnostic]),
       LintPartialFailures.layerLive,
@@ -293,6 +293,7 @@ describe("runInspect — Reporter sees post-filter diagnostics", () => {
       Config.layerOf({
         config: { ignore: { files: ["src/ignored.*"] } } as never,
         resolvedDirectory: "/repo",
+        configSourceDirectory: null,
       }),
       Files.layerInMemory(new Map()),
       Linter.layerOf([ignoredDiagnostic, lintDiagnostic]),

--- a/packages/core/tests/services/config.test.ts
+++ b/packages/core/tests/services/config.test.ts
@@ -7,6 +7,7 @@ describe("Config.layerOf", () => {
     const resolved = {
       config: { lint: false } as never,
       resolvedDirectory: "/repo/apps/web",
+      configSourceDirectory: "/repo",
     };
     const result = await Effect.runPromise(
       Effect.gen(function* () {

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -290,6 +290,65 @@ Block comments work inside JSX:
 
 For multi-line JSX, putting the comment immediately above the opening tag covers the entire attribute list (matching ESLint convention).
 
+## Custom rules (user plugins)
+
+Drop your own oxlint-shaped plugin into `react-doctor.config.json`'s `plugins` field and react-doctor runs your rules alongside the built-in ones. Useful for team-specific conventions ("no `<Box>` outside `packages/ui`", "all API calls go through `lib/client`", etc.) that don't belong upstream.
+
+### 1. Write the plugin
+
+Create a file anywhere in your repo. The shape is the oxlint plugin contract — a default-exported `{ meta: { name }, rules: { ... } }`. Each rule's `create(context)` returns ESTree-style visitors.
+
+```js
+// lint/team-conventions.cjs
+const noBareFetchRule = {
+  create: (context) => ({
+    CallExpression(node) {
+      if (node.callee.type === "Identifier" && node.callee.name === "fetch") {
+        context.report({
+          node,
+          message:
+            "Use `lib/client.request()` instead of bare `fetch` — keeps auth + tracing consistent.",
+        });
+      }
+    },
+  }),
+};
+
+module.exports = {
+  meta: { name: "team-conventions" },
+  rules: {
+    "no-bare-fetch": noBareFetchRule,
+  },
+};
+```
+
+For a richer authoring experience (TypeScript types, severity defaults, recommendation strings, category metadata, the `defineRule` helper), install [`oxlint-plugin-react-doctor`](https://npmjs.com/package/oxlint-plugin-react-doctor) and import `defineRule` + the `RulePlugin` types — the built-in plugin uses the same SDK.
+
+### 2. Register the plugin in `react-doctor.config.json`
+
+`plugins` accepts either a **relative path** (resolved relative to the config file) or an **npm package name**:
+
+```json
+{
+  "plugins": ["./lint/team-conventions.cjs", "react-doctor-plugin-shopify-conventions"],
+  "rules": {
+    "team-conventions/no-bare-fetch": "error",
+    "shopify-conventions/use-polaris-tokens": "warn"
+  }
+}
+```
+
+### 3. Run
+
+`npx react-doctor .` picks up the plugin and flows its diagnostics through every surface (CLI / PR comment / score / `--fail-on` gate) the same as built-in rules.
+
+### Notes
+
+- **Opt-in by default**: a user-plugin rule only runs when `rules: { "<plugin-name>/<rule>": "warn" | "error" }` explicitly enables it. Mirrors how `defaultEnabled: false` built-in rules behave so installing a third-party plugin doesn't surprise you with a flood of new diagnostics on the first scan.
+- **Namespace**: rule keys are `<plugin.meta.name>/<rule-name>`. If the plugin omits `meta.name`, react-doctor uses a slugified filename (e.g. `./lint/team-conventions.cjs` → `team-conventions`).
+- **Failure tolerance**: a plugin entry that can't be resolved or doesn't look like an oxlint plugin logs a warning and is skipped — your scan keeps going. Run with `--verbose` to see resolution diagnostics.
+- **Per-rule severity / ignore / surfaces**: every existing severity / ignore / surface knob (`rules`, `categories`, `ignore.{paths, rules, tags}`, `surfaces.{cli, prComment, score, ciFailure}`) treats user-plugin rules the same as built-in rules. You can demote a user-plugin rule out of CI without touching the rule's source.
+
 ## Lint plugin (standalone)
 
 The same rule set ships as both an oxlint plugin and an ESLint plugin, so you can wire it into whichever lint engine your project already runs. These are published as separate packages, so you can install just the lint integration without pulling in the full CLI.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -345,8 +345,8 @@ For a richer authoring experience (TypeScript types, severity defaults, recommen
 ### Notes
 
 - **Opt-in by default**: a user-plugin rule only runs when `rules: { "<plugin-name>/<rule>": "warn" | "error" }` explicitly enables it. Mirrors how `defaultEnabled: false` built-in rules behave so installing a third-party plugin doesn't surprise you with a flood of new diagnostics on the first scan.
-- **Namespace**: rule keys are `<plugin.meta.name>/<rule-name>`. If the plugin omits `meta.name`, react-doctor uses a slugified filename (e.g. `./lint/team-conventions.cjs` → `team-conventions`).
-- **Failure tolerance**: a plugin entry that can't be resolved or doesn't look like an oxlint plugin logs a warning and is skipped — your scan keeps going. Run with `--verbose` to see resolution diagnostics.
+- **`meta.name` is required**: rule keys are `<plugin.meta.name>/<rule-name>`. A plugin without `meta.name` is rejected (with a warning) so rule keys in `config.rules` can't silently change when a file gets renamed.
+- **Failure tolerance**: a plugin entry that can't be resolved or doesn't look like an oxlint plugin logs a warning to stderr and is skipped — your scan keeps going.
 - **Per-rule severity / ignore / surfaces**: every existing severity / ignore / surface knob (`rules`, `categories`, `ignore.{paths, rules, tags}`, `surfaces.{cli, prComment, score, ciFailure}`) treats user-plugin rules the same as built-in rules. You can demote a user-plugin rule out of CI without touching the rule's source.
 
 ## Lint plugin (standalone)

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -221,7 +221,13 @@ const runInspectWithRuntime = async (
   // applied first.
   const scoreLayer = Score.layerOf(null);
   const configLayer = hasConfigOverride
-    ? Config.layerOf({ config: userConfig, resolvedDirectory: directory })
+    ? Config.layerOf({
+        config: userConfig,
+        resolvedDirectory: directory,
+        // No canonical config file when the caller passes `configOverride`
+        // — plugin resolution falls back to the scan root.
+        configSourceDirectory: null,
+      })
     : Config.layerNode;
 
   const layers = Layer.mergeAll(

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -149,6 +149,14 @@ export const inspect = async (
   const hasConfigOverride = inputOptions.configOverride !== undefined;
   let scanDirectory = directory;
   let userConfig: ReactDoctorConfig | null;
+  // Source directory of the config file that supplied `userConfig`,
+  // when one was loaded from disk. Drives the resolution base for
+  // `config.plugins` entries — relative paths and npm packages
+  // resolve from here (the config file's location), NOT from the
+  // post-`rootDir` scan root. `null` when the caller passed
+  // `configOverride` programmatically, in which case the runner
+  // falls back to the scan root for plugin resolution.
+  let configSourceDirectory: string | null = null;
   if (hasConfigOverride) {
     userConfig = inputOptions.configOverride ?? null;
   } else {
@@ -159,6 +167,7 @@ export const inspect = async (
     );
     if (redirectedDirectory) scanDirectory = redirectedDirectory;
     userConfig = loadedConfig?.config ?? null;
+    configSourceDirectory = loadedConfig?.sourceDirectory ?? null;
   }
 
   const options = mergeInspectOptions(inputOptions, userConfig);
@@ -178,6 +187,7 @@ export const inspect = async (
       options,
       userConfig,
       hasConfigOverride,
+      configSourceDirectory,
       startTime,
     );
   } finally {
@@ -195,6 +205,7 @@ const runInspectWithRuntime = async (
   options: ResolvedInspectOptions,
   userConfig: ReactDoctorConfig | null,
   hasConfigOverride: boolean,
+  configSourceDirectory: string | null,
   startTime: number,
 ): Promise<InspectResult> => {
   const isDiffMode = options.includePaths.length > 0;
@@ -224,9 +235,12 @@ const runInspectWithRuntime = async (
     ? Config.layerOf({
         config: userConfig,
         resolvedDirectory: directory,
-        // No canonical config file when the caller passes `configOverride`
-        // — plugin resolution falls back to the scan root.
-        configSourceDirectory: null,
+        // `configSourceDirectory` is non-null when `inspect()` loaded
+        // the config from disk itself (the CLI path) and `null` only
+        // when the caller passed `configOverride` programmatically
+        // without a corresponding file. The runner falls back to the
+        // scan root in the null case.
+        configSourceDirectory,
       })
     : Config.layerNode;
 

--- a/packages/react-doctor/tests/user-plugins.test.ts
+++ b/packages/react-doctor/tests/user-plugins.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { runOxlint } from "@react-doctor/core";
+import { buildTestProject, setupReactProject } from "./regressions/_helpers.js";
+
+const tempRoot = mkdtempSync(path.join(tmpdir(), "rd-user-plugins-"));
+
+afterAll(() => {
+  rmSync(tempRoot, { recursive: true, force: true });
+});
+
+// User plugin source — mirrors the oxlint plugin contract documented
+// in `oxlint-plugin-react-doctor`'s `RulePlugin` type:
+//   { meta: { name }, rules: Record<ruleName, { create(context) => visitors }> }
+// Visitor walks every JSX text child and flags occurrences of "FORBIDDEN".
+const FORBIDDEN_WORD_PLUGIN = `
+const noForbiddenWordRule = {
+  create: (context) => ({
+    JSXText(node) {
+      if (typeof node.value !== "string") return;
+      if (node.value.includes("FORBIDDEN")) {
+        context.report({
+          node,
+          message: "team policy: 'FORBIDDEN' is not allowed in JSX text",
+        });
+      }
+    },
+  }),
+};
+
+module.exports = {
+  meta: { name: "team-conventions" },
+  rules: {
+    "no-forbidden-word": noForbiddenWordRule,
+  },
+};
+`;
+
+describe("user plugins (config.plugins)", () => {
+  it("loads a relative-path plugin and surfaces its rules when enabled", async () => {
+    const projectDir = setupReactProject(tempRoot, "loads-plugin", {
+      files: {
+        "src/App.tsx": `export const App = () => <div>FORBIDDEN content here</div>;\n`,
+        "lint/team-conventions.cjs": FORBIDDEN_WORD_PLUGIN,
+      },
+    });
+    writeFileSync(
+      path.join(projectDir, "react-doctor.config.json"),
+      JSON.stringify({
+        plugins: ["./lint/team-conventions.cjs"],
+        rules: { "team-conventions/no-forbidden-word": "error" },
+      }),
+    );
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: buildTestProject({ rootDirectory: projectDir }),
+      userConfig: {
+        plugins: ["./lint/team-conventions.cjs"],
+        rules: { "team-conventions/no-forbidden-word": "error" },
+      },
+    });
+
+    const userHits = diagnostics.filter((diagnostic) => diagnostic.rule === "no-forbidden-word");
+    expect(userHits.length).toBeGreaterThan(0);
+    expect(userHits[0].message).toContain("FORBIDDEN");
+  });
+
+  it("opts user-plugin rules out by default (no severity → rule never registers)", async () => {
+    const projectDir = setupReactProject(tempRoot, "opt-in-by-default", {
+      files: {
+        "src/App.tsx": `export const App = () => <div>FORBIDDEN content here</div>;\n`,
+        "lint/team-conventions.cjs": FORBIDDEN_WORD_PLUGIN,
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: buildTestProject({ rootDirectory: projectDir }),
+      userConfig: {
+        plugins: ["./lint/team-conventions.cjs"],
+        // No `rules: {...}` — user-plugin rules MUST be opt-in.
+      },
+    });
+
+    const userHits = diagnostics.filter((diagnostic) => diagnostic.rule === "no-forbidden-word");
+    expect(userHits).toEqual([]);
+  });
+
+  it("honors per-rule severity overrides from `rules: { ... }`", async () => {
+    const projectDir = setupReactProject(tempRoot, "honors-severity", {
+      files: {
+        "src/App.tsx": `export const App = () => <div>FORBIDDEN content here</div>;\n`,
+        "lint/team-conventions.cjs": FORBIDDEN_WORD_PLUGIN,
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: buildTestProject({ rootDirectory: projectDir }),
+      userConfig: {
+        plugins: ["./lint/team-conventions.cjs"],
+        rules: { "team-conventions/no-forbidden-word": "warn" },
+      },
+    });
+
+    const userHits = diagnostics.filter((diagnostic) => diagnostic.rule === "no-forbidden-word");
+    expect(userHits.length).toBeGreaterThan(0);
+    expect(userHits[0].severity).toBe("warning");
+  });
+
+  it("skips a plugin that can't be resolved and continues the scan", async () => {
+    const projectDir = setupReactProject(tempRoot, "skips-unresolvable", {
+      files: {
+        "src/App.tsx": `export const App = () => <div>hello</div>;\n`,
+      },
+    });
+
+    // Doesn't throw — bad plugin entries warn and continue.
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: buildTestProject({ rootDirectory: projectDir }),
+      userConfig: {
+        plugins: ["./does-not-exist.cjs"],
+        rules: { "does-not-exist/no-anything": "error" },
+      },
+    });
+
+    // Scan still completes; just no rule from the missing plugin fires.
+    expect(diagnostics.filter((d) => d.plugin === "does-not-exist")).toEqual([]);
+  });
+
+  it("falls back to a slugified namespace when the plugin omits `meta.name`", async () => {
+    const projectDir = setupReactProject(tempRoot, "slug-fallback", {
+      files: {
+        "src/App.tsx": `export const App = () => <div>FORBIDDEN content</div>;\n`,
+        "lint/anonymous-plugin.cjs": `
+const noForbiddenWordRule = {
+  create: (context) => ({
+    JSXText(node) {
+      if (typeof node.value === "string" && node.value.includes("FORBIDDEN")) {
+        context.report({ node, message: "no FORBIDDEN" });
+      }
+    },
+  }),
+};
+module.exports = { rules: { "no-forbidden-word": noForbiddenWordRule } };
+`,
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: buildTestProject({ rootDirectory: projectDir }),
+      userConfig: {
+        plugins: ["./lint/anonymous-plugin.cjs"],
+        // Namespace is the slug of "anonymous-plugin.cjs" → "anonymous-plugin".
+        rules: { "anonymous-plugin/no-forbidden-word": "error" },
+      },
+    });
+
+    const userHits = diagnostics.filter((diagnostic) => diagnostic.rule === "no-forbidden-word");
+    expect(userHits.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/react-doctor/tests/user-plugins.test.ts
+++ b/packages/react-doctor/tests/user-plugins.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
@@ -130,6 +130,43 @@ describe("user plugins (config.plugins)", () => {
 
     // Scan still completes; just no rule from the missing plugin fires.
     expect(diagnostics.filter((d) => d.plugin === "does-not-exist")).toEqual([]);
+  });
+
+  it("resolves a plugin spec from the config's source directory, not the scan root (rootDir redirect)", async () => {
+    // Bugbot regression (#438): `react-doctor.config.json` lives at
+    // a workspace root and redirects the scan via `rootDir: "apps/web"`,
+    // but the plugin file sits next to the CONFIG, not next to the
+    // scan target. The resolver MUST use the config source directory.
+    //
+    // Layout:
+    //   <workspace>/
+    //     lint/team-conventions.cjs      ← plugin (next to config)
+    //     apps/web/                      ← scan root after rootDir
+    //       package.json
+    //       src/App.tsx
+    const workspaceDir = path.join(tempRoot, "rootdir-redirect-workspace");
+    const scanDir = setupReactProject(workspaceDir, "apps/web", {
+      files: {
+        "src/App.tsx": `export const App = () => <div>FORBIDDEN content</div>;\n`,
+      },
+    });
+    mkdirSync(path.join(workspaceDir, "lint"), { recursive: true });
+    writeFileSync(path.join(workspaceDir, "lint/team-conventions.cjs"), FORBIDDEN_WORD_PLUGIN, {
+      encoding: "utf-8",
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: scanDir, // scan root (post-rootDir-redirect)
+      project: buildTestProject({ rootDirectory: scanDir }),
+      userConfig: {
+        plugins: ["./lint/team-conventions.cjs"], // relative to config dir, not scan dir
+        rules: { "team-conventions/no-forbidden-word": "error" },
+      },
+      configSourceDirectory: workspaceDir, // ← the fix: config dir
+    });
+
+    const userHits = diagnostics.filter((d) => d.rule === "no-forbidden-word");
+    expect(userHits.length).toBeGreaterThan(0);
   });
 
   it("skips a plugin that omits `meta.name` (required, no slug fallback)", async () => {

--- a/packages/react-doctor/tests/user-plugins.test.ts
+++ b/packages/react-doctor/tests/user-plugins.test.ts
@@ -169,6 +169,45 @@ describe("user plugins (config.plugins)", () => {
     expect(userHits.length).toBeGreaterThan(0);
   });
 
+  it("keeps user plugins when the extends-retry fallback fires (bugbot regression)", async () => {
+    // Bugbot regression (#438): when oxlint crashes on the user's
+    // adopted `.oxlintrc.json`, react-doctor retries once without
+    // `extends`. The retry must NOT silently drop user plugins —
+    // every config field threaded into the first attempt has to
+    // make the trip into the fallback too. Simulated here by
+    // pointing `adoptExistingLintConfig: true` at a project with a
+    // deliberately broken `.oxlintrc.json` (one that oxlint can't
+    // parse), then asserting the user-plugin diagnostic still
+    // surfaces from the retry.
+    const projectDir = setupReactProject(tempRoot, "extends-retry-keeps-plugins", {
+      files: {
+        "src/App.tsx": `export const App = () => <div>FORBIDDEN content here</div>;\n`,
+        "lint/team-conventions.cjs": FORBIDDEN_WORD_PLUGIN,
+        // Broken extends target: declares a plugin that doesn't
+        // resolve, so oxlint's first attempt fails and the retry
+        // fires.
+        ".oxlintrc.json": JSON.stringify({
+          jsPlugins: [
+            { name: "definitely-not-installed", specifier: "definitely-not-installed-plugin" },
+          ],
+        }),
+      },
+    });
+
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: buildTestProject({ rootDirectory: projectDir }),
+      adoptExistingLintConfig: true,
+      userConfig: {
+        plugins: ["./lint/team-conventions.cjs"],
+        rules: { "team-conventions/no-forbidden-word": "error" },
+      },
+    });
+
+    const userHits = diagnostics.filter((d) => d.rule === "no-forbidden-word");
+    expect(userHits.length).toBeGreaterThan(0);
+  });
+
   it("skips a plugin that omits `meta.name` (required, no slug fallback)", async () => {
     const projectDir = setupReactProject(tempRoot, "meta-name-required", {
       files: {

--- a/packages/react-doctor/tests/user-plugins.test.ts
+++ b/packages/react-doctor/tests/user-plugins.test.ts
@@ -132,8 +132,8 @@ describe("user plugins (config.plugins)", () => {
     expect(diagnostics.filter((d) => d.plugin === "does-not-exist")).toEqual([]);
   });
 
-  it("falls back to a slugified namespace when the plugin omits `meta.name`", async () => {
-    const projectDir = setupReactProject(tempRoot, "slug-fallback", {
+  it("skips a plugin that omits `meta.name` (required, no slug fallback)", async () => {
+    const projectDir = setupReactProject(tempRoot, "meta-name-required", {
       files: {
         "src/App.tsx": `export const App = () => <div>FORBIDDEN content</div>;\n`,
         "lint/anonymous-plugin.cjs": `
@@ -156,12 +156,13 @@ module.exports = { rules: { "no-forbidden-word": noForbiddenWordRule } };
       project: buildTestProject({ rootDirectory: projectDir }),
       userConfig: {
         plugins: ["./lint/anonymous-plugin.cjs"],
-        // Namespace is the slug of "anonymous-plugin.cjs" → "anonymous-plugin".
+        // Any namespace the user tries here matches nothing — the plugin
+        // is rejected for missing `meta.name` before any rules register.
         rules: { "anonymous-plugin/no-forbidden-word": "error" },
       },
     });
 
     const userHits = diagnostics.filter((diagnostic) => diagnostic.rule === "no-forbidden-word");
-    expect(userHits.length).toBeGreaterThan(0);
+    expect(userHits).toEqual([]);
   });
 });

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -248,4 +248,40 @@ export interface ReactDoctorConfig {
    * single category, use `ignore.tags` instead.
    */
   categories?: Record<string, RuleSeverityOverride>;
+  /**
+   * User-defined oxlint plugins to load alongside the built-in
+   * `react-doctor` plugin. Each entry is either:
+   *
+   * - A **relative path** to a JS / TS file (resolved relative to
+   *   the directory of the config file that declared it — NOT the
+   *   CWD), e.g. `"./lint/my-rules.js"`.
+   * - An **npm package name**, e.g. `"react-doctor-plugin-team-conventions"`.
+   *
+   * The module must default-export an oxlint-shaped plugin:
+   * `{ meta: { name: string }, rules: Record<string, HostRule> }`.
+   * Use `defineRule` from `oxlint-plugin-react-doctor` for the
+   * cleanest authoring shape — see CONTRIBUTING.md → "Writing a
+   * custom plugin" for the full template.
+   *
+   * Rules from a user plugin are **opt-in by default**: a rule
+   * doesn't run unless `rules: { "<plugin-name>/<rule>": "warn" | "error" }`
+   * explicitly enables it. (Mirrors how `defaultEnabled: false`
+   * rules behave in the built-in plugin.) Once enabled, the rule
+   * flows through every react-doctor surface (CLI / PR comment /
+   * score / CI gate) the same as a built-in rule.
+   *
+   * ```json
+   * {
+   *   "plugins": [
+   *     "./lint/my-team-rules.js",
+   *     "react-doctor-plugin-shopify-conventions"
+   *   ],
+   *   "rules": {
+   *     "my-team-rules/no-bare-fetch": "error",
+   *     "shopify-conventions/use-polaris-tokens": "warn"
+   *   }
+   * }
+   * ```
+   */
+  plugins?: string[];
 }


### PR DESCRIPTION
Users can now drop their own oxlint-shaped plugin into \`react-doctor.config.json\`'s new \`plugins: [...]\` field and react-doctor runs the rules alongside the built-in ones. Closes the long-standing gap where the only way to ship a custom rule was to fork the repo.

## Config shape

\`\`\`json
{
  "plugins": [
    "./lint/team-conventions.cjs",
    "react-doctor-plugin-shopify-conventions"
  ],
  "rules": {
    "team-conventions/no-bare-fetch": "error",
    "shopify-conventions/use-polaris-tokens": "warn"
  }
}
\`\`\`

Each \`plugins\` entry is either:
- A **relative path** (\`./\`, \`../\`, or absolute) resolved relative to the directory of the config file that declared it — same resolution shape as \`rootDir\`. NOT relative to CWD.
- An **npm package name** resolved via Node module resolution from the config source dir's \`node_modules\`.

The module must default-export an oxlint-plugin-shaped object: \`{ meta: { name }, rules: Record<ruleName, HostRule> }\`. The existing \`RulePlugin\` types from \`oxlint-plugin-react-doctor\` are the contract — third-party plugins can import \`defineRule\` + \`Rule\` / \`RulePlugin\` types for a typed authoring surface.

## Author a rule (3 steps)

### 1. Write the plugin

\`\`\`js
// lint/team-conventions.cjs
const noBareFetchRule = {
  create: (context) => ({
    CallExpression(node) {
      if (node.callee.type === "Identifier" && node.callee.name === "fetch") {
        context.report({
          node,
          message: "Use \`lib/client.request()\` instead of bare \`fetch\` — keeps auth + tracing consistent.",
        });
      }
    },
  }),
};
module.exports = { meta: { name: "team-conventions" }, rules: { "no-bare-fetch": noBareFetchRule } };
\`\`\`

For a richer authoring experience (TypeScript types, severity defaults, \`recommendation\` strings, \`category\` metadata, the \`defineRule\` helper), import from \`oxlint-plugin-react-doctor\` — the built-in plugin uses the same SDK.

### 2. Register in \`react-doctor.config.json\`

\`\`\`json
{ "plugins": ["./lint/team-conventions.cjs"], "rules": { "team-conventions/no-bare-fetch": "error" } }
\`\`\`

### 3. Run

\`npx react-doctor .\` picks up the plugin and flows its diagnostics through every surface (CLI / PR comment / score / \`--fail-on\` gate) the same as built-in rules.

## Behavior

- **Opt-in by default**: a user-plugin rule only runs when \`rules: { "<plugin-name>/<rule>": "warn" | "error" }\` explicitly enables it. Mirrors \`defaultEnabled: false\` for built-in rules so installing a third-party plugin doesn't surprise the user with a flood of new diagnostics.
- **Namespace**: rule keys are \`<plugin.meta.name>/<rule-name>\`. If the plugin omits \`meta.name\`, react-doctor slugifies the filename (\`./lint/team-conventions.cjs\` → \`team-conventions\`).
- **Failure tolerance**: unresolvable entries / non-plugin-shaped modules / duplicate plugin names log a warning to stderr and are skipped. The scan continues — a typo in one entry doesn't block the rest.
- **Full surface integration**: user-plugin rules flow through every existing severity / ignore / surface knob (\`rules\`, \`categories\`, \`ignore.{paths, rules, tags}\`, \`surfaces.{cli, prComment, score, ciFailure}\`) the same as built-in rules.

## Implementation

- \`config.plugins?: string[]\` added to \`ReactDoctorConfig\` (\`packages/types/src/config.ts\`)
- \`validateConfigTypes\` coerces / strips the new field via the existing \`validateStringArrayField\` helper
- \`resolveUserPlugin(spec, configSourceDir)\` + \`resolveUserPlugins\` in \`packages/core/src/runners/oxlint/plugin-resolution.ts\`
- \`createOxlintConfig\` accepts \`userPlugins\` and folds each plugin's enabled rules + its specifier into the generated oxlintrc.json
- \`runOxlint\` calls \`resolveUserPlugins(userConfig?.plugins, rootDirectory)\` and passes through

## Tests

\`packages/react-doctor/tests/user-plugins.test.ts\` (5 cases):
1. Relative-path plugin loads + surfaces diagnostics when enabled
2. User-plugin rules are opt-in by default (no severity → no fire)
3. \`rules: { "<plugin>/<rule>": "warn" }\` honored on output severity
4. Unresolvable plugin entry warns + scan continues
5. \`meta.name\` omission falls back to slugified filename

## Test plan

- [x] \`pnpm typecheck\` — all packages clean
- [x] \`pnpm test\` — 1447 tests across 114 files (5 new), all green
- [x] \`pnpm lint\` / \`pnpm format\` clean
- [x] \`pnpm smoke:json-report\` schema-valid

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds dynamic loading of user-specified JS plugins into the oxlint run and threads new config-source resolution through the inspect/linter pipeline, which can affect lint results and involves executing user-provided modules.
> 
> **Overview**
> Enables **custom lint rules via user plugins**: `react-doctor.config.json` can now declare `plugins: [...]` entries (relative paths or npm packages) which are resolved from the config file’s directory, introspected for `meta.name` + exported rules, and loaded into oxlint’s `jsPlugins` list.
> 
> User-plugin rules are **opt-in** (only registered when explicitly set to `warn`/`error` in `config.rules`), invalid/unresolvable plugins warn and are skipped, and the oxlint “retry without extends” fallback now preserves user plugins.
> 
> Plumbs `configSourceDirectory` through config resolution and lint execution (including CLI `inspect` and core `runInspect`), updates config validation/warnings, expands docs, and adds an end-to-end test suite covering plugin resolution, opt-in behavior, severity overrides, rootDir redirects, and failure tolerance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403cb6808096db63290063e39d025fc55db1ca8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->