### PR TITLE
Revert "docs: README integration coverage + TODOS bookkeeping (#425)"

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,6 +1,6 @@
 # React Doctor / React Review TODOs
 
-Last refreshed against `main` (commit `2cc0a603`). Items that have
+Last refreshed against `main` (commit `77b49650`). Items that have
 landed in code or whose tracking issues/PRs were resolved on GitHub
 have been removed; everything below is still genuinely open.
 
@@ -24,18 +24,27 @@ Fix:
 
 ## P1 - CI, Docs, Config, Product Semantics
 
-### [~] Stop recommending `millionco/react-doctor@main`
+### [ ] Stop recommending `millionco/react-doctor@main`
 
-Status: partial. README continues to recommend `@main` per maintainer preference; the versioned-tag path is documented as an opt-in alternative in the new "Release versioning" section. `.github/workflows/release.yml` republishes the floating major/minor action tags after every `changesets` publish so consumers who want `@v0` / `@v0.2` / `@v0.2.3` pinning can.
+Status: still open in code.
 
 Links:
 
 - https://github.com/millionco/react-doctor/issues/75
 - https://github.com/millionco/react-doctor/issues/79
 
-Remaining:
+Current problem:
 
-- Maintainer decision: keep `@main` as the recommended default (current stance) or eventually flip the README to a pinned-tag recommendation.
+- README still uses `uses: millionco/react-doctor@main` (README lines 67, 86, 115, 127, 138).
+- `.github/workflows/` contains only `ci.yml` and `update-leaderboard.yml`; no `release.yml`.
+- `@main` was explicitly reported as a supply-chain risk.
+
+Fix:
+
+- Recommend stable action tags in the README.
+- Add a release workflow that publishes a versioned action tag.
+- Ensure released action inputs match docs.
+- Document npm / action / marketing version mapping.
 
 ### [ ] Support mature-codebase adoption workflows natively
 
@@ -120,9 +129,21 @@ Fix:
 - Document memory expectations and large-repo mitigations.
 - Re-check Windows / path-length behavior outside dead-code scanning.
 
-### [x] Clarify React Doctor vs React Review
+### [ ] Clarify React Doctor vs React Review
 
-Status: docs shipped. README now opens with an explicit "React Doctor vs React Review" callout that names the CLI vs hosted split, and points out that the hosted product augments (rather than replaces) CLI users. Hosted-side onboarding / migration path remains a product task.
+Status: hosted/product.
+
+User confusion:
+
+- "Should we use react doctor or react review?"
+- "Is there additional benefit if already using react-doctor?"
+- "So a react-doctor clone?"
+
+Fix:
+
+- React Doctor: local CLI, packages, CI command, offline / local workflows.
+- React Review: hosted dashboard, GitHub App, PR comments, baseline / delta, team workflow.
+- Add an "Already using React Doctor?" migration path.
 
 ### [ ] Fix hosted private-repo / repo-not-found failures
 
@@ -165,48 +186,49 @@ Fix:
 - Add states for waiting, queued, running, no issues, comment failed, repo access failed, unsupported project, backend error.
 - Alert internally when install succeeds but no analysis / comment appears.
 
-### [x] Make local and hosted privacy/data behavior explicit
+### [ ] Make local and hosted privacy/data behavior explicit
 
-Status: shipped. README has a dedicated "Privacy and data" section
-that itemizes the score and share-URL network calls, what each request
-actually carries (and what it doesn't: no source code, no file
-paths), what `--offline` / `"share": false` disable, and how hosted
-React Review's GitHub App scope differs.
+Status: partially addressed. README documents `--offline` and the
+share-URL behavior, but no dedicated privacy / data section exists.
+Underlying issues #35 / #89 / #92 are closed on GitHub.
 
-### [~] Improve score-change communication
+Fix:
 
