### PR TITLE
feat: agent install hint, concurrent lint+dead-code, remove setup delay

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -159,3 +159,8 @@ export const CONFIG_CACHE_TTL_MS = 5 * 60 * 1_000;
  * binary-split-retry loop.
  */
 export const OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT = 3;
+
+// HACK: interval for simulated per-file progress ticks while an oxlint
+// batch subprocess runs. The timer increments a counter so the spinner
+// updates smoothly instead of jumping by the batch size on completion.
+export const PROGRESS_TICK_INTERVAL_MS = 50;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -24,7 +24,7 @@ export const SCORE_BAR_WIDTH_CHARS = 50;
 
 export const SCORE_API_URL = "https://www.react.doctor/api/score";
 
-export const SHARE_BASE_URL = "https://www.react.doctor/share";
+export const SHARE_BASE_URL = "https://react.doctor/share";
 
 export const FETCH_TIMEOUT_MS = 10_000;
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -24,7 +24,7 @@ export const SCORE_BAR_WIDTH_CHARS = 50;
 
 export const SCORE_API_URL = "https://www.react.doctor/api/score";
 
-export const SHARE_BASE_URL = "https://react.doctor/share";
+export const SHARE_BASE_URL = "https://www.react.doctor/share";
 
 export const FETCH_TIMEOUT_MS = 10_000;
 

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -121,13 +121,11 @@ const fileReader =
     return lines === null ? null : [...lines];
   };
 
-const LINT_FAIL_TEXT = "Lint checks failed (non-fatal, skipping).";
-const LINT_SUCCESS_TEXT = "Running lint checks.";
+const SCAN_SUCCESS_TEXT = "Scanning.";
+const LINT_FAIL_TEXT = "Scanning failed (lint, non-fatal).";
 const LINT_NATIVE_BINDING_FAIL_TEXT = (nodeVersion: string): string =>
