### PR TITLE
MIL-1560: Fix false positives in `control-has-associated-label`

### DIFF
--- a/.agents/skills/rule-research/SKILL.md
+++ b/.agents/skills/rule-research/SKILL.md
@@ -68,6 +68,7 @@ Goal:
 Find examples where <exact bug definition>.
 
 Return:
+
 - Strong positive examples
 - Pattern-adjacent examples
 - False-positive traps
@@ -93,24 +94,31 @@ Detector precision:
 Syntax-only | scope-aware | path-aware
 
 Evidence:
+
 - <docs, OSS, issue, RDE, or similar-tool evidence>
 
 Strong positives:
+
 - <exact reportable examples>
 
 False-positive traps:
+
 - <valid examples that must stay quiet>
 
 In scope for v1:
+
 - <supported cases>
 
 Out of scope for v1:
+
 - <explicit non-goals>
 
 Test seeds:
+
 - <invalid and valid fixture ideas>
 
 Open questions:
+
 - <only questions that affect correctness or scope>
 ```
 

--- a/.agents/skills/rule-validate/SKILL.md
+++ b/.agents/skills/rule-validate/SKILL.md
@@ -96,11 +96,13 @@ Catches <specific issue>.
 <Runtime reason in 1-3 sentences.>
 
 Before:
+
 ```tsx
 <bad example>
 ```
 
 After:
+
 ```tsx
 <good example>
 ```
@@ -115,14 +117,14 @@ After:
 
 ## Eval results
 
-| Check | Result |
-| --- | --- |
-| Repos scanned | `<distinct repo count>` |
-| RootDir scans | `<manifest/rootDir entries>` |
-| Target rule | `<rule-name>` |
-| Diagnostics | `<target-rule diagnostics>` |
-| False positives found | `<count after manual inspection>` |
-| Output artifact | `<filtered JSONL or summary path>` |
+| Check                 | Result                             |
+| --------------------- | ---------------------------------- |
+| Repos scanned         | `<distinct repo count>`            |
+| RootDir scans         | `<manifest/rootDir entries>`       |
+| Target rule           | `<rule-name>`                      |
+| Diagnostics           | `<target-rule diagnostics>`        |
+| False positives found | `<count after manual inspection>`  |
+| Output artifact       | `<filtered JSONL or summary path>` |
 
 ## Test plan
 
@@ -150,6 +152,7 @@ Return:
 
 ```md
 Validation summary:
+
 - <commands and results>
 - <implementation review findings>
 - <RDE summary or skip reason>
@@ -157,8 +160,10 @@ Validation summary:
 - <regression tests added>
 
 PR-ready notes:
+
 - <Why/What/Test plan highlights>
 
 Residual risk:
+
 - <known v1 non-goals or unchecked areas>
 ```

--- a/.agents/skills/rule-writing/SKILL.md
+++ b/.agents/skills/rule-writing/SKILL.md
@@ -107,18 +107,23 @@ When the writing stage is done, report:
 
 ```md
 Implemented:
+
 - <rule, tests, registry, utilities>
 
 Detector behavior:
+
 - <what reports>
 - <what intentionally stays quiet>
 
 Validation run:
+
 - <focused tests/checks>
 
 Known v1 non-goals:
+
 - <unsupported cases preserved from the rule contract>
 
 Next stage:
