### PR TITLE
feat(rn): add `rn-no-renderitem-key` rule

### DIFF
--- a/.agents/skills/rule-research/SKILL.md
+++ b/.agents/skills/rule-research/SKILL.md
@@ -68,6 +68,7 @@ Goal:
 Find examples where <exact bug definition>.
 
 Return:
+
 - Strong positive examples
 - Pattern-adjacent examples
 - False-positive traps
@@ -93,24 +94,31 @@ Detector precision:
 Syntax-only | scope-aware | path-aware
 
 Evidence:
+
 - <docs, OSS, issue, RDE, or similar-tool evidence>
 
 Strong positives:
+
 - <exact reportable examples>
 
 False-positive traps:
+
 - <valid examples that must stay quiet>
 
 In scope for v1:
+
 - <supported cases>
 
 Out of scope for v1:
+
 - <explicit non-goals>
 
 Test seeds:
+
 - <invalid and valid fixture ideas>
 
 Open questions:
+
 - <only questions that affect correctness or scope>
 ```
 

--- a/.agents/skills/rule-validate/SKILL.md
+++ b/.agents/skills/rule-validate/SKILL.md
@@ -96,11 +96,13 @@ Catches <specific issue>.
 <Runtime reason in 1-3 sentences.>
 
 Before:
+
 ```tsx
 <bad example>
 ```
 
 After:
+
 ```tsx
 <good example>
 ```
@@ -115,14 +117,14 @@ After:
 
 ## Eval results
 
-| Check | Result |
-| --- | --- |
-| Repos scanned | `<distinct repo count>` |
-| RootDir scans | `<manifest/rootDir entries>` |
-| Target rule | `<rule-name>` |
-| Diagnostics | `<target-rule diagnostics>` |
-| False positives found | `<count after manual inspection>` |
-| Output artifact | `<filtered JSONL or summary path>` |
+| Check                 | Result                             |
+| --------------------- | ---------------------------------- |
+| Repos scanned         | `<distinct repo count>`            |
+| RootDir scans         | `<manifest/rootDir entries>`       |
+| Target rule           | `<rule-name>`                      |
+| Diagnostics           | `<target-rule diagnostics>`        |
+| False positives found | `<count after manual inspection>`  |
+| Output artifact       | `<filtered JSONL or summary path>` |
 
 ## Test plan
 
@@ -150,6 +152,7 @@ Return:
 
 ```md
 Validation summary:
+
 - <commands and results>
 - <implementation review findings>
 - <RDE summary or skip reason>
@@ -157,8 +160,10 @@ Validation summary:
 - <regression tests added>
 
 PR-ready notes:
+
 - <Why/What/Test plan highlights>
 
 Residual risk:
+
 - <known v1 non-goals or unchecked areas>
 ```

--- a/.agents/skills/rule-writing/SKILL.md
+++ b/.agents/skills/rule-writing/SKILL.md
@@ -107,18 +107,23 @@ When the writing stage is done, report:
 
 ```md
 Implemented:
+
 - <rule, tests, registry, utilities>
 
 Detector behavior:
+
 - <what reports>
 - <what intentionally stays quiet>
 
 Validation run:
+
 - <focused tests/checks>
 
 Known v1 non-goals:
+
 - <unsupported cases preserved from the rule contract>
 
 Next stage:
