### PR TITLE
feat(oxlint-plugin): error on manual memoization when React Compiler is enabled

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -219,6 +219,7 @@ import { queryNoUseQueryForMutation } from "./rules/tanstack-query/query-no-use-
 import { queryNoVoidQueryFn } from "./rules/tanstack-query/query-no-void-query-fn.js";
 import { queryStableQueryClient } from "./rules/tanstack-query/query-stable-query-client.js";
 import { reactCompilerDestructureMethod } from "./rules/architecture/react-compiler-destructure-method.js";
+import { reactCompilerNoManualMemoization } from "./rules/architecture/react-compiler-no-manual-memoization.js";
 import { reactInJsxScope } from "./rules/react-builtins/react-in-jsx-scope.js";
 import { renderingAnimateSvgWrapper } from "./rules/performance/rendering-animate-svg-wrapper.js";
 import { renderingConditionalRender } from "./rules/correctness/rendering-conditional-render.js";
@@ -2613,6 +2614,17 @@ export const reactDoctorRules = [
     originallyExternal: false,
     rule: {
       ...reactCompilerDestructureMethod,
+      framework: "global",
+      category: "Architecture",
+    },
+  },
+  {
+    key: "react-doctor/react-compiler-no-manual-memoization",
+    id: "react-compiler-no-manual-memoization",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...reactCompilerNoManualMemoization,
       framework: "global",
       category: "Architecture",
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { reactCompilerNoManualMemoization } from "./react-compiler-no-manual-memoization.js";
+
+const expectDiagnosticCount = (code: string, expectedDiagnosticCount: number): void => {
+  const result = runRule(reactCompilerNoManualMemoization, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedDiagnosticCount);
+};
+
+const expectFlaggedApiNames = (code: string, expectedApiSnippets: ReadonlyArray<string>): void => {
+  const result = runRule(reactCompilerNoManualMemoization, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedApiSnippets.length);
+  for (let diagnosticIndex = 0; diagnosticIndex < expectedApiSnippets.length; diagnosticIndex++) {
+    const matchingDiagnostic = result.diagnostics[diagnosticIndex];
+    const expectedSnippet = expectedApiSnippets[diagnosticIndex];
+    expect(matchingDiagnostic.message).toContain(expectedSnippet);
+  }
+};
+
+describe("architecture/react-compiler-no-manual-memoization — fail cases", () => {
+  it("flags `useMemo` from named import", () => {
+    expectFlaggedApiNames(
+      `import { useMemo } from "react";
+const Component = () => {
+  const cachedValue = useMemo(() => 1, []);
+  return <span>{cachedValue}</span>;
+};`,
+      ["useMemo"],
+    );
+  });
+
+  it("flags `useCallback` from named import", () => {
+    expectFlaggedApiNames(
+      `import { useCallback } from "react";
+const Component = () => {
+  const cachedHandler = useCallback(() => undefined, []);
+  return <button onClick={cachedHandler} />;
+};`,
+      ["useCallback"],
+    );
+  });
+
+  it("flags `memo` HOC call from named import", () => {
+    expectFlaggedApiNames(
+      `import { memo } from "react";
+const Component = memo(({ value }) => <span>{value}</span>);
+export default Component;`,
+      ["memo()"],
+    );
+  });
+
+  it("flags renamed named import (`useMemo as memoize`)", () => {
+    expectFlaggedApiNames(
+      `import { useMemo as memoize } from "react";
+const Component = () => {
+  const cachedValue = memoize(() => 1, []);
+  return <span>{cachedValue}</span>;
+};`,
+      ["useMemo"],
+    );
+  });
+
+  it("flags renamed `useCallback` and `memo` aliases", () => {
+    expectFlaggedApiNames(
+      `import { useCallback as stableCallback, memo as wrapMemo } from "react";
+const Inner = ({ onClick }) => <button onClick={onClick} />;
+const Wrapped = wrapMemo(Inner);
+const Container = () => {
+  const handler = stableCallback(() => undefined, []);
+  return <Wrapped onClick={handler} />;
+};`,
+      ["memo()", "useCallback"],
+    );
+  });
+
+  it("flags `React.useMemo` via default import", () => {
+    expectFlaggedApiNames(
+      `import React from "react";
+const Component = () => {
+  const cachedValue = React.useMemo(() => 1, []);
+  return <span>{cachedValue}</span>;
+};`,
+      ["useMemo"],
+    );
+  });
+
+  it("flags `React.useCallback` and `React.memo` namespace calls", () => {
+    expectFlaggedApiNames(
+      `import * as React from "react";
+const Inner = React.memo(({ onClick }) => <button onClick={onClick} />);
+const Container = () => {
+  const handler = React.useCallback(() => undefined, []);
+  return <Inner onClick={handler} />;
+};`,
+      ["memo()", "useCallback"],
+    );
+  });
+
+  it("flags namespace import aliased to a non-React name", () => {
+    expectFlaggedApiNames(
+      `import * as ReactStuff from "react";
+const Component = () => {
+  const cachedValue = ReactStuff.useMemo(() => 1, []);
+  return <span>{cachedValue}</span>;
+};`,
+      ["useMemo"],
+    );
+  });
+
+  it("flags default-imported React aliased to a non-canonical name", () => {
+    expectFlaggedApiNames(
+      `import MyReact from "react";
+const Component = () => {
+  const cachedValue = MyReact.useMemo(() => 1, []);
+  return <span>{cachedValue}</span>;
+};`,
+      ["useMemo"],
+    );
+  });
+
+  it("flags transpiled `_react.useMemo` even without an import declaration", () => {
+    expectFlaggedApiNames(`_react.useMemo(() => 1, []);`, ["useMemo"]);
+  });
+
+  it("flags `React.memo(Component, areEqual)` with custom comparator", () => {
+    expectFlaggedApiNames(
+      `import React from "react";
+const Inner = ({ value }) => <span>{value}</span>;
+const areEqual = (prev, next) => prev.value === next.value;
+const Wrapped = React.memo(Inner, areEqual);
+export default Wrapped;`,
+      ["memo()"],
+    );
+  });
+
+  it("emits one diagnostic per manual-memoization call in the file", () => {
+    expectDiagnosticCount(
+      `import { memo, useCallback, useMemo } from "react";
+const Inner = memo(({ value, onClick }) => <button onClick={onClick}>{value}</button>);
+const Container = () => {
+  const value = useMemo(() => 1, []);
+  const handler = useCallback(() => undefined, []);
+  return <Inner value={value} onClick={handler} />;
+};`,
+      3,
+    );
+  });
+
+  it("flags the outer `memo(forwardRef(...))` even when nested", () => {
+    expectFlaggedApiNames(
+      `import { memo, forwardRef } from "react";
+const Wrapped = memo(forwardRef(({ value }, ref) => <span ref={ref}>{value}</span>));
+export default Wrapped;`,
+      ["memo()"],
+    );
+  });
+
+  it("flags module-scope `memo(Component)` calls (not just inside components)", () => {
+    expectFlaggedApiNames(
+      `import { memo } from "react";
+const Inner = ({ value }) => <span>{value}</span>;
+export const Wrapped = memo(Inner);`,
+      ["memo()"],
+    );
+  });
+
+  it("flags `useMemo` inside a conditional expression branch", () => {
+    expectFlaggedApiNames(
+      `import { useMemo } from "react";
+const Component = ({ shouldCache, value }) => {
+  const resolved = shouldCache ? useMemo(() => value * 2, [value]) : value;
+  return <span>{resolved}</span>;
+};`,
+      ["useMemo"],
+    );
+  });
+});
+
+describe("architecture/react-compiler-no-manual-memoization — pass cases (no diagnostics)", () => {
+  it("does not flag a locally-declared `useMemo` lookalike", () => {
+    expectDiagnosticCount(
+      `const useMemo = (compute) => compute();
+const Component = () => {
+  const cachedValue = useMemo(() => 1);
+  return <span>{cachedValue}</span>;
+};`,
+      0,
+    );
+  });
+
+  it("does not flag `useMemo` imported from a sibling module", () => {
+    expectDiagnosticCount(
+      `import { useMemo } from "./local-memo";
+const Component = () => {
+  const cachedValue = useMemo(() => 1);
+  return <span>{cachedValue}</span>;
+};`,
+      0,
+    );
+  });
+
+  it("does not flag hook-named symbols imported from a different package", () => {
+    expectDiagnosticCount(
+      `import { useMemo, useCallback, memo } from "preact/hooks";
+const Component = () => {
+  const cachedValue = useMemo(() => 1);
+  const handler = useCallback(() => undefined);
+  return memo(<span onClick={handler}>{cachedValue}</span>);
+};`,
+      0,
+    );
+  });
+
+  it("does not flag `lodash.memoize` and other look-alike method calls", () => {
+    expectDiagnosticCount(
+      `import lodash from "lodash";
+const memoized = lodash.memoize(() => 1);
+const result = memoized();
+export { result };`,
+      0,
+    );
+  });
+
+  it("does not flag `someObject.useMemo()` when `someObject` is not from react", () => {
+    expectDiagnosticCount(
+      `import { Dispatcher } from "some-internal-renderer";
+const cached = Dispatcher.useMemo(() => 1, []);
+export { cached };`,
+      0,
+    );
+  });
+
+  it("does not flag non-memoization React APIs (`useState`, `createContext`, …)", () => {
+    expectDiagnosticCount(
+      `import React, { useState } from "react";
+const Context = React.createContext(null);
+const Component = () => {
+  const [value, setValue] = useState(0);
+  return <Context.Provider value={value}>{setValue}</Context.Provider>;
+};`,
+      0,
+    );
+  });
+
+  it('does not flag computed member access `React["useMemo"]()`', () => {
+    expectDiagnosticCount(
+      `import React from "react";
+const Component = () => {
+  const cachedValue = React["useMemo"](() => 1, []);
+  return <span>{cachedValue}</span>;
+};`,
+      0,
+    );
+  });
+
+  it("does not flag `useMemo` referenced without being called", () => {
+    expectDiagnosticCount(
+      `import { useMemo } from "react";
+const reference = useMemo;
+export { reference };`,
+      0,
+    );
+  });
+
+  it("does not flag identifier-name collisions in unrelated positions (JSX text, strings)", () => {
+    expectDiagnosticCount(
+      `const Component = () => (
+  <div>
+    <span>Why useMemo?</span>
+    <code>{"React.memo(Component)"}</code>
+  </div>
+);`,
+      0,
+    );
+  });
+
+  it("does not flag aliased call when the alias resolves to a non-memoization React API", () => {
+    expectDiagnosticCount(
+      `import { useState as memoize } from "react";
+const Component = () => {
+  const [value, setValue] = memoize(0);
+  return <button onClick={() => setValue(value + 1)}>{value}</button>;
+};`,
+      0,
+    );
+  });
+
+  it("does not flag default-import `React()` direct call (React itself is not a memoization API)", () => {
+    expectDiagnosticCount(
+      `import React from "react";
+const created = React();
+export { created };`,
+      0,
+    );
+  });
+
+  it("does not flag `_react.something` when `something` is not a memoization API", () => {
+    expectDiagnosticCount(`_react.createContext(null); _react.useState(0);`, 0);
+  });
+
+  it("does not flag `Reactosaurus.useMemo()` (canonical-prefix check is exact, not startsWith)", () => {
+    expectDiagnosticCount(
+      `const cached = Reactosaurus.useMemo(() => 1, []);
+export { cached };`,
+      0,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
@@ -1,7 +1,11 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { isImportedFromModule } from "../../utils/find-import-source-for-name.js";
+import {
+  getImportedNameFromModule,
+  isImportedFromModule,
+} from "../../utils/find-import-source-for-name.js";
+import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -21,56 +25,50 @@ const REMOVAL_MESSAGE_BY_REACT_API_NAME = new Map<string, string>([
   ],
 ]);
 
-const REACT_NAMESPACE_NAME_PREFIXES = ["React", "react", "_react", "_React"] as const;
-
-const isCanonicalReactNamespaceName = (namespaceName: string): boolean => {
-  for (const reactNamespacePrefix of REACT_NAMESPACE_NAME_PREFIXES) {
-    if (namespaceName === reactNamespacePrefix) return true;
-    if (namespaceName.startsWith(reactNamespacePrefix)) return true;
-  }
-  return false;
-};
-
-const resolveRemovalMessageForCallee = (callee: EsTreeNode): string | null => {
-  if (isNodeOfType(callee, "Identifier")) {
-    const removalMessage = REMOVAL_MESSAGE_BY_REACT_API_NAME.get(callee.name);
-    if (!removalMessage) return null;
-    if (!isImportedFromModule(callee, callee.name, "react")) return null;
-    return removalMessage;
-  }
-  if (isNodeOfType(callee, "MemberExpression")) {
-    if (callee.computed) return null;
-    const namespaceIdentifier = callee.object;
-    const propertyIdentifier = callee.property;
-    if (!isNodeOfType(namespaceIdentifier, "Identifier")) return null;
-    if (!isNodeOfType(propertyIdentifier, "Identifier")) return null;
-    const removalMessage = REMOVAL_MESSAGE_BY_REACT_API_NAME.get(propertyIdentifier.name);
-    if (!removalMessage) return null;
-    const namespaceName = namespaceIdentifier.name;
-    if (isCanonicalReactNamespaceName(namespaceName)) return removalMessage;
-    if (isImportedFromModule(namespaceIdentifier, namespaceName, "react")) return removalMessage;
-    return null;
+// Resolves a callee identifier (e.g. `memoize` in `memoize(...)`) to
+// the React API it ultimately points at, OR null if it doesn't point
+// at one. Handles three import shapes:
+//   import { memo } from "react"                     → "memo"
+//   import { useMemo as memoize } from "react"       → "useMemo"
+//   import * as ReactNS from "react"; ReactNS.memo() → namespace path
+const resolveReactApiNameForIdentifier = (callee: EsTreeNode): string | null => {
+  if (!isNodeOfType(callee, "Identifier")) return null;
+  const importedName = getImportedNameFromModule(callee, callee.name, "react");
+  if (importedName && REMOVAL_MESSAGE_BY_REACT_API_NAME.has(importedName)) {
+    return importedName;
   }
   return null;
 };
 
-// Active only when React Compiler is detected for the project (the
-// rule registry gates this with `requires: ["react-compiler"]`). When
-// the compiler is on, `useMemo`, `useCallback`, and `memo(...)` are
-// strictly redundant — the compiler memoizes every value, every
-// function, and every component output automatically. Manual
-// memoization adds maintenance overhead and hides bugs (stale deps in
-// `useMemo`/`useCallback`, redundant equality checks in `memo`).
-//
-// The rule only fires when the callee resolves back to the `react`
-// package (named import, namespace import, or canonical `React.`
-// prefix). Userland `useMemo` / `useCallback` / `memo` helpers
-// (Lodash's `memoize`, custom `useMemo` lookalikes, etc.) are
-// untouched. The `react-hooks-js/preserve-manual-memoization`
-// compiler-frontend rule continues to flag the *opposite* case —
-// removals the compiler can't safely auto-memoize — so the two rules
-// compose: this one drives removal, the compiler frontend protects
-// the cases that must stay.
+const resolveReactApiNameForMemberExpression = (callee: EsTreeNode): string | null => {
+  if (!isNodeOfType(callee, "MemberExpression")) return null;
+  if (callee.computed) return null;
+  const namespaceIdentifier = callee.object;
+  const propertyIdentifier = callee.property;
+  if (!isNodeOfType(namespaceIdentifier, "Identifier")) return null;
+  if (!isNodeOfType(propertyIdentifier, "Identifier")) return null;
+  if (!REMOVAL_MESSAGE_BY_REACT_API_NAME.has(propertyIdentifier.name)) return null;
+  const namespaceName = namespaceIdentifier.name;
+  if (isCanonicalReactNamespaceName(namespaceName)) return propertyIdentifier.name;
+  if (isImportedFromModule(namespaceIdentifier, namespaceName, "react")) {
+    return propertyIdentifier.name;
+  }
+  return null;
+};
+
+const resolveRemovalMessageForCallee = (callee: EsTreeNode): string | null => {
+  const apiName =
+    resolveReactApiNameForIdentifier(callee) ?? resolveReactApiNameForMemberExpression(callee);
+  if (!apiName) return null;
+  return REMOVAL_MESSAGE_BY_REACT_API_NAME.get(apiName) ?? null;
+};
+
+// Active only when React Compiler is detected (`requires:
+// ["react-compiler"]` in the rule registry). Userland helpers and
+// `useMemo` from non-react packages are filtered out by the import-
+// source check below. Composes with `react-hooks-js/preserve-manual-
+// memoization`, which inverts the rule for cases the compiler cannot
+// safely auto-memoize.
 export const reactCompilerNoManualMemoization = defineRule<Rule>({
   id: "react-compiler-no-manual-memoization",
   severity: "error",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
@@ -1,0 +1,90 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isImportedFromModule } from "../../utils/find-import-source-for-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const REMOVAL_MESSAGE_BY_REACT_API_NAME = new Map<string, string>([
+  [
+    "useMemo",
+    "Remove `useMemo` — React Compiler auto-memoizes every value in this component. Manual `useMemo` adds noise without improving performance.",
+  ],
+  [
+    "useCallback",
+    "Remove `useCallback` — React Compiler auto-memoizes every function in this component. Manual `useCallback` adds noise without improving performance.",
+  ],
+  [
+    "memo",
+    "Remove `memo()` — React Compiler memoizes component output automatically. Wrapping with `memo` is redundant and obscures the component tree.",
+  ],
+]);
+
+const REACT_NAMESPACE_NAME_PREFIXES = ["React", "react", "_react", "_React"] as const;
+
+const isCanonicalReactNamespaceName = (namespaceName: string): boolean => {
+  for (const reactNamespacePrefix of REACT_NAMESPACE_NAME_PREFIXES) {
+    if (namespaceName === reactNamespacePrefix) return true;
+    if (namespaceName.startsWith(reactNamespacePrefix)) return true;
+  }
+  return false;
+};
+
+const resolveRemovalMessageForCallee = (callee: EsTreeNode): string | null => {
+  if (isNodeOfType(callee, "Identifier")) {
+    const removalMessage = REMOVAL_MESSAGE_BY_REACT_API_NAME.get(callee.name);
+    if (!removalMessage) return null;
+    if (!isImportedFromModule(callee, callee.name, "react")) return null;
+    return removalMessage;
+  }
+  if (isNodeOfType(callee, "MemberExpression")) {
+    if (callee.computed) return null;
+    const namespaceIdentifier = callee.object;
+    const propertyIdentifier = callee.property;
+    if (!isNodeOfType(namespaceIdentifier, "Identifier")) return null;
+    if (!isNodeOfType(propertyIdentifier, "Identifier")) return null;
+    const removalMessage = REMOVAL_MESSAGE_BY_REACT_API_NAME.get(propertyIdentifier.name);
+    if (!removalMessage) return null;
+    const namespaceName = namespaceIdentifier.name;
+    if (isCanonicalReactNamespaceName(namespaceName)) return removalMessage;
+    if (isImportedFromModule(namespaceIdentifier, namespaceName, "react")) return removalMessage;
+    return null;
+  }
+  return null;
+};
+
+// Active only when React Compiler is detected for the project (the
+// rule registry gates this with `requires: ["react-compiler"]`). When
+// the compiler is on, `useMemo`, `useCallback`, and `memo(...)` are
+// strictly redundant — the compiler memoizes every value, every
+// function, and every component output automatically. Manual
+// memoization adds maintenance overhead and hides bugs (stale deps in
+// `useMemo`/`useCallback`, redundant equality checks in `memo`).
+//
+// The rule only fires when the callee resolves back to the `react`
+// package (named import, namespace import, or canonical `React.`
+// prefix). Userland `useMemo` / `useCallback` / `memo` helpers
+// (Lodash's `memoize`, custom `useMemo` lookalikes, etc.) are
+// untouched. The `react-hooks-js/preserve-manual-memoization`
+// compiler-frontend rule continues to flag the *opposite* case —
+// removals the compiler can't safely auto-memoize — so the two rules
+// compose: this one drives removal, the compiler frontend protects
+// the cases that must stay.
+export const reactCompilerNoManualMemoization = defineRule<Rule>({
+  id: "react-compiler-no-manual-memoization",
+  severity: "error",
+  requires: ["react-compiler"],
+  recommendation:
+    "Delete the `useMemo` / `useCallback` / `memo` call and use the bare expression or component — React Compiler memoizes it for you.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const removalMessage = resolveRemovalMessageForCallee(node.callee);
+      if (!removalMessage) return;
+      context.report({
+        node,
+        message: removalMessage,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-usememo-simple-expression.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isImportedFromModule } from "../../utils/find-import-source-for-name.js";
+import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
@@ -62,21 +63,8 @@ export const noUsememoSimpleExpression = defineRule<Rule>({
         const namespaceIdentifier = node.callee.object;
         if (isNodeOfType(namespaceIdentifier, "Identifier")) {
           const namespaceName = namespaceIdentifier.name;
-          // Accept `React.useMemo` / `react.useMemo` / transpiled
-          // `_react.useMemo` / `_React.useMemo` by name (the canonical
-          // shapes — esbuild / SWC / tsc all use a `_react`-prefixed
-          // alias), and any identifier that the file's imports resolve
-          // back to the `react` package — e.g. `import * as R from 'react'`
-          // → `R.useMemo`. Anything else (Dispatcher.useMemo,
-          // MyTestRenderer.useMemo, _myCustomLib.useMemo, …) is a
-          // non-React lookalike.
-          const isCanonicalReactNamespace =
-            namespaceName === "React" ||
-            namespaceName === "react" ||
-            namespaceName.startsWith("_react") ||
-            namespaceName.startsWith("_React");
           if (
-            !isCanonicalReactNamespace &&
+            !isCanonicalReactNamespaceName(namespaceName) &&
             !isImportedFromModule(namespaceIdentifier, namespaceName, "react")
           ) {
             return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
@@ -84,3 +84,25 @@ export const isImportedFromModule = (
   if (!info) return false;
   return info.source === moduleSource;
 };
+
+// Returns the originally-exported symbol name for a local binding that
+// came from a specific module, resolving renamed imports like
+// `import { useMemo as memoize } from "react"` so callers can match
+// against the canonical name instead of the local alias.
+//
+// Returns null when:
+//   - the local binding doesn't exist
+//   - the binding's source module doesn't match `moduleSource`
+//   - the binding is a default or namespace import (no "imported" name)
+export const getImportedNameFromModule = (
+  contextNode: EsTreeNode,
+  localIdentifierName: string,
+  moduleSource: string,
+): string | null => {
+  const lookup = getImportLookup(contextNode);
+  if (!lookup) return null;
+  const info = lookup.get(localIdentifierName);
+  if (!info) return null;
+  if (info.source !== moduleSource) return null;
+  return info.imported;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-canonical-react-namespace-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-canonical-react-namespace-name.ts
@@ -1,0 +1,17 @@
+// Recognises identifier names that conventionally bind to the `react`
+// package without an explicit `import * as` resolution step:
+//
+//   - `React`, `react`               — hand-written named imports
+//   - `_react*`, `_React*` prefixes  — esbuild / SWC / tsc transpilation
+//     of `import * as React from "react"` and friends
+//
+// Anything else (`Dispatcher`, `MyTestRenderer`, `_myLib`, `Reactor`,
+// `Reactosaurus`, …) must fall through to an import-lookup check
+// before the caller treats it as React-flavoured.
+export const isCanonicalReactNamespaceName = (namespaceName: string): boolean => {
+  if (namespaceName === "React") return true;
+  if (namespaceName === "react") return true;
+  if (namespaceName.startsWith("_react")) return true;
+  if (namespaceName.startsWith("_React")) return true;
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/tests/is-canonical-react-namespace-name.test.ts
+++ b/packages/oxlint-plugin-react-doctor/tests/is-canonical-react-namespace-name.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isCanonicalReactNamespaceName } from "../src/plugin/utils/is-canonical-react-namespace-name.js";
+
+describe("isCanonicalReactNamespaceName", () => {
+  it("matches the exact `React` and `react` identifiers", () => {
+    expect(isCanonicalReactNamespaceName("React")).toBe(true);
+    expect(isCanonicalReactNamespaceName("react")).toBe(true);
+  });
+
+  it("matches transpiled `_react*` and `_React*` prefixes", () => {
+    expect(isCanonicalReactNamespaceName("_react")).toBe(true);
+    expect(isCanonicalReactNamespaceName("_react2")).toBe(true);
+    expect(isCanonicalReactNamespaceName("_React")).toBe(true);
+    expect(isCanonicalReactNamespaceName("_ReactNamespace")).toBe(true);
+  });
+
+  it("does NOT match identifiers that merely start with `React` / `react`", () => {
+    expect(isCanonicalReactNamespaceName("Reactor")).toBe(false);
+    expect(isCanonicalReactNamespaceName("Reactosaurus")).toBe(false);
+    expect(isCanonicalReactNamespaceName("reactor")).toBe(false);
+    expect(isCanonicalReactNamespaceName("ReactStuff")).toBe(false);
+  });
+
+  it("does NOT match arbitrary unrelated identifiers", () => {
+    expect(isCanonicalReactNamespaceName("Dispatcher")).toBe(false);
+    expect(isCanonicalReactNamespaceName("MyTestRenderer")).toBe(false);
+    expect(isCanonicalReactNamespaceName("_myLib")).toBe(false);
+    expect(isCanonicalReactNamespaceName("")).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/regressions/architecture-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/architecture-rules.test.ts
@@ -97,3 +97,109 @@ export const RouteButton = () => {
     expect(hits[0].message).toContain("useNavigation");
   });
 });
+
+describe("react-compiler-no-manual-memoization", () => {
+  it("flags useMemo, useCallback, and memo when React Compiler is enabled", async () => {
+    const projectDir = setupReactProject(tempRoot, "manual-memoization-with-compiler", {
+      files: {
+        "src/Widget.tsx": `import { memo, useCallback, useMemo } from "react";
+
+interface WidgetProps {
+  items: ReadonlyArray<{ id: string; label: string }>;
+  onSelect: (id: string) => void;
+}
+
+export const Widget = memo(({ items, onSelect }: WidgetProps) => {
+  const sortedItems = useMemo(() => [...items].sort(), [items]);
+  const handleClick = useCallback((id: string) => onSelect(id), [onSelect]);
+  return (
+    <ul>
+      {sortedItems.map((entry) => (
+        <li key={entry.id} onClick={() => handleClick(entry.id)}>
+          {entry.label}
+        </li>
+      ))}
+    </ul>
+  );
+});
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "react-compiler-no-manual-memoization", {
+      hasReactCompiler: true,
+    });
+    const messages = hits.map((hit) => hit.message);
+    expect(messages).toHaveLength(3);
+    expect(messages.some((message) => message.includes("useMemo"))).toBe(true);
+    expect(messages.some((message) => message.includes("useCallback"))).toBe(true);
+    expect(messages.some((message) => message.includes("memo()"))).toBe(true);
+  });
+
+  it("matches React.useMemo / React.useCallback / React.memo namespace calls", async () => {
+    const projectDir = setupReactProject(tempRoot, "manual-memoization-namespaced", {
+      files: {
+        "src/Counter.tsx": `import * as React from "react";
+
+interface CounterProps {
+  initial: number;
+}
+
+export const Counter = React.memo(({ initial }: CounterProps) => {
+  const doubled = React.useMemo(() => initial * 2, [initial]);
+  const noop = React.useCallback(() => undefined, []);
+  return <button onClick={noop}>{doubled}</button>;
+});
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "react-compiler-no-manual-memoization", {
+      hasReactCompiler: true,
+    });
+    expect(hits).toHaveLength(3);
+  });
+
+  it("does not flag manual memoization when React Compiler is disabled", async () => {
+    const projectDir = setupReactProject(tempRoot, "manual-memoization-no-compiler", {
+      files: {
+        "src/Widget.tsx": `import { useMemo } from "react";
+
+export const Widget = ({ items }: { items: ReadonlyArray<string> }) => {
+  const sortedItems = useMemo(() => [...items].sort(), [items]);
+  return <ul>{sortedItems.map((label) => <li key={label}>{label}</li>)}</ul>;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "react-compiler-no-manual-memoization", {
+      hasReactCompiler: false,
+    });
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag userland helpers that share React-hook names", async () => {
+    const projectDir = setupReactProject(tempRoot, "manual-memoization-userland-helpers", {
+      files: {
+        "src/use-memo.ts": `export const useMemo = <Value,>(compute: () => Value): Value => compute();
+export const useCallback = <Fn extends (...args: never[]) => unknown>(fn: Fn): Fn => fn;
+export const memo = <Component,>(component: Component): Component => component;
+`,
+        "src/Widget.tsx": `import { memo, useCallback, useMemo } from "./use-memo";
+
+export const Widget = memo(() => {
+  const value = useMemo(() => 1);
+  const handler = useCallback(() => undefined);
+  return <button onClick={handler}>{value}</button>;
+});
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "react-compiler-no-manual-memoization", {
+      hasReactCompiler: true,
+    });
+    expect(hits).toHaveLength(0);
+  });
+});

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -569,6 +569,27 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
     }
   });
 
+  // The inverse of the rule above: `react-compiler-no-manual-memoization`
+  // is gated with `requires: ["react-compiler"]` so it ONLY fires once
+  // the project ships with React Compiler. Without the compiler, manual
+  // `useMemo` / `useCallback` / `memo()` are still legitimate perf
+  // tools — the gate must keep the rule out of the default config.
+  it("enables react-compiler-no-manual-memoization only when React Compiler is detected", () => {
+    const ruleKey = "react-doctor/react-compiler-no-manual-memoization";
+
+    const withoutCompiler = createOxlintConfig({
+      pluginPath: "/tmp/react-doctor-plugin.js",
+      project: buildTestProject({ rootDirectory: "/tmp/test", hasReactCompiler: false }),
+    });
+    expect(withoutCompiler.rules[ruleKey]).toBeUndefined();
+
+    const withCompiler = createOxlintConfig({
+      pluginPath: "/tmp/react-doctor-plugin.js",
+      project: buildTestProject({ rootDirectory: "/tmp/test", hasReactCompiler: true }),
+    });
+    expect(withCompiler.rules[ruleKey]).toBe("error");
+  });
+
   // The three noisy upstream rules ship `defaultEnabled: false` —
   // they're imported and runnable, but the default config skips them.
   // Users opt in via `severityControls.rules`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `react-doctor/react-compiler-no-manual-memoization`, an architecture rule that **errors** on every `useMemo`, `useCallback`, and `memo(...)` call from `react` once the project ships with the React Compiler. Without the compiler installed, the rule is silent — the existing perf trade-offs around manual memoization still apply.

The rule answers the user request directly: _"if user has React Compiler installed, detect manual memoization and discourage it with an error."_

## Why

When the React Compiler is enabled, it auto-memoizes:

- every value (replaces `useMemo`)
- every callback (replaces `useCallback`)
- every component output (replaces `memo(...)`)

Manual memoization on top of that adds noise and introduces a class of bugs the compiler does not have (stale `useMemo`/`useCallback` deps, redundant `memo` equality checks, refactor drift between dep arrays and call sites).

## Implementation

- **Rule:** `packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts`
- **Gating:** `requires: ["react-compiler"]` — uses the existing `hasReactCompiler` project signal (package deps, Next/Vite/Babel/Expo config files, or any ancestor `package.json`).
- **Severity:** `error`.
- **Detection:** callee must resolve back to the `react` package — named import, namespace import (`import * as React from "react"`), renamed named import (`import { useMemo as memoize }`), canonical `React.` / transpiled `_react.` prefix, or any local alias whose import source is `react`. Userland `useMemo` / `useCallback` / `memo` lookalikes (Lodash `memoize`, custom hooks) are untouched.
- **Composition:** complements `react-hooks-js/preserve-manual-memoization`, which protects the inverse case (memoization the compiler cannot safely remove). The two rules together drive the migration in one direction and pin the carve-outs.

## Iteration after AGENTS.md review

The second commit hardened the rule:

1. **Bugfix — renamed imports were silently missed.** `import { useMemo as memoize } from "react"; memoize(...)` did not fire because the lookup was keyed by the local alias instead of the originally-imported name. Added a new `getImportedNameFromModule` helper alongside the existing `isImportedFromModule` so the rule can match on the canonical name.
2. **Bugfix — too-loose canonical-prefix check.** `startsWith("React")` matched `Reactosaurus.useMemo()`. Tightened to exact match for `React`/`react`, prefix match only for the transpiled `_react*`/`_React*` forms.
3. **DRY refactor.** The canonical-React-namespace check duplicated logic from `no-usememo-simple-expression`. Extracted to a shared `is-canonical-react-namespace-name.ts` util used by both rules — semantics can't drift between them.

## Test coverage

**Unit tests** (`react-compiler-no-manual-memoization.test.ts`, fast, 28 cases via `runRule`):

Fail cases (each fires exactly the expected diagnostic count):

- Named imports: `memo`, `useMemo`, `useCallback`
- Renamed: `useMemo as memoize` + combined renames
- Default-import + `React.useMemo`
- Namespace import `* as React` for `React.memo` / `React.useCallback`
- Namespace import aliased to a non-React name (`* as ReactStuff`)
- Default import aliased to a non-React name (`import MyReact`)
- Transpiled `_react.useMemo(...)` without an import declaration
- `React.memo(Component, areEqual)` with custom comparator
- Multiple memoization calls per file → multiple diagnostics
- `memo(forwardRef(...))` → only the outer memo flagged
- Module-scope `memo(Component)`
- Conditional-branch `useMemo` call

Pass cases (zero diagnostics):

- Locally-declared `useMemo` lookalike
- `useMemo` imported from sibling module (`./local-memo`)
- Hook-named symbols imported from a different package (`preact/hooks`)
- `lodash.memoize`
- `Dispatcher.useMemo()` (internal renderer with React-shaped namespace)
- Non-memoization React APIs (`useState`, `createContext`)
- Computed member access `React["useMemo"]()`
- Identifier referenced without being called
- Identifier-name collisions in JSX text / strings
- Aliased React-import resolving to a non-memoization API (`import { useState as memoize } from "react"`)
- Default-import `React()` direct call
- `_react.createContext` / `_react.useState` (canonical prefix, wrong API)
- `Reactosaurus.useMemo()` (proves the tightened prefix check)

**Integration regression tests** (`architecture-rules.test.ts`):

- Named imports `{ memo, useCallback, useMemo }` all fire with the compiler on
- `React.useMemo` / `React.useCallback` / `React.memo` namespace calls fire
- With `hasReactCompiler: false`, manual memoization is silent
- Userland `useMemo` / `useCallback` / `memo` re-exported from a local module are not flagged

**Gating test** (`scan-resilience.test.ts`):

- Rule is absent from the oxlint config without React Compiler, present at `error` severity with it

**Shared-util test** (`is-canonical-react-namespace-name.test.ts`):

- Exact-match for `React`/`react`
- Prefix-match only for `_react*`/`_React*`
- Negative: `Reactosaurus`, `Reactor`, `ReactStuff`, `reactor`, `Dispatcher`, `_myLib`

## Checks

- `pnpm typecheck` ✅
- `pnpm test` ✅ (1376 passed, 12 skipped)
- `pnpm exec vp test run` on the affected oxlint-plugin tests ✅ (32 passed)
- `pnpm lint` ✅ (no errors)
- `pnpm format:check` ✅
- `pnpm smoke:json-report` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6036efb5-1ce0-4237-a12e-677313acd6d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6036efb5-1ce0-4237-a12e-677313acd6d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

