### PR TITLE
fix(cli): suppress CI and agent interactivity

### DIFF
--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import Conf from "conf";
 import basePrompts from "prompts";
 import { findNearestPackageDirectory, hasDoctorScript } from "./install-doctor-script.js";
+import { isCiOrCodingAgentEnvironment } from "./is-ci-environment.js";
 import { SETUP_PROMPT_DELAY_MS } from "./constants.js";
 
 export interface InstallSkillRunnerOptions {
@@ -120,6 +121,7 @@ export const shouldPromptInstallSetup = (options: ShouldPromptInstallSetupOption
   if (options.isScoreOnly) return false;
   if (options.isStaged) return false;
   if (options.skipPrompts) return false;
+  if (isCiOrCodingAgentEnvironment()) return false;
   if (hasDisabledSetupPrompt(options.projectRoot, options.store)) return false;
   return !hasDoctorScript(options.projectRoot);
 };

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -22,6 +22,7 @@ import type {
 } from "@react-doctor/core";
 import { makeNoopConsole } from "./cli/utils/noop-console.js";
 import { printAgentGuidance } from "./cli/utils/render-agent-guidance.js";
+import { isCiOrCodingAgentEnvironment } from "./cli/utils/is-ci-environment.js";
 import { printDiagnostics } from "./cli/utils/render-diagnostics.js";
 import { isNonInteractiveEnvironment } from "./cli/utils/is-non-interactive-environment.js";
 import { printProjectDetection } from "./cli/utils/render-project-detection.js";
@@ -48,6 +49,7 @@ interface ResolvedInspectOptions {
   scoreOnly: boolean;
   noScore: boolean;
   isCi: boolean;
+  isCiOrCodingAgentEnvironment: boolean;
   isNonInteractiveEnvironment: boolean;
   silent: boolean;
   includePaths: string[];
@@ -77,6 +79,7 @@ const mergeInspectOptions = (
   scoreOnly: inputOptions.scoreOnly ?? false,
   noScore: inputOptions.noScore ?? userConfig?.noScore ?? false,
   isCi: inputOptions.isCi ?? false,
+  isCiOrCodingAgentEnvironment: isCiOrCodingAgentEnvironment(),
   isNonInteractiveEnvironment: isNonInteractiveEnvironment(),
   silent: inputOptions.silent ?? false,
   includePaths: inputOptions.includePaths ?? [],
@@ -175,7 +178,11 @@ const runInspectWithRuntime = async (
   // skipped entirely). `Progress.layerNoop` makes the lifecycle a
   // no-op; the rest of the pipeline is unchanged.
   const shouldShowProgressSpinners =
-    !options.silent && !options.scoreOnly && options.lint && Boolean(resolvedNodeBinaryPath);
+    !options.isCiOrCodingAgentEnvironment &&
+    !options.silent &&
+    !options.scoreOnly &&
+    options.lint &&
+    Boolean(resolvedNodeBinaryPath);
 
   const layers = buildRuntimeLayers({
     directory,

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -47,12 +47,20 @@ const readSetupPromptConfig = (configRoot: string): Record<string, unknown> =>
 
 describe("shouldPromptInstallSetup", () => {
   let fixture: PromptInstallSetupFixture;
+  let previousCursorAgent: string | undefined;
 
   beforeEach(() => {
+    previousCursorAgent = process.env.CURSOR_AGENT;
+    delete process.env.CURSOR_AGENT;
     fixture = setupFixture();
   });
 
   afterEach(() => {
+    if (previousCursorAgent === undefined) {
+      delete process.env.CURSOR_AGENT;
+    } else {
+      process.env.CURSOR_AGENT = previousCursorAgent;
+    }
     fixture.cleanup();
   });
 
@@ -253,6 +261,23 @@ describe("shouldPromptInstallSetup", () => {
     expect(shouldPromptInstallSetup({ ...baseOptions, isStaged: true })).toBe(false);
     expect(shouldPromptInstallSetup({ ...baseOptions, skipPrompts: true })).toBe(false);
     expect(shouldPromptInstallSetup({ ...baseOptions, hasScoredScan: false })).toBe(false);
+  });
+
+  it("skips setup prompts in agent shells even when the caller did not pre-skip prompts", () => {
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    process.env.CURSOR_AGENT = "1";
+
+    expect(
+      shouldPromptInstallSetup({
+        projectRoot: fixture.projectRoot,
+        hasScoredScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        skipPrompts: false,
+        store: { cwd: fixture.configRoot },
+      }),
+    ).toBe(false);
   });
 
   it("waits after score output, prints a setup pitch, then installs when accepted", async () => {

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import { SETUP_PROMPT_DELAY_MS } from "../src/cli/utils/constants.js";
 import {
+  CI_ENVIRONMENT_VARIABLES,
+  CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+  CODING_AGENT_ENVIRONMENT_VARIABLES,
+} from "../src/cli/utils/is-ci-environment.js";
+import {
   buildInstallSetupPitchLines,
   disableSetupPrompt,
   getSetupPromptConfigPath,
@@ -45,21 +50,34 @@ const readPackageJson = (projectRoot: string): Record<string, unknown> =>
 const readSetupPromptConfig = (configRoot: string): Record<string, unknown> =>
   JSON.parse(readFileSync(getSetupPromptConfigPath({ cwd: configRoot }), "utf8"));
 
+const ENVIRONMENT_VARIABLES = [
+  "CI",
+  ...CI_ENVIRONMENT_VARIABLES,
+  ...CODING_AGENT_ENVIRONMENT_VARIABLES,
+  ...CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+] as const;
+
 describe("shouldPromptInstallSetup", () => {
   let fixture: PromptInstallSetupFixture;
-  let previousCursorAgent: string | undefined;
+  let savedEnv: Record<string, string | undefined>;
 
   beforeEach(() => {
-    previousCursorAgent = process.env.CURSOR_AGENT;
-    delete process.env.CURSOR_AGENT;
+    savedEnv = {};
+    for (const envVariable of ENVIRONMENT_VARIABLES) {
+      savedEnv[envVariable] = process.env[envVariable];
+      delete process.env[envVariable];
+    }
     fixture = setupFixture();
   });
 
   afterEach(() => {
-    if (previousCursorAgent === undefined) {
-      delete process.env.CURSOR_AGENT;
-    } else {
-      process.env.CURSOR_AGENT = previousCursorAgent;
+    for (const envVariable of ENVIRONMENT_VARIABLES) {
+      const previousValue = savedEnv[envVariable];
+      if (previousValue === undefined) {
+        delete process.env[envVariable];
+      } else {
+        process.env[envVariable] = previousValue;
+      }
     }
     fixture.cleanup();
   });
@@ -266,6 +284,23 @@ describe("shouldPromptInstallSetup", () => {
   it("skips setup prompts in agent shells even when the caller did not pre-skip prompts", () => {
     writePackageJson(fixture.projectRoot, { scripts: {} });
     process.env.CURSOR_AGENT = "1";
+
+    expect(
+      shouldPromptInstallSetup({
+        projectRoot: fixture.projectRoot,
+        hasScoredScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        skipPrompts: false,
+        store: { cwd: fixture.configRoot },
+      }),
+    ).toBe(false);
+  });
+
+  it("skips setup prompts in CI even when the caller did not pre-skip prompts", () => {
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    process.env.CI = "true";
 
     expect(
       shouldPromptInstallSetup({


### PR DESCRIPTION
## Summary
- Reuse the existing `isCiOrCodingAgentEnvironment()` helper to identify CI and coding-agent runs.
- Disable core progress spinners for CI/agent React Doctor runs.
- Prevent the post-scan setup prompt from appearing in CI/agent contexts even when prompt skipping was not precomputed.

## Test plan
- nr test tests/is-ci-environment.test.ts tests/prompt-install-setup.test.ts tests/is-spinner-interactive.test.ts (from packages/react-doctor)
- nr typecheck
- nr lint
- nr format:check
- nr test