### PR TITLE
Normalize static template literal handling

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-is-valid.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-is-valid.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
@@ -58,9 +59,8 @@ const checkValueIsEmptyOrInvalid = (
       if (typeof expression.value === "string") return isInvalidHref(expression.value, validHrefs);
     }
     if (isNodeOfType(expression, "TemplateLiteral")) {
-      if (expression.expressions.length > 0) return false;
-      const cooked = expression.quasis[0]?.value.cooked ?? "";
-      return isInvalidHref(cooked, validHrefs);
+      const staticValue = getStaticTemplateLiteralValue(expression);
+      return staticValue === null ? false : isInvalidHref(staticValue, validHrefs);
     }
   }
   if (isNodeOfType(value, "JSXFragment")) return true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/aria-proptypes.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/aria-proptypes.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
@@ -153,11 +154,8 @@ const expressionToBoolean = (expression: EsTreeNode): boolean | null => {
     return null;
   }
   if (isNodeOfType(expression, "TemplateLiteral")) {
-    if (expression.expressions.length === 0 && expression.quasis.length === 1) {
-      const cooked = expression.quasis[0]?.value.cooked ?? "";
-      return cooked.length > 0;
-    }
-    return null;
+    const staticValue = getStaticTemplateLiteralValue(expression);
+    return staticValue === null ? null : staticValue.length > 0;
   }
   if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "!") {
     const inner = expressionToBoolean(expression.argument as EsTreeNode);
@@ -204,10 +202,7 @@ const parseAriaValueAsString = (value: EsTreeNode, booleanAsString: boolean): st
       return null;
     }
     if (isNodeOfType(expression, "TemplateLiteral")) {
-      if (expression.expressions.length === 0 && expression.quasis.length === 1) {
-        return (expression.quasis[0]?.value.cooked ?? "").toLowerCase();
-      }
-      return null;
+      return getStaticTemplateLiteralValue(expression)?.toLowerCase() ?? null;
     }
     if (
       booleanAsString &&
@@ -228,7 +223,7 @@ const isMultiQuasiTemplate = (value: EsTreeNode): boolean => {
   if (!isNodeOfType(value, "JSXExpressionContainer")) return false;
   const expression = value.expression;
   if (!isNodeOfType(expression, "TemplateLiteral")) return false;
-  return expression.expressions.length > 0;
+  return (expression.expressions ?? []).length > 0;
 };
 
 const isValidValueForType = (propType: AriaPropType, value: EsTreeNode): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/html-has-lang.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/html-has-lang.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
@@ -54,11 +55,8 @@ const evaluateLang = (attributeValue: EsTreeNode | null | undefined): LangVerdic
       return "ok"; // dynamic identifier, assume valid
     }
     if (isNodeOfType(expression, "TemplateLiteral")) {
-      if (expression.expressions.length === 0 && expression.quasis.length === 1) {
-        const cooked = expression.quasis[0]!.value.cooked;
-        return cooked && cooked.length > 0 ? "ok" : "empty";
-      }
-      return "ok"; // template with interpolation, dynamic
+      const staticValue = getStaticTemplateLiteralValue(expression);
+      return staticValue === null ? "ok" : staticValue.length > 0 ? "ok" : "empty";
     }
     return "ok";
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
@@ -34,11 +35,8 @@ const evaluateTitleValue = (value: EsTreeNode | null | undefined): StaticVerdict
     if (isNodeOfType(expression, "TemplateLiteral")) {
       // Template with interpolation → dynamic OK; pure-string check
       // cooked content for emptiness.
-      if (expression.expressions.length === 0 && expression.quasis.length === 1) {
-        const cooked = expression.quasis[0]!.value.cooked;
-        return cooked && cooked.length > 0 ? "ok" : "empty";
-      }
-      return "dynamic-ok";
+      const staticValue = getStaticTemplateLiteralValue(expression);
+      return staticValue === null ? "dynamic-ok" : staticValue.length > 0 ? "ok" : "empty";
     }
     return "dynamic-ok";
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-autofocus.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-autofocus.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import type { Rule } from "../../utils/rule.js";
@@ -81,11 +82,7 @@ const isFalseAttributeValue = (value: EsTreeNode): boolean => {
       return false;
     }
     if (isNodeOfType(expression, "TemplateLiteral")) {
-      return (
-        expression.expressions.length === 0 &&
-        expression.quasis.length === 1 &&
-        expression.quasis[0]!.value.cooked === "false"
-      );
+      return getStaticTemplateLiteralValue(expression) === "false";
     }
   }
   return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isCreateElementCall } from "../../utils/is-create-element-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -60,13 +61,9 @@ const isProvenValidExpression = (
   if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
     return isValidTypeValue(expression.value, settings);
   }