-  `Lint checks failed — oxlint native binding not found (Node ${nodeVersion}).`;
-
-const DEAD_CODE_FAIL_TEXT = "Dead-code analysis failed (non-fatal, skipping).";
-const DEAD_CODE_SUCCESS_TEXT = "Analyzing dead code.";
+  `Scanning failed — oxlint native binding not found (Node ${nodeVersion}).`;
+const DEAD_CODE_FAIL_TEXT = "Scanning failed (dead-code analysis, non-fatal).";
 
 const formatLintFailText = (
   reasonTag: ReactDoctorErrorReason["_tag"] | null,
@@ -287,7 +285,7 @@ export const runInspect = <HooksR = never>(
         : Effect.succeed<Iterable<Diagnostic>>([]),
     );
 
-    const lintProgress = yield* progressService.start("Running lint checks...");
+    const lintProgress = yield* progressService.start("Scanning...");
 
     const rawLintStream = linterService
       .run({
@@ -301,9 +299,9 @@ export const runInspect = <HooksR = never>(
         ignoredTags: input.ignoredTags,
         userConfig: resolvedConfig.config ?? undefined,
         configSourceDirectory: resolvedConfig.configSourceDirectory ?? undefined,
-        onBatchComplete: (scannedFileCount, totalFileCount) => {
+        onFileProgress: (scannedFileCount, totalFileCount) => {
           Effect.runSync(
-            lintProgress.update(`Scanning files (${scannedFileCount}/${totalFileCount})...`),
+            lintProgress.update(`Scanning (${scannedFileCount}/${totalFileCount})...`),
           );
         },
       })
@@ -324,24 +322,20 @@ export const runInspect = <HooksR = never>(
 
     const lintCollected = yield* Stream.runCollect(applyPerElementPipeline(rawLintStream));
     const lintFailureState = yield* Ref.get(lintFailure);
-    if (lintFailureState.didFail) {
-      yield* lintProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
-    } else {
-      yield* lintProgress.succeed(LINT_SUCCESS_TEXT);
-    }
     yield* afterLint(lintFailureState.didFail);
 
-    const deadCodeProgress = shouldRunDeadCode
-      ? yield* progressService.start("Analyzing dead code...")
-      : null;
+    if (shouldRunDeadCode) {
+      yield* lintProgress.update("Analyzing dead code...");
+    }
     const deadCodeCollected = yield* Fiber.join(deadCodeFiber);
     const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
-    if (deadCodeProgress !== null) {
-      if (deadCodeFailureState.didFail) {
-        yield* deadCodeProgress.fail(DEAD_CODE_FAIL_TEXT);
-      } else {
-        yield* deadCodeProgress.succeed(DEAD_CODE_SUCCESS_TEXT);
-      }
+
+    if (lintFailureState.didFail) {
+      yield* lintProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
+    } else if (deadCodeFailureState.didFail) {
+      yield* lintProgress.fail(DEAD_CODE_FAIL_TEXT);
+    } else {
+      yield* lintProgress.succeed(SCAN_SUCCESS_TEXT);
     }
 
     yield* reporterService.finalize;

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -287,6 +287,8 @@ export const runInspect = <HooksR = never>(
         : Effect.succeed<Iterable<Diagnostic>>([]),
     );
 
+    const lintProgress = yield* progressService.start("Running lint checks...");
+
     const rawLintStream = linterService
       .run({
         rootDirectory: scanDirectory,
@@ -299,6 +301,11 @@ export const runInspect = <HooksR = never>(
         ignoredTags: input.ignoredTags,
         userConfig: resolvedConfig.config ?? undefined,
         configSourceDirectory: resolvedConfig.configSourceDirectory ?? undefined,
+        onBatchComplete: (scannedFileCount, totalFileCount) => {
+          Effect.runSync(
+            lintProgress.update(`Scanning files (${scannedFileCount}/${totalFileCount})...`),
+          );
+        },
       })
       .pipe(
         Stream.catchTag("ReactDoctorError", (error: ReactDoctorError) =>
@@ -315,7 +322,6 @@ export const runInspect = <HooksR = never>(
         ),
       );
 
-    const lintProgress = yield* progressService.start("Running lint checks...");
     const lintCollected = yield* Stream.runCollect(applyPerElementPipeline(rawLintStream));
     const lintFailureState = yield* Ref.get(lintFailure);
     if (lintFailureState.didFail) {

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -315,24 +315,8 @@ export const runInspect = <HooksR = never>(
         ),
       );
 
-    const totalSourceFileCount = lintIncludePaths?.length ?? project.sourceFileCount;
-    const lintProgress = yield* progressService.start(
-      `Running lint checks (0/${totalSourceFileCount})...`,
-    );
-    const lintSeenFiles = new Set<string>();
-    const lintCollected = yield* Stream.runCollect(
-      applyPerElementPipeline(rawLintStream).pipe(
-        Stream.tap((diagnostic) => {
-          if (!lintSeenFiles.has(diagnostic.filePath)) {
-            lintSeenFiles.add(diagnostic.filePath);
-            return lintProgress.update(
-              `Running lint checks (${lintSeenFiles.size}/${totalSourceFileCount})...`,
-            );
-          }
-          return Effect.void;
-        }),
-      ),
-    );
+    const lintProgress = yield* progressService.start("Running lint checks...");
+    const lintCollected = yield* Stream.runCollect(applyPerElementPipeline(rawLintStream));
     const lintFailureState = yield* Ref.get(lintFailure);
     if (lintFailureState.didFail) {
       yield* lintProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -324,9 +324,6 @@ export const runInspect = <HooksR = never>(
     const lintFailureState = yield* Ref.get(lintFailure);
     yield* afterLint(lintFailureState.didFail);
 
-    if (shouldRunDeadCode) {
-      yield* lintProgress.update("Analyzing dead code...");
-    }
     const deadCodeCollected = yield* Fiber.join(deadCodeFiber);
     const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
 

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -331,9 +331,7 @@ export const runInspect = <HooksR = never>(
       yield* scanProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
     }
 
-    const deadCodeCollected = lintFailureState.didFail
-      ? []
-      : yield* Fiber.join(deadCodeFiber);
+    const deadCodeCollected = lintFailureState.didFail ? [] : yield* Fiber.join(deadCodeFiber);
     const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
 
     const scanElapsedSeconds = ((Date.now() - scanStartTime) / 1000).toFixed(1);

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -251,8 +251,6 @@ export const runInspect = <HooksR = never>(
       applyPerElementPipeline(Stream.fromIterable(environmentDiagnostics)),
     );
 
-    // ── Phase: lint + dead-code (concurrent fibers) ───────────────
-
     const lintFailure = yield* Ref.make<{
       didFail: boolean;
       reason: string | null;

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Filter from "effect/Filter";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -141,24 +142,19 @@ const formatLintFailText = (
 /**
  * The full inspect orchestration as a single composable Effect.
  *
- * Phases (each one is a separate `Stream.runCollect` so the
- * `Progress` service can render a per-phase status line):
+ * Phases:
  *
  *   1. Config.resolve(directory) → Project.discover → Git metadata
  *   2. beforeLint hook (e.g. CLI renders the project-detection block)
- *   3. environment checks (reduced-motion + pnpm hardening) — emitted
- *      through the per-element pipeline so they participate in
- *      auto-suppress / severity / ignore / inline rules.
- *   4. Linter.run — fold `ReactDoctorError` into Ref state so a
- *      lint failure surfaces via `skippedCheckReasons` rather than
- *      sinking the whole scan. Wrapped in `Progress.start("Running
- *      lint checks...")` for terminal feedback.
+ *   3. environment checks (reduced-motion + pnpm hardening)
+ *   4. Linter.run + DeadCode.run — forked as concurrent fibers so
+ *      their wall-clock times overlap. Progress spinners stay
+ *      sequential (lint first, then dead-code) for clean terminal
+ *      output. GitHub viewer permission also runs as a background
+ *      fiber during this phase.
  *   5. afterLint hook
- *   6. DeadCode.run (gated on `runDeadCode && !isDiffMode`) — same
- *      Ref-fold pattern. Wrapped in `Progress.start("Analyzing dead
- *      code...")`.
- *   7. Reporter.finalize (side-channel: future LSP / NDJSON)
- *   8. Score.compute against the surface-filtered diagnostic set
+ *   6. Reporter.finalize
+ *   7. Score.compute against the surface-filtered diagnostic set
  *
  * The orchestrator owns spinner lifecycle via `Progress`; callers
  * choose `Progress.layerOra(...)` for CLI feedback or
@@ -216,23 +212,13 @@ export const runInspect = <HooksR = never>(
       { concurrency: 3 },
     );
     const githubActionsScoreMetadata = input.isCi ? resolveGithubActionsScoreMetadata() : {};
-    const githubViewerPermission =
+    const githubViewerPermissionFiber = yield* Effect.forkChild(
       input.resolveLocalGithubViewerPermission === true && !input.isCi && repo !== null
-        ? yield* gitService
+        ? gitService
             .githubViewerPermission({ directory: scanDirectory, repo })
             .pipe(Effect.orElseSucceed(() => null as string | null))
-        : null;
-    const scoreMetadata: ScoreRequestMetadata = {
-      ...(repo !== null ? { repo } : {}),
-      ...(sha !== null ? { sha } : {}),
-      framework: project.framework,
-      ...(project.reactVersion !== null ? { reactVersion: project.reactVersion } : {}),
-      sourceFileCount: project.sourceFileCount,
-      ...(defaultBranch !== null ? { defaultBranch } : {}),
-      ...(input.doctorVersion !== undefined ? { doctorVersion: input.doctorVersion } : {}),
-      ...githubActionsScoreMetadata,
-      ...(githubViewerPermission !== null ? { githubViewerPermission } : {}),
-    };
+        : Effect.succeed(null as string | null),
+    );
 
     const jsxIncludePaths = computeJsxIncludePaths([...input.includePaths]);
     const lintIncludePaths =
@@ -265,12 +251,43 @@ export const runInspect = <HooksR = never>(
       applyPerElementPipeline(Stream.fromIterable(environmentDiagnostics)),
     );
 
-    // ── Phase: lint ───────────────────────────────────────────────
+    // ── Phase: lint + dead-code (concurrent fibers) ───────────────
+
     const lintFailure = yield* Ref.make<{
       didFail: boolean;
       reason: string | null;
       reasonTag: ReactDoctorErrorReason["_tag"] | null;
     }>({ didFail: false, reason: null, reasonTag: null });
+    const deadCodeFailure = yield* Ref.make<{ didFail: boolean; reason: string | null }>({
+      didFail: false,
+      reason: null,
+    });
+
+    const shouldRunDeadCode = input.runDeadCode && !isDiffMode;
+
+    const deadCodeFiber = yield* Effect.forkChild(
+      shouldRunDeadCode
+        ? Stream.runCollect(
+            applyPerElementPipeline(
+              deadCodeService
+                .run({ rootDirectory: scanDirectory, userConfig: resolvedConfig.config })
+                .pipe(
+                  Stream.catchTag("ReactDoctorError", (error: ReactDoctorError) =>
+                    Stream.unwrap(
+                      Effect.gen(function* () {
+                        yield* Ref.set(deadCodeFailure, {
+                          didFail: true,
+                          reason: error.message,
+                        });
+                        return Stream.empty as Stream.Stream<Diagnostic, never>;
+                      }),
+                    ),
+                  ),
+                ),
+            ),
+          )
+        : Effect.succeed<Iterable<Diagnostic>>([]),
+    );
 
     const rawLintStream = linterService
       .run({
@@ -310,39 +327,18 @@ export const runInspect = <HooksR = never>(
     }
     yield* afterLint(lintFailureState.didFail);
 
-    // ── Phase: dead-code (gated on runDeadCode && !isDiffMode) ────
-    const shouldRunDeadCode = input.runDeadCode && !isDiffMode;
-    const deadCodeFailure = yield* Ref.make<{ didFail: boolean; reason: string | null }>({
-      didFail: false,
-      reason: null,
-    });
-    let deadCodeCollected: Iterable<Diagnostic> = [];
-    if (shouldRunDeadCode) {
-      const rawDeadCodeStream = deadCodeService
-        .run({ rootDirectory: scanDirectory, userConfig: resolvedConfig.config })
-        .pipe(
-          Stream.catchTag("ReactDoctorError", (error: ReactDoctorError) =>
-            Stream.unwrap(
-              Effect.gen(function* () {
-                yield* Ref.set(deadCodeFailure, {
-                  didFail: true,
-                  reason: error.message,
-                });
-                return Stream.empty as Stream.Stream<Diagnostic, never>;
-              }),
-            ),
-          ),
-        );
-      const deadCodeProgress = yield* progressService.start("Analyzing dead code...");
-      deadCodeCollected = yield* Stream.runCollect(applyPerElementPipeline(rawDeadCodeStream));
-      const deadCodeFailureStateInline = yield* Ref.get(deadCodeFailure);
-      if (deadCodeFailureStateInline.didFail) {
+    const deadCodeProgress = shouldRunDeadCode
+      ? yield* progressService.start("Analyzing dead code...")
+      : null;
+    const deadCodeCollected = yield* Fiber.join(deadCodeFiber);
+    const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
+    if (deadCodeProgress !== null) {
+      if (deadCodeFailureState.didFail) {
         yield* deadCodeProgress.fail(DEAD_CODE_FAIL_TEXT);
       } else {
         yield* deadCodeProgress.succeed(DEAD_CODE_SUCCESS_TEXT);
       }
     }
-    const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
 
     yield* reporterService.finalize;
 
@@ -352,11 +348,19 @@ export const runInspect = <HooksR = never>(
       ...deadCodeCollected,
     ];
 
-    // Score is computed off the surface-filtered diagnostic set so
-    // weak-signal rule families (design cleanup, etc.) can't dilute
-    // the headline number. The full `finalDiagnostics` array is what
-    // the caller sees on `InspectOutput.diagnostics`; only the score
-    // input is narrowed.
+    const githubViewerPermission = yield* Fiber.join(githubViewerPermissionFiber);
+    const scoreMetadata: ScoreRequestMetadata = {
+      ...(repo !== null ? { repo } : {}),
+      ...(sha !== null ? { sha } : {}),
+      framework: project.framework,
+      ...(project.reactVersion !== null ? { reactVersion: project.reactVersion } : {}),
+      sourceFileCount: project.sourceFileCount,
+      ...(defaultBranch !== null ? { defaultBranch } : {}),
+      ...(input.doctorVersion !== undefined ? { doctorVersion: input.doctorVersion } : {}),
+      ...githubActionsScoreMetadata,
+      ...(githubViewerPermission !== null ? { githubViewerPermission } : {}),
+    };
+
     const scoreSurface: DiagnosticSurface = input.scoreSurface ?? "score";
     const scoreDiagnostics = filterDiagnosticsForSurface(
       [...finalDiagnostics],

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -121,7 +121,6 @@ const fileReader =
     return lines === null ? null : [...lines];
   };
 
-const SCAN_SUCCESS_TEXT = "Scanning.";
 const LINT_FAIL_TEXT = "Scanning failed (lint, non-fatal).";
 const LINT_NATIVE_BINDING_FAIL_TEXT = (nodeVersion: string): string =>
   `Scanning failed — oxlint native binding not found (Node ${nodeVersion}).`;

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -330,9 +330,6 @@ export const runInspect = <HooksR = never>(
     const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
 
     const scanElapsedSeconds = ((Date.now() - scanStartTime) / 1000).toFixed(1);
-    const allScanDiagnostics = [...lintCollected, ...deadCodeCollected];
-    const filesWithIssueCount = new Set(allScanDiagnostics.map((diagnostic) => diagnostic.filePath))
-      .size;
     const totalFileCount =
       lastReportedTotalFileCount || (lintIncludePaths?.length ?? project.sourceFileCount);
 
@@ -341,12 +338,8 @@ export const runInspect = <HooksR = never>(
     } else if (deadCodeFailureState.didFail) {
       yield* scanProgress.fail(DEAD_CODE_FAIL_TEXT);
     } else {
-      const issueDetail =
-        filesWithIssueCount > 0
-          ? ` (${filesWithIssueCount} ${filesWithIssueCount === 1 ? "file" : "files"} with issues)`
-          : "";
       yield* scanProgress.succeed(
-        `Scanned ${totalFileCount} ${totalFileCount === 1 ? "file" : "files"}${issueDetail} in ${scanElapsedSeconds}s`,
+        `Scanned ${totalFileCount} ${totalFileCount === 1 ? "file" : "files"} in ${scanElapsedSeconds}s`,
       );
     }
 

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -315,8 +315,24 @@ export const runInspect = <HooksR = never>(
         ),
       );
 
-    const lintProgress = yield* progressService.start("Running lint checks...");
-    const lintCollected = yield* Stream.runCollect(applyPerElementPipeline(rawLintStream));
+    const totalSourceFileCount = lintIncludePaths?.length ?? project.sourceFileCount;
+    const lintProgress = yield* progressService.start(
+      `Running lint checks (0/${totalSourceFileCount})...`,
+    );
+    const lintSeenFiles = new Set<string>();
+    const lintCollected = yield* Stream.runCollect(
+      applyPerElementPipeline(rawLintStream).pipe(
+        Stream.tap((diagnostic) => {
+          if (!lintSeenFiles.has(diagnostic.filePath)) {
+            lintSeenFiles.add(diagnostic.filePath);
+            return lintProgress.update(
+              `Running lint checks (${lintSeenFiles.size}/${totalSourceFileCount})...`,
+            );
+          }
+          return Effect.void;
+        }),
+      ),
+    );
     const lintFailureState = yield* Ref.get(lintFailure);
     if (lintFailureState.didFail) {
       yield* lintProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -326,21 +326,28 @@ export const runInspect = <HooksR = never>(
     const lintFailureState = yield* Ref.get(lintFailure);
     yield* afterLint(lintFailureState.didFail);
 
-    const deadCodeCollected = yield* Fiber.join(deadCodeFiber);
+    if (lintFailureState.didFail) {
+      yield* Fiber.interrupt(deadCodeFiber);
+      yield* scanProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
+    }
+
+    const deadCodeCollected = lintFailureState.didFail
+      ? []
+      : yield* Fiber.join(deadCodeFiber);
     const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
 
     const scanElapsedSeconds = ((Date.now() - scanStartTime) / 1000).toFixed(1);
     const totalFileCount =
       lastReportedTotalFileCount || (lintIncludePaths?.length ?? project.sourceFileCount);
 
-    if (lintFailureState.didFail) {
-      yield* scanProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
-    } else if (deadCodeFailureState.didFail) {
-      yield* scanProgress.fail(DEAD_CODE_FAIL_TEXT);
-    } else {
-      yield* scanProgress.succeed(
-        `Scanned ${totalFileCount} ${totalFileCount === 1 ? "file" : "files"} in ${scanElapsedSeconds}s`,
-      );
+    if (!lintFailureState.didFail) {
+      if (deadCodeFailureState.didFail) {
+        yield* scanProgress.fail(DEAD_CODE_FAIL_TEXT);
+      } else {
+        yield* scanProgress.succeed(
+          `Scanned ${totalFileCount} ${totalFileCount === 1 ? "file" : "files"} in ${scanElapsedSeconds}s`,
+        );
+      }
     }
 
     yield* reporterService.finalize;

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -285,7 +285,9 @@ export const runInspect = <HooksR = never>(
         : Effect.succeed<Iterable<Diagnostic>>([]),
     );
 
-    const lintProgress = yield* progressService.start("Scanning...");
+    const scanProgress = yield* progressService.start("Scanning...");
+    const scanStartTime = Date.now();
+    let lastReportedTotalFileCount = 0;
 
     const rawLintStream = linterService
       .run({
@@ -300,8 +302,9 @@ export const runInspect = <HooksR = never>(
         userConfig: resolvedConfig.config ?? undefined,
         configSourceDirectory: resolvedConfig.configSourceDirectory ?? undefined,
         onFileProgress: (scannedFileCount, totalFileCount) => {
+          lastReportedTotalFileCount = totalFileCount;
           Effect.runSync(
-            lintProgress.update(`Scanning (${scannedFileCount}/${totalFileCount})...`),
+            scanProgress.update(`Scanning (${scannedFileCount}/${totalFileCount})...`),
           );
         },
       })
@@ -327,12 +330,25 @@ export const runInspect = <HooksR = never>(
     const deadCodeCollected = yield* Fiber.join(deadCodeFiber);
     const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
 
+    const scanElapsedSeconds = ((Date.now() - scanStartTime) / 1000).toFixed(1);
+    const allScanDiagnostics = [...lintCollected, ...deadCodeCollected];
+    const filesWithIssueCount = new Set(allScanDiagnostics.map((diagnostic) => diagnostic.filePath))
+      .size;
+    const totalFileCount =
+      lastReportedTotalFileCount || (lintIncludePaths?.length ?? project.sourceFileCount);
+
     if (lintFailureState.didFail) {
-      yield* lintProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
+      yield* scanProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
     } else if (deadCodeFailureState.didFail) {
-      yield* lintProgress.fail(DEAD_CODE_FAIL_TEXT);
+      yield* scanProgress.fail(DEAD_CODE_FAIL_TEXT);
     } else {
-      yield* lintProgress.succeed(SCAN_SUCCESS_TEXT);
+      const issueDetail =
+        filesWithIssueCount > 0
+          ? ` (${filesWithIssueCount} ${filesWithIssueCount === 1 ? "file" : "files"} with issues)`
+          : "";
+      yield* scanProgress.succeed(
+        `Scanned ${totalFileCount} ${totalFileCount === 1 ? "file" : "files"}${issueDetail} in ${scanElapsedSeconds}s`,
+      );
     }
 
     yield* reporterService.finalize;

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -58,6 +58,7 @@ interface RunOxlintOptions {
    * mode, or a logger message in human mode).
    */
   onPartialFailure?: (reason: string) => void;
+  onBatchComplete?: (scannedFileCount: number, totalFileCount: number) => void;
 }
 
 /**
@@ -215,6 +216,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         nodeBinaryPath,
         project,
         onPartialFailure,
+        onBatchComplete: options.onBatchComplete,
       });
 
     writeOxlintConfig(configPath, buildConfig(extendsPaths));

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -58,7 +58,7 @@ interface RunOxlintOptions {
    * mode, or a logger message in human mode).
    */
   onPartialFailure?: (reason: string) => void;
-  onBatchComplete?: (scannedFileCount: number, totalFileCount: number) => void;
+  onFileProgress?: (scannedFileCount: number, totalFileCount: number) => void;
 }
 
 /**
@@ -216,7 +216,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         nodeBinaryPath,
         project,
         onPartialFailure,
-        onBatchComplete: options.onBatchComplete,
+        onFileProgress: options.onFileProgress,
       });
 
     writeOxlintConfig(configPath, buildConfig(extendsPaths));

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -1,4 +1,7 @@
-import { OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT, PROGRESS_TICK_INTERVAL_MS } from "../../constants.js";
+import {
+  OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT,
+  PROGRESS_TICK_INTERVAL_MS,
+} from "../../constants.js";
 import type { Diagnostic, ProjectInfo } from "../../types/index.js";
 import { isSplittableReactDoctorError } from "../../errors.js";
 import { dedupeDiagnostics } from "../../utils/dedupe-diagnostics.js";

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -1,4 +1,4 @@
-import { OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT } from "../../constants.js";
+import { OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT, PROGRESS_TICK_INTERVAL_MS } from "../../constants.js";
 import type { Diagnostic, ProjectInfo } from "../../types/index.js";
 import { isSplittableReactDoctorError } from "../../errors.js";
 import { dedupeDiagnostics } from "../../utils/dedupe-diagnostics.js";
@@ -97,7 +97,7 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
               batchFileIndex += 1;
               onFileProgress(scannedFileCount + batchFileIndex, totalFileCount);
             }
-          }, 50)
+          }, PROGRESS_TICK_INTERVAL_MS)
         : null;
     const batchDiagnostics = await spawnLintBatch(batch);
     if (progressInterval !== null) clearInterval(progressInterval);

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -12,7 +12,7 @@ export interface SpawnLintBatchesInput {
   readonly nodeBinaryPath: string;
   readonly project: ProjectInfo;
   readonly onPartialFailure?: (reason: string) => void;
-  readonly onBatchComplete?: (scannedFileCount: number, totalFileCount: number) => void;
+  readonly onFileProgress?: (scannedFileCount: number, totalFileCount: number) => void;
 }
 
 /**
@@ -36,7 +36,7 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     nodeBinaryPath,
     project,
     onPartialFailure,
-    onBatchComplete,
+    onFileProgress,
   } = input;
   const totalFileCount = fileBatches.reduce((sum, batch) => sum + batch.length, 0);
 
@@ -84,9 +84,26 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
 
   let scannedFileCount = 0;
   for (const batch of fileBatches) {
-    allDiagnostics.push(...(await spawnLintBatch(batch)));
+    // HACK: tick the progress counter per-file on a timer while the
+    // batch subprocess runs, so the UI feels smooth instead of jumping
+    // by 100 when each batch completes. The interval is cleared as
+    // soon as the batch resolves — any remaining files in the batch
+    // are counted in one final update.
+    let batchFileIndex = 0;
+    const progressInterval =
+      onFileProgress && batch.length > 1
+        ? setInterval(() => {
+            if (batchFileIndex < batch.length) {
+              batchFileIndex += 1;
+              onFileProgress(scannedFileCount + batchFileIndex, totalFileCount);
+            }
+          }, 50)
+        : null;
+    const batchDiagnostics = await spawnLintBatch(batch);
+    if (progressInterval !== null) clearInterval(progressInterval);
+    allDiagnostics.push(...batchDiagnostics);
     scannedFileCount += batch.length;
-    onBatchComplete?.(scannedFileCount, totalFileCount);
+    onFileProgress?.(scannedFileCount, totalFileCount);
   }
 
   if (droppedFiles.length > 0 && onPartialFailure) {

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -12,6 +12,7 @@ export interface SpawnLintBatchesInput {
   readonly nodeBinaryPath: string;
   readonly project: ProjectInfo;
   readonly onPartialFailure?: (reason: string) => void;
+  readonly onBatchComplete?: (scannedFileCount: number, totalFileCount: number) => void;
 }
 
 /**
@@ -28,7 +29,16 @@ export interface SpawnLintBatchesInput {
  * with a slimmer config in that case.
  */
 export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Diagnostic[]> => {
-  const { baseArgs, fileBatches, rootDirectory, nodeBinaryPath, project, onPartialFailure } = input;
+  const {
+    baseArgs,
+    fileBatches,
+    rootDirectory,
+    nodeBinaryPath,
+    project,
+    onPartialFailure,
+    onBatchComplete,
+  } = input;
+  const totalFileCount = fileBatches.reduce((sum, batch) => sum + batch.length, 0);
 
   const allDiagnostics: Diagnostic[] = [];
   // HACK: tracks files whose smallest splittable batch (down to a
@@ -72,8 +82,11 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     }
   };
 
+  let scannedFileCount = 0;
   for (const batch of fileBatches) {
     allDiagnostics.push(...(await spawnLintBatch(batch)));
+    scannedFileCount += batch.length;
+    onBatchComplete?.(scannedFileCount, totalFileCount);
   }
 
   if (droppedFiles.length > 0 && onPartialFailure) {

--- a/packages/core/src/services/linter.ts
+++ b/packages/core/src/services/linter.ts
@@ -35,13 +35,9 @@ export interface LintInput {
   readonly adoptExistingLintConfig?: boolean;
   readonly ignoredTags?: ReadonlySet<string>;
   readonly userConfig?: ReactDoctorConfig | null;
-  /**
-   * Directory of the config file that declared `userConfig`.
-   * Used to resolve `userConfig.plugins` entries — diverges from
-   * `rootDirectory` after a `userConfig.rootDir` redirect.
-   */
   readonly configSourceDirectory?: string;
   readonly nodeBinaryPath?: string;
+  readonly onBatchComplete?: (scannedFileCount: number, totalFileCount: number) => void;
 }
 
 /**
@@ -119,6 +115,7 @@ export class Linter extends Context.Service<
                   onPartialFailure: (reason) => {
                     collectedFailures.push(reason);
                   },
+                  onBatchComplete: input.onBatchComplete,
                 }),
               catch: ensureReactDoctorError,
             });

--- a/packages/core/src/services/linter.ts
+++ b/packages/core/src/services/linter.ts
@@ -37,7 +37,7 @@ export interface LintInput {
   readonly userConfig?: ReactDoctorConfig | null;
   readonly configSourceDirectory?: string;
   readonly nodeBinaryPath?: string;
-  readonly onBatchComplete?: (scannedFileCount: number, totalFileCount: number) => void;
+  readonly onFileProgress?: (scannedFileCount: number, totalFileCount: number) => void;
 }
 
 /**
@@ -115,7 +115,7 @@ export class Linter extends Context.Service<
                   onPartialFailure: (reason) => {
                     collectedFailures.push(reason);
                   },
-                  onBatchComplete: input.onBatchComplete,
+                  onFileProgress: input.onFileProgress,
                 }),
               catch: ensureReactDoctorError,
             });

--- a/packages/core/src/services/progress.ts
+++ b/packages/core/src/services/progress.ts
@@ -9,6 +9,7 @@ import * as Ref from "effect/Ref";
  * implementation (ora instance, log lines, GitHub Action group, etc).
  */
 export interface ProgressHandle {
+  readonly update: (displayText: string) => Effect.Effect<void>;
   readonly succeed: (displayText: string) => Effect.Effect<void>;
   readonly fail: (displayText: string) => Effect.Effect<void>;
 }
@@ -55,6 +56,7 @@ export class Progress extends Context.Service<
     Progress.of({
       start: () =>
         Effect.succeed({
+          update: () => Effect.void,
           succeed: () => Effect.void,
           fail: () => Effect.void,
         }),
@@ -72,6 +74,7 @@ export class Progress extends Context.Service<
               { _tag: "Started" as const, text },
             ]);
             return {
+              update: () => Effect.void,
               succeed: (displayText: string) =>
                 Ref.update(events, (existing) => [
                   ...existing,

--- a/packages/core/src/services/progress.ts
+++ b/packages/core/src/services/progress.ts
@@ -4,8 +4,9 @@ import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 
 /**
- * Handle returned by `Progress.start`. Terminate exactly once with
- * `succeed` or `fail`. Callers don't manage the underlying
+ * Handle returned by `Progress.start`. Call `update` zero or more
+ * times for intermediate status changes, then terminate exactly once
+ * with `succeed` or `fail`. Callers don't manage the underlying
  * implementation (ora instance, log lines, GitHub Action group, etc).
  */
 export interface ProgressHandle {
@@ -15,7 +16,7 @@ export interface ProgressHandle {
 }
 
 export interface ProgressEvent {
-  readonly _tag: "Started" | "Succeeded" | "Failed";
+  readonly _tag: "Started" | "Updated" | "Succeeded" | "Failed";
   readonly text: string;
 }
 
@@ -74,7 +75,11 @@ export class Progress extends Context.Service<
               { _tag: "Started" as const, text },
             ]);
             return {
-              update: () => Effect.void,
+              update: (displayText: string) =>
+                Ref.update(events, (existing) => [
+                  ...existing,
+                  { _tag: "Updated" as const, text: displayText },
+                ]),
               succeed: (displayText: string) =>
                 Ref.update(events, (existing) => [
                   ...existing,

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -69,6 +69,13 @@ export interface InspectOptions {
    * everything.
    */
   outputSurface?: DiagnosticSurface;
+  /**
+   * Suppresses the per-project diagnostic/score rendering while
+   * keeping progress spinners. The CLI sets this when scanning
+   * multiple projects so it can render one aggregate summary
+   * instead of N individual ones.
+   */
+  suppressRendering?: boolean;
 }
 
 export interface DiffInfo {

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -292,9 +292,7 @@ describe("runInspect — mid-stream lint failure", () => {
     expect(output.lintFailureReasonTag).toBe("OxlintSpawnFailed");
     expect(output.lintFailureReason).toContain("oxlint");
     expect(output.score).toBeNull();
-    // Dead code still ran and surfaced its diagnostic
-    expect(output.diagnostics).toHaveLength(1);
-    expect(output.diagnostics[0].rule).toBe("unused-file");
+    expect(output.diagnostics).toHaveLength(0);
   });
 });
 

--- a/packages/oxlint-plugin-react-doctor/tests/get-static-template-literal-value.test.ts
+++ b/packages/oxlint-plugin-react-doctor/tests/get-static-template-literal-value.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { getStaticTemplateLiteralValue } from "./get-static-template-literal-value.js";
+import { getStaticTemplateLiteralValue } from "../src/plugin/utils/get-static-template-literal-value.js";
 
 describe("getStaticTemplateLiteralValue", () => {
   it("returns the cooked value for a no-substitution template literal", () => {

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -34,6 +34,7 @@ import {
 import { printAnnotations } from "../utils/print-annotations.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
 import { promptCopyIssues } from "../utils/copy-issues-to-clipboard.js";
+import { printMultiProjectSummary } from "../utils/render-multi-project-summary.js";
 import {
   printAgentInstallHint,
   promptInstallSetup,
@@ -254,6 +255,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
     const allDiagnostics: Diagnostic[] = [];
     const completedScans: Array<{ directory: string; result: InspectResult }> = [];
+    const isMultiProject = projectDirectories.length > 1;
 
     for (const projectDirectory of projectDirectories) {
       let includePaths: string[] | undefined;
@@ -272,19 +274,30 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         includePaths = changedSourceFiles;
       }
 
-      if (!isQuiet) {
+      if (!isQuiet && !isMultiProject) {
         logger.dim("  ");
       }
       const scanResult = await inspect(projectDirectory, {
         ...scanOptions,
         includePaths,
         configOverride: userConfig,
+        suppressRendering: isMultiProject,
       });
       allDiagnostics.push(...scanResult.diagnostics);
       completedScans.push({ directory: projectDirectory, result: scanResult });
-      if (!isQuiet) {
+      if (!isQuiet && !isMultiProject) {
         logger.break();
       }
+    }
+
+    if (!isQuiet && isMultiProject && completedScans.length > 0) {
+      await Effect.runPromise(
+        printMultiProjectSummary({
+          completedScans,
+          userConfig,
+          verbose: Boolean(flags.verbose),
+        }),
+      );
     }
 
     finalizeScans({

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -34,8 +34,10 @@ import {
 import { printAnnotations } from "../utils/print-annotations.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
 import {
+  printAgentInstallHint,
   promptInstallSetup,
   resolveInstallSetupProjectRoot,
+  shouldShowAgentInstallHint,
 } from "../utils/prompt-install-setup.js";
 import { resolveCliInspectOptions } from "../utils/resolve-cli-inspect-options.js";
 import { resolveDiffMode } from "../utils/resolve-diff-mode.js";
@@ -303,9 +305,11 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       completedScanDirectories: completedScans.map((scan) => scan.directory),
     });
     if (setupProjectRoot !== null) {
+      const hasScoredScan = completedScans.some((scan) => scan.result.score !== null);
+
       await promptInstallSetup({
         projectRoot: setupProjectRoot,
-        hasScoredScan: completedScans.some((scan) => scan.result.score !== null),
+        hasScoredScan,
         issueCount: filterDiagnosticsForSurface(
           allDiagnostics,
           scanOptions.outputSurface ?? "cli",
@@ -316,6 +320,18 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         isStaged: Boolean(flags.staged),
         skipPrompts,
       });
+
+      if (
+        shouldShowAgentInstallHint({
+          projectRoot: setupProjectRoot,
+          hasScoredScan,
+          isJsonMode,
+          isScoreOnly,
+          isStaged: Boolean(flags.staged),
+        })
+      ) {
+        printAgentInstallHint();
+      }
     }
   } catch (error) {
     if (isJsonMode) {

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -273,8 +273,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       }
 
       if (!isQuiet) {
-        logger.dim(`Scanning ${projectDirectory}...`);
-        logger.break();
+        logger.dim("  ");
       }
       const scanResult = await inspect(projectDirectory, {
         ...scanOptions,

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -340,7 +340,6 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       await promptCopyIssues({
         diagnostics: allDiagnostics,
         score: lastScan?.result.score ?? null,
-        directory: resolvedDirectory,
         projectName: lastScan?.result.project.projectName ?? path.basename(resolvedDirectory),
       });
     }

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -33,7 +33,7 @@ import {
 } from "../utils/json-mode.js";
 import { printAnnotations } from "../utils/print-annotations.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
-import { promptCopyTrace } from "../utils/copy-trace-to-clipboard.js";
+import { promptCopyIssues } from "../utils/copy-issues-to-clipboard.js";
 import {
   printAgentInstallHint,
   promptInstallSetup,
@@ -337,7 +337,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
     if (!skipPrompts && !isQuiet && allDiagnostics.length > 0) {
       const lastScan = completedScans[completedScans.length - 1];
-      await promptCopyTrace({
+      await promptCopyIssues({
         diagnostics: allDiagnostics,
         score: lastScan?.result.score ?? null,
         directory: resolvedDirectory,

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -33,6 +33,7 @@ import {
 } from "../utils/json-mode.js";
 import { printAnnotations } from "../utils/print-annotations.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
+import { promptCopyTrace } from "../utils/copy-trace-to-clipboard.js";
 import {
   printAgentInstallHint,
   promptInstallSetup,
@@ -332,6 +333,16 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       ) {
         printAgentInstallHint();
       }
+    }
+
+    if (!skipPrompts && !isQuiet && allDiagnostics.length > 0) {
+      const lastScan = completedScans[completedScans.length - 1];
+      await promptCopyTrace({
+        diagnostics: allDiagnostics,
+        score: lastScan?.result.score ?? null,
+        directory: resolvedDirectory,
+        projectName: lastScan?.result.project.projectName ?? path.basename(resolvedDirectory),
+      });
     }
   } catch (error) {
     if (isJsonMode) {

--- a/packages/react-doctor/src/cli/utils/build-runtime-layers.ts
+++ b/packages/react-doctor/src/cli/utils/build-runtime-layers.ts
@@ -52,6 +52,7 @@ export interface BuildRuntimeLayersInput {
 const buildSpinnerProgressHandle = (text: string): ProgressHandle => {
   const oraHandle = spinner(text).start();
   return {
+    update: (displayText: string) => Effect.sync(() => oraHandle.update(displayText)),
     succeed: (displayText: string) => Effect.sync(() => oraHandle.succeed(displayText)),
     fail: (displayText: string) => Effect.sync(() => oraHandle.fail(displayText)),
   };

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -8,7 +8,7 @@ export const GIT_HOOK_EXECUTABLE_MODE = 0o755;
 
 export const AGENT_HOOK_TIMEOUT_SECONDS = 120;
 
-export const SETUP_PROMPT_DELAY_MS = 300;
+export const SETUP_PROMPT_DELAY_MS = 0;
 
 // Last-resort fallback when buildJsonReportError itself throws — keeps
 // stdout valid JSON so downstream parsers don't see a half-written report.

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -8,7 +8,7 @@ export const GIT_HOOK_EXECUTABLE_MODE = 0o755;
 
 export const AGENT_HOOK_TIMEOUT_SECONDS = 120;
 
-export const SETUP_PROMPT_DELAY_MS = 0;
+export const SETUP_PROMPT_DELAY_MS = 100;
 
 // Last-resort fallback when buildJsonReportError itself throws — keeps
 // stdout valid JSON so downstream parsers don't see a half-written report.

--- a/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
@@ -19,7 +19,7 @@ const buildIssuesSummary = (input: CopyIssuesInput): string => {
   const lines: string[] = [];
 
   lines.push(`# React Doctor: ${input.projectName}`);
-  if (input.score) lines.push(`Score: ${input.score.score}/1000`);
+  if (input.score) lines.push(`Score: ${input.score.score}/100`);
   lines.push(`${input.diagnostics.length} issues found`);
   lines.push("");
 

--- a/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
@@ -8,14 +8,14 @@ import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 const MAX_RULES_SHOWN = 10;
 const MAX_FILES_PER_RULE = 3;
 
-interface CopyTraceInput {
+interface CopyIssuesInput {
   readonly diagnostics: ReadonlyArray<Diagnostic>;
   readonly score: ScoreResult | null;
   readonly directory: string;
   readonly projectName: string;
 }
 
-const buildTraceSummary = (input: CopyTraceInput): string => {
+const buildIssuesSummary = (input: CopyIssuesInput): string => {
   const lines: string[] = [];
 
   lines.push(`# React Doctor: ${input.projectName}`);
@@ -88,7 +88,7 @@ const copyToClipboard = (text: string): boolean => {
   }
 };
 
-export const promptCopyTrace = async (input: CopyTraceInput): Promise<void> => {
+export const promptCopyIssues = async (input: CopyIssuesInput): Promise<void> => {
   if (input.diagnostics.length === 0) return;
 
   const { shouldCopy } = await prompts(
@@ -102,8 +102,8 @@ export const promptCopyTrace = async (input: CopyTraceInput): Promise<void> => {
   );
   if (!shouldCopy) return;
 
-  const trace = buildTraceSummary(input);
-  if (copyToClipboard(trace)) {
+  const issuesSummary = buildIssuesSummary(input);
+  if (copyToClipboard(issuesSummary)) {
     console.log("  Copied to clipboard.");
   } else {
     console.log(trace);

--- a/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
@@ -2,6 +2,7 @@ import { execSync } from "node:child_process";
 import os from "node:os";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { groupBy } from "@react-doctor/core";
+import { cliLogger as logger } from "./cli-logger.js";
 import { prompts } from "./prompts.js";
 import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 
@@ -11,7 +12,6 @@ const MAX_FILES_PER_RULE = 3;
 interface CopyIssuesInput {
   readonly diagnostics: ReadonlyArray<Diagnostic>;
   readonly score: ScoreResult | null;
-  readonly directory: string;
   readonly projectName: string;
 }
 
@@ -104,8 +104,8 @@ export const promptCopyIssues = async (input: CopyIssuesInput): Promise<void> =>
 
   const issuesSummary = buildIssuesSummary(input);
   if (copyToClipboard(issuesSummary)) {
-    console.log("  Copied to clipboard.");
+    logger.log("  Copied to clipboard.");
   } else {
-    console.log(trace);
+    logger.log(issuesSummary);
   }
 };

--- a/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
@@ -1,0 +1,83 @@
+import { execSync } from "node:child_process";
+import os from "node:os";
+import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+import { groupBy } from "@react-doctor/core";
+import { prompts } from "./prompts.js";
+
+interface CopyTraceInput {
+  readonly diagnostics: ReadonlyArray<Diagnostic>;
+  readonly score: ScoreResult | null;
+  readonly directory: string;
+  readonly projectName: string;
+}
+
+const buildTraceSummary = (input: CopyTraceInput): string => {
+  const lines: string[] = [];
+
+  lines.push(`React Doctor — ${input.projectName}`);
+  if (input.score) {
+    lines.push(`Score: ${input.score.score} / 1000 (${input.score.label})`);
+  }
+  lines.push(`Issues: ${input.diagnostics.length}`);
+  lines.push("");
+
+  const categoryGroups = groupBy([...input.diagnostics], (diagnostic) => diagnostic.category);
+  for (const [category, categoryDiagnostics] of categoryGroups) {
+    const errorCount = categoryDiagnostics.filter(
+      (diagnostic) => diagnostic.severity === "error",
+    ).length;
+    const warningCount = categoryDiagnostics.filter(
+      (diagnostic) => diagnostic.severity === "warning",
+    ).length;
+    const parts: string[] = [];
+    if (errorCount > 0) parts.push(`${errorCount} errors`);
+    if (warningCount > 0) parts.push(`${warningCount} warnings`);
+    lines.push(`  ${category}: ${parts.join(", ")}`);
+  }
+
+  lines.push("");
+  lines.push("Run with details:");
+  lines.push(`  npx react-doctor@latest ${input.directory} --verbose`);
+
+  return lines.join("\n");
+};
+
+const copyToClipboard = (text: string): boolean => {
+  const platform = os.platform();
+  try {
+    if (platform === "darwin") {
+      execSync("pbcopy", { input: text, stdio: ["pipe", "ignore", "ignore"] });
+      return true;
+    }
+    if (platform === "win32") {
+      execSync("clip", { input: text, stdio: ["pipe", "ignore", "ignore"] });
+      return true;
+    }
+    execSync("xclip -selection clipboard", { input: text, stdio: ["pipe", "ignore", "ignore"] });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const promptCopyTrace = async (input: CopyTraceInput): Promise<void> => {
+  if (input.diagnostics.length === 0) return;
+
+  const { shouldCopy } = await prompts(
+    {
+      type: "confirm",
+      name: "shouldCopy",
+      message: "Copy trace to clipboard?",
+      initial: true,
+    },
+    { onCancel: () => true },
+  );
+  if (!shouldCopy) return;
+
+  const trace = buildTraceSummary(input);
+  if (copyToClipboard(trace)) {
+    console.log("  Copied to clipboard.");
+  } else {
+    console.log(trace);
+  }
+};

--- a/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { groupBy } from "@react-doctor/core";
 import { prompts } from "./prompts.js";
+import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 
 const MAX_RULES_SHOWN = 10;
 const MAX_FILES_PER_RULE = 3;
@@ -50,6 +51,12 @@ const buildTraceSummary = (input: CopyTraceInput): string => {
     lines.push("");
     lines.push(`+${hiddenRuleCount} more rules`);
   }
+
+  try {
+    const diagnosticsDirectory = writeDiagnosticsDirectory([...input.diagnostics]);
+    lines.push("");
+    lines.push(`Full trace: ${diagnosticsDirectory}`);
+  } catch {}
 
   lines.push("");
   lines.push("## How to fix");

--- a/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
@@ -4,6 +4,9 @@ import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { groupBy } from "@react-doctor/core";
 import { prompts } from "./prompts.js";
 
+const MAX_RULES_SHOWN = 10;
+const MAX_FILES_PER_RULE = 3;
+
 interface CopyTraceInput {
   readonly diagnostics: ReadonlyArray<Diagnostic>;
   readonly score: ScoreResult | null;
@@ -14,30 +17,42 @@ interface CopyTraceInput {
 const buildTraceSummary = (input: CopyTraceInput): string => {
   const lines: string[] = [];
 
-  lines.push(`React Doctor — ${input.projectName}`);
-  if (input.score) {
-    lines.push(`Score: ${input.score.score} / 1000 (${input.score.label})`);
-  }
-  lines.push(`Issues: ${input.diagnostics.length}`);
+  lines.push(`# React Doctor: ${input.projectName}`);
+  if (input.score) lines.push(`Score: ${input.score.score}/1000`);
+  lines.push(`${input.diagnostics.length} issues found`);
   lines.push("");
 
-  const categoryGroups = groupBy([...input.diagnostics], (diagnostic) => diagnostic.category);
-  for (const [category, categoryDiagnostics] of categoryGroups) {
-    const errorCount = categoryDiagnostics.filter(
-      (diagnostic) => diagnostic.severity === "error",
-    ).length;
-    const warningCount = categoryDiagnostics.filter(
-      (diagnostic) => diagnostic.severity === "warning",
-    ).length;
-    const parts: string[] = [];
-    if (errorCount > 0) parts.push(`${errorCount} errors`);
-    if (warningCount > 0) parts.push(`${warningCount} warnings`);
-    lines.push(`  ${category}: ${parts.join(", ")}`);
+  const ruleGroups = groupBy([...input.diagnostics], (diagnostic) => diagnostic.rule);
+  const sortedRules = [...ruleGroups.entries()].sort(
+    ([, diagnosticsA], [, diagnosticsB]) => diagnosticsB.length - diagnosticsA.length,
+  );
+
+  const visibleRules = sortedRules.slice(0, MAX_RULES_SHOWN);
+  for (const [rule, ruleDiagnostics] of visibleRules) {
+    const severity = ruleDiagnostics[0].severity;
+    const uniqueFiles = [...new Set(ruleDiagnostics.map((diagnostic) => diagnostic.filePath))];
+    const shownFiles = uniqueFiles.slice(0, MAX_FILES_PER_RULE);
+    const remainingFileCount = uniqueFiles.length - shownFiles.length;
+
+    lines.push(`${severity === "error" ? "ERROR" : "WARN"} ${rule} (×${ruleDiagnostics.length})`);
+    lines.push(`  ${ruleDiagnostics[0].message}`);
+    for (const filePath of shownFiles) {
+      const firstSite = ruleDiagnostics.find(
+        (diagnostic) => diagnostic.filePath === filePath && diagnostic.line > 0,
+      );
+      lines.push(`  - ${filePath}${firstSite ? `:${firstSite.line}` : ""}`);
+    }
+    if (remainingFileCount > 0) lines.push(`  - +${remainingFileCount} more files`);
+  }
+
+  const hiddenRuleCount = sortedRules.length - visibleRules.length;
+  if (hiddenRuleCount > 0) {
+    lines.push("");
+    lines.push(`+${hiddenRuleCount} more rules`);
   }
 
   lines.push("");
-  lines.push("Run with details:");
-  lines.push(`  npx react-doctor@latest ${input.directory} --verbose`);
+  lines.push("To fix: npx react-doctor@latest --verbose");
 
   return lines.join("\n");
 };

--- a/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
@@ -52,7 +52,13 @@ const buildTraceSummary = (input: CopyTraceInput): string => {
   }
 
   lines.push("");
-  lines.push("To fix: npx react-doctor@latest --verbose");
+  lines.push("## How to fix");
+  lines.push("1. Run `npx react-doctor@latest --verbose` to see full details");
+  lines.push("2. Fix errors first, then warnings. Start with high-count rules.");
+  lines.push("3. Read the code before acting — treat findings as hypotheses, not commands.");
+  lines.push("4. Fix root causes, not symptoms. Don't suppress rules without evidence.");
+  lines.push("5. Run `npx react-doctor@latest --verbose --diff` after changes to verify.");
+  lines.push("6. Split unrelated fixes into separate PRs.");
 
   return lines.join("\n");
 };

--- a/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
@@ -95,7 +95,7 @@ export const promptCopyTrace = async (input: CopyTraceInput): Promise<void> => {
     {
       type: "confirm",
       name: "shouldCopy",
-      message: "Copy trace to clipboard?",
+      message: "Copy issues to clipboard?",
       initial: true,
     },
     { onCancel: () => true },

--- a/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-trace-to-clipboard.ts
@@ -55,7 +55,7 @@ const buildTraceSummary = (input: CopyTraceInput): string => {
   lines.push("## How to fix");
   lines.push("1. Run `npx react-doctor@latest --verbose` to see full details");
   lines.push("2. Fix errors first, then warnings. Start with high-count rules.");
-  lines.push("3. Read the code before acting — treat findings as hypotheses, not commands.");
+  lines.push("3. Read the code before acting. Treat findings as hypotheses, not commands.");
   lines.push("4. Fix root causes, not symptoms. Don't suppress rules without evidence.");
   lines.push("5. Run `npx react-doctor@latest --verbose --diff` after changes to verify.");
   lines.push("6. Split unrelated fixes into separate PRs.");

--- a/packages/react-doctor/src/cli/utils/exit-gracefully.ts
+++ b/packages/react-doctor/src/cli/utils/exit-gracefully.ts
@@ -1,14 +1,16 @@
-import { cliLogger as logger } from "./cli-logger.js";
 import { SIGINT_EXIT_CODE } from "./constants.js";
 import { isJsonModeActive, writeJsonErrorReport } from "./json-mode.js";
 
 export const exitGracefully = (): void => {
-  if (isJsonModeActive()) {
-    writeJsonErrorReport(new Error("Scan cancelled by user (SIGINT/SIGTERM)"));
-    process.exit(SIGINT_EXIT_CODE);
-  }
-  logger.break();
-  logger.log("Cancelled.");
-  logger.break();
+  try {
+    if (isJsonModeActive()) {
+      writeJsonErrorReport(new Error("Scan cancelled by user (SIGINT/SIGTERM)"));
+    } else {
+      // HACK: use raw console.log instead of the Effect-based cliLogger
+      // because Effect.runSync throws when called from a SIGINT handler
+      // while an async Effect fiber is running (e.g. score animation).
+      console.log("\nCancelled.\n");
+    }
+  } catch {}
   process.exit(SIGINT_EXIT_CODE);
 };

--- a/packages/react-doctor/src/cli/utils/install-skill.ts
+++ b/packages/react-doctor/src/cli/utils/install-skill.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -25,7 +25,6 @@ import { prompts } from "./prompts.js";
 import { shouldSkipPrompts } from "./should-skip-prompts.js";
 import { spinner } from "./spinner.js";
 
-const NATIVE_AGENT_HOOK_AGENTS = new Set<SkillAgentType>(["claude-code", "cursor"]);
 const CONFIG_ONLY_GIT_HOOK_KINDS = new Set([
   GitHookKind.Ghooks,
   GitHookKind.GitHooksJs,
@@ -174,9 +173,6 @@ const buildManualGitHookTarget = (hookPath: string, projectRoot: string): GitHoo
   runnerRoot: projectRoot,
   kind: GitHookKind.Git,
 });
-
-const hasNativeAgentHookTarget = (agents: readonly SkillAgentType[]): boolean =>
-  agents.some((agent) => NATIVE_AGENT_HOOK_AGENTS.has(agent));
 
 const formatGitHookInstallMessage = (
   hookResult: ReturnType<typeof installReactDoctorGitHook>,
@@ -430,6 +426,54 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
     } catch (error) {
       hookSpinner.fail("Failed to install React Doctor agent hooks.");
       throw error;
+    }
+  }
+
+  const workflowsDirectory = path.join(projectRoot, ".github", "workflows");
+  const workflowTargetPath = path.join(workflowsDirectory, "react-doctor.yml");
+  if (existsSync(workflowsDirectory) && !existsSync(workflowTargetPath) && !skipPrompts) {
+    const { shouldInstallWorkflow } = await prompts<"shouldInstallWorkflow">(
+      {
+        type: "confirm",
+        name: "shouldInstallWorkflow",
+        message: "Add a GitHub Actions workflow to scan PRs?",
+        initial: true,
+      },
+      promptOptions,
+    );
+    if (shouldInstallWorkflow) {
+      const workflowSpinner = spinner("Adding GitHub Actions workflow...").start();
+      try {
+        const workflowContent = [
+          "name: React Doctor",
+          "",
+          "on:",
+          "  pull_request:",
+          "    branches: [main]",
+          "",
+          "permissions:",
+          "  contents: read",
+          "  pull-requests: write",
+          "",
+          "jobs:",
+          "  react-doctor:",
+          "    runs-on: ubuntu-latest",
+          "    steps:",
+          "      - uses: actions/checkout@v4",
+          "      - uses: millionco/react-doctor@main",
+          "        with:",
+          "          github-token: ${{ secrets.GITHUB_TOKEN }}",
+          "          diff: main",
+          "",
+        ].join("\n");
+        writeFileSync(workflowTargetPath, workflowContent);
+        workflowSpinner.succeed(
+          `GitHub Actions workflow added at ${path.relative(projectRoot, workflowTargetPath)}.`,
+        );
+      } catch (error) {
+        workflowSpinner.fail("Failed to add GitHub Actions workflow.");
+        throw error;
+      }
     }
   }
 };

--- a/packages/react-doctor/src/cli/utils/install-skill.ts
+++ b/packages/react-doctor/src/cli/utils/install-skill.ts
@@ -338,7 +338,7 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
               {
                 type: "confirm",
                 name: "installGitHook",
-                message: "Run React Doctor on staged files before commits? (non-blocking git hook)",
+                message: "Check for issues before each commit?",
                 initial: true,
               },
               promptOptions,

--- a/packages/react-doctor/src/cli/utils/install-skill.ts
+++ b/packages/react-doctor/src/cli/utils/install-skill.ts
@@ -346,23 +346,7 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
           ).installGitHook,
         )));
 
-  const shouldInstallAgentHooks =
-    Boolean(options.agentHooks) ||
-    (!skipPrompts &&
-      hasNativeAgentHookTarget(selectedAgents) &&
-      Boolean(
-        (
-          await prompts<"installAgentHooks">(
-            {
-              type: "confirm",
-              name: "installAgentHooks",
-              message: "Install native agent hooks after file edits? (Claude Code / Cursor)",
-              initial: false,
-            },
-            promptOptions,
-          )
-        ).installAgentHooks,
-      ));
+  const shouldInstallAgentHooks = Boolean(options.agentHooks);
 
   if (options.dryRun) {
     logger.log(`Dry run — would install ${SKILL_NAME} skill for:`);

--- a/packages/react-doctor/src/cli/utils/install-skill.ts
+++ b/packages/react-doctor/src/cli/utils/install-skill.ts
@@ -312,7 +312,7 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
           {
             type: "multiselect",
             name: "agents",
-            message: `Install the ${highlighter.info(SKILL_NAME)} skill for:`,
+            message: `Install the ${highlighter.info(`/${SKILL_NAME}`)} skill for:`,
             choices: detectedAgents.map((agent) => ({
               title: getSkillAgentConfig(agent).displayName,
               value: agent,

--- a/packages/react-doctor/src/cli/utils/install-skill.ts
+++ b/packages/react-doctor/src/cli/utils/install-skill.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -431,17 +431,21 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
 
   const workflowsDirectory = path.join(projectRoot, ".github", "workflows");
   const workflowTargetPath = path.join(workflowsDirectory, "react-doctor.yml");
-  if (existsSync(workflowsDirectory) && !existsSync(workflowTargetPath) && !skipPrompts) {
+  if (!existsSync(workflowTargetPath) && !skipPrompts) {
+    const hasExistingWorkflows = existsSync(workflowsDirectory);
     const { shouldInstallWorkflow } = await prompts<"shouldInstallWorkflow">(
       {
         type: "confirm",
         name: "shouldInstallWorkflow",
         message: "Add a GitHub Actions workflow to scan PRs?",
-        initial: true,
+        initial: hasExistingWorkflows,
       },
       promptOptions,
     );
     if (shouldInstallWorkflow) {
+      if (!hasExistingWorkflows) {
+        mkdirSync(workflowsDirectory, { recursive: true });
+      }
       const workflowSpinner = spinner("Adding GitHub Actions workflow...").start();
       try {
         const workflowContent = [

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -173,7 +173,7 @@ const defaultSelect: SetupPromptSelect = async (message) => {
     },
     { onCancel: () => true },
   );
-  return setupReactDoctorChoice ?? SETUP_PROMPT_CHOICE_NEVER;
+  return setupReactDoctorChoice ?? SETUP_PROMPT_CHOICE_NO;
 };
 
 const defaultWriteLine: SetupPitchWriter = (line = "") => {

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -160,12 +160,12 @@ const defaultSelect: SetupPromptSelect = async (message) => {
       choices: [
         {
           title: "Yes (recommended)",
-          description: "Installs agent skills, package script, and dev dependency",
+          description: "Use agents to automatically fix issues",
           value: SETUP_PROMPT_CHOICE_YES,
         },
         {
           title: "Skip",
-          description: "Not recommended — issues may go unfixed",
+          description: "Not recommended. Issues may go unfixed.",
           value: SETUP_PROMPT_CHOICE_NEVER,
         },
       ],

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import Conf from "conf";
 import basePrompts from "prompts";
 import { findNearestPackageDirectory, hasDoctorScript } from "./install-doctor-script.js";
-import { isCiOrCodingAgentEnvironment } from "./is-ci-environment.js";
+import { isCiOrCodingAgentEnvironment, isCodingAgentEnvironment } from "./is-ci-environment.js";
 import { SETUP_PROMPT_DELAY_MS } from "./constants.js";
 
 export interface InstallSkillRunnerOptions {
@@ -208,7 +208,9 @@ export const promptInstallSetup = async (options: PromptInstallSetupOptions): Pr
   try {
     if (!shouldPromptInstallSetup(options)) return;
 
-    await (options.wait ?? defaultWait)(SETUP_PROMPT_DELAY_MS);
+    if (SETUP_PROMPT_DELAY_MS > 0) {
+      await (options.wait ?? defaultWait)(SETUP_PROMPT_DELAY_MS);
+    }
 
     const writeLine = options.writeLine ?? defaultWriteLine;
     for (const line of buildInstallSetupPitchLines(options.issueCount)) {
@@ -242,5 +244,43 @@ export const promptInstallSetup = async (options: PromptInstallSetupOptions): Pr
     }
   } catch (error) {
     await warnSetupPromptFailure(options, error);
+  }
+};
+
+export interface ShouldShowAgentInstallHintOptions {
+  readonly projectRoot: string;
+  readonly hasScoredScan: boolean;
+  readonly isJsonMode: boolean;
+  readonly isScoreOnly: boolean;
+  readonly isStaged: boolean;
+  readonly isCodingAgent?: boolean;
+}
+
+export const shouldShowAgentInstallHint = (options: ShouldShowAgentInstallHintOptions): boolean => {
+  if (!options.hasScoredScan) return false;
+  if (options.isJsonMode) return false;
+  if (options.isScoreOnly) return false;
+  if (options.isStaged) return false;
+  if (!(options.isCodingAgent ?? isCodingAgentEnvironment())) return false;
+  return !hasDoctorScript(options.projectRoot);
+};
+
+const AGENT_INSTALL_HINT_LINES = [
+  "React Doctor is not installed in this project.",
+  "Ask the user if they would like to set it up, then run:",
+  "",
+  "  npx react-doctor install --yes",
+  "",
+  "This adds agent skill files, a `doctor` package script, and react-doctor as a dev dependency.",
+] as const;
+
+export const buildAgentInstallHintLines = (): readonly string[] => AGENT_INSTALL_HINT_LINES;
+
+export const printAgentInstallHint = (
+  writeLine: SetupPitchWriter = defaultWriteLine,
+): void => {
+  writeLine("");
+  for (const line of AGENT_INSTALL_HINT_LINES) {
+    writeLine(line);
   }
 };

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -180,16 +180,6 @@ const defaultWriteLine: SetupPitchWriter = (line = "") => {
   console.log(line);
 };
 
-export const buildInstallSetupPitchLines = (issueCount: number): readonly string[] => {
-  const issueLabel = `${issueCount} ${issueCount === 1 ? "issue" : "issues"}`;
-  const issueLine =
-    issueCount > 0
-      ? `React Doctor found ${issueLabel}! Do you want to add React Doctor to this project? It will help humans and agents keep working through those fixes after this scan.`
-      : "React Doctor did not find issues this time! Do you want to add React Doctor to this project? It will help humans and agents catch future regressions early.";
-
-  return ["", issueLine, ""];
-};
-
 const formatSetupPromptFailure = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -158,8 +158,16 @@ const defaultSelect: SetupPromptSelect = async (message) => {
       name: "setupReactDoctorChoice",
       message,
       choices: [
-        { title: "Yes (recommended)", value: SETUP_PROMPT_CHOICE_YES },
-        { title: "No, and don't ask again", value: SETUP_PROMPT_CHOICE_NEVER },
+        {
+          title: "Yes (recommended)",
+          description: "Installs agent skills, package script, and dev dependency",
+          value: SETUP_PROMPT_CHOICE_YES,
+        },
+        {
+          title: "No, and don't ask again",
+          description: "You can always run npx react-doctor@latest install later",
+          value: SETUP_PROMPT_CHOICE_NEVER,
+        },
       ],
       initial: 0,
     },

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -276,9 +276,7 @@ const AGENT_INSTALL_HINT_LINES = [
 
 export const buildAgentInstallHintLines = (): readonly string[] => AGENT_INSTALL_HINT_LINES;
 
-export const printAgentInstallHint = (
-  writeLine: SetupPitchWriter = defaultWriteLine,
-): void => {
+export const printAgentInstallHint = (writeLine: SetupPitchWriter = defaultWriteLine): void => {
   writeLine("");
   for (const line of AGENT_INSTALL_HINT_LINES) {
     writeLine(line);

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -208,9 +208,7 @@ export const promptInstallSetup = async (options: PromptInstallSetupOptions): Pr
   try {
     if (!shouldPromptInstallSetup(options)) return;
 
-    if (SETUP_PROMPT_DELAY_MS > 0) {
-      await (options.wait ?? defaultWait)(SETUP_PROMPT_DELAY_MS);
-    }
+    await (options.wait ?? defaultWait)(SETUP_PROMPT_DELAY_MS);
 
     const writeLine = options.writeLine ?? defaultWriteLine;
     for (const line of buildInstallSetupPitchLines(options.issueCount)) {
@@ -254,6 +252,7 @@ export interface ShouldShowAgentInstallHintOptions {
   readonly isScoreOnly: boolean;
   readonly isStaged: boolean;
   readonly isCodingAgent?: boolean;
+  readonly store?: SetupPromptStoreOptions;
 }
 
 export const shouldShowAgentInstallHint = (options: ShouldShowAgentInstallHintOptions): boolean => {
@@ -262,10 +261,11 @@ export const shouldShowAgentInstallHint = (options: ShouldShowAgentInstallHintOp
   if (options.isScoreOnly) return false;
   if (options.isStaged) return false;
   if (!(options.isCodingAgent ?? isCodingAgentEnvironment())) return false;
+  if (hasDisabledSetupPrompt(options.projectRoot, options.store)) return false;
   return !hasDoctorScript(options.projectRoot);
 };
 
-const AGENT_INSTALL_HINT_LINES = [
+export const AGENT_INSTALL_HINT_LINES = [
   "React Doctor is not installed in this project.",
   "Ask the user if they would like to set it up, then run:",
   "",
@@ -273,8 +273,6 @@ const AGENT_INSTALL_HINT_LINES = [
   "",
   "This adds agent skill files, a `doctor` package script, and react-doctor as a dev dependency.",
 ] as const;
-
-export const buildAgentInstallHintLines = (): readonly string[] => AGENT_INSTALL_HINT_LINES;
 
 export const printAgentInstallHint = (writeLine: SetupPitchWriter = defaultWriteLine): void => {
   writeLine("");

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -164,8 +164,8 @@ const defaultSelect: SetupPromptSelect = async (message) => {
           value: SETUP_PROMPT_CHOICE_YES,
         },
         {
-          title: "No, and don't ask again",
-          description: "You can always run npx react-doctor@latest install later",
+          title: "Skip",
+          description: "Not recommended — issues may go unfixed",
           value: SETUP_PROMPT_CHOICE_NEVER,
         },
       ],

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -158,18 +158,14 @@ const defaultSelect: SetupPromptSelect = async (message) => {
       name: "setupReactDoctorChoice",
       message,
       choices: [
-        { title: "Yes", value: SETUP_PROMPT_CHOICE_YES },
-        { title: "No", value: SETUP_PROMPT_CHOICE_NO },
-        {
-          title: "No, never ask again for this project",
-          value: SETUP_PROMPT_CHOICE_NEVER,
-        },
+        { title: "Yes (recommended)", value: SETUP_PROMPT_CHOICE_YES },
+        { title: "No, and don't ask again", value: SETUP_PROMPT_CHOICE_NEVER },
       ],
       initial: 0,
     },
     { onCancel: () => true },
   );
-  return setupReactDoctorChoice ?? SETUP_PROMPT_CHOICE_NO;
+  return setupReactDoctorChoice ?? SETUP_PROMPT_CHOICE_NEVER;
 };
 
 const defaultWriteLine: SetupPitchWriter = (line = "") => {
@@ -213,11 +209,15 @@ export const promptInstallSetup = async (options: PromptInstallSetupOptions): Pr
     const setupReactDoctorChoice = await (options.select ?? defaultSelect)(
       "Set up React Doctor for this project?",
     );
-    if (setupReactDoctorChoice === SETUP_PROMPT_CHOICE_NEVER) {
-      disableSetupPrompt(options.projectRoot, options.store);
+    if (setupReactDoctorChoice !== SETUP_PROMPT_CHOICE_YES) {
+      if (setupReactDoctorChoice === SETUP_PROMPT_CHOICE_NEVER) {
+        disableSetupPrompt(options.projectRoot, options.store);
+      }
+      const writeLine = options.writeLine ?? defaultWriteLine;
+      writeLine("");
+      writeLine("You can always run `npx react-doctor@latest install` to set it up later.");
       return;
     }
-    if (setupReactDoctorChoice !== SETUP_PROMPT_CHOICE_YES) return;
 
     const install = options.install ?? (await import("./install-skill.js")).runInstallSkill;
     const previousExitCode = process.exitCode;

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -210,11 +210,6 @@ export const promptInstallSetup = async (options: PromptInstallSetupOptions): Pr
 
     await (options.wait ?? defaultWait)(SETUP_PROMPT_DELAY_MS);
 
-    const writeLine = options.writeLine ?? defaultWriteLine;
-    for (const line of buildInstallSetupPitchLines(options.issueCount)) {
-      writeLine(line);
-    }
-
     const setupReactDoctorChoice = await (options.select ?? defaultSelect)(
       "Set up React Doctor for this project?",
     );

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -1,3 +1,4 @@
+import isUnicodeSupported from "is-unicode-supported";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import {
@@ -8,6 +9,8 @@ import {
 } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
 import { indentMultilineText } from "./indent-multiline-text.js";
+
+const POINTER = isUnicodeSupported() ? "›" : ">";
 
 const SEVERITY_ORDER: Record<Diagnostic["severity"], number> = {
   error: 0,
@@ -129,7 +132,7 @@ const buildCompactCategoryLine = (categoryGroup: CategoryDiagnosticGroup): strin
     parts.push(highlighter.error(`${errorCount} ${errorCount === 1 ? "error" : "errors"}`));
   if (warningCount > 0)
     parts.push(highlighter.warn(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`));
-  return `  ${highlighter.bold(categoryGroup.category)} ${highlighter.dim("›")} ${parts.join(highlighter.dim(", "))}`;
+  return `  ${highlighter.bold(categoryGroup.category)} ${highlighter.dim(POINTER)} ${parts.join(highlighter.dim(", "))}`;
 };
 
 const buildVerboseRuleGroupLines = (

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -131,7 +131,11 @@ const buildCompactCategoryLine = (categoryGroup: CategoryDiagnosticGroup): strin
   if (errorCount > 0)
     parts.push(highlighter.error(`${errorCount} ${errorCount === 1 ? "error" : "errors"}`));
   if (warningCount > 0)
-    parts.push(highlighter.warn(highlighter.dim(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`)));
+    parts.push(
+      highlighter.warn(
+        highlighter.dim(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`),
+      ),
+    );
   return `  ${highlighter.bold(categoryGroup.category)} ${highlighter.dim(POINTER)} ${parts.join(highlighter.dim(", "))}`;
 };
 

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -129,7 +129,7 @@ const buildCompactCategoryLine = (categoryGroup: CategoryDiagnosticGroup): strin
     parts.push(highlighter.error(`${errorCount} ${errorCount === 1 ? "error" : "errors"}`));
   if (warningCount > 0)
     parts.push(highlighter.warn(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`));
-  return `  ${highlighter.bold(categoryGroup.category)}  ${parts.join(highlighter.dim(", "))}`;
+  return `  ${highlighter.bold(categoryGroup.category)} ${highlighter.dim("›")} ${parts.join(highlighter.dim(", "))}`;
 };
 
 const buildVerboseRuleGroupLines = (

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -175,8 +175,6 @@ const buildDefaultDiagnosticsLines = (diagnostics: Diagnostic[]): ReadonlyArray<
     lines.push(buildCompactCategoryLine(categoryGroup));
   }
   lines.push("");
-  lines.push(grayLine("  Run `npx react-doctor@latest . --verbose` to see details"));
-  lines.push("");
   return lines;
 };
 

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -131,7 +131,7 @@ const buildCompactCategoryLine = (categoryGroup: CategoryDiagnosticGroup): strin
   if (errorCount > 0)
     parts.push(highlighter.error(`${errorCount} ${errorCount === 1 ? "error" : "errors"}`));
   if (warningCount > 0)
-    parts.push(highlighter.dim(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`));
+    parts.push(highlighter.warn(highlighter.dim(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`)));
   return `  ${highlighter.bold(categoryGroup.category)} ${highlighter.dim(POINTER)} ${parts.join(highlighter.dim(", "))}`;
 };
 

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -3,17 +3,11 @@ import * as Effect from "effect/Effect";
 import {
   groupBy,
   highlighter,
-  MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE,
-  MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
   MILLISECONDS_PER_SECOND,
-  OUTPUT_DETAIL_WRAP_WIDTH_CHARS,
   RULE_NAME_COLUMN_WIDTH_CHARS,
-  toRelativePath,
 } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
-import { buildHiddenDiagnosticsSummary } from "./build-hidden-diagnostics-summary.js";
 import { indentMultilineText } from "./indent-multiline-text.js";
-import { wrapIndentedText } from "./wrap-indented-text.js";
 
 const SEVERITY_ORDER: Record<Diagnostic["severity"], number> = {
   error: 0,
@@ -59,17 +53,6 @@ const buildVerboseSiteMap = (diagnostics: Diagnostic[]): Map<string, VerboseSite
 
 const formatSiteCountBadge = (count: number): string => (count > 1 ? `×${count}` : "");
 
-const formatIssueCount = (count: number): string => `${count} ${count === 1 ? "issue" : "issues"}`;
-
-const toRuleTitle = (ruleName: string): string => {
-  const readableRuleName = ruleName
-    .replace(/^(no|prefer|require|use)-/, "")
-    .replace(/^(nextjs|tanstack-start)-/, "")
-    .replaceAll("-", " ");
-  const title = readableRuleName.charAt(0).toUpperCase() + readableRuleName.slice(1);
-  return title.replace(/\b(css|html|url|svg|jsx|api|ua)\b/gi, (match) => match.toUpperCase());
-};
-
 const computeRuleNameColumnWidth = (ruleKeys: string[]): number => {
   const longestRuleNameLength = ruleKeys.reduce(
     (longest, ruleKey) => Math.max(longest, ruleKey.length),
@@ -84,9 +67,6 @@ const padRuleNameToColumn = (ruleName: string, columnWidth: number): string => {
 };
 
 const grayLine = (text: string): string => highlighter.gray(text);
-
-const grayWrappedLine = (text: string, linePrefix: string): string =>
-  grayLine(wrapIndentedText(text, linePrefix, OUTPUT_DETAIL_WRAP_WIDTH_CHARS));
 
 const buildCompactRuleGroupLine = (
   ruleKey: string,
@@ -137,49 +117,19 @@ const buildCategoryDiagnosticGroups = (diagnostics: Diagnostic[]): CategoryDiagn
     });
 };
 
-const buildDefaultRuleGroupLines = (
-  ruleKey: string,
-  ruleDiagnostics: Diagnostic[],
-  rootDirectory: string,
-): ReadonlyArray<string> => {
-  const firstDiagnostic = ruleDiagnostics[0];
-  const ruleTitle = toRuleTitle(firstDiagnostic.rule);
-  const severitySymbol = firstDiagnostic.severity === "error" ? "✗" : "⚠";
-  const icon = colorizeBySeverity(severitySymbol, firstDiagnostic.severity);
-  const siteCountBadge = formatSiteCountBadge(ruleDiagnostics.length);
-  const trailingBadge = siteCountBadge.length > 0 ? ` ${highlighter.gray(siteCountBadge)}` : "";
-
-  const lines: string[] = [];
-  lines.push(`  ${icon} ${ruleTitle}${trailingBadge}`);
-  lines.push(grayWrappedLine(firstDiagnostic.message, "    "));
-  if (firstDiagnostic.help) {
-    lines.push(grayWrappedLine(firstDiagnostic.help, "    "));
-  }
-  if (firstDiagnostic.url) {
-    lines.push(grayLine(`    ${firstDiagnostic.url}`));
-  }
-  const firstLocation = ruleDiagnostics.find((diagnostic) => diagnostic.line > 0);
-  if (firstLocation) {
-    const locationPath = toRelativePath(firstLocation.filePath, rootDirectory);
-    lines.push(grayLine(`    ${locationPath}:${firstLocation.line}`));
-  }
-  return lines;
-};
-
-const buildDefaultCategoryGroupLines = (
-  categoryGroup: CategoryDiagnosticGroup,
-  visibleRuleGroups: [string, Diagnostic[]][],
-  rootDirectory: string,
-): ReadonlyArray<string> => {
-  const issueCount = formatIssueCount(categoryGroup.diagnostics.length);
-  const lines: string[] = [
-    `${highlighter.bold(categoryGroup.category)} ${highlighter.dim(issueCount)}`,
-  ];
-  for (const [ruleKey, ruleDiagnostics] of visibleRuleGroups) {
-    lines.push(...buildDefaultRuleGroupLines(ruleKey, ruleDiagnostics, rootDirectory));
-  }
-  lines.push("");
-  return lines;
+const buildCompactCategoryLine = (categoryGroup: CategoryDiagnosticGroup): string => {
+  const errorCount = categoryGroup.diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "error",
+  ).length;
+  const warningCount = categoryGroup.diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "warning",
+  ).length;
+  const parts: string[] = [];
+  if (errorCount > 0)
+    parts.push(highlighter.error(`${errorCount} ${errorCount === 1 ? "error" : "errors"}`));
+  if (warningCount > 0)
+    parts.push(highlighter.warn(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`));
+  return `  ${highlighter.bold(categoryGroup.category)}  ${parts.join(highlighter.dim(", "))}`;
 };
 
 const buildVerboseRuleGroupLines = (
@@ -211,50 +161,15 @@ const buildVerboseRuleGroupLines = (
   return lines;
 };
 
-const buildHiddenDiagnosticsLines = (
-  hiddenRuleGroups: [string, Diagnostic[]][],
-): ReadonlyArray<string> => {
-  const hiddenDiagnostics = hiddenRuleGroups.flatMap(([, ruleDiagnostics]) => ruleDiagnostics);
-  const renderedParts = buildHiddenDiagnosticsSummary(hiddenDiagnostics).map((part) => {
-    const [icon, ...labelParts] = part.text.split(" ");
-    return `${colorizeBySeverity(icon, part.severity)} ${highlighter.dim(labelParts.join(" "))}`;
-  });
-
-  return [
-    `  ${renderedParts.join("  ")}`,
-    grayLine("    Run `npx react-doctor@latest . --verbose` to get all details"),
-    "",
-  ];
-};
-
-const buildDefaultDiagnosticsLines = (
-  diagnostics: Diagnostic[],
-  rootDirectory: string,
-): ReadonlyArray<string> => {
+const buildDefaultDiagnosticsLines = (diagnostics: Diagnostic[]): ReadonlyArray<string> => {
   const categoryGroups = buildCategoryDiagnosticGroups(diagnostics);
-  const hiddenRuleGroups: [string, Diagnostic[]][] = [];
-  const visibleCategoryGroups = categoryGroups.slice(0, MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE);
-  const hiddenCategoryGroups = categoryGroups.slice(MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE);
-
   const lines: string[] = [];
-  for (const categoryGroup of visibleCategoryGroups) {
-    const visibleRuleGroups = categoryGroup.ruleGroups.slice(
-      0,
-      MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
-    );
-    const remainingRuleGroups = categoryGroup.ruleGroups.slice(
-      MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
-    );
-    lines.push(...buildDefaultCategoryGroupLines(categoryGroup, visibleRuleGroups, rootDirectory));
-    hiddenRuleGroups.push(...remainingRuleGroups);
+  for (const categoryGroup of categoryGroups) {
+    lines.push(buildCompactCategoryLine(categoryGroup));
   }
-  hiddenRuleGroups.push(
-    ...hiddenCategoryGroups.flatMap((categoryGroup) => categoryGroup.ruleGroups),
-  );
-
-  if (hiddenRuleGroups.length > 0) {
-    lines.push(...buildHiddenDiagnosticsLines(hiddenRuleGroups));
-  }
+  lines.push("");
+  lines.push(grayLine("  Run `npx react-doctor@latest . --verbose` to see details"));
+  lines.push("");
   return lines;
 };
 
@@ -272,7 +187,7 @@ export const printDiagnostics = (
   Effect.gen(function* () {
     let lines: ReadonlyArray<string>;
     if (!isVerbose) {
-      lines = buildDefaultDiagnosticsLines(diagnostics, rootDirectory);
+      lines = buildDefaultDiagnosticsLines(diagnostics);
     } else {
       const ruleGroups = groupBy(
         diagnostics,

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -131,7 +131,7 @@ const buildCompactCategoryLine = (categoryGroup: CategoryDiagnosticGroup): strin
   if (errorCount > 0)
     parts.push(highlighter.error(`${errorCount} ${errorCount === 1 ? "error" : "errors"}`));
   if (warningCount > 0)
-    parts.push(highlighter.warn(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`));
+    parts.push(highlighter.dim(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`));
   return `  ${highlighter.bold(categoryGroup.category)} ${highlighter.dim(POINTER)} ${parts.join(highlighter.dim(", "))}`;
 };
 

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -33,10 +33,7 @@ const getScoreLabel = (score: number): string => {
   return "Needs work";
 };
 
-const buildSummaryLine = (
-  entry: ProjectScanEntry,
-  longestProjectNameLength: number,
-): string => {
+const buildSummaryLine = (entry: ProjectScanEntry, longestProjectNameLength: number): string => {
   const paddedName = entry.projectName.padEnd(longestProjectNameLength);
   const nameRendering =
     entry.score !== null ? colorizeByScore(paddedName, entry.score) : highlighter.dim(paddedName);
@@ -89,20 +86,12 @@ export interface MultiProjectSummaryInput {
   readonly verbose: boolean;
 }
 
-export const printMultiProjectSummary = (
-  input: MultiProjectSummaryInput,
-): Effect.Effect<void> =>
+export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effect.Effect<void> =>
   Effect.gen(function* () {
     const { completedScans, userConfig, verbose } = input;
 
-    const allDiagnostics: Diagnostic[] = completedScans.flatMap(
-      (scan) => scan.result.diagnostics,
-    );
-    const surfaceDiagnostics = filterDiagnosticsForSurface(
-      allDiagnostics,
-      "cli",
-      userConfig,
-    );
+    const allDiagnostics: Diagnostic[] = completedScans.flatMap((scan) => scan.result.diagnostics);
+    const surfaceDiagnostics = filterDiagnosticsForSurface(allDiagnostics, "cli", userConfig);
 
     if (surfaceDiagnostics.length > 0) {
       yield* Console.log("");
@@ -142,9 +131,7 @@ export const printMultiProjectSummary = (
       };
     });
 
-    const longestProjectNameLength = Math.max(
-      ...entries.map((entry) => entry.projectName.length),
-    );
+    const longestProjectNameLength = Math.max(...entries.map((entry) => entry.projectName.length));
 
     for (const entry of entries) {
       yield* Console.log(buildSummaryLine(entry, longestProjectNameLength));

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -1,0 +1,154 @@
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import {
+  filterDiagnosticsForSurface,
+  highlighter,
+  PERFECT_SCORE,
+  SCORE_GOOD_THRESHOLD,
+  SCORE_OK_THRESHOLD,
+} from "@react-doctor/core";
+import type { Diagnostic, InspectResult, ReactDoctorConfig, ScoreResult } from "@react-doctor/core";
+import { colorizeByScore } from "./colorize-by-score.js";
+import { printDiagnostics } from "./render-diagnostics.js";
+import { printSummary } from "./render-summary.js";
+
+const SUMMARY_BAR_WIDTH_CHARS = 20;
+
+interface ProjectScanEntry {
+  readonly projectName: string;
+  readonly score: number | null;
+  readonly issueCount: number;
+  readonly errorCount: number;
+}
+
+const buildMiniBar = (score: number): string => {
+  const filledCount = Math.round((score / PERFECT_SCORE) * SUMMARY_BAR_WIDTH_CHARS);
+  const emptyCount = SUMMARY_BAR_WIDTH_CHARS - filledCount;
+  return colorizeByScore("█".repeat(filledCount), score) + highlighter.dim("░".repeat(emptyCount));
+};
+
+const getScoreLabel = (score: number): string => {
+  if (score >= SCORE_GOOD_THRESHOLD) return "Great";
+  if (score >= SCORE_OK_THRESHOLD) return "OK";
+  return "Needs work";
+};
+
+const buildSummaryLine = (
+  entry: ProjectScanEntry,
+  longestProjectNameLength: number,
+): string => {
+  const paddedName = entry.projectName.padEnd(longestProjectNameLength);
+  const nameRendering =
+    entry.score !== null ? colorizeByScore(paddedName, entry.score) : highlighter.dim(paddedName);
+
+  if (entry.score === null) {
+    const issueLabel = `${entry.issueCount} ${entry.issueCount === 1 ? "issue" : "issues"}`;
+    return `  ${nameRendering}  ${highlighter.dim("—".repeat(SUMMARY_BAR_WIDTH_CHARS))}  ${highlighter.dim("no score")}  ${highlighter.dim(issueLabel)}`;
+  }
+
+  const scoreRendering = colorizeByScore(String(entry.score).padStart(3), entry.score);
+  const bar = buildMiniBar(entry.score);
+  const label = colorizeByScore(getScoreLabel(entry.score), entry.score);
+
+  const issuesParts: string[] = [];
+  if (entry.errorCount > 0) {
+    issuesParts.push(
+      highlighter.error(`${entry.errorCount} ${entry.errorCount === 1 ? "error" : "errors"}`),
+    );
+  }
+  const warningCount = entry.issueCount - entry.errorCount;
+  if (warningCount > 0) {
+    issuesParts.push(
+      highlighter.warn(`${warningCount} ${warningCount === 1 ? "warning" : "warnings"}`),
+    );
+  }
+  const issuesRendering = issuesParts.length > 0 ? issuesParts.join(highlighter.dim(", ")) : "";
+
+  return `  ${nameRendering}  ${scoreRendering}  ${bar}  ${label}  ${issuesRendering}`;
+};
+
+const computeAggregateScore = (
+  completedScans: ReadonlyArray<{ readonly result: InspectResult }>,
+): ScoreResult | null => {
+  const scoredScans = completedScans.filter(
+    (scan): scan is { readonly result: InspectResult & { score: ScoreResult } } =>
+      scan.result.score !== null,
+  );
+  if (scoredScans.length === 0) return null;
+
+  const lowestScoredScan = scoredScans.reduce((worst, scan) =>
+    scan.result.score.score < worst.result.score.score ? scan : worst,
+  );
+
+  return lowestScoredScan.result.score;
+};
+
+export interface MultiProjectSummaryInput {
+  readonly completedScans: ReadonlyArray<{ readonly result: InspectResult }>;
+  readonly userConfig: ReactDoctorConfig | null;
+  readonly verbose: boolean;
+}
+
+export const printMultiProjectSummary = (
+  input: MultiProjectSummaryInput,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const { completedScans, userConfig, verbose } = input;
+
+    const allDiagnostics: Diagnostic[] = completedScans.flatMap(
+      (scan) => scan.result.diagnostics,
+    );
+    const surfaceDiagnostics = filterDiagnosticsForSurface(
+      allDiagnostics,
+      "cli",
+      userConfig,
+    );
+
+    if (surfaceDiagnostics.length > 0) {
+      yield* Console.log("");
+      yield* printDiagnostics(surfaceDiagnostics, verbose, "");
+    }
+
+    const aggregateScore = computeAggregateScore(completedScans);
+    const totalSourceFileCount = completedScans.reduce(
+      (sum, scan) => sum + scan.result.project.sourceFileCount,
+      0,
+    );
+    const totalElapsedMilliseconds = completedScans.reduce(
+      (sum, scan) => sum + scan.result.elapsedMilliseconds,
+      0,
+    );
+
+    yield* printSummary({
+      diagnostics: surfaceDiagnostics,
+      elapsedMilliseconds: totalElapsedMilliseconds,
+      scoreResult: aggregateScore,
+      projectName: completedScans.map((scan) => scan.result.project.projectName).join(", "),
+      totalSourceFileCount,
+      noScoreMessage: "Score unavailable.",
+      isOffline: true,
+      verbose,
+    });
+
+    const entries: ProjectScanEntry[] = completedScans.map((scan) => {
+      const errorCount = scan.result.diagnostics.filter(
+        (diagnostic) => diagnostic.severity === "error",
+      ).length;
+      return {
+        projectName: scan.result.project.projectName,
+        score: scan.result.score?.score ?? null,
+        issueCount: scan.result.diagnostics.length,
+        errorCount,
+      };
+    });
+
+    const longestProjectNameLength = Math.max(
+      ...entries.map((entry) => entry.projectName.length),
+    );
+
+    for (const entry of entries) {
+      yield* Console.log(buildSummaryLine(entry, longestProjectNameLength));
+    }
+
+    yield* Console.log("");
+  });

--- a/packages/react-doctor/src/cli/utils/render-project-detection.ts
+++ b/packages/react-doctor/src/cli/utils/render-project-detection.ts
@@ -1,7 +1,4 @@
-import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import { highlighter } from "@react-doctor/core";
-import { formatFrameworkName } from "@react-doctor/core";
 import type { ProjectInfo, ReactDoctorConfig } from "@react-doctor/core";
 
 export interface PrintProjectDetectionInput {
@@ -12,33 +9,5 @@ export interface PrintProjectDetectionInput {
   readonly lintSourceFileCount: number | undefined;
 }
 
-const buildProjectSummaryParts = (input: PrintProjectDetectionInput): string[] => {
-  const parts: string[] = [];
-  parts.push(highlighter.info(formatFrameworkName(input.projectInfo.framework)));
-  parts.push(highlighter.info(`React ${input.projectInfo.reactVersion}`));
-  parts.push(highlighter.info(input.projectInfo.hasTypeScript ? "TypeScript" : "JavaScript"));
-  if (input.projectInfo.tailwindVersion) {
-    parts.push(highlighter.info(`Tailwind ${input.projectInfo.tailwindVersion}`));
-  }
-  if (input.projectInfo.hasReactCompiler) {
-    parts.push(highlighter.info("React Compiler"));
-  }
-  return parts;
-};
-
-const buildFileCountLabel = (input: PrintProjectDetectionInput): string => {
-  if (input.isDiffMode) {
-    return `${highlighter.info(`${input.includePaths.length}`)} changed files`;
-  }
-  const fileCount = input.lintSourceFileCount ?? input.projectInfo.sourceFileCount;
-  return `${highlighter.info(`${fileCount}`)} files`;
-};
-
-export const printProjectDetection = (input: PrintProjectDetectionInput): Effect.Effect<void> =>
-  Effect.gen(function* () {
-    const projectParts = buildProjectSummaryParts(input);
-    const fileCountLabel = buildFileCountLabel(input);
-    const configLabel = input.userConfig ? ` · ${highlighter.info("config loaded")}` : "";
-    yield* Console.log(`  ${projectParts.join(" · ")} · ${fileCountLabel}${configLabel}`);
-    yield* Console.log("");
-  });
+export const printProjectDetection = (_input: PrintProjectDetectionInput): Effect.Effect<void> =>
+  Effect.void;

--- a/packages/react-doctor/src/cli/utils/render-project-detection.ts
+++ b/packages/react-doctor/src/cli/utils/render-project-detection.ts
@@ -3,7 +3,6 @@ import * as Effect from "effect/Effect";
 import { highlighter } from "@react-doctor/core";
 import { formatFrameworkName } from "@react-doctor/core";
 import type { ProjectInfo, ReactDoctorConfig } from "@react-doctor/core";
-import { spinner } from "./spinner.js";
 
 export interface PrintProjectDetectionInput {
   readonly projectInfo: ProjectInfo;
@@ -13,54 +12,33 @@ export interface PrintProjectDetectionInput {
   readonly lintSourceFileCount: number | undefined;
 }
 
-/**
- * Each "completed step" is rendered by ora's `succeed` (writes a
- * green ✔ + the supplied label) — the ora handle is created, started,
- * and immediately succeeded so the user sees a static checklist
- * rather than a spinning frame for steps that finish synchronously.
- * The wrapping `Effect.sync` keeps the imperative IO inside the
- * Effect graph so cancellation / Console swap behave consistently
- * with the rest of the renderer.
- */
-const completeStep = (message: string): Effect.Effect<void> =>
-  Effect.sync(() => {
-    spinner(message).start().succeed(message);
-  });
+const buildProjectSummaryParts = (input: PrintProjectDetectionInput): string[] => {
+  const parts: string[] = [];
+  parts.push(highlighter.info(formatFrameworkName(input.projectInfo.framework)));
+  parts.push(highlighter.info(`React ${input.projectInfo.reactVersion}`));
+  parts.push(highlighter.info(input.projectInfo.hasTypeScript ? "TypeScript" : "JavaScript"));
+  if (input.projectInfo.tailwindVersion) {
+    parts.push(highlighter.info(`Tailwind ${input.projectInfo.tailwindVersion}`));
+  }
+  if (input.projectInfo.hasReactCompiler) {
+    parts.push(highlighter.info("React Compiler"));
+  }
+  return parts;
+};
+
+const buildFileCountLabel = (input: PrintProjectDetectionInput): string => {
+  if (input.isDiffMode) {
+    return `${highlighter.info(`${input.includePaths.length}`)} changed files`;
+  }
+  const fileCount = input.lintSourceFileCount ?? input.projectInfo.sourceFileCount;
+  return `${highlighter.info(`${fileCount}`)} files`;
+};
 
 export const printProjectDetection = (input: PrintProjectDetectionInput): Effect.Effect<void> =>
   Effect.gen(function* () {
-    const frameworkLabel = formatFrameworkName(input.projectInfo.framework);
-    const languageLabel = input.projectInfo.hasTypeScript ? "TypeScript" : "JavaScript";
-
-    yield* completeStep(`Detecting framework. Found ${highlighter.info(frameworkLabel)}.`);
-    yield* completeStep(
-      `Detecting React version. Found ${highlighter.info(`React ${input.projectInfo.reactVersion}`)}.`,
-    );
-    yield* completeStep(
-      `Detecting Tailwind. ${
-        input.projectInfo.tailwindVersion
-          ? `Found ${highlighter.info(`Tailwind ${input.projectInfo.tailwindVersion}`)}.`
-          : "Not found."
-      }`,
-    );
-    yield* completeStep(`Detecting language. Found ${highlighter.info(languageLabel)}.`);
-    yield* completeStep(
-      `Detecting React Compiler. ${input.projectInfo.hasReactCompiler ? highlighter.info("Found React Compiler.") : "Not found."}`,
-    );
-
-    if (input.isDiffMode) {
-      yield* completeStep(
-        `Scanning ${highlighter.info(`${input.includePaths.length}`)} changed source files.`,
-      );
-    } else {
-      yield* completeStep(
-        `Found ${highlighter.info(`${input.lintSourceFileCount ?? input.projectInfo.sourceFileCount}`)} source files.`,
-      );
-    }
-
-    if (input.userConfig) {
-      yield* completeStep(`Loaded ${highlighter.info("react-doctor config")}.`);
-    }
-
+    const projectParts = buildProjectSummaryParts(input);
+    const fileCountLabel = buildFileCountLabel(input);
+    const configLabel = input.userConfig ? ` · ${highlighter.info("config loaded")}` : "";
+    yield* Console.log(`  ${projectParts.join(" · ")} · ${fileCountLabel}${configLabel}`);
     yield* Console.log("");
   });

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -66,31 +66,51 @@ const writeScoreHeaderLine = (line: string): Effect.Effect<void> =>
     process.stdout.write(line);
   });
 
-const printAnimatedScoreBarLine = (faceLine: string, score: number): Effect.Effect<void> =>
+const buildScoreLine = (displayScore: number, finalScore: number, label: string): string => {
+  const scoreNumber = colorizeByScore(`${displayScore}`, finalScore);
+  const scoreLabel = colorizeByScore(label, finalScore);
+  return `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}`;
+};
+
+const printAnimatedScore = (
+  scoreFaceLine: string,
+  barFaceLine: string,
+  score: number,
+  label: string,
+): Effect.Effect<void> =>
   Effect.gen(function* () {
     for (let frame = 0; frame <= SCORE_BAR_ANIMATION_FRAME_COUNT; frame += 1) {
       const progress = easeOutCubic(frame / SCORE_BAR_ANIMATION_FRAME_COUNT);
       const animatedScore = Math.round(score * progress);
-      const scoreBarLine = buildScoreBar(animatedScore, score);
-      yield* writeScoreHeaderLine(`\r${buildScoreHeaderLine(faceLine, scoreBarLine)}`);
+      const animatedScoreLine = buildScoreLine(animatedScore, score, label);
+      const animatedBarLine = buildScoreBar(animatedScore, score);
+      // HACK: \x1b[2A moves cursor up 2 lines to overwrite both the
+      // score number line and the bar line in place each frame.
+      const cursorUp = frame === 0 ? "" : "\x1b[2A";
+      yield* writeScoreHeaderLine(
+        `${cursorUp}\r${buildScoreHeaderLine(scoreFaceLine, animatedScoreLine)}\n\r${buildScoreHeaderLine(barFaceLine, animatedBarLine)}\n`,
+      );
       if (frame < SCORE_BAR_ANIMATION_FRAME_COUNT) {
         yield* sleep(SCORE_BAR_ANIMATION_FRAME_DELAY_MS);
       }
     }
-    yield* writeScoreHeaderLine("\n");
   });
 
 export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> =>
   Effect.gen(function* () {
     const renderedFaceLines = buildFaceRenderedLines(scoreResult.score);
-
-    const scoreNumber = colorizeByScore(`${scoreResult.score}`, scoreResult.score);
-    const scoreLabel = colorizeByScore(scoreResult.label, scoreResult.score);
-    const scoreLine = `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}`;
-    const scoreBarLine = buildScoreBar(scoreResult.score);
-
     const shouldAnimate = !isSpinnerSilent() && isSpinnerInteractive(process.stdout);
-    const rightColumnLines = [scoreLine, shouldAnimate ? "" : scoreBarLine, BRANDING_LINE, ""];
+
+    const scoreLine = buildScoreLine(
+      shouldAnimate ? 0 : scoreResult.score,
+      scoreResult.score,
+      scoreResult.label,
+    );
+    const scoreBarLine = shouldAnimate
+      ? buildScoreBar(0, scoreResult.score)
+      : buildScoreBar(scoreResult.score);
+
+    const rightColumnLines = [scoreLine, scoreBarLine, BRANDING_LINE, ""];
 
     for (let lineIndex = 0; lineIndex < renderedFaceLines.length; lineIndex += 1) {
       const rightColumnContent = rightColumnLines[lineIndex] ?? "";
@@ -99,12 +119,17 @@ export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> 
     yield* Console.log("");
 
     if (shouldAnimate) {
-      // HACK: move cursor up to the score bar line (line index 1 of
-      // the 4-line face block + 1 trailing blank = 4 lines up) and
-      // animate the bar in place, then restore the cursor position.
-      yield* writeScoreHeaderLine(`\x1b[4A`);
-      yield* printAnimatedScoreBarLine(renderedFaceLines[1], scoreResult.score);
-      yield* writeScoreHeaderLine(`\x1b[3B`);
+      // HACK: move cursor up to the score number line (5 lines up:
+      // 4 face lines + 1 trailing blank) and animate score + bar
+      // together, then move cursor back down past branding + blank.
+      yield* writeScoreHeaderLine("\x1b[5A");
+      yield* printAnimatedScore(
+        renderedFaceLines[0],
+        renderedFaceLines[1],
+        scoreResult.score,
+        scoreResult.label,
+      );
+      yield* writeScoreHeaderLine("\x1b[3B");
     }
   });
 

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -74,7 +74,9 @@ const buildScoreLine = (
 ): string => {
   const scoreNumber = colorizeByScore(`${displayScore}`, finalScore);
   const scoreLabel = colorizeByScore(label, finalScore);
-  const projectSuffix = projectName ? ` ${highlighter.dim("·")} ${highlighter.dim(projectName)}` : "";
+  const projectSuffix = projectName
+    ? ` ${highlighter.dim("·")} ${highlighter.dim(projectName)}`
+    : "";
   return `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}${projectSuffix}`;
 };
 

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -12,8 +12,8 @@ import { colorizeByScore } from "./colorize-by-score.js";
 import { isSpinnerInteractive } from "./is-spinner-interactive.js";
 import { isSpinnerSilent } from "./spinner.js";
 
-const SCORE_BAR_ANIMATION_FRAME_COUNT = 12;
-const SCORE_BAR_ANIMATION_FRAME_DELAY_MS = 20;
+const SCORE_BAR_ANIMATION_FRAME_COUNT = 80;
+const SCORE_BAR_ANIMATION_FRAME_DELAY_MS = 50;
 
 interface ScoreBarSegments {
   filledSegment: string;

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -12,7 +12,7 @@ import { colorizeByScore } from "./colorize-by-score.js";
 import { isSpinnerInteractive } from "./is-spinner-interactive.js";
 import { isSpinnerSilent } from "./spinner.js";
 
-const SCORE_BAR_ANIMATION_FRAME_COUNT = 80;
+const SCORE_BAR_ANIMATION_FRAME_COUNT = 40;
 const SCORE_BAR_ANIMATION_FRAME_DELAY_MS = 50;
 
 interface ScoreBarSegments {
@@ -48,7 +48,7 @@ const getDoctorFace = (score: number): string[] => {
   return ["x x", " ▽ "];
 };
 
-const BRANDING_LINE = `React Doctor ${highlighter.dim("(www.react.doctor)")}`;
+const BRANDING_LINE = `React Doctor ${highlighter.dim("(https://react.doctor)")}`;
 
 const buildFaceRenderedLines = (score: number): string[] => {
   const [eyes, mouth] = getDoctorFace(score);
@@ -66,10 +66,16 @@ const writeScoreHeaderLine = (line: string): Effect.Effect<void> =>
     process.stdout.write(line);
   });
 
-const buildScoreLine = (displayScore: number, finalScore: number, label: string): string => {
+const buildScoreLine = (
+  displayScore: number,
+  finalScore: number,
+  label: string,
+  projectName?: string,
+): string => {
   const scoreNumber = colorizeByScore(`${displayScore}`, finalScore);
   const scoreLabel = colorizeByScore(label, finalScore);
-  return `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}`;
+  const projectSuffix = projectName ? ` ${highlighter.dim("·")} ${highlighter.dim(projectName)}` : "";
+  return `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}${projectSuffix}`;
 };
 
 const printAnimatedScore = (
@@ -77,12 +83,13 @@ const printAnimatedScore = (
   barFaceLine: string,
   score: number,
   label: string,
+  projectName?: string,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     for (let frame = 0; frame <= SCORE_BAR_ANIMATION_FRAME_COUNT; frame += 1) {
       const progress = easeOutCubic(frame / SCORE_BAR_ANIMATION_FRAME_COUNT);
       const animatedScore = Math.round(score * progress);
-      const animatedScoreLine = buildScoreLine(animatedScore, score, label);
+      const animatedScoreLine = buildScoreLine(animatedScore, score, label, projectName);
       const animatedBarLine = buildScoreBar(animatedScore, score);
       // HACK: \x1b[2A moves cursor up 2 lines to overwrite both the
       // score number line and the bar line in place each frame.
@@ -96,7 +103,10 @@ const printAnimatedScore = (
     }
   });
 
-export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> =>
+export const printScoreHeader = (
+  scoreResult: ScoreResult,
+  projectName?: string,
+): Effect.Effect<void> =>
   Effect.gen(function* () {
     const renderedFaceLines = buildFaceRenderedLines(scoreResult.score);
     const shouldAnimate = !isSpinnerSilent() && isSpinnerInteractive(process.stdout);
@@ -105,6 +115,7 @@ export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> 
       shouldAnimate ? 0 : scoreResult.score,
       scoreResult.score,
       scoreResult.label,
+      projectName,
     );
     const scoreBarLine = shouldAnimate
       ? buildScoreBar(0, scoreResult.score)
@@ -128,6 +139,7 @@ export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> 
         renderedFaceLines[1],
         scoreResult.score,
         scoreResult.label,
+        projectName,
       );
       yield* writeScoreHeaderLine("\x1b[3B");
     }

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -89,18 +89,23 @@ export const printScoreHeader = (scoreResult: ScoreResult): Effect.Effect<void> 
     const scoreLine = `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}`;
     const scoreBarLine = buildScoreBar(scoreResult.score);
 
-    const rightColumnLines = [scoreLine, scoreBarLine, BRANDING_LINE, ""];
+    const shouldAnimate = !isSpinnerSilent() && isSpinnerInteractive(process.stdout);
+    const rightColumnLines = [scoreLine, shouldAnimate ? "" : scoreBarLine, BRANDING_LINE, ""];
 
     for (let lineIndex = 0; lineIndex < renderedFaceLines.length; lineIndex += 1) {
       const rightColumnContent = rightColumnLines[lineIndex] ?? "";
-      if (lineIndex === 1 && !isSpinnerSilent() && isSpinnerInteractive(process.stdout)) {
-        yield* printAnimatedScoreBarLine(renderedFaceLines[lineIndex], scoreResult.score);
-        continue;
-      }
       yield* Console.log(buildScoreHeaderLine(renderedFaceLines[lineIndex], rightColumnContent));
     }
-
     yield* Console.log("");
+
+    if (shouldAnimate) {
+      // HACK: move cursor up to the score bar line (line index 1 of
+      // the 4-line face block + 1 trailing blank = 4 lines up) and
+      // animate the bar in place, then restore the cursor position.
+      yield* writeScoreHeaderLine(`\x1b[4A`);
+      yield* printAnimatedScoreBarLine(renderedFaceLines[1], scoreResult.score);
+      yield* writeScoreHeaderLine(`\x1b[3B`);
+    }
   });
 
 export const printBrandingOnlyHeader: Effect.Effect<void> = Effect.gen(function* () {

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -83,7 +83,7 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
       yield* Console.log("");
       const shareUrl = buildShareUrl(input.diagnostics, input.scoreResult, input.projectName);
       yield* Console.log(
-        `  ${highlighter.bold("→ Share your results:")} ${highlighter.info(shareUrl)}`,
+        `  ${highlighter.bold("→ Share:")} ${highlighter.info(shareUrl)}`,
       );
       yield* Console.log("");
     }

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -47,6 +47,7 @@ export interface PrintSummaryInput {
   readonly totalSourceFileCount: number;
   readonly noScoreMessage: string;
   readonly isOffline: boolean;
+  readonly verbose?: boolean;
 }
 
 export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
@@ -68,7 +69,7 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
       try: () => writeDiagnosticsDirectory(input.diagnostics),
       catch: (cause) => cause,
     }).pipe(Effect.orElseSucceed(() => null as string | null));
-    if (diagnosticsDirectory !== null) {
+    if (diagnosticsDirectory !== null && input.verbose) {
       yield* Console.log(highlighter.gray(`  Full diagnostics written to ${diagnosticsDirectory}`));
     }
 

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -40,9 +40,12 @@ const printCountsSummaryLine = (
     const issueText = issueCountColor(
       `${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`,
     );
-    const verboseHint =
-      !isVerbose && totalIssueCount > 0 ? highlighter.dim("  Run --verbose to see details") : "";
-    yield* Console.log(`  ${issueText}${verboseHint}`);
+    yield* Console.log(`  ${issueText}`);
+    if (!isVerbose && totalIssueCount > 0) {
+      yield* Console.log(
+        highlighter.dim(`  Run ${highlighter.info("npx react-doctor@latest --verbose")} to see details`),
+      );
+    }
   });
 
 export interface PrintSummaryInput {

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -43,7 +43,9 @@ const printCountsSummaryLine = (
     yield* Console.log(`  ${issueText}`);
     if (!isVerbose && totalIssueCount > 0) {
       yield* Console.log(
-        highlighter.dim(`  Run ${highlighter.info("npx react-doctor@latest --verbose")} to see details`),
+        highlighter.dim(
+          `  Run ${highlighter.info("npx react-doctor@latest --verbose")} to see details`,
+        ),
       );
     }
   });

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -25,7 +25,10 @@ const buildShareUrl = (
   return `${SHARE_BASE_URL}?${params.toString()}`;
 };
 
-const printCountsSummaryLine = (diagnostics: Diagnostic[]): Effect.Effect<void> =>
+const printCountsSummaryLine = (
+  diagnostics: Diagnostic[],
+  isVerbose: boolean,
+): Effect.Effect<void> =>
   Effect.gen(function* () {
     const totalIssueCount = diagnostics.length;
     const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
@@ -34,9 +37,12 @@ const printCountsSummaryLine = (diagnostics: Diagnostic[]): Effect.Effect<void> 
     ).length;
     const issueCountColor =
       errorCount > 0 ? highlighter.error : warningCount > 0 ? highlighter.warn : highlighter.dim;
-    yield* Console.log(
-      `  ${issueCountColor(`${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`)}`,
+    const issueText = issueCountColor(
+      `${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`,
     );
+    const verboseHint =
+      !isVerbose && totalIssueCount > 0 ? highlighter.dim("  Run --verbose to see details") : "";
+    yield* Console.log(`  ${issueText}${verboseHint}`);
   });
 
 export interface PrintSummaryInput {
@@ -58,7 +64,7 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
       yield* printNoScoreHeader(input.noScoreMessage);
     }
 
-    yield* printCountsSummaryLine(input.diagnostics);
+    yield* printCountsSummaryLine(input.diagnostics, input.verbose ?? false);
 
     // v4 forbids try/catch inside Effect.gen — wrap the sync write
     // in `Effect.try` (always-tagged form: `{ try, catch }`) and

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -2,7 +2,7 @@ import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import { highlighter, SHARE_BASE_URL } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
-import { collectAffectedFiles, formatElapsedTime } from "./render-diagnostics.js";
+import { collectAffectedFiles } from "./render-diagnostics.js";
 import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
 import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 
@@ -25,31 +25,17 @@ const buildShareUrl = (
   return `${SHARE_BASE_URL}?${params.toString()}`;
 };
 
-const printCountsSummaryLine = (
-  diagnostics: Diagnostic[],
-  totalSourceFileCount: number,
-  elapsedMilliseconds: number,
-): Effect.Effect<void> =>
+const printCountsSummaryLine = (diagnostics: Diagnostic[]): Effect.Effect<void> =>
   Effect.gen(function* () {
+    const totalIssueCount = diagnostics.length;
     const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
     const warningCount = diagnostics.filter(
       (diagnostic) => diagnostic.severity === "warning",
     ).length;
-    const affectedFileCount = collectAffectedFiles(diagnostics).size;
-    const totalIssueCount = diagnostics.length;
-    const elapsedTimeLabel = formatElapsedTime(elapsedMilliseconds);
-
     const issueCountColor =
       errorCount > 0 ? highlighter.error : warningCount > 0 ? highlighter.warn : highlighter.dim;
-    const issueCountText = `${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`;
-    const fileCountText =
-      totalSourceFileCount > 0
-        ? `across ${affectedFileCount}/${totalSourceFileCount} files`
-        : `across ${affectedFileCount} file${affectedFileCount === 1 ? "" : "s"}`;
-    const elapsedTimeText = `in ${elapsedTimeLabel}`;
-
     yield* Console.log(
-      `  ${issueCountColor(issueCountText)} ${highlighter.dim(`${fileCountText}  ${elapsedTimeText}`)}`,
+      `  ${issueCountColor(`${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`)}`,
     );
   });
 
@@ -71,11 +57,7 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
       yield* printNoScoreHeader(input.noScoreMessage);
     }
 
-    yield* printCountsSummaryLine(
-      input.diagnostics,
-      input.totalSourceFileCount,
-      input.elapsedMilliseconds,
-    );
+    yield* printCountsSummaryLine(input.diagnostics);
 
     // v4 forbids try/catch inside Effect.gen — wrap the sync write
     // in `Effect.try` (always-tagged form: `{ try, catch }`) and

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -59,7 +59,7 @@ export interface PrintSummaryInput {
 export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
   Effect.gen(function* () {
     if (input.scoreResult) {
-      yield* printScoreHeader(input.scoreResult);
+      yield* printScoreHeader(input.scoreResult, input.projectName);
     } else {
       yield* printNoScoreHeader(input.noScoreMessage);
     }

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -82,9 +82,7 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
     if (!input.isOffline) {
       yield* Console.log("");
       const shareUrl = buildShareUrl(input.diagnostics, input.scoreResult, input.projectName);
-      yield* Console.log(
-        `  ${highlighter.bold("→ Share:")} ${highlighter.info(shareUrl)}`,
-      );
+      yield* Console.log(`  ${highlighter.bold("→ Share:")} ${highlighter.info(shareUrl)}`);
       yield* Console.log("");
     }
   });

--- a/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
@@ -39,7 +39,7 @@ export const resolveDiffMode = async (
   const { scanScope } = await prompts({
     type: "select",
     name: "scanScope",
-    message: "Scan",
+    message: "Select",
     choices: [
       { title: "Full codebase", value: "full" },
       { title: `Changed files (${changedSourceFiles.length})`, value: "branch" },

--- a/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
@@ -37,15 +37,19 @@ export const resolveDiffMode = async (
   if (isQuiet) return false;
 
   const currentBranchLabel = diffInfo.currentBranch ?? "(detached HEAD)";
-  const promptMessage = diffInfo.isCurrentChanges
-    ? `Found ${changedSourceFiles.length} uncommitted changed files. Only scan those?`
-    : `On branch ${currentBranchLabel} (${changedSourceFiles.length} files changed vs ${diffInfo.baseBranch}). Only scan changed files?`;
+  const promptContext = diffInfo.isCurrentChanges
+    ? `${changedSourceFiles.length} uncommitted changed files`
+    : `${changedSourceFiles.length} files changed vs ${diffInfo.baseBranch}`;
 
-  const { shouldScanChangedOnly } = await prompts({
-    type: "confirm",
-    name: "shouldScanChangedOnly",
-    message: promptMessage,
-    initial: true,
+  const { scanScope } = await prompts({
+    type: "select",
+    name: "scanScope",
+    message: `On branch ${currentBranchLabel} (${promptContext}). What do you want to scan?`,
+    choices: [
+      { title: "Full codebase", value: "full" },
+      { title: "This branch", value: "branch" },
+    ],
+    initial: 0,
   });
-  return Boolean(shouldScanChangedOnly);
+  return scanScope === "branch";
 };

--- a/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
@@ -36,18 +36,13 @@ export const resolveDiffMode = async (
   if (shouldSkipPrompts) return false;
   if (isQuiet) return false;
 
-  const currentBranchLabel = diffInfo.currentBranch ?? "(detached HEAD)";
-  const promptContext = diffInfo.isCurrentChanges
-    ? `${changedSourceFiles.length} uncommitted changed files`
-    : `${changedSourceFiles.length} files changed vs ${diffInfo.baseBranch}`;
-
   const { scanScope } = await prompts({
     type: "select",
     name: "scanScope",
-    message: `On branch ${currentBranchLabel} (${promptContext}). What do you want to scan?`,
+    message: "Scan",
     choices: [
       { title: "Full codebase", value: "full" },
-      { title: "This branch", value: "branch" },
+      { title: `Changed files (${changedSourceFiles.length})`, value: "branch" },
     ],
     initial: 0,
   });

--- a/packages/react-doctor/src/cli/utils/spinner.ts
+++ b/packages/react-doctor/src/cli/utils/spinner.ts
@@ -11,6 +11,7 @@ export const setSpinnerSilent = (silent: boolean): void => {
 export const isSpinnerSilent = (): boolean => isSilent;
 
 const noopHandle = Object.freeze({
+  update: () => {},
   succeed: () => {},
   fail: () => {},
 });
@@ -34,6 +35,10 @@ export const spinner = (text: string) => ({
 
     let didFinalize = false;
     return {
+      update(displayText: string) {
+        if (didFinalize) return;
+        instance.text = displayText;
+      },
       succeed(displayText: string) {
         if (didFinalize) return;
         didFinalize = true;

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -441,6 +441,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       totalSourceFileCount: lintSourceFileCount,
       noScoreMessage,
       isOffline: !shouldShowShareLink,
+      verbose: options.verbose,
     });
 
     if (hasSkippedChecks) {

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -59,6 +59,7 @@ interface ResolvedInspectOptions {
   adoptExistingLintConfig: boolean;
   ignoredTags: ReadonlySet<string>;
   outputSurface: DiagnosticSurface;
+  suppressRendering: boolean;
 }
 
 const buildIgnoredTags = (userConfig: ReactDoctorConfig | null): ReadonlySet<string> => {
@@ -90,6 +91,7 @@ const mergeInspectOptions = (
   adoptExistingLintConfig: userConfig?.adoptExistingLintConfig ?? true,
   ignoredTags: buildIgnoredTags(userConfig),
   outputSurface: inputOptions.outputSurface ?? "cli",
+  suppressRendering: inputOptions.suppressRendering ?? false,
 });
 
 export const inspect = async (
@@ -212,7 +214,7 @@ const runInspectWithRuntime = async (
     {
       beforeLint: (projectInfo, lintIncludePaths) =>
         Effect.gen(function* () {
-          if (options.scoreOnly) return;
+          if (options.scoreOnly || options.suppressRendering) return;
           const lintSourceFileCount = lintIncludePaths?.length ?? projectInfo.sourceFileCount;
           yield* printProjectDetection({
             projectInfo,
@@ -369,6 +371,10 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       project,
       elapsedMilliseconds,
     });
+
+    if (options.suppressRendering) {
+      return buildResult();
+    }
 
     if (options.scoreOnly) {
       if (score) {

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -622,7 +622,6 @@ describe("shouldPromptInstallSetup", () => {
     expect(disableSetupPrompt(fixture.projectRoot, { cwd: fixture.configRoot })).toBe(true);
     expect(hasDisabledSetupPrompt(fixture.projectRoot, { cwd: fixture.configRoot })).toBe(true);
   });
-
 });
 
 describe("shouldShowAgentInstallHint", () => {

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -284,6 +284,7 @@ describe("shouldPromptInstallSetup", () => {
     expect(shouldPromptInstallSetup({ ...baseOptions, hasScoredScan: false })).toBe(false);
   });
 
+<<<<<<< HEAD
   it("skips setup prompts in agent shells even when the caller did not pre-skip prompts", () => {
     writePackageJson(fixture.projectRoot, { scripts: {} });
     process.env.CURSOR_AGENT = "1";
@@ -318,9 +319,8 @@ describe("shouldPromptInstallSetup", () => {
     ).toBe(false);
   });
 
-  it("waits after score output, prints a setup pitch, then installs when accepted", async () => {
+  it("waits after score output then installs when accepted", async () => {
     writePackageJson(fixture.projectRoot, { scripts: {} });
-    const writtenLines: string[] = [];
     let waitedMilliseconds = 0;
     let selectMessage = "";
     let didInstall = false;
@@ -337,9 +337,6 @@ describe("shouldPromptInstallSetup", () => {
       wait: async (milliseconds) => {
         waitedMilliseconds = milliseconds;
       },
-      writeLine: (line = "") => {
-        writtenLines.push(line);
-      },
       select: async (message) => {
         selectMessage = message;
         return SETUP_PROMPT_CHOICE_YES;
@@ -350,9 +347,6 @@ describe("shouldPromptInstallSetup", () => {
     });
 
     expect(waitedMilliseconds).toBe(SETUP_PROMPT_DELAY_MS);
-    expect(writtenLines.join("\n")).toContain("2 issues");
-    expect(writtenLines.join("\n")).toContain("humans and agents");
-    expect(writtenLines.join("\n")).not.toContain("Setup will add");
     expect(selectMessage).toBe("Set up React Doctor for this project?");
     expect(didInstall).toBe(true);
   });

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -283,7 +283,6 @@ describe("shouldPromptInstallSetup", () => {
     expect(shouldPromptInstallSetup({ ...baseOptions, hasScoredScan: false })).toBe(false);
   });
 
-<<<<<<< HEAD
   it("skips setup prompts in agent shells even when the caller did not pre-skip prompts", () => {
     writePackageJson(fixture.projectRoot, { scripts: {} });
     process.env.CURSOR_AGENT = "1";

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -10,7 +10,6 @@ import {
 } from "../src/cli/utils/is-ci-environment.js";
 import {
   AGENT_INSTALL_HINT_LINES,
-  buildInstallSetupPitchLines,
   disableSetupPrompt,
   getSetupPromptConfigPath,
   getSetupPromptProjectKey,
@@ -625,9 +624,6 @@ describe("shouldPromptInstallSetup", () => {
     expect(hasDisabledSetupPrompt(fixture.projectRoot, { cwd: fixture.configRoot })).toBe(true);
   });
 
-  it("pitches future regression checks when no issues were found", () => {
-    expect(buildInstallSetupPitchLines(0).join("\n")).toContain("catch future regressions early");
-  });
 });
 
 describe("shouldShowAgentInstallHint", () => {

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -9,17 +9,20 @@ import {
   CODING_AGENT_ENVIRONMENT_VARIABLES,
 } from "../src/cli/utils/is-ci-environment.js";
 import {
+  buildAgentInstallHintLines,
   buildInstallSetupPitchLines,
   disableSetupPrompt,
   getSetupPromptConfigPath,
   getSetupPromptProjectKey,
   hasDisabledSetupPrompt,
+  printAgentInstallHint,
   promptInstallSetup,
   resolveInstallSetupProjectRoot,
   SETUP_PROMPT_CHOICE_NEVER,
   SETUP_PROMPT_CHOICE_NO,
   SETUP_PROMPT_CHOICE_YES,
   shouldPromptInstallSetup,
+  shouldShowAgentInstallHint,
 } from "../src/cli/utils/prompt-install-setup.js";
 
 interface PromptInstallSetupFixture {
@@ -630,5 +633,118 @@ describe("shouldPromptInstallSetup", () => {
 
   it("pitches future regression checks when no issues were found", () => {
     expect(buildInstallSetupPitchLines(0).join("\n")).toContain("catch future regressions early");
+  });
+});
+
+describe("shouldShowAgentInstallHint", () => {
+  let fixture: PromptInstallSetupFixture;
+
+  beforeEach(() => {
+    fixture = setupFixture();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  it("returns true in a coding agent environment when doctor script is missing", () => {
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+
+    expect(
+      shouldShowAgentInstallHint({
+        projectRoot: fixture.projectRoot,
+        hasScoredScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        isCodingAgent: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when the doctor script already exists", () => {
+    writePackageJson(fixture.projectRoot, {
+      scripts: { doctor: "react-doctor" },
+    });
+
+    expect(
+      shouldShowAgentInstallHint({
+        projectRoot: fixture.projectRoot,
+        hasScoredScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        isCodingAgent: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when not in a coding agent environment", () => {
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+
+    expect(
+      shouldShowAgentInstallHint({
+        projectRoot: fixture.projectRoot,
+        hasScoredScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        isCodingAgent: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false in JSON mode, score-only, staged, or without a scored scan", () => {
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const baseOptions = {
+      projectRoot: fixture.projectRoot,
+      hasScoredScan: true,
+      isJsonMode: false,
+      isScoreOnly: false,
+      isStaged: false,
+      isCodingAgent: true,
+    };
+
+    expect(shouldShowAgentInstallHint({ ...baseOptions, isJsonMode: true })).toBe(false);
+    expect(shouldShowAgentInstallHint({ ...baseOptions, isScoreOnly: true })).toBe(false);
+    expect(shouldShowAgentInstallHint({ ...baseOptions, isStaged: true })).toBe(false);
+    expect(shouldShowAgentInstallHint({ ...baseOptions, hasScoredScan: false })).toBe(false);
+  });
+
+  it("returns false when the fallback react-doctor script exists", () => {
+    writePackageJson(fixture.projectRoot, {
+      scripts: { doctor: "vitest", "react-doctor": "npx react-doctor@latest" },
+    });
+
+    expect(
+      shouldShowAgentInstallHint({
+        projectRoot: fixture.projectRoot,
+        hasScoredScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        isCodingAgent: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("printAgentInstallHint", () => {
+  it("prints the install command and description", () => {
+    const writtenLines: string[] = [];
+    printAgentInstallHint((line = "") => {
+      writtenLines.push(line);
+    });
+    const output = writtenLines.join("\n");
+
+    expect(output).toContain("npx react-doctor install --yes");
+    expect(output).toContain("not installed");
+    expect(output).toContain("Ask the user");
+  });
+
+  it("buildAgentInstallHintLines returns stable lines", () => {
+    const lines = buildAgentInstallHintLines();
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.some((line) => line.includes("npx react-doctor install --yes"))).toBe(true);
   });
 });

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -9,7 +9,7 @@ import {
   CODING_AGENT_ENVIRONMENT_VARIABLES,
 } from "../src/cli/utils/is-ci-environment.js";
 import {
-  buildAgentInstallHintLines,
+  AGENT_INSTALL_HINT_LINES,
   buildInstallSetupPitchLines,
   disableSetupPrompt,
   getSetupPromptConfigPath,
@@ -711,6 +711,23 @@ describe("shouldShowAgentInstallHint", () => {
     expect(shouldShowAgentInstallHint({ ...baseOptions, hasScoredScan: false })).toBe(false);
   });
 
+  it("returns false when setup prompt has been disabled for this project", () => {
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    disableSetupPrompt(fixture.projectRoot, { cwd: fixture.configRoot });
+
+    expect(
+      shouldShowAgentInstallHint({
+        projectRoot: fixture.projectRoot,
+        hasScoredScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        isCodingAgent: true,
+        store: { cwd: fixture.configRoot },
+      }),
+    ).toBe(false);
+  });
+
   it("returns false when the fallback react-doctor script exists", () => {
     writePackageJson(fixture.projectRoot, {
       scripts: { doctor: "vitest", "react-doctor": "npx react-doctor@latest" },
@@ -742,9 +759,10 @@ describe("printAgentInstallHint", () => {
     expect(output).toContain("Ask the user");
   });
 
-  it("buildAgentInstallHintLines returns stable lines", () => {
-    const lines = buildAgentInstallHintLines();
-    expect(lines.length).toBeGreaterThan(0);
-    expect(lines.some((line) => line.includes("npx react-doctor install --yes"))).toBe(true);
+  it("AGENT_INSTALL_HINT_LINES contains the install command", () => {
+    expect(AGENT_INSTALL_HINT_LINES.length).toBeGreaterThan(0);
+    expect(
+      AGENT_INSTALL_HINT_LINES.some((line) => line.includes("npx react-doctor install --yes")),
+    ).toBe(true);
   });
 });

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -183,7 +183,7 @@ export const App = ({ name }: { name: string }) => {
 `,
     );
     const defaultRun = await captureScanOutput(projectDir, { noScore: false });
-    expect(defaultRun.stdout).toContain("Share your results");
+    expect(defaultRun.stdout).toContain("Share:");
 
     const projectDir2 = setupMinimalReactProject("issue-92-disabled");
     writeFile(

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -231,14 +231,10 @@ export const Cart = () => {
     );
     const normalizedStdout = stripAnsi(localRun.stdout);
 
-    expect(normalizedStdout).toMatch(/State & Effects \d+ issues/);
-    expect(normalizedStdout).toContain("  ⚠ Direct state mutation ×2");
-    expect(normalizedStdout).toContain("    src/Cart.tsx:");
-    expect(normalizedStdout.indexOf("Direct state mutation")).toBeLessThan(
-      normalizedStdout.indexOf("React Doctor"),
-    );
+    expect(normalizedStdout).toContain("State & Effects");
+    expect(normalizedStdout).toMatch(/\d+ warnings?/);
+    expect(normalizedStdout).toContain("--verbose");
     expect(normalizedStdout).not.toContain("Agent guidance");
-    expect(normalizedStdout).not.toContain("  By category");
   });
 
   it("prints agent guidance in automated environments", async () => {

--- a/packages/website/src/app/share/page.tsx
+++ b/packages/website/src/app/share/page.tsx
@@ -108,7 +108,7 @@ const SharePage = async ({ searchParams }: { searchParams: Promise<ShareSearchPa
         {projectName && <div className="mb-4 text-xl text-white">{projectName}</div>}
         <DoctorFace score={score} />
         <div className="mt-2 text-neutral-500">
-          React Doctor <span className="text-neutral-600">(www.react.doctor)</span>
+          React Doctor <span className="text-neutral-600">(https://react.doctor)</span>
         </div>
       </div>
 

--- a/packages/website/src/components/terminal.tsx
+++ b/packages/website/src/components/terminal.tsx
@@ -154,7 +154,7 @@ const ScoreHeader = ({ score }: { score: number }) => {
           </span>
         </div>
         <div>
-          React Doctor <span className="text-neutral-500">(www.react.doctor)</span>
+          React Doctor <span className="text-neutral-500">(https://react.doctor)</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Why

When a coding agent runs `npx react-doctor@latest .` for the first time, it never learns that it should install React Doctor into the project. The interactive setup prompt is gated behind `skipPrompts`, which is always true in agent environments. The agent finishes the scan, shows diagnostics, and moves on — the project never gets the `doctor` script, agent skill files, or dev dependency.

Separately, the scan pipeline runs lint, dead-code analysis, and the GitHub viewer permission lookup sequentially, adding unnecessary wall-clock time.

## What changed

- When a coding agent environment is detected and no `doctor` script exists, print a text block after the scan telling the agent to ask the user before running `npx react-doctor install --yes`.
- Fork dead-code analysis (`deslop-js`) and GitHub viewer permission (`gh api graphql`) as concurrent Effect child fibers so they overlap with lint instead of running sequentially.
- Remove the 300ms `SETUP_PROMPT_DELAY_MS` and skip the `setTimeout` entirely when the delay is zero.

## Test plan

```
pnpm test
pnpm typecheck
pnpm format:check
```

- 7 new unit tests for `shouldShowAgentInstallHint` and `printAgentInstallHint`
- Manual: `CURSOR_AGENT=1 npx react-doctor@latest .` in a project without a doctor script — verify install hint appears
- Manual: `npx react-doctor@latest .` interactively — verify no install hint, setup prompt appears immediately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Orchestration changes (concurrent dead-code, lint-failure interrupt, score metadata timing) affect scan results and timing; broad CLI/output changes alter user-visible behavior and tests.
> 
> **Overview**
> The inspect pipeline **overlaps lint with dead-code analysis and GitHub viewer permission** via Effect child fibers, uses one **“Scanning (n/m)…”** progress line with **per-file ticks** during oxlint batches, and **stops dead-code / drops its diagnostics when lint fails**.
> 
> The CLI gets a **leaner terminal experience**: no project-detection checklist, **compact category summaries** (verbose still detailed), **multi-project aggregate summary** via `suppressRendering`, refreshed score animation/branding, **diff scope as a select** (full vs changed files), optional **copy-issues-to-clipboard**, and **coding-agent install hint** when there’s no `doctor` script. Setup/install flows are trimmed (**shorter setup delay**, simpler prompts, optional **PR workflow** on install; agent hooks only when flagged). **SIGINT** uses raw `console.log` to avoid Effect errors during animations.
> 
> `Progress` gains **`update`**; lint failure behavior is covered by an updated **run-inspect** test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7998ec880f9f5fa6b76332908d4902bee82236e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->