### PR TITLE
feat(oxlint-plugin): expand shadow, style, and scroll rules

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-legacy-shadow-styles.ts
@@ -38,7 +38,9 @@ export const rnNoLegacyShadowStyles = defineRule<Rule>({
     "Use `boxShadow` for cross-platform shadows on the new architecture instead of platform-specific shadow properties",
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "style") return;
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+      const attrName = node.name.name;
+      if (attrName !== "style" && !attrName.endsWith("Style")) return;
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const expression = node.value.expression;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-scroll-state.ts
@@ -6,6 +6,23 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+const SET_STATE_PATTERN = /^set[A-Z]/;
+
+const findSetStateInBody = (body: EsTreeNode): EsTreeNode | null => {
+  let setStateCallNode: EsTreeNode | null = null;
+  walkAst(body, (child: EsTreeNode) => {
+    if (setStateCallNode) return;
+    if (
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "Identifier") &&
+      SET_STATE_PATTERN.test(child.callee.name)
+    ) {
+      setStateCallNode = child;
+    }
+  });
+  return setStateCallNode;
+};
+
 // HACK: setting React state inside an onScroll handler triggers a re-render
 // at scroll-event frequency (60-120Hz). Use a Reanimated shared value
 // (useSharedValue + useAnimatedScrollHandler) or a ref + raf throttle so
