### PR TITLE
feat: run formatter pre-commit

### DIFF
--- a/.vite-hooks/pre-commit
+++ b/.vite-hooks/pre-commit
@@ -1,5 +1,26 @@
 #!/bin/sh
 
+# vite-plus hook start
+vite_plus_run_staged_files() {
+  if [ -x "./node_modules/.bin/vp" ]; then
+    "./node_modules/.bin/vp" staged
+    return
+  fi
+
+  if command -v vp >/dev/null 2>&1; then
+    vp staged
+    return
+  fi
+
+  printf '%s\n' "vite-plus: command not found; skipping staged checks."
+}
+
+if ! vite_plus_run_staged_files; then
+  printf '%s\n' "Vite+ staged checks failed. Run vp staged to inspect." >&2
+  exit 1
+fi
+# vite-plus hook end
+
 # react-doctor hook start
 react_doctor_scan_staged_files() {
   if [ -x "./node_modules/.bin/react-doctor" ]; then

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "vite-plus";
 export default defineConfig({
   staged: {
     "*.{js,ts,tsx}": "vp check --fix",
+    "*.{json,jsonc,json5,yaml,yml,toml,html,css,scss,less,md,mdx,graphql,gql}":
+      "vp fmt",
   },
   lint: {
     ignorePatterns: [


### PR DESCRIPTION
## Why?

The pre-commit hook should run the same Vite+ staged workflow that is configured in `vite.config.ts`, so formatting and staged checks happen before a commit is created. This keeps the hook behavior centralized around Vite+ instead of relying only on the existing React Doctor scan, and it gives common non-code files like JSON, YAML, Markdown, CSS, and GraphQL formatter coverage before they land in commits.

## What changed?

- Added a Vite+ section to `.vite-hooks/pre-commit` that runs `vp staged` through the local `node_modules/.bin/vp` binary when available, or a globally available `vp` command as a fallback.
- Left the existing React Doctor staged scan in place, now running after Vite+ staged checks pass.
- Added a `vite.config.ts` staged formatter rule that runs `vp fmt` for common formatter-supported non-code file extensions.

Before: the pre-commit hook only ran the React Doctor staged scan, and the Vite+ staged config only covered JS/TS files with `vp check --fix`.

After: the pre-commit hook runs Vite+ staged checks first, including the existing JS/TS check path and the new formatter path for non-code files, then runs the React Doctor staged scan.

## Test plan

Test users can run these commands to verify correctness:

```sh
sh -n .vite-hooks/pre-commit
vp staged
```

They can also stage a supported file such as `README.md`, `package.json`, or `vite.config.ts`, then create a commit and confirm the Vite+ staged checks run before the React Doctor scan.