### PR TITLE
implement no-mutating-reducer-state rule

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -1984,9 +1984,6 @@ export const reactDoctorRules = [
     id: "no-mutating-reducer-state",
     source: "react-doctor",
     originallyExternal: false,
-    framework: "global",
-    category: "State & Effects",
-    severity: "error",
     rule: {
       ...noMutatingReducerState,
       framework: "global",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -161,6 +161,7 @@ import { noMirrorPropEffect } from "./rules/state-and-effects/no-mirror-prop-eff
 import { noMoment } from "./rules/bundle-size/no-moment.js";
 import { noMultiComp } from "./rules/react-builtins/no-multi-comp.js";
 import { noMutableInDeps } from "./rules/state-and-effects/no-mutable-in-deps.js";
+import { noMutatingReducerState } from "./rules/state-and-effects/no-mutating-reducer-state.js";
 import { noNamespace } from "./rules/react-builtins/no-namespace.js";
 import { noNestedComponentDefinition } from "./rules/architecture/no-nested-component-definition.js";
 import { noNoninteractiveElementInteractions } from "./rules/a11y/no-noninteractive-element-interactions.js";
@@ -1974,6 +1975,20 @@ export const reactDoctorRules = [
     originallyExternal: false,
     rule: {
       ...noMutableInDeps,
+      framework: "global",
+      category: "State & Effects",
+    },
+  },
+  {
+    key: "react-doctor/no-mutating-reducer-state",
+    id: "no-mutating-reducer-state",
+    source: "react-doctor",
+    originallyExternal: false,
+    framework: "global",
+    category: "State & Effects",
+    severity: "error",
+    rule: {
+      ...noMutatingReducerState,
       framework: "global",
       category: "State & Effects",
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
@@ -244,6 +244,52 @@ describe("no-mutating-reducer-state", () => {
     expect(result.diagnostics).toHaveLength(2);
   });
 
+  it("handles static and dynamic computed mutating method names", () => {
+    const staticResult = runRule(
+      noMutatingReducerState,
+      `
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        if (action.type === "array") {
+          state.items["push"](action.item);
+          return state;
+        }
+
+        Object["assign"](state, action.patch);
+        return state;
+      }
+
+      useReducer(reducer, { items: [] });
+    `,
+    );
+
+    const dynamicResult = runRule(
+      noMutatingReducerState,
+      `
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        const push = action.method;
+        const assign = action.assignMethod;
+
+        if (action.type === "array") {
+          state.items[push](action.item);
+          return state;
+        }
+
+        Object[assign](state, action.patch);
+        return state;
+      }
+
+      useReducer(reducer, { items: [] });
+    `,
+    );
+
+    expect(staticResult.diagnostics).toHaveLength(2);
+    expect(dynamicResult.diagnostics).toHaveLength(0);
+  });
+
   it("flags switch fallthrough from mutation into same-reference return", () => {
     const result = runRule(
       noMutatingReducerState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
@@ -102,6 +102,18 @@ describe("no-mutating-reducer-state", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not treat nested array mutator returns as top-level same-reference returns", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      useReducer((state, action) => {
+        return state.items.sort((a, b) => a.id - b.id);
+      }, { items: [] });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags nested aliases into reducer state when the original state is returned", () => {
     const result = run(`
       import React from "react";
@@ -131,6 +143,28 @@ describe("no-mutating-reducer-state", () => {
     `);
 
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags same-reference mutations through parenthesized and TypeScript wrappers", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      type State = { count: number; items: string[] };
+
+      function reducer(state: State, action) {
+        if (action.type === "count") {
+          state.count++;
+          return state as State;
+        }
+
+        state.items!.push(action.item);
+        return (state);
+      }
+
+      useReducer(reducer, { count: 0, items: [] });
+    `);
+
+    expect(result.diagnostics).toHaveLength(2);
   });
 
   it("flags collection mutators when the same state reference is returned", () => {
@@ -506,6 +540,41 @@ describe("no-mutating-reducer-state", () => {
     `);
 
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("preserves state rebinding and var aliases across standalone blocks", () => {
+    const rebound = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        {
+          state = { ...state };
+        }
+
+        state.count++;
+        return state;
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    const varAlias = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        {
+          var alias = state;
+        }
+
+        alias.count++;
+        return alias;
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(rebound.diagnostics).toHaveLength(0);
+    expect(varAlias.diagnostics).toHaveLength(1);
   });
 
   it("skips unresolved imported reducers for v1", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noMutatingReducerState } from "./no-mutating-reducer-state.js";
 
-const run = (code: string) => runRule(noMutatingReducerState, code);
-
 describe("no-mutating-reducer-state", () => {
   it("flags direct property mutation followed by returning the same reducer state", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -15,7 +15,8 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { age: 0 });
-    `);
+    `,
+    );
 
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
@@ -23,20 +24,25 @@ describe("no-mutating-reducer-state", () => {
   });
 
   it("flags array mutator calls on inline reducers", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import * as React from "react";
 
       React.useReducer((state, action) => {
         state.todos.push(action.todo);
         return state;
       }, []);
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it("flags aliased reducer state mutation and aliased return", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer as useReactReducer } from "react";
 
       const reducer = (state, action) => {
@@ -46,13 +52,16 @@ describe("no-mutating-reducer-state", () => {
       };
 
       useReactReducer(reducer, { name: "" });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it("flags compound and update expressions before same-reference returns", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -68,13 +77,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(2);
   });
 
   it("flags mutations in branch conditions before same-reference returns", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -85,37 +97,46 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it("flags returning the result of in-place state array methods", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       useReducer((state, action) => {
         return state.sort((a, b) => a.id - b.id);
       }, []);
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it("does not treat nested array mutator returns as top-level same-reference returns", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       useReducer((state, action) => {
         return state.items.sort((a, b) => a.id - b.id);
       }, { items: [] });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("flags nested aliases into reducer state when the original state is returned", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import React from "react";
 
       function reducer(state, action) {
@@ -125,13 +146,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       React.useReducer(reducer, { items: [] });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it("flags same-reference returns hidden inside conditional expressions", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -140,13 +164,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it("flags same-reference mutations through parenthesized and TypeScript wrappers", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       type State = { count: number; items: string[] };
@@ -162,13 +189,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0, items: [] });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(2);
   });
 
   it("flags collection mutators when the same state reference is returned", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function mapReducer(state, action) {
@@ -183,13 +213,16 @@ describe("no-mutating-reducer-state", () => {
 
       useReducer(mapReducer, new Map());
       useReducer(setReducer, new Set());
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(2);
   });
 
   it("flags standard object mutation APIs before same-reference returns", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -205,13 +238,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, {});
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(2);
   });
 
   it("flags switch fallthrough from mutation into same-reference return", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -226,13 +262,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it("does not carry switch mutations across break boundaries", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -250,13 +289,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag ordinary no-op return branches", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function dropdownReducer(state, action) {
@@ -271,13 +313,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(dropdownReducer, { activeAction: "idle" });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("flags logical assignment before a same-reference no-op guard", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -294,13 +339,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { nodes: [] });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it("does not flag mutation in one branch when that branch returns a fresh object", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -313,13 +361,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { items: [] });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag clone-first object or array mutations", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -347,13 +398,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { items: [] });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag standard object APIs when mutating a fresh target", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -363,13 +417,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, {});
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag clone-first Map mutations", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       const groupReducer = (state, action) => {
@@ -388,13 +445,16 @@ describe("no-mutating-reducer-state", () => {
       };
 
       useReducer(groupReducer, new Map());
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag nested mutation when returning a new top-level wrapper", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -416,13 +476,16 @@ describe("no-mutating-reducer-state", () => {
         replayerCleanup: new Map(),
         replayers: [],
       });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag shallow-clone writes through the clone identifier", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -435,13 +498,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, {});
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag Array.reduce accumulators or locally shadowed useReducer", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       items.reduce((state, item) => {
         state.push(item);
         return state;
@@ -457,13 +523,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag non-React or shadowed useReducer calls", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer as useStoreReducer } from "not-react";
       import { useReducer } from "react";
 
@@ -478,13 +547,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useStoreReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag Immer-backed reducer wrappers", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
       import { produce } from "immer";
       import { useImmerReducer } from "use-immer";
@@ -497,13 +569,16 @@ describe("no-mutating-reducer-state", () => {
         state.count++;
         return state;
       }, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag nested function or block-local state shadowing", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -521,13 +596,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag state after it is rebound to a fresh object", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -537,13 +615,16 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });
 
   it("preserves state rebinding and var aliases across standalone blocks", () => {
-    const rebound = run(`
+    const rebound = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -556,9 +637,12 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
-    const varAlias = run(`
+    const varAlias = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
 
       function reducer(state, action) {
@@ -571,21 +655,25 @@ describe("no-mutating-reducer-state", () => {
       }
 
       useReducer(reducer, { count: 0 });
-    `);
+    `,
+    );
 
     expect(rebound.diagnostics).toHaveLength(0);
     expect(varAlias.diagnostics).toHaveLength(1);
   });
 
   it("skips unresolved imported reducers for v1", () => {
-    const result = run(`
+    const result = runRule(
+      noMutatingReducerState,
+      `
       import { useReducer } from "react";
       import { reducer } from "./reducer";
 
       // Imported reducer bodies require module graph resolution. The v1 rule
       // treats this as a coverage gap instead of guessing across files.
       useReducer(reducer, {});
-    `);
+    `,
+    );
 
     expect(result.diagnostics).toHaveLength(0);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
@@ -176,6 +176,51 @@ describe("no-mutating-reducer-state", () => {
     expect(result.diagnostics).toHaveLength(2);
   });
 
+  it("flags switch fallthrough from mutation into same-reference return", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        switch (action.type) {
+          case "mutate":
+            state.count++;
+          case "done":
+            return state;
+          default:
+            return { ...state };
+        }
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not carry switch mutations across break boundaries", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        switch (action.type) {
+          case "mutate":
+            state.count++;
+            break;
+          case "done":
+            return state;
+          default:
+            return state;
+        }
+
+        return { ...state };
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag ordinary no-op return branches", () => {
     const result = run(`
       import { useReducer } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
@@ -1,0 +1,478 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noMutatingReducerState } from "./no-mutating-reducer-state.js";
+
+const run = (code: string) => runRule(noMutatingReducerState, code);
+
+describe("no-mutating-reducer-state", () => {
+  it("flags direct property mutation followed by returning the same reducer state", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        state.age = state.age + 1;
+        return state;
+      }
+
+      useReducer(reducer, { age: 0 });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("same reference");
+  });
+
+  it("flags array mutator calls on inline reducers", () => {
+    const result = run(`
+      import * as React from "react";
+
+      React.useReducer((state, action) => {
+        state.todos.push(action.todo);
+        return state;
+      }, []);
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags aliased reducer state mutation and aliased return", () => {
+    const result = run(`
+      import { useReducer as useReactReducer } from "react";
+
+      const reducer = (state, action) => {
+        const next = state;
+        next.name = action.name;
+        return next;
+      };
+
+      useReactReducer(reducer, { name: "" });
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags compound and update expressions before same-reference returns", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        if (action.type === "inc") {
+          state.count += 1;
+          return state;
+        }
+        if (action.type === "dec") {
+          state.count--;
+          return state;
+        }
+        return state;
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("flags mutations in branch conditions before same-reference returns", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        if (state.count++ > action.limit) {
+          return state;
+        }
+        return { ...state, count: action.limit };
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags returning the result of in-place state array methods", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      useReducer((state, action) => {
+        return state.sort((a, b) => a.id - b.id);
+      }, []);
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags nested aliases into reducer state when the original state is returned", () => {
+    const result = run(`
+      import React from "react";
+
+      function reducer(state, action) {
+        const items = state.items;
+        items.push(action.item);
+        return state;
+      }
+
+      React.useReducer(reducer, { items: [] });
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags same-reference returns hidden inside conditional expressions", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        state.count++;
+        return action.keep ? state : { ...state };
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags collection mutators when the same state reference is returned", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function mapReducer(state, action) {
+        state.set(action.key, action.value);
+        return state;
+      }
+
+      function setReducer(state, action) {
+        state.add(action.value);
+        return state;
+      }
+
+      useReducer(mapReducer, new Map());
+      useReducer(setReducer, new Set());
+    `);
+
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("flags standard object mutation APIs before same-reference returns", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        if (action.type === "assign") {
+          Object.assign(state, action.patch);
+          return state;
+        }
+        if (action.type === "reflect") {
+          Reflect.set(state, action.key, action.value);
+          return state;
+        }
+        return state;
+      }
+
+      useReducer(reducer, {});
+    `);
+
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not flag ordinary no-op return branches", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function dropdownReducer(state, action) {
+        switch (action.type) {
+          case "START_SAVE":
+            return state.activeAction === "idle"
+              ? { ...state, activeAction: { type: "saving" } }
+              : state;
+          default:
+            return state;
+        }
+      }
+
+      useReducer(dropdownReducer, { activeAction: "idle" });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags logical assignment before a same-reference no-op guard", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        state.activeNode ??= action.node;
+
+        if (state.nodes.includes(action.node)) {
+          return state;
+        }
+
+        state.nodes.push(action.node);
+        state.nodes.sort(compareNodes);
+
+        return { ...state };
+      }
+
+      useReducer(reducer, { nodes: [] });
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag mutation in one branch when that branch returns a fresh object", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        if (action.type === "add") {
+          state.items.push(action.item);
+          return { ...state, changed: true };
+        }
+
+        return state;
+      }
+
+      useReducer(reducer, { items: [] });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag clone-first object or array mutations", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        if (action.type === "remove") {
+          const next = { ...state };
+          delete next.items[action.id];
+          return next;
+        }
+        if (action.type === "move") {
+          const nextItems = [...state.items];
+          nextItems.splice(action.from, 1);
+          return { ...state, items: nextItems };
+        }
+        if (action.type === "slice") {
+          const nextItems = state.items.slice();
+          nextItems.push(action.item);
+          return { ...state, items: nextItems };
+        }
+        if (action.type === "arrayFrom") {
+          const nextItems = Array.from(state.items);
+          nextItems.reverse();
+          return { ...state, items: nextItems };
+        }
+        return state;
+      }
+
+      useReducer(reducer, { items: [] });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag standard object APIs when mutating a fresh target", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        const next = Object.assign({}, state, action.patch);
+        Reflect.set(next, action.key, action.value);
+        return next;
+      }
+
+      useReducer(reducer, {});
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag clone-first Map mutations", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      const groupReducer = (state, action) => {
+        const newState = new Map(state);
+
+        switch (action.type) {
+          case "register":
+            newState.set(action.id, { visible: action.visible });
+            return newState;
+          case "unregister":
+            newState.delete(action.id);
+            return newState;
+          default:
+            return state;
+        }
+      };
+
+      useReducer(groupReducer, new Map());
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag nested mutation when returning a new top-level wrapper", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        switch (action.type) {
+          case "surface":
+            state.screens[state.activeScreen].payload.surface = action.payload;
+            return { ...state };
+          case "mount":
+            state.replayerCleanup.set(action.replayer, action.cleanup);
+            return { ...state, replayers: [...state.replayers, action.replayer] };
+          default:
+            return state;
+        }
+      }
+
+      useReducer(reducer, {
+        activeScreen: "one",
+        screens: { one: { payload: {} } },
+        replayerCleanup: new Map(),
+        replayers: [],
+      });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag shallow-clone writes through the clone identifier", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        const newState = { ...state };
+        if (typeof newState[action.relationTo] !== "object") {
+          newState[action.relationTo] = {};
+        }
+        newState[action.relationTo][action.id] = action.doc;
+        return newState;
+      }
+
+      useReducer(reducer, {});
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag Array.reduce accumulators or locally shadowed useReducer", () => {
+    const result = run(`
+      items.reduce((state, item) => {
+        state.push(item);
+        return state;
+      }, []);
+
+      function useReducer(reducer, initialState) {
+        return [initialState, reducer];
+      }
+
+      function reducer(state, action) {
+        state.count++;
+        return state;
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag non-React or shadowed useReducer calls", () => {
+    const result = run(`
+      import { useReducer as useStoreReducer } from "not-react";
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        state.count++;
+        return state;
+      }
+
+      function Component() {
+        const useReducer = (reducer, initialState) => [initialState, reducer];
+        useReducer(reducer, { count: 0 });
+      }
+
+      useStoreReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag Immer-backed reducer wrappers", () => {
+    const result = run(`
+      import { useReducer } from "react";
+      import { produce } from "immer";
+      import { useImmerReducer } from "use-immer";
+
+      useReducer(produce((state, action) => {
+        state.count++;
+      }), { count: 0 });
+
+      useImmerReducer((state, action) => {
+        state.count++;
+        return state;
+      }, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag nested function or block-local state shadowing", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        function helper(state) {
+          state.count++;
+          return state;
+        }
+
+        {
+          const state = { count: 0 };
+          state.count++;
+        }
+
+        return state;
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag state after it is rebound to a fresh object", () => {
+    const result = run(`
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        state = { ...state };
+        state.count++;
+        return state;
+      }
+
+      useReducer(reducer, { count: 0 });
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips unresolved imported reducers for v1", () => {
+    const result = run(`
+      import { useReducer } from "react";
+      import { reducer } from "./reducer";
+
+      // Imported reducer bodies require module graph resolution. The v1 rule
+      // treats this as a coverage gap instead of guessing across files.
+      useReducer(reducer, {});
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -1,10 +1,12 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 const MESSAGE =
@@ -119,12 +121,9 @@ const isFunctionLikeAstNode = (
   );
 
 const isSpecifierImportedFromReact = (node: EsTreeNode): boolean => {
-  const parent = node.parent;
+  const parent = node.parent ?? null;
   return (
-    parent !== null &&
-    parent !== undefined &&
-    isNodeOfType(parent, "ImportDeclaration") &&
-    parent.source.value === "react"
+    parent !== null && isNodeOfType(parent, "ImportDeclaration") && parent.source.value === "react"
   );
 };
 
@@ -172,21 +171,29 @@ const isCallToImportedReactUseReducer = (node: EsTreeNodeOfType<"CallExpression"
 // preserve plain reducer state.
 const resolveSameFileReducerFunction = (node: EsTreeNode | null | undefined): EsTreeNode | null => {
   if (!node) return null;
-  if (isFunctionLikeAstNode(node)) return node;
-  if (!isNodeOfType(node, "Identifier")) return null;
+  const unwrappedNode = stripParenExpression(node);
+  if (isFunctionLikeAstNode(unwrappedNode)) return unwrappedNode;
+  if (!isNodeOfType(unwrappedNode, "Identifier")) return null;
 
-  const binding = findVariableInitializer(node, node.name);
+  const binding = findVariableInitializer(unwrappedNode, unwrappedNode.name);
   const initializer = binding?.initializer;
-  return isFunctionLikeAstNode(initializer) ? initializer : null;
+  if (!initializer) return null;
+  const unwrappedInitializer = stripParenExpression(initializer);
+  return isFunctionLikeAstNode(unwrappedInitializer) ? unwrappedInitializer : null;
 };
 
 // Reads member names from static member access (`state.items.push` -> `push`,
 // `state["items"]` -> `items`) while ignoring dynamic computed properties.
 const getStaticMemberPropertyName = (node: EsTreeNode | null | undefined): string | null => {
-  if (!node || !isNodeOfType(node, "MemberExpression")) return null;
-  if (isNodeOfType(node.property, "Identifier")) return node.property.name;
-  if (isNodeOfType(node.property, "Literal") && typeof node.property.value === "string") {
-    return node.property.value;
+  if (!node) return null;
+  const unwrappedNode = stripParenExpression(node);
+  if (!isNodeOfType(unwrappedNode, "MemberExpression")) return null;
+  if (isNodeOfType(unwrappedNode.property, "Identifier")) return unwrappedNode.property.name;
+  if (
+    isNodeOfType(unwrappedNode.property, "Literal") &&
+    typeof unwrappedNode.property.value === "string"
+  ) {
+    return unwrappedNode.property.value;
   }
   return null;
 };
@@ -199,15 +206,17 @@ const isStaticMethodCallOnNamedObject = (
   node: EsTreeNode,
   objectName: string,
   methodNames: ReadonlySet<string>,
-): boolean =>
-  Boolean(
-    isNodeOfType(node, "CallExpression") &&
-      isNodeOfType(node.callee, "MemberExpression") &&
-      isNodeOfType(node.callee.object, "Identifier") &&
-      node.callee.object.name === objectName &&
-      isNodeOfType(node.callee.property, "Identifier") &&
-      methodNames.has(node.callee.property.name),
+): boolean => {
+  const unwrappedNode = stripParenExpression(node);
+  return Boolean(
+    isNodeOfType(unwrappedNode, "CallExpression") &&
+      isNodeOfType(unwrappedNode.callee, "MemberExpression") &&
+      isNodeOfType(unwrappedNode.callee.object, "Identifier") &&
+      unwrappedNode.callee.object.name === objectName &&
+      isNodeOfType(unwrappedNode.callee.property, "Identifier") &&
+      methodNames.has(unwrappedNode.callee.property.name),
   );
+};
 
 // Determines whether an expression's root identifier is known to be the
 // original reducer state, an alias to it, or a value reachable from it.
@@ -215,9 +224,9 @@ const isExpressionRootedInMutableReducerStateSource = (
   node: EsTreeNode,
   state: ReducerPathState,
 ): boolean => {
-  let current: EsTreeNode | null | undefined = node;
+  let current: EsTreeNode | null | undefined = stripParenExpression(node);
   while (current && isNodeOfType(current, "MemberExpression")) {
-    current = current.object;
+    current = stripParenExpression(current.object);
   }
   return (
     isNodeOfType(current, "Identifier") && state.mutableStateSourceNames.has(current.name)
@@ -227,7 +236,14 @@ const isExpressionRootedInMutableReducerStateSource = (
 const isExpressionOriginalReducerStateReference = (
   node: EsTreeNode | null | undefined,
   state: ReducerPathState,
-): boolean => isNodeOfType(node, "Identifier") && state.originalStateReferenceNames.has(node.name);
+): boolean => {
+  if (!node) return false;
+  const unwrappedNode = stripParenExpression(node);
+  return (
+    isNodeOfType(unwrappedNode, "Identifier") &&
+    state.originalStateReferenceNames.has(unwrappedNode.name)
+  );
+};
 
 // Captures assignments like `const items = state.items`, where mutating `items`
 // still mutates data reachable from the original reducer state.
@@ -237,9 +253,10 @@ const isExpressionReachableFromOriginalReducerState = (
 ): boolean => {
   if (!node) return false;
   if (isExpressionOriginalReducerStateReference(node, state)) return true;
+  const unwrappedNode = stripParenExpression(node);
   return (
-    isNodeOfType(node, "MemberExpression") &&
-    isExpressionRootedInMutableReducerStateSource(node, state)
+    isNodeOfType(unwrappedNode, "MemberExpression") &&
+    isExpressionRootedInMutableReducerStateSource(unwrappedNode, state)
   );
 };
 
@@ -251,6 +268,7 @@ const canExpressionReturnOriginalReducerStateReference = (
   state: ReducerPathState,
 ): boolean => {
   if (!node) return false;
+  const unwrappedNode = stripParenExpression(node);
 
   // Direct same-reference return:
   //
@@ -258,26 +276,26 @@ const canExpressionReturnOriginalReducerStateReference = (
   //   return alias;
   //
   // where `alias` was established by `const alias = state`.
-  if (isExpressionOriginalReducerStateReference(node, state)) return true;
+  if (isExpressionOriginalReducerStateReference(unwrappedNode, state)) return true;
 
-  if (isNodeOfType(node, "CallExpression")) {
+  if (isNodeOfType(unwrappedNode, "CallExpression")) {
     // Object.assign returns its first argument, so this is still a same-reference
     // return when the first argument is the original reducer state:
     //
     //   return Object.assign(state, patch);
-    if (isStaticMethodCallOnNamedObject(node, "Object", OBJECT_ASSIGN_METHOD)) {
-      return isExpressionOriginalReducerStateReference(node.arguments?.[0], state);
+    if (isStaticMethodCallOnNamedObject(unwrappedNode, "Object", OBJECT_ASSIGN_METHOD)) {
+      return isExpressionOriginalReducerStateReference(unwrappedNode.arguments?.[0], state);
     }
 
-    if (isNodeOfType(node.callee, "MemberExpression")) {
-      const methodName = getStaticMemberPropertyName(node.callee);
+    if (isNodeOfType(unwrappedNode.callee, "MemberExpression")) {
+      const methodName = getStaticMemberPropertyName(unwrappedNode.callee);
       // In-place array methods like sort/reverse/fill return the same array
-      // receiver. If that receiver is the reducer state or a state-derived
-      // array alias, React still receives the old reference.
+      // receiver. Only count this when the receiver is the top-level reducer
+      // state or a top-level alias, not a nested array like `state.items`.
       if (
         methodName &&
         SAME_REFERENCE_ARRAY_RETURN_METHODS.has(methodName) &&
-        isExpressionRootedInMutableReducerStateSource(node.callee.object, state)
+        isExpressionOriginalReducerStateReference(unwrappedNode.callee.object, state)
       ) {
         return true;
       }
@@ -287,7 +305,7 @@ const canExpressionReturnOriginalReducerStateReference = (
       if (
         methodName &&
         SAME_REFERENCE_COLLECTION_RETURN_METHODS.has(methodName) &&
-        isExpressionOriginalReducerStateReference(node.callee.object, state)
+        isExpressionOriginalReducerStateReference(unwrappedNode.callee.object, state)
       ) {
         return true;
       }
@@ -301,25 +319,25 @@ const canExpressionReturnOriginalReducerStateReference = (
   //
   // If any possible branch returns the original reference, a prior mutation on
   // this path is enough to report.
-  if (isNodeOfType(node, "ConditionalExpression")) {
+  if (isNodeOfType(unwrappedNode, "ConditionalExpression")) {
     return (
-      canExpressionReturnOriginalReducerStateReference(node.consequent, state) ||
-      canExpressionReturnOriginalReducerStateReference(node.alternate, state)
+      canExpressionReturnOriginalReducerStateReference(unwrappedNode.consequent, state) ||
+      canExpressionReturnOriginalReducerStateReference(unwrappedNode.alternate, state)
     );
   }
 
-  if (isNodeOfType(node, "LogicalExpression")) {
+  if (isNodeOfType(unwrappedNode, "LogicalExpression")) {
     return (
-      canExpressionReturnOriginalReducerStateReference(node.left, state) ||
-      canExpressionReturnOriginalReducerStateReference(node.right, state)
+      canExpressionReturnOriginalReducerStateReference(unwrappedNode.left, state) ||
+      canExpressionReturnOriginalReducerStateReference(unwrappedNode.right, state)
     );
   }
 
   // Sequence expressions return their last expression, so earlier expressions
   // don't affect whether React receives the original state reference.
-  if (isNodeOfType(node, "SequenceExpression")) {
+  if (isNodeOfType(unwrappedNode, "SequenceExpression")) {
     return canExpressionReturnOriginalReducerStateReference(
-      node.expressions[node.expressions.length - 1],
+      unwrappedNode.expressions[unwrappedNode.expressions.length - 1],
       state,
     );
   }
@@ -339,54 +357,55 @@ const collectReducerStateMutationsInExpressionOrStatement = (
   if (isFunctionLikeAstNode(node)) return [];
   const mutations: ReducerStateMutation[] = [];
   walkAst(node, (child: EsTreeNode) => {
+    const unwrappedChild = stripParenExpression(child);
     // Prune nested function bodies for the same reason: only collect mutations
     // that execute in the currently analyzed reducer path.
-    if (child !== node && isFunctionLikeAstNode(child)) return false;
+    if (child !== node && isFunctionLikeAstNode(unwrappedChild)) return false;
 
-    if (isNodeOfType(child, "AssignmentExpression")) {
+    if (isNodeOfType(unwrappedChild, "AssignmentExpression")) {
       // Direct property writes mutate the previous state when their left-hand
       // side is rooted in the original state or a state-derived alias:
       //
       //   state.count = 1;
       //   alias.items[index] = item;
       if (
-        isNodeOfType(child.left, "MemberExpression") &&
-        isExpressionRootedInMutableReducerStateSource(child.left, state)
+        isNodeOfType(stripParenExpression(unwrappedChild.left), "MemberExpression") &&
+        isExpressionRootedInMutableReducerStateSource(unwrappedChild.left, state)
       ) {
-        mutations.push({ node: child });
+        mutations.push({ node: unwrappedChild });
       }
       return;
     }
 
-    if (isNodeOfType(child, "UpdateExpression")) {
+    if (isNodeOfType(unwrappedChild, "UpdateExpression")) {
       // Updates are writes too:
       //
       //   state.count++;
       //   --alias.count;
       if (
-        isNodeOfType(child.argument, "MemberExpression") &&
-        isExpressionRootedInMutableReducerStateSource(child.argument, state)
+        isNodeOfType(stripParenExpression(unwrappedChild.argument), "MemberExpression") &&
+        isExpressionRootedInMutableReducerStateSource(unwrappedChild.argument, state)
       ) {
-        mutations.push({ node: child });
+        mutations.push({ node: unwrappedChild });
       }
       return;
     }
 
-    if (isNodeOfType(child, "UnaryExpression") && child.operator === "delete") {
+    if (isNodeOfType(unwrappedChild, "UnaryExpression") && unwrappedChild.operator === "delete") {
       // Deleting a property mutates the containing object:
       //
       //   delete state.items[id];
       if (
-        isNodeOfType(child.argument, "MemberExpression") &&
-        isExpressionRootedInMutableReducerStateSource(child.argument, state)
+        isNodeOfType(stripParenExpression(unwrappedChild.argument), "MemberExpression") &&
+        isExpressionRootedInMutableReducerStateSource(unwrappedChild.argument, state)
       ) {
-        mutations.push({ node: child });
+        mutations.push({ node: unwrappedChild });
       }
       return;
     }
 
-    if (!isNodeOfType(child, "CallExpression")) return;
-    const firstArgument = child.arguments?.[0];
+    if (!isNodeOfType(unwrappedChild, "CallExpression")) return;
+    const firstArgument = unwrappedChild.arguments?.[0];
     // Built-in object APIs mutate their first argument:
     //
     //   Object.assign(state, patch);
@@ -396,14 +415,14 @@ const collectReducerStateMutationsInExpressionOrStatement = (
     if (
       firstArgument &&
       isExpressionRootedInMutableReducerStateSource(firstArgument, state) &&
-      (isStaticMethodCallOnNamedObject(child, "Object", OBJECT_MUTATION_METHODS) ||
-        isStaticMethodCallOnNamedObject(child, "Reflect", REFLECT_MUTATION_METHODS))
+      (isStaticMethodCallOnNamedObject(unwrappedChild, "Object", OBJECT_MUTATION_METHODS) ||
+        isStaticMethodCallOnNamedObject(unwrappedChild, "Reflect", REFLECT_MUTATION_METHODS))
     ) {
-      mutations.push({ node: child });
+      mutations.push({ node: unwrappedChild });
       return;
     }
-    if (!isNodeOfType(child.callee, "MemberExpression")) return;
-    const methodName = getStaticMemberPropertyName(child.callee);
+    if (!isNodeOfType(unwrappedChild.callee, "MemberExpression")) return;
+    const methodName = getStaticMemberPropertyName(unwrappedChild.callee);
     // Receiver-mutating methods mutate the object/array/collection they are
     // called on. We only record them when the receiver is state-derived:
     //
@@ -420,11 +439,44 @@ const collectReducerStateMutationsInExpressionOrStatement = (
       (!MUTATING_ARRAY_METHODS.has(methodName) && !MUTATING_COLLECTION_METHODS.has(methodName))
     )
       return;
-    if (isExpressionRootedInMutableReducerStateSource(child.callee.object, state)) {
-      mutations.push({ node: child });
+    if (isExpressionRootedInMutableReducerStateSource(unwrappedChild.callee.object, state)) {
+      mutations.push({ node: unwrappedChild });
     }
   });
   return mutations;
+};
+
+const collectBlockScopedBindingNames = (blockStatement: EsTreeNodeOfType<"BlockStatement">): Set<string> => {
+  const blockScopedBindingNames = new Set<string>();
+  for (const statement of blockStatement.body ?? []) {
+    if (!isNodeOfType(statement, "VariableDeclaration")) continue;
+    if (statement.kind !== "let" && statement.kind !== "const") continue;
+    for (const declarator of statement.declarations ?? []) {
+      collectPatternNames(declarator.id, blockScopedBindingNames);
+    }
+  }
+  return blockScopedBindingNames;
+};
+
+const restoreOuterIdentityForBlockScopedNames = (
+  blockState: ReducerPathState,
+  outerState: ReducerPathState,
+  blockScopedBindingNames: ReadonlySet<string>,
+): ReducerPathState => {
+  const nextState = cloneReducerPathState(blockState);
+  for (const name of blockScopedBindingNames) {
+    if (outerState.originalStateReferenceNames.has(name)) {
+      nextState.originalStateReferenceNames.add(name);
+    } else {
+      nextState.originalStateReferenceNames.delete(name);
+    }
+    if (outerState.mutableStateSourceNames.has(name)) {
+      nextState.mutableStateSourceNames.add(name);
+    } else {
+      nextState.mutableStateSourceNames.delete(name);
+    }
+  }
+  return nextState;
 };
 
 const updateReducerStateIdentityForVariableDeclaration = (
@@ -578,14 +630,18 @@ const analyzeReactUseReducerFunctionForStateMutation = (
         }
 
         if (isNodeOfType(statement, "BlockStatement")) {
-          // Keep mutations from the block, but don't leak block-local aliases.
+          // Keep outer identity changes from the block, but don't leak aliases
+          // created by block-scoped declarations.
+          const blockScopedBindingNames = collectBlockScopedBindingNames(statement);
           const blockStates = analyzeReducerStatementListByPath(statement.body, activeState);
           for (const blockState of blockStates) {
-            const nextState = cloneReducerPathState(activeState);
-            nextState.mutations.push(
-              ...blockState.mutations.filter((mutation) => !activeState.mutations.includes(mutation)),
+            nextStates.push(
+              restoreOuterIdentityForBlockScopedNames(
+                blockState,
+                activeState,
+                blockScopedBindingNames,
+              ),
             );
-            nextStates.push(nextState);
           }
           continue;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -8,6 +8,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
 
 const MESSAGE =
   "Reducer mutates its current state and returns the same reference. Return a copied object or array so React can observe the update.";
@@ -72,6 +73,10 @@ const REFLECT_MUTATION_METHODS = new Set(["deleteProperty", "set"]);
 // mutations plus a small set of built-in mutating APIs. Helper calls like
 // `mutate(state)`, lodash-style `set(state, path, value)`, and type-dependent
 // custom methods are skipped unless we can prove the mutation target.
+//
+// TODO(v2 - destructured aliases): aliases created by destructuring, such as
+// `const { items } = state`, are skipped for now. Add pattern-aware alias
+// tracking before diagnosing mutations through those names.
 //
 // Logical assignments (`??=`, `||=`, `&&=`) are treated as reducer mutations.
 // They may be no-ops at runtime, but reducer mutation is nonstandard enough that
@@ -184,22 +189,6 @@ const resolveSameFileReducerFunction = (node: EsTreeNode | null | undefined): Es
   return isFunctionLikeAstNode(unwrappedInitializer) ? unwrappedInitializer : null;
 };
 
-// Reads member names from static member access (`state.items.push` -> `push`,
-// `state["items"]` -> `items`) while ignoring dynamic computed properties.
-const getStaticMemberPropertyName = (node: EsTreeNode | null | undefined): string | null => {
-  if (!node) return null;
-  const unwrappedNode = stripParenExpression(node);
-  if (!isNodeOfType(unwrappedNode, "MemberExpression")) return null;
-  if (isNodeOfType(unwrappedNode.property, "Identifier")) return unwrappedNode.property.name;
-  if (
-    isNodeOfType(unwrappedNode.property, "Literal") &&
-    typeof unwrappedNode.property.value === "string"
-  ) {
-    return unwrappedNode.property.value;
-  }
-  return null;
-};
-
 // Matches static calls like `Object.assign(...)` or `Reflect.set(...)` without
 // resolving bindings. This is intentionally limited to built-in global names.
 // TODO(v2 - global shadowing): check scope bindings before treating Object or
@@ -215,8 +204,7 @@ const isStaticMethodCallOnNamedObject = (
     isNodeOfType(unwrappedNode.callee, "MemberExpression") &&
     isNodeOfType(unwrappedNode.callee.object, "Identifier") &&
     unwrappedNode.callee.object.name === objectName &&
-    isNodeOfType(unwrappedNode.callee.property, "Identifier") &&
-    methodNames.has(unwrappedNode.callee.property.name),
+    methodNames.has(getStaticMemberPropertyName(unwrappedNode.callee) ?? ""),
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -577,7 +577,9 @@ const analyzeReactUseReducerFunctionForStateMutation = (
         }
 
         if (isNodeOfType(statement, "IfStatement")) {
-          // The condition runs before either branch.
+          // An if statement cannot use the generic statement path: the
+          // consequent and alternate are separate possible paths. Therefore,
+          // each branch is evaluated from the state after the condition runs.
           const conditionState = cloneReducerPathState(activeState);
           conditionState.mutations.push(
             ...collectReducerStateMutationsInExpressionOrStatement(statement.test, conditionState),
@@ -603,7 +605,9 @@ const analyzeReactUseReducerFunctionForStateMutation = (
         }
 
         if (isNodeOfType(statement, "SwitchStatement")) {
-          // The switch value runs before any case.
+          // A switch cannot use the generic statement path: each case is a
+          // separate possible path, and cases can fall through into later cases.
+          // Therefore, each possible starting case is evaluated separately.
           const discriminantState = cloneReducerPathState(activeState);
           discriminantState.mutations.push(
             ...collectReducerStateMutationsInExpressionOrStatement(
@@ -652,7 +656,6 @@ const analyzeReactUseReducerFunctionForStateMutation = (
           continue;
         }
 
-        // Ordinary statements may mutate state and may also introduce aliases.
         const nextState = cloneReducerPathState(activeState);
         nextState.mutations.push(
           ...collectReducerStateMutationsInExpressionOrStatement(statement, nextState),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -34,8 +34,6 @@ const OBJECT_MUTATION_METHODS = new Set(["assign", "defineProperties", "definePr
 
 const REFLECT_MUTATION_METHODS = new Set(["deleteProperty", "set"]);
 
-const OBJECT_ASSIGN_METHOD = new Set(["assign"]);
-
 // React reducer state is compared by identity (`Object.is`). A reducer may
 // legitimately return the previous state object for no-op actions, and it may
 // legitimately mutate freshly-cloned data before returning the clone. The bug
@@ -285,12 +283,16 @@ const canExpressionReturnOriginalReducerStateReference = (
     // return when the first argument is the original reducer state:
     //
     //   return Object.assign(state, patch);
-    if (isStaticMethodCallOnNamedObject(unwrappedNode, "Object", OBJECT_ASSIGN_METHOD)) {
-      return isExpressionOriginalReducerStateReference(unwrappedNode.arguments?.[0], state);
-    }
-
     if (isNodeOfType(unwrappedNode.callee, "MemberExpression")) {
       const methodName = getStaticMemberPropertyName(unwrappedNode.callee);
+      if (
+        methodName === "assign" &&
+        isNodeOfType(unwrappedNode.callee.object, "Identifier") &&
+        unwrappedNode.callee.object.name === "Object"
+      ) {
+        return isExpressionOriginalReducerStateReference(unwrappedNode.arguments?.[0], state);
+      }
+
       // In-place array methods like sort/reverse/fill return the same array
       // receiver. Only count this when the receiver is the top-level reducer
       // state or a top-level alias, not a nested array like `state.items`.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -97,13 +97,6 @@ interface ReducerPathState {
   mutations: ReducerStateMutation[];
 }
 
-type FunctionLikeNode =
-  | EsTreeNodeOfType<"FunctionDeclaration">
-  | EsTreeNodeOfType<"FunctionExpression">
-  | EsTreeNodeOfType<"ArrowFunctionExpression">;
-
-// Forks path state when control flow branches. Each path carries its own alias
-// set and list of mutations seen before the current statement.
 const cloneReducerPathState = (state: ReducerPathState): ReducerPathState => ({
   originalStateReferenceNames: new Set(state.originalStateReferenceNames),
   mutableStateSourceNames: new Set(state.mutableStateSourceNames),
@@ -112,7 +105,12 @@ const cloneReducerPathState = (state: ReducerPathState): ReducerPathState => ({
 
 // Narrows the generic AST node to the function shapes that can be passed to
 // React.useReducer as reducer functions.
-const isFunctionLikeAstNode = (node: EsTreeNode | null | undefined): node is FunctionLikeNode =>
+const isFunctionLikeAstNode = (
+  node: EsTreeNode | null | undefined,
+): node is
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"ArrowFunctionExpression"> =>
   Boolean(
     node &&
       (isNodeOfType(node, "FunctionDeclaration") ||
@@ -120,8 +118,6 @@ const isFunctionLikeAstNode = (node: EsTreeNode | null | undefined): node is Fun
         isNodeOfType(node, "ArrowFunctionExpression")),
   );
 
-// Checks whether an import specifier's enclosing import declaration is from
-// React. Used before trusting any `useReducer`-looking identifier.
 const isSpecifierImportedFromReact = (node: EsTreeNode): boolean => {
   const parent = node.parent;
   return (
@@ -228,8 +224,6 @@ const isExpressionRootedInMutableReducerStateSource = (
   );
 };
 
-// Tracks top-level identity only: identifiers in this set are references React
-// would compare directly against the previous reducer state.
 const isExpressionOriginalReducerStateReference = (
   node: EsTreeNode | null | undefined,
   state: ReducerPathState,
@@ -433,8 +427,6 @@ const collectReducerStateMutationsInExpressionOrStatement = (
   return mutations;
 };
 
-// Updates alias sets for declarations such as `const alias = state` and
-// `const items = state.items`. Fresh clones are intentionally not added.
 const updateReducerStateIdentityForVariableDeclaration = (
   declaration: EsTreeNodeOfType<"VariableDeclaration">,
   state: ReducerPathState,
@@ -505,7 +497,6 @@ const analyzeReactUseReducerFunctionForStateMutation = (
     }
   };
 
-  // Returns the paths that are still alive after these statements run.
   const analyzeReducerStatementListByPath = (
     statements: EsTreeNode[],
     initialState: ReducerPathState,
@@ -564,11 +555,24 @@ const analyzeReactUseReducerFunctionForStateMutation = (
               discriminantState,
             ),
           );
-          nextStates.push(cloneReducerPathState(discriminantState));
-          for (const switchCase of statement.cases ?? []) {
-            nextStates.push(
-              ...analyzeReducerStatementListByPath(switchCase.consequent, discriminantState),
-            );
+          const switchCases = statement.cases ?? [];
+          if (!switchCases.some((switchCase) => switchCase.test === null)) {
+            nextStates.push(cloneReducerPathState(discriminantState));
+          }
+          for (let startIndex = 0; startIndex < switchCases.length; startIndex += 1) {
+            const fallthroughStatements: EsTreeNode[] = [];
+            for (let caseIndex = startIndex; caseIndex < switchCases.length; caseIndex += 1) {
+              let didHitBreak = false;
+              for (const caseStatement of switchCases[caseIndex].consequent ?? []) {
+                if (isNodeOfType(caseStatement, "BreakStatement")) {
+                  didHitBreak = true;
+                  break;
+                }
+                fallthroughStatements.push(caseStatement);
+              }
+              if (didHitBreak) break;
+            }
+            nextStates.push(...analyzeReducerStatementListByPath(fallthroughStatements, discriminantState));
           }
           continue;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -115,9 +115,9 @@ const isFunctionLikeAstNode = (
   | EsTreeNodeOfType<"ArrowFunctionExpression"> =>
   Boolean(
     node &&
-      (isNodeOfType(node, "FunctionDeclaration") ||
-        isNodeOfType(node, "FunctionExpression") ||
-        isNodeOfType(node, "ArrowFunctionExpression")),
+    (isNodeOfType(node, "FunctionDeclaration") ||
+      isNodeOfType(node, "FunctionExpression") ||
+      isNodeOfType(node, "ArrowFunctionExpression")),
   );
 
 const isSpecifierImportedFromReact = (node: EsTreeNode): boolean => {
@@ -150,7 +150,9 @@ const isCallToImportedReactUseReducer = (node: EsTreeNodeOfType<"CallExpression"
   const callee = node.callee;
   if (isNodeOfType(callee, "Identifier")) {
     const binding = findVariableInitializer(callee, callee.name);
-    return Boolean(binding?.initializer && isNamedReactUseReducerImportSpecifier(binding.initializer));
+    return Boolean(
+      binding?.initializer && isNamedReactUseReducerImportSpecifier(binding.initializer),
+    );
   }
 
   if (!isNodeOfType(callee, "MemberExpression")) return false;
@@ -159,7 +161,9 @@ const isCallToImportedReactUseReducer = (node: EsTreeNodeOfType<"CallExpression"
   if (callee.property.name !== "useReducer") return false;
 
   const binding = findVariableInitializer(callee.object, callee.object.name);
-  return Boolean(binding?.initializer && isReactNamespaceOrDefaultImportSpecifier(binding.initializer));
+  return Boolean(
+    binding?.initializer && isReactNamespaceOrDefaultImportSpecifier(binding.initializer),
+  );
 };
 
 // Resolves only reducer bodies already present in this file. Imported reducer
@@ -210,11 +214,11 @@ const isStaticMethodCallOnNamedObject = (
   const unwrappedNode = stripParenExpression(node);
   return Boolean(
     isNodeOfType(unwrappedNode, "CallExpression") &&
-      isNodeOfType(unwrappedNode.callee, "MemberExpression") &&
-      isNodeOfType(unwrappedNode.callee.object, "Identifier") &&
-      unwrappedNode.callee.object.name === objectName &&
-      isNodeOfType(unwrappedNode.callee.property, "Identifier") &&
-      methodNames.has(unwrappedNode.callee.property.name),
+    isNodeOfType(unwrappedNode.callee, "MemberExpression") &&
+    isNodeOfType(unwrappedNode.callee.object, "Identifier") &&
+    unwrappedNode.callee.object.name === objectName &&
+    isNodeOfType(unwrappedNode.callee.property, "Identifier") &&
+    methodNames.has(unwrappedNode.callee.property.name),
   );
 };
 
@@ -228,9 +232,7 @@ const isExpressionRootedInMutableReducerStateSource = (
   while (current && isNodeOfType(current, "MemberExpression")) {
     current = stripParenExpression(current.object);
   }
-  return (
-    isNodeOfType(current, "Identifier") && state.mutableStateSourceNames.has(current.name)
-  );
+  return isNodeOfType(current, "Identifier") && state.mutableStateSourceNames.has(current.name);
 };
 
 const isExpressionOriginalReducerStateReference = (
@@ -446,7 +448,9 @@ const collectReducerStateMutationsInExpressionOrStatement = (
   return mutations;
 };
 
-const collectBlockScopedBindingNames = (blockStatement: EsTreeNodeOfType<"BlockStatement">): Set<string> => {
+const collectBlockScopedBindingNames = (
+  blockStatement: EsTreeNodeOfType<"BlockStatement">,
+): Set<string> => {
   const blockScopedBindingNames = new Set<string>();
   for (const statement of blockStatement.body ?? []) {
     if (!isNodeOfType(statement, "VariableDeclaration")) continue;
@@ -624,7 +628,9 @@ const analyzeReactUseReducerFunctionForStateMutation = (
               }
               if (didHitBreak) break;
             }
-            nextStates.push(...analyzeReducerStatementListByPath(fallthroughStatements, discriminantState));
+            nextStates.push(
+              ...analyzeReducerStatementListByPath(fallthroughStatements, discriminantState),
+            );
           }
           continue;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -1,0 +1,645 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const MESSAGE =
+  "Reducer mutates its current state and returns the same reference. Return a copied object or array so React can observe the update.";
+
+const MUTATING_ARRAY_METHODS = new Set([
+  "copyWithin",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "shift",
+  "sort",
+  "splice",
+  "unshift",
+]);
+
+const MUTATING_COLLECTION_METHODS = new Set(["add", "clear", "delete", "set"]);
+
+const SAME_REFERENCE_ARRAY_RETURN_METHODS = new Set(["copyWithin", "fill", "reverse", "sort"]);
+
+const SAME_REFERENCE_COLLECTION_RETURN_METHODS = new Set(["add", "set"]);
+
+const OBJECT_MUTATION_METHODS = new Set(["assign", "defineProperties", "defineProperty"]);
+
+const REFLECT_MUTATION_METHODS = new Set(["deleteProperty", "set"]);
+
+const OBJECT_ASSIGN_METHOD = new Set(["assign"]);
+
+// React reducer state is compared by identity (`Object.is`). A reducer may
+// legitimately return the previous state object for no-op actions, and it may
+// legitimately mutate freshly-cloned data before returning the clone. The bug
+// this rule targets is narrower:
+//
+//   1. a reducer that is actually wired to React's `useReducer`,
+//   2. mutates the original reducer state object, or an alias/reachable value
+//      derived from that original object,
+//   3. and then returns the original top-level state reference on the same
+//      control-flow path.
+//
+// The implementation mirrors those three requirements. First, it resolves only
+// real React imports (`useReducer`, aliased named imports, and `React.useReducer`
+// through namespace/default React imports) so Array.reduce callbacks and
+// user-defined useReducer helpers are ignored. Second, it tracks identity through
+// each reducer path: `const next = state` remains the original reference, while
+// `const next = { ...state }`, `[...state.items]`, `new Map(state)`, etc. do not.
+// Third, it reports only when a remembered mutation is followed by a same-path
+// same-reference return such as `return state`, `return alias`,
+// `return state.sort(...)`, or `return Object.assign(state, patch)`.
+//
+// TODO(v2 - module resolution): reducer bodies must currently be present in the
+// same file. Imported reducer identifiers are intentionally skipped instead of
+// followed through the module graph. Cross-file resolution would need to handle
+// barrels, TS path aliases, package exports, generated files, duplicate reports
+// for one reducer used in many components, and performance caps. Treat imported
+// reducers as coverage gaps until this rule has a dedicated module-resolution
+// pass.
+//
+// TODO(v2 - nested identity): this intentionally does not diagnose
+// nested-reference preservation like `state.user.name = "Ada"; return { ...state }`.
+// React will see a new top-level state object in that case, so it belongs to a
+// separate, lower-confidence rule.
+//
+// TODO(v2 - broader mutation APIs): this rule only models syntactically obvious
+// mutations plus a small set of built-in mutating APIs. Helper calls like
+// `mutate(state)`, lodash-style `set(state, path, value)`, and type-dependent
+// custom methods are skipped unless we can prove the mutation target.
+//
+// Logical assignments (`??=`, `||=`, `&&=`) are treated as reducer mutations.
+// They may be no-ops at runtime, but reducer mutation is nonstandard enough that
+// callers can ignore the diagnostic if they intentionally rely on that behavior.
+//
+// TODO(v2 - deeper control flow): current path analysis is precise for
+// straight-line code, `if`, `switch`, and standalone blocks. Loops,
+// try/catch/finally, labeled flow, breaks/continues, and short-circuit
+// reachability are approximated because mutation collection walks their AST
+// without modeling every execution path. Add CFG-backed path analysis before
+// treating those cases as precise.
+interface ReducerStateMutation {
+  node: EsTreeNode;
+}
+
+interface ReducerPathState {
+  // Names that refer to the original reducer state object, so returning one
+  // of them returns the same top-level reference React compares with Object.is.
+  originalStateReferenceNames: Set<string>;
+  // Names that refer to either the original state object or data reachable
+  // from it. Mutating any of these mutates the previous reducer state.
+  mutableStateSourceNames: Set<string>;
+  mutations: ReducerStateMutation[];
+}
+
+type FunctionLikeNode =
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"ArrowFunctionExpression">;
+
+// Forks path state when control flow branches. Each path carries its own alias
+// set and list of mutations seen before the current statement.
+const cloneReducerPathState = (state: ReducerPathState): ReducerPathState => ({
+  originalStateReferenceNames: new Set(state.originalStateReferenceNames),
+  mutableStateSourceNames: new Set(state.mutableStateSourceNames),
+  mutations: [...state.mutations],
+});
+
+// Narrows the generic AST node to the function shapes that can be passed to
+// React.useReducer as reducer functions.
+const isFunctionLikeAstNode = (node: EsTreeNode | null | undefined): node is FunctionLikeNode =>
+  Boolean(
+    node &&
+      (isNodeOfType(node, "FunctionDeclaration") ||
+        isNodeOfType(node, "FunctionExpression") ||
+        isNodeOfType(node, "ArrowFunctionExpression")),
+  );
+
+// Checks whether an import specifier's enclosing import declaration is from
+// React. Used before trusting any `useReducer`-looking identifier.
+const isSpecifierImportedFromReact = (node: EsTreeNode): boolean => {
+  const parent = node.parent;
+  return (
+    parent !== null &&
+    parent !== undefined &&
+    isNodeOfType(parent, "ImportDeclaration") &&
+    parent.source.value === "react"
+  );
+};
+
+// Matches `import { useReducer } from "react"` and aliased variants such as
+// `import { useReducer as useReactReducer } from "react"`.
+const isNamedReactUseReducerImportSpecifier = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "ImportSpecifier")) return false;
+  if (!isSpecifierImportedFromReact(node)) return false;
+  const imported = node.imported;
+  if (isNodeOfType(imported, "Identifier")) return imported.name === "useReducer";
+  if (isNodeOfType(imported, "Literal")) return imported.value === "useReducer";
+  return false;
+};
+
+// Matches `import * as React from "react"` and default React imports that can
+// be used as `React.useReducer(...)`.
+const isReactNamespaceOrDefaultImportSpecifier = (node: EsTreeNode): boolean =>
+  isSpecifierImportedFromReact(node) &&
+  (isNodeOfType(node, "ImportNamespaceSpecifier") || isNodeOfType(node, "ImportDefaultSpecifier"));
+
+// Verifies that a call expression is wired to React's useReducer import rather
+// than a local helper, another library's hook, or Array.prototype.reduce.
+const isCallToImportedReactUseReducer = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = node.callee;
+  if (isNodeOfType(callee, "Identifier")) {
+    const binding = findVariableInitializer(callee, callee.name);
+    return Boolean(binding?.initializer && isNamedReactUseReducerImportSpecifier(binding.initializer));
+  }
+
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  if (!isNodeOfType(callee.object, "Identifier")) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  if (callee.property.name !== "useReducer") return false;
+
+  const binding = findVariableInitializer(callee.object, callee.object.name);
+  return Boolean(binding?.initializer && isReactNamespaceOrDefaultImportSpecifier(binding.initializer));
+};
+
+// Resolves only reducer bodies already present in this file. Imported reducer
+// identifiers resolve to import specifiers, not function bodies, and are skipped
+// per the v1 module-resolution limitation documented above.
+// TODO(v2 - reducer wrappers): wrapper calls are skipped entirely today. If we
+// later unwrap reducer wrappers, suppress known draft-producing wrappers like
+// Immer `produce` / `useImmerReducer`, and only analyze wrappers whose semantics
+// preserve plain reducer state.
+const resolveSameFileReducerFunction = (node: EsTreeNode | null | undefined): EsTreeNode | null => {
+  if (!node) return null;
+  if (isFunctionLikeAstNode(node)) return node;
+  if (!isNodeOfType(node, "Identifier")) return null;
+
+  const binding = findVariableInitializer(node, node.name);
+  const initializer = binding?.initializer;
+  return isFunctionLikeAstNode(initializer) ? initializer : null;
+};
+
+// Reads member names from static member access (`state.items.push` -> `push`,
+// `state["items"]` -> `items`) while ignoring dynamic computed properties.
+const getStaticMemberPropertyName = (node: EsTreeNode | null | undefined): string | null => {
+  if (!node || !isNodeOfType(node, "MemberExpression")) return null;
+  if (isNodeOfType(node.property, "Identifier")) return node.property.name;
+  if (isNodeOfType(node.property, "Literal") && typeof node.property.value === "string") {
+    return node.property.value;
+  }
+  return null;
+};
+
+// Matches static calls like `Object.assign(...)` or `Reflect.set(...)` without
+// resolving bindings. This is intentionally limited to built-in global names.
+// TODO(v2 - global shadowing): check scope bindings before treating Object or
+// Reflect as built-ins if false positives show up in real code.
+const isStaticMethodCallOnNamedObject = (
+  node: EsTreeNode,
+  objectName: string,
+  methodNames: ReadonlySet<string>,
+): boolean =>
+  Boolean(
+    isNodeOfType(node, "CallExpression") &&
+      isNodeOfType(node.callee, "MemberExpression") &&
+      isNodeOfType(node.callee.object, "Identifier") &&
+      node.callee.object.name === objectName &&
+      isNodeOfType(node.callee.property, "Identifier") &&
+      methodNames.has(node.callee.property.name),
+  );
+
+// Determines whether an expression's root identifier is known to be the
+// original reducer state, an alias to it, or a value reachable from it.
+const isExpressionRootedInMutableReducerStateSource = (
+  node: EsTreeNode,
+  state: ReducerPathState,
+): boolean => {
+  let current: EsTreeNode | null | undefined = node;
+  while (current && isNodeOfType(current, "MemberExpression")) {
+    current = current.object;
+  }
+  return (
+    isNodeOfType(current, "Identifier") && state.mutableStateSourceNames.has(current.name)
+  );
+};
+
+// Tracks top-level identity only: identifiers in this set are references React
+// would compare directly against the previous reducer state.
+const isExpressionOriginalReducerStateReference = (
+  node: EsTreeNode | null | undefined,
+  state: ReducerPathState,
+): boolean => isNodeOfType(node, "Identifier") && state.originalStateReferenceNames.has(node.name);
+
+// Captures assignments like `const items = state.items`, where mutating `items`
+// still mutates data reachable from the original reducer state.
+const isExpressionReachableFromOriginalReducerState = (
+  node: EsTreeNode | null | undefined,
+  state: ReducerPathState,
+): boolean => {
+  if (!node) return false;
+  if (isExpressionOriginalReducerStateReference(node, state)) return true;
+  return (
+    isNodeOfType(node, "MemberExpression") &&
+    isExpressionRootedInMutableReducerStateSource(node, state)
+  );
+};
+
+// Detects whether a return expression can hand React the original state object
+// back, including conditional/logical expressions and APIs that return their
+// receiver or first argument.
+const canExpressionReturnOriginalReducerStateReference = (
+  node: EsTreeNode | null | undefined,
+  state: ReducerPathState,
+): boolean => {
+  if (!node) return false;
+
+  // Direct same-reference return:
+  //
+  //   return state;
+  //   return alias;
+  //
+  // where `alias` was established by `const alias = state`.
+  if (isExpressionOriginalReducerStateReference(node, state)) return true;
+
+  if (isNodeOfType(node, "CallExpression")) {
+    // Object.assign returns its first argument, so this is still a same-reference
+    // return when the first argument is the original reducer state:
+    //
+    //   return Object.assign(state, patch);
+    if (isStaticMethodCallOnNamedObject(node, "Object", OBJECT_ASSIGN_METHOD)) {
+      return isExpressionOriginalReducerStateReference(node.arguments?.[0], state);
+    }
+
+    if (isNodeOfType(node.callee, "MemberExpression")) {
+      const methodName = getStaticMemberPropertyName(node.callee);
+      // In-place array methods like sort/reverse/fill return the same array
+      // receiver. If that receiver is the reducer state or a state-derived
+      // array alias, React still receives the old reference.
+      if (
+        methodName &&
+        SAME_REFERENCE_ARRAY_RETURN_METHODS.has(methodName) &&
+        isExpressionRootedInMutableReducerStateSource(node.callee.object, state)
+      ) {
+        return true;
+      }
+      // Map#set and Set#add return the collection receiver. Only count this as
+      // a top-level same-reference return when the receiver itself is the
+      // reducer state reference, not merely a nested collection in a new wrapper.
+      if (
+        methodName &&
+        SAME_REFERENCE_COLLECTION_RETURN_METHODS.has(methodName) &&
+        isExpressionOriginalReducerStateReference(node.callee.object, state)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  // Conditional/logical expressions may return the old state on just one side:
+  //
+  //   return changed ? { ...state } : state;
+  //   return maybeNext || state;
+  //
+  // If any possible branch returns the original reference, a prior mutation on
+  // this path is enough to report.
+  if (isNodeOfType(node, "ConditionalExpression")) {
+    return (
+      canExpressionReturnOriginalReducerStateReference(node.consequent, state) ||
+      canExpressionReturnOriginalReducerStateReference(node.alternate, state)
+    );
+  }
+
+  if (isNodeOfType(node, "LogicalExpression")) {
+    return (
+      canExpressionReturnOriginalReducerStateReference(node.left, state) ||
+      canExpressionReturnOriginalReducerStateReference(node.right, state)
+    );
+  }
+
+  // Sequence expressions return their last expression, so earlier expressions
+  // don't affect whether React receives the original state reference.
+  if (isNodeOfType(node, "SequenceExpression")) {
+    return canExpressionReturnOriginalReducerStateReference(
+      node.expressions[node.expressions.length - 1],
+      state,
+    );
+  }
+
+  return false;
+};
+
+// Walks one statement/expression and records direct mutations of the original
+// reducer state, aliases to it, or values reachable from it.
+const collectReducerStateMutationsInExpressionOrStatement = (
+  node: EsTreeNode,
+  state: ReducerPathState,
+): ReducerStateMutation[] => {
+  // Nested reducer-local helpers are declarations, not code that runs on this
+  // path. Their bodies may mutate a parameter named `state`, but that is a
+  // different binding and should not be attributed to the outer reducer path.
+  if (isFunctionLikeAstNode(node)) return [];
+  const mutations: ReducerStateMutation[] = [];
+  walkAst(node, (child: EsTreeNode) => {
+    // Prune nested function bodies for the same reason: only collect mutations
+    // that execute in the currently analyzed reducer path.
+    if (child !== node && isFunctionLikeAstNode(child)) return false;
+
+    if (isNodeOfType(child, "AssignmentExpression")) {
+      // Direct property writes mutate the previous state when their left-hand
+      // side is rooted in the original state or a state-derived alias:
+      //
+      //   state.count = 1;
+      //   alias.items[index] = item;
+      if (
+        isNodeOfType(child.left, "MemberExpression") &&
+        isExpressionRootedInMutableReducerStateSource(child.left, state)
+      ) {
+        mutations.push({ node: child });
+      }
+      return;
+    }
+
+    if (isNodeOfType(child, "UpdateExpression")) {
+      // Updates are writes too:
+      //
+      //   state.count++;
+      //   --alias.count;
+      if (
+        isNodeOfType(child.argument, "MemberExpression") &&
+        isExpressionRootedInMutableReducerStateSource(child.argument, state)
+      ) {
+        mutations.push({ node: child });
+      }
+      return;
+    }
+
+    if (isNodeOfType(child, "UnaryExpression") && child.operator === "delete") {
+      // Deleting a property mutates the containing object:
+      //
+      //   delete state.items[id];
+      if (
+        isNodeOfType(child.argument, "MemberExpression") &&
+        isExpressionRootedInMutableReducerStateSource(child.argument, state)
+      ) {
+        mutations.push({ node: child });
+      }
+      return;
+    }
+
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const firstArgument = child.arguments?.[0];
+    // Built-in object APIs mutate their first argument:
+    //
+    //   Object.assign(state, patch);
+    //   Reflect.set(state, key, value);
+    //
+    // Only count them when that first argument is rooted in reducer state.
+    if (
+      firstArgument &&
+      isExpressionRootedInMutableReducerStateSource(firstArgument, state) &&
+      (isStaticMethodCallOnNamedObject(child, "Object", OBJECT_MUTATION_METHODS) ||
+        isStaticMethodCallOnNamedObject(child, "Reflect", REFLECT_MUTATION_METHODS))
+    ) {
+      mutations.push({ node: child });
+      return;
+    }
+    if (!isNodeOfType(child.callee, "MemberExpression")) return;
+    const methodName = getStaticMemberPropertyName(child.callee);
+    // Receiver-mutating methods mutate the object/array/collection they are
+    // called on. We only record them when the receiver is state-derived:
+    //
+    //   state.items.push(item);
+    //   items.splice(index, 1);
+    //   stateMap.set(key, value);
+    //
+    // TODO(v2 - type-aware receivers): collection method names like `set` and
+    // `add` are assumed mutating when called on state-derived values. Type
+    // information could distinguish real Map/Set receivers from custom
+    // immutable APIs that happen to use the same names.
+    if (
+      !methodName ||
+      (!MUTATING_ARRAY_METHODS.has(methodName) && !MUTATING_COLLECTION_METHODS.has(methodName))
+    )
+      return;
+    if (isExpressionRootedInMutableReducerStateSource(child.callee.object, state)) {
+      mutations.push({ node: child });
+    }
+  });
+  return mutations;
+};
+
+// Updates alias sets for declarations such as `const alias = state` and
+// `const items = state.items`. Fresh clones are intentionally not added.
+const updateReducerStateIdentityForVariableDeclaration = (
+  declaration: EsTreeNodeOfType<"VariableDeclaration">,
+  state: ReducerPathState,
+): void => {
+  for (const declarator of declaration.declarations ?? []) {
+    if (!isNodeOfType(declarator.id, "Identifier")) continue;
+    const name = declarator.id.name;
+    state.originalStateReferenceNames.delete(name);
+    state.mutableStateSourceNames.delete(name);
+
+    if (isExpressionOriginalReducerStateReference(declarator.init, state)) {
+      state.originalStateReferenceNames.add(name);
+      state.mutableStateSourceNames.add(name);
+      continue;
+    }
+
+    if (isExpressionReachableFromOriginalReducerState(declarator.init, state)) {
+      state.mutableStateSourceNames.add(name);
+    }
+  }
+};
+
+// Handles rebinding like `alias = state` or `state = { ...state }`; the latter
+// removes the identifier from the original-reference set for this path.
+const updateReducerStateIdentityForIdentifierAssignment = (
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+  state: ReducerPathState,
+): void => {
+  if (!isNodeOfType(assignment.left, "Identifier")) return;
+  const name = assignment.left.name;
+  state.originalStateReferenceNames.delete(name);
+  state.mutableStateSourceNames.delete(name);
+
+  if (isExpressionOriginalReducerStateReference(assignment.right, state)) {
+    state.originalStateReferenceNames.add(name);
+    state.mutableStateSourceNames.add(name);
+    return;
+  }
+
+  if (isExpressionReachableFromOriginalReducerState(assignment.right, state)) {
+    state.mutableStateSourceNames.add(name);
+  }
+};
+
+// Walks a reducer body one path at a time. If a path changes old state and then
+// returns that same old state, we report the change.
+const analyzeReactUseReducerFunctionForStateMutation = (
+  context: RuleContext,
+  functionNode: EsTreeNode,
+  reportedNodes: WeakSet<EsTreeNode>,
+): void => {
+  if (!isFunctionLikeAstNode(functionNode) || !isNodeOfType(functionNode.body, "BlockStatement"))
+    return;
+
+  const firstParam = functionNode.params?.[0];
+  const stateName = isNodeOfType(firstParam, "Identifier")
+    ? firstParam.name
+    : isNodeOfType(firstParam, "AssignmentPattern") && isNodeOfType(firstParam.left, "Identifier")
+      ? firstParam.left.name
+      : null;
+  if (!stateName) return;
+
+  const reportReducerStateMutations = (mutations: ReducerStateMutation[]): void => {
+    for (const mutation of mutations) {
+      if (reportedNodes.has(mutation.node)) continue;
+      reportedNodes.add(mutation.node);
+      context.report({ node: mutation.node, message: MESSAGE });
+    }
+  };
+
+  // Returns the paths that are still alive after these statements run.
+  const analyzeReducerStatementListByPath = (
+    statements: EsTreeNode[],
+    initialState: ReducerPathState,
+  ): ReducerPathState[] => {
+    let activeStates = [cloneReducerPathState(initialState)];
+
+    for (const statement of statements) {
+      const nextStates: ReducerPathState[] = [];
+
+      for (const activeState of activeStates) {
+        if (isNodeOfType(statement, "ReturnStatement")) {
+          // Some returns mutate as they return, like `return state.sort(...)`.
+          const returnMutations = collectReducerStateMutationsInExpressionOrStatement(
+            statement,
+            activeState,
+          );
+          const mutationsAtReturn = [...activeState.mutations, ...returnMutations];
+          if (canExpressionReturnOriginalReducerStateReference(statement.argument, activeState)) {
+            reportReducerStateMutations(mutationsAtReturn);
+          }
+          continue;
+        }
+
+        if (isNodeOfType(statement, "IfStatement")) {
+          // The condition runs before either branch.
+          const conditionState = cloneReducerPathState(activeState);
+          conditionState.mutations.push(
+            ...collectReducerStateMutationsInExpressionOrStatement(statement.test, conditionState),
+          );
+          const consequentStates = analyzeReducerStatementListByPath(
+            isNodeOfType(statement.consequent, "BlockStatement")
+              ? statement.consequent.body
+              : [statement.consequent],
+            conditionState,
+          );
+
+          const alternateStates = statement.alternate
+            ? analyzeReducerStatementListByPath(
+                isNodeOfType(statement.alternate, "BlockStatement")
+                  ? statement.alternate.body
+                  : [statement.alternate],
+                conditionState,
+              )
+            : [cloneReducerPathState(conditionState)];
+
+          nextStates.push(...consequentStates, ...alternateStates);
+          continue;
+        }
+
+        if (isNodeOfType(statement, "SwitchStatement")) {
+          // The switch value runs before any case.
+          const discriminantState = cloneReducerPathState(activeState);
+          discriminantState.mutations.push(
+            ...collectReducerStateMutationsInExpressionOrStatement(
+              statement.discriminant,
+              discriminantState,
+            ),
+          );
+          nextStates.push(cloneReducerPathState(discriminantState));
+          for (const switchCase of statement.cases ?? []) {
+            nextStates.push(
+              ...analyzeReducerStatementListByPath(switchCase.consequent, discriminantState),
+            );
+          }
+          continue;
+        }
+
+        if (isNodeOfType(statement, "BlockStatement")) {
+          // Keep mutations from the block, but don't leak block-local aliases.
+          const blockStates = analyzeReducerStatementListByPath(statement.body, activeState);
+          for (const blockState of blockStates) {
+            const nextState = cloneReducerPathState(activeState);
+            nextState.mutations.push(
+              ...blockState.mutations.filter((mutation) => !activeState.mutations.includes(mutation)),
+            );
+            nextStates.push(nextState);
+          }
+          continue;
+        }
+
+        // Ordinary statements may mutate state and may also introduce aliases.
+        const nextState = cloneReducerPathState(activeState);
+        nextState.mutations.push(
+          ...collectReducerStateMutationsInExpressionOrStatement(statement, nextState),
+        );
+
+        if (isNodeOfType(statement, "VariableDeclaration")) {
+          updateReducerStateIdentityForVariableDeclaration(statement, nextState);
+        } else if (
+          isNodeOfType(statement, "ExpressionStatement") &&
+          isNodeOfType(statement.expression, "AssignmentExpression")
+        ) {
+          updateReducerStateIdentityForIdentifierAssignment(statement.expression, nextState);
+        }
+
+        nextStates.push(nextState);
+      }
+
+      activeStates = nextStates;
+      if (activeStates.length === 0) break;
+    }
+
+    return activeStates;
+  };
+
+  analyzeReducerStatementListByPath(functionNode.body.body, {
+    originalStateReferenceNames: new Set([stateName]),
+    mutableStateSourceNames: new Set([stateName]),
+    mutations: [],
+  });
+};
+
+export const noMutatingReducerState = defineRule<Rule>({
+  id: "no-mutating-reducer-state",
+  severity: "error",
+  recommendation:
+    "Return a new reducer state object instead of mutating the current state and returning the same reference. React uses object identity to decide whether reducer state changed.",
+  create: (context: RuleContext) => {
+    const analyzedReducers = new WeakSet<EsTreeNode>();
+    const reportedNodes = new WeakSet<EsTreeNode>();
+
+    return {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        // Pipeline:
+        // 1. accept only calls proven to be React's imported useReducer;
+        // 2. resolve the reducer body when it is local to this file;
+        // 3. analyze that reducer once, reporting mutations only when a path
+        //    returns the original state reference.
+        if (!isCallToImportedReactUseReducer(node)) return;
+        const reducerFunction = resolveSameFileReducerFunction(node.arguments?.[0]);
+        if (!reducerFunction || analyzedReducers.has(reducerFunction)) return;
+        analyzedReducers.add(reducerFunction);
+        analyzeReactUseReducerFunctionForStateMutation(context, reducerFunction, reportedNodes);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-function-like-local-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-function-like-local-names.ts
@@ -2,7 +2,6 @@ import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isInlineFunctionExpression } from "../../../utils/is-inline-function-expression.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import {
-  getStaticMemberPropertyName,
   getStaticMemberReferenceName,
   getStaticPropertyKeyName,
 } from "./event-handler-reference.js";
@@ -14,6 +13,7 @@ import {
   resolveBindingName,
   type BindingScope,
 } from "./scope-aware-reference-names.js";
+import { getStaticMemberPropertyName } from "./static-member-property-name.js";
 
 const isUseCallbackCall = (node: EsTreeNode): boolean =>
   isNodeOfType(node, "CallExpression") && getCalleeName(node.callee) === "useCallback";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/event-handler-reference.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/event-handler-reference.ts
@@ -1,15 +1,9 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isInlineFunctionExpression } from "../../../utils/is-inline-function-expression.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { getStaticMemberPropertyName } from "./static-member-property-name.js";
 
 export const isEventHandlerName = (name: string): boolean => /^on[A-Z]/.test(name);
-
-export const getStaticMemberPropertyName = (node: EsTreeNode): string | null => {
-  if (!isNodeOfType(node, "MemberExpression")) return null;
-  if (node.computed) return null;
-  if (isNodeOfType(node.property, "Identifier")) return node.property.name;
-  return null;
-};
 
 export const getStaticMemberReferenceName = (
   node: EsTreeNode,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/static-member-property-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/static-member-property-name.ts
@@ -1,0 +1,24 @@
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
+
+export const getStaticMemberPropertyName = (node: EsTreeNode | null | undefined): string | null => {
+  if (!node) return null;
+
+  const unwrappedNode = stripParenExpression(node);
+  if (!isNodeOfType(unwrappedNode, "MemberExpression")) return null;
+
+  if (!unwrappedNode.computed && isNodeOfType(unwrappedNode.property, "Identifier")) {
+    return unwrappedNode.property.name;
+  }
+
+  if (
+    unwrappedNode.computed &&
+    isNodeOfType(unwrappedNode.property, "Literal") &&
+    typeof unwrappedNode.property.value === "string"
+  ) {
+    return unwrappedNode.property.value;
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Why

Catches reducers that mutate the current state object and then return that same object.

React compares reducer state by reference. If a reducer changes the old object in place and returns it, React can treat the update as unchanged. That can skip rerenders or leave memoized consumers with stale data.

Before, this reducer mutates `state.items` and returns the same `state` object, so the rule reports it:

```tsx
import { useReducer } from "react";

function reducer(state, action) {
  if (action.type === "add") {
    state.items.push(action.item);
    return state;
  }

  return state;
}

useReducer(reducer, { items: [] });
```

After, the reducer returns a new state object, so the rule does not report it:

```tsx
import { useReducer } from "react";

function reducer(state, action) {
  if (action.type === "add") {
    return {
      ...state,
      items: [...state.items, action.item],
    };
  }

  return state;
}

useReducer(reducer, { items: [] });
```

## What changed

- Added `no-mutating-reducer-state` under State & Effects.
- Detects real React `useReducer` calls and same-file reducer functions.
- Tracks aliases to the original state, like `const next = state`.
- Reports common mutations when the same state reference can be returned.
- Allows safe patterns like clone-first updates, no-op `return state`, Immer-style wrappers, and non-React `useReducer` calls.
- Added tests for valid bugs, false-positive guards, and eval-derived edge cases.

## Test plan

```
pnpm exec vp test run packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
pnpm --filter oxlint-plugin-react-doctor typecheck
pnpm lint
```