### PR TITLE
MIL-1559: `no-giant-component` flags non-React TypeScript modules

### DIFF
--- a/.agents/skills/rule-research/SKILL.md
+++ b/.agents/skills/rule-research/SKILL.md
@@ -68,6 +68,7 @@ Goal:
 Find examples where <exact bug definition>.
 
 Return:
+
 - Strong positive examples
 - Pattern-adjacent examples
 - False-positive traps
@@ -93,24 +94,31 @@ Detector precision:
 Syntax-only | scope-aware | path-aware
 
 Evidence:
+
 - <docs, OSS, issue, RDE, or similar-tool evidence>
 
 Strong positives:
+
 - <exact reportable examples>
 
 False-positive traps:
+
 - <valid examples that must stay quiet>
 
 In scope for v1:
+
 - <supported cases>
 
 Out of scope for v1:
+
 - <explicit non-goals>
 
 Test seeds:
+
 - <invalid and valid fixture ideas>
 
 Open questions:
+
 - <only questions that affect correctness or scope>
 ```
 

--- a/.agents/skills/rule-validate/SKILL.md
+++ b/.agents/skills/rule-validate/SKILL.md
@@ -96,11 +96,13 @@ Catches <specific issue>.
 <Runtime reason in 1-3 sentences.>
 
 Before:
+
 ```tsx
 <bad example>
 ```
 
 After:
+
 ```tsx
 <good example>
 ```
@@ -115,14 +117,14 @@ After:
 
 ## Eval results
 
-| Check | Result |
-| --- | --- |
-| Repos scanned | `<distinct repo count>` |
-| RootDir scans | `<manifest/rootDir entries>` |
-| Target rule | `<rule-name>` |
-| Diagnostics | `<target-rule diagnostics>` |
-| False positives found | `<count after manual inspection>` |
-| Output artifact | `<filtered JSONL or summary path>` |
+| Check                 | Result                             |
+| --------------------- | ---------------------------------- |
+| Repos scanned         | `<distinct repo count>`            |
+| RootDir scans         | `<manifest/rootDir entries>`       |
+| Target rule           | `<rule-name>`                      |
+| Diagnostics           | `<target-rule diagnostics>`        |
+| False positives found | `<count after manual inspection>`  |
+| Output artifact       | `<filtered JSONL or summary path>` |
 
 ## Test plan
 
@@ -150,6 +152,7 @@ Return:
 
 ```md
 Validation summary:
+
 - <commands and results>
 - <implementation review findings>
 - <RDE summary or skip reason>
@@ -157,8 +160,10 @@ Validation summary:
 - <regression tests added>
 
 PR-ready notes:
+
 - <Why/What/Test plan highlights>
 
 Residual risk:
+
 - <known v1 non-goals or unchecked areas>
 ```

--- a/.agents/skills/rule-writing/SKILL.md
+++ b/.agents/skills/rule-writing/SKILL.md
@@ -107,18 +107,23 @@ When the writing stage is done, report:
 
 ```md
 Implemented:
+
 - <rule, tests, registry, utilities>
 
 Detector behavior:
+
 - <what reports>
 - <what intentionally stays quiet>
 
 Validation run:
+
 - <focused tests/checks>
 
 Known v1 non-goals:
+
 - <unsupported cases preserved from the rule contract>
 
 Next stage:
