### PR TITLE
Stop jsx-key from flagging shorthand fragments

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
@@ -48,6 +48,17 @@ export const DIVERGENCES: Record<string, OxcDivergence> = {
     failSkips: [3],
     reason: "Intentional: default allowLeadingUnderscore=true for Radix-style wrappers.",
   },
+  "jsx-key": {
+    // OXC can be configured to report shorthand fragments (`<>...</>`)
+    // in arrays / iterators via `checkFragmentShorthand`. React Doctor
+    // intentionally never reports shorthand fragments here: a shorthand
+    // fragment cannot carry a key, and the actionable fix would be
+    // rewriting syntax rather than adding the missing prop the rule is
+    // meant to guide. fail[14-15] are the explicit fragment-option
+    // fixtures.
+    failSkips: [14, 15],
+    reason: "Intentional: never report shorthand fragments from jsx-key.",
+  },
   "no-unstable-nested-components": {
     // OXC defaults `allowAsProps: false`, which flags render-prop
     // components passed as JSX props. We default to `true` because

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
@@ -8,8 +8,30 @@ const expectFail = (code: string): void => {
   expect(result.diagnostics.length).toBeGreaterThan(0);
 };
 
+const expectPass = (code: string): void => {
+  const result = runRule(jsxKey, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(0);
+};
+
 describe("react-builtins/jsx-key — regressions", () => {
   // Bugbot review: key sandwiched between two spreads should still flag
   // (key appears after the FIRST spread, even if before LATER spreads).
   it("flags key between two spreads", () => expectFail(`[<App {...a} key="x" {...b} />];`));
+
+  it("does not flag shorthand fragments returned from iterators", () => {
+    expectPass(`items.map((item) => <>{item.name}</>);`);
+  });
+
+  it("does not flag shorthand fragments in array literals", () => {
+    expectPass(`[<>one</>, <>two</>];`);
+  });
+
+  it("does not flag shorthand fragments even when the old explicit setting is present", () => {
+    const result = runRule(jsxKey, `items.map((item) => <>{item.name}</>);`, {
+      settings: { "react-doctor": { jsxKey: { checkFragmentShorthand: true } } },
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
@@ -15,7 +15,6 @@ const DUPLICATE_KEY = (keyValue: string): string =>
 interface JsxKeySettings {
   checkKeyMustBeforeSpread?: boolean;
   warnOnDuplicates?: boolean;
-  checkFragmentShorthand?: boolean;
 }
 
 const resolveSettings = (
@@ -29,7 +28,6 @@ const resolveSettings = (
   return {
     checkKeyMustBeforeSpread: ruleSettings.checkKeyMustBeforeSpread ?? true,
     warnOnDuplicates: ruleSettings.warnOnDuplicates ?? false,
-    checkFragmentShorthand: ruleSettings.checkFragmentShorthand ?? true,
   };
 };
 
@@ -229,12 +227,11 @@ const getKeyAttributeValueString = (
   return null;
 };
 
-// Port of `oxc_linter::rules::react::jsx_key`. Reports JSX elements (and
-// optionally `<>` fragments) inside array literals or `.map` / `.flatMap`
-// / `Array.from` callbacks that lack a `key` prop. Honors three settings:
+// Port of `oxc_linter::rules::react::jsx_key`. Reports JSX elements inside
+// array literals or `.map` / `.flatMap` / `Array.from` callbacks that lack a
+// `key` prop. Honors two settings:
 //   - checkKeyMustBeforeSpread (default true): reports `<X {...p} key=…>`
-//   - warnOnDuplicates (default true): duplicate `key` values among siblings
-//   - checkFragmentShorthand (default true): also flags `<>` in iterators
+//   - warnOnDuplicates (default false): duplicate `key` values among siblings
 // Skips elements wrapped by `Children.toArray(...)` since React's runtime
 // assigns synthetic keys for those.
 export const jsxKey = defineRule<Rule>({
@@ -270,16 +267,6 @@ export const jsxKey = defineRule<Rule>({
         if (hasKeyAttribute(openingElement)) return;
         context.report({
           node: openingElement,
-          message: enclosingContext.kind === "array" ? MISSING_KEY_ARRAY : MISSING_KEY_ITERATOR,
-        });
-      },
-      JSXFragment(node: EsTreeNodeOfType<"JSXFragment">) {
-        if (!settings.checkFragmentShorthand) return;
-        const enclosingContext = findEnclosingIteratorContext(node);
-        if (!enclosingContext) return;
-        if (isWithinChildrenToArray(node)) return;
-        context.report({
-          node,
           message: enclosingContext.kind === "array" ? MISSING_KEY_ARRAY : MISSING_KEY_ITERATOR,
         });
       },


### PR DESCRIPTION
## Summary
- Stop reporting shorthand fragments from `jsx-key`, since they cannot carry a `key` prop.
- Add regression coverage and document the intentional OXC divergence.

## Test plan
- `pnpm exec vp test run src/plugin/rules/react-builtins/jsx-key.regressions.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows lint behavior for a known false-positive pattern; missing-key checks on real JSX elements in lists are unchanged.
> 
> **Overview**
> **`jsx-key` no longer reports missing keys on shorthand fragments** (`<>...</>`) in array literals or `.map` / iterator callbacks. The `JSXFragment` visitor and the `checkFragmentShorthand` setting are removed so the rule only targets elements that can actually take a `key` prop.
> 
> Regression tests cover iterator and array shorthand fragments, including legacy `react-doctor.jsxKey.checkFragmentShorthand: true`, which is now ignored. **`oxc-divergences`** records that OXC may still fail fragment fixtures when that option is on; React Doctor skips those on purpose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6dce1b924e19d93de835f53bc7f988959f10509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->