### PR TITLE
feat(api): add diagnoseModules() for native per-module scoring

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @react-doctor/api
 
+## 0.2.8
+
+### Patch Changes
+
+- add react-doctor.config.json schema field
+
+- Updated dependencies []:
+  - @react-doctor/core@0.2.8
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-doctor/api",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "description": "Internal: programmatic diagnose() API for React Doctor — thin Effect.runPromise shell around @react-doctor/core's runInspect orchestrator. Not published.",
   "license": "MIT",

--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -1,55 +1,95 @@
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import {
-  layerInspectLive,
+  Config,
+  DeadCode,
+  Files,
+  Git,
   layerOtlp,
+  Linter,
+  LintPartialFailures,
+  Progress,
+  Project,
+  Reporter,
   resolveScanTarget,
   restoreLegacyThrow,
   runInspect,
+  Score,
   type InspectOutput,
+  type ResolvedScanTarget,
 } from "@react-doctor/core";
-import type { DiagnoseOptions, DiagnoseResult } from "@react-doctor/core";
+import type {
+  DiagnoseModulesOptions,
+  DiagnoseModulesResult,
+  DiagnoseOptions,
+  DiagnoseResult,
+  ModuleDefinition,
+  ModuleError,
+  ModuleResult,
+  ReactDoctorConfig,
+  ScoreResult,
+} from "@react-doctor/core";
 