-  if (
-    isNodeOfType(expression, "TemplateLiteral") &&
-    expression.expressions.length === 0 &&
-    expression.quasis.length === 1
-  ) {
-    const cookedValue = expression.quasis[0].value.cooked;
-    if (typeof cookedValue === "string") return isValidTypeValue(cookedValue, settings);
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    const staticValue = getStaticTemplateLiteralValue(expression);
+    if (staticValue !== null) return isValidTypeValue(staticValue, settings);
   }
   if (isNodeOfType(expression, "ConditionalExpression")) {
     return (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -8,6 +8,7 @@ import { isDescendantScope } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isReactComponentOrHookName } from "../../utils/is-react-component-or-hook-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -243,7 +244,10 @@ const symbolHasStableHookOrigin = (symbol: SymbolDescriptor): boolean => {
     ) {
       return true;
     }
-    if (isNodeOfType(initializer, "TemplateLiteral") && initializer.expressions.length === 0) {
+    if (
+      isNodeOfType(initializer, "TemplateLiteral") &&
+      getStaticTemplateLiteralValue(initializer) !== null
+    ) {
       return true;
     }
   }
@@ -584,7 +588,7 @@ const isOutsideAllFunctions = (symbol: SymbolDescriptor): boolean => {
 
 const isLiteralOrEmptyTemplate = (node: EsTreeNode): boolean =>
   isNodeOfType(node, "Literal") ||
-  (isNodeOfType(node, "TemplateLiteral") && node.expressions.length === 0);
+  (isNodeOfType(node, "TemplateLiteral") && getStaticTemplateLiteralValue(node) !== null);
 
 const isNonStringLiteral = (node: EsTreeNode): boolean =>
   isNodeOfType(node, "Literal") && typeof node.value !== "string";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-curly-brace-presence.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-curly-brace-presence.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 
@@ -104,9 +105,7 @@ const isAllowedStringLikeInContainer = (
 // expression is a single-quasi template literal; else null.
 const singleQuasiTemplateValue = (expression: EsTreeNode): string | null => {
   if (!isNodeOfType(expression, "TemplateLiteral")) return null;
-  if (expression.expressions.length !== 0) return null;
-  if (expression.quasis.length !== 1) return null;
-  return expression.quasis[0]!.value.cooked ?? null;
+  return getStaticTemplateLiteralValue(expression);
 };
 
 const checkExpressionContainer = (
@@ -156,10 +155,9 @@ const checkExpressionContainer = (
     return;
   }
   if (isNodeOfType(expression, "TemplateLiteral") && allowed === "never") {
-    if (expression.expressions.length !== 0 || expression.quasis.length !== 1) return;
-    const quasi = expression.quasis[0]!;
-    const rawSource = quasi.value.raw ?? "";
-    const cooked = quasi.value.cooked ?? "";
+    const cooked = getStaticTemplateLiteralValue(expression);
+    if (cooked === null) return;
+    const rawSource = expression.quasis?.[0]?.value.raw ?? "";
     if (!parentIsAttribute && containsAnyQuote(cooked)) return;
     if (isAllowedStringLikeInContainer(rawSource, container, parentIsAttribute)) return;
     context.report({ node: container, message: UNNECESSARY_BRACES_MESSAGE });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 
@@ -214,15 +215,9 @@ const getKeyAttributeValueString = (
         }
         return null;
       }
-      if (
-        isNodeOfType(expression, "TemplateLiteral") &&
-        expression.expressions.length === 0 &&
-        expression.quasis.length === 1
-      ) {
-        const cookedValue = expression.quasis[0].value.cooked;
-        if (typeof cookedValue === "string") {
-          return { keyValue: cookedValue, node: attribute };
-        }
+      if (isNodeOfType(expression, "TemplateLiteral")) {
+        const staticValue = getStaticTemplateLiteralValue(expression);
+        if (staticValue !== null) return { keyValue: staticValue, node: attribute };
       }
     }
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
@@ -1,6 +1,7 @@
 import { VAGUE_BUTTON_LABELS } from "../../constants/design.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getOpeningElementTagName } from "./utils/get-opening-element-tag-name.js";
@@ -30,10 +31,10 @@ const collectJsxLabelText = (jsxElementNode: EsTreeNode): string | null => {
         collectedFragments.push(expression.value);
         continue;
       }
-      if (isNodeOfType(expression, "TemplateLiteral") && expression.quasis?.length === 1) {
-        const rawTemplate = expression.quasis[0].value?.raw;
-        if (typeof rawTemplate === "string" && expression.expressions.length === 0) {
-          collectedFragments.push(rawTemplate);
+      if (isNodeOfType(expression, "TemplateLiteral")) {
+        const staticValue = getStaticTemplateLiteralValue(expression);
+        if (staticValue !== null) {
+          collectedFragments.push(staticValue);
           continue;
         }
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-template-literal-value.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-template-literal-value.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+import { getStaticTemplateLiteralValue } from "./get-static-template-literal-value.js";
+
+describe("getStaticTemplateLiteralValue", () => {
+  it("returns the cooked value for a no-substitution template literal", () => {
+    expect(
+      getStaticTemplateLiteralValue({
+        expressions: [],
+        quasis: [{ value: { cooked: "button", raw: "button" } }],
+      }),
+    ).toBe("button");
+  });
+
+  it("falls back to raw text when cooked is unavailable", () => {
+    expect(
+      getStaticTemplateLiteralValue({
+        expressions: [],
+        quasis: [{ value: { cooked: null, raw: "button" } }],
+      }),
+    ).toBe("button");
+  });
+
+  it("treats omitted empty expressions as static", () => {
+    expect(
+      getStaticTemplateLiteralValue({
+        quasis: [{ value: { cooked: "#", raw: "#" } }],
+      }),
+    ).toBe("#");
+  });
+
+  it("returns null for dynamic or malformed template literals", () => {
+    expect(
+      getStaticTemplateLiteralValue({
+        expressions: [{}],
+        quasis: [{ value: { cooked: "", raw: "" } }, { value: { cooked: "", raw: "" } }],
+      }),
+    ).toBeNull();
+    expect(getStaticTemplateLiteralValue({ expressions: [] })).toBeNull();
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-template-literal-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-template-literal-value.ts
@@ -1,0 +1,23 @@
+interface TemplateElementValueLike {
+  readonly cooked?: string | null;
+  readonly raw?: string | null;
+}
+
+interface TemplateElementLike {
+  readonly value?: TemplateElementValueLike;
+}
+
+interface StaticTemplateLiteralLike {
+  readonly expressions?: ReadonlyArray<unknown>;
+  readonly quasis?: ReadonlyArray<TemplateElementLike>;
+}
+
+export const getStaticTemplateLiteralValue = (
+  templateLiteral: StaticTemplateLiteralLike,
+): string | null => {
+  const expressions = templateLiteral.expressions ?? [];
+  const quasis = templateLiteral.quasis ?? [];
+  if (expressions.length !== 0 || quasis.length !== 1) return null;
+  const value = quasis[0]?.value;
+  return value?.cooked ?? value?.raw ?? null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-inside-platform-os-web-branch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-inside-platform-os-web-branch.ts
@@ -59,7 +59,9 @@ const isPlatformSelectCallee = (callee: EsTreeNode | undefined | null): boolean 
 const isStringLiteralEqualTo = (node: EsTreeNode | undefined | null, expected: string): boolean => {
   if (!node) return false;
   if (isNodeOfType(node, "Literal") && node.value === expected) return true;
-  if (isNodeOfType(node, "TemplateLiteral")) return getStaticTemplateLiteralValue(node) === expected;
+  if (isNodeOfType(node, "TemplateLiteral")) {
+    return getStaticTemplateLiteralValue(node) === expected;
+  }
   return false;
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-inside-platform-os-web-branch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-inside-platform-os-web-branch.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { getStaticTemplateLiteralValue } from "./get-static-template-literal-value.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 // Strips TypeScript and optional-chain wrappers that can appear around
@@ -58,9 +59,7 @@ const isPlatformSelectCallee = (callee: EsTreeNode | undefined | null): boolean 
 const isStringLiteralEqualTo = (node: EsTreeNode | undefined | null, expected: string): boolean => {
   if (!node) return false;
   if (isNodeOfType(node, "Literal") && node.value === expected) return true;
-  if (isNodeOfType(node, "TemplateLiteral") && node.quasis.length === 1) {
-    return node.quasis[0]?.value?.cooked === expected;
-  }
+  if (isNodeOfType(node, "TemplateLiteral")) return getStaticTemplateLiteralValue(node) === expected;
   return false;
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/parse-jsx-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/parse-jsx-value.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { getStaticTemplateLiteralValue } from "./get-static-template-literal-value.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 // Best-effort parse a JSX attribute value to a number. Mirrors
@@ -30,13 +31,10 @@ export const parseJsxValue = (value: EsTreeNode | null | undefined): number | nu
     ) {
       return -expression.argument.value;
     }
-    if (
-      isNodeOfType(expression, "TemplateLiteral") &&
-      expression.expressions.length === 0 &&
-      expression.quasis.length === 1
-    ) {
-      const cooked = expression.quasis[0]!.value.cooked ?? "";
-      const parsed = Number(cooked);
+    if (isNodeOfType(expression, "TemplateLiteral")) {
+      const staticValue = getStaticTemplateLiteralValue(expression);
+      if (staticValue === null) return null;
+      const parsed = Number(staticValue);
       return Number.isFinite(parsed) ? parsed : null;
     }
     if (isNodeOfType(expression, "ConditionalExpression")) {


### PR DESCRIPTION
## Summary
- Add a shared static template literal helper for no-substitution template literals.
- Use it across oxlint React Doctor rules that previously hand-checked template literals.

## Test plan
- `pnpm exec vp test run src/plugin/utils/get-static-template-literal-value.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of static-analysis helpers with unit tests; may slightly change lint outcomes for edge-case AST shapes (e.g. missing `expressions` on single-quasi templates) but does not touch runtime app code.
> 
> **Overview**
> Introduces **`getStaticTemplateLiteralValue`** to resolve no-substitution template literals (zero `${…}`, single quasi; **`cooked`**, else **`raw`**; otherwise **`null`**) and replaces duplicated quasi/`expressions` checks across oxlint React Doctor a11y, React builtin, and UI rules plus **`parseJsxValue`** and **`isInsidePlatformOsWebBranch`**.
> 
> Call sites now branch on **`null`** vs a string the same way they did for dynamic vs static templates. **`get-static-template-literal-value.test.ts`** covers cooked/raw fallback, omitted empty **`expressions`**, and dynamic/malformed shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8401598ea88e8127cb93050b1bcd7c2da3dc61ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->