### PR TITLE
feat(core): wire opt-in OpenTelemetry export via REACT_DOCTOR_OTLP_*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,10 +168,15 @@ for this codebase) for canonical examples.
   keys use dotted namespacing (`inspect.directory`, `inspect.isCi`).
 - Per-service-method spans come from `Effect.fn("Service.method")` — see Services section
   above. The two compose: `runInspect` is the parent span, every `Service.method` is a child.
-- Production observability layer (when wired): `Otlp.layerJson({ baseUrl, resource, headers })`
-  from `effect/unstable/observability/Otlp` + `NodeHttpClient.layerUndici`. Eval reference:
-  `react-doctor-evals/src/Observability.ts → layerAxiom`. Not currently wired in
-  react-doctor; the spans are in place so it's a one-liner when an end user opts in.
+- Production observability layer is `layerOtlp` in `core/src/observability.ts`
+  (wired into both `inspect()` and `diagnose()`). It's a no-op unless the user
+  sets BOTH `REACT_DOCTOR_OTLP_ENDPOINT` (e.g. `https://api.axiom.co`) and
+  `REACT_DOCTOR_OTLP_AUTH_HEADER` (e.g. `Bearer <token>`) in the environment.
+  When both are set, it provides `Otlp.layerJson({...})` from
+  `effect/unstable/observability/Otlp` with `NodeHttpClient.layerUndici` as the
+  transport, so every `Effect.fn("Service.method")` span and every top-level
+  `Effect.withSpan("...")` ships to the configured backend. Eval reference:
+  `react-doctor-evals/src/Observability.ts → layerAxiom`.
 
 ### Console / logging
 

