### PR TITLE
[MIL-1555] False positive for `tanstack-start-missing-head-content`

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vite-plus/test";
+import { attachParentReferences } from "../../../test-utils/attach-parent-references.js";
+import { parseFixture } from "../../../test-utils/parse-fixture.js";
+import { analyzeControlFlow } from "../../semantic/control-flow-graph.js";
+import { analyzeScopes } from "../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
+import type { ReportDescriptor } from "../../utils/report-descriptor.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
+import { tanstackStartMissingHeadContent } from "./tanstack-start-missing-head-content.js";
+
+const ROOT_ROUTE_FILENAME = "src/routes/__root.tsx";
+
+interface RuleDiagnostic {
+  message: string;
+  nodeType: string;
+}
+
+interface RunMissingHeadContentRuleResult {
+  diagnostics: RuleDiagnostic[];
+  parseErrors: ReadonlyArray<{ message: string }>;
+}
+
+const dispatchTreeWalkWithProgramExit = (root: EsTreeNode, visitors: RuleVisitors): void => {
+  const visit = (node: EsTreeNode): void => {
+    const handler = visitors[node.type];
+    if (typeof handler === "function") handler(node);
+
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const key of Object.keys(nodeRecord)) {
+      if (key === "parent") continue;
+      const child = nodeRecord[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (isAstNode(item)) visit(item);
+        }
+      } else if (isAstNode(child)) {
+        visit(child);
+      }
+    }
+  };
+
+  visit(root);
+  const programExitHandler = visitors["Program:exit"];
+  if (typeof programExitHandler === "function") programExitHandler(root);
+};
+
+const runMissingHeadContentRule = (
+  code: string,
+  filename = ROOT_ROUTE_FILENAME,
+): RunMissingHeadContentRuleResult => {
+  const parsed = parseFixture(code, { filename });
+  attachParentReferences(parsed.program);
+
+  const diagnostics: RuleDiagnostic[] = [];
+  const context: RuleContext = {
+    report: (descriptor: ReportDescriptor) => {
+      diagnostics.push({
+        message: descriptor.message,
+        nodeType: descriptor.node.type,
+      });
+    },
+    getFilename: () => filename,
+    scopes: analyzeScopes(parsed.program),
+    cfg: analyzeControlFlow(parsed.program),
+  };
+
+  const visitors = tanstackStartMissingHeadContent.create(context);
+  dispatchTreeWalkWithProgramExit(parsed.program, visitors);
+
+  return {
+    diagnostics,
+    parseErrors: parsed.errors,
+  };
+};
+
+const runRootRoute = (code: string) => runMissingHeadContentRule(code, ROOT_ROUTE_FILENAME);
+
+describe("tanstack-start/missing-head-content", () => {
+  it("flags root route document heads without HeadContent", () => {
+    const result = runRootRoute(`
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head />
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows direct HeadContent usage", () => {
+    const result = runRootRoute(`
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <HeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows aliased HeadContent imports from TanStack Router", () => {
+    const result = runRootRoute(`
+      import { HeadContent as RouterHeadContent } from "@tanstack/react-router";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <RouterHeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows namespace HeadContent imports from TanStack Router", () => {
+    const result = runRootRoute(`
+      import * as TanStackRouter from "@tanstack/react-router";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <TanStackRouter.HeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag root routes that delegate the document shell", () => {
+    const result = runRootRoute(`
+      import { RootDocument } from "../components/root-document";
+
+      export const Route = createRootRoute({
+        shellComponent: RootDocument,
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag non-root route files", () => {
+    const result = runMissingHeadContentRule(
+      `
+        export const Route = createFileRoute("/about")({
+          component: () => (
+            <html>
+              <head />
+              <body />
+            </html>
+          ),
+        });
+      `,
+      "src/routes/about.tsx",
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.test.ts
@@ -1,79 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
-import { attachParentReferences } from "../../../test-utils/attach-parent-references.js";
-import { parseFixture } from "../../../test-utils/parse-fixture.js";
-import { analyzeControlFlow } from "../../semantic/control-flow-graph.js";
-import { analyzeScopes } from "../../semantic/scope-analysis.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
-import { isAstNode } from "../../utils/is-ast-node.js";
-import type { ReportDescriptor } from "../../utils/report-descriptor.js";
-import type { RuleContext } from "../../utils/rule-context.js";
-import type { RuleVisitors } from "../../utils/rule-visitors.js";
+import { runRule } from "../../../test-utils/run-rule.js";
 import { tanstackStartMissingHeadContent } from "./tanstack-start-missing-head-content.js";
 
 const ROOT_ROUTE_FILENAME = "src/routes/__root.tsx";
 
-interface RuleDiagnostic {
-  message: string;
-  nodeType: string;
-}
-
-interface RunMissingHeadContentRuleResult {
-  diagnostics: RuleDiagnostic[];
-  parseErrors: ReadonlyArray<{ message: string }>;
-}
-
-const dispatchTreeWalkWithProgramExit = (root: EsTreeNode, visitors: RuleVisitors): void => {
-  const visit = (node: EsTreeNode): void => {
-    const handler = visitors[node.type];
-    if (typeof handler === "function") handler(node);
-
-    const nodeRecord = node as unknown as Record<string, unknown>;
-    for (const key of Object.keys(nodeRecord)) {
-      if (key === "parent") continue;
-      const child = nodeRecord[key];
-      if (Array.isArray(child)) {
-        for (const item of child) {
-          if (isAstNode(item)) visit(item);
-        }
-      } else if (isAstNode(child)) {
-        visit(child);
-      }
-    }
-  };
-
-  visit(root);
-  const programExitHandler = visitors["Program:exit"];
-  if (typeof programExitHandler === "function") programExitHandler(root);
-};
-
-const runMissingHeadContentRule = (
-  code: string,
-  filename = ROOT_ROUTE_FILENAME,
-): RunMissingHeadContentRuleResult => {
-  const parsed = parseFixture(code, { filename });
-  attachParentReferences(parsed.program);
-
-  const diagnostics: RuleDiagnostic[] = [];
-  const context: RuleContext = {
-    report: (descriptor: ReportDescriptor) => {
-      diagnostics.push({
-        message: descriptor.message,
-        nodeType: descriptor.node.type,
-      });
-    },
-    getFilename: () => filename,
-    scopes: analyzeScopes(parsed.program),
-    cfg: analyzeControlFlow(parsed.program),
-  };
-
-  const visitors = tanstackStartMissingHeadContent.create(context);
-  dispatchTreeWalkWithProgramExit(parsed.program, visitors);
-
-  return {
-    diagnostics,
-    parseErrors: parsed.errors,
-  };
-};
+const runMissingHeadContentRule = (code: string, filename = ROOT_ROUTE_FILENAME) =>
+  runRule(tanstackStartMissingHeadContent, code, { filename });
 
 const runRootRoute = (code: string) => runMissingHeadContentRule(code, ROOT_ROUTE_FILENAME);
 
@@ -94,6 +26,25 @@ describe("tanstack-start/missing-head-content", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags root route document heads that only contain intrinsic elements", () => {
+    const result = runRootRoute(`
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <title>Example</title>
+              <meta name="description" content="Example" />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("allows direct HeadContent usage", () => {
     const result = runRootRoute(`
       export const Route = createRootRoute({
@@ -101,6 +52,26 @@ describe("tanstack-start/missing-head-content", () => {
           <html>
             <head>
               <HeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows local HeadContent wrapper components", () => {
+    const result = runRootRoute(`
+      const AppHead = () => <HeadContent />;
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <AppHead />
             </head>
             <body />
           </html>
@@ -132,6 +103,66 @@ describe("tanstack-start/missing-head-content", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("allows aliased HeadContent imports declared after the route", () => {
+    const result = runRootRoute(`
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <RouterHeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+
+      import { HeadContent as RouterHeadContent } from "@tanstack/react-router";
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows aliased HeadContent imports from project barrels", () => {
+    const result = runRootRoute(`
+      import { HeadContent as RouterHeadContent } from "@/router-components";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <RouterHeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows project barrel HeadContent imports declared after the route", () => {
+    const result = runRootRoute(`
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <RouterHeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+
+      import { HeadContent as RouterHeadContent } from "@/router-components";
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("allows namespace HeadContent imports from TanStack Router", () => {
     const result = runRootRoute(`
       import * as TanStackRouter from "@tanstack/react-router";
@@ -152,9 +183,153 @@ describe("tanstack-start/missing-head-content", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("allows namespace HeadContent imports declared after the route", () => {
+    const result = runRootRoute(`
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <TanStackRouter.HeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+
+      import * as TanStackRouter from "@tanstack/react-router";
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows component aliases assigned from HeadContent", () => {
+    const result = runRootRoute(`
+      const AppHead = HeadContent;
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <AppHead />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows top-level component aliases declared after the route", () => {
+    const result = runRootRoute(`
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <AppHead />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+
+      const AppHead = HeadContent;
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows component aliases assigned from TanStack Router namespace HeadContent", () => {
+    const result = runRootRoute(`
+      import * as TanStackRouter from "@tanstack/react-router";
+
+      const AppHead = TanStackRouter.HeadContent;
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <AppHead />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows namespace aliases assigned from TanStack Router namespace imports", () => {
+    const result = runRootRoute(`
+      import * as TanStackRouter from "@tanstack/react-router";
+
+      const Router = TanStackRouter;
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <Router.HeadContent />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows custom head components from wrapper libraries", () => {
+    const result = runRootRoute(`
+      import { DocumentHead } from "@acme/tanstack-layout";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head>
+              <DocumentHead />
+            </head>
+            <body />
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not flag root routes that delegate the document shell", () => {
     const result = runRootRoute(`
       import { RootDocument } from "../components/root-document";
+
+      export const Route = createRootRoute({
+        shellComponent: RootDocument,
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag same-file document shells used through shellComponent", () => {
+    const result = runRootRoute(`
+      const RootDocument = ({ children }) => (
+        <html>
+          <head>
+            <HeadContent />
+          </head>
+          <body>{children}</body>
+        </html>
+      );
 
       export const Route = createRootRoute({
         shellComponent: RootDocument,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
@@ -21,6 +21,49 @@ const getJsxMemberPropertyName = (node: EsTreeNodeOfType<"JSXMemberExpression">)
   return null;
 };
 
+const getMemberRootName = (node: EsTreeNodeOfType<"MemberExpression">): string | null => {
+  if (isNodeOfType(node.object, "Identifier")) return node.object.name;
+  if (isNodeOfType(node.object, "MemberExpression")) return getMemberRootName(node.object);
+  return null;
+};
+
+const getMemberPropertyName = (node: EsTreeNodeOfType<"MemberExpression">): string | null => {
+  if (isNodeOfType(node.property, "Identifier")) return node.property.name;
+  return null;
+};
+
+const isDocumentHeadElement = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "JSXElement") &&
+  isNodeOfType(node.openingElement.name, "JSXIdentifier") &&
+  node.openingElement.name.name === DOCUMENT_HEAD_ELEMENT_NAME;
+
+const isInsideDocumentHeadElement = (node: EsTreeNode): boolean => {
+  let currentNode = node.parent;
+  while (currentNode) {
+    if (isDocumentHeadElement(currentNode)) return true;
+    currentNode = currentNode.parent;
+  }
+  return false;
+};
+
+const isCustomJsxElementName = (node: EsTreeNodeOfType<"JSXOpeningElement">["name"]): boolean => {
+  if (isNodeOfType(node, "JSXIdentifier")) {
+    const firstCharacter = node.name.charAt(0);
+    return (
+      firstCharacter.toUpperCase() === firstCharacter &&
+      firstCharacter.toLowerCase() !== firstCharacter
+    );
+  }
+  if (!isNodeOfType(node, "JSXMemberExpression")) return false;
+  const rootName = getJsxMemberRootName(node);
+  if (!rootName) return false;
+  const firstCharacter = rootName.charAt(0);
+  return (
+    firstCharacter.toUpperCase() === firstCharacter &&
+    firstCharacter.toLowerCase() !== firstCharacter
+  );
+};
+
 export const tanstackStartMissingHeadContent = defineRule<Rule>({
   id: "tanstack-start-missing-head-content",
   tags: ["test-noise"],
@@ -31,31 +74,90 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
   create: (context: RuleContext) => {
     let hasHeadContentElement = false;
     let hasDocumentHeadElement = false;
+    let hasCustomHeadChildElement = false;
     const headContentComponentNames = new Set([HEAD_CONTENT_COMPONENT_NAME]);
     const tanstackRouterNamespaceNames = new Set<string>();
 
+    const collectImportBindings = (node: EsTreeNode): void => {
+      if (!isNodeOfType(node, "ImportDeclaration")) return;
+
+      const isTanstackRouterImport = node.source.value === TANSTACK_ROUTER_PACKAGE;
+
+      const specifiers = node.specifiers ?? [];
+      for (const specifier of specifiers) {
+        if (isTanstackRouterImport && isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
+          tanstackRouterNamespaceNames.add(specifier.local.name);
+          continue;
+        }
+
+        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+        if (
+          !isNodeOfType(specifier.imported, "Identifier") ||
+          specifier.imported.name !== HEAD_CONTENT_COMPONENT_NAME
+        )
+          continue;
+        headContentComponentNames.add(specifier.local.name);
+      }
+    };
+
+    const collectVariableAlias = (node: EsTreeNode): void => {
+      if (!isNodeOfType(node, "VariableDeclarator")) return;
+      if (!isNodeOfType(node.id, "Identifier")) return;
+
+      const initializer = node.init;
+      if (!initializer) return;
+
+      if (isNodeOfType(initializer, "Identifier")) {
+        if (headContentComponentNames.has(initializer.name)) {
+          headContentComponentNames.add(node.id.name);
+        }
+        if (tanstackRouterNamespaceNames.has(initializer.name)) {
+          tanstackRouterNamespaceNames.add(node.id.name);
+        }
+        return;
+      }
+
+      if (!isNodeOfType(initializer, "MemberExpression")) return;
+
+      const rootName = getMemberRootName(initializer);
+      const propertyName = getMemberPropertyName(initializer);
+      if (
+        rootName &&
+        tanstackRouterNamespaceNames.has(rootName) &&
+        propertyName === HEAD_CONTENT_COMPONENT_NAME
+      ) {
+        headContentComponentNames.add(node.id.name);
+      }
+    };
+
     return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        const filename = context.getFilename?.() ?? "";
+        const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
+        if (!isRootRouteFile) return;
+
+        const statements = node.body ?? [];
+        for (const statement of statements) {
+          collectImportBindings(statement);
+        }
+        for (const statement of statements) {
+          if (!isNodeOfType(statement, "VariableDeclaration")) continue;
+          for (const declaration of statement.declarations ?? []) {
+            collectVariableAlias(declaration);
+          }
+        }
+      },
       ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
         const filename = context.getFilename?.() ?? "";
         const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
         if (!isRootRouteFile) return;
-        if (node.source.value !== TANSTACK_ROUTER_PACKAGE) return;
-
-        const specifiers = node.specifiers ?? [];
-        for (const specifier of specifiers) {
-          if (isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
-            tanstackRouterNamespaceNames.add(specifier.local.name);
-            continue;
-          }
-
-          if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
-          if (
-            !isNodeOfType(specifier.imported, "Identifier") ||
-            specifier.imported.name !== HEAD_CONTENT_COMPONENT_NAME
-          )
-            continue;
-          headContentComponentNames.add(specifier.local.name);
-        }
+        collectImportBindings(node);
+      },
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+        const filename = context.getFilename?.() ?? "";
+        const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
+        if (!isRootRouteFile) return;
+        collectVariableAlias(node);
       },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         const filename = context.getFilename?.() ?? "";
@@ -68,6 +170,9 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
           }
           if (headContentComponentNames.has(node.name.name)) {
             hasHeadContentElement = true;
+          }
+          if (isInsideDocumentHeadElement(node) && isCustomJsxElementName(node.name)) {
+            hasCustomHeadChildElement = true;
           }
           return;
         }
@@ -83,13 +188,16 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
         ) {
           hasHeadContentElement = true;
         }
+        if (isInsideDocumentHeadElement(node) && isCustomJsxElementName(node.name)) {
+          hasCustomHeadChildElement = true;
+        }
       },
       "Program:exit"(programNode: EsTreeNode) {
         const filename = context.getFilename?.() ?? "";
         const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
         if (!isRootRouteFile) return;
 
-        if (hasDocumentHeadElement && !hasHeadContentElement) {
+        if (hasDocumentHeadElement && !hasHeadContentElement && !hasCustomHeadChildElement) {
           context.report({
             node: programNode,
             message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
@@ -85,11 +85,15 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
 
       const specifiers = node.specifiers ?? [];
       for (const specifier of specifiers) {
+        // Namespace imports are only trusted from TanStack Router because
+        // `<Namespace.HeadContent />` otherwise has no portable meaning.
         if (isTanstackRouterImport && isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
           tanstackRouterNamespaceNames.add(specifier.local.name);
           continue;
         }
 
+        // Named `HeadContent` imports are trusted from any source to avoid
+        // false positives for project barrels that re-export TanStack's component.
         if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
         if (
           !isNodeOfType(specifier.imported, "Identifier") ||
@@ -108,6 +112,8 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
       if (!initializer) return;
 
       if (isNodeOfType(initializer, "Identifier")) {
+        // Propagate simple aliases like `const AppHead = HeadContent` and
+        // namespace aliases like `const Router = TanStackRouter`.
         if (headContentComponentNames.has(initializer.name)) {
           headContentComponentNames.add(node.id.name);
         }
@@ -126,6 +132,7 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
         tanstackRouterNamespaceNames.has(rootName) &&
         propertyName === HEAD_CONTENT_COMPONENT_NAME
       ) {
+        // Captures `const AppHead = TanStackRouter.HeadContent`.
         headContentComponentNames.add(node.id.name);
       }
     };
@@ -137,9 +144,13 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
         if (!isRootRouteFile) return;
 
         const statements = node.body ?? [];
+        // Pre-scan top-level imports before JSX visits so late import
+        // declarations do not make alias detection source-order dependent.
         for (const statement of statements) {
           collectImportBindings(statement);
         }
+        // Then collect top-level aliases once the import namespace/name sets
+        // are populated.
         for (const statement of statements) {
           if (!isNodeOfType(statement, "VariableDeclaration")) continue;
           for (const declaration of statement.declarations ?? []) {
@@ -171,6 +182,8 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
           if (headContentComponentNames.has(node.name.name)) {
             hasHeadContentElement = true;
           }
+          // Any custom component under `<head>` may wrap HeadContent from
+          // another module. Treat it as a safe signal rather than guessing.
           if (isInsideDocumentHeadElement(node) && isCustomJsxElementName(node.name)) {
             hasCustomHeadChildElement = true;
           }
@@ -188,6 +201,7 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
         ) {
           hasHeadContentElement = true;
         }
+        // Same conservative treatment for `<Namespace.DocumentHead />`.
         if (isInsideDocumentHeadElement(node) && isCustomJsxElementName(node.name)) {
           hasCustomHeadChildElement = true;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
@@ -6,6 +6,21 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+const TANSTACK_ROUTER_PACKAGE = "@tanstack/react-router";
+const HEAD_CONTENT_COMPONENT_NAME = "HeadContent";
+const DOCUMENT_HEAD_ELEMENT_NAME = "head";
+
+const getJsxMemberRootName = (node: EsTreeNodeOfType<"JSXMemberExpression">): string | null => {
+  if (isNodeOfType(node.object, "JSXIdentifier")) return node.object.name;
+  if (isNodeOfType(node.object, "JSXMemberExpression")) return getJsxMemberRootName(node.object);
+  return null;
+};
+
+const getJsxMemberPropertyName = (node: EsTreeNodeOfType<"JSXMemberExpression">): string | null => {
+  if (isNodeOfType(node.property, "JSXIdentifier")) return node.property.name;
+  return null;
+};
+
 export const tanstackStartMissingHeadContent = defineRule<Rule>({
   id: "tanstack-start-missing-head-content",
   tags: ["test-noise"],
@@ -15,14 +30,57 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
     "Add `<HeadContent />` inside `<head>` in your __root route — without it, route `head()` meta tags are silently dropped",
   create: (context: RuleContext) => {
     let hasHeadContentElement = false;
+    let hasDocumentHeadElement = false;
+    const headContentComponentNames = new Set([HEAD_CONTENT_COMPONENT_NAME]);
+    const tanstackRouterNamespaceNames = new Set<string>();
 
     return {
+      ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
+        const filename = context.getFilename?.() ?? "";
+        const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
+        if (!isRootRouteFile) return;
+        if (node.source.value !== TANSTACK_ROUTER_PACKAGE) return;
+
+        const specifiers = node.specifiers ?? [];
+        for (const specifier of specifiers) {
+          if (isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
+            tanstackRouterNamespaceNames.add(specifier.local.name);
+            continue;
+          }
+
+          if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+          if (
+            !isNodeOfType(specifier.imported, "Identifier") ||
+            specifier.imported.name !== HEAD_CONTENT_COMPONENT_NAME
+          )
+            continue;
+          headContentComponentNames.add(specifier.local.name);
+        }
+      },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         const filename = context.getFilename?.() ?? "";
         const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
         if (!isRootRouteFile) return;
 
-        if (isNodeOfType(node.name, "JSXIdentifier") && node.name.name === "HeadContent") {
+        if (isNodeOfType(node.name, "JSXIdentifier")) {
+          if (node.name.name === DOCUMENT_HEAD_ELEMENT_NAME) {
+            hasDocumentHeadElement = true;
+          }
+          if (headContentComponentNames.has(node.name.name)) {
+            hasHeadContentElement = true;
+          }
+          return;
+        }
+
+        if (!isNodeOfType(node.name, "JSXMemberExpression")) return;
+
+        const rootName = getJsxMemberRootName(node.name);
+        const propertyName = getJsxMemberPropertyName(node.name);
+        if (
+          rootName &&
+          tanstackRouterNamespaceNames.has(rootName) &&
+          propertyName === HEAD_CONTENT_COMPONENT_NAME
+        ) {
           hasHeadContentElement = true;
         }
       },
@@ -31,7 +89,7 @@ export const tanstackStartMissingHeadContent = defineRule<Rule>({
         const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
         if (!isRootRouteFile) return;
 
-        if (!hasHeadContentElement) {
+        if (hasDocumentHeadElement && !hasHeadContentElement) {
           context.report({
             node: programNode,
             message:

--- a/packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts
@@ -46,13 +46,15 @@ const dispatchTreeWalk = (root: EsTreeNode, visitors: RuleVisitors): void => {
     }
   };
   visit(root);
+  const programExitHandler = visitors["Program:exit"];
+  if (typeof programExitHandler === "function") programExitHandler(root);
 };
 
 // Pure-TS rule runner mirroring what oxlint does at runtime: parse code,
 // attach `parent` references, build a fake `RuleContext`, dispatch each
-// `node.type` to the matching visitor, and collect every `report({...})`
-// call as a `RuleDiagnostic`. Used by every `<rule>.test.ts` to assert
-// pass/fail semantics ported from OXC's `Tester::new(...).pass / .fail`.
+// `node.type` / `Program:exit` to the matching visitor, and collect every
+// `report({...})` call as a `RuleDiagnostic`. Used by every `<rule>.test.ts`
+// to assert pass/fail semantics ported from OXC's `Tester::new(...).pass / .fail`.
 export const runRule = (rule: Rule, code: string, options: RunRuleOptions = {}): RunRuleResult => {
   const parsed = parseFixture(code, {
     filename: options.filename,


### PR DESCRIPTION
## Why?

TanStack Start apps can define their root document shell in ways that do not place a literal `<HeadContent />` element directly in the same simple shape the rule previously expected. The old `tanstack-start-missing-head-content` check reported every `__root` route file that did not contain a bare `HeadContent` JSX identifier, which created false positives for valid root routes that delegate the document shell elsewhere or render `HeadContent` through an alias or TanStack Router namespace import.

The rule should still catch the real bug: a root document that renders a `<head>` element but omits TanStack Router's `HeadContent`, causing route `head()` metadata to be dropped. This change narrows the diagnostic to that concrete document-head case and recognizes common valid import/render forms.

## What changed?

- Updated `tanstack-start-missing-head-content` to report only when a TanStack Start `__root` file renders a document `<head>` without `HeadContent`.
- Added import tracking for `HeadContent` aliases from `@tanstack/react-router`, so `<RouterHeadContent />` is treated as valid.
- Added namespace import tracking for `@tanstack/react-router`, so `<TanStackRouter.HeadContent />` is treated as valid.
- Added regression coverage for failing and passing cases.

Before:

```tsx
export const Route = createRootRoute({
  shellComponent: RootDocument,
})
```

This could be flagged even though the root route delegates document rendering.

After:

```tsx
export const Route = createRootRoute({
  shellComponent: RootDocument,
})
```

This is allowed because the file does not render a document `<head>` missing `HeadContent`.

Before:

```tsx
import { HeadContent as RouterHeadContent } from "@tanstack/react-router"

<head>
  <RouterHeadContent />
</head>
```

This could be flagged because only the literal `HeadContent` JSX name was recognized.

After:

```tsx
import { HeadContent as RouterHeadContent } from "@tanstack/react-router"

<head>
  <RouterHeadContent />
</head>
```

This is allowed because the alias resolves to TanStack Router's `HeadContent`.

## Test plan

Users can verify correctness by running:

```bash
pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.test.ts
pnpm --filter oxlint-plugin-react-doctor typecheck
pnpm --filter react-doctor test tests/run-oxlint/tanstack-start.test.ts
pnpm format:check
```

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule heuristic and test-harness changes only; no runtime app or security impact, with expanded tests limiting regression risk.
> 
> **Overview**
> Narrows **`tanstack-start-missing-head-content`** so it only warns when a TanStack Start **`__root`** file actually renders a document **`<head>`** that lacks **`HeadContent`** (or a plausible stand-in), instead of flagging every root route missing a literal `<HeadContent />` JSX name.
> 
> The rule now **pre-scans imports and aliases** (named/barrel **`HeadContent`**, **`@tanstack/react-router`** namespace **`HeadContent`**, and simple variable aliases) and treats **custom components under `<head>`** as safe. Routes that only use **`shellComponent`** or non-root files are no longer reported. **`runRule`** test harness now runs **`Program:exit`** visitors so exit-time diagnostics match oxlint.
> 
> Adds a broad regression test suite for pass/fail cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd96fc340c09407a4285088dedc372bb3859ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->