### PR TITLE
feat(oxlint-plugin): expand deprecated package and import detection

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
@@ -56,6 +56,12 @@ export const LEGACY_EXPO_PACKAGE_REPLACEMENTS = new Map<string, string>([
     "expo-permissions",
     "the permissions API in each module (e.g. Camera.requestPermissionsAsync())",
   ],
+  ["expo-app-loading", "expo-splash-screen"],
+  [
+    "expo-linear-gradient",
+    "the `backgroundImage` CSS gradient style prop (New Architecture) or expo-linear-gradient's successor",
+  ],
+  ["react-native-fast-image", "expo-image (drop-in with caching, placeholders, and crossfades)"],
 ]);
 
 export const REACT_NATIVE_LIST_COMPONENTS = new Set([
@@ -63,6 +69,13 @@ export const REACT_NATIVE_LIST_COMPONENTS = new Set([
   "SectionList",
   "VirtualizedList",
   "FlashList",
+  "LegendList",
+]);
+
+export const RENDER_ITEM_PROP_NAMES = new Set([
+  "renderItem",
+  "renderSectionHeader",
+  "renderSectionFooter",
 ]);
 
 export const LEGACY_SHADOW_STYLE_PROPERTIES = new Set([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
@@ -69,13 +69,6 @@ export const REACT_NATIVE_LIST_COMPONENTS = new Set([
   "SectionList",
   "VirtualizedList",
   "FlashList",
-  "LegendList",
-]);
-
-export const RENDER_ITEM_PROP_NAMES = new Set([
-  "renderItem",
-  "renderSectionHeader",
-  "renderSectionFooter",
 ]);
 
 export const LEGACY_SHADOW_STYLE_PROPERTIES = new Set([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-bottom-sheet-prefer-native.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-bottom-sheet-prefer-native.ts
@@ -7,6 +7,10 @@ const JS_BOTTOM_SHEET_PACKAGES = new Set([
   "react-native-bottom-sheet",
   "react-native-modal-bottom-sheet",
   "react-native-raw-bottom-sheet",
+  "react-native-modalize",
+  "react-native-actions-sheet",
+  "react-native-bottomsheet-reanimated",
+  "@discord/bottom-sheet",
 ]);
 
 export const rnBottomSheetPreferNative = defineRule<Rule>({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-deprecated-modules.ts
@@ -4,7 +4,19 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
+import { isExpoManagedFileActive } from "../../utils/is-expo-managed-file.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+const getExpoAwareReplacement = (
+  importedName: string,
+  baseReplacement: string,
+  isExpo: boolean,
+): string => {
+  if (!isExpo) return baseReplacement;
+  if (importedName === "AsyncStorage")
+    return 'expo-sqlite/localStorage (import "expo-sqlite/localStorage/install") for simple key-value storage, or expo-secure-store for sensitive data';
+  return baseReplacement;
+};
 
 export const rnNoDeprecatedModules = defineRule<Rule>({
   id: "rn-no-deprecated-modules",
@@ -13,23 +25,28 @@ export const rnNoDeprecatedModules = defineRule<Rule>({
   severity: "error",
   recommendation:
     "Import from the community package instead — deprecated modules were removed from the react-native core",
-  create: (context: RuleContext) => ({
-    ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
-      if (node.source?.value !== "react-native") return;
+  create: (context: RuleContext) => {
+    const isExpo = isExpoManagedFileActive(context);
 
-      for (const specifier of node.specifiers ?? []) {
-        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
-        const importedName = getImportedName(specifier);
-        if (!importedName) continue;
+    return {
+      ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
+        if (node.source?.value !== "react-native") return;
 
-        const replacement = DEPRECATED_RN_MODULE_REPLACEMENTS.get(importedName);
-        if (!replacement) continue;
+        for (const specifier of node.specifiers ?? []) {
+          if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+          const importedName = getImportedName(specifier);
+          if (!importedName) continue;
 
-        context.report({
-          node: specifier,
-          message: `"${importedName}" was removed from react-native — use ${replacement} instead`,
-        });
-      }
-    },
-  }),
+          const baseReplacement = DEPRECATED_RN_MODULE_REPLACEMENTS.get(importedName);
+          if (!baseReplacement) continue;
+
+          const replacement = getExpoAwareReplacement(importedName, baseReplacement, isExpo);
+          context.report({
+            node: specifier,
+            message: `"${importedName}" was removed from react-native — use ${replacement} instead`,
+          });
+        }
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-non-native-navigator.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-non-native-navigator.ts
@@ -3,9 +3,16 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const NON_NATIVE_NAVIGATOR_PACKAGES = new Set([
-  "@react-navigation/stack",
-  "@react-navigation/drawer",
+const NON_NATIVE_NAVIGATOR_PACKAGES = new Map<string, string>([
+  ["@react-navigation/stack", "@react-navigation/native-stack"],
+  [
+    "@react-navigation/drawer",
+    "expo-router Drawer (no native equivalent exists for standalone React Navigation)",
+  ],
+  [
+    "@react-navigation/bottom-tabs",
+    "@react-navigation/native-tabs (v7+) or expo-router NativeTabs",
+  ],
 ]);
 
 // HACK: @react-navigation/stack uses a JS-implemented stack with
@@ -22,8 +29,9 @@ export const rnNoNonNativeNavigator = defineRule<Rule>({
   create: (context: RuleContext) => ({
     ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       const source = node.source?.value;
-      if (typeof source !== "string" || !NON_NATIVE_NAVIGATOR_PACKAGES.has(source)) return;
-      const replacement = source.replace("@react-navigation/", "@react-navigation/native-");
+      if (typeof source !== "string") return;
+      const replacement = NON_NATIVE_NAVIGATOR_PACKAGES.get(source);
+      if (!replacement) return;
       context.report({
         node,
         message: `${source} uses a JS-implemented navigator — use ${replacement} for native iOS/Android transitions and gestures`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-expo-image.ts
@@ -26,14 +26,16 @@ export const rnPreferExpoImage = defineRule<Rule>({
 
     return {
       ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
-        if (node.source?.value !== "react-native") return;
+        const source = node.source?.value;
+
+        if (source !== "react-native") return;
         for (const specifier of node.specifiers ?? []) {
           if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
-          if (getImportedName(specifier) !== "Image") continue;
+          const importedName = getImportedName(specifier);
+          if (importedName !== "Image" && importedName !== "ImageBackground") continue;
           context.report({
             node: specifier,
-            message:
-              "Importing Image from react-native — prefer expo-image for caching, placeholders, and progressive loading (drop-in API)",
+            message: `Importing ${importedName} from react-native — prefer expo-image for caching, placeholders, and progressive loading (drop-in API)`,
           });
         }
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable.ts
@@ -12,6 +12,8 @@ const TOUCHABLE_COMPONENTS = new Set([
   "TouchableNativeFeedback",
 ]);
 
+const TOUCHABLE_SOURCES = new Set(["react-native", "react-native-gesture-handler"]);
+
 // HACK: TouchableOpacity / TouchableHighlight / TouchableWithoutFeedback /
 // TouchableNativeFeedback are legacy and feature-frozen. Pressable is the
 // modern, more configurable, more accessible replacement that works the
@@ -25,7 +27,8 @@ export const rnPreferPressable = defineRule<Rule>({
     "Use `<Pressable>` from react-native (or react-native-gesture-handler) instead of legacy Touchable* components",
   create: (context: RuleContext) => ({
     ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
-      if (node.source?.value !== "react-native") return;
+      const source = node.source?.value;
+      if (typeof source !== "string" || !TOUCHABLE_SOURCES.has(source)) return;
       for (const specifier of node.specifiers ?? []) {
         if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
         const importedName = getImportedName(specifier);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
@@ -5,6 +5,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+const JS_THREAD_ANIMATION_IMPORTS = new Set(["Animated", "LayoutAnimation"]);
+
 export const rnPreferReanimated = defineRule<Rule>({
   id: "rn-prefer-reanimated",
   tags: ["test-noise"],
@@ -18,12 +20,17 @@ export const rnPreferReanimated = defineRule<Rule>({
 
       for (const specifier of node.specifiers ?? []) {
         if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
-        if (getImportedName(specifier) !== "Animated") continue;
+        const importedName = getImportedName(specifier);
+        if (!importedName || !JS_THREAD_ANIMATION_IMPORTS.has(importedName)) continue;
+
+        const suggestion =
+          importedName === "LayoutAnimation"
+            ? "LayoutAnimation runs animations on the JS thread and causes full layout recalculations — use Reanimated's Layout Animations (entering/exiting/layout props) for UI-thread layout transitions"
+            : "Animated from react-native runs animations on the JS thread — use react-native-reanimated for performant UI-thread animations";
 
         context.report({
           node: specifier,
-          message:
-            "Animated from react-native runs animations on the JS thread — use react-native-reanimated for performant UI-thread animations",
+          message: suggestion,
         });
       }
     },


### PR DESCRIPTION
## Why

Several common deprecated/unmaintained RN packages were not flagged, and some rules had incorrect or missing recommendations.

**Before:**
```tsx
import { LinearGradient } from 'expo-linear-gradient';  // Not caught
import FastImage from 'react-native-fast-image';  // Not caught
import { TouchableOpacity } from 'react-native-gesture-handler';  // Not caught
import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';  // Not caught
```

**After:** All caught with actionable fix recommendations.

## What changed

- `rn-no-legacy-expo-packages`: add `expo-app-loading`, `expo-linear-gradient`, `react-native-fast-image`
- `rn-no-non-native-navigator`: add `@react-navigation/bottom-tabs`; fix drawer recommendation (no native equivalent exists)
- `rn-prefer-expo-image`: also flag `ImageBackground` import
- `rn-prefer-pressable`: also catch Touchable imports from `react-native-gesture-handler`
- `rn-prefer-reanimated`: also flag `LayoutAnimation` with specific message
- `rn-no-deprecated-modules`: Expo-aware AsyncStorage recommendation
- `rn-bottom-sheet-prefer-native`: add 4 more JS bottom-sheet packages

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only rule and message updates in the oxlint plugin; no runtime app behavior changes.
> 
> **Overview**
> Expands **react-doctor** oxlint rules so more deprecated RN/Expo imports and legacy patterns surface with clearer fix guidance.
> 
> **Legacy packages:** `LEGACY_EXPO_PACKAGE_REPLACEMENTS` now includes `expo-app-loading`, `expo-linear-gradient`, and `react-native-fast-image` (consumed by `rn-no-legacy-expo-packages`).
> 
> **Navigators:** `rn-no-non-native-navigator` switches from a package set to a **package → replacement** map: adds `@react-navigation/bottom-tabs`, fixes drawer messaging (no bogus `native-drawer`), and stops naive `native-` string substitution.
> 
> **Imports:** `rn-prefer-expo-image` also flags `ImageBackground`; `rn-prefer-pressable` covers Touchables from `react-native-gesture-handler`; `rn-prefer-reanimated` also flags `LayoutAnimation` with a dedicated message; `rn-no-deprecated-modules` uses **Expo-managed** context to suggest `expo-sqlite/localStorage` / `expo-secure-store` for removed `AsyncStorage`; `rn-bottom-sheet-prefer-native` adds four more JS bottom-sheet libraries plus `@discord/bottom-sheet`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c36d12b7dc04441bc2afd6ee65e85294d828c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->