### PR TITLE
refactor: decompose run-oxlint.ts + inspect.ts, adopt Layer.mock in tests

### DIFF
--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -1,365 +1,23 @@
-import { spawn } from "node:child_process";
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import {
-  ERROR_PREVIEW_LENGTH_CHARS,
-  OXLINT_OUTPUT_MAX_BYTES,
-  OXLINT_SPAWN_TIMEOUT_MS as DEFAULT_OXLINT_SPAWN_TIMEOUT_MS,
-  SOURCE_FILE_PATTERN,
-} from "./constants.js";
-import {
-  isSplittableReactDoctorError,
-  OxlintBatchExceeded,
-  OxlintOutputUnparseable,
-  OxlintSpawnFailed,
-  ReactDoctorError,
-} from "./errors.js";
+import type { Diagnostic, ProjectInfo, ReactDoctorConfig } from "@react-doctor/types";
 import { batchIncludePaths } from "./batch-include-paths.js";
 import { buildRuleSeverityControls } from "./build-rule-severity-controls.js";
 import { canOxlintExtendConfig } from "./can-oxlint-extend-config.js";
-import { resolveUserPlugins } from "./runners/oxlint/plugin-resolution.js";
 import { collectIgnorePatterns } from "./collect-ignore-patterns.js";
 import { detectUserLintConfigPaths } from "./detect-user-lint-config.js";
-import { dedupeDiagnostics } from "./utils/dedupe-diagnostics.js";
-import { listSourceFiles } from "./utils/list-source-files.js";
-import { createOxlintConfig } from "./runners/oxlint/config.js";
-import { shouldSuppressLocalUseHookDiagnostic } from "./runners/oxlint/should-suppress-local-use-hook-diagnostic.js";
-import reactDoctorPlugin, {
-  ALL_REACT_DOCTOR_RULE_KEYS,
-  FRAMEWORK_SPECIFIC_RULE_KEYS,
-} from "oxlint-plugin-react-doctor";
-import type {
-  CleanedDiagnostic,
-  Diagnostic,
-  OxlintOutput,
-  ProjectInfo,
-  ReactDoctorConfig,
-} from "@react-doctor/types";
-import { buildNoSecretsRecommendation } from "./utils/build-no-secrets-recommendation.js";
 import { neutralizeDisableDirectives } from "./neutralize-disable-directives.js";