--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -5,6 +5,7 @@ import {
   Config,
   DeadCode,
   Files,
+  layerOtlp,
   Linter,
   LintPartialFailures,
   loadConfigWithSource,
@@ -94,6 +95,10 @@ export const diagnose = async (
   const output: InspectOutput = await Effect.runPromise(
     program.pipe(
       Effect.provide(buildLayerStack()),
+      // Opt-in OTLP exporter. No-op unless REACT_DOCTOR_OTLP_ENDPOINT
+      // + REACT_DOCTOR_OTLP_AUTH_HEADER are set in the environment;
+      // see `core/observability.ts` for the env-driven config.
+      Effect.provide(layerOtlp),
       Effect.catchReasons(
         "ReactDoctorError",
         {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from "./types/index.js";
 export * from "./project-info/index.js";
 export * from "./build-diagnostic-pipeline.js";
 export * from "./errors.js";
+export * from "./observability.js";
 export * from "./paths.js";
 export * from "./refs.js";
 export * from "./run-inspect.js";

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -1,0 +1,46 @@
+import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as Otlp from "effect/unstable/observability/Otlp";
+
+const TRACER_PROJECT_NAME = "react-doctor";
+
+const OTEL_ENDPOINT = Config.string("REACT_DOCTOR_OTLP_ENDPOINT").pipe(Config.option);
+const OTEL_AUTH_HEADER = Config.redacted("REACT_DOCTOR_OTLP_AUTH_HEADER").pipe(Config.option);
+
+/**
+ * Opt-in OpenTelemetry layer. The default `Effect.fn(...)` spans
+ * already populate the in-process tracer; this layer plugs an OTLP
+ * HTTP exporter into the runtime when the user opts in via:
+ *
+ *   REACT_DOCTOR_OTLP_ENDPOINT      e.g. https://api.axiom.co
+ *   REACT_DOCTOR_OTLP_AUTH_HEADER   e.g. "Bearer <token>"
+ *
+ * Both env vars are required to enable export — if either is
+ * missing, the layer is a no-op (matches the pattern from
+ * `react-doctor-evals/src/Observability.ts`, where the equivalent
+ * absent-env path returns `Layer.empty`).
+ *
+ * No setup is required for users who don't care about tracing — the
+ * inspect / diagnose orchestrators always run, this layer just
+ * dictates whether the spans they emit get shipped to a backend.
+ */
+export const layerOtlp: Layer.Layer<never> = Layer.unwrap(
+  Effect.gen(function* () {
+    const endpoint = yield* OTEL_ENDPOINT;
+    const authHeader = yield* OTEL_AUTH_HEADER;
+    if (endpoint._tag === "None" || authHeader._tag === "None") {
+      return Layer.empty;
+    }
+    const headers: Record<string, string> = {
+      Authorization: Redacted.value(authHeader.value),
+    };
+    return Otlp.layerJson({
+      baseUrl: endpoint.value,
+      resource: { serviceName: TRACER_PROJECT_NAME },
+      headers,
+    }).pipe(Layer.provide(NodeHttpClient.layerUndici));
+  }).pipe(Effect.orDie),
+);

--- a/packages/core/tests/observability.test.ts
+++ b/packages/core/tests/observability.test.ts
@@ -1,0 +1,51 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { describe, expect, it } from "vite-plus/test";
+import { layerOtlp } from "../src/observability.js";
+
+const withoutOtlpEnv = async <A>(body: () => Promise<A>): Promise<A> => {
+  const previous = {
+    endpoint: process.env["REACT_DOCTOR_OTLP_ENDPOINT"],
+    auth: process.env["REACT_DOCTOR_OTLP_AUTH_HEADER"],
+  };
+  delete process.env["REACT_DOCTOR_OTLP_ENDPOINT"];
+  delete process.env["REACT_DOCTOR_OTLP_AUTH_HEADER"];
+  try {
+    return await body();
+  } finally {
+    if (previous.endpoint !== undefined) {
+      process.env["REACT_DOCTOR_OTLP_ENDPOINT"] = previous.endpoint;
+    }
+    if (previous.auth !== undefined) {
+      process.env["REACT_DOCTOR_OTLP_AUTH_HEADER"] = previous.auth;
+    }
+  }
+};
+
+describe("layerOtlp", () => {
+  it("is a no-op when REACT_DOCTOR_OTLP_ENDPOINT is missing", async () => {
+    await withoutOtlpEnv(async () => {
+      const program = Effect.succeed("ran");
+      const result = await Effect.runPromise(program.pipe(Effect.provide(layerOtlp)));
+      expect(result).toBe("ran");
+    });
+  });
+
+  it("is a no-op when only the endpoint is set (auth header missing)", async () => {
+    await withoutOtlpEnv(async () => {
+      process.env["REACT_DOCTOR_OTLP_ENDPOINT"] = "https://example.invalid";
+      const program = Effect.succeed("ran");
+      const result = await Effect.runPromise(program.pipe(Effect.provide(layerOtlp)));
+      expect(result).toBe("ran");
+    });
+  });
+
+  it("composes with other layers without leaking requirements", async () => {
+    await withoutOtlpEnv(async () => {
+      const baseLayer = Layer.empty;
+      const composed = Layer.merge(baseLayer, layerOtlp);
+      const result = await Effect.runPromise(Effect.succeed(42).pipe(Effect.provide(composed)));
+      expect(result).toBe(42);
+    });
+  });
+});

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -549,6 +549,20 @@ const counts = summarizeDiagnostics(result.diagnostics);
 
 `react-doctor/api` re-exports `JsonReport`, `JsonReportSummary`, `JsonReportProjectEntry`, `JsonReportMode`, plus the lower-level `buildJsonReport` and `buildJsonReportError` builders. See [`packages/react-doctor/src/api.ts`](https://github.com/millionco/react-doctor/blob/main/packages/react-doctor/src/api.ts) for the full types.
 
+## OpenTelemetry tracing (opt-in)
+
+Every internal service method (`Project.discover`, `Linter.run`, `Config.resolve`, `Score.compute`, etc.) is instrumented as a named span; the top-level `runInspect` orchestrator is the parent span. By default the spans run in-process and don't ship anywhere.
+
+To export spans to an OTLP-compatible backend (Axiom, Honeycomb, Datadog, Tempo, etc.), set both env vars before running:
+
+```bash
+REACT_DOCTOR_OTLP_ENDPOINT="https://api.axiom.co" \
+REACT_DOCTOR_OTLP_AUTH_HEADER="Bearer $AXIOM_TOKEN" \
+react-doctor
+```
+
+If either var is missing, no exporter is attached and there's no network traffic. Both the CLI (`inspect()`) and the programmatic `diagnose()` API honor these.
+
 ## Leaderboard
 
 Top React codebases scanned by React Doctor, ranked by score. Updated automatically from [millionco/react-doctor-benchmarks](https://github.com/millionco/react-doctor-benchmarks).

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -6,6 +6,7 @@ import {
   calculateScore,
   filterDiagnosticsForSurface,
   highlighter,
+  layerOtlp,
   loadConfigWithSource,
   OXLINT_NODE_REQUIREMENT,
   ReactDoctorError,
@@ -279,9 +280,17 @@ const runInspectWithRuntime = async (
   // check a flag itself. Driven by Effect's built-in Console
   // reference, which is `Context.Reference<Console>` with the
   // default value `globalThis.console`.
+  // Otlp layer is a no-op unless REACT_DOCTOR_OTLP_ENDPOINT /
+  // REACT_DOCTOR_OTLP_AUTH_HEADER are set, so we always provide it
+  // regardless of `options.silent` — the silent toggle only swaps
+  // the Console reference, not the tracer.
   const programWithLayers = options.silent
-    ? program.pipe(Effect.provide(layers), Effect.provideService(Console.Console, silentConsole))
-    : program.pipe(Effect.provide(layers));
+    ? program.pipe(
+        Effect.provide(layers),
+        Effect.provideService(Console.Console, silentConsole),
+        Effect.provide(layerOtlp),
+      )
+    : program.pipe(Effect.provide(layers), Effect.provide(layerOtlp));
   const { output, finalHandle: finalSpinnerHandle } = await Effect.runPromise(
     restoreLegacyThrow(programWithLayers),
   );


### PR DESCRIPTION
## Summary

Wires the OpenTelemetry Protocol exporter into the runtime so every \`Effect.fn(\"Service.method\")\` span and the top-level \`Effect.withSpan(\"runInspect\", ...)\` ship to an OTLP-compatible backend (Axiom, Honeycomb, Datadog, Tempo, etc.) when the user opts in.

Closes the **#8** bigger-bet item from the prioritized-improvements list ("Wire \`Otlp.layerJson\` so users opt into traces").

## How it works

Adds \`layerOtlp\` in \`packages/core/src/observability.ts\` and provides it to:
- \`inspect()\` in \`packages/react-doctor/src/inspect.ts\` (CLI path)
- \`diagnose()\` in \`packages/api/src/diagnose.ts\` (programmatic API path)

The layer is a **strict no-op** unless BOTH env vars are set:

\`\`\`
REACT_DOCTOR_OTLP_ENDPOINT     e.g. https://api.axiom.co
REACT_DOCTOR_OTLP_AUTH_HEADER  e.g. Bearer <token>
\`\`\`

When unset → \`Layer.empty\` → zero network traffic. When set → \`Otlp.layerJson({...})\` from \`effect/unstable/observability/Otlp\` with \`@effect/platform-node/NodeHttpClient.layerUndici\` as the transport, no further wiring required.

Mirrors the canonical eval pattern from \`react-doctor-evals/src/Observability.ts → layerAxiom\`.

## No behavior change for default users

Default scans behave identically. The spans were always emitted in-process (Effect's default in-memory tracer); this PR just adds the optional export pipe.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm format\`
- [x] \`pnpm test\` (1449 passing, 3 skipped) — includes new \`observability.test.ts\`
- [x] \`pnpm smoke:json-report\`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces optional network-export behavior and runtime layering changes on the main execution paths (`inspect()`/`diagnose()`), though it is designed to be a strict no-op unless both env vars are set.
> 
> **Overview**
> Adds a new `layerOtlp` in `core/src/observability.ts` that conditionally attaches an OTLP HTTP exporter (`Otlp.layerJson` over `NodeHttpClient.layerUndici`) when **both** `REACT_DOCTOR_OTLP_ENDPOINT` and `REACT_DOCTOR_OTLP_AUTH_HEADER` are present.
> 
> Wires this layer into the CLI (`react-doctor/src/inspect.ts`) and programmatic API (`api/src/diagnose.ts`) so existing `Effect.fn(...)`/`Effect.withSpan(...)` spans can be exported without changing default behavior, and adds a small test suite plus documentation updates (AGENTS.md + README) describing the opt-in tracing setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55dd27fda823d6b69ec9302d1191be03ae1b5188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->