### PR TITLE
Cover child workspace diff include paths

### DIFF
--- a/packages/react-doctor/tests/resolve-project-diff-include-paths.test.ts
+++ b/packages/react-doctor/tests/resolve-project-diff-include-paths.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
-import type { DiffInfo } from "@react-doctor/core";
+import type { DiffInfo } from "../src/index.js";
 import { resolveProjectDiffIncludePaths } from "../src/cli/utils/resolve-project-diff-include-paths.js";
 
 const buildDiffInfo = (changedFiles: string[]): DiffInfo => ({
@@ -40,6 +40,24 @@ describe("resolveProjectDiffIncludePaths", () => {
     const diffInfo = buildDiffInfo(["apps/web/src/App.tsx"]);
 
     expect(resolveProjectDiffIncludePaths(rootDirectory, projectDirectory, diffInfo)).toEqual([]);
+  });
+
+  it("returns no files when only non-source files changed in a child workspace", () => {
+    const rootDirectory = path.join("/repo");
+    const projectDirectory = path.join(rootDirectory, "apps", "web");
+    const diffInfo = buildDiffInfo(["apps/web/package.json", "apps/web/README.md"]);
+
+    expect(resolveProjectDiffIncludePaths(rootDirectory, projectDirectory, diffInfo)).toEqual([]);
+  });
+
+  it("keeps nested paths relative to the selected child workspace", () => {
+    const rootDirectory = path.join("/repo");
+    const projectDirectory = path.join(rootDirectory, "packages", "ui");
+    const diffInfo = buildDiffInfo(["packages/ui/src/components/Button.tsx"]);
+
+    expect(resolveProjectDiffIncludePaths(rootDirectory, projectDirectory, diffInfo)).toEqual([
+      "src/components/Button.tsx",
+    ]);
   });
 
   it("does not match sibling names that merely share a prefix", () => {


### PR DESCRIPTION
## Summary
- Add CLI tests for child workspace diff include path filtering.
- Cover non-source child workspace changes and nested source paths relative to the selected workspace.

## Test plan
- `nr build --filter=@react-doctor/core`
- `pnpm exec vp test run tests/resolve-project-diff-include-paths.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production logic modified.
> 
> **Overview**
> Adds **CLI unit tests** for `resolveProjectDiffIncludePaths` so child workspaces in a monorepo filter git diff paths correctly.
> 
> New cases assert that **non-source** changes under a selected workspace (e.g. `package.json`, `README.md`) yield **no include paths**, and that **nested source** paths are returned **relative to that workspace** (e.g. `packages/ui/...` → `src/components/Button.tsx`). The test file now imports `DiffInfo` from the local package entry instead of `@react-doctor/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b072591421e56319442187cb01cc8e2f9a5af1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->