### PR TITLE
Add automated agent guidance to inspect output

### DIFF
--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -228,25 +228,22 @@ export class Git extends Context.Service<
             return { status, stdout, stderr } satisfies GitInvocationResult;
           }),
         ).pipe(
-          Effect.catchTag(
-            "PlatformError",
-            (cause) => {
-              if (input.command !== "git") {
-                return Effect.succeed({
-                  status: 127,
-                  stdout: "",
-                  stderr: String(cause),
-                } satisfies GitInvocationResult);
-              }
-              return new ReactDoctorError({
-                reason: new GitInvocationFailed({
-                  args: [...input.args],
-                  directory: input.directory,
-                  cause,
-                }),
-              });
-            },
-          ),
+          Effect.catchTag("PlatformError", (cause) => {
+            if (input.command !== "git") {
+              return Effect.succeed({
+                status: 127,
+                stdout: "",
+                stderr: String(cause),
+              } satisfies GitInvocationResult);
+            }
+            return new ReactDoctorError({
+              reason: new GitInvocationFailed({
+                args: [...input.args],
+                directory: input.directory,
+                cause,
+              }),
+            });
+          }),
         );
 
       const runGit = (

--- a/packages/core/tests/resolve-github-actions-score-metadata.test.ts
+++ b/packages/core/tests/resolve-github-actions-score-metadata.test.ts
@@ -34,9 +34,9 @@ describe("resolveGithubActionsScoreMetadata", () => {
   });
 
   it("returns empty metadata outside GitHub Actions", () => {
-    expect(resolveGithubActionsScoreMetadata(buildEnvironment({ GITHUB_ACTIONS: "false" }))).toEqual(
-      {},
-    );
+    expect(
+      resolveGithubActionsScoreMetadata(buildEnvironment({ GITHUB_ACTIONS: "false" })),
+    ).toEqual({});
   });
 
   it("extracts pull request relationship metadata", () => {

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -158,9 +158,7 @@ describe("runInspect — happy path", () => {
         ...baseInput,
         isCi: true,
         resolveLocalGithubViewerPermission: true,
-      }).pipe(
-        Effect.provide(layersOf({ githubViewerPermission: "maintain" })),
-      ),
+      }).pipe(Effect.provide(layersOf({ githubViewerPermission: "maintain" }))),
     );
 
     expect(output.scoreMetadata).not.toHaveProperty("githubViewerPermission");

--- a/packages/react-doctor/src/cli/utils/is-non-interactive-environment.ts
+++ b/packages/react-doctor/src/cli/utils/is-non-interactive-environment.ts
@@ -8,7 +8,7 @@
 // pre-commit, and anything else that lives in `.git/hooks/`. That's the
 // canonical "I'm inside a git hook" signal and dodges the issue #293
 // spinner hang for every hook manager at once.
-const NON_INTERACTIVE_ENVIRONMENT_VARIABLES = [
+export const NON_INTERACTIVE_ENVIRONMENT_VARIABLES = [
   "CI",
   "GITHUB_ACTIONS",
   "GITLAB_CI",

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -181,11 +181,7 @@ export const buildInstallSetupPitchLines = (issueCount: number): readonly string
       ? `React Doctor found ${issueLabel}! Do you want to add React Doctor to this project? It will help humans and agents keep working through those fixes after this scan.`
       : "React Doctor did not find issues this time! Do you want to add React Doctor to this project? It will help humans and agents catch future regressions early.";
 
-  return [
-    "",
-    issueLine,
-    "",
-  ];
+  return ["", issueLine, ""];
 };
 
 const formatSetupPromptFailure = (error: unknown): string =>

--- a/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
+++ b/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
@@ -1,0 +1,20 @@
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import { highlighter } from "@react-doctor/core";
+
+const AGENT_GUIDANCE_LINES = [
+  "Triage diagnostics before editing: mark true positives, false positives, or needs-human-review.",
+  "Assign high/medium/low confidence and start with high-confidence, low-risk fixes.",
+  "Group related diagnostics by root cause before making changes.",
+  "Split unrelated or behavior-changing work into separate PRs/branches.",
+  "Run relevant tests after each focused batch.",
+] as const;
+
+export const printAgentGuidance = (): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* Console.log(`${highlighter.bold("Agent guidance")}`);
+    for (const line of AGENT_GUIDANCE_LINES) {
+      yield* Console.log(highlighter.gray(`  - ${line}`));
+    }
+    yield* Console.log("");
+  });