@@ -17,38 +34,62 @@ export const rnNoScrollState = defineRule<Rule>({
   severity: "error",
   recommendation:
     "Track scroll position with a Reanimated shared value (`useAnimatedScrollHandler`) or a ref — `setState` on every scroll event causes re-render storms",
-  create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-      if (node.name.name !== "onScroll") return;
-      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
-      const expression = node.value.expression;
-      if (
-        !isNodeOfType(expression, "ArrowFunctionExpression") &&
-        !isNodeOfType(expression, "FunctionExpression")
-      ) {
-        return;
-      }
+  create: (context: RuleContext) => {
+    const stateSettersInHandlers = new Map<string, EsTreeNode>();
 
-      let setStateCallNode: EsTreeNode | null = null;
-      walkAst(expression.body, (child: EsTreeNode) => {
-        if (setStateCallNode) return;
+    return {
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+        if (!isNodeOfType(node.id, "Identifier")) return;
+        const variableName = node.id.name;
+        if (!/scroll/i.test(variableName)) return;
+
+        const init = node.init;
         if (
-          isNodeOfType(child, "CallExpression") &&
-          isNodeOfType(child.callee, "Identifier") &&
-          /^set[A-Z]/.test(child.callee.name)
-        ) {
-          setStateCallNode = child;
-        }
-      });
+          !isNodeOfType(init, "ArrowFunctionExpression") &&
+          !isNodeOfType(init, "FunctionExpression")
+        )
+          return;
 
-      if (setStateCallNode) {
-        context.report({
-          node: setStateCallNode,
-          message:
-            "setState in onScroll triggers re-renders on every scroll event — use a Reanimated shared value (useAnimatedScrollHandler) or a ref to track scroll position",
-        });
-      }
-    },
-  }),
+        const setStateCall = findSetStateInBody(init.body);
+        if (setStateCall) {
+          stateSettersInHandlers.set(variableName, setStateCall);
+        }
+      },
+
+      JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
+        if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+        if (node.name.name !== "onScroll") return;
+        if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
+        const expression = node.value.expression;
+
+        if (isNodeOfType(expression, "Identifier")) {
+          const tracked = stateSettersInHandlers.get(expression.name);
+          if (tracked) {
+            context.report({
+              node: tracked,
+              message:
+                "setState in onScroll handler triggers re-renders on every scroll event — use a Reanimated shared value (useAnimatedScrollHandler) or a ref to track scroll position",
+            });
+          }
+          return;
+        }
+
+        if (
+          !isNodeOfType(expression, "ArrowFunctionExpression") &&
+          !isNodeOfType(expression, "FunctionExpression")
+        ) {
+          return;
+        }
+
+        const setStateCallNode = findSetStateInBody(expression.body);
+        if (setStateCallNode) {
+          context.report({
+            node: setStateCallNode,
+            message:
+              "setState in onScroll triggers re-renders on every scroll event — use a Reanimated shared value (useAnimatedScrollHandler) or a ref to track scroll position",
+          });
+        }
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-content-inset-adjustment.ts
@@ -28,11 +28,11 @@ export const rnPreferContentInsetAdjustment = defineRule<Rule>({
         if (!isNodeOfType(child, "JSXElement")) continue;
         const childName = resolveJsxElementName(child.openingElement);
         if (!childName || !SCROLLVIEW_NAMES.has(childName)) continue;
+        if (childName === "KeyboardAwareScrollView") continue;
 
         context.report({
           node,
-          message:
-            '<SafeAreaView> wrapping <ScrollView> — set `contentInsetAdjustmentBehavior="automatic"` on the ScrollView and drop the SafeAreaView wrapper for native safe-area handling',
+          message: `<SafeAreaView> wrapping <${childName}> — set \`contentInsetAdjustmentBehavior="automatic"\` on the ${childName} and drop the SafeAreaView wrapper for native safe-area handling`,
         });
         return;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
@@ -23,12 +23,8 @@ export const rnScrollviewDynamicPadding = defineRule<Rule>({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const elementName = resolveJsxElementName(node);
       if (!elementName) return;
-      if (
-        !SCROLLVIEW_NAMES.has(elementName) &&
-        elementName !== "FlatList" &&
-        elementName !== "FlashList"
-      )
-        return;
+      if (!SCROLLVIEW_NAMES.has(elementName) && elementName !== "FlashList") return;
+      if (elementName === "KeyboardAwareScrollView") return;
 
       for (const attr of node.attributes ?? []) {
         if (!isNodeOfType(attr, "JSXAttribute")) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-style-prefer-box-shadow.ts
@@ -46,13 +46,28 @@ export const rnStylePreferBoxShadow = defineRule<Rule>({
       if (attrName !== "style" && !attrName.endsWith("Style")) return;
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
       const expression = node.value.expression;
-      if (!isNodeOfType(expression, "ObjectExpression")) return;
-      const match = findLegacyShadowProperty(expression);
-      if (!match) return;
-      context.report({
-        node: match.node,
-        message: `${match.keyName} is iOS/Android-platform-specific — use the cross-platform CSS \`boxShadow\` string (e.g. \`boxShadow: "0 2px 8px rgba(0,0,0,0.1)"\`) on RN v7+`,
-      });
+
+      if (isNodeOfType(expression, "ObjectExpression")) {
+        const match = findLegacyShadowProperty(expression);
+        if (match) {
+          context.report({
+            node: match.node,
+            message: `${match.keyName} is iOS/Android-platform-specific — use the cross-platform CSS \`boxShadow\` string (e.g. \`boxShadow: "0 2px 8px rgba(0,0,0,0.1)"\`) on RN v7+`,
+          });
+        }
+      } else if (isNodeOfType(expression, "ArrayExpression")) {
+        for (const element of expression.elements ?? []) {
+          if (!isNodeOfType(element, "ObjectExpression")) continue;
+          const match = findLegacyShadowProperty(element);
+          if (match) {
+            context.report({
+              node: match.node,
+              message: `${match.keyName} is iOS/Android-platform-specific — use the cross-platform CSS \`boxShadow\` string on RN v7+`,
+            });
+            return;
+          }
+        }
+      }
     },
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "MemberExpression")) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/utils/scrollview_names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/utils/scrollview_names.ts
@@ -1,1 +1,7 @@
-export const SCROLLVIEW_NAMES = new Set(["ScrollView"]);
+export const SCROLLVIEW_NAMES = new Set([
+  "ScrollView",
+  "FlatList",
+  "SectionList",
+  "VirtualizedList",
+  "KeyboardAwareScrollView",
+]);


### PR DESCRIPTION
## Why

Shadow rules only checked the `style` prop (missing `contentContainerStyle` etc.), `rn-style-prefer-box-shadow` missed array-style values, `rn-no-scroll-state` only caught inline handlers, and `SCROLLVIEW_NAMES` was too narrow for content-inset rules.

**Before:**
```tsx
<View contentContainerStyle={{ shadowColor: '#000' }}>  // Not caught by shadow rules
<ScrollView style={[{ shadowColor: '#000' }]}>  // Not caught by box-shadow rule
const handleScroll = (e) => { setY(e.y); };
<ScrollView onScroll={handleScroll}>  // Not caught
<SafeAreaView><FlatList>  // Not caught by content-inset rule
```

**After:** All caught, with `KeyboardAwareScrollView` correctly excluded from content-inset and dynamic-padding rules.

## What changed

- `rn-no-legacy-shadow-styles`: check `*Style` props (e.g. `contentContainerStyle`)
- `rn-style-prefer-box-shadow`: check `ArrayExpression` style values
- `rn-no-scroll-state`: detect named scroll handlers; simplify regex
- `rn-prefer-content-inset-adjustment`: dynamic element name in message; skip `KeyboardAwareScrollView`
- `rn-scrollview-dynamic-padding`: skip `KeyboardAwareScrollView`
- `SCROLLVIEW_NAMES`: add FlatList, SectionList, VirtualizedList, KeyboardAwareScrollView

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only heuristic changes in oxlint-plugin-react-doctor; broader matches may surface new warnings but do not affect runtime app behavior.
> 
> **Overview**
> Tightens several **react-native** oxlint rules so they catch more real-world patterns without changing rule IDs or severity.
> 
> **Shadow rules** (`rn-no-legacy-shadow-styles`, `rn-style-prefer-box-shadow`) now lint any JSX prop named `style` or ending in `Style` (e.g. `contentContainerStyle`), and `rn-style-prefer-box-shadow` also walks **array** style values (`style={[{ shadowColor: ... }]}`).
> 
> **Scroll performance** (`rn-no-scroll-state`) registers scroll-named handler variables that call `setState`, then flags `onScroll={handler}` references—not only inline arrow/function bodies. Shared `findSetStateInBody` / `SET_STATE_PATTERN` replace duplicated AST walks.
> 
> **Scroll/list coverage** expands `SCROLLVIEW_NAMES` to include `FlatList`, `SectionList`, `VirtualizedList`, and `KeyboardAwareScrollView`. Content-inset and dynamic-padding rules use that set (with redundant `FlatList` checks removed from dynamic-padding). **`KeyboardAwareScrollView`** is explicitly **skipped** for content-inset and dynamic-padding warnings. Safe-area messaging names the actual child component (e.g. `FlatList`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c61696b807da52f071439569a4aa8cf48fb837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->