### PR TITLE
feat: monorepo aggregate summary + /doctor callout

### DIFF
--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -18,6 +18,14 @@ export interface InspectResult {
   skippedCheckReasons?: Record<string, string>;
   project: ProjectInfo;
   elapsedMilliseconds: number;
+  /**
+   * Absolute path of the per-project diagnostics dump (rule-grouped
+   * `.txt` files + `diagnostics.json`). `null` when the dump was not
+   * written for this run (silent / score-only / JSON modes, or when the
+   * write failed). Populated for monorepo aggregation so the CLI can
+   * list each project's full-diagnostics path in the final summary.
+   */
+  diagnosticsDirectory: string | null;
 }
 
 /**
@@ -57,6 +65,15 @@ export interface InspectOptions {
    */
   isCi?: boolean;
   silent?: boolean;
+  /**
+   * Suppress the per-project score header (the ASCII face + score number
+   * + bar) and the per-project share-URL / diagnostics-dir lines. The
+   * inline diagnostics list and the counts line still render so the
+   * user sees progress per project. Set by the CLI's monorepo path so
+   * the final aggregate summary can list every project's score + share
+   * link + diagnostics path together, with one combined score header.
+   */
+  aggregateMode?: boolean;
   /**
    * Surface that consumes the printed diagnostic output (terminal
    * summary + per-rule list). Defaults to `"cli"`, which shows every

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -33,6 +33,8 @@ import {
 } from "../utils/json-mode.js";
 import { printAnnotations } from "../utils/print-annotations.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
+import { printDoctorCallout } from "../utils/render-doctor-callout.js";
+import { printMonorepoSummary } from "../utils/render-monorepo-summary.js";
 import {
   promptInstallSetup,
   resolveInstallSetupProjectRoot,
@@ -251,6 +253,12 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
     const allDiagnostics: Diagnostic[] = [];
     const completedScans: Array<{ directory: string; result: InspectResult }> = [];
+    // Multi-project (monorepo) runs render an aggregate summary at the
+    // end: per-project score + share + diagnostics-dir + one combined
+    // score header. Suppress the per-project score header on each
+    // inspect() call so we don't print it twice. Quiet modes (JSON,
+    // score-only) skip the aggregate entirely.
+    const isMonorepoScan = projectDirectories.length > 1 && !isQuiet;
 
     for (const projectDirectory of projectDirectories) {
       let includePaths: string[] | undefined;
@@ -277,12 +285,31 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         ...scanOptions,
         includePaths,
         configOverride: userConfig,
+        aggregateMode: isMonorepoScan,
       });
       allDiagnostics.push(...scanResult.diagnostics);
       completedScans.push({ directory: projectDirectory, result: scanResult });
       if (!isQuiet) {
         logger.break();
       }
+    }
+
+    // Render the aggregate even when only one project actually ran
+    // (e.g. monorepo diff scan where every other project had no
+    // changes) — otherwise the suppressed per-project score header
+    // would leave that scan with no final score at all.
+    if (isMonorepoScan && completedScans.length > 0) {
+      const isShareOffline =
+        scanOptions.noScore === true ||
+        userConfig?.share === false ||
+        scanOptions.isCi === true;
+      await Effect.runPromise(
+        printMonorepoSummary({
+          scans: completedScans,
+          rootDirectory: resolvedDirectory,
+          isOffline: isShareOffline,
+        }),
+      );
     }
 
     finalizeScans({
@@ -316,6 +343,10 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         isStaged: Boolean(flags.staged),
         skipPrompts,
       });
+    }
+
+    if (!isQuiet && !flags.staged && scanOptions.isCi !== true) {
+      await Effect.runPromise(printDoctorCallout());
     }
   } catch (error) {
     if (isJsonMode) {

--- a/packages/react-doctor/src/cli/utils/render-doctor-callout.ts
+++ b/packages/react-doctor/src/cli/utils/render-doctor-callout.ts
@@ -1,0 +1,88 @@
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import {
+  getSkillAgentConfig,
+  isSkillInstalledForAgent,
+  type SkillAgentType,
+} from "agent-install";
+import { highlighter, SKILL_NAME } from "@react-doctor/core";
+import { detectAvailableAgents } from "./detect-agents.js";
+
+const CALLOUT_INSTALL_COMMAND = "npx react-doctor@latest install";
+
+const findAgentsWithInstalledSkill = async (
+  agents: ReadonlyArray<SkillAgentType>,
+): Promise<SkillAgentType[]> => {
+  const checks = await Promise.all(
+    agents.map(async (agent) => {
+      try {
+        const installed = await isSkillInstalledForAgent(SKILL_NAME, agent);
+        return installed ? agent : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return checks.filter((agent): agent is SkillAgentType => agent !== null);
+};
+
+const formatAgentList = (agents: ReadonlyArray<SkillAgentType>): string =>
+  agents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ");
+
+interface CalloutShape {
+  readonly headlineLeft: string;
+  readonly headlineRight: string;
+  readonly subLines: ReadonlyArray<string>;
+}
+
+const buildCallout = (
+  installedAgents: ReadonlyArray<SkillAgentType>,
+  hasAnyAgent: boolean,
+): CalloutShape => {
+  if (installedAgents.length > 0) {
+    return {
+      headlineLeft: "▸ Next:",
+      headlineRight: `run ${highlighter.bold(highlighter.info("/doctor"))} in ${formatAgentList(installedAgents)} to fix these with React Doctor.`,
+      subLines: [],
+    };
+  }
+  if (hasAnyAgent) {
+    return {
+      headlineLeft: "▸ Next:",
+      headlineRight: `install the ${highlighter.bold("React Doctor")} skill so your coding agent can fix these for you.`,
+      subLines: [`   ${highlighter.bold(highlighter.info(CALLOUT_INSTALL_COMMAND))}`],
+    };
+  }
+  return {
+    headlineLeft: "▸ Tip:",
+    headlineRight: `install React Doctor for your coding agent (Claude Code, Cursor, Codex, ...).`,
+    subLines: [`   ${highlighter.bold(highlighter.info(CALLOUT_INSTALL_COMMAND))}`],
+  };
+};
+
+const printCalloutBlock = (shape: CalloutShape): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* Console.log("");
+    yield* Console.log(
+      `  ${highlighter.bold(highlighter.info(shape.headlineLeft))} ${shape.headlineRight}`,
+    );
+    for (const subLine of shape.subLines) {
+      yield* Console.log(`  ${subLine}`);
+    }
+    yield* Console.log("");
+  });
+
+export interface PrintDoctorCalloutOptions {
+  /** Test seam: skip the live filesystem detection. */
+  readonly detectedAgents?: ReadonlyArray<SkillAgentType>;
+}
+
+export const printDoctorCallout = (
+  options: PrintDoctorCalloutOptions = {},
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const detected =
+      options.detectedAgents ?? (yield* Effect.promise(() => detectAvailableAgents()));
+    const installed = yield* Effect.promise(() => findAgentsWithInstalledSkill(detected));
+    yield* printCalloutBlock(buildCallout(installed, detected.length > 0));
+  });

