### PR TITLE
[MIL-1547] Recognize `subscription.remove()` as effect cleanup

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -91,12 +91,8 @@ export const SUBSCRIPTION_METHOD_NAMES = new Set([
 // via `{ signal }`: a single `controller.abort()` removes every
 // listener bound to that signal in one shot, so it IS the matching
 // "remove" call even when no literal `removeEventListener(...)` is present.
-// `remove` covers React Native's EventSubscription objects returned by
-// APIs like AppState.addEventListener, Keyboard.addListener, Appearance,
-// and Dimensions.
 export const UNSUBSCRIPTION_METHOD_NAMES = new Set([
   "unsubscribe",
-  "remove",
   "removeEventListener",
   "removeListener",
   "off",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -81,17 +81,16 @@ export const SUBSCRIPTION_METHOD_NAMES = new Set([
   "sub",
 ]);
 
-// Methods that pair with the subscription methods above as their cleanup
-// counterparts. Used to recognize a valid `return () => removeEventListener(...)`
-// cleanup form even when the subscribe call is `addEventListener` rather
-// than a `subscribe()` whose return value gets re-bound.
+// Cleanup method names that are meaningful without knowing where the receiver
+// came from. A call like `target.removeEventListener(...)`, `emitter.off(...)`,
+// or `controller.abort()` describes the teardown in the method name itself, so
+// it is safe to accept on any receiver inside an effect cleanup.
 //
-// `abort` covers the AbortController pattern, which is the recommended
-// modern shape for tearing down `addEventListener` registrations bound
-// via `{ signal }`: a single `controller.abort()` removes every
-// listener bound to that signal in one shot, so it IS the matching
-// "remove" call even when no literal `removeEventListener(...)` is present.
-export const UNSUBSCRIPTION_METHOD_NAMES = new Set([
+// Keep generic resource verbs such as `remove`, `dispose`, `destroy`, and
+// `teardown` OUT of this set. On an arbitrary receiver, `node.remove()` or
+// `cache.dispose()` does not prove it releases the listener/subscription that
+// was created earlier in the effect.
+export const GLOBAL_RELEASE_METHOD_NAMES = new Set([
   "unsubscribe",
   "removeEventListener",
   "removeListener",
@@ -102,11 +101,17 @@ export const UNSUBSCRIPTION_METHOD_NAMES = new Set([
   "abort",
 ]);
 
-// Methods accepted only when called on a variable bound to a subscribe-like
-// return value (`const sub = source.addListener(...); return () => sub.remove()`).
-// These names are too generic to trust on arbitrary receivers, but they are
-// common release verbs for subscription/resource objects.
-export const BOUND_SUBSCRIPTION_RELEASE_METHOD_NAMES = new Set([
+// Cleanup method names that are only meaningful when the receiver is the value
+// returned by a subscribe-like call in the same effect. For example:
+//
+//   const sub = AppState.addEventListener(...);
+//   return () => sub.remove();
+//
+// In that shape, the receiver (`sub`) ties the generic verb (`remove`) back to
+// the resource created by the effect. Without that binding relationship, these
+// verbs are too broad and would create false negatives for unrelated cleanup
+// calls.
+export const BOUND_RESOURCE_RELEASE_METHOD_NAMES = new Set([
   "remove",
   "unsubscribe",
   "unsub",
@@ -119,11 +124,11 @@ export const BOUND_SUBSCRIPTION_RELEASE_METHOD_NAMES = new Set([
 // Identifier names recognized as "this is a release/teardown call"
 // when they appear as a direct call inside an effect's cleanup
 // return — covers both library unsubscribe shorthands
-// (UNSUBSCRIPTION_METHOD_NAMES) and the generic teardown vocabulary
+// (GLOBAL_RELEASE_METHOD_NAMES) and the generic teardown vocabulary
 // (`cleanup`, `dispose`, `destroy`, `teardown`). Matched
 // case-insensitively at the call site.
 export const CLEANUP_LIKE_RELEASE_CALLEE_NAMES = new Set([
-  ...UNSUBSCRIPTION_METHOD_NAMES,
+  ...GLOBAL_RELEASE_METHOD_NAMES,
   "cleanup",
   "dispose",
   "destroy",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -102,6 +102,20 @@ export const UNSUBSCRIPTION_METHOD_NAMES = new Set([
   "abort",
 ]);
 
+// Methods accepted only when called on a variable bound to a subscribe-like
+// return value (`const sub = source.addListener(...); return () => sub.remove()`).
+// These names are too generic to trust on arbitrary receivers, but they are
+// common release verbs for subscription/resource objects.
+export const BOUND_SUBSCRIPTION_RELEASE_METHOD_NAMES = new Set([
+  "remove",
+  "unsubscribe",
+  "unsub",
+  "cleanup",
+  "dispose",
+  "destroy",
+  "teardown",
+]);
+
 // Identifier names recognized as "this is a release/teardown call"
 // when they appear as a direct call inside an effect's cleanup
 // return — covers both library unsubscribe shorthands

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -81,22 +81,12 @@ export const SUBSCRIPTION_METHOD_NAMES = new Set([
   "sub",
 ]);
 
-// Subscribe-like methods whose return value is itself the cleanup function.
-// Do not include EventTarget/EventEmitter-style registrations here:
-// `addEventListener`, `addListener`, and `on` often return void or a
-// subscription object, so accepting their return value as cleanup would hide
-// missing teardown.
+// Subscribe-like methods that return the cleanup function directly.
+// EventTarget/EventEmitter APIs often return void or subscription objects.
 export const CLEANUP_RETURNING_SUBSCRIPTION_METHOD_NAMES = new Set(["subscribe", "sub"]);
 
-// Cleanup method names that are meaningful without knowing where the receiver
-// came from. A call like `target.removeEventListener(...)`, `emitter.off(...)`,
-// or `controller.abort()` describes the teardown in the method name itself, so
-// it is safe to accept on any receiver inside an effect cleanup.
-//
-// Keep generic resource verbs such as `remove`, `dispose`, `destroy`, and
-// `teardown` OUT of this set. On an arbitrary receiver, `node.remove()` or
-// `cache.dispose()` does not prove it releases the listener/subscription that
-// was created earlier in the effect.
+// Cleanup methods that are specific enough to trust on any receiver.
+// Generic verbs like `remove` need a known subscription receiver.
 export const GLOBAL_RELEASE_METHOD_NAMES = new Set([
   "unsubscribe",
   "removeEventListener",
@@ -108,16 +98,7 @@ export const GLOBAL_RELEASE_METHOD_NAMES = new Set([
   "abort",
 ]);
 
-// Cleanup method names that are only meaningful when the receiver is the value
-// returned by a subscribe-like call in the same effect. For example:
-//
-//   const sub = AppState.addEventListener(...);
-//   return () => sub.remove();
-//
-// In that shape, the receiver (`sub`) ties the generic verb (`remove`) back to
-// the resource created by the effect. Without that binding relationship, these
-// verbs are too broad and would create false negatives for unrelated cleanup
-// calls.
+// Generic cleanup methods accepted only on values returned by subscribe-like calls.
 export const BOUND_RESOURCE_RELEASE_METHOD_NAMES = new Set([
   "remove",
   "cleanup",
@@ -127,12 +108,7 @@ export const BOUND_RESOURCE_RELEASE_METHOD_NAMES = new Set([
   "teardown",
 ]);
 
-// Identifier names recognized as "this is a release/teardown call"
-// when they appear as a direct call inside an effect's cleanup
-// return — covers both library unsubscribe shorthands
-// (GLOBAL_RELEASE_METHOD_NAMES) and the generic teardown vocabulary
-// (`cleanup`, `dispose`, `destroy`, `teardown`). Matched
-// case-insensitively at the call site.
+// Direct cleanup function names accepted inside returned cleanup functions.
 export const CLEANUP_LIKE_RELEASE_CALLEE_NAMES = new Set([
   ...GLOBAL_RELEASE_METHOD_NAMES,
   "cleanup",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -113,8 +113,6 @@ export const GLOBAL_RELEASE_METHOD_NAMES = new Set([
 // calls.
 export const BOUND_RESOURCE_RELEASE_METHOD_NAMES = new Set([
   "remove",
-  "unsubscribe",
-  "unsub",
   "cleanup",
   "dispose",
   "destroy",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -81,6 +81,13 @@ export const SUBSCRIPTION_METHOD_NAMES = new Set([
   "sub",
 ]);
 
+// Subscribe-like methods whose return value is itself the cleanup function.
+// Do not include EventTarget/EventEmitter-style registrations here:
+// `addEventListener`, `addListener`, and `on` often return void or a
+// subscription object, so accepting their return value as cleanup would hide
+// missing teardown.
+export const CLEANUP_RETURNING_SUBSCRIPTION_METHOD_NAMES = new Set(["subscribe", "sub"]);
+
 // Cleanup method names that are meaningful without knowing where the receiver
 // came from. A call like `target.removeEventListener(...)`, `emitter.off(...)`,
 // or `controller.abort()` describes the teardown in the method name itself, so

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -123,6 +123,7 @@ export const BOUND_RESOURCE_RELEASE_METHOD_NAMES = new Set([
   "cleanup",
   "dispose",
   "destroy",
+  "stop",
   "teardown",
 ]);
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -91,8 +91,12 @@ export const SUBSCRIPTION_METHOD_NAMES = new Set([
 // via `{ signal }`: a single `controller.abort()` removes every
 // listener bound to that signal in one shot, so it IS the matching
 // "remove" call even when no literal `removeEventListener(...)` is present.
+// `remove` covers React Native's EventSubscription objects returned by
+// APIs like AppState.addEventListener, Keyboard.addListener, Appearance,
+// and Dimensions.
 export const UNSUBSCRIPTION_METHOD_NAMES = new Set([
   "unsubscribe",
+  "remove",
   "removeEventListener",
   "removeListener",
   "off",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -81,12 +81,8 @@ export const SUBSCRIPTION_METHOD_NAMES = new Set([
   "sub",
 ]);
 
-// Subscribe-like methods that return the cleanup function directly.
-// EventTarget/EventEmitter APIs often return void or subscription objects.
 export const CLEANUP_RETURNING_SUBSCRIPTION_METHOD_NAMES = new Set(["subscribe", "sub"]);
 
-// Cleanup methods that are specific enough to trust on any receiver.
-// Generic verbs like `remove` need a known subscription receiver.
 export const GLOBAL_RELEASE_METHOD_NAMES = new Set([
   "unsubscribe",
   "removeEventListener",
@@ -98,7 +94,6 @@ export const GLOBAL_RELEASE_METHOD_NAMES = new Set([
   "abort",
 ]);
 
-// Generic cleanup methods accepted only on values returned by subscribe-like calls.
 export const BOUND_RESOURCE_RELEASE_METHOD_NAMES = new Set([
   "remove",
   "cleanup",
@@ -108,7 +103,6 @@ export const BOUND_RESOURCE_RELEASE_METHOD_NAMES = new Set([
   "teardown",
 ]);
 
-// Direct cleanup function names accepted inside returned cleanup functions.
 export const CLEANUP_LIKE_RELEASE_CALLEE_NAMES = new Set([
   ...GLOBAL_RELEASE_METHOD_NAMES,
   "cleanup",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -29,7 +29,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 //   - setInterval / setTimeout (without explicit clear)
 //
 // The subscribe / unsubscribe method allowlists live in `constants.ts`
-// (`SUBSCRIPTION_METHOD_NAMES`, `UNSUBSCRIPTION_METHOD_NAMES`) so the
+// (`SUBSCRIPTION_METHOD_NAMES`, `GLOBAL_RELEASE_METHOD_NAMES`) so the
 // cleanup-needed detector and the prefer-use-sync-external-store
 // detector share a single source of truth. Inline duplicates would
 // silently drift out of sync as new library shapes get added.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -12,7 +12,7 @@ import {
   isCleanupReturningSubscribeLikeCallExpression,
   isSubscribeLikeCallExpression,
 } from "./utils/is-subscribe-like-call-expression.js";
-import { isCleanupReturn } from "./utils/is-cleanup-return.js";
+import { isCleanupFunctionLike, isCleanupReturn } from "./utils/is-cleanup-return.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -93,21 +93,20 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
   return usages;
 };
 
-interface ReleasableBindings {
-  releaseNames: Set<string>;
+interface CleanupBindings {
+  cleanupFunctionNames: Set<string>;
   subscriptionNames: Set<string>;
+  effectScopeVariableNames: Set<string>;
 }
 
-// HACK: variables bound to a subscribe-like or timer-like call inside
-// an effect body are CLEANUP TARGETS — `return X` or `() => X()` /
-// `() => clearTimeout(X)` releases the resource. Collecting them here
-// lets the shared release predicate accept user-named bindings
-// (`const unsub = ...; return unsub`) without falling back to the
-// previous "any Identifier is fine" behavior.
-const collectReleasableBindings = (effectCallback: EsTreeNode): ReleasableBindings => {
-  const bindings: ReleasableBindings = {
-    releaseNames: new Set<string>(),
+// HACK: cleanup names must come from the effect's own scope, except for
+// assignments to an outer effect variable (`let remove; remove = () => ...`)
+// that happen inside a local setup helper.
+const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => {
+  const bindings: CleanupBindings = {
+    cleanupFunctionNames: new Set<string>(),
     subscriptionNames: new Set<string>(),
+    effectScopeVariableNames: new Set<string>(),
   };
   if (
     !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
@@ -116,28 +115,68 @@ const collectReleasableBindings = (effectCallback: EsTreeNode): ReleasableBindin
     return bindings;
   }
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) return bindings;
+
   walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "VariableDeclaration")) return;
     for (const declarator of child.declarations ?? []) {
       if (!isNodeOfType(declarator.id, "Identifier")) continue;
       const bindingName = declarator.id.name;
+      bindings.effectScopeVariableNames.add(bindingName);
       const init = declarator.init;
       if (!init || !isNodeOfType(init, "CallExpression")) continue;
       if (isSubscribeLikeCallExpression(init)) {
         bindings.subscriptionNames.add(bindingName);
         if (isCleanupReturningSubscribeLikeCallExpression(init)) {
-          bindings.releaseNames.add(bindingName);
+          bindings.cleanupFunctionNames.add(bindingName);
         }
-        continue;
-      }
-      if (
-        isNodeOfType(init.callee, "Identifier") &&
-        TIMER_CALLEE_NAMES_REQUIRING_CLEANUP.has(init.callee.name)
-      ) {
-        bindings.releaseNames.add(bindingName);
       }
     }
   });
+
+  walkAst(effectCallback.body, (child: EsTreeNode) => {
+    if (
+      child !== effectCallback.body &&
+      (isNodeOfType(child, "ArrowFunctionExpression") || isNodeOfType(child, "FunctionExpression"))
+    ) {
+      return false;
+    }
+    if (
+      isNodeOfType(child, "FunctionDeclaration") &&
+      child.id &&
+      isCleanupFunctionLike(child, bindings.cleanupFunctionNames, bindings.subscriptionNames)
+    ) {
+      bindings.cleanupFunctionNames.add(child.id.name);
+      return false;
+    }
+  });
+
+  walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "VariableDeclaration")) return;
+    for (const declarator of child.declarations ?? []) {
+      if (!isNodeOfType(declarator.id, "Identifier") || !declarator.init) continue;
+      if (
+        isCleanupFunctionLike(
+          declarator.init,
+          bindings.cleanupFunctionNames,
+          bindings.subscriptionNames,
+        )
+      ) {
+        bindings.cleanupFunctionNames.add(declarator.id.name);
+      }
+    }
+  });
+
+  walkAst(effectCallback.body, (child: EsTreeNode) => {
+    if (
+      isNodeOfType(child, "AssignmentExpression") &&
+      isNodeOfType(child.left, "Identifier") &&
+      bindings.effectScopeVariableNames.has(child.left.name) &&
+      isCleanupFunctionLike(child.right, bindings.cleanupFunctionNames, bindings.subscriptionNames)
+    ) {
+      bindings.cleanupFunctionNames.add(child.left.name);
+    }
+  });
+
   return bindings;
 };
 
@@ -161,7 +200,7 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   if (!isNodeOfType(callback.body, "BlockStatement")) {
     return isCleanupReturningSubscribeLikeCallExpression(callback.body);
   }
-  const releasableBindings = collectReleasableBindings(callback);
+  const cleanupBindings = collectCleanupBindings(callback);
   // HACK: scan ALL `return` statements at the effect's own function
   // scope (skipping nested functions via `walkInsideStatementBlocks`),
   // not just the top-level last statement. The last-statement check
@@ -186,8 +225,8 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
     if (
       isCleanupReturn(
         child.argument,
-        releasableBindings.releaseNames,
-        releasableBindings.subscriptionNames,
+        cleanupBindings.cleanupFunctionNames,
+        cleanupBindings.subscriptionNames,
       )
     ) {
       didFindCleanupReturn = true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -16,26 +16,9 @@ import { isCleanupFunctionLike, isCleanupReturn } from "./utils/is-cleanup-retur
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-// HACK: From "Lifecycle of Reactive Effects":
-//
-//   "Each Effect describes a separate synchronization process. When
-//    the component is removed, your Effect needs to stop synchronizing.
-//    The cleanup function should stop or undo whatever the Effect was
-//    doing."
-//
-// An effect that adds a listener / subscribes / sets a timer but
-// returns no cleanup leaks memory and triggers React's "you forgot
-// to clean up an effect" StrictMode hint at runtime. We flag it
-// statically. Three subscribe-shaped families:
-//   - addEventListener (browser DOM, EventTarget-shaped libs)
-//   - subscribe / addListener / on / watch / listen / sub
-//   - setInterval / setTimeout (without explicit clear)
-//
-// The subscribe / unsubscribe method allowlists live in `constants.ts`
-// (`SUBSCRIPTION_METHOD_NAMES`, `GLOBAL_RELEASE_METHOD_NAMES`) so the
-// cleanup-needed detector and the prefer-use-sync-external-store
-// detector share a single source of truth. Inline duplicates would
-// silently drift out of sync as new library shapes get added.
+// Effects that register listeners, subscriptions, or timers should return a
+// cleanup. Shared method allowlists keep this rule aligned with
+// `prefer-use-sync-external-store`.
 interface SubscribeLikeUsage {
   kind: "subscribe" | "timer";
   resourceName: string;
@@ -49,12 +32,7 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
   ) {
     return usages;
   }
-  // HACK: timer/subscribe calls inside the EFFECT'S CLEANUP RETURN
-  // are not new registrations — they're the disposal step. The old
-  // walker traversed the full callback including any returned
-  // cleanup function, so a `setTimeout` inside `return () => { ... }`
-  // got counted as a usage. Detect and skip the cleanup ReturnStatement's
-  // argument body during the walk.
+  // Returned cleanup bodies are disposal code, not new registrations.
   let cleanupArgument: EsTreeNode | null = null;
   if (isNodeOfType(callback.body, "BlockStatement")) {
     const callbackStatements = callback.body.body ?? [];
@@ -99,9 +77,8 @@ interface CleanupBindings {
   effectScopeVariableNames: Set<string>;
 }
 
-// HACK: cleanup names must come from the effect's own scope, except for
-// assignments to an outer effect variable (`let remove; remove = () => ...`)
-// that happen inside a local setup helper.
+// Trust cleanup names from the effect scope. Also allow local helpers to assign
+// cleanup functions to an effect-scope variable.
 const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => {
   const bindings: CleanupBindings = {
     cleanupFunctionNames: new Set<string>(),
@@ -134,6 +111,8 @@ const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => 
   });
 
   walkAst(effectCallback.body, (child: EsTreeNode) => {
+    // Function expressions create inner scopes; their cleanup is not returned
+    // by the effect unless the function itself is returned.
     if (
       child !== effectCallback.body &&
       (isNodeOfType(child, "ArrowFunctionExpression") || isNodeOfType(child, "FunctionExpression"))
@@ -167,6 +146,7 @@ const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => 
   });
 
   walkAst(effectCallback.body, (child: EsTreeNode) => {
+    // Local helpers may assign cleanup into an effect-scope variable.
     if (
       isNodeOfType(child, "AssignmentExpression") &&
       isNodeOfType(child.left, "Identifier") &&
@@ -187,37 +167,14 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   ) {
     return false;
   }
-  // HACK: expression-body arrows are the dominant shape for trivial
-  // cleanup-returning subscribe-only effects:
-  //
-  //   useEffect(() => store.subscribe(handler), []);
-  //
-  // The arrow's expression body IS the body, and its evaluation
-  // result is implicitly returned as the effect's cleanup function. Only
-  // accept subscribe-shaped methods whose return value is known to be a
-  // cleanup function; `addEventListener` / `addListener` may return void
-  // or a subscription object that still needs explicit teardown.
+  // `useEffect(() => store.subscribe(handler), [])` returns cleanup implicitly.
+  // Only accept subscribe methods known to return cleanup functions.
   if (!isNodeOfType(callback.body, "BlockStatement")) {
     return isCleanupReturningSubscribeLikeCallExpression(callback.body);
   }
   const cleanupBindings = collectCleanupBindings(callback);
-  // HACK: scan ALL `return` statements at the effect's own function
-  // scope (skipping nested functions via `walkInsideStatementBlocks`),
-  // not just the top-level last statement. The last-statement check
-  // false-positives on the very common conditional-cleanup shape:
-  //
-  //   useEffect(() => {
-  //     if (!enabled) return;
-  //     const sub = subscribe(...);
-  //     if (someCondition) {
-  //       return () => sub();
-  //     }
-  //   }, [enabled]);
-  //
-  // Either accept the conditional cleanup as intentional, or risk
-  // ~36% FPs on real codebases (measured: react-grab, excalidraw,
-  // textarea/popover patterns). Accepting nested cleanup mirrors how
-  // exhaustive-deps treats branched returns: trust the author.
+  // Cleanup can live in guarded branches; inspect effect-scope returns, but
+  // skip nested functions.
   let didFindCleanupReturn = false;
   walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
     if (didFindCleanupReturn) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -90,21 +90,29 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
   return usages;
 };
 
+interface ReleasableBindings {
+  releaseNames: Set<string>;
+  subscriptionNames: Set<string>;
+}
+
 // HACK: variables bound to a subscribe-like or timer-like call inside
 // an effect body are CLEANUP TARGETS — `return X` or `() => X()` /
 // `() => clearTimeout(X)` releases the resource. Collecting them here
 // lets the shared release predicate accept user-named bindings
 // (`const unsub = ...; return unsub`) without falling back to the
 // previous "any Identifier is fine" behavior.
-const collectReleasableBindingNames = (effectCallback: EsTreeNode): Set<string> => {
-  const releasableNames = new Set<string>();
+const collectReleasableBindings = (effectCallback: EsTreeNode): ReleasableBindings => {
+  const bindings: ReleasableBindings = {
+    releaseNames: new Set<string>(),
+    subscriptionNames: new Set<string>(),
+  };
   if (
     !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
     !isNodeOfType(effectCallback, "FunctionExpression")
   ) {
-    return releasableNames;
+    return bindings;
   }
-  if (!isNodeOfType(effectCallback.body, "BlockStatement")) return releasableNames;
+  if (!isNodeOfType(effectCallback.body, "BlockStatement")) return bindings;
   for (const statement of effectCallback.body.body ?? []) {
     if (!isNodeOfType(statement, "VariableDeclaration")) continue;
     for (const declarator of statement.declarations ?? []) {
@@ -112,18 +120,19 @@ const collectReleasableBindingNames = (effectCallback: EsTreeNode): Set<string> 
       const init = declarator.init;
       if (!init || !isNodeOfType(init, "CallExpression")) continue;
       if (isSubscribeLikeCallExpression(init)) {
-        releasableNames.add(declarator.id.name);
+        bindings.releaseNames.add(declarator.id.name);
+        bindings.subscriptionNames.add(declarator.id.name);
         continue;
       }
       if (
         isNodeOfType(init.callee, "Identifier") &&
         TIMER_CALLEE_NAMES_REQUIRING_CLEANUP.has(init.callee.name)
       ) {
-        releasableNames.add(declarator.id.name);
+        bindings.releaseNames.add(declarator.id.name);
       }
     }
   }
-  return releasableNames;
+  return bindings;
 };
 
 const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
@@ -146,7 +155,7 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   if (!isNodeOfType(callback.body, "BlockStatement")) {
     return isSubscribeLikeCallExpression(callback.body);
   }
-  const knownBoundReleaseNames = collectReleasableBindingNames(callback);
+  const knownBoundReleaseNames = collectReleasableBindings(callback);
   // HACK: scan ALL `return` statements at the effect's own function
   // scope (skipping nested functions via `walkInsideStatementBlocks`),
   // not just the top-level last statement. The last-statement check
@@ -168,7 +177,13 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
     if (didFindCleanupReturn) return;
     if (!isNodeOfType(child, "ReturnStatement")) return;
-    if (isCleanupReturn(child.argument, knownBoundReleaseNames)) {
+    if (
+      isCleanupReturn(
+        child.argument,
+        knownBoundReleaseNames.releaseNames,
+        knownBoundReleaseNames.subscriptionNames,
+      )
+    ) {
       didFindCleanupReturn = true;
     }
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -124,8 +124,10 @@ const collectReleasableBindings = (effectCallback: EsTreeNode): ReleasableBindin
       const init = declarator.init;
       if (!init || !isNodeOfType(init, "CallExpression")) continue;
       if (isSubscribeLikeCallExpression(init)) {
-        bindings.releaseNames.add(bindingName);
         bindings.subscriptionNames.add(bindingName);
+        if (isCleanupReturningSubscribeLikeCallExpression(init)) {
+          bindings.releaseNames.add(bindingName);
+        }
         continue;
       }
       if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -8,7 +8,10 @@ import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blo
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { isSubscribeLikeCallExpression } from "./utils/is-subscribe-like-call-expression.js";
+import {
+  isCleanupReturningSubscribeLikeCallExpression,
+  isSubscribeLikeCallExpression,
+} from "./utils/is-subscribe-like-call-expression.js";
 import { isCleanupReturn } from "./utils/is-cleanup-return.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -117,18 +120,19 @@ const collectReleasableBindings = (effectCallback: EsTreeNode): ReleasableBindin
     if (!isNodeOfType(child, "VariableDeclaration")) return;
     for (const declarator of child.declarations ?? []) {
       if (!isNodeOfType(declarator.id, "Identifier")) continue;
+      const bindingName = declarator.id.name;
       const init = declarator.init;
       if (!init || !isNodeOfType(init, "CallExpression")) continue;
       if (isSubscribeLikeCallExpression(init)) {
-        bindings.releaseNames.add(declarator.id.name);
-        bindings.subscriptionNames.add(declarator.id.name);
+        bindings.releaseNames.add(bindingName);
+        bindings.subscriptionNames.add(bindingName);
         continue;
       }
       if (
         isNodeOfType(init.callee, "Identifier") &&
         TIMER_CALLEE_NAMES_REQUIRING_CLEANUP.has(init.callee.name)
       ) {
-        bindings.releaseNames.add(declarator.id.name);
+        bindings.releaseNames.add(bindingName);
       }
     }
   });
@@ -143,17 +147,17 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
     return false;
   }
   // HACK: expression-body arrows are the dominant shape for trivial
-  // subscribe-only effects:
+  // cleanup-returning subscribe-only effects:
   //
   //   useEffect(() => store.subscribe(handler), []);
   //
   // The arrow's expression body IS the body, and its evaluation
-  // result is implicitly returned as the effect's cleanup function.
-  // For subscribe-shaped calls we know the return value is the
-  // unsubscribe — accept this case before the BlockStatement-only
-  // checks below.
+  // result is implicitly returned as the effect's cleanup function. Only
+  // accept subscribe-shaped methods whose return value is known to be a
+  // cleanup function; `addEventListener` / `addListener` may return void
+  // or a subscription object that still needs explicit teardown.
   if (!isNodeOfType(callback.body, "BlockStatement")) {
-    return isSubscribeLikeCallExpression(callback.body);
+    return isCleanupReturningSubscribeLikeCallExpression(callback.body);
   }
   const releasableBindings = collectReleasableBindings(callback);
   // HACK: scan ALL `return` statements at the effect's own function

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -113,9 +113,9 @@ const collectReleasableBindings = (effectCallback: EsTreeNode): ReleasableBindin
     return bindings;
   }
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) return bindings;
-  for (const statement of effectCallback.body.body ?? []) {
-    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
-    for (const declarator of statement.declarations ?? []) {
+  walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "VariableDeclaration")) return;
+    for (const declarator of child.declarations ?? []) {
       if (!isNodeOfType(declarator.id, "Identifier")) continue;
       const init = declarator.init;
       if (!init || !isNodeOfType(init, "CallExpression")) continue;
@@ -131,7 +131,7 @@ const collectReleasableBindings = (effectCallback: EsTreeNode): ReleasableBindin
         bindings.releaseNames.add(declarator.id.name);
       }
     }
-  }
+  });
   return bindings;
 };
 
@@ -155,7 +155,7 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   if (!isNodeOfType(callback.body, "BlockStatement")) {
     return isSubscribeLikeCallExpression(callback.body);
   }
-  const knownBoundReleaseNames = collectReleasableBindings(callback);
+  const releasableBindings = collectReleasableBindings(callback);
   // HACK: scan ALL `return` statements at the effect's own function
   // scope (skipping nested functions via `walkInsideStatementBlocks`),
   // not just the top-level last statement. The last-statement check
@@ -180,8 +180,8 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
     if (
       isCleanupReturn(
         child.argument,
-        knownBoundReleaseNames.releaseNames,
-        knownBoundReleaseNames.subscriptionNames,
+        releasableBindings.releaseNames,
+        releasableBindings.subscriptionNames,
       )
     ) {
       didFindCleanupReturn = true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -65,7 +65,7 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
   }
 
   walkAst(callback, (child: EsTreeNode) => {
-    if (child === cleanupArgument) return false;
+    if (child === cleanupArgument && !isSubscribeLikeCallExpression(child)) return false;
     if (!isNodeOfType(child, "CallExpression")) return;
 
     if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -16,9 +16,6 @@ import { isCleanupFunctionLike, isCleanupReturn } from "./utils/is-cleanup-retur
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-// Effects that register listeners, subscriptions, or timers should return a
-// cleanup. Shared method allowlists keep this rule aligned with
-// `prefer-use-sync-external-store`.
 interface SubscribeLikeUsage {
   kind: "subscribe" | "timer";
   resourceName: string;
@@ -32,7 +29,6 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
   ) {
     return usages;
   }
-  // Returned cleanup bodies are disposal code, not new registrations.
   let cleanupArgument: EsTreeNode | null = null;
   if (isNodeOfType(callback.body, "BlockStatement")) {
     const callbackStatements = callback.body.body ?? [];
@@ -77,8 +73,6 @@ interface CleanupBindings {
   effectScopeVariableNames: Set<string>;
 }
 
-// Trust cleanup names from the effect scope. Also allow local helpers to assign
-// cleanup functions to an effect-scope variable.
 const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => {
   const bindings: CleanupBindings = {
     cleanupFunctionNames: new Set<string>(),
@@ -111,8 +105,6 @@ const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => 
   });
 
   walkAst(effectCallback.body, (child: EsTreeNode) => {
-    // Function expressions create inner scopes; their cleanup is not returned
-    // by the effect unless the function itself is returned.
     if (
       child !== effectCallback.body &&
       (isNodeOfType(child, "ArrowFunctionExpression") || isNodeOfType(child, "FunctionExpression"))
@@ -146,7 +138,6 @@ const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => 
   });
 
   walkAst(effectCallback.body, (child: EsTreeNode) => {
-    // Local helpers may assign cleanup into an effect-scope variable.
     if (
       isNodeOfType(child, "AssignmentExpression") &&
       isNodeOfType(child.left, "Identifier") &&
@@ -167,14 +158,10 @@ const effectHasCleanupRelease = (callback: EsTreeNode): boolean => {
   ) {
     return false;
   }
-  // `useEffect(() => store.subscribe(handler), [])` returns cleanup implicitly.
-  // Only accept subscribe methods known to return cleanup functions.
   if (!isNodeOfType(callback.body, "BlockStatement")) {
     return isCleanupReturningSubscribeLikeCallExpression(callback.body);
   }
   const cleanupBindings = collectCleanupBindings(callback);
-  // Cleanup can live in guarded branches; inspect effect-scope returns, but
-  // skip nested functions.
   let didFindCleanupReturn = false;
   walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
     if (didFindCleanupReturn) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
@@ -12,6 +12,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isCleanupReturn } from "./utils/is-cleanup-return.js";
+import { isCleanupReturningSubscribeLikeCallExpression } from "./utils/is-subscribe-like-call-expression.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -49,9 +50,13 @@ const findUseEffectsInComponent = (componentBody: EsTreeNode | undefined): EsTre
   return effectCalls;
 };
 
-const findSubscriptionCall = (
-  effectBodyStatements: EsTreeNode[],
-): { call: EsTreeNode; boundUnsubscribeName: string | null } | null => {
+interface SubscriptionCallMatch {
+  call: EsTreeNode;
+  boundReleaseName: string | null;
+  boundSubscriptionName: string | null;
+}
+
+const findSubscriptionCall = (effectBodyStatements: EsTreeNode[]): SubscriptionCallMatch | null => {
   for (const statement of effectBodyStatements) {
     if (isNodeOfType(statement, "VariableDeclaration")) {
       for (const declarator of statement.declarations ?? []) {
@@ -60,10 +65,17 @@ const findSubscriptionCall = (
         if (!isNodeOfType(init.callee, "MemberExpression")) continue;
         if (!isNodeOfType(init.callee.property, "Identifier")) continue;
         if (!SUBSCRIPTION_METHOD_NAMES.has(init.callee.property.name)) continue;
-        const boundUnsubscribeName = isNodeOfType(declarator.id, "Identifier")
+        const boundSubscriptionName = isNodeOfType(declarator.id, "Identifier")
           ? declarator.id.name
           : null;
-        return { call: init, boundUnsubscribeName };
+        return {
+          call: init,
+          boundReleaseName:
+            boundSubscriptionName && isCleanupReturningSubscribeLikeCallExpression(init)
+              ? boundSubscriptionName
+              : null,
+          boundSubscriptionName,
+        };
       }
     }
     if (isNodeOfType(statement, "ExpressionStatement")) {
@@ -72,7 +84,7 @@ const findSubscriptionCall = (
       if (!isNodeOfType(expression.callee, "MemberExpression")) continue;
       if (!isNodeOfType(expression.callee.property, "Identifier")) continue;
       if (!SUBSCRIPTION_METHOD_NAMES.has(expression.callee.property.name)) continue;
-      return { call: expression, boundUnsubscribeName: null };
+      return { call: expression, boundReleaseName: null, boundSubscriptionName: null };
     }
   }
   return null;
@@ -137,13 +149,20 @@ const getSingleSetterCallFromHandler = (
 
 const cleanupReleasesSubscription = (
   effectBodyStatements: EsTreeNode[],
-  boundUnsubscribeName: string | null,
+  boundReleaseName: string | null,
+  boundSubscriptionName: string | null,
 ): boolean => {
   const lastStatement = effectBodyStatements[effectBodyStatements.length - 1];
   if (!isNodeOfType(lastStatement, "ReturnStatement")) return false;
   const knownBoundReleaseNames = new Set<string>();
-  if (boundUnsubscribeName) knownBoundReleaseNames.add(boundUnsubscribeName);
-  return isCleanupReturn(lastStatement.argument, knownBoundReleaseNames, knownBoundReleaseNames);
+  const knownBoundSubscriptionNames = new Set<string>();
+  if (boundReleaseName) knownBoundReleaseNames.add(boundReleaseName);
+  if (boundSubscriptionName) knownBoundSubscriptionNames.add(boundSubscriptionName);
+  return isCleanupReturn(
+    lastStatement.argument,
+    knownBoundReleaseNames,
+    knownBoundSubscriptionNames,
+  );
 };
 
 export const preferUseSyncExternalStore = defineRule<Rule>({
@@ -221,7 +240,13 @@ export const preferUseSyncExternalStore = defineRule<Rule>({
           continue;
         }
 
-        if (!cleanupReleasesSubscription(effectBodyStatements, subscription.boundUnsubscribeName)) {
+        if (
+          !cleanupReleasesSubscription(
+            effectBodyStatements,
+            subscription.boundReleaseName,
+            subscription.boundSubscriptionName,
+          )
+        ) {
           continue;
         }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
@@ -143,7 +143,7 @@ const cleanupReleasesSubscription = (
   if (!isNodeOfType(lastStatement, "ReturnStatement")) return false;
   const knownBoundReleaseNames = new Set<string>();
   if (boundUnsubscribeName) knownBoundReleaseNames.add(boundUnsubscribeName);
-  return isCleanupReturn(lastStatement.argument, knownBoundReleaseNames);
+  return isCleanupReturn(lastStatement.argument, knownBoundReleaseNames, knownBoundReleaseNames);
 };
 
 export const preferUseSyncExternalStore = defineRule<Rule>({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -11,6 +11,7 @@ import { isSubscribeLikeCallExpression } from "./is-subscribe-like-call-expressi
 const isReleaseLikeCall = (
   callNode: EsTreeNode,
   knownBoundReleaseNames: ReadonlySet<string>,
+  knownBoundSubscriptionNames: ReadonlySet<string>,
 ): boolean => {
   if (!isNodeOfType(callNode, "CallExpression")) return false;
   const callee = callNode.callee;
@@ -21,6 +22,13 @@ const isReleaseLikeCall = (
     return false;
   }
   if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
+    if (
+      callee.property.name === "remove" &&
+      isNodeOfType(callee.object, "Identifier") &&
+      knownBoundSubscriptionNames.has(callee.object.name)
+    ) {
+      return true;
+    }
     return UNSUBSCRIPTION_METHOD_NAMES.has(callee.property.name);
   }
   return false;
@@ -29,11 +37,12 @@ const isReleaseLikeCall = (
 const containsReleaseLikeCall = (
   node: EsTreeNode,
   knownBoundReleaseNames: ReadonlySet<string>,
+  knownBoundSubscriptionNames: ReadonlySet<string>,
 ): boolean => {
   let didFindRelease = false;
   walkAst(node, (child: EsTreeNode) => {
     if (didFindRelease) return false;
-    if (isReleaseLikeCall(child, knownBoundReleaseNames)) {
+    if (isReleaseLikeCall(child, knownBoundReleaseNames, knownBoundSubscriptionNames)) {
       didFindRelease = true;
       return false;
     }
@@ -44,6 +53,7 @@ const containsReleaseLikeCall = (
 export const isCleanupReturn = (
   returnedValue: EsTreeNode | null | undefined,
   knownBoundReleaseNames: ReadonlySet<string>,
+  knownBoundSubscriptionNames: ReadonlySet<string> = new Set(),
 ): boolean => {
   if (!returnedValue) return false;
   if (isNodeOfType(returnedValue, "Identifier")) {
@@ -54,7 +64,11 @@ export const isCleanupReturn = (
     isNodeOfType(returnedValue, "ArrowFunctionExpression") ||
     isNodeOfType(returnedValue, "FunctionExpression")
   ) {
-    return containsReleaseLikeCall(returnedValue, knownBoundReleaseNames);
+    return containsReleaseLikeCall(
+      returnedValue,
+      knownBoundReleaseNames,
+      knownBoundSubscriptionNames,
+    );
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -7,7 +7,7 @@ import {
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import { walkAst } from "../../../utils/walk-ast.js";
-import { isSubscribeLikeCallExpression } from "./is-subscribe-like-call-expression.js";
+import { isCleanupReturningSubscribeLikeCallExpression } from "./is-subscribe-like-call-expression.js";
 
 const isReleaseLikeCall = (
   callNode: EsTreeNode,
@@ -63,7 +63,7 @@ export const isCleanupReturn = (
   if (isNodeOfType(returnedValue, "Identifier")) {
     return knownBoundReleaseNames.has(returnedValue.name);
   }
-  if (isSubscribeLikeCallExpression(returnedValue)) return true;
+  if (isCleanupReturningSubscribeLikeCallExpression(returnedValue)) return true;
   if (
     isNodeOfType(returnedValue, "ArrowFunctionExpression") ||
     isNodeOfType(returnedValue, "FunctionExpression")

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -1,5 +1,6 @@
 import { TIMER_CLEANUP_CALLEE_NAMES } from "../../../constants/dom.js";
 import {
+  BOUND_SUBSCRIPTION_RELEASE_METHOD_NAMES,
   CLEANUP_LIKE_RELEASE_CALLEE_NAMES,
   UNSUBSCRIPTION_METHOD_NAMES,
 } from "../../../constants/react.js";
@@ -23,7 +24,7 @@ const isReleaseLikeCall = (
   }
   if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
     if (
-      callee.property.name === "remove" &&
+      BOUND_SUBSCRIPTION_RELEASE_METHOD_NAMES.has(callee.property.name) &&
       isNodeOfType(callee.object, "Identifier") &&
       knownBoundSubscriptionNames.has(callee.object.name)
     ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -21,6 +21,7 @@ const isNullLiteral = (node: EsTreeNode | null | undefined): boolean =>
 const isListenerRemovalViaNullHandler = (callNode: EsTreeNode): boolean => {
   if (!isNodeOfType(callNode, "CallExpression")) return false;
   const callee = unwrapChainExpression(callNode.callee);
+  // d3-style `.on(name, null)` removes a listener.
   return (
     isNodeOfType(callee, "MemberExpression") &&
     isNodeOfType(callee.property, "Identifier") &&
@@ -47,9 +48,8 @@ const isReleaseLikeCall = (
   if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
     if (
       BOUND_RESOURCE_RELEASE_METHOD_NAMES.has(callee.property.name) &&
-      // TODO: This deliberately only accepts identifier-bound subscription
-      // receivers. Shapes like `subRef.current.remove()` need receiver-aware
-      // binding analysis before they can be credited safely.
+      // Generic release verbs need a known subscription receiver.
+      // TODO(v2 - receiver analysis): handle `subRef.current.remove()`.
       isNodeOfType(callee.object, "Identifier") &&
       knownBoundSubscriptionNames.has(callee.object.name)
     ) {
@@ -80,6 +80,8 @@ const containsReleaseLikeCall = (
   let didFindRelease = false;
   walkAst(node, (child: EsTreeNode) => {
     if (didFindRelease) return false;
+    // Cleanup inside arbitrary nested callbacks does not run on unmount.
+    // Synchronous iteration callbacks are part of the cleanup body.
     if (child !== node && isFunctionLike(child) && !isSynchronousIterationCallback(child)) {
       return false;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -10,6 +10,26 @@ import { isFunctionLike } from "../../../utils/is-function-like.js";
 import { walkAst } from "../../../utils/walk-ast.js";
 import { isCleanupReturningSubscribeLikeCallExpression } from "./is-subscribe-like-call-expression.js";
 
+const ITERATOR_CALLBACK_METHOD_NAMES = new Set([
+  "each",
+  "every",
+  "filter",
+  "find",
+  "findIndex",
+  "findLast",
+  "findLastIndex",
+  "flatMap",
+  "forEach",
+  "map",
+  "reduce",
+  "reduceRight",
+  "some",
+  "sort",
+  "toSorted",
+]);
+
+const STATIC_ITERATOR_CALLBACK_METHOD_NAMES = new Set(["from", "fromAsync", "groupBy"]);
+
 const unwrapChainExpression = (node: EsTreeNode): EsTreeNode =>
   isNodeOfType(node, "ChainExpression") ? node.expression : node;
 
@@ -58,6 +78,26 @@ const isReleaseLikeCall = (
   return false;
 };
 
+const isStaticIteratorCallbackCallee = (callee: EsTreeNode): boolean =>
+  isNodeOfType(callee, "MemberExpression") &&
+  isNodeOfType(callee.object, "Identifier") &&
+  isNodeOfType(callee.property, "Identifier") &&
+  (callee.object.name === "Array" || callee.object.name === "Object") &&
+  STATIC_ITERATOR_CALLBACK_METHOD_NAMES.has(callee.property.name);
+
+const isIteratorCallbackArgument = (node: EsTreeNode): boolean => {
+  const parentNode = node.parent;
+  if (!isNodeOfType(parentNode, "CallExpression")) return false;
+  if (!parentNode.arguments?.some((argument) => argument === node)) return false;
+  const callee = unwrapChainExpression(parentNode.callee);
+  if (parentNode.arguments[1] === node && isStaticIteratorCallbackCallee(callee)) return true;
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    isNodeOfType(callee.property, "Identifier") &&
+    ITERATOR_CALLBACK_METHOD_NAMES.has(callee.property.name)
+  );
+};
+
 const containsReleaseLikeCall = (
   node: EsTreeNode,
   knownCleanupFunctionNames: ReadonlySet<string>,
@@ -66,7 +106,9 @@ const containsReleaseLikeCall = (
   let didFindRelease = false;
   walkAst(node, (child: EsTreeNode) => {
     if (didFindRelease) return false;
-    if (child !== node && isFunctionLike(child)) return false;
+    if (child !== node && isFunctionLike(child) && !isIteratorCallbackArgument(child)) {
+      return false;
+    }
     if (isReleaseLikeCall(child, knownCleanupFunctionNames, knownBoundSubscriptionNames)) {
       didFindRelease = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -10,8 +10,6 @@ import { isFunctionLike } from "../../../utils/is-function-like.js";
 import { walkAst } from "../../../utils/walk-ast.js";
 import { isCleanupReturningSubscribeLikeCallExpression } from "./is-subscribe-like-call-expression.js";
 
-const SYNC_ITERATION_METHOD_NAMES = new Set(["forEach"]);
-
 const unwrapChainExpression = (node: EsTreeNode): EsTreeNode =>
   isNodeOfType(node, "ChainExpression") ? node.expression : node;
 
@@ -60,18 +58,6 @@ const isReleaseLikeCall = (
   return false;
 };
 
-const isSynchronousIterationCallback = (node: EsTreeNode): boolean => {
-  const parentNode = node.parent;
-  if (!isNodeOfType(parentNode, "CallExpression")) return false;
-  if (!parentNode.arguments?.some((argument) => argument === node)) return false;
-  const callee = unwrapChainExpression(parentNode.callee);
-  return (
-    isNodeOfType(callee, "MemberExpression") &&
-    isNodeOfType(callee.property, "Identifier") &&
-    SYNC_ITERATION_METHOD_NAMES.has(callee.property.name)
-  );
-};
-
 const containsReleaseLikeCall = (
   node: EsTreeNode,
   knownCleanupFunctionNames: ReadonlySet<string>,
@@ -80,11 +66,7 @@ const containsReleaseLikeCall = (
   let didFindRelease = false;
   walkAst(node, (child: EsTreeNode) => {
     if (didFindRelease) return false;
-    // Cleanup inside arbitrary nested callbacks does not run on unmount.
-    // Synchronous iteration callbacks are part of the cleanup body.
-    if (child !== node && isFunctionLike(child) && !isSynchronousIterationCallback(child)) {
-      return false;
-    }
+    if (child !== node && isFunctionLike(child)) return false;
     if (isReleaseLikeCall(child, knownCleanupFunctionNames, knownBoundSubscriptionNames)) {
       didFindRelease = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -25,6 +25,9 @@ const isReleaseLikeCall = (
   if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
     if (
       BOUND_RESOURCE_RELEASE_METHOD_NAMES.has(callee.property.name) &&
+      // TODO: This deliberately only accepts `sub.remove()`-style identifiers.
+      // Shapes like `subRef.current.remove()` and `sub?.remove()` need
+      // receiver-aware binding analysis before they can be credited safely.
       isNodeOfType(callee.object, "Identifier") &&
       knownBoundSubscriptionNames.has(callee.object.name)
     ) {
@@ -54,7 +57,7 @@ const containsReleaseLikeCall = (
 export const isCleanupReturn = (
   returnedValue: EsTreeNode | null | undefined,
   knownBoundReleaseNames: ReadonlySet<string>,
-  knownBoundSubscriptionNames: ReadonlySet<string> = new Set(),
+  knownBoundSubscriptionNames: ReadonlySet<string>,
 ): boolean => {
   if (!returnedValue) return false;
   if (isNodeOfType(returnedValue, "Identifier")) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -6,28 +6,50 @@ import {
 } from "../../../constants/react.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isFunctionLike } from "../../../utils/is-function-like.js";
 import { walkAst } from "../../../utils/walk-ast.js";
 import { isCleanupReturningSubscribeLikeCallExpression } from "./is-subscribe-like-call-expression.js";
 
+const SYNC_ITERATION_METHOD_NAMES = new Set(["forEach"]);
+
+const unwrapChainExpression = (node: EsTreeNode): EsTreeNode =>
+  isNodeOfType(node, "ChainExpression") ? node.expression : node;
+
+const isNullLiteral = (node: EsTreeNode | null | undefined): boolean =>
+  isNodeOfType(node, "Literal") && node.value === null;
+
+const isListenerRemovalViaNullHandler = (callNode: EsTreeNode): boolean => {
+  if (!isNodeOfType(callNode, "CallExpression")) return false;
+  const callee = unwrapChainExpression(callNode.callee);
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === "on" &&
+    isNullLiteral(callNode.arguments?.[1])
+  );
+};
+
 const isReleaseLikeCall = (
-  callNode: EsTreeNode,
-  knownBoundReleaseNames: ReadonlySet<string>,
+  node: EsTreeNode,
+  knownCleanupFunctionNames: ReadonlySet<string>,
   knownBoundSubscriptionNames: ReadonlySet<string>,
 ): boolean => {
+  const callNode = unwrapChainExpression(node);
   if (!isNodeOfType(callNode, "CallExpression")) return false;
-  const callee = callNode.callee;
+  if (isListenerRemovalViaNullHandler(callNode)) return true;
+  const callee = unwrapChainExpression(callNode.callee);
   if (isNodeOfType(callee, "Identifier")) {
     if (TIMER_CLEANUP_CALLEE_NAMES.has(callee.name)) return true;
     if (CLEANUP_LIKE_RELEASE_CALLEE_NAMES.has(callee.name)) return true;
-    if (knownBoundReleaseNames.has(callee.name)) return true;
+    if (knownCleanupFunctionNames.has(callee.name)) return true;
     return false;
   }
   if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
     if (
       BOUND_RESOURCE_RELEASE_METHOD_NAMES.has(callee.property.name) &&
-      // TODO: This deliberately only accepts `sub.remove()`-style identifiers.
-      // Shapes like `subRef.current.remove()` and `sub?.remove()` need
-      // receiver-aware binding analysis before they can be credited safely.
+      // TODO: This deliberately only accepts identifier-bound subscription
+      // receivers. Shapes like `subRef.current.remove()` need receiver-aware
+      // binding analysis before they can be credited safely.
       isNodeOfType(callee.object, "Identifier") &&
       knownBoundSubscriptionNames.has(callee.object.name)
     ) {
@@ -38,15 +60,30 @@ const isReleaseLikeCall = (
   return false;
 };
 
+const isSynchronousIterationCallback = (node: EsTreeNode): boolean => {
+  const parentNode = node.parent;
+  if (!isNodeOfType(parentNode, "CallExpression")) return false;
+  if (!parentNode.arguments?.some((argument) => argument === node)) return false;
+  const callee = unwrapChainExpression(parentNode.callee);
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    isNodeOfType(callee.property, "Identifier") &&
+    SYNC_ITERATION_METHOD_NAMES.has(callee.property.name)
+  );
+};
+
 const containsReleaseLikeCall = (
   node: EsTreeNode,
-  knownBoundReleaseNames: ReadonlySet<string>,
+  knownCleanupFunctionNames: ReadonlySet<string>,
   knownBoundSubscriptionNames: ReadonlySet<string>,
 ): boolean => {
   let didFindRelease = false;
   walkAst(node, (child: EsTreeNode) => {
     if (didFindRelease) return false;
-    if (isReleaseLikeCall(child, knownBoundReleaseNames, knownBoundSubscriptionNames)) {
+    if (child !== node && isFunctionLike(child) && !isSynchronousIterationCallback(child)) {
+      return false;
+    }
+    if (isReleaseLikeCall(child, knownCleanupFunctionNames, knownBoundSubscriptionNames)) {
       didFindRelease = true;
       return false;
     }
@@ -54,25 +91,30 @@ const containsReleaseLikeCall = (
   return didFindRelease;
 };
 
+export const isCleanupFunctionLike = (
+  node: EsTreeNode,
+  knownCleanupFunctionNames: ReadonlySet<string>,
+  knownBoundSubscriptionNames: ReadonlySet<string>,
+): boolean => {
+  if (!isFunctionLike(node)) return false;
+  return containsReleaseLikeCall(node.body, knownCleanupFunctionNames, knownBoundSubscriptionNames);
+};
+
 export const isCleanupReturn = (
   returnedValue: EsTreeNode | null | undefined,
-  knownBoundReleaseNames: ReadonlySet<string>,
+  knownCleanupFunctionNames: ReadonlySet<string>,
   knownBoundSubscriptionNames: ReadonlySet<string>,
 ): boolean => {
   if (!returnedValue) return false;
-  if (isNodeOfType(returnedValue, "Identifier")) {
-    return knownBoundReleaseNames.has(returnedValue.name);
+  const unwrappedValue = unwrapChainExpression(returnedValue);
+  if (isNodeOfType(unwrappedValue, "Identifier")) {
+    return knownCleanupFunctionNames.has(unwrappedValue.name);
   }
-  if (isCleanupReturningSubscribeLikeCallExpression(returnedValue)) return true;
+  if (isCleanupReturningSubscribeLikeCallExpression(unwrappedValue)) return true;
   if (
-    isNodeOfType(returnedValue, "ArrowFunctionExpression") ||
-    isNodeOfType(returnedValue, "FunctionExpression")
+    isCleanupFunctionLike(unwrappedValue, knownCleanupFunctionNames, knownBoundSubscriptionNames)
   ) {
-    return containsReleaseLikeCall(
-      returnedValue,
-      knownBoundReleaseNames,
-      knownBoundSubscriptionNames,
-    );
+    return true;
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -82,7 +82,9 @@ const isStaticIteratorCallbackCallee = (callee: EsTreeNode): boolean =>
   isNodeOfType(callee, "MemberExpression") &&
   isNodeOfType(callee.object, "Identifier") &&
   isNodeOfType(callee.property, "Identifier") &&
-  (callee.object.name === "Array" || callee.object.name === "Object") &&
+  (callee.object.name === "Array" ||
+    callee.object.name === "Map" ||
+    callee.object.name === "Object") &&
   STATIC_ITERATOR_CALLBACK_METHOD_NAMES.has(callee.property.name);
 
 const isIteratorCallbackArgument = (node: EsTreeNode): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -1,8 +1,8 @@
 import { TIMER_CLEANUP_CALLEE_NAMES } from "../../../constants/dom.js";
 import {
-  BOUND_SUBSCRIPTION_RELEASE_METHOD_NAMES,
+  BOUND_RESOURCE_RELEASE_METHOD_NAMES,
   CLEANUP_LIKE_RELEASE_CALLEE_NAMES,
-  UNSUBSCRIPTION_METHOD_NAMES,
+  GLOBAL_RELEASE_METHOD_NAMES,
 } from "../../../constants/react.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
@@ -24,13 +24,13 @@ const isReleaseLikeCall = (
   }
   if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
     if (
-      BOUND_SUBSCRIPTION_RELEASE_METHOD_NAMES.has(callee.property.name) &&
+      BOUND_RESOURCE_RELEASE_METHOD_NAMES.has(callee.property.name) &&
       isNodeOfType(callee.object, "Identifier") &&
       knownBoundSubscriptionNames.has(callee.object.name)
     ) {
       return true;
     }
-    return UNSUBSCRIPTION_METHOD_NAMES.has(callee.property.name);
+    return GLOBAL_RELEASE_METHOD_NAMES.has(callee.property.name);
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-subscribe-like-call-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-subscribe-like-call-expression.ts
@@ -1,10 +1,23 @@
-import { SUBSCRIPTION_METHOD_NAMES } from "../../../constants/react.js";
+import {
+  CLEANUP_RETURNING_SUBSCRIPTION_METHOD_NAMES,
+  SUBSCRIPTION_METHOD_NAMES,
+} from "../../../constants/react.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
+const getSubscribeLikeMethodName = (node: EsTreeNode): string | null => {
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  if (!isNodeOfType(node.callee, "MemberExpression")) return null;
+  if (!isNodeOfType(node.callee.property, "Identifier")) return null;
+  return node.callee.property.name;
+};
+
 export const isSubscribeLikeCallExpression = (node: EsTreeNode): boolean => {
-  if (!isNodeOfType(node, "CallExpression")) return false;
-  if (!isNodeOfType(node.callee, "MemberExpression")) return false;
-  if (!isNodeOfType(node.callee.property, "Identifier")) return false;
-  return SUBSCRIPTION_METHOD_NAMES.has(node.callee.property.name);
+  const methodName = getSubscribeLikeMethodName(node);
+  return methodName !== null && SUBSCRIPTION_METHOD_NAMES.has(methodName);
+};
+
+export const isCleanupReturningSubscribeLikeCallExpression = (node: EsTreeNode): boolean => {
+  const methodName = getSubscribeLikeMethodName(node);
+  return methodName !== null && CLEANUP_RETURNING_SUBSCRIPTION_METHOD_NAMES.has(methodName);
 };

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -345,7 +345,7 @@ export const Emitter = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("still flags cleanup hidden inside an iteration callback", async () => {
+  it("does not flag listeners cleaned up inside an iteration callback", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-for-each-cleanup", {
       files: {
         "src/Pointer.tsx": `import { useEffect } from "react";
@@ -372,7 +372,60 @@ export const Pointer = () => {
     });
 
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
-    expect(hits).toHaveLength(1);
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag timers cleaned up inside a reduce callback", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-reduce-cleanup", {
+      files: {
+        "src/Timers.tsx": `import { useEffect } from "react";
+
+declare const tick: () => void;
+
+export const Timers = () => {
+  useEffect(() => {
+    const timerIds = [setTimeout(tick, 1000), setTimeout(tick, 2000)];
+    return () => {
+      timerIds.reduce((count, timerId) => {
+        clearTimeout(timerId);
+        return count + 1;
+      }, 0);
+    };
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag timers cleaned up inside an Array.from callback", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-array-from-cleanup", {
+      files: {
+        "src/Timers.tsx": `import { useEffect } from "react";
+
+declare const tick: () => void;
+
+export const Timers = () => {
+  useEffect(() => {
+    const timerIds = [setTimeout(tick, 1000), setTimeout(tick, 2000)];
+    return () => {
+      Array.from(timerIds, (timerId) => {
+        clearTimeout(timerId);
+      });
+    };
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
   });
 
   it("does not flag a subscription chain binding cleaned up with `.stop()`", async () => {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -150,8 +150,6 @@ export const AppFocus = () => {
   it("recognizes release methods on objects returned by subscribe-like calls", async () => {
     for (const releaseName of [
       "remove",
-      "unsubscribe",
-      "unsub",
       "cleanup",
       "dispose",
       "destroy",
@@ -184,6 +182,32 @@ export const Subscribe = () => {
       const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
       expect(hits).toHaveLength(0);
     }
+  });
+
+  it("does NOT flag bound subscription cleanup inside a conditional branch", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-bound-conditional", {
+      files: {
+        "src/ConditionalSubscribe.tsx": `import { useEffect } from "react";
+
+declare const isOn: boolean;
+declare const source: { addListener: (handler: () => void) => { remove: () => void } };
+declare const handler: () => void;
+
+export const ConditionalSubscribe = () => {
+  useEffect(() => {
+    if (isOn) {
+      const sub = source.addListener(handler);
+      return () => sub.remove();
+    }
+  }, [isOn]);
+  return null;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
   });
 
   it("still flags when cleanup only calls an unrelated bound-resource release method", async () => {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -114,6 +114,39 @@ export const Resize = () => {
     expect(hits).toHaveLength(0);
   });
 
+  it("does NOT flag React Native subscription objects cleaned up with `.remove()`", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-rn-sub-remove", {
+      packageJson: {
+        dependencies: {
+          react: "19.0.0",
+          "react-native": "0.82.0",
+        },
+      },
+      files: {
+        "src/AppFocus.tsx": `import { useEffect } from "react";
+import { AppState } from "react-native";
+
+declare const focusManager: { setFocused: (focused: boolean) => void };
+
+export const AppFocus = () => {
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", status => {
+      focusManager.setFocused(status === "active");
+    });
+    return () => {
+      sub.remove();
+    };
+  }, []);
+  return null;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
   it("does NOT flag a useEffect that returns a cleanup arrow calling clearInterval", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-clear-interval", {
       files: {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -288,9 +288,12 @@ export const Subscribe = () => {
   });
 
   it("flags expression-body `addEventListener` because it does not return cleanup", async () => {
-    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-expression-add-listener", {
-      files: {
-        "src/Resize.tsx": `import { useEffect } from "react";
+    const projectDir = setupReactProject(
+      tempRoot,
+      "effect-needs-cleanup-expression-add-listener",
+      {
+        files: {
+          "src/Resize.tsx": `import { useEffect } from "react";
 
 declare const handler: () => void;
 
@@ -299,8 +302,9 @@ export const Resize = () => {
   return <span />;
 };
 `,
+        },
       },
-    });
+    );
 
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
     expect(hits).toHaveLength(1);
@@ -420,9 +424,12 @@ export const Subscribe = () => {
   });
 
   it("flags a BlockStatement that returns `addEventListener` directly", async () => {
-    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-return-add-listener", {
-      files: {
-        "src/Resize.tsx": `import { useEffect } from "react";
+    const projectDir = setupReactProject(
+      tempRoot,
+      "effect-needs-cleanup-return-add-listener",
+      {
+        files: {
+          "src/Resize.tsx": `import { useEffect } from "react";
 
 declare const handler: () => void;
 
@@ -433,8 +440,9 @@ export const Resize = () => {
   return <span />;
 };
 `,
+        },
       },
-    });
+    );
 
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
     expect(hits).toHaveLength(1);

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -287,6 +287,25 @@ export const Subscribe = () => {
     expect(hits).toHaveLength(0);
   });
 
+  it("flags expression-body `addEventListener` because it does not return cleanup", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-expression-add-listener", {
+      files: {
+        "src/Resize.tsx": `import { useEffect } from "react";
+
+declare const handler: () => void;
+
+export const Resize = () => {
+  useEffect(() => window.addEventListener("resize", handler), []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(1);
+  });
+
   it("does NOT flag a `setTimeout` that lives inside the cleanup return (Bugbot #157 round 3)", async () => {
     // Regression: the subscribe/timer scanner walked the entire
     // callback including the cleanup return body. A \`setTimeout\` in
@@ -398,6 +417,27 @@ export const Subscribe = () => {
 
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
     expect(hits).toHaveLength(0);
+  });
+
+  it("flags a BlockStatement that returns `addEventListener` directly", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-return-add-listener", {
+      files: {
+        "src/Resize.tsx": `import { useEffect } from "react";
+
+declare const handler: () => void;
+
+export const Resize = () => {
+  useEffect(() => {
+    return window.addEventListener("resize", handler);
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(1);
   });
 
   // HACK: regression for the ~36% FP rate measured against

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -255,7 +255,7 @@ export const Clock = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("does NOT flag a timer cleaned up by a local function returned by identifier", async () => {
+  it("does not flag a timer cleaned up by a local function returned by identifier", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-return-local-clear", {
       files: {
         "src/Clock.tsx": `import { useEffect, useRef, useState } from "react";
@@ -286,7 +286,7 @@ export const Clock = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("does NOT flag a listener cleaned up by an optionally called local cleanup variable", async () => {
+  it("does not flag a listener cleaned up by an optionally called local cleanup variable", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-optional-cleanup", {
       files: {
         "src/Resolution.tsx": `import { useEffect } from "react";
@@ -319,7 +319,7 @@ export const Resolution = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("does NOT flag a subscription cleaned up by a returned local function declaration", async () => {
+  it("does not flag a subscription cleaned up by a returned local function declaration", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-function-declaration", {
       files: {
         "src/Emitter.tsx": `import { useEffect } from "react";
@@ -345,7 +345,7 @@ export const Emitter = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("does NOT flag listeners cleaned up inside a synchronous iteration callback", async () => {
+  it("does not flag listeners cleaned up inside a synchronous iteration callback", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-for-each-cleanup", {
       files: {
         "src/Pointer.tsx": `import { useEffect } from "react";
@@ -375,7 +375,7 @@ export const Pointer = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("does NOT flag a subscription chain binding cleaned up with `.stop()`", async () => {
+  it("does not flag a subscription chain binding cleaned up with `.stop()`", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-bound-stop-cleanup", {
       files: {
         "src/Simulation.tsx": `import { useEffect } from "react";
@@ -400,7 +400,7 @@ export const Simulation = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("does NOT flag listener cleanup expressed as `.on(name, null)`", async () => {
+  it("does not flag listener cleanup expressed as `.on(name, null)`", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-on-null-cleanup", {
       files: {
         "src/Zoom.tsx": `import { useEffect } from "react";
@@ -479,12 +479,7 @@ export const Clock = () => {
   });
 
   it("does NOT flag expression-body arrow whose subscribe return is the implicit cleanup (Bugbot #157)", async () => {
-    // Regression: \`useEffect(() => store.subscribe(handler), [])\` is a
-    // common compact form — the arrow's expression body IS the body,
-    // and the subscribe call's return value (the unsubscribe fn) is
-    // implicitly returned as the effect's cleanup. The earlier
-    // detector rejected non-BlockStatement bodies outright and
-    // false-positived this shape.
+    // Expression-body effects return the subscribe cleanup directly.
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-expression-body", {
       files: {
         "src/Subscribe.tsx": `import { useEffect } from "react";
@@ -524,10 +519,7 @@ export const Resize = () => {
   });
 
   it("does NOT flag a `setTimeout` that lives inside the cleanup return (Bugbot #157 round 3)", async () => {
-    // Regression: the subscribe/timer scanner walked the entire
-    // callback including the cleanup return body. A \`setTimeout\` in
-    // the cleanup is a disposal step, not a new registration; it
-    // should not produce a 'missing cleanup' diagnostic.
+    // Timers inside returned cleanup functions are disposal work.
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-timer-in-cleanup", {
       files: {
         "src/Beacon.tsx": `import { useEffect } from "react";
@@ -553,11 +545,7 @@ export const Beacon = () => {
   });
 
   it("does NOT flag `return () => unsub()` after `const unsub = subscribe(...)` (Bugbot #157 round 3)", async () => {
-    // Regression: the Identifier-callee cleanup regex only matched
-    // long-form names (unsubscribe / cleanup / dispose / destroy /
-    // teardown). \`unsub\` (and other short forms) were missing,
-    // producing a false positive on the canonical bind-the-result-
-    // and-call-it shape.
+    // The cleanup name comes from the subscribe result, not a naming heuristic.
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-short-unsub-call", {
       files: {
         "src/Subscribe.tsx": `import { useEffect } from "react";
@@ -581,10 +569,7 @@ export const Subscribe = () => {
   });
 
   it("recognizes the generic teardown vocabulary (`cleanup`, `dispose`, `destroy`, `teardown`) as a release call", async () => {
-    // The release-callee allowlist now lives in `constants.ts` as
-    // `CLEANUP_LIKE_RELEASE_CALLEE_NAMES`. Each of the generic
-    // teardown verbs satisfies the cleanup check on its own — no
-    // false positive on this shape.
+    // Generic teardown names are valid as direct cleanup calls.
     for (const releaseName of ["cleanup", "dispose", "destroy", "teardown"]) {
       const projectDir = setupReactProject(
         tempRoot,
@@ -684,10 +669,7 @@ export const Resize = () => {
     expect(hits).toHaveLength(1);
   });
 
-  // HACK: regression for the ~36% FP rate measured against
-  // react-grab/excalidraw/etc. The previous detector only inspected the
-  // top-level last statement; cleanup nested inside an `if` block was
-  // invisible. Real-world shape: gated subscription + early-return.
+  // Guarded effects often return cleanup from inside a branch.
   it("does NOT flag cleanup nested inside an `if` block (early-return guard pattern)", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-conditional-cleanup", {
       files: {
@@ -763,11 +745,7 @@ export const Subscribe = () => {
     expect(hits).toHaveLength(0);
   });
 
-  // Regression for #310: AbortController is the modern, idiomatic way to
-  // tear down many `addEventListener` registrations in one call. A single
-  // `controller.abort()` removes every listener that was bound via
-  // `{ signal: controller.signal }`, so the cleanup return IS valid even
-  // though no literal `removeEventListener(...)` appears.
+  // AbortController can clean up listeners registered with its signal.
   it("does NOT flag `addEventListener({ signal })` cleaned up via `controller.abort()`", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-abort-controller", {
       files: {
@@ -823,10 +801,7 @@ export const FileDrop = () => {
     expect(hits).toHaveLength(0);
   });
 
-  // HACK: ensure the broader walk does NOT credit cleanup returns from a
-  // *nested* function expression (e.g. an inner callback) as the effect's
-  // own cleanup. The walker stops at function boundaries; this protects
-  // the bug fix from over-correcting.
+  // Cleanup returned from an inner callback is not the effect's cleanup.
   it("DOES still flag when the only `return cleanup` is inside a nested callback (not the effect's body)", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-nested-fn-return", {
       files: {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -345,7 +345,7 @@ export const Emitter = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("does not flag listeners cleaned up inside a synchronous iteration callback", async () => {
+  it("still flags cleanup hidden inside an iteration callback", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-for-each-cleanup", {
       files: {
         "src/Pointer.tsx": `import { useEffect } from "react";
@@ -372,7 +372,7 @@ export const Pointer = () => {
     });
 
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
-    expect(hits).toHaveLength(0);
+    expect(hits).toHaveLength(1);
   });
 
   it("does not flag a subscription chain binding cleaned up with `.stop()`", async () => {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -116,7 +116,7 @@ export const Resize = () => {
 
   it("does NOT flag React Native subscription objects cleaned up with `.remove()`", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-rn-sub-remove", {
-      packageJson: {
+      packageJsonExtras: {
         dependencies: {
           react: "19.0.0",
           "react-native": "0.82.0",
@@ -145,6 +145,30 @@ export const AppFocus = () => {
 
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
     expect(hits).toHaveLength(0);
+  });
+
+  it("still flags when cleanup only calls an unrelated `.remove()` method", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-unrelated-remove", {
+      files: {
+        "src/Resize.tsx": `import { useEffect } from "react";
+
+declare const node: { remove: () => void };
+
+export const Resize = () => {
+  useEffect(() => {
+    window.addEventListener("resize", () => {});
+    return () => {
+      node.remove();
+    };
+  }, []);
+  return null;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(1);
   });
 
   it("does NOT flag a useEffect that returns a cleanup arrow calling clearInterval", async () => {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -848,7 +848,6 @@ export const FileDrop = () => {
     expect(hits).toHaveLength(0);
   });
 
-  // Cleanup returned from an inner callback is not the effect's cleanup.
   it("DOES still flag when the only `return cleanup` is inside a nested callback (not the effect's body)", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-nested-fn-return", {
       files: {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -148,13 +148,7 @@ export const AppFocus = () => {
   });
 
   it("recognizes release methods on objects returned by subscribe-like calls", async () => {
-    for (const releaseName of [
-      "remove",
-      "cleanup",
-      "dispose",
-      "destroy",
-      "teardown",
-    ]) {
+    for (const releaseName of ["remove", "cleanup", "dispose", "destroy", "teardown"]) {
       const projectDir = setupReactProject(
         tempRoot,
         `effect-needs-cleanup-bound-resource-${releaseName}`,

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -434,6 +434,33 @@ export const Resize = () => {
     expect(hits).toHaveLength(1);
   });
 
+  it("flags an `addEventListener` result binding returned directly", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "effect-needs-cleanup-return-add-listener-binding",
+      {
+        files: {
+          "src/Resize.tsx": `import { useEffect } from "react";
+
+declare const target: { addEventListener: (eventName: string, handler: () => void) => void };
+declare const handler: () => void;
+
+export const Resize = () => {
+  useEffect(() => {
+    const subscription = target.addEventListener("resize", handler);
+    return subscription;
+  }, []);
+  return <span />;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(1);
+  });
+
   // HACK: regression for the ~36% FP rate measured against
   // react-grab/excalidraw/etc. The previous detector only inspected the
   // top-level last statement; cleanup nested inside an `if` block was

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -147,28 +147,73 @@ export const AppFocus = () => {
     expect(hits).toHaveLength(0);
   });
 
-  it("still flags when cleanup only calls an unrelated `.remove()` method", async () => {
-    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-unrelated-remove", {
-      files: {
-        "src/Resize.tsx": `import { useEffect } from "react";
+  it("recognizes release methods on objects returned by subscribe-like calls", async () => {
+    for (const releaseName of [
+      "remove",
+      "unsubscribe",
+      "unsub",
+      "cleanup",
+      "dispose",
+      "destroy",
+      "teardown",
+    ]) {
+      const projectDir = setupReactProject(
+        tempRoot,
+        `effect-needs-cleanup-bound-resource-${releaseName}`,
+        {
+          files: {
+            "src/Subscribe.tsx": `import { useEffect } from "react";
 
-declare const node: { remove: () => void };
+declare const source: { addListener: (handler: () => void) => { ${releaseName}: () => void } };
+declare const handler: () => void;
 
-export const Resize = () => {
+export const Subscribe = () => {
   useEffect(() => {
-    window.addEventListener("resize", () => {});
+    const subscription = source.addListener(handler);
     return () => {
-      node.remove();
+      subscription.${releaseName}();
     };
   }, []);
   return null;
 };
 `,
-      },
-    });
+          },
+        },
+      );
 
-    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
-    expect(hits).toHaveLength(1);
+      const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+      expect(hits).toHaveLength(0);
+    }
+  });
+
+  it("still flags when cleanup only calls an unrelated bound-resource release method", async () => {
+    for (const releaseName of ["remove", "cleanup", "dispose", "destroy", "teardown"]) {
+      const projectDir = setupReactProject(
+        tempRoot,
+        `effect-needs-cleanup-unrelated-${releaseName}`,
+        {
+          files: {
+            "src/Resize.tsx": `import { useEffect } from "react";
+
+declare const node: { ${releaseName}: () => void };
+
+export const Resize = () => {
+  useEffect(() => {
+    window.addEventListener("resize", () => {});
+    return () => {
+      node.${releaseName}();
+    };
+  }, []);
+  return null;
+};
+`,
+          },
+        },
+      );
+
+      const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+      expect(hits).toHaveLength(1);
+    }
   });
 
   it("does NOT flag a useEffect that returns a cleanup arrow calling clearInterval", async () => {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -255,6 +255,229 @@ export const Clock = () => {
     expect(hits).toHaveLength(0);
   });
 
+  it("does NOT flag a timer cleaned up by a local function returned by identifier", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-return-local-clear", {
+      files: {
+        "src/Clock.tsx": `import { useEffect, useRef, useState } from "react";
+
+export const Clock = () => {
+  const [, setTick] = useState(0);
+  const intervalIdRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    const startInterval = () => {
+      if (intervalIdRef.current) return;
+      intervalIdRef.current = setInterval(() => setTick((state) => state + 1), 1000);
+    };
+    const stopInterval = () => {
+      if (!intervalIdRef.current) return;
+      clearInterval(intervalIdRef.current);
+      intervalIdRef.current = null;
+    };
+    startInterval();
+    return stopInterval;
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag a listener cleaned up by an optionally called local cleanup variable", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-optional-cleanup", {
+      files: {
+        "src/Resolution.tsx": `import { useEffect } from "react";
+
+declare const win: Window;
+declare const updatePixelRatio: () => void;
+
+export const Resolution = () => {
+  useEffect(() => {
+    let remove: (() => void) | null = null;
+    const subscribe = () => {
+      const media = win.matchMedia("(resolution: 1dppx)");
+      media.addEventListener("change", updatePixelRatio);
+      remove = () => {
+        media.removeEventListener("change", updatePixelRatio);
+      };
+    };
+    subscribe();
+    return () => {
+      remove?.();
+    };
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag a subscription cleaned up by a returned local function declaration", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-function-declaration", {
+      files: {
+        "src/Emitter.tsx": `import { useEffect } from "react";
+
+declare const emitter: { on: (eventName: string, handler: () => void) => void; off: (eventName: string, handler: () => void) => void };
+declare const handler: () => void;
+
+export const Emitter = () => {
+  useEffect(() => {
+    emitter.on("change", handler);
+    function cleanup() {
+      emitter.off("change", handler);
+    }
+    return cleanup;
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag listeners cleaned up inside a synchronous iteration callback", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-for-each-cleanup", {
+      files: {
+        "src/Pointer.tsx": `import { useEffect } from "react";
+
+declare const handler: () => void;
+declare const target: { addEventListener: (eventName: string, handler: () => void) => void; removeEventListener: (eventName: string, handler: () => void) => void };
+
+export const Pointer = () => {
+  useEffect(() => {
+    const eventNames = ["pointerdown", "mousedown"];
+    eventNames.forEach((eventName) => {
+      target.addEventListener(eventName, handler);
+    });
+    return () => {
+      eventNames.forEach((eventName) => {
+        target.removeEventListener(eventName, handler);
+      });
+    };
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag a subscription chain binding cleaned up with `.stop()`", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-bound-stop-cleanup", {
+      files: {
+        "src/Simulation.tsx": `import { useEffect } from "react";
+
+declare const forceSimulation: () => { on: (eventName: string, handler: () => void) => { stop: () => void } };
+declare const tick: () => void;
+
+export const Simulation = () => {
+  useEffect(() => {
+    const simulation = forceSimulation().on("tick", tick);
+    return () => {
+      simulation.stop();
+    };
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does NOT flag listener cleanup expressed as `.on(name, null)`", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-on-null-cleanup", {
+      files: {
+        "src/Zoom.tsx": `import { useEffect } from "react";
+
+declare const zoom: { on: (eventName: string, handler: (() => void) | null) => void };
+declare const update: () => void;
+
+export const Zoom = () => {
+  useEffect(() => {
+    zoom.on("zoom", update);
+    return () => {
+      zoom.on("zoom", null);
+    };
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("still flags a returned local function that does not release the resource", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-return-non-cleanup", {
+      files: {
+        "src/Clock.tsx": `import { useEffect } from "react";
+
+declare const track: () => void;
+
+export const Clock = () => {
+  useEffect(() => {
+    setInterval(track, 1000);
+    const stopInterval = () => {
+      track();
+    };
+    return stopInterval;
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(1);
+  });
+
+  it("still flags when cleanup only exists in a nested local scope", async () => {
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-nested-cleanup-scope", {
+      files: {
+        "src/Clock.tsx": `import { useEffect } from "react";
+
+declare const tick: () => void;
+
+export const Clock = () => {
+  useEffect(() => {
+    const id = setInterval(tick, 1000);
+    let stopInterval: (() => void) | undefined;
+    const install = () => {
+      const stopInterval = () => clearInterval(id);
+      return stopInterval;
+    };
+    install();
+    return stopInterval;
+  }, []);
+  return <span />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
+    expect(hits).toHaveLength(1);
+  });
+
   it("does NOT flag expression-body arrow whose subscribe return is the implicit cleanup (Bugbot #157)", async () => {
     // Regression: \`useEffect(() => store.subscribe(handler), [])\` is a
     // common compact form — the arrow's expression body IS the body,

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -532,7 +532,6 @@ export const Clock = () => {
   });
 
   it("does NOT flag expression-body arrow whose subscribe return is the implicit cleanup (Bugbot #157)", async () => {
-    // Expression-body effects return the subscribe cleanup directly.
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-expression-body", {
       files: {
         "src/Subscribe.tsx": `import { useEffect } from "react";
@@ -572,7 +571,6 @@ export const Resize = () => {
   });
 
   it("does NOT flag a `setTimeout` that lives inside the cleanup return (Bugbot #157 round 3)", async () => {
-    // Timers inside returned cleanup functions are disposal work.
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-timer-in-cleanup", {
       files: {
         "src/Beacon.tsx": `import { useEffect } from "react";
@@ -598,7 +596,6 @@ export const Beacon = () => {
   });
 
   it("does NOT flag `return () => unsub()` after `const unsub = subscribe(...)` (Bugbot #157 round 3)", async () => {
-    // The cleanup name comes from the subscribe result, not a naming heuristic.
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-short-unsub-call", {
       files: {
         "src/Subscribe.tsx": `import { useEffect } from "react";
@@ -622,7 +619,6 @@ export const Subscribe = () => {
   });
 
   it("recognizes the generic teardown vocabulary (`cleanup`, `dispose`, `destroy`, `teardown`) as a release call", async () => {
-    // Generic teardown names are valid as direct cleanup calls.
     for (const releaseName of ["cleanup", "dispose", "destroy", "teardown"]) {
       const projectDir = setupReactProject(
         tempRoot,
@@ -722,7 +718,6 @@ export const Resize = () => {
     expect(hits).toHaveLength(1);
   });
 
-  // Guarded effects often return cleanup from inside a branch.
   it("does NOT flag cleanup nested inside an `if` block (early-return guard pattern)", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-conditional-cleanup", {
       files: {
@@ -798,7 +793,6 @@ export const Subscribe = () => {
     expect(hits).toHaveLength(0);
   });
 
-  // AbortController can clean up listeners registered with its signal.
   it("does NOT flag `addEventListener({ signal })` cleaned up via `controller.abort()`", async () => {
     const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-abort-controller", {
       files: {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts
@@ -288,12 +288,9 @@ export const Subscribe = () => {
   });
 
   it("flags expression-body `addEventListener` because it does not return cleanup", async () => {
-    const projectDir = setupReactProject(
-      tempRoot,
-      "effect-needs-cleanup-expression-add-listener",
-      {
-        files: {
-          "src/Resize.tsx": `import { useEffect } from "react";
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-expression-add-listener", {
+      files: {
+        "src/Resize.tsx": `import { useEffect } from "react";
 
 declare const handler: () => void;
 
@@ -302,9 +299,8 @@ export const Resize = () => {
   return <span />;
 };
 `,
-        },
       },
-    );
+    });
 
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
     expect(hits).toHaveLength(1);
@@ -424,12 +420,9 @@ export const Subscribe = () => {
   });
 
   it("flags a BlockStatement that returns `addEventListener` directly", async () => {
-    const projectDir = setupReactProject(
-      tempRoot,
-      "effect-needs-cleanup-return-add-listener",
-      {
-        files: {
-          "src/Resize.tsx": `import { useEffect } from "react";
+    const projectDir = setupReactProject(tempRoot, "effect-needs-cleanup-return-add-listener", {
+      files: {
+        "src/Resize.tsx": `import { useEffect } from "react";
 
 declare const handler: () => void;
 
@@ -440,9 +433,8 @@ export const Resize = () => {
   return <span />;
 };
 `,
-        },
       },
-    );
+    });
 
     const hits = await collectRuleHits(projectDir, "effect-needs-cleanup");
     expect(hits).toHaveLength(1);

--- a/packages/react-doctor/tests/regressions/state-rules/prefer-use-sync-external-store.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/prefer-use-sync-external-store.test.ts
@@ -228,6 +228,36 @@ export const Leaky = () => {
     expect(hits).toHaveLength(0);
   });
 
+  it("does NOT flag when an addEventListener result binding is returned directly", async () => {
+    const projectDir = setupReactProject(
+      tempRoot,
+      "prefer-use-sync-external-store-return-add-listener-binding",
+      {
+        files: {
+          "src/Online.tsx": `import { useEffect, useState } from "react";
+
+declare const source: { addEventListener: (eventName: string, handler: () => void) => void };
+declare const getSnapshot: () => boolean;
+
+export const Online = () => {
+  const [isOnline, setIsOnline] = useState(getSnapshot());
+  useEffect(() => {
+    const subscription = source.addEventListener("online", () => {
+      setIsOnline(getSnapshot());
+    });
+    return subscription;
+  }, []);
+  return <span>{isOnline ? "online" : "offline"}</span>;
+};
+`,
+        },
+      },
+    );
+
+    const hits = await collectRuleHits(projectDir, "prefer-use-sync-external-store");
+    expect(hits).toHaveLength(0);
+  });
+
   it("DOES flag a useSyncExternalStore reimplementation whose cleanup uses a generic teardown verb (`cleanup()`)", async () => {
     // Regression: `cleanupReleasesSubscription` previously only accepted
     // `GLOBAL_RELEASE_METHOD_NAMES` plus the literal bound-unsubscribe

--- a/packages/react-doctor/tests/regressions/state-rules/prefer-use-sync-external-store.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/prefer-use-sync-external-store.test.ts
@@ -201,7 +201,7 @@ export const Leaky = () => {
 
   it("DOES flag a useSyncExternalStore reimplementation whose cleanup uses a generic teardown verb (`cleanup()`)", async () => {
     // Regression: `cleanupReleasesSubscription` previously only accepted
-    // `UNSUBSCRIPTION_METHOD_NAMES` plus the literal bound-unsubscribe
+    // `GLOBAL_RELEASE_METHOD_NAMES` plus the literal bound-unsubscribe
     // name. Generic teardown verbs from `CLEANUP_LIKE_RELEASE_CALLEE_NAMES`
     // (`cleanup`, `dispose`, `destroy`, `teardown`) were silently ignored,
     // so a complete useSyncExternalStore reimplementation with a

--- a/packages/react-doctor/tests/regressions/state-rules/prefer-use-sync-external-store.test.ts
+++ b/packages/react-doctor/tests/regressions/state-rules/prefer-use-sync-external-store.test.ts
@@ -60,6 +60,35 @@ export const Online = () => {
     expect(hits).toHaveLength(1);
   });
 
+  it("flags a useSyncExternalStore reimplementation cleaned up with a bound `.remove()`", async () => {
+    const projectDir = setupReactProject(tempRoot, "prefer-use-sync-external-store-bound-remove", {
+      files: {
+        "src/BoundRemove.tsx": `import { useEffect, useState } from "react";
+
+declare const store: {
+  subscribe: (listener: () => void) => { remove: () => void };
+  getSnapshot: () => number;
+};
+
+export const BoundRemove = () => {
+  const [snapshot, setSnapshot] = useState(store.getSnapshot());
+  useEffect(() => {
+    const sub = store.subscribe(() => {
+      setSnapshot(store.getSnapshot());
+    });
+    return () => sub.remove();
+  }, []);
+  return <span>{snapshot}</span>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "prefer-use-sync-external-store");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("useSyncExternalStore");
+  });
+
   it("flags the lazy-initializer variant `useState(() => getSnapshot())`", async () => {
     const projectDir = setupReactProject(tempRoot, "prefer-use-sync-external-store-lazy", {
       files: {


### PR DESCRIPTION
## Why

Fixes false positives where `effect-needs-cleanup` reported effects that already return a valid cleanup, such as React Native `subscription.remove()` or a returned `stopInterval` helper.

This is not just adding `.remove()` to a global allowlist. A global `.remove()` rule would hide real leaks because many unrelated objects have a `remove()` method:

```tsx
useEffect(() => {
  window.addEventListener("resize", onResize);
  return () => {
    node.remove();
  };
}, []);
```

That cleanup removes `node`, not the resize listener, so the rule should still report it.

The safe version needs a small amount of binding analysis: accept `.remove()` only when the receiver is the value returned by the subscription call in the same effect.

```tsx
useEffect(() => {
  const subscription = AppState.addEventListener("change", onChange);
  return () => {
    subscription.remove();
  };
}, []);
```

React reruns effect cleanup before the next effect run and on unmount. A listener, subscription, interval, or timeout that is not cleaned up can leave stale callbacks behind. This PR keeps reporting those leaks while accepting library-supported cleanup shapes that can be found from the effect body and returned cleanup body.

## What changed

- Splits cleanup methods into global cleanup calls, cleanup-returning subscribe calls, and methods that are valid only on subscription-bound receivers.
- Accepts subscription-bound cleanup methods such as `subscription.remove()` and `simulation.stop()` only when the receiver comes from a subscribe-like call in the same effect.
- Accepts common indirect cleanup forms found in the eval: returned local cleanup functions, optional cleanup calls like `remove?.()`, iterator callback cleanup, and d3-style `.on(name, null)` listener removal.
- Keeps generic cleanup verbs narrow so unrelated calls like `node.remove()` do not hide real missing cleanup.
- Adds adversarial regression coverage for valid cleanup shapes and for false-negative traps where cleanup is unrelated or scoped inside an inner callback.

## Test plan

```sh
nr build # in packages/oxlint-plugin-react-doctor
nr typecheck # in packages/oxlint-plugin-react-doctor
nr test tests/regressions/state-rules/effect-needs-cleanup.test.ts tests/regressions/state-rules/prefer-use-sync-external-store.test.ts # in packages/react-doctor
nr format:check
git diff --check
```

Focused eval:

- Rule: `react-doctor/effect-needs-cleanup`
- Dataset: first 100 entries from `react-doctor-evals` `repos.json`
- Result: 26 diagnostics across 9 roots -> 20 diagnostics across 7 roots
- Scan failures: 0
- Remaining non-timer diagnostic was manually checked and appears to be a real missing `textEditor.off(...)` cleanup in tldraw.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis heuristics for two user-facing rules; incorrect binding logic could hide real leaks or reintroduce noise, though coverage is heavily regression-tested.
> 
> **Overview**
> Tightens **effect cleanup** detection for `effect-needs-cleanup` and aligned `prefer-use-sync-external-store` logic so fewer real cleanups are reported as missing.
> 
> Release method constants are split into **global** teardown (`removeEventListener`, `abort`, …), **cleanup-returning** subscribe calls (`subscribe` / `sub` only), and **receiver-bound** verbs (`remove`, `stop`, `dispose`, …) that count only when the object is bound from a subscribe-like call in the same effect—so patterns like React Native `sub.remove()` pass while unrelated `node.remove()` after `addEventListener` still fails.
> 
> `effect-needs-cleanup` now **collects cleanup bindings** (subscriptions, inferred cleanup functions from declarations/assignments) and feeds them into shared **`isCleanupReturn` / `isCleanupFunctionLike`** checks, including iterator-callback cleanup, optional `remove?.()`, d3-style `.on(name, null)`, and stricter rules for expression-body arrows (`addEventListener` no longer treated like `subscribe`). Large regression tests cover valid and adversarial shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9514445e4f6b28ebb321837b39da906652af503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->