-Status: docs partially shipped. The Scoring section now spells out
-how to debug a score change (release changelog, unique-rules diff,
-`--explain`/`--why`), tells users not to chase 100/100, and points at
-the new "Release versioning" pin recipe for score-floor automation.
+- Explain what the CLI sends to score / share APIs.
+- Explain exactly what `--offline` disables.
+- Explain hosted Review repo / code access.
+- Explain local CLI-only mode and the share-link opt-out.
 
-Remaining:
+### [ ] Improve score-change communication
 
-- Auto-generate the "what rules moved between X and Y" diff in the
-  changelog tooling so the docs link points to concrete content per
-  release.
+Status: partially addressed. README warns "Scores may decrease across
+releases" but there is no per-release rule-diff / score-impact path.
 
-### [x] Add clear release/version mapping
+Sources:
 
-Status: shipped. README "Release versioning" section publishes the
-mapping table (CLI npm, plugin npm, composite action git tags,
-hosted Review) and documents the `@v0` / `@v0.2` / `@v0.2.3` floating
-vs exact-pin recommendations. Release workflow keeps the floating
-action tags in sync with each npm publish.
+- 89 -> 49.
+- 93 -> 68.
+- 44/100 with hundreds of warnings.
 
-Remaining:
+Fix:
 
-- Bake a "rules added / removed since previous release" section into
-  the auto-generated changelog so the per-release score impact is
-  visible at a glance.
+- Add release notes for material rule changes.
+- Show why scores changed: new rules, changed severities, formula, unique error/warning rules.
+- Avoid encouraging blind 100/100 chasing.
 
-### [~] Verify local report / export support and docs
+### [ ] Add clear release/version mapping
 
-Status: docs partially shipped. README now has a "Non-GitHub CI"
-section that walks through the JSON-report flow for GitLab /
-CircleCI / Jenkins / Buildkite consumers and pins the
-`JsonReport` / `JsonReportSummary` API surface as the stable
-integration contract.
+Status: open.
+
+Fix:
+
+- Publish a mapping for marketing version, npm version, action tag, and hosted Review version.
+- Include rule diff and expected score impact in releases.
+
+### [ ] Verify local report / export support and docs
+
+Status: partially addressed. `--json`, `--score`, and the Node API
+(`react-doctor/api`) are documented; SARIF is not.
 
 Links:
 
@@ -214,11 +236,11 @@ Links:
 - #60
 - #88
 
-Remaining:
+Fix:
 
-- Decide whether to ship a first-class SARIF output (or a
-  GitLab Code Quality report adapter) instead of relying on
-  caller-side translation.
+- Confirm current JSON / report / share outputs.
+- Document the local-only report workflow.
+- Add a SARIF or generic report path if needed for non-GitHub CI.
 
 ## P2 - Platform and Product Expansion
 
@@ -283,17 +305,18 @@ Fix:
 - Detect `preact`, `preact/compat`, and `@preact/signals`.
 - Document unsupported React-specific rules.
 
-### [x] Clarify React Native coverage
+### [ ] Clarify React Native coverage
 
-Status: shipped. README has a new "React Native support matrix"
-table (CLI / tvOS / Expo / Windows / macOS / out-of-tree, plus the
-file-extension overrides) directly above the existing mixed-monorepo
-section, and the `rawTextWrapperComponents` / `textComponents`
-escape hatches are now called out next to the matrix.
+Status: partially addressed.
 
 Links:
 
 - Support: #21, #65, #64
+
+Fix:
+
+- Publish RN support matrix.
+- Document `rawTextWrapperComponents`.
 
 ### [ ] Decide HIR precision work priority
 
@@ -331,6 +354,55 @@ Decision:
 - Keep React Doctor React-only, or create separate rule packs / products.
 - If broadening, separate branding and diagnostics so React-specific quality is not diluted.
 