-
-const getRuleRecommendation = (ruleName: string, project: ProjectInfo): string | undefined => {
-  if (ruleName === "no-secrets-in-client-code") {
-    return buildNoSecretsRecommendation(
-      project,
-      reactDoctorPlugin.rules["no-secrets-in-client-code"]?.recommendation ??
-        "Move secrets to server-only code",
-    );
-  }
-  return reactDoctorPlugin.rules[ruleName]?.recommendation;
-};
-
-// Same shape as `getRuleRecommendation`, but for the diagnostic category
-// (`State & Effects`, `Performance`, …) the rule rolls up under in the
-// scan summary. Used by `resolveDiagnosticCategory` below and by
-// `validateRuleRegistration` to assert per-rule metadata coverage.
-const getRuleCategory = (ruleName: string): string | undefined =>
-  reactDoctorPlugin.rules[ruleName]?.category;
-
-const esmRequire = createRequire(import.meta.url);
-
-const PLUGIN_CATEGORY_MAP: Record<string, string> = {
-  react: "Correctness",
-  "react-hooks": "Correctness",
-  "react-hooks-js": "React Compiler",
-  "react-doctor": "Other",
-  "jsx-a11y": "Accessibility",
-  effect: "State & Effects",
-  // Plugins users commonly enable in their own oxlint / eslint config
-  // and that react-doctor folds into the scan via `extends`. Sensible
-  // defaults so adopted-rule diagnostics don't all collapse into the
-  // generic "Other" bucket in the output grouping.
-  eslint: "Correctness",
-  oxc: "Correctness",
-  typescript: "Correctness",
-  unicorn: "Correctness",
-  import: "Bundle Size",
-  promise: "Correctness",
-  n: "Correctness",
-  node: "Correctness",
-  vitest: "Correctness",
-  jest: "Correctness",
-  nextjs: "Next.js",
-};
-
-const FILEPATH_WITH_LOCATION_PATTERN = /\S+\.\w+:\d+:\d+[\s\S]*$/;
-
-const REACT_COMPILER_MESSAGE = "React Compiler can't optimize this code";
-
-// HACK: `Object.hasOwn` guards against falling through to
-// `Object.prototype` when oxlint emits a rule whose name happens to
-// shadow a base Object property (`constructor`, `toString`, …). Without
-// the guard the rule's help text would render as
-// `function Object() { [native code] }`. Same defense applied to the
-// plugin-/rule-category lookups below.
-const lookupOwnString = (record: Record<string, string>, key: string): string | undefined =>
-  Object.hasOwn(record, key) ? record[key] : undefined;
-
-const cleanDiagnosticMessage = (
-  message: string,
-  help: string,
-  plugin: string,
-  rule: string,
-  project: ProjectInfo,
-): CleanedDiagnostic => {
-  if (plugin === "react-hooks-js") {
-    const rawMessage = message.replace(FILEPATH_WITH_LOCATION_PATTERN, "").trim();
-    return { message: REACT_COMPILER_MESSAGE, help: rawMessage || help };
-  }
-  const cleaned = message.replace(FILEPATH_WITH_LOCATION_PATTERN, "").trim();
-  return {
-    message: cleaned || message,
-    help: help || getRuleRecommendation(rule, project) || "",
-  };
-};
-
-const parseRuleCode = (code: string): { plugin: string; rule: string } => {
-  const match = code.match(/^(.+)\((.+)\)$/);
-  if (!match) return { plugin: "unknown", rule: code };
-  return { plugin: match[1].replace(/^eslint-plugin-/, ""), rule: match[2] };
-};
-
-const resolveOxlintBinary = (): string => {
-  const oxlintMainPath = esmRequire.resolve("oxlint");
-  const oxlintPackageDirectory = path.resolve(path.dirname(oxlintMainPath), "..");
-  return path.join(oxlintPackageDirectory, "bin", "oxlint");
-};
-
-// Oxlint loads JS plugins by file path (`await import(specifier)`). We resolve
-// the installed `oxlint-plugin-react-doctor` package's main entry — it ships a
-// default-exported plugin module that oxlint accepts as-is. This works in dev
-// (workspace symlink), in npm installs (node_modules/.pnpm/...), and from
-// pnpm dlx / npx temp directories.
-const resolvePluginPath = (): string => esmRequire.resolve("oxlint-plugin-react-doctor");
-
-const resolveDiagnosticCategory = (plugin: string, rule: string): string =>
-  getRuleCategory(rule) ?? lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ?? "Other";
-
-// HACK: Sanitize child env so a developer's NODE_OPTIONS=--inspect (or
-// --max-old-space-size=128, etc.) doesn't leak into oxlint and either spawn a
-// debugger port or starve it of memory. We also drop npm_config_* lifecycle
-// vars to keep oxlint from picking up package-manager state. PATH, HOME,
-// NODE_ENV, NODE_PATH, etc. pass through unchanged.
-const SANITIZED_ENV: NodeJS.ProcessEnv = (() => {
-  const sanitized: NodeJS.ProcessEnv = {};
-  for (const [name, value] of Object.entries(process.env)) {
-    if (name === "NODE_OPTIONS" || name === "NODE_DEBUG") continue;
-    if (name.startsWith("npm_config_")) continue;
-    sanitized[name] = value;
-  }
-  return sanitized;
-})();
-
-// HACK: env override (`REACT_DOCTOR_OXLINT_SPAWN_TIMEOUT_MS`) so the
-// evals harness can raise the per-batch budget when running under
-// Vercel Sandbox microVMs, where the oxlint native binding is markedly
-// slower than on a developer laptop and the default starves every
-// batch. The default (and the docstring naming the regression that
-// pinned it) lives in constants.ts. Tests can override via the
-// OxlintSpawnTimeoutMs Context.Reference once the Linter service
-// wraps this function in PR 3.
-const OXLINT_SPAWN_TIMEOUT_MS = (() => {
-  const raw = process.env["REACT_DOCTOR_OXLINT_SPAWN_TIMEOUT_MS"];
-  if (raw === undefined) return DEFAULT_OXLINT_SPAWN_TIMEOUT_MS;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_OXLINT_SPAWN_TIMEOUT_MS;
-  return parsed;
-})();
-
-const spawnOxlint = (
-  args: string[],
-  rootDirectory: string,
-  nodeBinaryPath: string,
-): Promise<string> =>
-  new Promise<string>((resolve, reject) => {
-    const child = spawn(nodeBinaryPath, args, {
-      cwd: rootDirectory,
-      env: SANITIZED_ENV,
-    });
-
-    const timeoutHandle = setTimeout(() => {
-      child.kill("SIGKILL");
-      reject(
-        new ReactDoctorError({
-          reason: new OxlintBatchExceeded({
-            kind: "timeout",
-            detail: `${OXLINT_SPAWN_TIMEOUT_MS / 1000}s budget exceeded`,
-          }),
-        }),
-      );
-    }, OXLINT_SPAWN_TIMEOUT_MS);
-    timeoutHandle.unref?.();
-
-    const stdoutBuffers: Buffer[] = [];
-    const stderrBuffers: Buffer[] = [];
-    let stdoutByteCount = 0;
-    let stderrByteCount = 0;
-    let didKillForSize = false;
-
-    const killIfTooLarge = (incomingBytes: number, isStdout: boolean): boolean => {
-      if (isStdout) {
-        stdoutByteCount += incomingBytes;
-      } else {
-        stderrByteCount += incomingBytes;
-      }
-      if (stdoutByteCount + stderrByteCount > OXLINT_OUTPUT_MAX_BYTES && !didKillForSize) {
-        didKillForSize = true;
-        child.kill("SIGKILL");
-        return true;
-      }
-      return false;
-    };
-
-    child.stdout.on("data", (buffer: Buffer) => {
-      if (didKillForSize) return;
-      stdoutBuffers.push(buffer);
-      killIfTooLarge(buffer.length, true);
-    });
-    child.stderr.on("data", (buffer: Buffer) => {
-      if (didKillForSize) return;
-      stderrBuffers.push(buffer);
-      killIfTooLarge(buffer.length, false);
-    });
-
-    child.on("error", (error) => {
-      clearTimeout(timeoutHandle);
-      reject(new ReactDoctorError({ reason: new OxlintSpawnFailed({ cause: error }) }));
-    });
-    child.on("close", (_code, signal) => {
-      clearTimeout(timeoutHandle);
-      if (didKillForSize) {
-        reject(
-          new ReactDoctorError({
-            reason: new OxlintBatchExceeded({
-              kind: "output-too-large",
-              detail: `exceeded ${OXLINT_OUTPUT_MAX_BYTES} bytes — scan a smaller subset with --diff or --staged`,
-            }),
-          }),
-        );
-        return;
-      }
-      if (signal) {
-        const stderrOutput = Buffer.concat(stderrBuffers).toString("utf-8").trim();
-        const isOom = signal === "SIGABRT";
-        const detailParts: string[] = [`killed by ${signal}`];
-        if (isOom) detailParts.push("try scanning fewer files with --diff");
-        if (stderrOutput) detailParts.push(stderrOutput);
-        reject(
-          new ReactDoctorError({
-            reason: new OxlintBatchExceeded({
-              kind: isOom ? "oom" : "killed",
-              detail: detailParts.join(" — "),
-            }),
-          }),
-        );
-        return;
-      }
-      const output = Buffer.concat(stdoutBuffers).toString("utf-8").trim();
-      if (!output) {
-        const stderrOutput = Buffer.concat(stderrBuffers).toString("utf-8").trim();
-        if (stderrOutput) {
-          reject(new ReactDoctorError({ reason: new OxlintSpawnFailed({ cause: stderrOutput }) }));
-          return;
-        }
-      }
-      resolve(output);
-    });
-  });
-
-const isOxlintOutput = (value: unknown): value is OxlintOutput => {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as { diagnostics?: unknown };
-  return Array.isArray(candidate.diagnostics);
-};
-
-const parseOxlintOutput = (
-  stdout: string,
-  project: ProjectInfo,
-  rootDirectory: string,
-): Diagnostic[] => {
-  if (!stdout) return [];
-
-  // HACK: oxlint sometimes prepends a notice line to stdout (e.g. when
-  // every input was ignored — "No files found to lint. Please check…").
-  // Skip any leading non-JSON noise by jumping to the first `{` we see;
-  // the remainder is the actual report. Locale- and wording-agnostic.
-  const jsonStart = stdout.indexOf("{");
-  const sanitizedStdout = jsonStart > 0 ? stdout.slice(jsonStart) : stdout;
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(sanitizedStdout);
-  } catch {
-    throw new ReactDoctorError({
-      reason: new OxlintOutputUnparseable({
-        preview: stdout.slice(0, ERROR_PREVIEW_LENGTH_CHARS),
-      }),
-    });
-  }
-
-  if (!isOxlintOutput(parsed)) {
-    throw new ReactDoctorError({
-      reason: new OxlintOutputUnparseable({
-        preview: stdout.slice(0, ERROR_PREVIEW_LENGTH_CHARS),
-      }),
-    });
-  }
-  const output = parsed;
-
-  // HACK: oxlint reports diagnostics for every JS/TS extension it
-  // scanned (`.ts`, `.tsx`, `.js`, `.jsx`). The previous filter only
-  // kept `.tsx` / `.jsx` — fine when react-doctor's curated rules were
-  // the only sources (they're React-specific anyway), but adopted
-  // user rules like `eslint/no-debugger` or `unicorn/*` typically
-  // fire on plain `.ts` / `.js` files; dropping those silently
-  // erased their score impact. SOURCE_FILE_PATTERN matches the same
-  // extensions we count as source files everywhere else.
-  return output.diagnostics
-    .filter(
-      (diagnostic) =>
-        diagnostic.code &&
-        SOURCE_FILE_PATTERN.test(diagnostic.filename) &&
-        !shouldSuppressLocalUseHookDiagnostic(diagnostic, rootDirectory),
-    )
-    .map((diagnostic) => {
-      const { plugin, rule } = parseRuleCode(diagnostic.code);
-      const primaryLabel = diagnostic.labels[0];
-
-      const cleaned = cleanDiagnosticMessage(
-        diagnostic.message,
-        diagnostic.help,
-        plugin,
-        rule,
-        project,
-      );
-
-      return {
-        filePath: diagnostic.filename,
-        plugin,
-        rule,
-        severity: diagnostic.severity,
-        message: cleaned.message,
-        help: cleaned.help,
-        url: diagnostic.url,
-        line: primaryLabel?.span.line ?? 0,
-        column: primaryLabel?.span.column ?? 0,
-        category: resolveDiagnosticCategory(plugin, rule),
-      };
-    });
-};
-
-const TSCONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"];
-
-const resolveTsConfigRelativePath = (rootDirectory: string): string | null => {
-  for (const filename of TSCONFIG_FILENAMES) {
-    if (fs.existsSync(path.join(rootDirectory, filename))) {
-      return `./${filename}`;
-    }
-  }
-  return null;
-};
+import { createOxlintConfig } from "./runners/oxlint/config.js";
+import { resolveUserPlugins } from "./runners/oxlint/plugin-resolution.js";
+import {
+  resolveOxlintBinary,
+  resolvePluginPath,
+  resolveTsConfigRelativePath,
+} from "./runners/oxlint/resolve-paths.js";
+import { spawnLintBatches } from "./runners/oxlint/spawn-batches.js";
+import { validateRuleRegistration } from "./runners/oxlint/validate-rule-registration.js";
+import { listSourceFiles } from "./utils/list-source-files.js";
 
 interface RunOxlintOptions {
   rootDirectory: string;
@@ -373,9 +31,11 @@ interface RunOxlintOptions {
   /**
    * Optional react-doctor user config (already-loaded
    * `react-doctor.config.json` or `package.json#reactDoctor`). When
-   * provided, project-level knobs the rule surface honors — currently
-   * `serverAuthFunctionNames` — are forwarded to the generated oxlint
-   * settings so plugin rules can read them via `context.settings`.
+   * provided, project-level knobs the rule surface honors —
+   * currently `serverAuthFunctionNames` — are forwarded to the
+   * generated oxlint settings so plugin rules can read them via
+   * `context.settings`. `userConfig.plugins` resolves through
+   * `configSourceDirectory` (or `rootDirectory` as the fallback).
    */
   userConfig?: ReactDoctorConfig | null;
   /**
@@ -384,62 +44,61 @@ interface RunOxlintOptions {
    * `userConfig.plugins` entries — relative paths resolve against
    * this directory and npm package names resolve through its
    * `node_modules`, matching how `rootDir` resolves. Diverges from
-   * `rootDirectory` whenever `userConfig.rootDir` redirects the
-   * scan to a subtree.
+   * `rootDirectory` whenever `userConfig.rootDir` redirects the scan.
    *
    * Defaults to `rootDirectory` for direct callers that don't load
-   * a config file (e.g. tests that pass `userConfig` synthetically).
+   * a config file.
    */
   configSourceDirectory?: string;
   /**
    * Called once per soft-fail event (e.g. a batch hit
    * `OXLINT_SPAWN_TIMEOUT_MS` and was skipped). The lint scan keeps
-   * going on remaining batches; the caller is expected to surface the
-   * warning to the user (via `skippedCheckReasons` in JSON mode, or
-   * a logger message in human mode).
+   * going on remaining batches; the caller is expected to surface
+   * the warning to the user (via `skippedCheckReasons` in JSON
+   * mode, or a logger message in human mode).
    */
   onPartialFailure?: (reason: string) => void;
 }
 
-let didValidateRuleRegistration = false;
-
-const validateRuleRegistration = (): void => {
-  if (didValidateRuleRegistration) return;
-  didValidateRuleRegistration = true;
-  const missingHelp: string[] = [];
-  const missingCategory: string[] = [];
-  const missingMetadata: string[] = [];
-  for (const fullKey of ALL_REACT_DOCTOR_RULE_KEYS) {
-    const ruleName = fullKey.replace(/^react-doctor\//, "");
-    if (!getRuleCategory(ruleName)) {
-      missingCategory.push(fullKey);
-    }
-    if (!reactDoctorPlugin.rules[ruleName]?.recommendation) {
-      missingHelp.push(fullKey);
-    }
-    if (FRAMEWORK_SPECIFIC_RULE_KEYS.has(fullKey) && !reactDoctorPlugin.rules[ruleName]?.requires) {
-      missingMetadata.push(fullKey);
-    }
-  }
-  if (missingCategory.length > 0 || missingHelp.length > 0 || missingMetadata.length > 0) {
-    const detail = [
-      missingCategory.length > 0
-        ? `Missing rule categories (add to defineRule call): ${missingCategory.join(", ")}`
-        : null,
-      missingHelp.length > 0
-        ? `Missing rule recommendations (add to defineRule call): ${missingHelp.join(", ")}`
-        : null,
-      missingMetadata.length > 0
-        ? `Missing rule \`requires\` capability gate (add to defineRule call): ${missingMetadata.join(", ")}`
-        : null,
-    ]
-      .filter((entry): entry is string => entry !== null)
-      .join("; ");
-    // HACK: warn rather than throw — never block the user's scan over a metadata gap.
-    console.warn(`[react-doctor] rule-registration drift: ${detail}`);
+/**
+ * Atomically (re)writes the generated oxlintrc.json. Used twice in
+ * the runner: once for the primary scan, once for the
+ * extends-stripped retry fallback. Re-creates the file via
+ * `open(wx)` after `fs.rm` so a stale config at the path is treated
+ * as a failure rather than silently overwritten — the only
+ * legitimate overwriter is `this` runner inside the same temp dir.
+ */
+const writeOxlintConfig = (
+  configPath: string,
+  configToWrite: ReturnType<typeof createOxlintConfig>,
+): void => {
+  fs.rmSync(configPath, { force: true });
+  const fileHandle = fs.openSync(configPath, "wx", 0o600);
+  try {
+    fs.writeFileSync(fileHandle, JSON.stringify(configToWrite));
+  } finally {
+    fs.closeSync(fileHandle);
   }
 };
 
+/**
+ * The oxlint runner. Composed of three pieces in `runners/oxlint/`:
+ *
+ *   - `resolve-paths.ts`    — oxlint binary + plugin + tsconfig resolution
+ *   - `spawn-oxlint.ts`     — one subprocess invocation with hard ceilings
+ *   - `spawn-batches.ts`    — the batching loop with binary-split retry
+ *   - `parse-output.ts`     — oxlint stdout → `Diagnostic[]`
+ *   - `validate-rule-registration.ts` — one-time metadata-drift check
+ *
+ * This file owns the orchestration:
+ *
+ *   1. resolve plugins / extends / ignore patterns / tsconfig path
+ *   2. build the oxlintrc.json via `createOxlintConfig`
+ *   3. neutralize inline disable directives in audit mode
+ *   4. spawn `spawnLintBatches` against the file batches
+ *   5. on extends-related crashes, retry once with extends stripped
+ *   6. always restore disable directives + clean up the temp dir
+ */
 export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]> => {
   const {
     rootDirectory,
@@ -472,45 +131,37 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   const configPath = path.join(configDirectory, "oxlintrc.json");
   const pluginPath = resolvePluginPath();
   // HACK: pass user lint configs to oxlint as absolute paths. oxlint's
-  // docs say `extends` is "resolved relative to the configuration file
-  // that declares extends," but a literal `path.relative(configDir, ...)`
+  // docs say `extends` is "resolved relative to the configuration
+  // file that declares extends," but a literal `path.relative(configDir, ...)`
   // breaks when the OS resolves symlinked tmp dirs (e.g. macOS's
   // `/var/folders/.../T/...` actually lives under `/private/var/...`,
   // so a `../../../...` walk from the symlink view doesn't equal the
   // same walk from the canonical view and oxlint's NotFound errors
-  // out). Absolute paths sidestep the whole symlink dance — oxlint
-  // accepts them and they're stable across runtimes. We skip extends
-  // entirely under `customRulesOnly` because that mode opts out of
-  // every rule outside the react-doctor plugin.
+  // out). Absolute paths sidestep the whole symlink dance. We skip
+  // extends entirely under `customRulesOnly` because that mode opts
+  // out of every rule outside the react-doctor plugin.
   const detectedConfigPaths =
     adoptExistingLintConfig && !customRulesOnly ? detectUserLintConfigPaths(rootDirectory) : [];
   // HACK: filter out `.eslintrc.json` files whose `extends` lists only
-  // bare-package refs (`"next"`, `"airbnb"`, `"plugin:foo/bar"`). oxlint's
-  // resolver can't follow those — adopting them guarantees the parser
-  // crash + misleading "could not adopt existing lint config" warning.
-  // Drop them up front so the scan starts in the same state the fallback
-  // would land in, with no stderr noise.
+  // bare-package refs (`"next"`, `"airbnb"`, `"plugin:foo/bar"`).
+  // oxlint's resolver can't follow those — adopting them guarantees
+  // the parser crash + misleading warning. Drop them up front so the
+  // scan starts in the same state the fallback would land in.
   const extendsPaths = detectedConfigPaths.filter(canOxlintExtendConfig);
-  // Resolve user-declared plugins (`config.plugins: [...]`) against
-  // the config file's source directory — NOT the scan root, since
-  // those diverge whenever `userConfig.rootDir` redirects the scan
-  // to a subtree (the canonical monorepo case: the config sits at
-  // the workspace root with `rootDir: "apps/web"`, the scan root is
-  // `apps/web/`, but `./lint/team.cjs` still resolves from the
-  // workspace root). Defaults to `rootDirectory` for direct callers
-  // that don't load a config file (e.g. tests passing `userConfig`
-  // synthetically without a corresponding `configSourceDirectory`).
   const userPlugins = resolveUserPlugins(userConfig?.plugins, configSourceDirectory);
-  const config = createOxlintConfig({
-    pluginPath,
-    project,
-    customRulesOnly,
-    extendsPaths,
-    ignoredTags,
-    serverAuthFunctionNames,
-    severityControls,
-    userPlugins,
-  });
+
+  const buildConfig = (extendsForThisAttempt: string[]) =>
+    createOxlintConfig({
+      pluginPath,
+      project,
+      customRulesOnly,
+      extendsPaths: extendsForThisAttempt,
+      ignoredTags,
+      serverAuthFunctionNames,
+      severityControls,
+      userPlugins,
+    });
+
   // HACK: only neutralize disable comments in audit mode. Default
   // behavior respects the user's existing `// eslint-disable*` /
   // `// oxlint-disable*` directives — we let oxlint apply them.
@@ -529,13 +180,13 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       }
     }
 
-    // HACK: pass every ignore source via a single combined `--ignore-path`
-    // file (cheap on `baseArgs` length) rather than N `--ignore-pattern`
-    // entries (which would inflate per-batch arg length and shrink the
-    // file-count budget on large diffs). The combined file MUST include
-    // `.eslintignore` patterns because `--ignore-path` overrides oxlint's
-    // automatic `.eslintignore` lookup — that responsibility now lives
-    // in `collectIgnorePatterns`.
+    // HACK: pass every ignore source via a single combined
+    // `--ignore-path` file (cheap on `baseArgs` length) rather than
+    // N `--ignore-pattern` entries (which would inflate per-batch
+    // arg length and shrink the file-count budget on large diffs).
+    // The combined file MUST include `.eslintignore` patterns
+    // because `--ignore-path` overrides oxlint's automatic
+    // `.eslintignore` lookup.
     const combinedPatterns = collectIgnorePatterns(rootDirectory);
     if (combinedPatterns.length > 0) {
       const combinedIgnorePath = path.join(configDirectory, "combined.ignore");
@@ -543,128 +194,48 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       baseArgs.push("--ignore-path", combinedIgnorePath);
     }
 
-    // HACK: when `includePaths` is undefined we used to pass `["."]` and
-    // let oxlint walk the tree itself. That defeated batching entirely
-    // — verified on supabase/studio (3567 source files) that JS-plugin
-    // rules (originally the upstream `effect` plugin; now the natively
-    // ported `react-doctor/no-derived-state` family with comparable
-    // scope-walking cost) hit the 5-min `OXLINT_SPAWN_TIMEOUT_MS` in a
-    // single batch, leaving `skippedChecks: ["lint"]` and zero
-    // diagnostics for the entire project. Materializing the file list
-    // ahead of time and feeding it through `batchIncludePaths` keeps
-    // each spawn under the timeout (~7-8s per 100-file batch on studio)
-    // and recovers the diagnostics we were silently dropping.
+    // HACK: when `includePaths` is undefined we used to pass `["."]`
+    // and let oxlint walk the tree itself. That defeated batching
+    // entirely — verified on supabase/studio (3567 source files)
+    // that JS-plugin rules hit the 5-min `OXLINT_SPAWN_TIMEOUT_MS`
+    // in a single batch, leaving `skippedChecks: ["lint"]` and zero
+    // diagnostics. Materializing the file list ahead of time and
+    // feeding it through `batchIncludePaths` keeps each spawn under
+    // the timeout and recovers the diagnostics we were dropping.
     const fileBatches = batchIncludePaths(
       baseArgs,
       includePaths !== undefined ? includePaths : listSourceFiles(rootDirectory),
     );
 
-    const writeOxlintConfig = (configToWrite: ReturnType<typeof createOxlintConfig>): void => {
-      // HACK: fs.rm + open(wx) (instead of plain open(w)) so we keep
-      // the original "fail if a stale file exists at this exact path"
-      // safety net while still allowing the retry-without-extends
-      // fallback below to overwrite our own config in place.
-      fs.rmSync(configPath, { force: true });
-      const fileHandle = fs.openSync(configPath, "wx", 0o600);
-      try {
-        fs.writeFileSync(fileHandle, JSON.stringify(configToWrite));
-      } finally {
-        fs.closeSync(fileHandle);
-      }
-    };
+    const runBatches = () =>
+      spawnLintBatches({
+        baseArgs,
+        fileBatches,
+        rootDirectory,
+        nodeBinaryPath,
+        project,
+        onPartialFailure,
+      });
 
-    const spawnLintBatches = async (): Promise<Diagnostic[]> => {
-      const allDiagnostics: Diagnostic[] = [];
-      // HACK: tracks files whose smallest splittable batch (down to a
-      // single file) still failed with a splittable error — surfaced
-      // via `onPartialFailure` so JSON consumers see WHICH files were
-      // dropped instead of silently losing them. Compose with the
-      // binary-split below: large batches that time out / OOM split in
-      // half and retry; the only files that reach this set are the
-      // genuinely-pathological ones (e.g. one file × one quadratic
-      // JS-plugin rule, originally hit on supabase/studio's
-      // `apps/studio/pages/...` bucket against the upstream `effect`
-      // plugin and now applicable to the native port).
-      const droppedFiles: string[] = [];
-      // HACK: keep the first splittable error message we saw so
-      // `onPartialFailure` can report WHY each batch failed instead
-      // of misleadingly always blaming the per-batch budget. Same
-      // root cause across a project tends to repeat (e.g. native
-      // binding crash on every invocation in a sandbox runtime), so
-      // surfacing one example is enough to diagnose.
-      let firstDropReason: string | null = null;
-
-      const spawnLintBatch = async (batch: string[]): Promise<Diagnostic[]> => {
-        const batchArgs = [...baseArgs, ...batch];
-        try {
-          const stdout = await spawnOxlint(batchArgs, rootDirectory, nodeBinaryPath);
-          return parseOxlintOutput(stdout, project, rootDirectory);
-        } catch (error) {
-          if (!isSplittableReactDoctorError(error)) throw error;
-          if (batch.length <= 1) {
-            // Single-file batch still fails with a splittable error —
-            // drop the file, record it, and let the scan continue.
-            droppedFiles.push(...batch);
-            if (firstDropReason === null) {
-              firstDropReason = error.message;
-            }
-            return [];
-          }
-          const splitIndex = Math.ceil(batch.length / 2);
-          return [
-            ...(await spawnLintBatch(batch.slice(0, splitIndex))),
-            ...(await spawnLintBatch(batch.slice(splitIndex))),
-          ];
-        }
-      };
-
-      for (const batch of fileBatches) {
-        allDiagnostics.push(...(await spawnLintBatch(batch)));
-      }
-
-      if (droppedFiles.length > 0 && onPartialFailure) {
-        const previewCount = 3;
-        const previewFiles = droppedFiles.slice(0, previewCount).join(", ");
-        const remainderHint =
-          droppedFiles.length > previewCount ? `, +${droppedFiles.length - previewCount} more` : "";
-        const reasonHint = firstDropReason ? ` — first failure: ${firstDropReason}` : "";
-        onPartialFailure(
-          `${droppedFiles.length} file(s) failed to lint and were skipped (${previewFiles}${remainderHint})${reasonHint}`,
-        );
-      }
-      return dedupeDiagnostics(allDiagnostics);
-    };
-
-    writeOxlintConfig(config);
+    writeOxlintConfig(configPath, buildConfig(extendsPaths));
     try {
-      return await spawnLintBatches();
+      return await runBatches();
     } catch (error) {
       // HACK: if the user's adopted lint config is the reason oxlint
       // crashed (broken JSON, missing plugin, unknown rule), failing
       // the entire lint pass would leave the user with a 100/100
-      // score off zero diagnostics — a worse outcome than running our
-      // curated rules without their extras. Retry once without
-      // `extends` and keep the scan useful. The retry is silent: a
-      // mid-output stderr warning was noisy enough that users took it
-      // as react-doctor itself crashing; the curated-rules scan is the
-      // graceful path.
+      // score off zero diagnostics — a worse outcome than running
+      // our curated rules without their extras. Retry once without
+      // `extends` and keep the scan useful. The retry is silent:
+      // mid-output stderr warning was noisy enough that users took
+      // it as react-doctor itself crashing; the curated-rules scan
+      // is the graceful path.
       if (extendsPaths.length === 0) throw error;
-      // Drop `extendsPaths` only — keep `userPlugins` (and every
-      // other option) so the retry still runs the user's custom
-      // rules. Forgetting one option here silently disappears those
-      // diagnostics from the successful retry without warning.
-      const fallbackConfig = createOxlintConfig({
-        pluginPath,
-        project,
-        customRulesOnly,
-        extendsPaths: [],
-        ignoredTags,
-        serverAuthFunctionNames,
-        severityControls,
-        userPlugins,
-      });
-      writeOxlintConfig(fallbackConfig);
-      return await spawnLintBatches();
+      // `buildConfig([])` carries every other option through — most
+      // importantly `userPlugins`, so custom rules from
+      // `config.plugins` still run on the retry.
+      writeOxlintConfig(configPath, buildConfig([]));
+      return await runBatches();
     }
   } finally {
     restoreDisableDirectives();

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -1,0 +1,174 @@
+import reactDoctorPlugin from "oxlint-plugin-react-doctor";
+import type { CleanedDiagnostic, Diagnostic, OxlintOutput, ProjectInfo } from "@react-doctor/types";
+import { ERROR_PREVIEW_LENGTH_CHARS, SOURCE_FILE_PATTERN } from "../../constants.js";
+import { OxlintOutputUnparseable, ReactDoctorError } from "../../errors.js";
+import { buildNoSecretsRecommendation } from "../../utils/build-no-secrets-recommendation.js";
+import { shouldSuppressLocalUseHookDiagnostic } from "./should-suppress-local-use-hook-diagnostic.js";
+
+const FILEPATH_WITH_LOCATION_PATTERN = /\S+\.\w+:\d+:\d+[\s\S]*$/;
+
+const REACT_COMPILER_MESSAGE = "React Compiler can't optimize this code";
+
+const PLUGIN_CATEGORY_MAP: Record<string, string> = {
+  react: "Correctness",
+  "react-hooks": "Correctness",
+  "react-hooks-js": "React Compiler",
+  "react-doctor": "Other",
+  "jsx-a11y": "Accessibility",
+  effect: "State & Effects",
+  // Plugins users commonly enable in their own oxlint / eslint config
+  // and that react-doctor folds into the scan via `extends`. Sensible
+  // defaults so adopted-rule diagnostics don't all collapse into the
+  // generic "Other" bucket in the output grouping.
+  eslint: "Correctness",
+  oxc: "Correctness",
+  typescript: "Correctness",
+  unicorn: "Correctness",
+  import: "Bundle Size",
+  promise: "Correctness",
+  n: "Correctness",
+  node: "Correctness",
+  vitest: "Correctness",
+  jest: "Correctness",
+  nextjs: "Next.js",
+};
+
+// HACK: `Object.hasOwn` guards against falling through to
+// `Object.prototype` when oxlint emits a rule whose name happens to
+// shadow a base Object property (`constructor`, `toString`, …). Without
+// the guard the rule's help text would render as
+// `function Object() { [native code] }`. Same defense applied to the
+// plugin-/rule-category lookups below.
+const lookupOwnString = (record: Record<string, string>, key: string): string | undefined =>
+  Object.hasOwn(record, key) ? record[key] : undefined;
+
+const getRuleRecommendation = (ruleName: string, project: ProjectInfo): string | undefined => {
+  if (ruleName === "no-secrets-in-client-code") {
+    return buildNoSecretsRecommendation(
+      project,
+      reactDoctorPlugin.rules["no-secrets-in-client-code"]?.recommendation ??
+        "Move secrets to server-only code",
+    );
+  }
+  return reactDoctorPlugin.rules[ruleName]?.recommendation;
+};
+
+// Same shape as `getRuleRecommendation`, but for the diagnostic category
+// (`State & Effects`, `Performance`, …) the rule rolls up under in the
+// scan summary. Used by `resolveDiagnosticCategory` below and by
+// `validateRuleRegistration` to assert per-rule metadata coverage.
+export const getRuleCategory = (ruleName: string): string | undefined =>
+  reactDoctorPlugin.rules[ruleName]?.category;
+
+const cleanDiagnosticMessage = (
+  message: string,
+  help: string,
+  plugin: string,
+  rule: string,
+  project: ProjectInfo,
+): CleanedDiagnostic => {
+  if (plugin === "react-hooks-js") {
+    const rawMessage = message.replace(FILEPATH_WITH_LOCATION_PATTERN, "").trim();
+    return { message: REACT_COMPILER_MESSAGE, help: rawMessage || help };
+  }
+  const cleaned = message.replace(FILEPATH_WITH_LOCATION_PATTERN, "").trim();
+  return {
+    message: cleaned || message,
+    help: help || getRuleRecommendation(rule, project) || "",
+  };
+};
+
+const parseRuleCode = (code: string): { plugin: string; rule: string } => {
+  const match = code.match(/^(.+)\((.+)\)$/);
+  if (!match) return { plugin: "unknown", rule: code };
+  return { plugin: match[1].replace(/^eslint-plugin-/, ""), rule: match[2] };
+};
+
+const resolveDiagnosticCategory = (plugin: string, rule: string): string =>
+  getRuleCategory(rule) ?? lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ?? "Other";
+
+const isOxlintOutput = (value: unknown): value is OxlintOutput => {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as { diagnostics?: unknown };
+  return Array.isArray(candidate.diagnostics);
+};
+
+/**
+ * Parses one oxlint subprocess's stdout into a flat `Diagnostic[]`.
+ * Tolerates the leading-notice-line shape oxlint sometimes prints
+ * before the JSON body (e.g. "No files found to lint…") by skipping
+ * to the first `{`. Raises `OxlintOutputUnparseable` when the
+ * stdout isn't valid JSON or doesn't carry a `diagnostics` array.
+ */
+export const parseOxlintOutput = (
+  stdout: string,
+  project: ProjectInfo,
+  rootDirectory: string,
+): Diagnostic[] => {
+  if (!stdout) return [];
+
+  // HACK: oxlint sometimes prepends a notice line to stdout (e.g. when
+  // every input was ignored — "No files found to lint. Please check…").
+  // Skip any leading non-JSON noise by jumping to the first `{` we see;
+  // the remainder is the actual report. Locale- and wording-agnostic.
+  const jsonStart = stdout.indexOf("{");
+  const sanitizedStdout = jsonStart > 0 ? stdout.slice(jsonStart) : stdout;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sanitizedStdout);
+  } catch {
+    throw new ReactDoctorError({
+      reason: new OxlintOutputUnparseable({
+        preview: stdout.slice(0, ERROR_PREVIEW_LENGTH_CHARS),
+      }),
+    });
+  }
+
+  if (!isOxlintOutput(parsed)) {
+    throw new ReactDoctorError({
+      reason: new OxlintOutputUnparseable({
+        preview: stdout.slice(0, ERROR_PREVIEW_LENGTH_CHARS),
+      }),
+    });
+  }
+
+  // HACK: oxlint reports diagnostics for every JS/TS extension it
+  // scanned (`.ts`, `.tsx`, `.js`, `.jsx`). The previous filter only
+  // kept `.tsx` / `.jsx` — fine when react-doctor's curated rules were
+  // the only sources (they're React-specific anyway), but adopted
+  // user rules like `eslint/no-debugger` or `unicorn/*` typically
+  // fire on plain `.ts` / `.js` files; dropping those silently
+  // erased their score impact. SOURCE_FILE_PATTERN matches the same
+  // extensions we count as source files everywhere else.
+  return parsed.diagnostics
+    .filter(
+      (diagnostic) =>
+        diagnostic.code &&
+        SOURCE_FILE_PATTERN.test(diagnostic.filename) &&
+        !shouldSuppressLocalUseHookDiagnostic(diagnostic, rootDirectory),
+    )
+    .map((diagnostic) => {
+      const { plugin, rule } = parseRuleCode(diagnostic.code);
+      const primaryLabel = diagnostic.labels[0];
+      const cleaned = cleanDiagnosticMessage(
+        diagnostic.message,
+        diagnostic.help,
+        plugin,
+        rule,
+        project,
+      );
+      return {
+        filePath: diagnostic.filename,
+        plugin,
+        rule,
+        severity: diagnostic.severity,
+        message: cleaned.message,
+        help: cleaned.help,
+        url: diagnostic.url,
+        line: primaryLabel?.span.line ?? 0,
+        column: primaryLabel?.span.column ?? 0,
+        category: resolveDiagnosticCategory(plugin, rule),
+      };
+    });
+};

--- a/packages/core/src/runners/oxlint/resolve-paths.ts
+++ b/packages/core/src/runners/oxlint/resolve-paths.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const esmRequire = createRequire(import.meta.url);
+
+export const resolveOxlintBinary = (): string => {
+  const oxlintMainPath = esmRequire.resolve("oxlint");
+  const oxlintPackageDirectory = path.resolve(path.dirname(oxlintMainPath), "..");
+  return path.join(oxlintPackageDirectory, "bin", "oxlint");
+};
+
+// Oxlint loads JS plugins by file path (`await import(specifier)`). We
+// resolve the installed `oxlint-plugin-react-doctor` package's main
+// entry — it ships a default-exported plugin module that oxlint
+// accepts as-is. Works in dev (workspace symlink), in npm installs
+// (node_modules/.pnpm/...), and from pnpm dlx / npx temp directories.
+export const resolvePluginPath = (): string => esmRequire.resolve("oxlint-plugin-react-doctor");
+
+const TSCONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"];
+
+export const resolveTsConfigRelativePath = (rootDirectory: string): string | null => {
+  for (const filename of TSCONFIG_FILENAMES) {
+    if (fs.existsSync(path.join(rootDirectory, filename))) {
+      return `./${filename}`;
+    }
+  }
+  return null;
+};

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -1,0 +1,90 @@
+import type { Diagnostic, ProjectInfo } from "@react-doctor/types";
+import { isSplittableReactDoctorError } from "../../errors.js";
+import { dedupeDiagnostics } from "../../utils/dedupe-diagnostics.js";
+import { parseOxlintOutput } from "./parse-output.js";
+import { spawnOxlint } from "./spawn-oxlint.js";
+
+export interface SpawnLintBatchesInput {
+  readonly baseArgs: ReadonlyArray<string>;
+  readonly fileBatches: ReadonlyArray<string[]>;
+  readonly rootDirectory: string;
+  readonly nodeBinaryPath: string;
+  readonly project: ProjectInfo;
+  readonly onPartialFailure?: (reason: string) => void;
+}
+
+const PREVIEW_COUNT = 3;
+
+/**
+ * Runs every prebuilt file batch through oxlint, with binary-split
+ * retry on the splittable error classes (timeout / output-too-large /
+ * OOM / killed by signal). When a single-file batch still fails with
+ * a splittable error, the file is recorded into a dropped-files list
+ * (surfaced via `onPartialFailure`) so JSON-mode consumers see WHICH
+ * files were skipped instead of silently losing them.
+ *
+ * Errors that aren't splittable (oxlint config crash, JS plugin
+ * resolution failure, etc.) propagate to the caller — the
+ * `runOxlint` retry-without-extends fallback re-spawns this loop
+ * with a slimmer config in that case.
+ */
+export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Diagnostic[]> => {
+  const { baseArgs, fileBatches, rootDirectory, nodeBinaryPath, project, onPartialFailure } = input;
+
+  const allDiagnostics: Diagnostic[] = [];
+  // HACK: tracks files whose smallest splittable batch (down to a
+  // single file) still failed with a splittable error — surfaced via
+  // `onPartialFailure` so JSON consumers see WHICH files were dropped
+  // instead of silently losing them. Composes with the binary-split:
+  // large batches that time out / OOM split in half and retry; the
+  // only files that reach this set are the genuinely-pathological
+  // ones (e.g. one file × one quadratic JS-plugin rule, originally
+  // hit on supabase/studio's `apps/studio/pages/...` bucket).
+  const droppedFiles: string[] = [];
+  // HACK: keep the first splittable error message we saw so
+  // `onPartialFailure` can report WHY each batch failed instead of
+  // misleadingly always blaming the per-batch budget. Same root cause
+  // across a project tends to repeat (e.g. native binding crash on
+  // every invocation in a sandbox runtime), so surfacing one example
+  // is enough to diagnose.
+  let firstDropReason: string | null = null;
+
+  const spawnLintBatch = async (batch: string[]): Promise<Diagnostic[]> => {
+    const batchArgs = [...baseArgs, ...batch];
+    try {
+      const stdout = await spawnOxlint(batchArgs, rootDirectory, nodeBinaryPath);
+      return parseOxlintOutput(stdout, project, rootDirectory);
+    } catch (error) {
+      if (!isSplittableReactDoctorError(error)) throw error;
+      if (batch.length <= 1) {
+        // Single-file batch still fails with a splittable error —
+        // drop the file, record it, and let the scan continue.
+        droppedFiles.push(...batch);
+        if (firstDropReason === null) {
+          firstDropReason = error.message;
+        }
+        return [];
+      }
+      const splitIndex = Math.ceil(batch.length / 2);
+      return [
+        ...(await spawnLintBatch(batch.slice(0, splitIndex))),
+        ...(await spawnLintBatch(batch.slice(splitIndex))),
+      ];
+    }
+  };
+
+  for (const batch of fileBatches) {
+    allDiagnostics.push(...(await spawnLintBatch(batch)));
+  }
+
+  if (droppedFiles.length > 0 && onPartialFailure) {
+    const previewFiles = droppedFiles.slice(0, PREVIEW_COUNT).join(", ");
+    const remainderHint =
+      droppedFiles.length > PREVIEW_COUNT ? `, +${droppedFiles.length - PREVIEW_COUNT} more` : "";
+    const reasonHint = firstDropReason ? ` — first failure: ${firstDropReason}` : "";
+    onPartialFailure(
+      `${droppedFiles.length} file(s) failed to lint and were skipped (${previewFiles}${remainderHint})${reasonHint}`,
+    );
+  }
+  return dedupeDiagnostics(allDiagnostics);
+};

--- a/packages/core/src/runners/oxlint/spawn-oxlint.ts
+++ b/packages/core/src/runners/oxlint/spawn-oxlint.ts
@@ -1,0 +1,151 @@
+import { spawn } from "node:child_process";
+import {
+  OXLINT_OUTPUT_MAX_BYTES,
+  OXLINT_SPAWN_TIMEOUT_MS as DEFAULT_OXLINT_SPAWN_TIMEOUT_MS,
+} from "../../constants.js";
+import { OxlintBatchExceeded, OxlintSpawnFailed, ReactDoctorError } from "../../errors.js";
+
+// HACK: Sanitize child env so a developer's NODE_OPTIONS=--inspect (or
+// --max-old-space-size=128, etc.) doesn't leak into oxlint and either spawn a
+// debugger port or starve it of memory. We also drop npm_config_* lifecycle
+// vars to keep oxlint from picking up package-manager state. PATH, HOME,
+// NODE_ENV, NODE_PATH, etc. pass through unchanged.
+const SANITIZED_ENV: NodeJS.ProcessEnv = (() => {
+  const sanitized: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (name === "NODE_OPTIONS" || name === "NODE_DEBUG") continue;
+    if (name.startsWith("npm_config_")) continue;
+    sanitized[name] = value;
+  }
+  return sanitized;
+})();
+
+// HACK: env override (`REACT_DOCTOR_OXLINT_SPAWN_TIMEOUT_MS`) so the
+// evals harness can raise the per-batch budget when running under
+// Vercel Sandbox microVMs, where the oxlint native binding is markedly
+// slower than on a developer laptop and the default starves every
+// batch. The default (and the docstring naming the regression that
+// pinned it) lives in constants.ts.
+const OXLINT_SPAWN_TIMEOUT_MS = (() => {
+  const raw = process.env["REACT_DOCTOR_OXLINT_SPAWN_TIMEOUT_MS"];
+  if (raw === undefined) return DEFAULT_OXLINT_SPAWN_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_OXLINT_SPAWN_TIMEOUT_MS;
+  return parsed;
+})();
+
+/**
+ * Spawn one oxlint subprocess with hard ceilings on wall time and
+ * output size. Returns stdout on success; raises a tagged
+ * `ReactDoctorError` for every documented failure mode:
+ *
+ * - `OxlintBatchExceeded { kind: "timeout" }` — wall budget elapsed.
+ * - `OxlintBatchExceeded { kind: "output-too-large" }` — stdout+stderr
+ *   crossed `OXLINT_OUTPUT_MAX_BYTES`.
+ * - `OxlintBatchExceeded { kind: "oom" | "killed" }` — child exited
+ *   on a signal (SIGABRT → OOM, others → generic kill).
+ * - `OxlintSpawnFailed { cause }` — `spawn` itself errored, or the
+ *   child exited successfully but printed only stderr.
+ *
+ * The first three are splittable (the caller's binary-split retry
+ * shrinks the batch and re-spawns); the fourth isn't.
+ */
+export const spawnOxlint = (
+  args: string[],
+  rootDirectory: string,
+  nodeBinaryPath: string,
+): Promise<string> =>
+  new Promise<string>((resolve, reject) => {
+    const child = spawn(nodeBinaryPath, args, {
+      cwd: rootDirectory,
+      env: SANITIZED_ENV,
+    });
+
+    const timeoutHandle = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(
+        new ReactDoctorError({
+          reason: new OxlintBatchExceeded({
+            kind: "timeout",
+            detail: `${OXLINT_SPAWN_TIMEOUT_MS / 1000}s budget exceeded`,
+          }),
+        }),
+      );
+    }, OXLINT_SPAWN_TIMEOUT_MS);
+    timeoutHandle.unref?.();
+
+    const stdoutBuffers: Buffer[] = [];
+    const stderrBuffers: Buffer[] = [];
+    let stdoutByteCount = 0;
+    let stderrByteCount = 0;
+    let didKillForSize = false;
+
+    const killIfTooLarge = (incomingBytes: number, isStdout: boolean): boolean => {
+      if (isStdout) {
+        stdoutByteCount += incomingBytes;
+      } else {
+        stderrByteCount += incomingBytes;
+      }
+      if (stdoutByteCount + stderrByteCount > OXLINT_OUTPUT_MAX_BYTES && !didKillForSize) {
+        didKillForSize = true;
+        child.kill("SIGKILL");
+        return true;
+      }
+      return false;
+    };
+
+    child.stdout.on("data", (buffer: Buffer) => {
+      if (didKillForSize) return;
+      stdoutBuffers.push(buffer);
+      killIfTooLarge(buffer.length, true);
+    });
+    child.stderr.on("data", (buffer: Buffer) => {
+      if (didKillForSize) return;
+      stderrBuffers.push(buffer);
+      killIfTooLarge(buffer.length, false);
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timeoutHandle);
+      reject(new ReactDoctorError({ reason: new OxlintSpawnFailed({ cause: error }) }));
+    });
+    child.on("close", (_code, signal) => {
+      clearTimeout(timeoutHandle);
+      if (didKillForSize) {
+        reject(
+          new ReactDoctorError({
+            reason: new OxlintBatchExceeded({
+              kind: "output-too-large",
+              detail: `exceeded ${OXLINT_OUTPUT_MAX_BYTES} bytes — scan a smaller subset with --diff or --staged`,
+            }),
+          }),
+        );
+        return;
+      }
+      if (signal) {
+        const stderrOutput = Buffer.concat(stderrBuffers).toString("utf-8").trim();
+        const isOom = signal === "SIGABRT";
+        const detailParts: string[] = [`killed by ${signal}`];
+        if (isOom) detailParts.push("try scanning fewer files with --diff");
+        if (stderrOutput) detailParts.push(stderrOutput);
+        reject(
+          new ReactDoctorError({
+            reason: new OxlintBatchExceeded({
+              kind: isOom ? "oom" : "killed",
+              detail: detailParts.join(" — "),
+            }),
+          }),
+        );
+        return;
+      }
+      const output = Buffer.concat(stdoutBuffers).toString("utf-8").trim();
+      if (!output) {
+        const stderrOutput = Buffer.concat(stderrBuffers).toString("utf-8").trim();
+        if (stderrOutput) {
+          reject(new ReactDoctorError({ reason: new OxlintSpawnFailed({ cause: stderrOutput }) }));
+          return;
+        }
+      }
+      resolve(output);
+    });
+  });