+
 - Run `rule-validate`.
 ```

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { controlHasAssociatedLabel } from "./control-has-associated-label.js";
+
+describe("a11y/control-has-associated-label regressions", () => {
+  it("accepts a control nested inside a label with sibling text", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = ({ texts, sf }) => (
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="spelformer" value={sf} />
+            <span>{texts.spelform[sf]}</span>
+          </label>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts matching htmlFor and id JSX identifier expressions", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = ({ texts }) => {
+          const tomDatumId = useId() + "-tom";
+
+          return (
+            <div>
+              <label htmlFor={tomDatumId} className="text-sm font-medium">
+                {texts.tomDatumLabel}
+              </label>
+              <input id={tomDatumId} name="tom_datum" type="date" />
+            </div>
+          );
+        };
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts component-internal htmlFor and id prop pairs", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const BeloppField = ({ id, name, label }) => (
+          <div>
+            <label htmlFor={id}>{label}</label>
+            <input id={id} name={name} type="number" />
+          </div>
+        );
+
+        const Demo = ({ texts }) => (
+          <BeloppField id="ersattning_5v5" name="ersattning_5v5" label={texts.label5v5} />
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -80,4 +80,64 @@ describe("a11y/control-has-associated-label regressions", () => {
 
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("does not treat ancestor labels across render-prop boundaries as associations", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = () => (
+          <label>
+            Some text
+            <Component render={() => <input type="text" />} />
+          </label>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts htmlFor/id pairs inside conditional rendering", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = ({ showField }) => (
+          <div>
+            {showField && (
+              <>
+                <label htmlFor="amount">Amount</label>
+                <input id="amount" name="amount" type="number" />
+              </>
+            )}
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts htmlFor/id pairs inside ternary expressions", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = ({ variant }) => (
+          <div>
+            {variant === "a"
+              ? <>
+                  <label htmlFor="fieldA">Field A</label>
+                  <input id="fieldA" type="text" />
+                </>
+              : <>
+                  <label htmlFor="fieldB">Field B</label>
+                  <input id="fieldB" type="text" />
+                </>
+            }
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -60,4 +60,24 @@ describe("a11y/control-has-associated-label regressions", () => {
 
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("does not treat labels inside callback props as rendered labels", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = () => {
+          const fieldId = "amount";
+
+          return (
+            <div>
+              <FieldShell renderLabel={() => <label htmlFor={fieldId}>Amount</label>} />
+              <input id={fieldId} name="amount" type="number" />
+            </div>
+          );
+        };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -13,6 +13,7 @@ import { isInteractiveRole } from "../../utils/is-interactive-role.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { Rule } from "../../utils/rule.js";
 
 const MESSAGE =
@@ -182,12 +183,18 @@ const hasAccessibleLabelText = (
   return element.children.some((child) => checkChildForLabel(child as EsTreeNode, 1, context));
 };
 
+const isFunctionBoundary = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "ArrowFunctionExpression") ||
+  isNodeOfType(node, "FunctionExpression") ||
+  isNodeOfType(node, "FunctionDeclaration");
+
 const hasAncestorLabel = (
   element: EsTreeNodeOfType<"JSXElement">,
   context: CheckChildContext,
 ): boolean => {
   let current = element.parent;
   while (current) {
+    if (isFunctionBoundary(current)) break;
     if (isNodeOfType(current, "JSXElement")) {
       const tagName = getElementType(current.openingElement, context.settings);
       if (tagName === LABEL_ELEMENT && hasAccessibleLabelText(current, context)) {
@@ -203,6 +210,7 @@ const findEnclosingJsxTreeRoot = (element: EsTreeNodeOfType<"JSXElement">): EsTr
   let root: EsTreeNode = element;
   let current = element.parent;
   while (current) {
+    if (isFunctionBoundary(current)) break;
     if (isNodeOfType(current, "JSXElement") || isNodeOfType(current, "JSXFragment")) {
       root = current;
     }
@@ -211,11 +219,36 @@ const findEnclosingJsxTreeRoot = (element: EsTreeNodeOfType<"JSXElement">): EsTr
   return root;
 };
 
+const collectJsxFromExpression = (rawExpression: EsTreeNode): ReadonlyArray<EsTreeNode> => {
+  const expression = stripParenExpression(rawExpression);
+  if (isNodeOfType(expression, "JSXElement") || isNodeOfType(expression, "JSXFragment")) {
+    return [expression];
+  }
+  if (isNodeOfType(expression, "LogicalExpression")) {
+    return [
+      ...collectJsxFromExpression(expression.left as EsTreeNode),
+      ...collectJsxFromExpression(expression.right as EsTreeNode),
+    ];
+  }
+  if (isNodeOfType(expression, "ConditionalExpression")) {
+    return [
+      ...collectJsxFromExpression(expression.consequent as EsTreeNode),
+      ...collectJsxFromExpression(expression.alternate as EsTreeNode),
+    ];
+  }
+  return [];
+};
+
 const searchForHtmlForLabel = (
   node: EsTreeNode,
   controlIdKey: string,
   context: CheckChildContext,
 ): boolean => {
+  if (isNodeOfType(node, "JSXExpressionContainer")) {
+    return collectJsxFromExpression(node.expression as EsTreeNode).some((jsxNode) =>
+      searchForHtmlForLabel(jsxNode, controlIdKey, context),
+    );
+  }
   const children =
     isNodeOfType(node, "JSXElement") || isNodeOfType(node, "JSXFragment") ? node.children : [];
   if (isNodeOfType(node, "JSXElement")) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -7,7 +7,6 @@ import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-l
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
-import { isAstNode } from "../../utils/is-ast-node.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isInteractiveElement } from "../../utils/is-interactive-element.js";
 import { isInteractiveRole } from "../../utils/is-interactive-role.js";
@@ -132,22 +131,6 @@ const getAttributeMatchKey = (
   return null;
 };
 
-const getAstChildren = (node: EsTreeNode): ReadonlyArray<EsTreeNode> => {
-  const children: EsTreeNode[] = [];
-  const nodeRecord = node as unknown as Record<string, unknown>;
-  for (const [key, value] of Object.entries(nodeRecord)) {
-    if (key === "parent") continue;
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (isAstNode(item)) children.push(item);
-      }
-      continue;
-    }
-    if (isAstNode(value)) children.push(value);
-  }
-  return children;
-};
-
 interface CheckChildContext {
   depth: number;
   customAttributes: ReadonlyArray<string>;
@@ -233,6 +216,8 @@ const searchForHtmlForLabel = (
   controlIdKey: string,
   context: CheckChildContext,
 ): boolean => {
+  const children =
+    isNodeOfType(node, "JSXElement") || isNodeOfType(node, "JSXFragment") ? node.children : [];
   if (isNodeOfType(node, "JSXElement")) {
     const tagName = getElementType(node.openingElement, context.settings);
     if (tagName === LABEL_ELEMENT) {
@@ -248,8 +233,8 @@ const searchForHtmlForLabel = (
       }
     }
   }
-  for (const child of getAstChildren(node)) {
-    if (searchForHtmlForLabel(child, controlIdKey, context)) {
+  for (const child of children) {
+    if (searchForHtmlForLabel(child as EsTreeNode, controlIdKey, context)) {
       return true;
     }
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -3,9 +3,11 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isInteractiveElement } from "../../utils/is-interactive-element.js";
 import { isInteractiveRole } from "../../utils/is-interactive-role.js";
@@ -35,6 +37,9 @@ interface ControlHasAssociatedLabelSettings {
 // to enforce regardless can override via `ignoreElements: []`.
 const DEFAULT_IGNORE_ELEMENTS: ReadonlyArray<string> = ["link", "canvas"];
 const DEFAULT_LABELLING_PROPS: ReadonlyArray<string> = ["alt", "aria-label", "aria-labelledby"];
+const ID_ATTRIBUTE = "id";
+const HTML_FOR_ATTRIBUTE = "htmlFor";
+const LABEL_ELEMENT = "label";
 
 // Default depth for the children-walk. Upstream `eslint-plugin-jsx-a11y`
 // defaults to 2, but real-world buttons routinely nest text deeper
@@ -93,6 +98,56 @@ const hasLabellingProp = (
   return false;
 };
 
+const toAttributeMatchKey = (kind: "identifier" | "literal", value: string): string | null => {
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? `${kind}:${trimmedValue}` : null;
+};
+
+const getLiteralAttributeMatchKey = (value: unknown): string | null => {
+  if (typeof value === "string") return toAttributeMatchKey("literal", value);
+  if (typeof value === "number") return toAttributeMatchKey("literal", String(value));
+  return null;
+};
+
+const getAttributeMatchKey = (
+  attribute: EsTreeNodeOfType<"JSXAttribute"> | undefined,
+): string | null => {
+  if (!attribute?.value) return null;
+  const value = attribute.value;
+  if (isNodeOfType(value, "Literal")) {
+    return getLiteralAttributeMatchKey(value.value);
+  }
+  if (!isNodeOfType(value, "JSXExpressionContainer")) return null;
+  const expression = value.expression as EsTreeNode;
+  if (isNodeOfType(expression, "Identifier")) {
+    return toAttributeMatchKey("identifier", expression.name);
+  }
+  if (isNodeOfType(expression, "Literal")) {
+    return getLiteralAttributeMatchKey(expression.value);
+  }
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    const staticValue = getStaticTemplateLiteralValue(expression);
+    return staticValue === null ? null : toAttributeMatchKey("literal", staticValue);
+  }
+  return null;
+};
+
+const getAstChildren = (node: EsTreeNode): ReadonlyArray<EsTreeNode> => {
+  const children: EsTreeNode[] = [];
+  const nodeRecord = node as unknown as Record<string, unknown>;
+  for (const [key, value] of Object.entries(nodeRecord)) {
+    if (key === "parent") continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isAstNode(item)) children.push(item);
+      }
+      continue;
+    }
+    if (isAstNode(value)) children.push(value);
+  }
+  return children;
+};
+
 interface CheckChildContext {
   depth: number;
   customAttributes: ReadonlyArray<string>;
@@ -130,6 +185,85 @@ const checkChildForLabel = (
     }
   }
   return false;
+};
+
+const hasAccessibleLabelText = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  context: CheckChildContext,
+): boolean => {
+  if (
+    hasLabellingProp(element.openingElement.attributes as EsTreeNode[], context.customAttributes)
+  ) {
+    return true;
+  }
+  return element.children.some((child) => checkChildForLabel(child as EsTreeNode, 1, context));
+};
+
+const hasAncestorLabel = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  context: CheckChildContext,
+): boolean => {
+  let current = element.parent;
+  while (current) {
+    if (isNodeOfType(current, "JSXElement")) {
+      const tagName = getElementType(current.openingElement, context.settings);
+      if (tagName === LABEL_ELEMENT && hasAccessibleLabelText(current, context)) {
+        return true;
+      }
+    }
+    current = current.parent ?? null;
+  }
+  return false;
+};
+
+const findEnclosingJsxTreeRoot = (element: EsTreeNodeOfType<"JSXElement">): EsTreeNode => {
+  let root: EsTreeNode = element;
+  let current = element.parent;
+  while (current) {
+    if (isNodeOfType(current, "JSXElement") || isNodeOfType(current, "JSXFragment")) {
+      root = current;
+    }
+    current = current.parent ?? null;
+  }
+  return root;
+};
+
+const searchForHtmlForLabel = (
+  node: EsTreeNode,
+  controlIdKey: string,
+  context: CheckChildContext,
+): boolean => {
+  if (isNodeOfType(node, "JSXElement")) {
+    const tagName = getElementType(node.openingElement, context.settings);
+    if (tagName === LABEL_ELEMENT) {
+      const htmlForAttribute = hasJsxPropIgnoreCase(
+        node.openingElement.attributes,
+        HTML_FOR_ATTRIBUTE,
+      );
+      if (
+        getAttributeMatchKey(htmlForAttribute) === controlIdKey &&
+        hasAccessibleLabelText(node, context)
+      ) {
+        return true;
+      }
+    }
+  }
+  for (const child of getAstChildren(node)) {
+    if (searchForHtmlForLabel(child, controlIdKey, context)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const hasHtmlForLabel = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  context: CheckChildContext,
+): boolean => {
+  const idAttribute = hasJsxPropIgnoreCase(element.openingElement.attributes, ID_ATTRIBUTE);
+  const controlIdKey = getAttributeMatchKey(idAttribute);
+  if (controlIdKey === null) return false;
+  return searchForHtmlForLabel(findEnclosingJsxTreeRoot(element), controlIdKey, context);
 };
 
 // Port of `oxc_linter::rules::jsx_a11y::control_has_associated_label`.
@@ -173,6 +307,8 @@ export const controlHasAssociatedLabel = defineRule<Rule>({
           controlComponents: settings.controlComponents,
           settings: context.settings,
         };
+        if (hasAncestorLabel(node, checkContext)) return;
+        if (hasHtmlForLabel(node, checkContext)) return;
         for (const child of node.children) {
           if (checkChildForLabel(child as EsTreeNode, 1, checkContext)) return;
         }


### PR DESCRIPTION
## Why?

`react-doctor/control-has-associated-label` was reporting false positives for form controls that already have valid HTML label associations. The rule previously checked the control's own props and children, but not the surrounding label structure that browsers and assistive technologies use to compute the control's accessible name.

This made standard form patterns look broken, including wrapped controls, same-identifier `htmlFor` / `id` pairs, and component-internal field helpers. The suggested workaround, adding `aria-label`, can make accessibility worse by duplicating the announced label.

Before:

```tsx
<label className="flex items-center gap-2 text-sm">
  <input type="checkbox" name="spelformer" value={sf} />
  <span>{texts.spelform[sf]}</span>
