### PR TITLE
refactor(api): rename diagnoseModules → diagnoseProjects, clean up API shape

### DIFF
--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -19,13 +19,12 @@ import {
   type ResolvedScanTarget,
 } from "@react-doctor/core";
 import type {
-  DiagnoseModulesOptions,
-  DiagnoseModulesResult,
   DiagnoseOptions,
+  DiagnoseProjectsInput,
+  DiagnoseProjectsResult,
   DiagnoseResult,
-  ModuleDefinition,
-  ModuleError,
-  ModuleResult,
+  ProjectDefinition,
+  ProjectResult,
   ReactDoctorConfig,
   ScoreResult,
 } from "@react-doctor/core";
@@ -132,136 +131,127 @@ export const diagnose = async (
   return outputToDiagnoseResult(output, globalThis.performance.now() - startTime);
 };
 
-const findWorstScore = (moduleResults: ModuleResult[]): ScoreResult | null => {
+const findWorstScore = (projectResults: ProjectResult[]): ScoreResult | null => {
   let worstResult: ScoreResult | null = null;
   let worstScore = Number.POSITIVE_INFINITY;
-  for (const moduleResult of moduleResults) {
-    if (moduleResult.score === null) continue;
-    if (moduleResult.score.score < worstScore) {
-      worstScore = moduleResult.score.score;
-      worstResult = moduleResult.score;
+  for (const projectResult of projectResults) {
+    if (!projectResult.ok || projectResult.score === null) continue;
+    if (projectResult.score.score < worstScore) {
+      worstScore = projectResult.score.score;
+      worstResult = projectResult.score;
     }
   }
   return worstResult;
 };
 
-const diagnoseModule = async (
-  moduleDefinition: ModuleDefinition,
+const diagnoseProject = async (
+  projectDefinition: ProjectDefinition,
   baseOptions: DiagnoseOptions,
-): Promise<ModuleResult> => {
+): Promise<ProjectResult> => {
   const startTime = globalThis.performance.now();
-  const scanTarget = resolveScanTarget(moduleDefinition.directory);
-  const { reactDoctorConfig: configOverride, ...perModuleOptions } =
-    moduleDefinition.config ?? {};
-  const mergedOptions: DiagnoseOptions = { ...baseOptions, ...perModuleOptions };
 
-  const program = buildInspectProgram(scanTarget, mergedOptions, configOverride);
+  try {
+    const scanTarget = resolveScanTarget(projectDefinition.directory);
+    const { directory: _, config: configOverride, ...perProjectOptions } = projectDefinition;
+    const mergedOptions: DiagnoseOptions = { ...baseOptions, ...perProjectOptions };
 
-  const layer =
-    configOverride !== undefined
-      ? buildLayerWithConfigOverride(configOverride, scanTarget.resolvedDirectory)
-      : DEFAULT_LAYER;
+    const program = buildInspectProgram(scanTarget, mergedOptions, configOverride);
 
-  const output: InspectOutput = await Effect.runPromise(
-    restoreLegacyThrow(
-      program.pipe(Effect.provide(layer), Effect.provide(layerOtlp)),
-    ),
-  );
+    const layer =
+      configOverride !== undefined
+        ? buildLayerWithConfigOverride(configOverride, scanTarget.resolvedDirectory)
+        : DEFAULT_LAYER;
 
-  return {
-    ...outputToDiagnoseResult(output, globalThis.performance.now() - startTime),
-    directory: scanTarget.resolvedDirectory,
-  };
+    const output: InspectOutput = await Effect.runPromise(
+      restoreLegacyThrow(
+        program.pipe(Effect.provide(layer), Effect.provide(layerOtlp)),
+      ),
+    );
+
+    return {
+      ok: true,
+      ...outputToDiagnoseResult(output, globalThis.performance.now() - startTime),
+      directory: scanTarget.resolvedDirectory,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      directory: projectDefinition.directory,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
 };
 
 /**
- * Scan multiple modules in parallel and return per-module scores,
- * diagnostics, and an aggregate score (worst-of across all modules).
+ * Scan multiple projects in parallel and return per-project scores,
+ * diagnostics, and an aggregate score (worst-of across all projects).
  *
- * Each module runs its own independent `runInspect` pipeline — the
- * same pipeline `diagnose()` uses — so per-module config overrides,
+ * Each project runs its own independent `runInspect` pipeline — the
+ * same pipeline `diagnose()` uses — so per-project config overrides,
  * dead-code analysis, and scoring all work identically to a single
  * `diagnose()` call.
  *
- * Modules that fail (e.g. missing `package.json`, no React dependency)
- * are collected in `result.errors` rather than aborting the entire
- * batch, so callers always receive partial results from the modules
- * that succeeded.
+ * Projects that fail (e.g. missing `package.json`, no React dependency)
+ * are included in the result with `ok: false` rather than aborting the
+ * entire batch, so callers always receive partial results.
  *
  * ```ts
- * const result = await diagnoseModules([
- *   { directory: "packages/app" },
- *   { directory: "packages/shared", config: { deadCode: false } },
- *   { directory: "packages/admin", config: {
- *     reactDoctorConfig: { rules: { "react-doctor/no-array-index-as-key": "off" } },
- *   }},
- * ], { concurrency: 4 });
+ * const result = await diagnoseProjects({
+ *   projects: [
+ *     { directory: "packages/app" },
+ *     { directory: "packages/shared", deadCode: false },
+ *     { directory: "packages/admin", config: {
+ *       rules: { "react-doctor/no-array-index-as-key": "off" },
+ *     }},
+ *   ],
+ *   concurrency: 4,
+ * });
  *
- * for (const mod of result.modules) {
- *   console.log(mod.directory, mod.score);
+ * for (const project of result.projects) {
+ *   if (project.ok) {
+ *     console.log(project.directory, project.score);
+ *   } else {
+ *     console.error(project.directory, project.error);
+ *   }
  * }
  * ```
  */
-export const diagnoseModules = async (
-  modules: ModuleDefinition[],
-  options: DiagnoseModulesOptions = {},
-): Promise<DiagnoseModulesResult> => {
+export const diagnoseProjects = async (
+  input: DiagnoseProjectsInput,
+): Promise<DiagnoseProjectsResult> => {
   const startTime = globalThis.performance.now();
-  const { concurrency: rawConcurrency, ...baseOptions } = options;
-  const concurrency = Math.max(1, rawConcurrency ?? modules.length);
+  const { projects, concurrency: rawConcurrency, ...baseOptions } = input;
+  const concurrency = Math.max(1, rawConcurrency ?? projects.length);
 
-  const moduleResults: ModuleResult[] = [];
-  const moduleErrors: ModuleError[] = [];
-  const pendingModules = [...modules];
+  const projectResults: ProjectResult[] = [];
+  const pendingProjects = [...projects];
 
   const runBatch = async (): Promise<void> => {
-    const batch: Promise<
-      | { ok: true; result: ModuleResult }
-      | { ok: false; directory: string; error: Error }
-    >[] = [];
+    const batch: Promise<ProjectResult>[] = [];
 
-    while (pendingModules.length > 0 && batch.length < concurrency) {
-      const moduleDefinition = pendingModules.shift()!;
-      batch.push(
-        diagnoseModule(moduleDefinition, baseOptions).then(
-          (result) => ({ ok: true as const, result }),
-          (error: unknown) => ({
-            ok: false as const,
-            directory: moduleDefinition.directory,
-            error: error instanceof Error ? error : new Error(String(error)),
-          }),
-        ),
-      );
+    while (pendingProjects.length > 0 && batch.length < concurrency) {
+      const projectDefinition = pendingProjects.shift()!;
+      batch.push(diagnoseProject(projectDefinition, baseOptions));
     }
 
-    const settled = await Promise.all(batch);
-    for (const outcome of settled) {
-      if (outcome.ok) {
-        moduleResults.push(outcome.result);
-      } else {
-        moduleErrors.push({
-          directory: outcome.directory,
-          error: outcome.error,
-        });
-      }
-    }
+    const batchResults = await Promise.all(batch);
+    projectResults.push(...batchResults);
 
-    if (pendingModules.length > 0) {
+    if (pendingProjects.length > 0) {
       await runBatch();
     }
   };
 
   await runBatch();
 
-  const allDiagnostics = moduleResults.flatMap(
-    (moduleResult) => moduleResult.diagnostics,
+  const allDiagnostics = projectResults.flatMap((projectResult) =>
+    projectResult.ok ? projectResult.diagnostics : [],
   );
 
   return {
-    modules: moduleResults,
-    errors: moduleErrors,
+    projects: projectResults,
     diagnostics: allDiagnostics,
-    score: findWorstScore(moduleResults),
+    score: findWorstScore(projectResults),
     elapsedMilliseconds: globalThis.performance.now() - startTime,
   };
 };

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,15 +1,16 @@
-export { diagnose, diagnoseModules } from "./diagnose.js";
+export { diagnose, diagnoseProjects } from "./diagnose.js";
 
 export type {
-  DiagnoseModulesOptions,
-  DiagnoseModulesResult,
   DiagnoseOptions,
+  DiagnoseProjectsInput,
+  DiagnoseProjectsResult,
   DiagnoseResult,
   Diagnostic,
-  ModuleDefinition,
-  ModuleError,
-  ModuleResult,
+  ProjectDefinition,
   ProjectInfo,
+  ProjectResult,
+  ProjectResultError,
+  ProjectResultOk,
   ReactDoctorConfig,
   ScoreResult,
 } from "@react-doctor/core";

--- a/packages/api/tests/diagnose.test.ts
+++ b/packages/api/tests/diagnose.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 import {
   diagnose,
-  diagnoseModules,
+  diagnoseProjects,
   NoReactDependencyError,
   ProjectNotFoundError,
 } from "../src/index.js";
@@ -67,146 +67,156 @@ describe("diagnose", () => {
   });
 });
 
-describe("diagnoseModules", () => {
-  it("returns per-module results for multiple directories", async () => {
-    const result = await diagnoseModules(
-      [
+describe("diagnoseProjects", () => {
+  it("returns per-project results for multiple directories", async () => {
+    const result = await diagnoseProjects({
+      projects: [
         { directory: path.join(FIXTURES_DIRECTORY, "basic-react") },
         { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app") },
       ],
-      { deadCode: false, lint: false },
-    );
+      deadCode: false,
+      lint: false,
+    });
 
-    expect(result.modules).toHaveLength(2);
+    expect(result.projects).toHaveLength(2);
     expect(result).toHaveProperty("diagnostics");
     expect(result).toHaveProperty("score");
     expect(result).toHaveProperty("elapsedMilliseconds");
     expect(Array.isArray(result.diagnostics)).toBe(true);
 
-    for (const moduleResult of result.modules) {
-      expect(moduleResult).toHaveProperty("directory");
-      expect(moduleResult).toHaveProperty("diagnostics");
-      expect(moduleResult).toHaveProperty("score");
-      expect(moduleResult).toHaveProperty("project");
-      expect(moduleResult).toHaveProperty("skippedChecks");
-      expect(moduleResult).toHaveProperty("elapsedMilliseconds");
+    for (const projectResult of result.projects) {
+      expect(projectResult.ok).toBe(true);
+      if (!projectResult.ok) continue;
+      expect(projectResult).toHaveProperty("directory");
+      expect(projectResult).toHaveProperty("diagnostics");
+      expect(projectResult).toHaveProperty("score");
+      expect(projectResult).toHaveProperty("project");
+      expect(projectResult).toHaveProperty("skippedChecks");
+      expect(projectResult).toHaveProperty("elapsedMilliseconds");
     }
   });
 
-  it("flattens diagnostics across all modules", async () => {
-    const result = await diagnoseModules(
-      [
+  it("flattens diagnostics across all succeeded projects", async () => {
+    const result = await diagnoseProjects({
+      projects: [
         { directory: path.join(FIXTURES_DIRECTORY, "basic-react") },
         { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app") },
       ],
-      { deadCode: false, lint: false },
-    );
+      deadCode: false,
+      lint: false,
+    });
 
-    const expectedTotal = result.modules.reduce(
-      (sum, moduleResult) => sum + moduleResult.diagnostics.length,
+    const expectedTotal = result.projects.reduce(
+      (sum, projectResult) => sum + (projectResult.ok ? projectResult.diagnostics.length : 0),
       0,
     );
     expect(result.diagnostics).toHaveLength(expectedTotal);
   });
 
-  it("supports per-module config overrides", async () => {
-    const result = await diagnoseModules(
-      [
-        { directory: path.join(FIXTURES_DIRECTORY, "basic-react"), config: { deadCode: false } },
-        { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app"), config: { deadCode: false } },
+  it("supports per-project scan option overrides", async () => {
+    const result = await diagnoseProjects({
+      projects: [
+        { directory: path.join(FIXTURES_DIRECTORY, "basic-react"), deadCode: false },
+        { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app"), deadCode: false },
       ],
-      { lint: false },
-    );
+      lint: false,
+    });
 
-    expect(result.modules).toHaveLength(2);
-    for (const moduleResult of result.modules) {
-      expect(moduleResult.skippedChecks).not.toContain("dead-code");
+    expect(result.projects).toHaveLength(2);
+    for (const projectResult of result.projects) {
+      expect(projectResult.ok).toBe(true);
+      if (!projectResult.ok) continue;
+      expect(projectResult.skippedChecks).not.toContain("dead-code");
     }
   });
 
   it("respects concurrency: 1 for sequential execution", async () => {
-    const result = await diagnoseModules(
-      [
+    const result = await diagnoseProjects({
+      projects: [
         { directory: path.join(FIXTURES_DIRECTORY, "basic-react") },
         { directory: path.join(FIXTURES_DIRECTORY, "nextjs-app") },
       ],
-      { deadCode: false, lint: false, concurrency: 1 },
-    );
+      deadCode: false,
+      lint: false,
+      concurrency: 1,
+    });
 
-    expect(result.modules).toHaveLength(2);
+    expect(result.projects).toHaveLength(2);
     expect(result.elapsedMilliseconds).toBeGreaterThanOrEqual(0);
   });
 
-  it("handles a single module identically to diagnose()", async () => {
-    const singleModuleResult = await diagnoseModules(
-      [{ directory: path.join(FIXTURES_DIRECTORY, "basic-react") }],
-      { deadCode: false, lint: false },
-    );
+  it("handles a single project identically to diagnose()", async () => {
+    const multiResult = await diagnoseProjects({
+      projects: [{ directory: path.join(FIXTURES_DIRECTORY, "basic-react") }],
+      deadCode: false,
+      lint: false,
+    });
     const directResult = await diagnose(path.join(FIXTURES_DIRECTORY, "basic-react"), {
       deadCode: false,
       lint: false,
     });
 
-    expect(singleModuleResult.modules).toHaveLength(1);
-    expect(singleModuleResult.errors).toHaveLength(0);
-    expect(singleModuleResult.modules[0].project.reactMajorVersion).toBe(
-      directResult.project.reactMajorVersion,
-    );
-    expect(singleModuleResult.modules[0].project.projectName).toBe(
-      directResult.project.projectName,
-    );
+    expect(multiResult.projects).toHaveLength(1);
+    const firstProject = multiResult.projects[0];
+    expect(firstProject.ok).toBe(true);
+    if (!firstProject.ok) return;
+    expect(firstProject.project.reactMajorVersion).toBe(directResult.project.reactMajorVersion);
+    expect(firstProject.project.projectName).toBe(directResult.project.projectName);
   });
 
-  it("collects failing modules into errors without aborting the batch", async () => {
-    const result = await diagnoseModules(
-      [
+  it("collects failing projects with ok: false without aborting the batch", async () => {
+    const result = await diagnoseProjects({
+      projects: [
         { directory: path.join(FIXTURES_DIRECTORY, "basic-react") },
         { directory: noReactTempDirectory },
       ],
-      { deadCode: false, lint: false },
-    );
+      deadCode: false,
+      lint: false,
+    });
 
-    expect(result.modules).toHaveLength(1);
-    expect(result.modules[0].project.projectName).toBe("test-basic-react");
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].directory).toBe(noReactTempDirectory);
-    expect(result.errors[0].error).toBeInstanceOf(Error);
+    const succeeded = result.projects.filter((projectResult) => projectResult.ok);
+    const failed = result.projects.filter((projectResult) => !projectResult.ok);
+
+    expect(succeeded).toHaveLength(1);
+    expect(succeeded[0].ok && succeeded[0].project.projectName).toBe("test-basic-react");
+    expect(failed).toHaveLength(1);
+    expect(failed[0].directory).toBe(noReactTempDirectory);
+    expect(!failed[0].ok && failed[0].error).toBeInstanceOf(Error);
   });
 
-  it("returns empty results for an empty modules array", async () => {
-    const result = await diagnoseModules([], { deadCode: false, lint: false });
+  it("returns empty results for an empty projects array", async () => {
+    const result = await diagnoseProjects({ projects: [], deadCode: false, lint: false });
 
-    expect(result.modules).toHaveLength(0);
-    expect(result.errors).toHaveLength(0);
+    expect(result.projects).toHaveLength(0);
     expect(result.diagnostics).toHaveLength(0);
     expect(result.score).toBeNull();
     expect(result.elapsedMilliseconds).toBeGreaterThanOrEqual(0);
   });
 
   it("clamps concurrency: 0 to 1 without hanging", async () => {
-    const result = await diagnoseModules(
-      [{ directory: path.join(FIXTURES_DIRECTORY, "basic-react") }],
-      { deadCode: false, lint: false, concurrency: 0 },
-    );
+    const result = await diagnoseProjects({
+      projects: [{ directory: path.join(FIXTURES_DIRECTORY, "basic-react") }],
+      deadCode: false,
+      lint: false,
+      concurrency: 0,
+    });
 
-    expect(result.modules).toHaveLength(1);
+    expect(result.projects).toHaveLength(1);
   });
 
-  it("accepts per-module reactDoctorConfig override", async () => {
-    const result = await diagnoseModules(
-      [
+  it("accepts per-project ReactDoctorConfig override", async () => {
+    const result = await diagnoseProjects({
+      projects: [
         {
           directory: path.join(FIXTURES_DIRECTORY, "basic-react"),
-          config: {
-            deadCode: false,
-            reactDoctorConfig: { ignore: { tags: ["design"] } },
-          },
+          deadCode: false,
+          config: { ignore: { tags: ["design"] } },
         },
       ],
-      { lint: false },
-    );
+      lint: false,
+    });
 
-    expect(result.modules).toHaveLength(1);
-    expect(result.errors).toHaveLength(0);
+    expect(result.projects).toHaveLength(1);
+    expect(result.projects[0].ok).toBe(true);
   });
 });

--- a/packages/core/src/types/diagnose.ts
+++ b/packages/core/src/types/diagnose.ts
@@ -32,52 +32,48 @@ export interface DiagnoseResult {
 }
 
 /**
- * A single module (directory) to scan as part of a `diagnoseModules()`
- * batch. Per-module `config` overrides layer on top of the global
- * `DiagnoseModulesOptions` — omitted fields fall through to the global
- * defaults, and per-module `ReactDoctorConfig` overrides take
- * precedence over any on-disk config file found in the module
- * directory.
+ * A single project to scan as part of a `diagnoseProjects()` batch.
+ * Scan options (`deadCode`, `lint`, etc.) are flat on the entry and
+ * layer on top of the global defaults — omitted fields fall through.
+ * `config` is a full `ReactDoctorConfig` override that replaces the
+ * on-disk `react-doctor.config.json` for this project's scan.
  */
-export interface ModuleDefinition {
+export interface ProjectDefinition extends DiagnoseOptions {
   directory: string;
-  config?: DiagnoseOptions & {
-    /**
-     * Full react-doctor config override for this module. When provided,
-     * replaces the on-disk `react-doctor.config.json` for this module's
-     * scan — the scan target resolver still runs (so `rootDir` and
-     * subproject discovery work), but its loaded config is swapped out.
-     */
-    reactDoctorConfig?: ReactDoctorConfig;
-  };
+  /**
+   * Full react-doctor config override for this project. When provided,
+   * replaces the on-disk `react-doctor.config.json` for this project's
+   * scan — the scan target resolver still runs (so `rootDir` and
+   * subproject discovery work), but its loaded config is swapped out.
+   */
+  config?: ReactDoctorConfig;
 }
 
-export interface ModuleResult extends DiagnoseResult {
+export interface ProjectResultOk extends DiagnoseResult {
+  ok: true;
   directory: string;
 }
 
-export interface ModuleError {
+export interface ProjectResultError {
+  ok: false;
   directory: string;
   error: Error;
 }
 
-export interface DiagnoseModulesOptions extends DiagnoseOptions {
+export type ProjectResult = ProjectResultOk | ProjectResultError;
+
+export interface DiagnoseProjectsInput extends DiagnoseOptions {
+  projects: ProjectDefinition[];
   /**
-   * Maximum number of modules to scan concurrently. Defaults to the
-   * number of modules (fully parallel). Set to `1` for sequential
+   * Maximum number of projects to scan concurrently. Defaults to the
+   * number of projects (fully parallel). Set to `1` for sequential
    * execution. Values below 1 are clamped to 1.
    */
   concurrency?: number;
 }
 
-export interface DiagnoseModulesResult {
-  modules: ModuleResult[];
-  /**
-   * Modules whose scans failed (e.g. `NoReactDependencyError`,
-   * `ProjectNotFoundError`). Succeeded modules are in `modules`;
-   * failed ones land here so callers always receive partial results.
-   */
-  errors: ModuleError[];
+export interface DiagnoseProjectsResult {
+  projects: ProjectResult[];
   diagnostics: Diagnostic[];
   score: ScoreResult | null;
   elapsedMilliseconds: number;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -8,13 +8,14 @@ export type {
   SurfaceControls,
 } from "./config.js";
 export type {
-  DiagnoseModulesOptions,
-  DiagnoseModulesResult,
   DiagnoseOptions,
+  DiagnoseProjectsInput,
+  DiagnoseProjectsResult,
   DiagnoseResult,
-  ModuleDefinition,
-  ModuleError,
-  ModuleResult,
+  ProjectDefinition,
+  ProjectResult,
+  ProjectResultError,
+  ProjectResultOk,
 } from "./diagnose.js";
 export type { CleanedDiagnostic, Diagnostic, OxlintOutput } from "./diagnostic.js";
 export type { HandleErrorOptions } from "./handle-error.js";


### PR DESCRIPTION
## Summary

Follow-up to #499. Refactors the `diagnoseModules()` API to a cleaner shape:

- **Single object arg** — `diagnoseProjects({ projects, concurrency, ...globalDefaults })` instead of `diagnoseModules(modules, options)` (matches codebase convention for >1 param)
- **"Projects" vocabulary** — matches the rest of the codebase (`selectProjects`, `JsonReportProjectEntry`, `printMultiProjectSummary`)
- **Flat per-project scan options** — `{ directory, deadCode: false }` instead of `{ directory, config: { deadCode: false } }`. No more confusing nesting where `config.deadCode` and `config.reactDoctorConfig.deadCode` both exist
- **`config` = `ReactDoctorConfig`** — `{ directory, config: { rules: { ... } } }` directly, no redundant `reactDoctorConfig` wrapper
- **Discriminated union results** — `ProjectResult` is `{ ok: true, ...DiagnoseResult } | { ok: false, directory, error }`. One array to iterate, discriminate with `.ok` — no separate `modules` + `errors` arrays to zip

### Before

```ts
const result = await diagnoseModules([
  { directory: "packages/app" },
  { directory: "packages/shared", config: { deadCode: false } },
  { directory: "packages/admin", config: {
    reactDoctorConfig: { rules: { "react-doctor/no-array-index-as-key": "off" } },
  }},
], { concurrency: 4 });

for (const mod of result.modules) { ... }
for (const err of result.errors) { ... }
```

### After

```ts
const result = await diagnoseProjects({
  projects: [
    { directory: "packages/app" },
    { directory: "packages/shared", deadCode: false },
    { directory: "packages/admin", config: {
      rules: { "react-doctor/no-array-index-as-key": "off" },
    }},
  ],
  concurrency: 4,
});

for (const project of result.projects) {
  if (project.ok) console.log(project.directory, project.score);
  else console.error(project.directory, project.error);
}
```

## Test plan

- [x] All 13 tests pass with the new API shape
- [x] Typecheck passes for both core and api packages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API rename and result-shape change for any consumer of `diagnoseModules`; behavior of parallel scanning and partial failures is preserved but callers must migrate.
> 
> **Overview**
> Renames the public batch API from **`diagnoseModules`** to **`diagnoseProjects`** and reshapes how callers pass options and read outcomes.
> 
> **Call shape:** one input object — `diagnoseProjects({ projects, concurrency, ...global DiagnoseOptions })` — instead of `(modules[], options)`. Per-entry scan flags (`deadCode`, `lint`, etc.) sit **flat** on each `ProjectDefinition`; **`config`** is only a `ReactDoctorConfig` override (no nested `config: { deadCode, reactDoctorConfig }`).
> 
> **Results:** a single **`projects`** array of discriminated **`ProjectResult`** (`ok: true` + full `DiagnoseResult` + `directory`, or `ok: false` + `error`). The separate **`errors`** list is removed; failures are handled in-place. Aggregate **`diagnostics`**, worst **`score`**, and timing behavior are unchanged aside from skipping failed entries when flattening diagnostics.
> 
> Exports and core types are renamed accordingly (`DiagnoseProjectsInput` / `DiagnoseProjectsResult`, etc.); tests are updated to the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531f26406586ef10ab384dbd8154c8ee0dcfe4a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->