--- a/packages/react-doctor/src/cli/utils/render-monorepo-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-monorepo-summary.ts
@@ -1,0 +1,190 @@
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import {
+  highlighter,
+  PERFECT_SCORE,
+  SCORE_GOOD_THRESHOLD,
+  SCORE_OK_THRESHOLD,
+  toRelativePath,
+} from "@react-doctor/core";
+import type { Diagnostic, InspectResult, ScoreResult } from "@react-doctor/core";
+import { colorizeByScore } from "./colorize-by-score.js";
+import { printScoreHeader } from "./render-score-header.js";
+import { buildShareUrl } from "./render-summary.js";
+
+export interface MonorepoSummaryScan {
+  readonly directory: string;
+  readonly result: InspectResult;
+}
+
+export interface PrintMonorepoSummaryInput {
+  readonly scans: ReadonlyArray<MonorepoSummaryScan>;
+  /** Root the per-project paths render relative to. */
+  readonly rootDirectory: string;
+  /** Drives whether the share URL row is suppressed (CI / --no-score / config.share). */
+  readonly isOffline: boolean;
+}
+
+const SEVERITY_DOT = "●";
+const DETAIL_PREFIX = "↳";
+
+const labelForCombinedScore = (score: number): string => {
+  if (score >= SCORE_GOOD_THRESHOLD) return "Great";
+  if (score >= SCORE_OK_THRESHOLD) return "Needs work";
+  return "Critical";
+};
+
+interface ComputedCombinedScore {
+  readonly score: number;
+  readonly totalSourceFileCount: number;
+  readonly scoredProjectCount: number;
+}
+
+const computeCombinedScore = (
+  scans: ReadonlyArray<MonorepoSummaryScan>,
+): ComputedCombinedScore | null => {
+  let weightedSum = 0;
+  let totalWeight = 0;
+  let scoredProjectCount = 0;
+  let totalSourceFileCount = 0;
+  for (const scan of scans) {
+    if (!scan.result.score) continue;
+    // Files-as-weight: a single source file lifts the project off zero
+    // so a tiny package can't dominate or vanish vs. a project that
+    // never produced a file count.
+    const weight = Math.max(scan.result.project.sourceFileCount, 1);
+    weightedSum += scan.result.score.score * weight;
+    totalWeight += weight;
+    totalSourceFileCount += scan.result.project.sourceFileCount;
+    scoredProjectCount += 1;
+  }
+  if (scoredProjectCount === 0 || totalWeight === 0) return null;
+  return {
+    score: Math.round(weightedSum / totalWeight),
+    totalSourceFileCount,
+    scoredProjectCount,
+  };
+};
+
+interface PerProjectRow {
+  readonly relativePath: string;
+  readonly score: ScoreResult | null;
+  readonly sourceFileCount: number;
+  readonly shareUrl: string | null;
+  readonly diagnosticsDirectory: string | null;
+  readonly issueCount: number;
+  readonly errorCount: number;
+}
+
+const buildRow = (
+  scan: MonorepoSummaryScan,
+  rootDirectory: string,
+  isOffline: boolean,
+): PerProjectRow => {
+  const surfaceDiagnostics: ReadonlyArray<Diagnostic> = scan.result.diagnostics;
+  const errorCount = surfaceDiagnostics.filter(
+    (diagnostic) => diagnostic.severity === "error",
+  ).length;
+  const relativePath = toRelativePath(scan.directory, rootDirectory) || ".";
+  return {
+    relativePath,
+    score: scan.result.score,
+    sourceFileCount: scan.result.project.sourceFileCount,
+    shareUrl: isOffline
+      ? null
+      : buildShareUrl(surfaceDiagnostics, scan.result.score, scan.result.project.projectName),
+    diagnosticsDirectory: scan.result.diagnosticsDirectory,
+    issueCount: surfaceDiagnostics.length,
+    errorCount,
+  };
+};
+
+const padRight = (text: string, width: number): string =>
+  text.length >= width ? text : text + " ".repeat(width - text.length);
+
+const padLeft = (text: string, width: number): string =>
+  text.length >= width ? text : " ".repeat(width - text.length) + text;
+
+// Worst first. Unscored projects sink to the bottom so the user's eye
+// lands on the most-urgent project rather than on rows we can't compare.
+const sortRowsByUrgency = (rows: ReadonlyArray<PerProjectRow>): PerProjectRow[] =>
+  rows.toSorted((a, b) => {
+    if (a.score === null && b.score === null) return a.relativePath.localeCompare(b.relativePath);
+    if (a.score === null) return 1;
+    if (b.score === null) return -1;
+    if (a.score.score !== b.score.score) return a.score.score - b.score.score;
+    return a.relativePath.localeCompare(b.relativePath);
+  });
+
+const formatFileCount = (count: number): string => {
+  const formatted = count.toLocaleString();
+  return `${formatted} ${count === 1 ? "file" : "files"}`;
+};
+
+const printPerProjectRow = (row: PerProjectRow, nameWidth: number): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const scoreText = row.score ? padLeft(String(row.score.score), 3) : padLeft("—", 3);
+    const score = row.score
+      ? colorizeByScore(scoreText, row.score.score)
+      : highlighter.gray(scoreText);
+    const dot = row.score ? colorizeByScore(SEVERITY_DOT, row.score.score) : highlighter.gray("·");
+    const name = highlighter.bold(padRight(row.relativePath, nameWidth));
+    const labelText = row.score
+      ? colorizeByScore(row.score.label, row.score.score)
+      : highlighter.gray("score unavailable");
+    const meta = highlighter.dim(
+      `· ${formatFileCount(row.sourceFileCount)} · ${row.issueCount} ${row.issueCount === 1 ? "issue" : "issues"}`,
+    );
+    yield* Console.log(`  ${score}  ${dot}  ${name}  ${labelText}  ${meta}`);
+
+    // 2 leading + 3 score + 2 + 1 dot + 2 + nameWidth = 10 + nameWidth.
+    // Re-anchor detail lines under the project name so they read as a
+    // continuation, not a new column.
+    const detailIndent = " ".repeat(10) + " ".repeat(nameWidth - 1);
+    if (row.shareUrl) {
+      yield* Console.log(
+        `${detailIndent}${highlighter.gray(DETAIL_PREFIX)} ${highlighter.info(row.shareUrl)}`,
+      );
+    }
+    if (row.diagnosticsDirectory) {
+      yield* Console.log(
+        `${detailIndent}${highlighter.gray(DETAIL_PREFIX)} ${highlighter.gray(row.diagnosticsDirectory)}`,
+      );
+    }
+  });
+
+export const printMonorepoSummary = (input: PrintMonorepoSummaryInput): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    if (input.scans.length === 0) return;
+
+    const rawRows = input.scans.map((scan) =>
+      buildRow(scan, input.rootDirectory, input.isOffline),
+    );
+    const rows = sortRowsByUrgency(rawRows);
+    const nameWidth = rows.reduce(
+      (widest, row) => Math.max(widest, row.relativePath.length),
+      "project".length,
+    );
+
+    const combined = computeCombinedScore(input.scans);
+    if (combined !== null) {
+      const combinedScore: ScoreResult = {
+        score: combined.score,
+        label: labelForCombinedScore(combined.score),
+      };
+      yield* Console.log("");
+      yield* Console.log(
+        `  ${highlighter.bold("Combined score")}  ${highlighter.dim(`weighted across ${combined.scoredProjectCount} project${combined.scoredProjectCount === 1 ? "" : "s"} · ${combined.totalSourceFileCount.toLocaleString()} source files · ${PERFECT_SCORE} max`)}`,
+      );
+      yield* printScoreHeader(combinedScore);
+    }
+
+    yield* Console.log(
+      `  ${highlighter.bold("By project")}  ${highlighter.dim(`worst first · ${rows.length} project${rows.length === 1 ? "" : "s"}`)}`,
+    );
+    yield* Console.log("");
+    for (const row of rows) {
+      yield* printPerProjectRow(row, nameWidth);
+    }
+    yield* Console.log("");
+  });

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -6,14 +6,14 @@ import { collectAffectedFiles, formatElapsedTime } from "./render-diagnostics.js
 import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
 import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 
