### PR TITLE
[MIL-1550] fix navigation and Expo image false positives

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
@@ -18,11 +18,22 @@ const HOOK_OBJECTS_WITH_METHODS = new Map<string, Set<string>>([
   ["useSearchParams", new Set(["get", "getAll", "has", "set"])],
 ]);
 
-const REACT_NAVIGATION_MODULES = ["@react-navigation/native", "@react-navigation/core"];
+// Some libraries expose method-bearing hook objects where destructuring is not
+// part of the supported API shape, even though the hook name and method access
+// look like a normal React Compiler candidate. Keep those carve-outs keyed by
+// hook name and import source so similarly named userland hooks still report.
+const HOOK_IMPORT_SOURCES_WITH_UNSAFE_METHOD_DESTRUCTURING = new Map<string, Set<string>>([
+  ["useNavigation", new Set(["@react-navigation/native", "@react-navigation/core"])],
+]);
 
-const isReactNavigationHook = (node: EsTreeNode, hookSource: string): boolean =>
-  hookSource === "useNavigation" &&
-  REACT_NAVIGATION_MODULES.some((moduleName) => isImportedFromModule(node, hookSource, moduleName));
+const isUnsafeMethodDestructureHookImport = (node: EsTreeNode, hookSource: string): boolean => {
+  const moduleSources = HOOK_IMPORT_SOURCES_WITH_UNSAFE_METHOD_DESTRUCTURING.get(hookSource);
+  if (!moduleSources) return false;
+  for (const moduleSource of moduleSources) {
+    if (isImportedFromModule(node, hookSource, moduleSource)) return true;
+  }
+  return false;
+};
 
 // HACK: O(1) lookup. Indexes top-level `const x = useFooBar(...)`
 // declarations once per component on enter, so subsequent
@@ -117,7 +128,7 @@ export const reactCompilerDestructureMethod = defineRule<Rule>({
 
         const allowedMethods = HOOK_OBJECTS_WITH_METHODS.get(hookSource);
         if (!allowedMethods || !allowedMethods.has(methodName)) return;
-        if (isReactNavigationHook(node, hookSource)) return;
+        if (isUnsafeMethodDestructureHookImport(node, hookSource)) return;
 
         if (!isNodeOfType(node.parent, "CallExpression") || node.parent.callee !== node) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
@@ -5,6 +5,7 @@ import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { isImportedFromModule } from "../../utils/find-import-source-for-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -16,6 +17,12 @@ const HOOK_OBJECTS_WITH_METHODS = new Map<string, Set<string>>([
   ],
   ["useSearchParams", new Set(["get", "getAll", "has", "set"])],
 ]);
+
+const REACT_NAVIGATION_MODULES = ["@react-navigation/native", "@react-navigation/core"];
+
+const isReactNavigationHook = (node: EsTreeNode, hookSource: string): boolean =>
+  hookSource === "useNavigation" &&
+  REACT_NAVIGATION_MODULES.some((moduleName) => isImportedFromModule(node, hookSource, moduleName));
 
 // HACK: O(1) lookup. Indexes top-level `const x = useFooBar(...)`
 // declarations once per component on enter, so subsequent