+
 - Run `rule-validate`.
 ```

--- a/.changeset/quiet-giant-components.md
+++ b/.changeset/quiet-giant-components.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Require `no-giant-component` candidates to contain React render output before reporting oversized components, reducing false positives for PascalCase services and helpers.

--- a/.changeset/quiet-giant-components.md
+++ b/.changeset/quiet-giant-components.md
@@ -1,5 +1,0 @@
----
-"oxlint-plugin-react-doctor": patch
----
-
-Require `no-giant-component` candidates to contain React render output before reporting oversized components, reducing false positives for PascalCase services and helpers.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noGiantComponent } from "./no-giant-component.js";
+
+const buildOversizedBody = (): string =>
+  Array.from(
+    { length: 301 },
+    (_, statementIndex) => `  const value${statementIndex} = ${statementIndex};`,
+  ).join("\n");
+
+const expectDiagnosticCount = (
+  code: string,
+  expectedDiagnosticCount: number,
+  filename = "fixture.tsx",
+): void => {
+  const result = runRule(noGiantComponent, code, { filename });
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedDiagnosticCount);
+};
+
+describe("architecture/no-giant-component — fail cases", () => {
+  it("flags an oversized PascalCase function that returns JSX", () => {
+    expectDiagnosticCount(
+      `function GiantComponent() {
+${buildOversizedBody()}
+  return <main />;
+}`,
+      1,
+    );
+  });
+
+  it("flags an oversized PascalCase arrow component that returns JSX", () => {
+    expectDiagnosticCount(
+      `const GiantComponent = () => {
+${buildOversizedBody()}
+  return <main />;
+};`,
+      1,
+    );
+  });
+
+  it("flags an oversized TypeScript component using React.createElement", () => {
+    expectDiagnosticCount(
+      `import React from "react";
+
+function GiantComponent() {
+${buildOversizedBody()}
+  return React.createElement("main", null);
+}`,
+      1,
+      "fixture.ts",
+    );
+  });
+
+  it("flags an oversized TypeScript component using aliased createElement from react", () => {
+    expectDiagnosticCount(
+      `import { createElement as h } from "react";
+
+const GiantComponent = () => {
+${buildOversizedBody()}
+  return h("main", null);
+};`,
+      1,
+      "fixture.ts",
+    );
+  });
+});
+
+describe("architecture/no-giant-component — pass cases (no diagnostics)", () => {
+  it("does not flag an oversized PascalCase service function without React output", () => {
+    expectDiagnosticCount(
+      `function ExampleService() {
+${buildOversizedBody()}
+  return fetch("/api/example");
+}`,
+      0,
+      "example.service.ts",
+    );
+  });
+
+  it("does not flag an oversized async PascalCase data helper", () => {
+    expectDiagnosticCount(
+      `const ExampleService = async () => {
+${buildOversizedBody()}
+  return fetch("/api/example");
+};`,
+      0,
+      "example.service.ts",
+    );
+  });
+
+  it("does not flag an exported PascalCase object literal service", () => {
+    const methods = Array.from(
+      { length: 80 },
+      (_, methodIndex) => `  getValue${methodIndex}: async () => fetch("/api/${methodIndex}"),`,
+    ).join("\n");
+    expectDiagnosticCount(
+      `export const ExampleService = {
+${methods}
+};`,
+      0,
+      "example.service.ts",
+    );
+  });
+
+  it("does not treat JSX inside a nested function as outer component evidence", () => {
+    expectDiagnosticCount(
+      `function ExampleService() {
+  const Inner = () => <main />;
+${buildOversizedBody()}
+  return fetch("/api/example");
+}`,
+      0,
+    );
+  });
+
+  it("does not flag createElement imported from a non-React module", () => {
+    expectDiagnosticCount(
+      `import { createElement } from "./dom";
+
+function ExampleService() {
+${buildOversizedBody()}
+  return createElement("main");
+}`,
+      0,
+      "example.service.ts",
+    );
+  });
+
+  it("does not flag a local createElement helper", () => {
+    expectDiagnosticCount(
+      `function createElement(tagName: string) {
+  return document.createElement(tagName);
+}
+
+function ExampleService() {
+${buildOversizedBody()}
+  return createElement("main");
+}`,
+      0,
+      "example.service.ts",
+    );
+  });
+
+  it("does not flag a shadowed createElement import", () => {
+    expectDiagnosticCount(
+      `import { createElement } from "react";
+
+function ExampleService() {
+  const createElement = document.createElement.bind(document);
+${buildOversizedBody()}
+  return createElement("main");
+}`,
+      0,
+      "example.service.ts",
+    );
+  });
+
+  it("does not flag a shadowed React namespace import", () => {
+    expectDiagnosticCount(
+      `import * as React from "react";
+
+function ExampleService(React: Document) {
+${buildOversizedBody()}
+  return React.createElement("main");
+}`,
+      0,
+      "example.service.ts",
+    );
+  });
+
+  it("does not flag global React.createElement without an import", () => {
+    expectDiagnosticCount(
+      `function ExampleService() {
+${buildOversizedBody()}
+  return React.createElement("main", null);
+}`,
+      0,
+      "example.service.ts",
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noGiantComponent } from "./no-giant-component.js";
 
-const buildOversizedBody = (): string =>
+const buildBodyExceedingThreshold = (): string =>
   Array.from(
     { length: 301 },
     (_, statementIndex) => `  const value${statementIndex} = ${statementIndex};`,
@@ -22,7 +22,7 @@ describe("architecture/no-giant-component — fail cases", () => {
   it("flags an oversized PascalCase function that returns JSX", () => {
     expectDiagnosticCount(
       `function GiantComponent() {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return <main />;
 }`,
       1,
@@ -32,7 +32,7 @@ ${buildOversizedBody()}
   it("flags an oversized PascalCase arrow component that returns JSX", () => {
     expectDiagnosticCount(
       `const GiantComponent = () => {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return <main />;
 };`,
       1,
@@ -44,7 +44,7 @@ ${buildOversizedBody()}
       `import React from "react";
 
 function GiantComponent() {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return React.createElement("main", null);
 }`,
       1,
@@ -57,7 +57,7 @@ ${buildOversizedBody()}
       `import { createElement as h } from "react";
 
 const GiantComponent = () => {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return h("main", null);
 };`,
       1,
@@ -70,7 +70,7 @@ describe("architecture/no-giant-component — pass cases (no diagnostics)", () =
   it("does not flag an oversized PascalCase service function without React output", () => {
     expectDiagnosticCount(
       `function ExampleService() {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return fetch("/api/example");
 }`,
       0,
@@ -81,7 +81,7 @@ ${buildOversizedBody()}
   it("does not flag an oversized async PascalCase data helper", () => {
     expectDiagnosticCount(
       `const ExampleService = async () => {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return fetch("/api/example");
 };`,
       0,
@@ -107,7 +107,7 @@ ${methods}
     expectDiagnosticCount(
       `function ExampleService() {
   const Inner = () => <main />;
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return fetch("/api/example");
 }`,
       0,
@@ -119,7 +119,7 @@ ${buildOversizedBody()}
       `import { createElement } from "./dom";
 
 function ExampleService() {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return createElement("main");
 }`,
       0,
@@ -134,7 +134,7 @@ ${buildOversizedBody()}
 }
 
 function ExampleService() {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return createElement("main");
 }`,
       0,