-export const diagnose = async (
-  directory: string,
-  options: DiagnoseOptions = {},
-): Promise<DiagnoseResult> => {
-  const startTime = globalThis.performance.now();
+const DEFAULT_LAYER = Layer.mergeAll(
+  Project.layerNode,
+  Config.layerNode,
+  DeadCode.layerNode,
+  Files.layerNode,
+  Git.layerNode,
+  Linter.layerOxlint,
+  LintPartialFailures.layerLive,
+  Progress.layerNoop,
+  Reporter.layerNoop,
+  Score.layerHttp,
+);
 
-  // `resolveScanTarget` is the canonical entry-point translation: it
-  // loads the user config, honors `config.rootDir`, and walks into a
-  // nested React subproject when the requested directory lacks a
-  // package.json (raising `AmbiguousProjectError` for multiple
-  // candidates, `ProjectNotFoundError` otherwise — propagated by
-  // `runInspect` via `restoreLegacyThrow`).
-  const scanTarget = resolveScanTarget(directory);
+const buildLayerWithConfigOverride = (
+  configOverride: ReactDoctorConfig,
+  resolvedDirectory: string,
+) =>
+  Layer.mergeAll(
+    Project.layerNode,
+    Config.layerOf({
+      config: configOverride,
+      resolvedDirectory,
+      configSourceDirectory: null,
+    }),
+    DeadCode.layerNode,
+    Files.layerNode,
+    Git.layerNode,
+    Linter.layerOxlint,
+    LintPartialFailures.layerLive,
+    Progress.layerNoop,
+    Reporter.layerNoop,
+    Score.layerHttp,
+  );
 
+const buildInspectProgram = (
+  scanTarget: ResolvedScanTarget,
+  options: DiagnoseOptions,
+  configOverride?: ReactDoctorConfig,
+) => {
+  const effectiveConfig = configOverride ?? scanTarget.userConfig;
   const includePaths = options.includePaths ?? [];
 
-  const program = runInspect({
+  return runInspect({
     directory: scanTarget.resolvedDirectory,
     includePaths,
-    customRulesOnly: scanTarget.userConfig?.customRulesOnly ?? false,
+    customRulesOnly: effectiveConfig?.customRulesOnly ?? false,
     respectInlineDisables:
-      options.respectInlineDisables ?? scanTarget.userConfig?.respectInlineDisables ?? true,
-    adoptExistingLintConfig: scanTarget.userConfig?.adoptExistingLintConfig ?? true,
-    ignoredTags: new Set(scanTarget.userConfig?.ignore?.tags ?? []),
-    runDeadCode: options.deadCode ?? scanTarget.userConfig?.deadCode ?? true,
+      options.respectInlineDisables ?? effectiveConfig?.respectInlineDisables ?? true,
+    adoptExistingLintConfig: effectiveConfig?.adoptExistingLintConfig ?? true,
+    ignoredTags: new Set(effectiveConfig?.ignore?.tags ?? []),
+    runDeadCode: options.deadCode ?? effectiveConfig?.deadCode ?? true,
     isCi: false,
     resolveLocalGithubViewerPermission: true,
   });
+};
 
-  const output: InspectOutput = await Effect.runPromise(
-    restoreLegacyThrow(
-      program.pipe(
-        Effect.provide(layerInspectLive),
-        // Opt-in OTLP exporter. No-op unless REACT_DOCTOR_OTLP_ENDPOINT
-        // + REACT_DOCTOR_OTLP_AUTH_HEADER are set in the environment;
-        // see `core/observability.ts` for the env-driven config.
-        Effect.provide(layerOtlp),
-      ),
-    ),
-  );
-
+const outputToDiagnoseResult = (
+  output: InspectOutput,
+  elapsedMilliseconds: number,
+): DiagnoseResult => {
   // HACK: preserve the legacy behavior of writing lint failures to
   // stderr. The orchestrator already folds them into didLintFail /
   // lintFailureReason; this mirror keeps long-running scripts that
@@ -71,6 +111,157 @@ export const diagnose = async (
     skippedChecks,
     ...(Object.keys(skippedCheckReasons).length > 0 ? { skippedCheckReasons } : {}),
     project: output.project,
+    elapsedMilliseconds,
+  };
+};
+
+export const diagnose = async (
+  directory: string,
+  options: DiagnoseOptions = {},
+): Promise<DiagnoseResult> => {
+  const startTime = globalThis.performance.now();
+  const scanTarget = resolveScanTarget(directory);
+  const program = buildInspectProgram(scanTarget, options);
+
+  const output: InspectOutput = await Effect.runPromise(
+    restoreLegacyThrow(
+      program.pipe(Effect.provide(DEFAULT_LAYER), Effect.provide(layerOtlp)),
+    ),
+  );
+
+  return outputToDiagnoseResult(output, globalThis.performance.now() - startTime);
+};
+
+const findWorstScore = (moduleResults: ModuleResult[]): ScoreResult | null => {
+  let worstResult: ScoreResult | null = null;
+  let worstScore = Number.POSITIVE_INFINITY;
+  for (const moduleResult of moduleResults) {
+    if (moduleResult.score === null) continue;
+    if (moduleResult.score.score < worstScore) {
+      worstScore = moduleResult.score.score;
+      worstResult = moduleResult.score;
+    }
+  }
+  return worstResult;
+};
+
+const diagnoseModule = async (
+  moduleDefinition: ModuleDefinition,
+  baseOptions: DiagnoseOptions,
+): Promise<ModuleResult> => {
+  const startTime = globalThis.performance.now();
+  const scanTarget = resolveScanTarget(moduleDefinition.directory);
+  const { reactDoctorConfig: configOverride, ...perModuleOptions } =
+    moduleDefinition.config ?? {};
+  const mergedOptions: DiagnoseOptions = { ...baseOptions, ...perModuleOptions };
+
+  const program = buildInspectProgram(scanTarget, mergedOptions, configOverride);
+
+  const layer =
+    configOverride !== undefined
+      ? buildLayerWithConfigOverride(configOverride, scanTarget.resolvedDirectory)
+      : DEFAULT_LAYER;
+
+  const output: InspectOutput = await Effect.runPromise(
+    restoreLegacyThrow(
+      program.pipe(Effect.provide(layer), Effect.provide(layerOtlp)),
+    ),
+  );
+
+  return {
+    ...outputToDiagnoseResult(output, globalThis.performance.now() - startTime),
+    directory: scanTarget.resolvedDirectory,
+  };
+};
+
+/**
+ * Scan multiple modules in parallel and return per-module scores,
+ * diagnostics, and an aggregate score (worst-of across all modules).
+ *
+ * Each module runs its own independent `runInspect` pipeline — the
+ * same pipeline `diagnose()` uses — so per-module config overrides,
+ * dead-code analysis, and scoring all work identically to a single
+ * `diagnose()` call.
+ *
+ * Modules that fail (e.g. missing `package.json`, no React dependency)
+ * are collected in `result.errors` rather than aborting the entire
+ * batch, so callers always receive partial results from the modules
+ * that succeeded.
+ *
+ * ```ts
+ * const result = await diagnoseModules([
+ *   { directory: "packages/app" },
+ *   { directory: "packages/shared", config: { deadCode: false } },
+ *   { directory: "packages/admin", config: {
+ *     reactDoctorConfig: { rules: { "react-doctor/no-array-index-as-key": "off" } },
+ *   }},
+ * ], { concurrency: 4 });
+ *
+ * for (const mod of result.modules) {
+ *   console.log(mod.directory, mod.score);
+ * }
+ * ```
+ */
+export const diagnoseModules = async (
+  modules: ModuleDefinition[],
+  options: DiagnoseModulesOptions = {},
+): Promise<DiagnoseModulesResult> => {
+  const startTime = globalThis.performance.now();
+  const { concurrency: rawConcurrency, ...baseOptions } = options;
+  const concurrency = Math.max(1, rawConcurrency ?? modules.length);
+
+  const moduleResults: ModuleResult[] = [];
+  const moduleErrors: ModuleError[] = [];
+  const pendingModules = [...modules];
+
+  const runBatch = async (): Promise<void> => {
+    const batch: Promise<
+      | { ok: true; result: ModuleResult }
+      | { ok: false; directory: string; error: Error }
+    >[] = [];
+
+    while (pendingModules.length > 0 && batch.length < concurrency) {
+      const moduleDefinition = pendingModules.shift()!;
+      batch.push(
+        diagnoseModule(moduleDefinition, baseOptions).then(
+          (result) => ({ ok: true as const, result }),
+          (error: unknown) => ({
+            ok: false as const,
+            directory: moduleDefinition.directory,
+            error: error instanceof Error ? error : new Error(String(error)),
+          }),
+        ),
+      );
+    }
+
+    const settled = await Promise.all(batch);
+    for (const outcome of settled) {
+      if (outcome.ok) {
+        moduleResults.push(outcome.result);
+      } else {
+        moduleErrors.push({
+          directory: outcome.directory,
+          error: outcome.error,
+        });
+      }
+    }
+
+    if (pendingModules.length > 0) {
+      await runBatch();
+    }
+  };
+
+  await runBatch();
+
+  const allDiagnostics = moduleResults.flatMap(
+    (moduleResult) => moduleResult.diagnostics,
+  );
+
+  return {
+    modules: moduleResults,
+    errors: moduleErrors,
+    diagnostics: allDiagnostics,
+    score: findWorstScore(moduleResults),
     elapsedMilliseconds: globalThis.performance.now() - startTime,
   };
 };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,9 +1,14 @@
-export { diagnose } from "./diagnose.js";
+export { diagnose, diagnoseModules } from "./diagnose.js";
 
 export type {
+  DiagnoseModulesOptions,
+  DiagnoseModulesResult,
   DiagnoseOptions,
   DiagnoseResult,
   Diagnostic,
+  ModuleDefinition,
+  ModuleError,
+  ModuleResult,
   ProjectInfo,
   ReactDoctorConfig,
   ScoreResult,

--- a/packages/api/tests/diagnose.test.ts
+++ b/packages/api/tests/diagnose.test.ts
@@ -2,7 +2,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
-import { diagnose, NoReactDependencyError, ProjectNotFoundError } from "../src/index.js";
+import {
+  diagnose,
+  diagnoseModules,
+  NoReactDependencyError,
+  ProjectNotFoundError,
+} from "../src/index.js";
 
 const FIXTURES_DIRECTORY = path.resolve(
   import.meta.dirname,
@@ -59,5 +64,149 @@ describe("diagnose", () => {
       lint: false,
     });
     expect(result.elapsedMilliseconds).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("diagnoseModules", () => {
+  it("returns per-module results for multiple directories", async () => {
+    const result = await diagnoseModules(
+      [
+        { directory: path.join(FIXTURES_DIRECTORY, "basic-react") },
+        { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app") },
+      ],
+      { deadCode: false, lint: false },
+    );
+
+    expect(result.modules).toHaveLength(2);
+    expect(result).toHaveProperty("diagnostics");
+    expect(result).toHaveProperty("score");
+    expect(result).toHaveProperty("elapsedMilliseconds");
+    expect(Array.isArray(result.diagnostics)).toBe(true);
+
+    for (const moduleResult of result.modules) {
+      expect(moduleResult).toHaveProperty("directory");
+      expect(moduleResult).toHaveProperty("diagnostics");
+      expect(moduleResult).toHaveProperty("score");
+      expect(moduleResult).toHaveProperty("project");
+      expect(moduleResult).toHaveProperty("skippedChecks");
+      expect(moduleResult).toHaveProperty("elapsedMilliseconds");
+    }
+  });
+
+  it("flattens diagnostics across all modules", async () => {
+    const result = await diagnoseModules(
+      [
+        { directory: path.join(FIXTURES_DIRECTORY, "basic-react") },
+        { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app") },
+      ],
+      { deadCode: false, lint: false },
+    );
+
+    const expectedTotal = result.modules.reduce(
+      (sum, moduleResult) => sum + moduleResult.diagnostics.length,
+      0,
+    );
+    expect(result.diagnostics).toHaveLength(expectedTotal);
+  });
+
+  it("supports per-module config overrides", async () => {
+    const result = await diagnoseModules(
+      [
+        { directory: path.join(FIXTURES_DIRECTORY, "basic-react"), config: { deadCode: false } },
+        { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app"), config: { deadCode: false } },
+      ],
+      { lint: false },
+    );
+
+    expect(result.modules).toHaveLength(2);
+    for (const moduleResult of result.modules) {
+      expect(moduleResult.skippedChecks).not.toContain("dead-code");
+    }
+  });
+
+  it("respects concurrency: 1 for sequential execution", async () => {
+    const result = await diagnoseModules(
+      [
+        { directory: path.join(FIXTURES_DIRECTORY, "basic-react") },
+        { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app") },
+      ],
+      { deadCode: false, lint: false, concurrency: 1 },
+    );
+
+    expect(result.modules).toHaveLength(2);
+    expect(result.elapsedMilliseconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it("handles a single module identically to diagnose()", async () => {
+    const singleModuleResult = await diagnoseModules(
+      [{ directory: path.join(FIXTURES_DIRECTORY, "basic-react") }],
+      { deadCode: false, lint: false },
+    );
+    const directResult = await diagnose(path.join(FIXTURES_DIRECTORY, "basic-react"), {
+      deadCode: false,
+      lint: false,
+    });
+
+    expect(singleModuleResult.modules).toHaveLength(1);
+    expect(singleModuleResult.errors).toHaveLength(0);
+    expect(singleModuleResult.modules[0].project.reactMajorVersion).toBe(
+      directResult.project.reactMajorVersion,
+    );
+    expect(singleModuleResult.modules[0].project.projectName).toBe(
+      directResult.project.projectName,
+    );
+  });
+
+  it("collects failing modules into errors without aborting the batch", async () => {
+    const result = await diagnoseModules(
+      [
+        { directory: path.join(FIXTURES_DIRECTORY, "basic-react") },
+        { directory: noReactTempDirectory },
+      ],
+      { deadCode: false, lint: false },
+    );
+
+    expect(result.modules).toHaveLength(1);
+    expect(result.modules[0].project.projectName).toBe("test-basic-react");
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].directory).toBe(noReactTempDirectory);
+    expect(result.errors[0].error).toBeInstanceOf(Error);
+  });
+
+  it("returns empty results for an empty modules array", async () => {
+    const result = await diagnoseModules([], { deadCode: false, lint: false });
+
+    expect(result.modules).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.score).toBeNull();
+    expect(result.elapsedMilliseconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it("clamps concurrency: 0 to 1 without hanging", async () => {
+    const result = await diagnoseModules(
+      [{ directory: path.join(FIXTURES_DIRECTORY, "basic-react") }],
+      { deadCode: false, lint: false, concurrency: 0 },
+    );
+
+    expect(result.modules).toHaveLength(1);
+  });
+
+  it("accepts per-module reactDoctorConfig override", async () => {
+    const result = await diagnoseModules(
+      [
+        {
+          directory: path.join(FIXTURES_DIRECTORY, "basic-react"),
+          config: {
+            deadCode: false,
+            reactDoctorConfig: { ignore: { tags: ["design"] } },
+          },
+        },
+      ],
+      { lint: false },
+    );
+
+    expect(result.modules).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
   });
 });

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @react-doctor/core
 
+## 0.2.8
+
+### Patch Changes
+
+- add react-doctor.config.json schema field
+
+- Updated dependencies []:
+  - oxlint-plugin-react-doctor@0.2.8
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-doctor/core",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "description": "Internal: diagnostic engine for React Doctor (lint runner, scoring, config, suppressions). Not published.",
   "license": "MIT",

--- a/packages/core/src/types/diagnose.ts
+++ b/packages/core/src/types/diagnose.ts
@@ -1,3 +1,4 @@
+import type { ReactDoctorConfig } from "./config.js";
 import type { Diagnostic } from "./diagnostic.js";
 import type { ProjectInfo } from "./project-info.js";
 import type { ScoreResult } from "./score.js";
@@ -27,5 +28,57 @@ export interface DiagnoseResult {
   /** See `InspectResult.skippedCheckReasons`. */
   skippedCheckReasons?: Record<string, string>;
   project: ProjectInfo;
+  elapsedMilliseconds: number;
+}
+
+/**
+ * A single module (directory) to scan as part of a `diagnoseModules()`
+ * batch. Per-module `config` overrides layer on top of the global
+ * `DiagnoseModulesOptions` — omitted fields fall through to the global
+ * defaults, and per-module `ReactDoctorConfig` overrides take
+ * precedence over any on-disk config file found in the module
+ * directory.
+ */
+export interface ModuleDefinition {
+  directory: string;
+  config?: DiagnoseOptions & {
+    /**
+     * Full react-doctor config override for this module. When provided,
+     * replaces the on-disk `react-doctor.config.json` for this module's
+     * scan — the scan target resolver still runs (so `rootDir` and
+     * subproject discovery work), but its loaded config is swapped out.
+     */
+    reactDoctorConfig?: ReactDoctorConfig;
+  };
+}
+
+export interface ModuleResult extends DiagnoseResult {
+  directory: string;
+}
+
+export interface ModuleError {
+  directory: string;
+  error: Error;
+}
+
+export interface DiagnoseModulesOptions extends DiagnoseOptions {
+  /**
+   * Maximum number of modules to scan concurrently. Defaults to the
+   * number of modules (fully parallel). Set to `1` for sequential
+   * execution. Values below 1 are clamped to 1.
+   */
+  concurrency?: number;
+}
+
+export interface DiagnoseModulesResult {
+  modules: ModuleResult[];
+  /**
+   * Modules whose scans failed (e.g. `NoReactDependencyError`,
+   * `ProjectNotFoundError`). Succeeded modules are in `modules`;
+   * failed ones land here so callers always receive partial results.
+   */
+  errors: ModuleError[];
+  diagnostics: Diagnostic[];
+  score: ScoreResult | null;
   elapsedMilliseconds: number;
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -7,7 +7,15 @@ export type {
   RuleSeverityOverride,
   SurfaceControls,
 } from "./config.js";
-export type { DiagnoseOptions, DiagnoseResult } from "./diagnose.js";
+export type {
+  DiagnoseModulesOptions,
+  DiagnoseModulesResult,
+  DiagnoseOptions,
+  DiagnoseResult,
+  ModuleDefinition,
+  ModuleError,
+  ModuleResult,
+} from "./diagnose.js";
 export type { CleanedDiagnostic, Diagnostic, OxlintOutput } from "./diagnostic.js";
 export type { HandleErrorOptions } from "./handle-error.js";
 export type {

--- a/packages/eslint-plugin-react-doctor/CHANGELOG.md
+++ b/packages/eslint-plugin-react-doctor/CHANGELOG.md
@@ -1,5 +1,14 @@
 # eslint-plugin-react-doctor
 
+## 0.2.8
+
+### Patch Changes
+
+- add react-doctor.config.json schema field
+
+- Updated dependencies []:
+  - oxlint-plugin-react-doctor@0.2.8
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/eslint-plugin-react-doctor/package.json
+++ b/packages/eslint-plugin-react-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-react-doctor",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "ESLint plugin for React Doctor: diagnose React codebases for security, performance, correctness, accessibility, bundle-size, and architecture issues",
   "keywords": [
     "accessibility",

--- a/packages/oxlint-plugin-react-doctor/CHANGELOG.md
+++ b/packages/oxlint-plugin-react-doctor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # oxlint-plugin-react-doctor
 
+## 0.2.8
+
+### Patch Changes
+
+- add react-doctor.config.json schema field
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/oxlint-plugin-react-doctor/package.json
+++ b/packages/oxlint-plugin-react-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oxlint-plugin-react-doctor",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "oxlint plugin for React Doctor: diagnose React codebases for security, performance, correctness, accessibility, bundle-size, and architecture issues",
   "keywords": [
     "accessibility",

--- a/packages/react-doctor/CHANGELOG.md
+++ b/packages/react-doctor/CHANGELOG.md
@@ -1,5 +1,14 @@
 # react-doctor
 
+## 0.2.8
+
+### Patch Changes
+
+- add react-doctor.config.json schema field
+
+- Updated dependencies []:
+  - oxlint-plugin-react-doctor@0.2.8
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-doctor",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Diagnose and fix React codebases for security, performance, correctness, accessibility, bundle-size, and architecture issues",
   "keywords": [
     "accessibility",


### PR DESCRIPTION
## Summary

- Adds `diagnoseModules()` to `@react-doctor/api` — scans multiple directories in parallel with per-module configs and returns per-module scores, replacing the need for custom parallel-worker plumbing
- Per-module `reactDoctorConfig` overrides are fully wired through `Config.layerOf` so `rules`, `categories`, `surfaces`, `ignore`, `plugins`, etc. all take effect (not just boolean flags)
- Partial-result semantics: failing modules land in `result.errors`, succeeded ones in `result.modules` — callers always get partial results
- Configurable `concurrency` (default: fully parallel, clamped to >= 1)
- Aggregate `score` uses worst-of across modules (matches existing JSON report behavior)

### New types

| Type | Description |
|------|-------------|
| `ModuleDefinition` | `{ directory, config? }` — per-module directory + optional `DiagnoseOptions` & `reactDoctorConfig` override |
| `ModuleResult` | `DiagnoseResult` + resolved `directory` |
| `ModuleError` | `{ directory, error }` for modules that failed |
| `DiagnoseModulesOptions` | `DiagnoseOptions` + `concurrency?` |
| `DiagnoseModulesResult` | `{ modules, errors, diagnostics, score, elapsedMilliseconds }` |

### Usage

```ts
import { diagnoseModules } from "@react-doctor/api";

const result = await diagnoseModules([
  { directory: "packages/app" },
  { directory: "packages/shared", config: { deadCode: false } },
  { directory: "packages/admin", config: {
    reactDoctorConfig: { rules: { "react-doctor/no-array-index-as-key": "off" } },
  }},
], { concurrency: 4 });

for (const mod of result.modules) {
  console.log(mod.directory, mod.score);
}
```

## Test plan

- [x] Multi-module scan returns per-module results with expected shape
- [x] Diagnostics are flattened across all modules
- [x] Per-module `DiagnoseOptions` overrides work (deadCode)
- [x] Per-module `reactDoctorConfig` override accepted and wired through
- [x] `concurrency: 1` runs sequentially
- [x] `concurrency: 0` clamps to 1 (no hang)
- [x] Single module matches `diagnose()` behavior
- [x] Failing module collected in `errors`, doesn't abort batch
- [x] Empty modules array returns empty results
- [x] All 13 tests pass (`pnpm --filter @react-doctor/api test`)
- [x] Typecheck passes for both core and api packages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API and parallel inspect runs increase resource use; `diagnose()` layer wiring changed though behavior should match prior `layerInspectLive` usage.
> 
> **Overview**
> Adds **`diagnoseModules()`** to `@react-doctor/api` so embedders can scan many package directories in one call, with **configurable concurrency** (default: all modules in parallel, minimum clamped to 1).
> 
> Each entry is a **`ModuleDefinition`** (`directory` plus optional per-module `DiagnoseOptions` and a full **`reactDoctorConfig`** override). Every module runs the same **`runInspect`** path as **`diagnose()`**; overrides are applied via **`Config.layerOf`** when `reactDoctorConfig` is set. Results include per-module **`ModuleResult`** rows, flattened **`diagnostics`**, a **worst-of aggregate `score`**, and **`errors`** for modules that failed without aborting the batch.
> 
> **`diagnose()`** is refactored to share **`buildInspectProgram`**, **`outputToDiagnoseResult`**, and an explicit Effect layer stack (equivalent to core’s inspect live stack) so single- and multi-module entry points stay aligned. New types are exported from **`@react-doctor/core`** and re-exported from the API package, with integration tests for batching, concurrency, partial failure, and config overrides. Workspace packages bump to **0.2.8** (changelog also notes a config JSON schema field).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7465c7d00aca00afb7a0a4c592625b45b58df7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->