@@ -110,6 +117,7 @@ export const reactCompilerDestructureMethod = defineRule<Rule>({
 
         const allowedMethods = HOOK_OBJECTS_WITH_METHODS.get(hookSource);
         if (!allowedMethods || !allowedMethods.has(methodName)) return;
+        if (isReactNavigationHook(node, hookSource)) return;
 
         if (!isNodeOfType(node.parent, "CallExpression") || node.parent.callee !== node) return;
 

--- a/packages/react-doctor/tests/regressions/architecture-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/architecture-rules.test.ts
@@ -50,6 +50,29 @@ export const NativeRouteButton = () => {
     expect(hits[0].message).not.toContain("useNavigation");
   });
 
+  it("does not flag React Navigation core methods", async () => {
+    const projectDir = setupReactProject(tempRoot, "react-navigation-core-methods", {
+      files: {
+        "src/Screen.tsx": `import { useNavigation } from "@react-navigation/core";
+
+declare module "@react-navigation/core" {
+  export function useNavigation(): {
+    dispatch: (action: { type: string }) => void;
+  };
+}
+
+export const NativeRouteButton = () => {
+  const navigation = useNavigation();
+  return <button onClick={() => navigation.dispatch({ type: "GO_BACK" })}>Back</button>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "react-compiler-destructure-method");
+    expect(hits).toHaveLength(0);
+  });
+
   it("still flags non-React-Navigation useNavigation hooks", async () => {
     const projectDir = setupReactProject(tempRoot, "custom-use-navigation-methods", {
       files: {

--- a/packages/react-doctor/tests/regressions/architecture-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/architecture-rules.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import { collectRuleHits, setupReactProject } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-architecture-rules-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("react-compiler-destructure-method", () => {
+  it("does not flag React Navigation methods", async () => {
+    const projectDir = setupReactProject(tempRoot, "react-navigation-methods", {
+      files: {
+        "src/Screen.tsx": `import { useNavigation } from "@react-navigation/native";
+
+declare function useRouter(): {
+  push: (path: string) => void;
+};
+
+declare module "@react-navigation/native" {
+  export function useNavigation(): {
+    navigate: (screen: string, params?: { sessionId: string }) => void;
+  };
+}
+
+export const WebRouteButton = () => {
+  const router = useRouter();
+  return <button onClick={() => router.push("/home")}>Go home</button>;
+};
+
+export const NativeRouteButton = () => {
+  const navigation = useNavigation();
+  return (
+    <button onClick={() => navigation.navigate("Chat", { sessionId: "abc" })}>
+      Open chat
+    </button>
+  );
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "react-compiler-destructure-method");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("useRouter");
+    expect(hits[0].message).not.toContain("useNavigation");
+  });
+
+  it("still flags non-React-Navigation useNavigation hooks", async () => {
+    const projectDir = setupReactProject(tempRoot, "custom-use-navigation-methods", {
+      files: {
+        "src/Screen.tsx": `declare function useNavigation(): {
+  navigate: (screen: string, params?: { sessionId: string }) => void;
+};
+
+export const RouteButton = () => {
+  const navigation = useNavigation();
+  return (
+    <button onClick={() => navigation.navigate("Chat", { sessionId: "abc" })}>
+      Open chat
+    </button>
+  );
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "react-compiler-destructure-method");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("useNavigation");
+  });
+});


### PR DESCRIPTION
## Why

Fixes two rule false positives:

- `react-compiler-destructure-method` should not ask React Navigation users to destructure `useNavigation()` methods. React Navigation returns a navigation object whose methods are meant to stay on that object.
- `rn-prefer-expo-image` should not ask bare React Native projects to add `expo-image`. `expo-image` is an Expo SDK package, so the recommendation only fits Expo or already `expo-image`-aware packages.

Before:

```tsx
import { useNavigation } from "@react-navigation/native";

const Screen = () => {
  const navigation = useNavigation();
  navigation.navigate("Chat", { sessionId });
};
```

```tsx
import { Image } from "react-native";

export const Screen = () => <Image source={{ uri }} />;
```

After: React Navigation method calls and bare React Native `Image` imports are not reported. Expo packages still get the `expo-image` recommendation, and non-React-Navigation hook objects still get the destructuring recommendation.

## What changed

- Skips `react-compiler-destructure-method` only for `useNavigation` imported from `@react-navigation/native` or `@react-navigation/core`.
- Keeps reporting same-named `useNavigation` hooks from unrelated packages or local code.
- Gates `rn-prefer-expo-image` on the nearest package declaring Expo or `expo-image`, with a fallback to the project-level Expo framework hint when package data is unavailable.
- Adds regression coverage for React Navigation native/core imports, unrelated `useNavigation`, bare RN `Image`, Expo `Image`, and mixed Expo + bare-RN workspaces.

## Test plan

```sh
pnpm --filter oxlint-plugin-react-doctor build && pnpm --filter @react-doctor/core build && pnpm exec vp test run packages/react-doctor/tests/regressions/architecture-rules.test.ts packages/react-doctor/tests/regressions/rn-package-scoping.test.ts
pnpm --filter oxlint-plugin-react-doctor typecheck
pnpm --filter @react-doctor/api build && pnpm --filter react-doctor typecheck
```