--- a/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
+++ b/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
@@ -3,11 +3,14 @@ import * as Effect from "effect/Effect";
 import { highlighter } from "@react-doctor/core";
 
 const AGENT_GUIDANCE_LINES = [
-  "Triage diagnostics before editing: mark true positives, false positives, or needs-human-review.",
-  "Assign high/medium/low confidence and start with high-confidence, low-risk fixes.",
-  "Group related diagnostics by root cause before making changes.",
-  "Split unrelated or behavior-changing work into separate PRs/branches.",
-  "Run relevant tests after each focused batch.",
+  "Treat React Doctor diagnostics as starting hypotheses. Read the relevant code before confirming or suppressing each finding.",
+  "For each group, decide true positive, false positive, or needs-human-review, then assign high/medium/low confidence.",
+  "Understand the root cause before editing. Fix the underlying code instead of changing react-doctor config or suppressing rules unless explicitly asked.",
+  "Start with high-confidence fixes that preserve behavior. Leave low-confidence or product-dependent changes as notes.",
+  "Run `npx react-doctor@latest --verbose --diff` before and after changes, plus relevant tests after each focused batch.",
+  "When available, spawn subagents or isolated worktrees for independent rule families, then review and merge only the best safe fixes.",
+  "Split unrelated, broad, or behavior-changing work into separate PRs/branches instead of one large cleanup.",
+  "If a fix needs an API, UX, or architecture decision, stop and ask before editing.",
 ] as const;
 
 export const printAgentGuidance = (): Effect.Effect<void> =>

