### PR TITLE
[MIL-1554] Skip prefilled project question outside monorepos

### DIFF
--- a/packages/react-doctor/src/cli/utils/select-projects.ts
+++ b/packages/react-doctor/src/cli/utils/select-projects.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import type { WorkspacePackage } from "@react-doctor/core";
-import { discoverReactSubprojects, listWorkspacePackages } from "@react-doctor/core";
-import { highlighter } from "@react-doctor/core";
+import {
+  discoverReactSubprojects,
+  highlighter,
+  isMonorepoRoot,
+  listWorkspacePackages,
+} from "@react-doctor/core";
 import { cliLogger as logger } from "./cli-logger.js";
 import { prompts } from "./prompts.js";
 
@@ -12,6 +16,7 @@ export const selectProjects = async (
 ): Promise<string[]> => {
   let packages = listWorkspacePackages(rootDirectory);
   if (packages.length === 0) {
+    if (!isMonorepoRoot(rootDirectory)) return [rootDirectory];
     packages = discoverReactSubprojects(rootDirectory);
   }
 

--- a/packages/react-doctor/tests/select-projects.test.ts
+++ b/packages/react-doctor/tests/select-projects.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { selectProjects } from "../src/cli/utils/select-projects.js";
+import { cliLogger } from "../src/cli/utils/cli-logger.js";
 import { prompts } from "../src/cli/utils/prompts.js";
 import { setupReactProject, writeJson } from "./regressions/_helpers.js";
 
@@ -10,36 +11,45 @@ vi.mock("../src/cli/utils/prompts.js", () => ({
   prompts: vi.fn(),
 }));
 
-const tempDirectories: string[] = [];
-
-const createTempDirectory = (): string => {
-  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-select-projects-"));
-  tempDirectories.push(tempDirectory);
-  return tempDirectory;
-};
-
-afterEach(() => {
-  vi.clearAllMocks();
-  for (const tempDirectory of tempDirectories.splice(0)) {
-    fs.rmSync(tempDirectory, { recursive: true, force: true });
-  }
-});
+vi.mock("../src/cli/utils/cli-logger.js", () => ({
+  cliLogger: {
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    dim: vi.fn(),
+    success: vi.fn(),
+    break: vi.fn(),
+  },
+}));
 
 describe("selectProjects", () => {
+  const tempDirectories: string[] = [];
+
+  const createTempDirectory = (): string => {
+    const tempDirectory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "react-doctor-select-projects-"),
+    );
+    tempDirectories.push(tempDirectory);
+    return tempDirectory;
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    for (const tempDirectory of tempDirectories.splice(0)) {
+      fs.rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("skips project selection output for a non-monorepo React project", async () => {
     const tempDirectory = createTempDirectory();
     const projectDirectory = setupReactProject(tempDirectory, "app");
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    try {
-      const selectedDirectories = await selectProjects(projectDirectory, undefined, false);
+    const selectedDirectories = await selectProjects(projectDirectory, undefined, false);
 
-      expect(selectedDirectories).toEqual([projectDirectory]);
-      expect(prompts).not.toHaveBeenCalled();
-      expect(consoleSpy).not.toHaveBeenCalled();
-    } finally {
-      consoleSpy.mockRestore();
-    }
+    expect(selectedDirectories).toEqual([projectDirectory]);
+    expect(prompts).not.toHaveBeenCalled();
+    expect(cliLogger.log).not.toHaveBeenCalled();
   });
 
   it("keeps the selected project output for a monorepo with one React workspace", async () => {
@@ -49,16 +59,31 @@ describe("selectProjects", () => {
       workspaces: ["apps/*"],
     });
     const projectDirectory = setupReactProject(path.join(tempDirectory, "apps"), "web");
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    try {
-      const selectedDirectories = await selectProjects(tempDirectory, undefined, false);
+    const selectedDirectories = await selectProjects(tempDirectory, undefined, false);
 
-      expect(selectedDirectories).toEqual([projectDirectory]);
-      expect(prompts).not.toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Select projects to scan"));
-    } finally {
-      consoleSpy.mockRestore();
-    }
+    expect(selectedDirectories).toEqual([projectDirectory]);
+    expect(prompts).not.toHaveBeenCalled();
+    expect(cliLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining("Select projects to scan"),
+    );
+  });
+
+  it("falls through to subproject discovery for a monorepo with no workspace React packages", async () => {
+    const tempDirectory = createTempDirectory();
+    writeJson(path.join(tempDirectory, "package.json"), {
+      name: "monorepo",
+      workspaces: ["packages/*"],
+    });
+    fs.mkdirSync(path.join(tempDirectory, "packages"), { recursive: true });
+    const projectDirectory = setupReactProject(path.join(tempDirectory, "nested"), "app");
+
+    const selectedDirectories = await selectProjects(tempDirectory, undefined, false);
+
+    expect(selectedDirectories).toEqual([projectDirectory]);
+    expect(prompts).not.toHaveBeenCalled();
+    expect(cliLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining("Select projects to scan"),
+    );
   });
 });

--- a/packages/react-doctor/tests/select-projects.test.ts
+++ b/packages/react-doctor/tests/select-projects.test.ts
@@ -27,9 +27,7 @@ describe("selectProjects", () => {
   const tempDirectories: string[] = [];
 
   const createTempDirectory = (): string => {
-    const tempDirectory = fs.mkdtempSync(
-      path.join(os.tmpdir(), "react-doctor-select-projects-"),
-    );
+    const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-select-projects-"));
     tempDirectories.push(tempDirectory);
     return tempDirectory;
   };
@@ -64,9 +62,7 @@ describe("selectProjects", () => {
 
     expect(selectedDirectories).toEqual([projectDirectory]);
     expect(prompts).not.toHaveBeenCalled();
-    expect(cliLogger.log).toHaveBeenCalledWith(
-      expect.stringContaining("Select projects to scan"),
-    );
+    expect(cliLogger.log).toHaveBeenCalledWith(expect.stringContaining("Select projects to scan"));
   });
 
   it("falls through to subproject discovery for a monorepo with no workspace React packages", async () => {
@@ -82,8 +78,6 @@ describe("selectProjects", () => {
 
     expect(selectedDirectories).toEqual([projectDirectory]);
     expect(prompts).not.toHaveBeenCalled();
-    expect(cliLogger.log).toHaveBeenCalledWith(
-      expect.stringContaining("Select projects to scan"),
-    );
+    expect(cliLogger.log).toHaveBeenCalledWith(expect.stringContaining("Select projects to scan"));
   });
 });

--- a/packages/react-doctor/tests/select-projects.test.ts
+++ b/packages/react-doctor/tests/select-projects.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { selectProjects } from "../src/cli/utils/select-projects.js";
+import { prompts } from "../src/cli/utils/prompts.js";
+import { setupReactProject, writeJson } from "./regressions/_helpers.js";
+
+vi.mock("../src/cli/utils/prompts.js", () => ({
+  prompts: vi.fn(),
+}));
+
+const tempDirectories: string[] = [];
+
+const createTempDirectory = (): string => {
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-select-projects-"));
+  tempDirectories.push(tempDirectory);
+  return tempDirectory;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  for (const tempDirectory of tempDirectories.splice(0)) {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  }
+});
+
+describe("selectProjects", () => {
+  it("skips project selection output for a non-monorepo React project", async () => {
+    const tempDirectory = createTempDirectory();
+    const projectDirectory = setupReactProject(tempDirectory, "app");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const selectedDirectories = await selectProjects(projectDirectory, undefined, false);
+
+      expect(selectedDirectories).toEqual([projectDirectory]);
+      expect(prompts).not.toHaveBeenCalled();
+      expect(consoleSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("keeps the selected project output for a monorepo with one React workspace", async () => {
+    const tempDirectory = createTempDirectory();
+    writeJson(path.join(tempDirectory, "package.json"), {
+      name: "workspace",
+      workspaces: ["apps/*"],
+    });
+    const projectDirectory = setupReactProject(path.join(tempDirectory, "apps"), "web");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const selectedDirectories = await selectProjects(tempDirectory, undefined, false);
+
+      expect(selectedDirectories).toEqual([projectDirectory]);
+      expect(prompts).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Select projects to scan"));
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Why?

React Doctor's CLI was treating any single React project discovered under the scan root as a project selection result. For a normal non-monorepo app, that produced a prefilled "Select projects to scan" line even though there is nothing for the user to choose. This made the interactive flow look like it asked a project question outside monorepos, contradicting the intended behavior from MIL-1554. The fix keeps project selection as a monorepo-only concern and lets single-package apps proceed directly.

## What changed?

- Before: `selectProjects` fell back to `discoverReactSubprojects` whenever `listWorkspacePackages` returned no packages. For a non-monorepo React app, discovery returned the root app and printed a prefilled project selection line.
- After: `selectProjects` first checks `isMonorepoRoot` before falling back to subproject discovery. Non-monorepo roots now return `[rootDirectory]` silently.
- Added regression tests for both the non-monorepo single-app path and the one-workspace monorepo path, so the new skip behavior does not remove the monorepo selection output.

## Test plan

Test users can run to verify correctness:

- `cd packages/react-doctor && nr test tests/select-projects.test.ts`
- `cd packages/react-doctor && nr typecheck`
- `nr lint`
- `nr format:check`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX-only change in project selection with targeted regression tests; no auth, data, or scan logic changes.
> 
> **Overview**
> **Non-monorepo apps** no longer show a prefilled *Select projects to scan* line. When `listWorkspacePackages` is empty, `selectProjects` now returns the scan root immediately if `isMonorepoRoot` is false, instead of always calling `discoverReactSubprojects` (which treated a lone React app as a one-package “selection”).
> 
> **Monorepos** keep the previous behavior: empty workspace lists still fall through to subproject discovery, and a single discovered package still logs the selection line.
> 
> New tests cover the silent non-monorepo path, a one-workspace monorepo (log still shown), and monorepo + nested React app via discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f6d31cbd1a4566af14f0e1a0860d8c57951fcf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->