--- a/packages/core/src/runners/oxlint/validate-rule-registration.ts
+++ b/packages/core/src/runners/oxlint/validate-rule-registration.ts
@@ -1,0 +1,56 @@
+import reactDoctorPlugin, {
+  ALL_REACT_DOCTOR_RULE_KEYS,
+  FRAMEWORK_SPECIFIC_RULE_KEYS,
+} from "oxlint-plugin-react-doctor";
+import { getRuleCategory } from "./parse-output.js";
+
+let didValidate = false;
+
+/**
+ * One-time lazy assertion that every shipped react-doctor rule has
+ * the metadata the renderer + capability gating depend on:
+ * `category` (drives the diagnostic grouping in CLI output),
+ * `recommendation` (the "Suggestion" line in `--verbose`), and —
+ * for framework-specific rules — a `requires` capability gate.
+ *
+ * Warns rather than throws so a metadata gap on one rule never
+ * blocks the user's whole scan; surfaced to the user as a single
+ * stderr line that's easy to grep / triage in CI logs.
+ */
+export const validateRuleRegistration = (): void => {
+  if (didValidate) return;
+  didValidate = true;
+  const missingHelp: string[] = [];
+  const missingCategory: string[] = [];
+  const missingMetadata: string[] = [];
+  for (const fullKey of ALL_REACT_DOCTOR_RULE_KEYS) {
+    const ruleName = fullKey.replace(/^react-doctor\//, "");
+    if (!getRuleCategory(ruleName)) {
+      missingCategory.push(fullKey);
+    }
+    if (!reactDoctorPlugin.rules[ruleName]?.recommendation) {
+      missingHelp.push(fullKey);
+    }
+    if (FRAMEWORK_SPECIFIC_RULE_KEYS.has(fullKey) && !reactDoctorPlugin.rules[ruleName]?.requires) {
+      missingMetadata.push(fullKey);
+    }
+  }
+  if (missingCategory.length === 0 && missingHelp.length === 0 && missingMetadata.length === 0) {
+    return;
+  }
+  const detail = [
+    missingCategory.length > 0
+      ? `Missing rule categories (add to defineRule call): ${missingCategory.join(", ")}`
+      : null,
+    missingHelp.length > 0
+      ? `Missing rule recommendations (add to defineRule call): ${missingHelp.join(", ")}`
+      : null,
+    missingMetadata.length > 0
+      ? `Missing rule \`requires\` capability gate (add to defineRule call): ${missingMetadata.join(", ")}`
+      : null,
+  ]
+    .filter((entry): entry is string => entry !== null)
+    .join("; ");
+  // HACK: warn rather than throw — never block the user's scan over a metadata gap.
+  console.warn(`[react-doctor] rule-registration drift: ${detail}`);
+};

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -141,9 +141,8 @@ describe("runInspect — missing React dependency", () => {
     // happens in the legacy inspect.ts before calling). For PR 5 the api
     // package adds the boundary check. This test verifies the orchestrator
     // *would* propagate a tagged error if one came from Project.
-    const failingProject = Project.layerOf(projectWithoutReact);
     const explicitFailLayers = Layer.mergeAll(
-      Layer.succeed(Project, {
+      Layer.mock(Project, {
         discover: () =>
           Effect.fail(
             new ReactDoctorError({ reason: new NoReactDependency({ directory: "/repo" }) }),
@@ -158,7 +157,6 @@ describe("runInspect — missing React dependency", () => {
       Reporter.layerNoop,
     );
     void layers;
-    void failingProject;
     const exit = await Effect.runPromiseExit(
       runInspect(baseInput).pipe(Effect.provide(explicitFailLayers)),
     );
@@ -178,7 +176,7 @@ describe("runInspect — missing React dependency", () => {
 
 describe("runInspect — mid-stream lint failure", () => {
   it("folds a Stream.fail into didLintFail without sinking the scan", async () => {
-    const failingLinter = Layer.succeed(Linter, {
+    const failingLinter = Layer.mock(Linter, {
       run: () =>
         Stream.fail(
           new ReactDoctorError({
@@ -209,7 +207,7 @@ describe("runInspect — mid-stream lint failure", () => {
 
 describe("runInspect — dead-code failure", () => {
   it("folds DeadCode failure without sinking the scan", async () => {
-    const failingDeadCode = Layer.succeed(DeadCode, {
+    const failingDeadCode = Layer.mock(DeadCode, {
       run: () =>
         Stream.fail(
           new ReactDoctorError({

--- a/packages/core/tests/services/staged-files.test.ts
+++ b/packages/core/tests/services/staged-files.test.ts
@@ -1,4 +1,3 @@
-import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import fs from "node:fs";
@@ -59,31 +58,23 @@ describe("StagedFiles.layerNode regression — per-file git failures", () => {
    * skip-and-continue behavior — never sink the whole snapshot.
    */
   it("skips files when git.showStagedContent raises and keeps materializing the rest", async () => {
-    const failingShowStagedGit = Layer.succeed(
-      Git,
-      Git.of({
-        currentBranch: () => Effect.succeed(null),
-        defaultBranch: () => Effect.succeed(null),
-        branchExists: () => Effect.succeed(false),
-        diffSelection: () => Effect.succeed(null),
-        stagedFilePaths: () => Effect.succeed(["src/a.ts", "src/b.ts"]),
-        showStagedContent: (_directory, relativePath) => {
-          if (relativePath === "src/a.ts") {
-            return Effect.fail(
-              new ReactDoctorError({
-                reason: new GitInvocationFailed({
-                  args: ["show", `:${relativePath}`],
-                  directory: "/repo",
-                  cause: new Error("simulated git missing"),
-                }),
+    const failingShowStagedGit = Layer.mock(Git, {
+      stagedFilePaths: () => Effect.succeed(["src/a.ts", "src/b.ts"]),
+      showStagedContent: (_directory, relativePath) => {
+        if (relativePath === "src/a.ts") {
+          return Effect.fail(
+            new ReactDoctorError({
+              reason: new GitInvocationFailed({
+                args: ["show", `:${relativePath}`],
+                directory: "/repo",
+                cause: new Error("simulated git missing"),
               }),
-            );
-          }
-          return Effect.succeed("export const b = 1;\n");
-        },
-        grep: () => Effect.succeed(null),
-      } satisfies Context.Tag.Service<typeof Git>),
-    );
+            }),
+          );
+        }
+        return Effect.succeed("export const b = 1;\n");
+      },
+    });
 
     const layer = StagedFiles.layerNode.pipe(Layer.provide(failingShowStagedGit));
 
@@ -123,23 +114,15 @@ describe("StagedFiles.layerNode — Zip-Slip defense (path traversal)", () => {
    * `writeFileSync` runs (the standard Zip-Slip defense shape).
    */
   it("skips a staged path that resolves outside the temp directory", async () => {
-    const escapingGit = Layer.succeed(
-      Git,
-      Git.of({
-        currentBranch: () => Effect.succeed(null),
-        defaultBranch: () => Effect.succeed(null),
-        branchExists: () => Effect.succeed(false),
-        diffSelection: () => Effect.succeed(null),
-        stagedFilePaths: () => Effect.succeed(["../escaped.ts", "src/inside.ts"]),
-        showStagedContent: (_directory, relativePath) =>
-          Effect.succeed(
-            relativePath === "../escaped.ts"
-              ? "// would land outside the temp dir\n"
-              : "// inside the temp dir\n",
-          ),
-        grep: () => Effect.succeed(null),
-      } satisfies Context.Tag.Service<typeof Git>),
-    );
+    const escapingGit = Layer.mock(Git, {
+      stagedFilePaths: () => Effect.succeed(["../escaped.ts", "src/inside.ts"]),
+      showStagedContent: (_directory, relativePath) =>
+        Effect.succeed(
+          relativePath === "../escaped.ts"
+            ? "// would land outside the temp dir\n"
+            : "// inside the temp dir\n",
+        ),
+    });
 
     const layer = StagedFiles.layerNode.pipe(Layer.provide(escapingGit));
 

--- a/packages/react-doctor/src/cli/utils/build-runtime-layers.ts
+++ b/packages/react-doctor/src/cli/utils/build-runtime-layers.ts
@@ -1,0 +1,82 @@
+import * as Layer from "effect/Layer";
+import {
+  Config,
+  DeadCode,
+  Files,
+  Linter,
+  LintPartialFailures,
+  Project,
+  Reporter,
+  Score,
+} from "@react-doctor/core";
+import type { ReactDoctorConfig } from "@react-doctor/types";
+
+export interface BuildRuntimeLayersInput {
+  readonly directory: string;
+  readonly hasConfigOverride: boolean;
+  readonly userConfig: ReactDoctorConfig | null;
+  readonly configSourceDirectory: string | null;
+  /**
+   * Whether lint is disabled (either by user flag or because the
+   * oxlint native binding can't load on this Node version). Switches
+   * the Linter to `layerOf([])` so the rest of the pipeline still
+   * runs.
+   */
+  readonly shouldSkipLint: boolean;
+  readonly shouldRunDeadCode: boolean;
+}
+
+/**
+ * Composes the production layer stack for `inspect()`'s
+ * `Effect.runPromise(Effect.provide(...))` call. Lives outside
+ * `inspect.ts` so the orchestrator stays focused on Effect program
+ * construction and post-scan rendering — layer wiring is its own
+ * concern with its own contract.
+ *
+ * Same shape as `core/src/run-inspect.ts → layerInspectLive`
+ * (the default for `@react-doctor/api → diagnose()`) with two
+ * differences specific to the CLI path:
+ *
+ * - **Config**: when the caller passes `configOverride`, the
+ *   already-loaded config is provided via `Config.layerOf` instead
+ *   of re-loading from disk; `configSourceDirectory` is threaded
+ *   through so `userConfig.plugins` resolution still anchors at
+ *   the original config file location.
+ * - **Score**: always `layerOf(null)` because the CLI computes the
+ *   real score AFTER `runInspect` returns, with surface filtering
+ *   applied (the orchestrator's `Score.compute` only sees the
+ *   per-element-filtered list, not the surface-filtered one).
+ */
+export const buildRuntimeLayers = (input: BuildRuntimeLayersInput) => {
+  const linterLayer = input.shouldSkipLint ? Linter.layerOf([]) : Linter.layerOxlint;
+  const deadCodeLayer = input.shouldRunDeadCode ? DeadCode.layerNode : DeadCode.layerOf([]);
+  // HACK: always provide layerOf(null) for Score — the orchestrator's
+  // Score.compute sees the per-element-filtered list, NOT the
+  // surface-filtered list this function needs. The CLI computes the
+  // real score below with `filterDiagnosticsForSurface("score", ...)`
+  // applied first.
+  const scoreLayer = Score.layerOf(null);
+  const configLayer = input.hasConfigOverride
+    ? Config.layerOf({
+        config: input.userConfig,
+        resolvedDirectory: input.directory,
+        // `configSourceDirectory` is non-null when `inspect()` loaded
+        // the config from disk itself (the CLI path) and `null` only
+        // when the caller passed `configOverride` programmatically
+        // without a corresponding file. The runner falls back to
+        // the scan root in the null case.
+        configSourceDirectory: input.configSourceDirectory,
+      })
+    : Config.layerNode;
+
+  return Layer.mergeAll(
+    Project.layerNode,
+    configLayer,
+    Files.layerNode,
+    linterLayer,
+    LintPartialFailures.layerLive,
+    deadCodeLayer,
+    Reporter.layerNoop,
+    scoreLayer,
+  );
+};

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -1,27 +1,19 @@
 import { performance } from "node:perf_hooks";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 import {
   calculateScore,
-  Config,
-  DeadCode,
-  Files,
   filterDiagnosticsForSurface,
   highlighter,
-  Linter,
-  LintPartialFailures,
   loadConfigWithSource,
   OXLINT_NODE_REQUIREMENT,
-  Project,
   ReactDoctorError,
-  Reporter,
   resolveConfigRootDir,
   runInspect as runInspectEffect,
-  Score,
   type ReactDoctorErrorReason,
 } from "@react-doctor/core";
+import { buildRuntimeLayers } from "./cli/utils/build-runtime-layers.js";
 import {
   AmbiguousProjectError,
   NoReactDependencyError,
@@ -223,37 +215,14 @@ const runInspectWithRuntime = async (
   );
   const lintBindingMissing = options.lint && !resolvedNodeBinaryPath;
 
-  const linterLayer = !options.lint || lintBindingMissing ? Linter.layerOf([]) : Linter.layerOxlint;
-  const deadCodeLayer = options.deadCode ? DeadCode.layerNode : DeadCode.layerOf([]);
-  // HACK: always provide layerOf(null) for Score — the orchestrator's
-  // Score.compute sees the per-element-filtered list, NOT the
-  // surface-filtered list this function needs. We compute the real
-  // score below with `filterDiagnosticsForSurface("score", ...)`
-  // applied first.
-  const scoreLayer = Score.layerOf(null);
-  const configLayer = hasConfigOverride
-    ? Config.layerOf({
-        config: userConfig,
-        resolvedDirectory: directory,
-        // `configSourceDirectory` is non-null when `inspect()` loaded
-        // the config from disk itself (the CLI path) and `null` only
-        // when the caller passed `configOverride` programmatically
-        // without a corresponding file. The runner falls back to the
-        // scan root in the null case.
-        configSourceDirectory,
-      })
-    : Config.layerNode;
-
-  const layers = Layer.mergeAll(
-    Project.layerNode,
-    configLayer,
-    Files.layerNode,
-    linterLayer,
-    LintPartialFailures.layerLive,
-    deadCodeLayer,
-    Reporter.layerNoop,
-    scoreLayer,
-  );
+  const layers = buildRuntimeLayers({
+    directory,
+    hasConfigOverride,
+    userConfig,
+    configSourceDirectory,
+    shouldSkipLint: !options.lint || lintBindingMissing,
+    shouldRunDeadCode: options.deadCode,
+  });
 
   const program = Effect.gen(function* () {
     const spinnerRef = yield* Ref.make<SpinnerHandle | null>(null);


### PR DESCRIPTION
## Summary

Three behavior-preserving structural wins — all validated by the existing 1448-test suite.

### `run-oxlint.ts`: 673 → 244 lines (-64%)

Extracted five focused modules under `runners/oxlint/`:
- `spawn-oxlint.ts` — one subprocess invocation with hard ceilings on wall time and output bytes; tagged-error reject contract.
- `parse-output.ts` — oxlint stdout → \`Diagnostic[]\`, including the leading-notice-line tolerance and category/recommendation lookups.
- \`resolve-paths.ts\` — oxlint binary, plugin path, tsconfig path.
- \`validate-rule-registration.ts\` — one-time metadata-drift check.
- \`spawn-batches.ts\` — the batching loop with binary-split retry and per-batch dropped-file tracking.

\`run-oxlint.ts\` is now a slim orchestrator that resolves plugins/extends/ignore patterns, builds the oxlintrc.json, neutralizes inline disable directives in audit mode, runs the batches, and on extends-related crashes retries once with extends stripped (still carrying \`userPlugins\` through to the fallback).

### \`inspect.ts\`: 551 → 520 lines, layer wiring extracted

\`cli/utils/build-runtime-layers.ts\` (82 lines) owns the production \`Layer.mergeAll(...)\` stack. \`inspect.ts\` keeps its post-scan rendering responsibilities; layer composition is no longer mixed in with \`Console.log\` calls and spinner finalization.

### Tests: \`Layer.mock\` for one-off service overrides

Replaced \`Layer.succeed(Service, Service.of({ ...every method... }))\` with \`Layer.mock(Service, { ...only methods this test exercises... })\` in:
- \`tests/run-inspect.test.ts\` (Project, Linter, DeadCode overrides)
- \`tests/services/staged-files.test.ts\` (Git override × 2)

Dropped the \`Git.of({...})\` ceremony and the \`Context.Tag.Service\` casts — \`Layer.mock\` raises an unimplemented defect if a test exercises a method the mock didn't provide, which is the failure shape we want anyway.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm format\`
- [x] \`pnpm test\` (1448 tests)
- [x] \`pnpm smoke:json-report\`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a behavior-preserving refactor, but it restructures the oxlint execution path (spawning, batching, output parsing, retry logic) and CLI runtime wiring, so regressions could affect lint diagnostics or failure handling.
> 
> **Overview**
> **Refactors the oxlint runner** by moving subprocess spawning, batch retry logic, path resolution, stdout parsing, and rule-metadata validation into dedicated `runners/oxlint/*` modules, leaving `run-oxlint.ts` as an orchestrator that still writes the generated config and retries once without `extends` on config-related crashes.
> 
> **Refactors the CLI `inspect` path** by extracting production `Layer.mergeAll(...)` wiring into `cli/utils/build-runtime-layers.ts`, and **updates tests** to use `Layer.mock` instead of full `Layer.succeed(...Service.of(...))` stubs for narrower, safer mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d8093b0dc6fdc969000b6306a4879d375c7cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->