+## Effect v4 runtime follow-ups
+
+The Effect v4 rewrite (#405, #410, #411, #412, #414, #417) landed the
+runtime; the items below are the deliberately-deferred consolidation
+work flagged in the per-PR descriptions.
+
+- [ ] **Collapse `@react-doctor/project-info` into `@react-doctor/core`.**
+      Naming collision blocks the move: `project-info/src/errors.ts` exports
+      `ReactDoctorError` as the legacy `Error` base class for thrown
+      `ProjectNotFoundError` / `NoReactDependencyError` / `AmbiguousProjectError`;
+      `core/src/errors.ts` exports `ReactDoctorError` as the new
+      `Schema.TaggedErrorClass` runtime wrapper. Both names ship via
+      `react-doctor`'s public re-exports. Resolve by either renaming the
+      tagged class (large rename across the runtime) or by re-exporting
+      with `as Legacy*` aliases (uglier surface). Defer until we decide
+      the public-API direction for v1.0.
+
+- [ ] **Collapse `@react-doctor/types` into `@react-doctor/core`.**
+      Blocked by the same `ReactDoctorError` collision plus a circular-dep
+      risk: `oxlint-plugin-react-doctor` imports
+      `isReactNativeDependencyName` from `@react-doctor/types`. If types
+      moves into core, oxlint-plugin would have to depend on core (which
+      already depends on oxlint-plugin) — cycle. Resolve by hoisting the
+      RN dependency constants into oxlint-plugin (it's the only direct
+      consumer; project-info reads them transitively).
+
+- [ ] **Extract `@react-doctor/cli` workspace package.**
+      Currently `packages/react-doctor/src/cli/` holds ~40 commander +
+      rendering files. Moving them into a dedicated `@react-doctor/cli`
+      package would let `react-doctor` shrink to a published front-door
+      (one-liner `index.ts` + bin shim). Mechanical but tedious — every
+      caller of `cli/utils/*` needs its import updated. No correctness
+      benefit; purely organizational.
+
+- [ ] **Decompose `core/src/run-oxlint.ts` into Effect Stream combinators.**
+      Today `Linter.layerOxlint` calls `Effect.runSync(Ref.update(...))`
+      inside `runOxlint`'s `onPartialFailure` callback because `runOxlint`
+      is callback-shaped. If `runOxlint` returned a `Stream<Diagnostic,
+ReactDoctorError>` natively, the sync bridge disappears. Documented
+      as a HACK in `core/src/services/linter.ts`.
+
+- [ ] **`Reporter.layerCapture` for production.** Today production
+      uses `Reporter.layerNoop` — the orchestrator returns the full
+      diagnostic array via `Stream.runCollect`, so the reporter has no
+      consumer. The eval harness uses `Reporter.layerNdjson(path)`. A
+      future LSP / watch mode would need either `layerCapture` exposed at
+      the api layer or a `Reporter.layerLsp` that pushes
+      `connection.sendDiagnostics`. Slot exists; integration is downstream.
+
 ## Historical Regression Ledger
 
 GitHub issues referenced below are all CLOSED; the entries kept here
@@ -338,7 +410,7 @@ are the ones whose code follow-up is still real.
 
 ### GitHub Action and CI
 
-- [~] #75 / #79: README still recommends `@main` per maintainer preference; `.github/workflows/release.yml` republishes floating action tags so `@v0` / `@v0.2` / `@v0.2.3` is available as an opt-in.
+- [ ] #75 / #79 — README still uses `@main`; no release workflow exists.
 
 ### CLI and agent workflow
 
@@ -354,9 +426,9 @@ are the ones whose code follow-up is still real.
 
 ### Product and docs
 
-- [~] #188 / #97 Action docs and PR blocking: stable tags available as an opt-in (`@v0` / `@v0.2` / `@v0.2.3`), README still recommends `@main`; delta semantics for the hosted PR comment still outstanding.
+- [ ] #188 / #97 Action docs and PR blocking — stable tags and delta semantics still outstanding.
 - [ ] #189 Simplified Chinese README — closed PR; decide whether to ship docs.
-- [x] #65 / #21 / #64 RN support: README now publishes the full RN support matrix.
+- [ ] #65 / #21 / #64 RN support exists; support matrix / docs remain open.
 
 ### Shipped enhancements
 
@@ -364,7 +436,7 @@ are the ones whose code follow-up is still real.
 
 ## Immediate Order
 
-1. [~] Update the README to recommend stable action tags and add a release workflow. Release workflow shipped; README keeps `@main` as the recommended ref per maintainer preference, versioned tags documented as an opt-in.
+1. [ ] Update the README to recommend stable action tags and add a release workflow.
 2. [ ] Change React Review PR comment semantics to delta-first.
 3. [ ] Decide and ship a stable `--package-json` (or equivalent) API.
 4. [ ] Ship baseline mode for mature-codebase adoption.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -135,23 +135,6 @@ Prefer not to add a marketplace action? The bare `npx` form works too:
 - run: npx react-doctor@latest --fail-on warning
 ```
 
-## Release versioning
-
-React Doctor ships a few related artifacts. Each one has its own version, and the table below is the mapping you should refer to when pinning.
-
-| Artifact                                                    | Where to find the version                                   | Example pin                              |
-| ----------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------- |
-| `react-doctor` npm package (the CLI and Node API)           | [npm](https://npmjs.com/package/react-doctor)               | `npx react-doctor@0.2.3`                 |
-| `oxlint-plugin-react-doctor` / `eslint-plugin-react-doctor` | [npm](https://npmjs.com/package/oxlint-plugin-react-doctor) | `"oxlint-plugin-react-doctor": "^0.2.3"` |
-| `millionco/react-doctor` GitHub composite action            | git refs on this repo (`@main` or version tag)              | `uses: millionco/react-doctor@main`      |
-| `react.doctor` hosted Review                                | the hosted dashboard auto-updates; no pin is required       | n/a                                      |
-
-The composite action is referenced as `@main` by default, which tracks the latest commit on the canonical branch. If you want a pinned action ref instead, every published `react-doctor@X.Y.Z` release also pushes a matching `vX.Y.Z` tag and moves the floating `vX` / `vX.Y` tags to that commit, so `@v0`, `@v0.2`, and `@v0.2.3` all resolve. Pin tighter when you need reproducible scores across releases (see [Scoring](#scoring)).
-
-> **Pinning the action ref doesn't pin the CLI version.** The composite action invokes `npx react-doctor@latest` internally, so the action ref pins the **workflow shape** (inputs, comment plumbing, score collection), not the **CLI version** running underneath. For genuinely deterministic scores in CI, also pin the CLI side: either run `npx react-doctor@0.2.3 ...` in a bare `- run:` step, or add `"react-doctor": "0.2.3"` to your project's dev deps and invoke it through `pnpm exec` / `npm exec`.
-
-Each release ships with the changeset-generated changelog. Material rule additions, severity changes, or score-formula tweaks are called out there so you can read the expected score impact before bumping a pin.
-
 ## PR blocking and exit codes
 
 Two independent gates can block a PR — pick one or both:
@@ -479,24 +462,6 @@ When a suppression isn't working, `--explain <file:line>` (or its alias `--why <
 
 `offline` skips the score API entirely — no score is shown and no share URL is generated. CI runs (GitHub Actions, GitLab CI, CircleCI) are not offline by default; only the share URL is suppressed. Set `offline: true` (or `--offline`) explicitly when you want zero network.
 
-### React Native support matrix
-
-`rn-*` rules cover the React Native ecosystem in addition to React DOM. Detection keys off `package.json` dependencies (or their hoisted equivalents) plus file-extension hints:
-
-| Stack / runtime                                                                              | Detection signal (in `package.json` or workspace)                                                                                   | `rn-*` rules |
-| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | :----------: |
-| React Native CLI                                                                             | `react-native` dependency                                                                                                           |      ON      |
-| React Native tvOS                                                                            | `react-native-tvos`                                                                                                                 |      ON      |
-| Expo (managed and bare)                                                                      | `expo`, `expo-router`, any `@expo/*`                                                                                                |      ON      |
-| React Native for Windows / macOS                                                             | `react-native-windows`, `react-native-macos`                                                                                        |      ON      |
-| Out-of-tree React Native targets                                                             | Any `@react-native/*` or `@react-native-*` package (e.g. `@react-native-firebase/app`, `@react-native-async-storage/async-storage`) |      ON      |
-| Metro-based projects without an `expo` / `react-native` dep                                  | Top-level `"react-native"` resolution field in `package.json`                                                                       |      ON      |
-| Web-only React (Next.js, Vite, CRA, Gatsby, Remix, Docusaurus, Storybook, plain `react-dom`) | `next`, `vite`, `react-scripts`, `gatsby`, `@remix-run/*`, `@docusaurus/*`, `@storybook/*`, `react-dom` (without an RN sibling)     |     OFF      |
-| `*.web.tsx` / `*.web.jsx` files in an RN package                                             | File extension                                                                                                                      |  OFF (file)  |
-| `*.ios.tsx` / `*.android.tsx` / `*.native.tsx` files                                         | File extension                                                                                                                      |  ON (file)   |
-
-Mixed monorepos work both ways: a web-rooted workspace with even one RN package gets the `rn-*` rules loaded, then file-level boundaries keep them silent on the web workspaces. The configuration knob `rawTextWrapperComponents` lets you teach `rn-no-raw-text` about library components that safely route string children through an internal `<Text>` (e.g. `heroui-native`'s `Button`); `textComponents` is the broader escape hatch for components that behave like `<Text>` themselves.
-
 ### React Native rules in mixed monorepos
 
 `rn-*` rules respect per-package boundaries automatically. In a mixed React Native + web monorepo (`apps/mobile` alongside `apps/web` / `apps/vite-app` / `packages/storybook` / `apps/docs`), every `rn-*` rule walks up to the file's nearest `package.json` before running:
@@ -531,14 +496,7 @@ Scoring runs on react.doctor's API and is **network-dependent**: without a succe
 
 Score labels: 75+ is **Great**, 50 to 74 is **Needs work**, under 50 is **Critical**.
 
-Scores may decrease across releases as new rules are added. Each new rule that fires in your codebase introduces an additional penalty. This is expected: it means the tool is catching more issues, not that your code got worse. Don't chase 100/100 blindly; the score is a signal to investigate, not a target.
-
-When a release moves your score noticeably:
-
-- Check the per-release changelog for added rules, severity changes, or formula tweaks. Each release ships with the changeset-generated notes.
-- Compare the `unique rules triggered` list against the previous run. A single new rule firing once can subtract 1.5 points.
-- Pin to a specific `react-doctor` version in CI (see [Release versioning](#release-versioning)) if you need stable scores across upgrades. Pinning the action ref alone is not enough; pin the CLI side too.
-- If a newly fired rule looks noisy in your codebase, `--explain <file:line>` (or `--why`) prints exactly which rule it is and the suppression snippet to silence it. See [Inline suppressions](#inline-suppressions) and [Configuration](#configuration).
+Scores may decrease across releases as new rules are added. Each new rule that fires in your codebase introduces an additional penalty. This is expected — it means the tool is catching more issues, not that your code got worse. Pin to a specific react-doctor version in CI if you need stable scores across upgrades.
 
 ## Diff and staged modes
 
@@ -611,22 +569,6 @@ React Doctor detects 50+ coding agents (Claude Code, Cursor, Codex, OpenCode, Wi
 
 In CI environments, prompts are automatically skipped. Pass `--offline` explicitly when you need zero network.
 
-### Non-GitHub CI (GitLab, Bitbucket, CircleCI, Jenkins, …)
-
-The composite action is GitHub-specific, but everything it does is built on top of the CLI; there's nothing GitHub-only about React Doctor itself. For other providers, run the CLI directly and consume the JSON report from your existing tooling:
-
-```bash
-npx react-doctor@latest --diff "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --fail-on warning --json > react-doctor.json
-```
-
-The JSON document is the same one the action consumes (`{ ok, score, diagnostics[], summary, project }`). Any CI dashboard that accepts a parsed report can read it. Three common patterns:
-
-- **GitLab CI**: invoke the CLI in a `merge_request` job and surface `react-doctor.json` as a [Code Quality report artifact](https://docs.gitlab.com/ci/testing/code_quality.html) by translating diagnostics into the GitLab Code Quality JSON shape. Until a first-class GitLab integration ships, this is the recommended path.
-- **CircleCI / Jenkins / Buildkite**: fail the step on a non-zero exit (`--fail-on warning`) and upload `react-doctor.json` as an artifact. Read `summary.errorCount` / `summary.warningCount` in a follow-up step for thresholding.
-- **Pre-merge gates without a dashboard**: `--diff <base> --fail-on warning` is enough; the build log carries the diagnostics.
-
-SARIF and a hosted GitLab integration are tracked separately; see `TODOS.md` if you'd like to follow along. In the meantime, the JSON output is intentionally stable: `JsonReport`, `JsonReportSummary`, and friends are exported from [`react-doctor/api`](packages/react-doctor/src/api.ts) for type-safe consumption.
-
 ## Node.js API
 
 ```js
@@ -647,28 +589,6 @@ const counts = summarizeDiagnostics(result.diagnostics);
 ```
 
 `react-doctor/api` re-exports `JsonReport`, `JsonReportSummary`, `JsonReportProjectEntry`, `JsonReportMode`, plus the lower-level `buildJsonReport` and `buildJsonReportError` builders. See [`packages/react-doctor/src/api.ts`](https://github.com/millionco/react-doctor/blob/main/packages/react-doctor/src/api.ts) for the full types.
-
-## Privacy and data
-
-React Doctor runs entirely on your machine. The only network traffic is the optional score lookup and an opt-out share URL, and both can be disabled.
-
-| Network call        | URL                                          | Sent                                                                                                                                                          | Disabled by                                  |
-| ------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| Score API           | `https://www.react.doctor/api/score`         | Gzipped JSON of the diagnostic list with **file paths stripped** (rule id, severity, message, position only). No source code, no file paths, no project name. | `--offline` / `"offline": true`              |
-| Share URL (printed) | `https://www.react.doctor/share?p=...&s=...` | Query parameters only: detected project name, score, error count, warning count, affected file count. Nothing is uploaded; the link is rendered locally.      | `--offline`, `"share": false`, or any CI run |
-
-What `--offline` disables, exactly:
-
-- The score API call. No score is computed and the `score` action output / `--score` value is empty.
-- The share URL line in the local CLI summary.
-
-What `--offline` does **not** affect:
-
-- Local rule execution, diagnostics, exit codes, JSON / annotation output, and the GitHub Actions sticky PR comment (the comment is constructed locally from the printed report).
-
-Source code never leaves your machine. There is no telemetry pipeline, no file upload, and no usage analytics in the CLI.
-
-For the hosted React Review product on [react.doctor](https://react.doctor), the GitHub App reads repository contents through GitHub's standard installation-scoped access in order to compute the same diagnostics server-side; review the App permissions screen before installing.
 
 ## Leaderboard
 


### PR DESCRIPTION
Reverts #425.

Reverts the squash-merge commit `de45e6c2`. Touches only `TODOS.md` and `packages/react-doctor/README.md`. The README changes from #307 and #438 that landed afterwards auto-merged cleanly during the revert.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes documentation/TODO tracking and does not modify runtime code paths. Main risk is user confusion from removed guidance (version pinning, privacy, RN coverage, non-GitHub CI).
> 
> **Overview**
> Reverts a previous docs pass by **removing multiple guidance sections from `packages/react-doctor/README.md`**, including release/version pinning details, a React Native support matrix, non-GitHub CI JSON-report workflow notes, and the dedicated privacy/data explanation; the scoring section is also simplified to a shorter warning about score changes.
> 
> Updates `TODOS.md` to re-open/adjust several doc/CI tracking items (e.g., `@main` action pinning, RN docs, privacy, version mapping) and adds a new **Effect v4 runtime follow-ups** checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38983f4d002eaf477e564cb16e7a8ba6c164821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->