### PR TITLE
fix(react-doctor): restore eslint-plugin-react-hooks as a hard dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,14 +36,6 @@
     "@types/picomatch": "^4.0.3",
     "eslint-plugin-react-hooks": "^7.1.1"
   },
-  "peerDependencies": {
-    "eslint-plugin-react-hooks": "^6 || ^7"
-  },
-  "peerDependenciesMeta": {
-    "eslint-plugin-react-hooks": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   }

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -60,6 +60,7 @@
     "conf": "^15.1.0",
     "deslop-js": "^0.0.13",
     "effect": "4.0.0-beta.70",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "oxlint": "^1.66.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "prompts": "^2.4.2",
@@ -70,16 +71,7 @@
     "@react-doctor/core": "workspace:*",
     "@types/prompts": "^2.4.9",
     "commander": "^14.0.3",
-    "eslint-plugin-react-hooks": "^7.1.1",
     "ora": "^9.4.0"
-  },
-  "peerDependencies": {
-    "eslint-plugin-react-hooks": "^6 || ^7"
-  },
-  "peerDependenciesMeta": {
-    "eslint-plugin-react-hooks": {
-      "optional": true
-    }
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@9.39.2(jiti@2.6.1))
       oxlint:
         specifier: ^1.66.0
         version: 1.66.0(oxlint-tsgolint@0.23.0)
@@ -155,9 +158,6 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
-      eslint-plugin-react-hooks:
-        specifier: ^7.1.1
-        version: 7.1.1(eslint@9.39.2(jiti@2.6.1))
       ora:
         specifier: ^9.4.0
         version: 9.4.0


### PR DESCRIPTION
## Summary

Since [PR #140](https://github.com/millionco/react-doctor/pull/140) (shipped in `react-doctor@0.0.44`, Apr 30 2026), `eslint-plugin-react-hooks` has been declared as an **optional peer dep** + `devDependency` instead of a hard `dependency`. The resolver in `oxlint-config.ts` was never updated to match — it kept calling `esmRequire.resolve("eslint-plugin-react-hooks")` against react-doctor's own location only. Under `npx react-doctor@latest` / `pnpm dlx` / `bunx`, where optional peers don't get installed, the resolver silently returned `null`. [PR #141](https://github.com/millionco/react-doctor/pull/141) then made that null path silent (skip the rules instead of crashing oxlint), hiding the regression entirely.

**Net effect from v0.0.44 through v0.2.6 (26+ days): every npx user lost the entire `react-hooks-js/*` React Compiler rule family without warning.**

## The fix

Move `eslint-plugin-react-hooks` back to `dependencies` in `packages/react-doctor/package.json` (the only published package). `npm` / `pnpm` / `bun` will now install it as a sibling of `react-doctor` on every install layout, so `esmRequire.resolve(...)` always succeeds. Also drops the now-redundant `peerDependencies` + `peerDependenciesMeta` blocks from both `react-doctor` and `core`.

Total diff: **+4 / −20 lines.** No new code paths, no pnpm-internal `.pnpm/` directory coupling, no `rootDirectory` threading. Works identically on npm hoisted, yarn classic, pnpm strict, bun isolated, and bun flat layouts because npm itself handles the install.

The ~10MB install footprint (plugin + `@babel/core` + `@babel/parser` + `hermes-parser` + `zod`) is small relative to the existing `oxlint` + `effect` + `deslop-js` payload, and is the price for "the React Compiler diagnostics actually appear when the CLI runs."

### Why this is strictly better than the resolver-based draft

The initial draft of this PR added a 3-strategy resolver (workspace deps → project resolution → `.pnpm/` walk). Even though it recovered diagnostics on projects with the plugin installed transitively, it left two failure modes unaddressed:

1. **Projects with React Compiler but no `eslint-plugin-react-hooks` anywhere on disk** (`semanticdiff`): resolver returned null → 0 diagnostics. The hard-dep revert installs the plugin alongside `react-doctor` so the lint runs.
2. **Projects with an old `eslint-plugin-react-hooks` version** (`t3chat-main` had `5.1.0`, pre-React-Compiler-rules): resolver picked up the user's older version → 0 compiler diagnostics. The hard-dep revert pins `^7.1.1` alongside `react-doctor`, so the user gets the full ruleset regardless of what's in their own `node_modules`.

## Verification — multi-repo matrix

Built the changed packages with `pnpm pack` and installed them into a clean temp directory via `npm install <tarball>` — exactly the layout `npx react-doctor@latest` creates. Ran against 7 React projects across pnpm strict, bun isolated, and pnpm hoisted layouts.

| Repo | Pkg mgr | React Compiler? | Before (broken) | Resolver draft | **This PR (hard-dep revert)** |
| --- | --- | --- | --- | --- | --- |
| `experiments/paper` | pnpm strict | yes | 478 / rh=0 | 505 / rh=27 | **531 / rh=53** |
| `million/pierre` | bun isolated | yes | 551 / rh=0 | 552 / rh=1 | 552 / rh=1 |
| `million/semanticdiff` | bun | yes | 55 / rh=0 | 55 / rh=0 (resolver couldn't help) | **62 / rh=7** |
| `million/t3chat-main` | pnpm | yes (newer ruleset only) | 413 / rh=0 | 413 / rh=0 (resolver couldn't help) | **432 / rh=19** |
| `million/new-website` | pnpm strict | yes | 16 / rh=0 | 16 / rh=0 | 16 / rh=0 (11 source files, compiler-clean) |
| `million/million-website` | pnpm | no | 27 / rh=0 | 27 / rh=0 | 27 / rh=0 (compiler gate stays off) |
| `million/ami-next-proto` | pnpm | no | 137 / rh=0 | 137 / rh=0 | 137 / rh=0 (compiler gate stays off) |

## Why this took 26 days to surface

- Workspace dev runs always passed because `eslint-plugin-react-hooks` was a devDep of the react-doctor workspace.
- The regression test for issue #141 (`scan-resilience.test.ts`) uses `rootDirectory: "/tmp/test"` — non-existent, but the workspace's own plugin resolves first, so the test passes regardless of project context.
- CI runs in the workspace layout (same install topology as dev), so it never reproduced the npx layout.
- PR #141's silence patch hid the failure: oxlint stopped erroring on the missing plugin, so the dropped diagnostics weren't visible in any failure mode.

## Test plan

- [x] `pnpm install` — clean (one-line `pnpm-lock.yaml` move from `devDependencies` to `dependencies` section)
- [x] `pnpm build` — all packages build clean
- [x] `pnpm test` — 1349 passed across 7 packages
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm smoke:json-report` — clean
- [x] Real npx-equivalent verification: `pnpm pack` + `npm install <tarball>` into a clean temp dir, then ran against 7 real-world repos (matrix above)