@@ -148,7 +148,7 @@ ${buildOversizedBody()}
 
 function ExampleService() {
   const createElement = document.createElement.bind(document);
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return createElement("main");
 }`,
       0,
@@ -161,7 +161,7 @@ ${buildOversizedBody()}
       `import * as React from "react";
 
 function ExampleService(React: Document) {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return React.createElement("main");
 }`,
       0,
@@ -172,7 +172,7 @@ ${buildOversizedBody()}
   it("does not flag global React.createElement without an import", () => {
     expectDiagnosticCount(
       `function ExampleService() {
-${buildOversizedBody()}
+${buildBodyExceedingThreshold()}
   return React.createElement("main", null);
 }`,
       0,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.ts
@@ -1,5 +1,6 @@
 import { GIANT_COMPONENT_LINE_THRESHOLD } from "../../constants/thresholds.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
@@ -33,11 +34,13 @@ export const noGiantComponent = defineRule<Rule>({
     return {
       FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
+        if (!functionContainsReactRenderOutput(node, context.scopes)) return;
         reportOversizedComponent(node.id, node.id.name, node);
       },
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
         if (!isNodeOfType(node.id, "Identifier") || !node.init) return;
+        if (!functionContainsReactRenderOutput(node.init, context.scopes)) return;
         reportOversizedComponent(node.id, node.id.name, node.init);
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.ts
@@ -16,32 +16,38 @@ export const noGiantComponent = defineRule<Rule>({
   recommendation:
     "Extract logical sections into focused components: `<UserHeader />`, `<UserActions />`, etc.",
   create: (context: RuleContext) => {
+    const getOversizedComponentLineCount = (bodyNode: EsTreeNode): number | null => {
+      if (!bodyNode.loc) return null;
+      const lineCount = bodyNode.loc.end.line - bodyNode.loc.start.line + 1;
+      return lineCount > GIANT_COMPONENT_LINE_THRESHOLD ? lineCount : null;
+    };
+
     const reportOversizedComponent = (
       nameNode: EsTreeNode,
       componentName: string,
-      bodyNode: EsTreeNode,
+      lineCount: number,
     ): void => {
-      if (!bodyNode.loc) return;
-      const lineCount = bodyNode.loc.end.line - bodyNode.loc.start.line + 1;
-      if (lineCount > GIANT_COMPONENT_LINE_THRESHOLD) {
-        context.report({
-          node: nameNode,
-          message: `Component "${componentName}" is ${lineCount} lines — consider breaking it into smaller focused components`,
-        });
-      }
+      context.report({
+        node: nameNode,
+        message: `Component "${componentName}" is ${lineCount} lines — consider breaking it into smaller focused components`,
+      });
     };
 
     return {
       FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!node.id?.name || !isUppercaseName(node.id.name)) return;
+        const lineCount = getOversizedComponentLineCount(node);
+        if (lineCount === null) return;
         if (!functionContainsReactRenderOutput(node, context.scopes)) return;
-        reportOversizedComponent(node.id, node.id.name, node);
+        reportOversizedComponent(node.id, node.id.name, lineCount);
       },
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
         if (!isNodeOfType(node.id, "Identifier") || !node.init) return;
+        const lineCount = getOversizedComponentLineCount(node.init);
+        if (lineCount === null) return;
         if (!functionContainsReactRenderOutput(node.init, context.scopes)) return;
-        reportOversizedComponent(node.id, node.id.name, node.init);
+        reportOversizedComponent(node.id, node.id.name, lineCount);
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
@@ -1,0 +1,92 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { walkAst } from "./walk-ast.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+
+const NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+  "ClassDeclaration",
+  "ClassExpression",
+]);
+
+const isReactImport = (symbol: SymbolDescriptor): boolean => {
+  let importDeclaration: EsTreeNode | null | undefined = symbol.declarationNode?.parent;
+  while (importDeclaration && !isNodeOfType(importDeclaration, "ImportDeclaration")) {
+    importDeclaration = importDeclaration.parent ?? null;
+  }
+  if (!importDeclaration || !isNodeOfType(importDeclaration, "ImportDeclaration")) return false;
+  return importDeclaration.source.value === "react";
+};
+
+const getImportedName = (symbol: SymbolDescriptor): string | null => {
+  if (symbol.kind !== "import") return null;
+  if (!isReactImport(symbol)) return null;
+  const declarationNode = symbol.declarationNode;
+  if (!isNodeOfType(declarationNode, "ImportSpecifier")) return null;
+  const importedName = declarationNode.imported;
+  if (isNodeOfType(importedName, "Identifier")) return importedName.name;
+  if (isNodeOfType(importedName, "Literal") && typeof importedName.value === "string") {
+    return importedName.value;
+  }
+  return null;
+};
+
+const isReactNamespaceImport = (symbol: SymbolDescriptor): boolean => {
+  if (symbol.kind !== "import") return false;
+  if (!isReactImport(symbol)) return false;
+  return (
+    isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||
+    isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier")
+  );
+};
+
+const isReactCreateElementIdentifierCall = (callee: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = scopes.symbolFor(callee);
+  return Boolean(symbol && getImportedName(symbol) === "createElement");
+};
+
+const isReactCreateElementMemberCall = (callee: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  if (callee.computed) return false;
+  if (!isNodeOfType(callee.object, "Identifier")) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  if (callee.property.name !== "createElement") return false;
+  const symbol = scopes.symbolFor(callee.object);
+  return Boolean(symbol && isReactNamespaceImport(symbol));
+};
+
+const isReactCreateElementCall = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  return (
+    isReactCreateElementIdentifierCall(node.callee, scopes) ||
+    isReactCreateElementMemberCall(node.callee, scopes)
+  );
+};
+
+export const functionContainsReactRenderOutput = (
+  functionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let didFindReactRenderOutput = false;
+
+  walkAst(functionNode, (child) => {
+    if (didFindReactRenderOutput) return false;
+    if (child !== functionNode && NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES.has(child.type)) {
+      return false;
+    }
+    if (child.type === "JSXElement" || child.type === "JSXFragment") {
+      didFindReactRenderOutput = true;
+      return false;
+    }
+    if (isReactCreateElementCall(child, scopes)) {
+      didFindReactRenderOutput = true;
+      return false;
+    }
+    return undefined;
+  });
+
+  return didFindReactRenderOutput;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { getImportedName as getImportSpecifierName } from "./get-imported-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { walkAst } from "./walk-ast.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
@@ -23,14 +24,7 @@ const isReactImport = (symbol: SymbolDescriptor): boolean => {
 const getImportedName = (symbol: SymbolDescriptor): string | null => {
   if (symbol.kind !== "import") return null;
   if (!isReactImport(symbol)) return null;
-  const declarationNode = symbol.declarationNode;
-  if (!isNodeOfType(declarationNode, "ImportSpecifier")) return null;
-  const importedName = declarationNode.imported;
-  if (isNodeOfType(importedName, "Identifier")) return importedName.name;
-  if (isNodeOfType(importedName, "Literal") && typeof importedName.value === "string") {
-    return importedName.value;
-  }
-  return null;
+  return getImportSpecifierName(symbol.declarationNode) ?? null;
 };
 
 const isReactNamespaceImport = (symbol: SymbolDescriptor): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
@@ -1,7 +1,7 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { getImportedName as getImportSpecifierName } from "./get-imported-name.js";
+import { isAstNode } from "./is-ast-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
-import { walkAst } from "./walk-ast.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 
 const NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
@@ -60,27 +60,38 @@ const isReactCreateElementCall = (node: EsTreeNode, scopes: ScopeAnalysis): bool
   );
 };
 
+const containsRenderOutput = (
+  node: EsTreeNode,
+  rootNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (node !== rootNode && NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES.has(node.type)) {
+    return false;
+  }
+  if (node.type === "JSXElement" || node.type === "JSXFragment") {
+    return true;
+  }
+  if (isReactCreateElementCall(node, scopes)) {
+    return true;
+  }
+  const nodeRecord = node as unknown as Record<string, unknown>;
+  for (const key of Object.keys(nodeRecord)) {
+    if (key === "parent") continue;
+    const child = nodeRecord[key];
+    if (Array.isArray(child)) {
+      for (const innerChild of child) {
+        if (isAstNode(innerChild) && containsRenderOutput(innerChild, rootNode, scopes)) {
+          return true;
+        }
+      }
+    } else if (isAstNode(child) && containsRenderOutput(child, rootNode, scopes)) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export const functionContainsReactRenderOutput = (
   functionNode: EsTreeNode,
   scopes: ScopeAnalysis,
-): boolean => {
-  let didFindReactRenderOutput = false;
-
-  walkAst(functionNode, (child) => {
-    if (didFindReactRenderOutput) return false;
-    if (child !== functionNode && NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES.has(child.type)) {
-      return false;
-    }
-    if (child.type === "JSXElement" || child.type === "JSXFragment") {
-      didFindReactRenderOutput = true;
-      return false;
-    }
-    if (isReactCreateElementCall(child, scopes)) {
-      didFindReactRenderOutput = true;
-      return false;
-    }
-    return undefined;
-  });
-
-  return didFindReactRenderOutput;
-};
+): boolean => containsRenderOutput(functionNode, functionNode, scopes);

--- a/packages/oxlint-plugin-react-doctor/src/test-utils/attach-source-locations.ts
+++ b/packages/oxlint-plugin-react-doctor/src/test-utils/attach-source-locations.ts
@@ -1,0 +1,72 @@
+import { isAstNode } from "../plugin/utils/is-ast-node.js";
+import type { EsTreeNode } from "../plugin/utils/es-tree-node.js";
+
+interface SourcePosition {
+  line: number;
+  column: number;
+}
+
+interface NodeWithOffsets {
+  start?: number;
+  end?: number;
+  loc?: {
+    start: SourcePosition;
+    end: SourcePosition;
+  };
+}
+
+const buildLineStartOffsets = (sourceText: string): number[] => {
+  const lineStartOffsets = [0];
+  for (let sourceIndex = 0; sourceIndex < sourceText.length; sourceIndex++) {
+    if (sourceText[sourceIndex] === "\n") lineStartOffsets.push(sourceIndex + 1);
+  }
+  return lineStartOffsets;
+};
+
+const offsetToSourcePosition = (
+  offset: number,
+  lineStartOffsets: ReadonlyArray<number>,
+): SourcePosition => {
+  let lowIndex = 0;
+  let highIndex = lineStartOffsets.length - 1;
+  while (lowIndex <= highIndex) {
+    const middleIndex = Math.floor((lowIndex + highIndex) / 2);
+    if (lineStartOffsets[middleIndex] <= offset) {
+      lowIndex = middleIndex + 1;
+    } else {
+      highIndex = middleIndex - 1;
+    }
+  }
+  const lineIndex = Math.max(0, highIndex);
+  return {
+    line: lineIndex + 1,
+    column: offset - lineStartOffsets[lineIndex],
+  };
+};
+
+export const attachSourceLocations = (root: EsTreeNode, sourceText: string): void => {
+  const lineStartOffsets = buildLineStartOffsets(sourceText);
+  const visit = (node: EsTreeNode): void => {
+    const nodeWithOffsets = node as NodeWithOffsets;
+    if (typeof nodeWithOffsets.start === "number" && typeof nodeWithOffsets.end === "number") {
+      nodeWithOffsets.loc = {
+        start: offsetToSourcePosition(nodeWithOffsets.start, lineStartOffsets),
+        end: offsetToSourcePosition(nodeWithOffsets.end, lineStartOffsets),
+      };
+    }
+
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const key of Object.keys(nodeRecord)) {
+      if (key === "parent") continue;
+      const child = nodeRecord[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (isAstNode(item)) visit(item);
+        }
+      } else if (isAstNode(child)) {
+        visit(child);
+      }
+    }
+  };
+  visit(root);
+};

--- a/packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts
@@ -1,4 +1,5 @@
 import { attachParentReferences } from "./attach-parent-references.js";
+import { attachSourceLocations } from "./attach-source-locations.js";
 import { parseFixture } from "./parse-fixture.js";
 import { isAstNode } from "../plugin/utils/is-ast-node.js";
 import type { EsTreeNode } from "../plugin/utils/es-tree-node.js";
@@ -61,6 +62,7 @@ export const runRule = (rule: Rule, code: string, options: RunRuleOptions = {}):
     forceJsx: options.forceJsx,
   });
   attachParentReferences(parsed.program);
+  attachSourceLocations(parsed.program, code);
 
   const diagnostics: RuleDiagnostic[] = [];
   const scopes = analyzeScopes(parsed.program);


### PR DESCRIPTION
## Why?

Catches false positives where `react-doctor/no-giant-component` treated large PascalCase helpers as React components even when they did not render React output.

The rule previously used a name-and-size heuristic: any oversized PascalCase function declaration or PascalCase function assignment could be reported as a component. That was too broad for service modules, adapters, and data helpers that happen to use PascalCase naming. The rule should only warn when the oversized candidate is actually component-shaped, so this change requires direct React render evidence before reporting.

RDE validation was run against the first 1000 distinct repos from `repos.json`, expanding to 4350 rootDir scans. Both baseline and this branch produced 0 `react-doctor/no-giant-component` diagnostics, parity diff was `[]`, and no false positives were found.

## What changed?

- Tightened `react-doctor/no-giant-component` so oversized PascalCase function candidates must contain direct React render output before they are reported.
- Added render-output detection for JSX, JSX fragments, `import { createElement } from "react"`, and React default/namespace imports used as `React.createElement(...)`.
- Made `createElement` evidence scope-aware so shadowed imports, non-React imports, local helpers, and global `React.createElement` without an import do not count.
- Pruned nested functions/classes while scanning for render evidence, so JSX inside an inner callback/component does not classify the outer function as a component.
- Added focused adversarial tests for real component cases and non-component false-positive traps.
- Updated the rule test harness to attach source locations from parser offsets, allowing line-count rules to be unit tested directly.
- Added a patch changeset for `oxlint-plugin-react-doctor`.

Before:

```ts
function ExampleService() {
  // 300+ lines of fetch/data helper logic
  return fetch("/api/example");
}
```

This could be reported as:

```text
Component "ExampleService" is 302 lines — consider breaking it into smaller focused components
```

After:

```ts
function ExampleService() {
  // 300+ lines of fetch/data helper logic
  return fetch("/api/example");
}
```

This stays quiet because it has no direct React render output.

A real oversized component is still reported:

```tsx
function GiantComponent() {
  // 300+ lines of component logic
  return <main />;
}
```

## Test plan

Users can verify correctness with:

```sh
pnpm exec vp test run packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.test.ts
pnpm exec vp test run packages/react-doctor/tests/run-oxlint/architecture.test.ts
pnpm --filter oxlint-plugin-react-doctor typecheck
pnpm exec vp fmt --check .changeset/quiet-giant-components.md packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.test.ts packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.ts packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts packages/oxlint-plugin-react-doctor/src/test-utils/attach-source-locations.ts
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows an architecture lint heuristic and adds tests; no auth, data, or runtime product behavior changes.
> 
> **Overview**
> **`no-giant-component`** no longer warns on every oversized PascalCase function. It now requires **direct React render evidence** (JSX/fragments or scope-resolved `createElement` from `react` / `React.createElement`) before reporting, so large service-style helpers stay quiet.
> 
> Detection is **scope-aware**: nested inner components don’t count as outer render output; shadowed or non-React `createElement`, locals, and unimported global `React` are ignored. The rule test harness **synthesizes `loc` from parser offsets** so line-threshold behavior is covered in unit tests, with adversarial pass/fail fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b365c392dd956651931300e9389a936e238ed974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->