-const buildShareUrl = (
-  diagnostics: Diagnostic[],
+export const buildShareUrl = (
+  diagnostics: ReadonlyArray<Diagnostic>,
   scoreResult: ScoreResult | null,
   projectName: string,
 ): string => {
   const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
   const warningCount = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
-  const affectedFileCount = collectAffectedFiles(diagnostics).size;
+  const affectedFileCount = collectAffectedFiles([...diagnostics]).size;
 
   const params = new URLSearchParams();
   params.set("p", projectName);
@@ -61,14 +61,29 @@ export interface PrintSummaryInput {
   readonly totalSourceFileCount: number;
   readonly noScoreMessage: string;
   readonly isOffline: boolean;
+  /**
+   * Suppress the per-project score header, the diagnostics-dir line,
+   * and the share-link line. The diagnostics dump still happens — the
+   * returned path is what the CLI feeds into the final monorepo
+   * aggregate summary. Counts line still prints so each project shows
+   * progress as it's scanned.
+   */
+  readonly aggregateMode?: boolean;
 }
 
-export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
+export interface PrintSummaryResult {
+  /** Path returned by writeDiagnosticsDirectory, or null if the write failed. */
+  readonly diagnosticsDirectory: string | null;
+}
+
+export const printSummary = (input: PrintSummaryInput): Effect.Effect<PrintSummaryResult> =>
   Effect.gen(function* () {
-    if (input.scoreResult) {
-      yield* printScoreHeader(input.scoreResult);
-    } else {
-      yield* printNoScoreHeader(input.noScoreMessage);
+    if (!input.aggregateMode) {
+      if (input.scoreResult) {
+        yield* printScoreHeader(input.scoreResult);
+      } else {
+        yield* printNoScoreHeader(input.noScoreMessage);
+      }
     }
 
     yield* printCountsSummaryLine(
@@ -86,11 +101,11 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
       try: () => writeDiagnosticsDirectory(input.diagnostics),
       catch: (cause) => cause,
     }).pipe(Effect.orElseSucceed(() => null as string | null));
-    if (diagnosticsDirectory !== null) {
+    if (!input.aggregateMode && diagnosticsDirectory !== null) {
       yield* Console.log(highlighter.gray(`  Full diagnostics written to ${diagnosticsDirectory}`));
     }
 
-    if (!input.isOffline) {
+    if (!input.aggregateMode && !input.isOffline) {
       yield* Console.log("");
       const shareUrl = buildShareUrl(input.diagnostics, input.scoreResult, input.projectName);
       yield* Console.log(
@@ -98,4 +113,6 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
       );
       yield* Console.log("");
     }
+
+    return { diagnosticsDirectory };
   });

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -95,6 +95,7 @@ export const toJsonReport = (result: DiagnoseResult, options: ToJsonReportOption
             : {}),
           project: result.project,
           elapsedMilliseconds: result.elapsedMilliseconds,
+          diagnosticsDirectory: null,
         },
       },
     ],

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -57,6 +57,7 @@ interface ResolvedInspectOptions {
   adoptExistingLintConfig: boolean;
   ignoredTags: ReadonlySet<string>;
   outputSurface: DiagnosticSurface;
+  aggregateMode: boolean;
 }
 
 const buildIgnoredTags = (userConfig: ReactDoctorConfig | null): ReadonlySet<string> => {
@@ -87,6 +88,7 @@ const mergeInspectOptions = (
   adoptExistingLintConfig: userConfig?.adoptExistingLintConfig ?? true,
   ignoredTags: buildIgnoredTags(userConfig),
   outputSurface: inputOptions.outputSurface ?? "cli",
+  aggregateMode: inputOptions.aggregateMode ?? false,
 });
 
 export const inspect = async (
@@ -354,13 +356,14 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       skippedCheckReasons["dead-code"] = deadCodeFailureReason;
     }
 
-    const buildResult = (): InspectResult => ({
+    const buildResult = (diagnosticsDirectory: string | null): InspectResult => ({
       diagnostics: [...diagnostics],
       score,
       skippedChecks,
       ...(Object.keys(skippedCheckReasons).length > 0 ? { skippedCheckReasons } : {}),
       project,
       elapsedMilliseconds,
+      diagnosticsDirectory,
     });
 
     if (options.scoreOnly) {
@@ -369,7 +372,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       } else {
         yield* Console.log(highlighter.gray(noScoreMessage));
       }
-      return buildResult();
+      return buildResult(null);
     }
 
     const surfaceDiagnostics = filterDiagnosticsForSurface(
@@ -399,15 +402,22 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
         yield* Console.log(highlighter.success("No issues found!"));
       }
       yield* Console.log("");
-      if (hasSkippedChecks) {
-        yield* printBrandingOnlyHeader;
-        yield* Console.log(highlighter.gray("  Score not shown — some checks could not complete."));
-      } else if (score) {
-        yield* printScoreHeader(score);
-      } else {
-        yield* printNoScoreHeader(noScoreMessage);
+      // In aggregate mode the combined score header renders once at the
+      // end across every project, so suppress the per-project header
+      // here too.
+      if (!options.aggregateMode) {
+        if (hasSkippedChecks) {
+          yield* printBrandingOnlyHeader;
+          yield* Console.log(
+            highlighter.gray("  Score not shown — some checks could not complete."),
+          );
+        } else if (score) {
+          yield* printScoreHeader(score);
+        } else {
+          yield* printNoScoreHeader(noScoreMessage);
+        }
       }
-      return buildResult();
+      return buildResult(null);
     }
 
     yield* Console.log("");
@@ -426,7 +436,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
     }
 
     const shouldShowShareLink = !options.noScore && options.share && !options.isCi;
-    yield* printSummary({
+    const summaryResult = yield* printSummary({
       diagnostics: [...surfaceDiagnostics],
       elapsedMilliseconds,
       scoreResult: score,
@@ -434,6 +444,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       totalSourceFileCount: lintSourceFileCount,
       noScoreMessage,
       isOffline: !shouldShowShareLink,
+      aggregateMode: options.aggregateMode,
     });
 
     if (hasSkippedChecks) {
@@ -444,5 +455,5 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       );
     }
 
-    return buildResult();
+    return buildResult(summaryResult.diagnosticsDirectory);
   });


