### PR TITLE
[MIL-1549] Gate `expo-image` recommendation for bare React Native

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rnPreferExpoImage } from "./rn-prefer-expo-image.js";
+
+const code = `import { Image } from "react-native";
+`;
+
+describe("rn-prefer-expo-image", () => {
+  let temporaryDirectory = "";
+
+  beforeEach(() => {
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-rn-expo-image-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  const createPackageFilename = (dependencies: Record<string, string>): string => {
+    const packageDirectory = fs.mkdtempSync(path.join(temporaryDirectory, "package-"));
+    fs.writeFileSync(
+      path.join(packageDirectory, "package.json"),
+      JSON.stringify({ dependencies }),
+    );
+    return path.join(packageDirectory, "src", "App.tsx");
+  };
+
+  it("flags react-native Image imports in Expo projects", () => {
+    const result = runRule(rnPreferExpoImage, code, {
+      settings: { "react-doctor": { framework: "expo" } },
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag react-native Image imports in bare React Native projects", () => {
+    const result = runRule(rnPreferExpoImage, code, {
+      settings: { "react-doctor": { framework: "react-native" } },
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("uses the nearest package.json to keep bare React Native workspaces quiet", () => {
+    const result = runRule(rnPreferExpoImage, code, {
+      filename: createPackageFilename({ "react-native": "0.82.0" }),
+      settings: { "react-doctor": { framework: "expo" } },
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("uses the nearest package.json to allow Expo-managed workspaces", () => {
+    const result = runRule(rnPreferExpoImage, code, {
+      filename: createPackageFilename({ expo: "54.0.0", "react-native": "0.82.0" }),
+      settings: { "react-doctor": { framework: "react-native" } },
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.test.ts
@@ -28,8 +28,12 @@ describe("rn-prefer-expo-image", () => {
     return path.join(packageDirectory, "src", "App.tsx");
   };
 
+  const createStandaloneFilename = (): string =>
+    path.join(temporaryDirectory, "standalone", "App.tsx");
+
   it("flags react-native Image imports in Expo projects", () => {
     const result = runRule(rnPreferExpoImage, code, {
+      filename: createStandaloneFilename(),
       settings: { "react-doctor": { framework: "expo" } },
     });
 
@@ -39,6 +43,7 @@ describe("rn-prefer-expo-image", () => {
 
   it("does not flag react-native Image imports in bare React Native projects", () => {
     const result = runRule(rnPreferExpoImage, code, {
+      filename: createStandaloneFilename(),
       settings: { "react-doctor": { framework: "react-native" } },
     });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.test.ts
@@ -21,10 +21,7 @@ describe("rn-prefer-expo-image", () => {
 
   const createPackageFilename = (dependencies: Record<string, string>): string => {
     const packageDirectory = fs.mkdtempSync(path.join(temporaryDirectory, "package-"));
-    fs.writeFileSync(
-      path.join(packageDirectory, "package.json"),
-      JSON.stringify({ dependencies }),
-    );
+    fs.writeFileSync(path.join(packageDirectory, "package.json"), JSON.stringify({ dependencies }));
     return path.join(packageDirectory, "src", "App.tsx");
   };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
@@ -1,9 +1,13 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isExpoManagedFileActive } from "../../utils/is-expo-managed-file.js";
+
+const EMPTY_VISITORS: RuleVisitors = {};
 
 // HACK: react-native's built-in <Image> has no caching, no placeholders,
 // no progressive loading, and no priority hints. expo-image is a drop-in
@@ -17,18 +21,22 @@ export const rnPreferExpoImage = defineRule<Rule>({
   severity: "warn",
   recommendation:
     "Use `<Image>` from `expo-image` instead of `react-native` — same prop API, plus disk + memory caching, placeholders, and crossfades",
-  create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
-      if (node.source?.value !== "react-native") return;
-      for (const specifier of node.specifiers ?? []) {
-        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
-        if (getImportedName(specifier) !== "Image") continue;
-        context.report({
-          node: specifier,
-          message:
-            "Importing Image from react-native — prefer expo-image for caching, placeholders, and progressive loading (drop-in API)",
-        });
-      }
-    },
-  }),
+  create: (context: RuleContext) => {
+    if (!isExpoManagedFileActive(context)) return EMPTY_VISITORS;
+
+    return {
+      ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
+        if (node.source?.value !== "react-native") return;
+        for (const specifier of node.specifiers ?? []) {
+          if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+          if (getImportedName(specifier) !== "Image") continue;
+          context.report({
+            node: specifier,
+            message:
+              "Importing Image from react-native — prefer expo-image for caching, placeholders, and progressive loading (drop-in API)",
+          });
+        }
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/classify-package-platform.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/classify-package-platform.ts
@@ -1,14 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { isReactNativeDependencyName } from "../../react-native-dependency-names.js";
-
-const EXPO_MANAGED_DEPENDENCY_NAMES: ReadonlySet<string> = new Set([
-  "expo",
-  "expo-router",
-  "@expo/cli",
-  "@expo/metro-config",
-  "@expo/metro-runtime",
-]);
+import {
+  isExpoManagedDependencyName,
+  isReactNativeDependencyName,
+} from "../../react-native-dependency-names.js";
 
 // Packages that mark the manifest as a web-only React target. If a manifest
 // contains one of these AND has no React Native indicator, every React
@@ -130,7 +125,7 @@ const isReactNativeAware = (packageJson: PackageJsonDependencyView): boolean => 
 
 const isExpoManaged = (packageJson: PackageJsonDependencyView): boolean => {
   for (const dependencyName of iterateDependencyNames(packageJson)) {
-    if (EXPO_MANAGED_DEPENDENCY_NAMES.has(dependencyName)) return true;
+    if (isExpoManagedDependencyName(dependencyName)) return true;
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/classify-package-platform.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/classify-package-platform.ts
@@ -2,6 +2,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { isReactNativeDependencyName } from "../../react-native-dependency-names.js";
 
+const EXPO_MANAGED_DEPENDENCY_NAMES: ReadonlySet<string> = new Set([
+  "expo",
+  "expo-router",
+  "@expo/cli",
+  "@expo/metro-config",
+  "@expo/metro-runtime",
+]);
+
 // Packages that mark the manifest as a web-only React target. If a manifest
 // contains one of these AND has no React Native indicator, every React
 // Native rule must skip files inside that package. `react-dom` covers
@@ -120,6 +128,13 @@ const isReactNativeAware = (packageJson: PackageJsonDependencyView): boolean => 
   return false;
 };
 
+const isExpoManaged = (packageJson: PackageJsonDependencyView): boolean => {
+  for (const dependencyName of iterateDependencyNames(packageJson)) {
+    if (EXPO_MANAGED_DEPENDENCY_NAMES.has(dependencyName)) return true;
+  }
+  return false;
+};
+
 const isWebFrameworkOnly = (packageJson: PackageJsonDependencyView): boolean => {
   for (const dependencyName of iterateDependencyNames(packageJson)) {
     if (WEB_FRAMEWORK_DEPENDENCY_NAMES.has(dependencyName)) return true;
@@ -127,16 +142,19 @@ const isWebFrameworkOnly = (packageJson: PackageJsonDependencyView): boolean => 
   return false;
 };
 
-export type PackagePlatform = "react-native" | "web" | "unknown";
+export type PackagePlatform = "expo" | "react-native" | "web" | "unknown";
 
 // Classifies the package owning `filename`:
 //
+//   "expo"         — the nearest `package.json` declares an Expo-managed
+//                    app dependency such as `expo` or `expo-router`.
+//
 //   "react-native" — the nearest `package.json` declares a React Native
-//                    or Expo dependency. Mixed RN+web monorepo packages
-//                    (which deliberately ship both `react-native` and
-//                    `react-dom` for `react-native-web`) ALSO land here:
-//                    RN takes precedence so RN rules continue to fire on
-//                    files that target mobile.
+//                    dependency. Mixed RN+web monorepo packages (which
+//                    deliberately ship both `react-native` and `react-dom`
+//                    for `react-native-web`) ALSO land here: RN takes
+//                    precedence so RN rules continue to fire on files that
+//                    target mobile.
 //
 //   "web"          — the nearest `package.json` declares a web-only
 //                    framework (`next`, `vite`, `react-scripts`,
@@ -164,7 +182,9 @@ export const classifyPackagePlatform = (filename: string): PackagePlatform => {
   }
 
   let result: PackagePlatform;
-  if (isReactNativeAware(packageJson)) {
+  if (isExpoManaged(packageJson)) {
+    result = "expo";
+  } else if (isReactNativeAware(packageJson)) {
     result = "react-native";
   } else if (isWebFrameworkOnly(packageJson)) {
     result = "web";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-expo-managed-file.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-expo-managed-file.ts
@@ -1,0 +1,15 @@
+import { classifyPackagePlatform } from "./classify-package-platform.js";
+import { getReactDoctorStringSetting } from "./get-react-doctor-setting.js";
+import type { RuleContext } from "./rule-context.js";
+
+export const isExpoManagedFileActive = (context: RuleContext): boolean => {
+  const filename = context.getFilename?.();
+  if (filename) {
+    const packagePlatform = classifyPackagePlatform(filename);
+    if (packagePlatform === "expo") return true;
+    if (packagePlatform === "react-native" || packagePlatform === "web") return false;
+  }
+
+  const framework = getReactDoctorStringSetting(context.settings, "framework");
+  return framework === "expo";
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-native-file.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-native-file.ts
@@ -25,7 +25,7 @@ const NATIVE_FILE_EXTENSION_PATTERN = /\.(?:ios|android|native)\.[cm]?[jt]sx?$/;
 //      `.native.tsx`) → ACTIVE. These files always target RN.
 //   2. Filename ends with a web extension (`.web.tsx`) → INACTIVE.
 //   3. Nearest package.json classifies as "web" → INACTIVE.
-//   4. Nearest package.json classifies as "react-native" → ACTIVE.
+//   4. Nearest package.json classifies as "expo" or "react-native" → ACTIVE.
 //   5. Nearest package.json classifies as "unknown" → fall back to the
 //      project-level framework setting:
 //      • `react-native` or `expo` → ACTIVE
@@ -49,7 +49,7 @@ export const isReactNativeFileActive = (context: RuleContext): boolean => {
 
   const packagePlatform = classifyPackagePlatform(filename);
   if (packagePlatform === "web") return false;
-  if (packagePlatform === "react-native") return true;
+  if (packagePlatform === "expo" || packagePlatform === "react-native") return true;
 
   const framework = getReactDoctorStringSetting(context.settings, "framework");
   if (framework === "react-native" || framework === "expo") return true;

--- a/packages/oxlint-plugin-react-doctor/src/react-native-dependency-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/react-native-dependency-names.ts
@@ -8,15 +8,20 @@
 // layer that pairs with `react-dom` / Next / Vite hosts, not a mobile
 // target.
 
-// Closed set of canonical RN/Expo dependency names.
-export const REACT_NATIVE_DEPENDENCY_NAMES: ReadonlySet<string> = new Set([
-  "react-native",
-  "react-native-tvos",
+// Closed set of canonical Expo-managed dependency names.
+export const EXPO_MANAGED_DEPENDENCY_NAMES: ReadonlySet<string> = new Set([
   "expo",
   "expo-router",
   "@expo/cli",
   "@expo/metro-config",
   "@expo/metro-runtime",
+]);
+
+// Closed set of canonical RN/Expo dependency names.
+export const REACT_NATIVE_DEPENDENCY_NAMES: ReadonlySet<string> = new Set([
+  "react-native",
+  "react-native-tvos",
+  ...EXPO_MANAGED_DEPENDENCY_NAMES,
   "react-native-windows",
   "react-native-macos",
 ]);
@@ -30,6 +35,9 @@ export const REACT_NATIVE_DEPENDENCY_PREFIXES: ReadonlyArray<string> = [
   "@react-native/",
   "@react-native-",
 ];
+
+export const isExpoManagedDependencyName = (dependencyName: string): boolean =>
+  EXPO_MANAGED_DEPENDENCY_NAMES.has(dependencyName);
 
 // True when `dependencyName` is either a known RN/Expo package or sits
 // inside one of the `@react-native/` / `@react-native-` namespaces.


### PR DESCRIPTION
## Why?

`rn-prefer-expo-image` was firing in bare React Native projects whenever they imported `Image` from `react-native`. That recommendation points users at `expo-image`, which is appropriate for Expo-managed apps but can pull Expo infrastructure into projects that are intentionally bare React Native.

This PR narrows the rule so it only recommends `expo-image` when the current file belongs to an Expo-managed package or the discovered project framework is Expo.

## What changed?

- Added an Expo-specific package classification alongside the existing React Native and web classifications.
- Added an `isExpoManagedFileActive` utility so individual rules can require Expo without disabling generic React Native rules.
- Updated `rn-prefer-expo-image` to return no visitors outside Expo-managed files/projects.
- Preserved generic React Native rule activation for both Expo and bare React Native packages.
- Added regression tests for project-level and nearest-`package.json` behavior.

Before:

```js
import { Image } from "react-native";
```

Bare React Native projects received a warning recommending `expo-image`.

After:

```js
import { Image } from "react-native";
```

Bare React Native projects stay quiet, while Expo-managed projects still receive the `expo-image` recommendation.

## Test plan

Test users can run to verify correctness:

```bash
cd packages/oxlint-plugin-react-doctor
nr test src/plugin/rules/react-native/rn-prefer-expo-image.test.ts
nr typecheck
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped lint gating and package classification with tests; no runtime app behavior changes.
> 
> **Overview**
> **`rn-prefer-expo-image`** no longer warns on `Image` imports from `react-native` in bare React Native apps; it only runs when the file is in an **Expo-managed** package or the project framework is **expo**.
> 
> Package detection now distinguishes **`expo`** from **`react-native`** via nearest `package.json` (Expo deps like `expo` / `expo-router` classify as expo; RN-only manifests stay `react-native`). A new **`isExpoManagedFileActive`** helper gates Expo-only rules without turning off other RN linting—**`isReactNativeFileActive`** still treats both expo and react-native platforms as RN-active. Regression tests cover framework settings and monorepo packages where nearest `package.json` overrides the global framework hint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0dc97227c2ce2494b92bca31d77553ed0490b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->