--- a/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
+++ b/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
@@ -5,7 +5,10 @@ import { highlighter } from "@react-doctor/core";
 const AGENT_GUIDANCE_LINES = [
   "Treat React Doctor diagnostics as starting hypotheses. Read the relevant code before confirming or suppressing each finding.",
   "For each group, decide true positive, false positive, or needs-human-review, then assign high/medium/low confidence.",
+  "Do not suppress a finding without evidence from the file in question. Confidence requires code context.",
   "Understand the root cause before editing. Fix the underlying code instead of changing react-doctor config or suppressing rules unless explicitly asked.",
+  "Investigate deeply where relevant: race conditions, security-sensitive flows, state propagation, multi-file refactors, and downstream dependency chains.",
+  "Ignore pure style preferences, theoretical issues without real impact, missing features, and unrelated pre-existing code.",
   "Start with high-confidence fixes that preserve behavior. Leave low-confidence or product-dependent changes as notes.",
   "Run `npx react-doctor@latest --verbose --diff` before and after changes, plus relevant tests after each focused batch.",
   "When available, spawn subagents or isolated worktrees for independent rule families, then review and merge only the best safe fixes.",

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -28,7 +28,9 @@ import type {
   ReactDoctorConfig,
   ScoreResult,
 } from "@react-doctor/core";
+import { printAgentGuidance } from "./cli/utils/render-agent-guidance.js";
 import { printDiagnostics } from "./cli/utils/render-diagnostics.js";
+import { isNonInteractiveEnvironment } from "./cli/utils/is-non-interactive-environment.js";
 import { printProjectDetection } from "./cli/utils/render-project-detection.js";
 import {
   printBrandingOnlyHeader,
@@ -63,6 +65,7 @@ interface ResolvedInspectOptions {
   scoreOnly: boolean;
   noScore: boolean;
   isCi: boolean;
+  isNonInteractiveEnvironment: boolean;
   silent: boolean;
   includePaths: string[];
   customRulesOnly: boolean;
@@ -91,6 +94,7 @@ const mergeInspectOptions = (
   scoreOnly: inputOptions.scoreOnly ?? false,
   noScore: inputOptions.noScore ?? userConfig?.noScore ?? false,
   isCi: inputOptions.isCi ?? false,
+  isNonInteractiveEnvironment: isNonInteractiveEnvironment(),
   silent: inputOptions.silent ?? false,
   includePaths: inputOptions.includePaths ?? [],
   customRulesOnly: userConfig?.customRulesOnly ?? false,
@@ -502,6 +506,9 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
 
     yield* Console.log("");
     yield* printDiagnostics([...surfaceDiagnostics], options.verbose, directory);
+    if (options.isNonInteractiveEnvironment) {
+      yield* printAgentGuidance();
+    }
 
     if (demotedDiagnosticCount > 0) {
       yield* Console.log(

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -506,7 +506,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
 
     yield* Console.log("");
     yield* printDiagnostics([...surfaceDiagnostics], options.verbose, directory);
-    if (options.isNonInteractiveEnvironment) {
+    if (options.isNonInteractiveEnvironment && options.outputSurface !== "prComment") {
       yield* printAgentGuidance();
     }
 

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -269,9 +269,13 @@ export const Cart = () => {
     const normalizedStdout = stripAnsi(automatedRun.stdout);
 
     expect(normalizedStdout).toContain("Agent guidance");
-    expect(normalizedStdout).toContain("  - Treat React Doctor diagnostics as starting hypotheses.");
+    expect(normalizedStdout).toContain(
+      "  - Treat React Doctor diagnostics as starting hypotheses.",
+    );
     expect(normalizedStdout).toContain("Confidence requires code context.");
-    expect(normalizedStdout).toContain("Fix the underlying code instead of changing react-doctor config");
+    expect(normalizedStdout).toContain(
+      "Fix the underlying code instead of changing react-doctor config",
+    );
     expect(normalizedStdout).toContain("race conditions, security-sensitive flows");
     expect(normalizedStdout).toContain("theoretical issues without real impact");
     expect(normalizedStdout).toContain("npx react-doctor@latest --verbose --diff");

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -269,10 +269,14 @@ export const Cart = () => {
     const normalizedStdout = stripAnsi(automatedRun.stdout);
 
     expect(normalizedStdout).toContain("Agent guidance");
-    expect(normalizedStdout).toContain("  - Triage diagnostics before editing:");
+    expect(normalizedStdout).toContain("  - Treat React Doctor diagnostics as starting hypotheses.");
+    expect(normalizedStdout).toContain("Fix the underlying code instead of changing react-doctor config");
+    expect(normalizedStdout).toContain("npx react-doctor@latest --verbose --diff");
     expect(normalizedStdout).toContain(
-      "  - Split unrelated or behavior-changing work into separate PRs/branches.",
+      "  - Split unrelated, broad, or behavior-changing work into separate PRs/branches",
     );
+    expect(normalizedStdout).toContain("  - When available, spawn subagents or isolated worktrees");
+    expect(normalizedStdout).toContain("  - If a fix needs an API, UX, or architecture decision");
     expect(normalizedStdout.indexOf("Agent guidance")).toBeLessThan(
       normalizedStdout.indexOf("React Doctor"),
     );

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -24,11 +24,16 @@ import {
   encodeAnnotationProperty,
   encodeAnnotationMessage,
 } from "../../src/cli/utils/annotation-encoding.js";
+import { NON_INTERACTIVE_ENVIRONMENT_VARIABLES } from "../../src/cli/utils/is-non-interactive-environment.js";
 import { setupReactProject, writeFile, writeJson } from "./_helpers.js";
 
 const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..", "..");
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-cli-and-output-"));
 const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
+
+interface EnvironmentVariableValues {
+  [environmentVariableName: string]: string | undefined;
+}
 
 afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -40,6 +45,37 @@ const setupMinimalReactProject = (caseId: string): string =>
   });
 
 const stripAnsi = (text: string): string => text.replace(ANSI_ESCAPE_PATTERN, "");
+
+const withAutomatedEnvironmentVariables = async <Value>(
+  overrides: EnvironmentVariableValues,
+  callback: () => Promise<Value>,
+): Promise<Value> => {
+  const savedEnvironment: EnvironmentVariableValues = {};
+  for (const environmentVariableName of NON_INTERACTIVE_ENVIRONMENT_VARIABLES) {
+    savedEnvironment[environmentVariableName] = process.env[environmentVariableName];
+    delete process.env[environmentVariableName];
+  }
+  for (const [environmentVariableName, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[environmentVariableName];
+    } else {
+      process.env[environmentVariableName] = value;
+    }
+  }
+
+  try {
+    return await callback();
+  } finally {
+    for (const environmentVariableName of NON_INTERACTIVE_ENVIRONMENT_VARIABLES) {
+      const previousValue = savedEnvironment[environmentVariableName];
+      if (previousValue === undefined) {
+        delete process.env[environmentVariableName];
+      } else {
+        process.env[environmentVariableName] = previousValue;
+      }
+    }
+  }
+};
 
 // Capture every line `inspect()` writes to console while it runs. We use
 // real I/O (logger / spinner / console.log) rather than scrub source
@@ -187,11 +223,13 @@ export const Cart = () => {
       },
     });
 
-    const { stdout } = await captureScanOutput(projectDir, {
-      lint: true,
-      noScore: true,
-    });
-    const normalizedStdout = stripAnsi(stdout);
+    const localRun = await withAutomatedEnvironmentVariables({}, () =>
+      captureScanOutput(projectDir, {
+        lint: true,
+        noScore: true,
+      }),
+    );
+    const normalizedStdout = stripAnsi(localRun.stdout);
 
     expect(normalizedStdout).toMatch(/State & Effects \d+ issues/);
     expect(normalizedStdout).toContain("  ⚠ Direct state mutation ×2");
@@ -199,7 +237,45 @@ export const Cart = () => {
     expect(normalizedStdout.indexOf("Direct state mutation")).toBeLessThan(
       normalizedStdout.indexOf("React Doctor"),
     );
+    expect(normalizedStdout).not.toContain("Agent guidance");
     expect(normalizedStdout).not.toContain("  By category");
+  });
+
+  it("prints agent guidance in automated environments", async () => {
+    const projectDir = setupReactProject(tempRoot, "automated-output-agent-guidance", {
+      files: {
+        "src/Cart.tsx": `import { useState } from "react";
+
+export const Cart = () => {
+  const [items, setItems] = useState<string[]>([]);
+  void setItems;
+
+  const onAdd = (nextItem: string) => {
+    items.push(nextItem);
+  };
+
+  return <button onClick={() => onAdd("x")}>{items.length}</button>;
+};
+`,
+      },
+    });
+
+    const automatedRun = await withAutomatedEnvironmentVariables({ CURSOR_AGENT: "1" }, () =>
+      captureScanOutput(projectDir, {
+        lint: true,
+        noScore: true,
+      }),
+    );
+    const normalizedStdout = stripAnsi(automatedRun.stdout);
+
+    expect(normalizedStdout).toContain("Agent guidance");
+    expect(normalizedStdout).toContain("  - Triage diagnostics before editing:");
+    expect(normalizedStdout).toContain(
+      "  - Split unrelated or behavior-changing work into separate PRs/branches.",
+    );
+    expect(normalizedStdout.indexOf("Agent guidance")).toBeLessThan(
+      normalizedStdout.indexOf("React Doctor"),
+    );
   });
 });
 

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -270,7 +270,10 @@ export const Cart = () => {
 
     expect(normalizedStdout).toContain("Agent guidance");
     expect(normalizedStdout).toContain("  - Treat React Doctor diagnostics as starting hypotheses.");
+    expect(normalizedStdout).toContain("Confidence requires code context.");
     expect(normalizedStdout).toContain("Fix the underlying code instead of changing react-doctor config");
+    expect(normalizedStdout).toContain("race conditions, security-sensitive flows");
+    expect(normalizedStdout).toContain("theoretical issues without real impact");
     expect(normalizedStdout).toContain("npx react-doctor@latest --verbose --diff");
     expect(normalizedStdout).toContain(
       "  - Split unrelated, broad, or behavior-changing work into separate PRs/branches",

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -288,6 +288,36 @@ export const Cart = () => {
       normalizedStdout.indexOf("React Doctor"),
     );
   });
+
+  it("does not print agent guidance in PR comment output", async () => {
+    const projectDir = setupReactProject(tempRoot, "pr-comment-output-agent-guidance", {
+      files: {
+        "src/Cart.tsx": `import { useState } from "react";
+
+export const Cart = () => {
+  const [items, setItems] = useState<string[]>([]);
+  void setItems;
+
+  const onAdd = (nextItem: string) => {
+    items.push(nextItem);
+  };
+
+  return <button onClick={() => onAdd("x")}>{items.length}</button>;
+};
+`,
+      },
+    });
+
+    const automatedRun = await withAutomatedEnvironmentVariables({ GITHUB_ACTIONS: "true" }, () =>
+      captureScanOutput(projectDir, {
+        lint: true,
+        noScore: true,
+        outputSurface: "prComment",
+      }),
+    );
+
+    expect(stripAnsi(automatedRun.stdout)).not.toContain("Agent guidance");
+  });
 });
 
 describe("issue #135: lint failures surface in skippedChecks", () => {


### PR DESCRIPTION
## Summary
- Add a plain-text Agent guidance section for automated/non-interactive inspect runs.
- Gate the guidance on the existing non-interactive environment detection so local interactive output stays clean.
- Cover both local output suppression and agent-environment rendering in CLI output regressions.

## Test plan
- `nr test tests/regressions/cli-and-output.test.ts`
- `nr typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only additive messaging gated on existing non-interactive detection; no changes to scanning, scoring APIs, or security-sensitive paths.
> 
> **Overview**
> Adds a plain-text **Agent guidance** block after diagnostics when inspect runs in a **non-interactive** environment (same signals as existing CI/agent/hook detection via `isNonInteractiveEnvironment()`), and **omits** it for local interactive runs and when `outputSurface` is `prComment`.
> 
> New `printAgentGuidance()` lists workflow bullets (treat findings as hypotheses, verify before suppressing, prefer code fixes over config changes, run `--verbose --diff`, split risky work, etc.). `NON_INTERACTIVE_ENVIRONMENT_VARIABLES` is exported so regression tests can clear/set env vars reliably.
> 
> Minor formatting-only edits in core git error handling and a few tests; no behavior change there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84366504039b94a9f2c4a2f7b2ec1887ea23d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->