### PR DESCRIPTION
## Summary

- Multi-project (monorepo) runs now print one combined-score header (weighted by `sourceFileCount`) plus a sorted per-project breakdown at the end, instead of a separate score header per project. Each project still shows detection + diagnostics + counts mid-run.
- New end-of-run callout (every interactive scan): suggests `/doctor` if the react-doctor skill is installed for any detected coding agent, otherwise `npx react-doctor@latest install`. Skipped in JSON, score-only, staged, and CI modes.
- New `InspectOptions.aggregateMode` (sets per-project score header / share link / diagnostics-dir line to suppressed) and `InspectResult.diagnosticsDirectory` (each project's dump path) feed the aggregate renderer.

cc @aidenybai

## Sample monorepo output

```
  Combined score  weighted across 5 projects · 641 source files · 100 max
  ┌─────┐  34 / 100 Critical
  │ x x │  █████████████░░░░░░░░░░░░░░░░░░░░░░░░░
  │  ▽  │  React Doctor (www.react.doctor)
  └─────┘
  By project  worst first · 5 projects

   21  ●  packages/interface   Critical    · 513 files · 1692 issues
                              ↳ https://www.react.doctor/share?p=...
                              ↳ /var/folders/.../react-doctor-e04d3a98
   69  ●  packages/website     Needs work  ·  43 files ·  149 issues
                              ↳ ...
                              ↳ ...
   92  ●  packages/agent       Great       ·  49 files ·   56 issues
                              ↳ ...
                              ↳ ...
   ...

  ▸ Next: run /doctor in Claude Code to fix these with React Doctor.
```

## Test plan

- [ ] `pnpm --filter react-doctor test` — confirms 45 directly-related tests still pass (one pre-existing failure on `main` in `cli-and-output.test.ts` is unrelated).
- [ ] Single-project scan: `npx react-doctor` in `packages/core/tests/fixtures/basic-react` — score header + share link + diagnostics path render per project as before.
- [ ] Monorepo scan: `npx react-doctor` in `packages/core/tests/fixtures/mixed-rn-web-monorepo` — per-project scans render without final score header; aggregate renders at the end with one combined score header and per-project rows sorted worst-first.
- [ ] `--score`, `--json`, `--staged`, and CI (`CI=true`) runs skip the new aggregate output and the /doctor callout.
- [ ] Callout shows `/doctor` variant when `~/.claude/skills/react-doctor` exists, install variant otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)