+
 - Run `rule-validate`.
 ```

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -254,6 +254,7 @@ import { rnNoLegacyExpoPackages } from "./rules/react-native/rn-no-legacy-expo-p
 import { rnNoLegacyShadowStyles } from "./rules/react-native/rn-no-legacy-shadow-styles.js";
 import { rnNoNonNativeNavigator } from "./rules/react-native/rn-no-non-native-navigator.js";
 import { rnNoRawText } from "./rules/react-native/rn-no-raw-text.js";
+import { rnNoRenderitemKey } from "./rules/react-native/rn-no-renderitem-key.js";
 import { rnNoScrollState } from "./rules/react-native/rn-no-scroll-state.js";
 import { rnNoScrollviewMappedList } from "./rules/react-native/rn-no-scrollview-mapped-list.js";
 import { rnNoSingleElementStyleArray } from "./rules/react-native/rn-no-single-element-style-array.js";
@@ -3017,6 +3018,18 @@ export const reactDoctorRules = [
       framework: "react-native",
       category: "React Native",
       tags: [...new Set(["react-native", ...(rnNoRawText.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/rn-no-renderitem-key",
+    id: "rn-no-renderitem-key",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...rnNoRenderitemKey,
+      framework: "react-native",
+      category: "React Native",
+      tags: [...new Set(["react-native", ...(rnNoRenderitemKey.tags ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-renderitem-key.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-renderitem-key.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rnNoRenderitemKey } from "./rn-no-renderitem-key.js";
+
+describe("rn-no-renderitem-key", () => {
+  it("flags arrow concise body returning a JSX element with key on FlatList", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList data={data} renderItem={({ item }) => <Row key={item.id} value={item.value} />} />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("FlatList");
+    expect(result.diagnostics[0].message).toContain("renderItem");
+    expect(result.diagnostics[0].message).toContain("keyExtractor");
+  });
+
+  it("flags arrow block body returning a JSX element with key", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList
+          data={data}
+          renderItem={({ item }) => {
+            return <Row key={item.id} value={item.value} />;
+          }}
+        />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags FunctionExpression returning a JSX element with key", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList
+          data={data}
+          renderItem={function ({ item }) {
+            return <Row key={item.id} />;
+          }}
+        />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags renderSectionHeader on SectionList", () => {
+    const code = `
+      const App = ({ sections }) => (
+        <SectionList
+          sections={sections}
+          renderSectionHeader={({ section }) => <Header key={section.id} title={section.title} />}
+          renderItem={({ item }) => <Row value={item.value} />}
+        />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("renderSectionHeader");
+  });
+
+  it("flags FlashList renderItem with key", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlashList data={data} renderItem={({ item }) => <Row key={item.id} />} />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("FlashList");
+  });
+
+  it("flags the JSX branch with key inside a ternary", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList
+          data={data}
+          renderItem={({ item }) => (item.kind === "header" ? <Header key={item.id} /> : <Row value={item.value} />)}
+        />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the JSX wrapped in TS `as`", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList
+          data={data}
+          renderItem={({ item }) => (<Row key={item.id} /> as React.ReactElement)}
+        />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags multiple return paths independently", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList
+          data={data}
+          renderItem={({ item }) => {
+            if (item.kind === "header") return <Header key={item.id} />;
+            return <Row key={item.id} value={item.value} />;
+          }}
+        />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does NOT flag renderItem without a key prop", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList data={data} renderItem={({ item }) => <Row value={item.value} />} />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag keys on descendants nested inside the returned row", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList
+          data={data}
+          renderItem={({ item }) => (
+            <View>
+              {item.tags.map((tag) => (
+                <Tag key={tag.id} value={tag} />
+              ))}
+            </View>
+          )}
+        />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag keys on JSX returned from a nested function inside renderItem", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList
+          data={data}
+          renderItem={({ item }) => {
+            const renderTag = (tag) => <Tag key={tag.id} value={tag} />;
+            return <View>{item.tags.map(renderTag)}</View>;
+          }}
+        />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag a renderItem on a non-list component", () => {
+    const code = `
+      const App = ({ data }) => (
+        <Carousel data={data} renderItem={({ item }) => <Slide key={item.id} />} />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag renderItem returning null", () => {
+    const code = `
+      const App = ({ data }) => (
+        <FlatList data={data} renderItem={() => null} />
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag mapped JSX outside of renderItem", () => {
+    const code = `
+      const App = ({ items }) => (
+        <View>
+          {items.map((item) => (
+            <Row key={item.id} value={item.value} />
+          ))}
+        </View>
+      );
+    `;
+    const result = runRule(rnNoRenderitemKey, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-renderitem-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-renderitem-key.ts
@@ -1,0 +1,124 @@
+import { FUNCTION_LIKE_TYPES } from "../../constants/js.js";
+import {
+  REACT_NATIVE_LIST_COMPONENTS,
+  RENDER_ITEM_PROP_NAMES,
+} from "../../constants/react-native.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { hasJsxKeyAttribute } from "../../utils/has-jsx-key-attribute.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+
+const collectTopLevelReturnExpressions = (
+  functionNode:
+    | EsTreeNodeOfType<"ArrowFunctionExpression">
+    | EsTreeNodeOfType<"FunctionExpression">,
+): EsTreeNode[] => {
+  if (isNodeOfType(functionNode, "ArrowFunctionExpression") && functionNode.body) {
+    if (!isNodeOfType(functionNode.body, "BlockStatement")) {
+      return [functionNode.body];
+    }
+  }
+
+  const block = functionNode.body;
+  if (!block || !isNodeOfType(block, "BlockStatement")) return [];
+
+  const returnExpressions: EsTreeNode[] = [];
+  const visit = (node: EsTreeNode): void => {
+    if (FUNCTION_LIKE_TYPES.has(node.type)) return;
+    if (isNodeOfType(node, "ReturnStatement") && node.argument) {
+      returnExpressions.push(node.argument);
+    }
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const fieldName of Object.keys(nodeRecord)) {
+      if (fieldName === "parent") continue;
+      const child = nodeRecord[fieldName];
+      if (Array.isArray(child)) {
+        for (const childItem of child) {
+          if (isAstNode(childItem)) visit(childItem);
+        }
+      } else if (isAstNode(child)) {
+        visit(child);
+      }
+    }
+  };
+  visit(block);
+  return returnExpressions;
+};
+
+const collectReturnedJsxElements = (expression: EsTreeNode): EsTreeNodeOfType<"JSXElement">[] => {
+  const elements: EsTreeNodeOfType<"JSXElement">[] = [];
+  const visit = (current: EsTreeNode): void => {
+    const unwrapped = stripParenExpression(current);
+    if (isNodeOfType(unwrapped, "JSXElement")) {
+      elements.push(unwrapped);
+      return;
+    }
+    if (isNodeOfType(unwrapped, "ConditionalExpression")) {
+      visit(unwrapped.consequent);
+      visit(unwrapped.alternate);
+      return;
+    }
+    if (isNodeOfType(unwrapped, "LogicalExpression")) {
+      visit(unwrapped.right);
+      if (unwrapped.operator === "||" || unwrapped.operator === "??") {
+        visit(unwrapped.left);
+      }
+    }
+  };
+  visit(expression);
+  return elements;
+};
+
+export const rnNoRenderitemKey = defineRule<Rule>({
+  id: "rn-no-renderitem-key",
+  tags: ["test-noise"],
+  requires: ["react-native"],
+  severity: "warn",
+  recommendation:
+    "Remove `key` from the JSX returned by renderItem — React Native lists key rows from `keyExtractor` (or `item.key`); the inner `key` is a no-op and hides a missing `keyExtractor`",
+  create: (context: RuleContext) => ({
+    JSXAttribute(attributeNode: EsTreeNodeOfType<"JSXAttribute">) {
+      if (
+        !isNodeOfType(attributeNode.name, "JSXIdentifier") ||
+        !RENDER_ITEM_PROP_NAMES.has(attributeNode.name.name)
+      )
+        return;
+
+      const openingElement = attributeNode.parent;
+      if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return;
+
+      const listComponentName = resolveJsxElementName(openingElement);
+      if (!listComponentName || !REACT_NATIVE_LIST_COMPONENTS.has(listComponentName)) return;
+
+      if (!attributeNode.value || !isNodeOfType(attributeNode.value, "JSXExpressionContainer"))
+        return;
+
+      const renderFunction = attributeNode.value.expression;
+      if (
+        !isNodeOfType(renderFunction, "ArrowFunctionExpression") &&
+        !isNodeOfType(renderFunction, "FunctionExpression")
+      )
+        return;
+
+      const returnExpressions = collectTopLevelReturnExpressions(renderFunction);
+      const renderPropName = attributeNode.name.name;
+
+      for (const returnExpression of returnExpressions) {
+        const returnedJsxElements = collectReturnedJsxElements(returnExpression);
+        for (const jsxElement of returnedJsxElements) {
+          if (!hasJsxKeyAttribute(jsxElement.openingElement)) continue;
+          context.report({
+            node: jsxElement.openingElement,
+            message: `\`key\` on the JSX returned by ${renderPropName} on <${listComponentName}> is a no-op — React Native lists key rows from \`keyExtractor\` (or \`item.key\`). Remove this \`key\` and set \`keyExtractor\` on the list instead`,
+          });
+        }
+      }
+    },
+  }),
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a new oxlint React Native rule, `rn-no-renderitem-key`, that flags a `key` prop set on the top-level JSX element returned from a list's render callback:

```tsx
<FlatList
  data={data}
  renderItem={({ item }) => <Row key={item.id} value={item.value} />}
//                                 ^^^^^^^^^^^^ flagged
/>
```

## Why

React Native virtualized lists (`FlatList`, `SectionList`, `VirtualizedList`, `FlashList`, `LegendList`) derive each row's reconciliation key from `keyExtractor` (or `item.key` / `item.id` fallback). A `key` set on the row JSX returned by `renderItem` is a no-op for the list's reconciliation — it only keys the inner element inside the row's `CellRenderer`. It is almost always a sign that:

1. The developer believes setting `key` on the row keys the list (it doesn't), and
2. There's a missing or incorrect `keyExtractor` on the list itself.

On `FlashList` / `LegendList` this is doubly misleading because cell recycling doesn't honor the inner key, so devs that rely on it for state isolation see surprising row reuse.

## Detector shape

Syntax-only AST visitor:

- Match `JSXAttribute` with name `renderItem` / `renderSectionHeader` / `renderSectionFooter`.
- Parent `JSXOpeningElement` must be one of `REACT_NATIVE_LIST_COMPONENTS` (`FlatList`, `SectionList`, `VirtualizedList`, `FlashList`, `LegendList`).
- The attribute value must be an `ArrowFunctionExpression` / `FunctionExpression`.
- Collect the function's top-level return expressions, skipping nested function bodies (those belong to inner closures).
- Strip TS / paren wrappers, descend into `ConditionalExpression` consequent/alternate and `LogicalExpression` short-circuit branches.
- If the resulting expression is a `JSXElement` whose opening element carries a `key` attribute → report.

The file-level gate provided by `framework: "react-native"` keeps the rule from firing in non-RN projects.

## Covered

- Arrow concise body, arrow block body, `FunctionExpression`.
- `renderItem`, `renderSectionHeader`, `renderSectionFooter`.
- `FlatList`, `SectionList`, `FlashList` (and the rest of the list set).
- Conditional returns (only the JSX branch with `key` is flagged).
- TS `as` wrapper, parentheses.
- Multiple `return` paths — each is flagged independently.

## Intentionally quiet (v1)

- `key` on JSX descendants nested inside the returned row (e.g. a `.map()` inside the row).
- `key` on JSX returned from a nested function defined inside `renderItem`.
- `renderItem` on non-list components (no exhaustive component-detection here — list literal name match keeps false positives low).
- `renderItem` returning `null` or non-JSX values.
- Mapped JSX outside of `renderItem` (covered by `react/jsx-key`).

## Tests

14 adversarial cases (8 invalid, 6 valid) in `rn-no-renderitem-key.test.ts` covering each branch above. All pass.

```
Test Files  1 passed (1)
     Tests  14 passed (14)
```

The wider `pnpm typecheck`, `pnpm lint`, and `pnpm format` also pass. The 38 pre-existing test failures in `react-builtins/*` are present on `main` and unrelated to this change.

## Files

- `packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-renderitem-key.ts` — detector
- `packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-renderitem-key.test.ts` — adversarial tests
- `packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts` — regenerated via `pnpm gen`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ee2c497-8696-4e09-987d-8c315a261cce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ee2c497-8696-4e09-987d-8c315a261cce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