</label>

<label htmlFor={tomDatumId}>{texts.tomDatumLabel}</label>
<input id={tomDatumId} name="tom_datum" type="date" />
```

After:

```tsx
// No diagnostic: the input is associated with its ancestor label.
<label className="flex items-center gap-2 text-sm">
  <input type="checkbox" name="spelformer" value={sf} />
  <span>{texts.spelform[sf]}</span>
</label>

// No diagnostic: htmlFor and id refer to the same JSX identifier.
<label htmlFor={tomDatumId}>{texts.tomDatumLabel}</label>
<input id={tomDatumId} name="tom_datum" type="date" />
```

## What changed?

- Added ancestor `<label>` detection for controls nested inside labels with accessible text.
- Added local `htmlFor` / `id` matching for string literals, numeric literals, static template literals, and same-identifier JSX expressions.
- Kept the search syntax-local and conservative: labels inside callback props/render props do not satisfy the association.
- Added regression coverage for the reported false positives and the callback-prop non-rendered-label case.
- Fixes #524.

## Test plan

Test users can run to verify correctness:

```sh
cd packages/oxlint-plugin-react-doctor
nr test src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts src/plugin/rules/a11y/control-has-associated-label.test.ts
nr typecheck
cd ../..
nr format:check packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
```

Local validation passed with 247 focused rule tests. Broader eval results are pending separately.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes accessibility lint behavior on common form patterns; logic is syntax-local and regression-tested but could miss edge cases where `id`/`htmlFor` are not statically matchable.
> 
> **Overview**
> Reduces false positives on **`react-doctor/control-has-associated-label`** by treating standard HTML label associations as satisfying the rule, not only direct `aria-*` props or label text on the control itself.
> 
> The detector now skips controls wrapped in an ancestor **`<label>`** with accessible text (stopping at function boundaries so render-prop/callback JSX is not credited). It also matches **`htmlFor`** / **`id`** within the same JSX tree using conservative keys for literals, static templates, and same-identifier expressions, including pairs under conditional/ternary JSX. Labels only inside callback/render props still do not count.
> 
> Adds **`control-has-associated-label.regressions.test.ts`** for reported FP patterns and conservative negatives. Agent rule skill templates get minor markdown spacing/table alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13fdf9aa8644db1a2d907ebeff6ad2272c10b25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->