### PR TITLE
[MIL-1552] Animate the React Doctor score progress bar

### DIFF
--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -9,14 +9,22 @@ import {
 } from "@react-doctor/core";
 import type { ScoreResult } from "@react-doctor/core";
 import { colorizeByScore } from "./colorize-by-score.js";
+import { isSpinnerInteractive } from "./is-spinner-interactive.js";
+
+const SCORE_BAR_ANIMATION_FRAME_COUNT = 12;
+const SCORE_BAR_ANIMATION_FRAME_DELAY_MS = 20;
 
 interface ScoreBarSegments {
   filledSegment: string;
   emptySegment: string;
 }
 
-const buildScoreBarSegments = (score: number): ScoreBarSegments => {
-  const filledCount = Math.round((score / PERFECT_SCORE) * SCORE_BAR_WIDTH_CHARS);
+const easeOutCubic = (progress: number): number => 1 - (1 - progress) ** 3;
+
+const sleep = (milliseconds: number): Effect.Effect<void> =>
+  Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+
+const buildScoreBarSegments = (filledCount: number): ScoreBarSegments => {
   const emptyCount = SCORE_BAR_WIDTH_CHARS - filledCount;
 
   return {
@@ -25,9 +33,12 @@ const buildScoreBarSegments = (score: number): ScoreBarSegments => {
   };
 };
 
-const buildScoreBar = (score: number): string => {
-  const { filledSegment, emptySegment } = buildScoreBarSegments(score);
-  return colorizeByScore(filledSegment, score) + highlighter.dim(emptySegment);
+const getFilledCount = (score: number): number =>
+  Math.round((score / PERFECT_SCORE) * SCORE_BAR_WIDTH_CHARS);
+
+const buildScoreBar = (displayScore: number, colorScore = displayScore): string => {
+  const { filledSegment, emptySegment } = buildScoreBarSegments(getFilledCount(displayScore));
+  return colorizeByScore(filledSegment, colorScore) + highlighter.dim(emptySegment);
 };
 
 const getDoctorFace = (score: number): string[] => {
@@ -44,6 +55,33 @@ const buildFaceRenderedLines = (score: number): string[] => {
   return ["┌─────┐", `│ ${eyes} │`, `│ ${mouth} │`, "└─────┘"].map(colorize);
 };
 
+const buildScoreHeaderLine = (
+  faceLine: string,
+  rightColumnContent: string,
+): string => {
+  const separator = rightColumnContent.length > 0 ? "  " : "";
+  return `  ${faceLine}${separator}${rightColumnContent}`;
+};
+
+const writeScoreHeaderLine = (line: string): Effect.Effect<void> =>
+  Effect.sync(() => {
+    process.stdout.write(line);
+  });
+
+const printAnimatedScoreBarLine = (faceLine: string, score: number): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    for (let frame = 0; frame <= SCORE_BAR_ANIMATION_FRAME_COUNT; frame += 1) {
+      const progress = easeOutCubic(frame / SCORE_BAR_ANIMATION_FRAME_COUNT);
+      const animatedScore = Math.round(score * progress);
+      const scoreBarLine = buildScoreBar(animatedScore, score);
+      yield* writeScoreHeaderLine(`\r${buildScoreHeaderLine(faceLine, scoreBarLine)}`);
+      if (frame < SCORE_BAR_ANIMATION_FRAME_COUNT) {
+        yield* sleep(SCORE_BAR_ANIMATION_FRAME_DELAY_MS);
+      }
+    }
+    yield* writeScoreHeaderLine("\n");
+  });
+
 export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> =>
   Effect.gen(function* () {
     const renderedFaceLines = buildFaceRenderedLines(scoreResult.score);
@@ -57,8 +95,11 @@ export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> 
 
     for (let lineIndex = 0; lineIndex < renderedFaceLines.length; lineIndex += 1) {
       const rightColumnContent = rightColumnLines[lineIndex] ?? "";
-      const separator = rightColumnContent.length > 0 ? "  " : "";
-      yield* Console.log(`  ${renderedFaceLines[lineIndex]}${separator}${rightColumnContent}`);
+      if (lineIndex === 1 && isSpinnerInteractive(process.stdout)) {
+        yield* printAnimatedScoreBarLine(renderedFaceLines[lineIndex], scoreResult.score);
+        continue;
+      }
+      yield* Console.log(buildScoreHeaderLine(renderedFaceLines[lineIndex], rightColumnContent));
     }
 
     yield* Console.log("");

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -55,10 +55,7 @@ const buildFaceRenderedLines = (score: number): string[] => {
   return ["┌─────┐", `│ ${eyes} │`, `│ ${mouth} │`, "└─────┘"].map(colorize);
 };
 
-const buildScoreHeaderLine = (
-  faceLine: string,
-  rightColumnContent: string,
-): string => {
+const buildScoreHeaderLine = (faceLine: string, rightColumnContent: string): string => {
   const separator = rightColumnContent.length > 0 ? "  " : "";
   return `  ${faceLine}${separator}${rightColumnContent}`;
 };

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -10,6 +10,7 @@ import {
 import type { ScoreResult } from "@react-doctor/core";
 import { colorizeByScore } from "./colorize-by-score.js";
 import { isSpinnerInteractive } from "./is-spinner-interactive.js";
+import { isSpinnerSilent } from "./spinner.js";
 
 const SCORE_BAR_ANIMATION_FRAME_COUNT = 12;
 const SCORE_BAR_ANIMATION_FRAME_DELAY_MS = 20;
@@ -92,7 +93,7 @@ export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> 
 
     for (let lineIndex = 0; lineIndex < renderedFaceLines.length; lineIndex += 1) {
       const rightColumnContent = rightColumnLines[lineIndex] ?? "";
-      if (lineIndex === 1 && isSpinnerInteractive(process.stdout)) {
+      if (lineIndex === 1 && !isSpinnerSilent() && isSpinnerInteractive(process.stdout)) {
         yield* printAnimatedScoreBarLine(renderedFaceLines[lineIndex], scoreResult.score);
         continue;
       }

--- a/packages/react-doctor/tests/render-score-header.test.ts
+++ b/packages/react-doctor/tests/render-score-header.test.ts
@@ -1,0 +1,41 @@
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ScoreResult } from "@react-doctor/core";
+import { silenceConsoleForTest } from "./helpers/silence-console.js";
+
+vi.mock("../src/cli/utils/is-spinner-interactive.js", () => ({
+  isSpinnerInteractive: () => true,
+}));
+
+import { printScoreHeader } from "../src/cli/utils/render-score-header.js";
+import { setSpinnerSilent } from "../src/cli/utils/spinner.js";
+
+const scoreResult: ScoreResult = {
+  score: 88,
+  label: "Great",
+};
+
+describe("printScoreHeader", () => {
+  let restoreConsole: () => void;
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restoreConsole = silenceConsoleForTest();
+    setSpinnerSilent(false);
+    stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore();
+    setSpinnerSilent(false);
+    restoreConsole();
+  });
+
+  it("does not write raw animation frames while spinner output is silent", async () => {
+    setSpinnerSilent(true);
+
+    await Effect.runPromise(printScoreHeader(scoreResult));
+
+    expect(stdoutWriteSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Animate the CLI score bar toward the final score in interactive terminals.
- Preserve static output for CI, redirected output, and other non-interactive environments.

## Test plan
- pnpm --filter react-doctor typecheck
- pnpm test tests/regressions/cli-and-output.test.ts (from packages/react-doctor)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation-only change with guards for non-interactive and silent output; no auth, data, or core scan logic affected.
> 
> **Overview**
> The CLI **score header** now **fills the progress bar with a short ease-out animation** on the face row in **interactive** terminals, using carriage-return redraws on `stdout` instead of a single static bar line.
> 
> **Non-interactive and quiet runs stay static:** animation runs only when the spinner is not silent and `isSpinnerInteractive(process.stdout)` is true, matching CI, redirects, and silent spinner output. Bar rendering was refactored so fill length can animate while **colors still reflect the final score**.
> 
> A focused test asserts that **silent spinner mode never writes raw animation frames** to `stdout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba661b42805b7d0f94ed3fd26aca7801bcbcdf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->