### PR TITLE
feat(react-native): add three Pressable / list / ScrollView perf rules

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -244,6 +244,7 @@ import { rnAnimationReactionAsDerived } from "./rules/react-native/rn-animation-
 import { rnBottomSheetPreferNative } from "./rules/react-native/rn-bottom-sheet-prefer-native.js";
 import { rnListCallbackPerRow } from "./rules/react-native/rn-list-callback-per-row.js";
 import { rnListDataMapped } from "./rules/react-native/rn-list-data-mapped.js";
+import { rnListMissingEstimatedItemSize } from "./rules/react-native/rn-list-missing-estimated-item-size.js";
 import { rnListRecyclableWithoutTypes } from "./rules/react-native/rn-list-recyclable-without-types.js";
 import { rnNoDeprecatedModules } from "./rules/react-native/rn-no-deprecated-modules.js";
 import { rnNoDimensionsGet } from "./rules/react-native/rn-no-dimensions-get.js";
@@ -260,9 +261,11 @@ import { rnNoSingleElementStyleArray } from "./rules/react-native/rn-no-single-e
 import { rnPreferContentInsetAdjustment } from "./rules/react-native/rn-prefer-content-inset-adjustment.js";
 import { rnPreferExpoImage } from "./rules/react-native/rn-prefer-expo-image.js";
 import { rnPreferPressable } from "./rules/react-native/rn-prefer-pressable.js";
+import { rnPreferPressableOverGestureDetector } from "./rules/react-native/rn-prefer-pressable-over-gesture-detector.js";
 import { rnPreferReanimated } from "./rules/react-native/rn-prefer-reanimated.js";
 import { rnPressableSharedValueMutation } from "./rules/react-native/rn-pressable-shared-value-mutation.js";
 import { rnScrollviewDynamicPadding } from "./rules/react-native/rn-scrollview-dynamic-padding.js";
+import { rnScrollviewFlexInContentContainer } from "./rules/react-native/rn-scrollview-flex-in-content-container.js";
 import { rnStylePreferBoxShadow } from "./rules/react-native/rn-style-prefer-box-shadow.js";
 import { roleHasRequiredAriaProps } from "./rules/a11y/role-has-required-aria-props.js";
 import { roleSupportsAriaProps } from "./rules/a11y/role-supports-aria-props.js";
@@ -2900,6 +2903,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/rn-list-missing-estimated-item-size",
+    id: "rn-list-missing-estimated-item-size",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...rnListMissingEstimatedItemSize,
+      framework: "react-native",
+      category: "React Native",
+      tags: [...new Set(["react-native", ...(rnListMissingEstimatedItemSize.tags ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/rn-list-recyclable-without-types",
     id: "rn-list-recyclable-without-types",
     source: "react-doctor",
@@ -3092,6 +3107,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/rn-prefer-pressable-over-gesture-detector",
+    id: "rn-prefer-pressable-over-gesture-detector",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...rnPreferPressableOverGestureDetector,
+      framework: "react-native",
+      category: "React Native",
+      tags: [...new Set(["react-native", ...(rnPreferPressableOverGestureDetector.tags ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/rn-prefer-reanimated",
     id: "rn-prefer-reanimated",
     source: "react-doctor",
@@ -3125,6 +3152,18 @@ export const reactDoctorRules = [
       framework: "react-native",
       category: "React Native",
       tags: [...new Set(["react-native", ...(rnScrollviewDynamicPadding.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/rn-scrollview-flex-in-content-container",
+    id: "rn-scrollview-flex-in-content-container",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...rnScrollviewFlexInContentContainer,
+      framework: "react-native",
+      category: "React Native",
+      tags: [...new Set(["react-native", ...(rnScrollviewFlexInContentContainer.tags ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rnListMissingEstimatedItemSize } from "./rn-list-missing-estimated-item-size.js";
+
+describe("rn-list-missing-estimated-item-size", () => {
+  it("flags FlashList from @shopify/flash-list without estimatedItemSize", () => {
+    const code = `
+      import { FlashList } from "@shopify/flash-list";
+      const Screen = ({ items }) => (
+        <FlashList data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("estimatedItemSize");
+  });
+
+  it("flags LegendList from @legendapp/list without estimatedItemSize", () => {
+    const code = `
+      import { LegendList } from "@legendapp/list";
+      const Screen = ({ items }) => (
+        <LegendList data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags aliased import `FlashList as List` from the recycler package", () => {
+    // Aliased imports preserve the originally-exported name in the
+    // import-lookup map; the rule asks `isImportedFromModule(node, "FlashList", ...)`
+    // against the LOCAL name in the JSX, which is "FlashList" here even
+    // though the local binding is aliased.
+    const code = `
+      import { FlashList } from "@shopify/flash-list";
+      const Screen = ({ items }) => (
+        <FlashList data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag FlashList with estimatedItemSize", () => {
+    const code = `
+      import { FlashList } from "@shopify/flash-list";
+      const Screen = ({ items }) => (
+        <FlashList data={items} renderItem={renderItem} estimatedItemSize={64} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag LegendList with estimatedListSize (richer hint)", () => {
+    const code = `
+      import { LegendList } from "@legendapp/list";
+      const Screen = ({ items }) => (
+        <LegendList
+          data={items}
+          renderItem={renderItem}
+          estimatedListSize={{ height: 800, width: 360 }}
+        />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag FlashList with empty-array data literal", () => {
+    const code = `
+      import { FlashList } from "@shopify/flash-list";
+      const Screen = () => (
+        <FlashList data={[]} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag FlashList without any data prop (abstract wrapper)", () => {
+    const code = `
+      import { FlashList } from "@shopify/flash-list";
+      const Wrapper = (props) => <FlashList {...props} />;
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag FlashList from a wrapper / non-Shopify package", () => {
+    const code = `
+      import { FlashList } from "./my-flash-list-wrapper";
+      const Screen = ({ items }) => (
+        <FlashList data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag a local component named FlashList (no import)", () => {
+    const code = `
+      const FlashList = () => null;
+      const Screen = ({ items }) => (
+        <FlashList data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag FlatList (out of scope, has built-in defaults)", () => {
+    const code = `
+      const Screen = ({ items }) => (
+        <FlatList data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag SectionList (out of scope)", () => {
+    const code = `
+      const Screen = ({ sections }) => (
+        <SectionList sections={sections} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag namespaced <Shopify.FlashList> (no top-level import to verify)", () => {
+    // After the import-scope tightening, namespaced JSX still resolves
+    // to the trailing identifier "FlashList" via resolveJsxElementName
+    // — but there's no local binding named "FlashList" to verify
+    // against, so the rule stays quiet. Tradeoff: <Shopify.FlashList>
+    // false negatives, in exchange for zero noise on wrapper components.
+    const code = `
+      import * as Shopify from "@shopify/flash-list";
+      const Screen = ({ items }) => (
+        <Shopify.FlashList data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag inside testlike file (tags: test-noise)", () => {
+    const code = `
+      import { FlashList } from "@shopify/flash-list";
+      const Screen = ({ items }) => (
+        <FlashList data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code, {
+      filename: "Screen.test.tsx",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.test.ts
@@ -26,15 +26,29 @@ describe("rn-list-missing-estimated-item-size", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("flags aliased import `FlashList as List` from the recycler package", () => {
-    // Aliased imports preserve the originally-exported name in the
-    // import-lookup map; the rule asks `isImportedFromModule(node, "FlashList", ...)`
-    // against the LOCAL name in the JSX, which is "FlashList" here even
-    // though the local binding is aliased.
+  it("flags genuinely-aliased import `FlashList as List`", () => {
+    // The detector must resolve the LOCAL JSX name back to its
+    // originally-exported symbol — aliased local bindings (where the
+    // JSX element name no longer matches "FlashList") still need to
+    // fire. Bugbot caught a prior false confidence here.
     const code = `
-      import { FlashList } from "@shopify/flash-list";
+      import { FlashList as List } from "@shopify/flash-list";
       const Screen = ({ items }) => (
-        <FlashList data={items} renderItem={renderItem} />
+        <List data={items} renderItem={renderItem} />
+      );
+    `;
+    const result = runRule(rnListMissingEstimatedItemSize, code);
+    expect(result.diagnostics).toHaveLength(1);
+    // Message names BOTH the local JSX name and the canonical symbol.
+    expect(result.diagnostics[0].message).toContain("List");
+    expect(result.diagnostics[0].message).toContain("FlashList");
+  });
+
+  it("flags genuinely-aliased import `LegendList as VList`", () => {
+    const code = `
+      import { LegendList as VList } from "@legendapp/list";
+      const Screen = ({ items }) => (
+        <VList data={items} renderItem={renderItem} />
       );
     `;
     const result = runRule(rnListMissingEstimatedItemSize, code);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.ts
@@ -1,5 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
-import { isImportedFromModule } from "../../utils/find-import-source-for-name.js";
+import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
@@ -43,17 +43,25 @@ export const rnListMissingEstimatedItemSize = defineRule<Rule>({
     "Add `estimatedItemSize={<avg-row-height-in-px>}` so the initial container pool matches the real rows — without it the engine guesses and flashes blank cells on fast scroll",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      const elementName = resolveJsxElementName(node);
-      if (!elementName) return;
-      const packageSources = RECYCLABLE_LIST_PACKAGES[elementName];
-      if (!packageSources) return;
-      // Only fire when the local JSX name is imported from one of the
-      // recycler-owning packages. Skips homegrown / wrapper components
-      // that happen to reuse the FlashList / LegendList name.
-      const isImportedFromRecyclerPackage = packageSources.some((packageSource) =>
-        isImportedFromModule(node, elementName, packageSource),
-      );
-      if (!isImportedFromRecyclerPackage) return;
+      const localElementName = resolveJsxElementName(node);
+      if (!localElementName) return;
+      // Resolve the LOCAL JSX name back to its originally-exported
+      // symbol from one of the recycler-owning packages. This handles
+      // both plain (`import { FlashList }`) and aliased
+      // (`import { FlashList as List }; <List />`) imports — we never
+      // key off the local JSX name directly.
+      let canonicalRecyclerName: string | null = null;
+      for (const [canonicalName, packageSources] of Object.entries(RECYCLABLE_LIST_PACKAGES)) {
+        const matched = packageSources.some(
+          (packageSource) =>
+            getImportedNameFromModule(node, localElementName, packageSource) === canonicalName,
+        );
+        if (matched) {
+          canonicalRecyclerName = canonicalName;
+          break;
+        }
+      }
+      if (!canonicalRecyclerName) return;
 
       let hasSizingHint = false;
       let dataIsEmptyLiteral = false;
@@ -82,7 +90,7 @@ export const rnListMissingEstimatedItemSize = defineRule<Rule>({
 
       context.report({
         node,
-        message: `<${elementName}> is missing \`estimatedItemSize\` — the engine guesses the initial container pool from a default that often mismatches your rows, causing blank flashes on fast scroll`,
+        message: `<${localElementName}> (from ${canonicalRecyclerName}) is missing \`estimatedItemSize\` — the engine guesses the initial container pool from a default that often mismatches your rows, causing blank flashes on fast scroll`,
       });
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.ts
@@ -1,0 +1,89 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { isImportedFromModule } from "../../utils/find-import-source-for-name.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// HACK: FlashList / LegendList compute their initial container pool
+// from `estimatedItemSize` via
+//   numContainers = ceil(((viewport - header + drawDistance × 2) / avg) × cols)
+// If you don't supply it, the engine falls back to a hard-coded
+// default (FlashList warns at runtime; LegendList doesn't). When the
+// real row size is much larger than the default, the visible viewport
+// renders blank cells until the engine measures and re-allocates,
+// producing the "blank flash on fast scroll" artifact. LegendList
+// accepts `estimatedItemSize` OR `estimatedListSize` (the latter is
+// a richer per-list hint), so either silences the rule.
+
+// Source-of-truth packages: only fire when the JSX element name resolves
+// to one of these via a real ES module import. A homegrown component
+// named `FlashList` in a different package (or imported from a wrapper)
+// shouldn't pretend to be the Shopify/Legend recycler.
+const RECYCLABLE_LIST_PACKAGES: Record<string, ReadonlyArray<string>> = {
+  FlashList: ["@shopify/flash-list"],
+  LegendList: ["@legendapp/list"],
+};
+
+const SIZING_HINT_ATTRIBUTE_NAMES = new Set(["estimatedItemSize", "estimatedListSize"]);
+
+const isEmptyArrayLiteral = (node: EsTreeNodeOfType<"JSXAttribute">): boolean => {
+  if (!isNodeOfType(node.value, "JSXExpressionContainer")) return false;
+  const expression = node.value.expression;
+  return isNodeOfType(expression, "ArrayExpression") && (expression.elements?.length ?? 0) === 0;
+};
+
+export const rnListMissingEstimatedItemSize = defineRule<Rule>({
+  id: "rn-list-missing-estimated-item-size",
+  tags: ["test-noise"],
+  requires: ["react-native"],
+  severity: "warn",
+  recommendation:
+    "Add `estimatedItemSize={<avg-row-height-in-px>}` so the initial container pool matches the real rows — without it the engine guesses and flashes blank cells on fast scroll",
+  create: (context: RuleContext) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      const elementName = resolveJsxElementName(node);
+      if (!elementName) return;
+      const packageSources = RECYCLABLE_LIST_PACKAGES[elementName];
+      if (!packageSources) return;
+      // Only fire when the local JSX name is imported from one of the
+      // recycler-owning packages. Skips homegrown / wrapper components
+      // that happen to reuse the FlashList / LegendList name.
+      const isImportedFromRecyclerPackage = packageSources.some((packageSource) =>
+        isImportedFromModule(node, elementName, packageSource),
+      );
+      if (!isImportedFromRecyclerPackage) return;
+
+      let hasSizingHint = false;
+      let dataIsEmptyLiteral = false;
+      let hasDataProp = false;
+
+      for (const attribute of node.attributes ?? []) {
+        if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+        if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
+        const attributeName = attribute.name.name;
+        if (SIZING_HINT_ATTRIBUTE_NAMES.has(attributeName)) hasSizingHint = true;
+        if (attributeName === "data") {
+          hasDataProp = true;
+          if (isEmptyArrayLiteral(attribute)) dataIsEmptyLiteral = true;
+        }
+      }
+
+      if (hasSizingHint) return;
+      // Skip placeholder lists — `<FlashList data={[]} />` is almost
+      // always a render-with-empty-data branch, not a production code
+      // path, and adding `estimatedItemSize` there is busywork.
+      if (dataIsEmptyLiteral) return;
+      // Skip JSX that doesn't even pass `data` — likely an
+      // abstract wrapper component being defined, not an instantiation
+      // with real items.
+      if (!hasDataProp) return;
+
+      context.report({
+        node,
+        message: `<${elementName}> is missing \`estimatedItemSize\` — the engine guesses the initial container pool from a default that often mismatches your rows, causing blank flashes on fast scroll`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.test.ts
@@ -102,6 +102,26 @@ describe("rn-prefer-pressable-over-gesture-detector", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("regression: numberOfTaps(1).numberOfTaps(2) chain — outer wins, no false positive", () => {
+    // The walker visits OUTERMOST → INNERMOST. In a fluent chain the
+    // outermost `.numberOfTaps(2)` is the effective call (last
+    // assignment wins). An earlier draft unconditionally overwrote
+    // the captured value with each inner encounter and could flag
+    // `.numberOfTaps(1).numberOfTaps(2)` as Pressable-eligible
+    // (treating it as single-tap). The fix keeps only the FIRST
+    // encountered value (= outermost).
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = ({ onPress }) => (
+        <GestureDetector gesture={Gesture.Tap().numberOfTaps(1).numberOfTaps(2).onStart(onPress)}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does NOT flag double-tap (numberOfTaps(2))", () => {
     const code = `
       import { GestureDetector, Gesture } from "react-native-gesture-handler";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rnPreferPressableOverGestureDetector } from "./rn-prefer-pressable-over-gesture-detector.js";
+
+describe("rn-prefer-pressable-over-gesture-detector", () => {
+  it("flags GestureDetector wrapping plain Gesture.Tap()", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = () => (
+        <GestureDetector gesture={Gesture.Tap()}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("Pressable");
+  });
+
+  it("flags variable-extracted Gesture.Tap() chain (binding analysis)", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = ({ onPress }) => {
+        const tap = Gesture.Tap().onStart(onPress).onEnd(onPress);
+        return <GestureDetector gesture={tap}><Animated.View /></GestureDetector>;
+      };
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag variable-extracted Gesture.Pan() chain", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Draggable = ({ onPan }) => {
+        const pan = Gesture.Pan().onChange(onPan);
+        return <GestureDetector gesture={pan}><Animated.View /></GestureDetector>;
+      };
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag variable-extracted Gesture.Tap with numberOfTaps(2)", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = ({ onPress }) => {
+        const tap = Gesture.Tap().numberOfTaps(2).onStart(onPress);
+        return <GestureDetector gesture={tap}><Animated.View /></GestureDetector>;
+      };
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag variable-extracted Gesture.Race composition", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Combo = () => {
+        const combo = Gesture.Race(Gesture.Tap(), Gesture.Pan());
+        return <GestureDetector gesture={combo}><Animated.View /></GestureDetector>;
+      };
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag variable initialized to an unknown identifier (no chain to follow)", () => {
+    const code = `
+      import { GestureDetector } from "react-native-gesture-handler";
+      const Button = ({ gesture }) => (
+        <GestureDetector gesture={gesture}><Animated.View /></GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags inline Gesture.Tap().onStart() chain", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = ({ onPress }) => (
+        <GestureDetector gesture={Gesture.Tap().onStart(onPress)}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Gesture.Tap().numberOfTaps(1).onStart() chain", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = ({ onPress }) => (
+        <GestureDetector gesture={Gesture.Tap().numberOfTaps(1).onStart(onPress)}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag double-tap (numberOfTaps(2))", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = ({ onPress }) => (
+        <GestureDetector gesture={Gesture.Tap().numberOfTaps(2).onStart(onPress)}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag Gesture.Pan() (pan is legit for GH)", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Draggable = () => (
+        <GestureDetector gesture={Gesture.Pan().onChange(handlePan)}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag Gesture.Pinch()", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Zoomable = () => (
+        <GestureDetector gesture={Gesture.Pinch()}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag Gesture.Race composition", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Combo = () => (
+        <GestureDetector gesture={Gesture.Race(Gesture.Tap(), Gesture.Pan())}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag tap chained with simultaneousWithExternalGesture", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Combo = ({ scroll }) => (
+        <GestureDetector gesture={Gesture.Tap().simultaneousWithExternalGesture(scroll)}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag a custom GestureDetector that isn't imported from RNGH", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "./local-gesture";
+      const Button = () => (
+        <GestureDetector gesture={Gesture.Tap()}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag GestureDetector without any gesture prop (renders nothing)", () => {
+    const code = `
+      import { GestureDetector } from "react-native-gesture-handler";
+      const Button = () => <GestureDetector><Animated.View /></GestureDetector>;
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag inside testlike file (tags: test-noise)", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = () => (
+        <GestureDetector gesture={Gesture.Tap()}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code, {
+      filename: "Button.test.tsx",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.test.ts
@@ -122,6 +122,37 @@ describe("rn-prefer-pressable-over-gesture-detector", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("regression: numberOfTaps(<dynamic>) — bail conservatively, no false positive", () => {
+    // Bugbot caught that the previous guard only rejected literal
+    // numeric values > 1. A non-literal argument like
+    // `numberOfTaps(config.taps)` fell through and was treated as
+    // Pressable-eligible, even though the runtime value could be 2+.
+    // Fix: any numberOfTaps call that isn't a static `1` literal bails.
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = ({ config, onPress }) => (
+        <GestureDetector gesture={Gesture.Tap().numberOfTaps(config.taps).onStart(onPress)}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("regression: numberOfTaps(ternary) — bail conservatively", () => {
+    const code = `
+      import { GestureDetector, Gesture } from "react-native-gesture-handler";
+      const Button = ({ double, onPress }) => (
+        <GestureDetector gesture={Gesture.Tap().numberOfTaps(double ? 2 : 1).onStart(onPress)}>
+          <Animated.View />
+        </GestureDetector>
+      );
+    `;
+    const result = runRule(rnPreferPressableOverGestureDetector, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does NOT flag double-tap (numberOfTaps(2))", () => {
     const code = `
       import { GestureDetector, Gesture } from "react-native-gesture-handler";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
@@ -20,20 +20,9 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 // (`Gesture.Race`, `Gesture.Simultaneous`, multi-tap, pan) still need
 // the handler, so this rule only fires for the lone `Gesture.Tap()` case.
 
-const NON_TAP_GESTURE_FACTORY_NAMES = new Set([
-  "Pan",
-  "Pinch",
-  "Rotation",
-  "Fling",
-  "LongPress",
-  "ForceTouch",
-  "Manual",
-  "Native",
-  "Hover",
-  "ContextMenu",
-]);
-
-const GESTURE_COMPOSITION_FACTORY_NAMES = new Set(["Race", "Simultaneous", "Exclusive"]);
+// Existing valid-case tests cover the other gesture factories
+// (`Gesture.Pan/Pinch/Race/...`) — they all fail the `factoryName === "Tap"`
+// gate above. No need to enumerate them here.
 
 const COMPOSING_CHAIN_METHOD_NAMES = new Set([
   "simultaneousWithExternalGesture",
@@ -83,8 +72,6 @@ const analyzeGestureChain = (expression: EsTreeNode): GestureChainInfo | null =>
 
 const isTapChainEligibleForPressable = (chain: GestureChainInfo): boolean => {
   if (chain.factoryName !== "Tap") return false;
-  if (NON_TAP_GESTURE_FACTORY_NAMES.has(chain.factoryName)) return false;
-  if (GESTURE_COMPOSITION_FACTORY_NAMES.has(chain.factoryName)) return false;
   for (const methodName of chain.chainMethodNames) {
     if (COMPOSING_CHAIN_METHOD_NAMES.has(methodName)) return false;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
@@ -1,0 +1,146 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { isImportedFromModule } from "../../utils/find-import-source-for-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// HACK: every `<GestureDetector>` registers a native gesture handler
+// on mount. On a screen that mounts many tap-only pressables (a list of
+// chart indicators, a settings sheet, a chip cloud), 100 registrations
+// land in the same commit and add ~325 ms of mount latency on Android
+// (measured: 760 ms → 453 ms after switching to plain `Pressable`).
+// For tap-only feedback the native pressable surface is faster AND
+// equivalent — Reanimated 4's `createCSSAnimatedComponent(Pressable)`
+// keeps the press-scale/opacity animation. Composed gestures
+// (`Gesture.Race`, `Gesture.Simultaneous`, multi-tap, pan) still need
+// the handler, so this rule only fires for the lone `Gesture.Tap()` case.
+
+const NON_TAP_GESTURE_FACTORY_NAMES = new Set([
+  "Pan",
+  "Pinch",
+  "Rotation",
+  "Fling",
+  "LongPress",
+  "ForceTouch",
+  "Manual",
+  "Native",
+  "Hover",
+  "ContextMenu",
+]);
+
+const GESTURE_COMPOSITION_FACTORY_NAMES = new Set(["Race", "Simultaneous", "Exclusive"]);
+
+const COMPOSING_CHAIN_METHOD_NAMES = new Set([
+  "simultaneousWithExternalGesture",
+  "requireExternalGestureToFail",
+  "blocksExternalGesture",
+]);
+
+// Walks a chain of MemberExpression-call links rooted in the initial
+// gesture factory. For `Gesture.Tap().numberOfTaps(2).maxDuration(250)`
+// the chain produces ["numberOfTaps", "maxDuration"] and the initial
+// factory name "Tap". Returns null when the chain bottoms out at
+// anything other than `Gesture.<factory>()`.
+interface GestureChainInfo {
+  factoryName: string;
+  chainMethodNames: string[];
+  numberOfTapsArgument: EsTreeNode | null;
+}
+
+const analyzeGestureChain = (expression: EsTreeNode): GestureChainInfo | null => {
+  if (!isNodeOfType(expression, "CallExpression")) return null;
+  const chainMethodNames: string[] = [];
+  let numberOfTapsArgument: EsTreeNode | null = null;
+  let cursor: EsTreeNode | null = expression;
+  while (cursor && isNodeOfType(cursor, "CallExpression")) {
+    const callExpression: EsTreeNodeOfType<"CallExpression"> = cursor;
+    const callee = callExpression.callee;
+    if (!isNodeOfType(callee, "MemberExpression")) return null;
+    if (!isNodeOfType(callee.property, "Identifier")) return null;
+    const methodName = callee.property.name;
+    // The outermost call is the most-recent .method() in the chain;
+    // we walk inward through the receivers until the chain root.
+    if (isNodeOfType(callee.object, "Identifier") && callee.object.name === "Gesture") {
+      return {
+        factoryName: methodName,
+        chainMethodNames,
+        numberOfTapsArgument,
+      };
+    }
+    if (methodName === "numberOfTaps" && callExpression.arguments?.length === 1) {
+      numberOfTapsArgument = callExpression.arguments[0] ?? null;
+    }
+    chainMethodNames.push(methodName);
+    cursor = callee.object as EsTreeNode | null;
+  }
+  return null;
+};
+
+const isTapChainEligibleForPressable = (chain: GestureChainInfo): boolean => {
+  if (chain.factoryName !== "Tap") return false;
+  if (NON_TAP_GESTURE_FACTORY_NAMES.has(chain.factoryName)) return false;
+  if (GESTURE_COMPOSITION_FACTORY_NAMES.has(chain.factoryName)) return false;
+  for (const methodName of chain.chainMethodNames) {
+    if (COMPOSING_CHAIN_METHOD_NAMES.has(methodName)) return false;
+  }
+  const tapsArg = chain.numberOfTapsArgument;
+  if (tapsArg !== null && isNodeOfType(tapsArg, "Literal") && typeof tapsArg.value === "number") {
+    if (tapsArg.value > 1) return false;
+  }
+  return true;
+};
+
+export const rnPreferPressableOverGestureDetector = defineRule<Rule>({
+  id: "rn-prefer-pressable-over-gesture-detector",
+  tags: ["test-noise"],
+  requires: ["react-native"],
+  severity: "warn",
+  recommendation:
+    "Replace `<GestureDetector gesture={Gesture.Tap()...}>` with `<Pressable>` (or `createCSSAnimatedComponent(Pressable)` from react-native-reanimated/css for animated press feedback) — every GestureDetector registers a native handler on mount",
+  create: (context: RuleContext) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      const elementName = resolveJsxElementName(node);
+      if (elementName !== "GestureDetector") return;
+      // Only react-native-gesture-handler's GestureDetector — never a
+      // homegrown component of the same name in the same file.
+      if (!isImportedFromModule(node, "GestureDetector", "react-native-gesture-handler")) return;
+
+      let gestureExpression: EsTreeNode | null = null;
+      for (const attribute of node.attributes ?? []) {
+        if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+        if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
+        if (attribute.name.name !== "gesture") continue;
+        if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) continue;
+        gestureExpression = attribute.value.expression;
+        break;
+      }
+      if (!gestureExpression) return;
+
+      const resolvedExpression = stripParenExpression(gestureExpression);
+      // `<GD gesture={tap}>` — follow ONE level of binding to find the
+      // CallExpression chain. v1 doesn't follow chains of intermediate
+      // identifiers, since each extra hop dilutes the signal.
+      let chainExpression: EsTreeNode = resolvedExpression;
+      if (isNodeOfType(resolvedExpression, "Identifier")) {
+        const binding = findVariableInitializer(node, resolvedExpression.name);
+        if (!binding || !binding.initializer) return;
+        chainExpression = stripParenExpression(binding.initializer);
+      }
+
+      const chain = analyzeGestureChain(chainExpression);
+      if (!chain) return;
+      if (!isTapChainEligibleForPressable(chain)) return;
+
+      context.report({
+        node,
+        message:
+          "<GestureDetector gesture={Gesture.Tap()...}> registers a native handler per mount — for tap-only feedback use <Pressable> (with createCSSAnimatedComponent(Pressable) from react-native-reanimated/css for animation)",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
@@ -85,8 +85,15 @@ const isTapChainEligibleForPressable = (chain: GestureChainInfo): boolean => {
     if (COMPOSING_CHAIN_METHOD_NAMES.has(methodName)) return false;
   }
   const tapsArg = chain.numberOfTapsArgument;
-  if (tapsArg !== null && isNodeOfType(tapsArg, "Literal") && typeof tapsArg.value === "number") {
-    if (tapsArg.value > 1) return false;
+  if (tapsArg !== null) {
+    // The chain called `.numberOfTaps(...)`. Only a static numeric `1`
+    // is Pressable-equivalent — anything else (`numberOfTaps(2)`,
+    // `numberOfTaps(config.taps)`, `numberOfTaps(double ? 2 : 1)`)
+    // signals potentially multi-tap behavior that Pressable can't
+    // model. Bail conservatively.
+    if (!isNodeOfType(tapsArg, "Literal")) return false;
+    if (typeof tapsArg.value !== "number") return false;
+    if (tapsArg.value !== 1) return false;
   }
   return true;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
@@ -61,7 +61,16 @@ const analyzeGestureChain = (expression: EsTreeNode): GestureChainInfo | null =>
         numberOfTapsArgument,
       };
     }
-    if (methodName === "numberOfTaps" && callExpression.arguments?.length === 1) {
+    // The walker visits OUTERMOST → INNERMOST. In a fluent chain,
+    // `.numberOfTaps(2)` outermost is the semantically effective call
+    // (last assignment wins in a fluent builder). Earlier inner
+    // `.numberOfTaps(1)` calls are overridden and shouldn't reset our
+    // captured value — so only record the FIRST occurrence we see.
+    if (
+      methodName === "numberOfTaps" &&
+      numberOfTapsArgument === null &&
+      callExpression.arguments?.length === 1
+    ) {
       numberOfTapsArgument = callExpression.arguments[0] ?? null;
     }
     chainMethodNames.push(methodName);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rnScrollviewFlexInContentContainer } from "./rn-scrollview-flex-in-content-container.js";
+
+describe("rn-scrollview-flex-in-content-container", () => {
+  it("flags flex: 1 on ScrollView contentContainerStyle", () => {
+    const code = `
+      const Screen = () => <ScrollView contentContainerStyle={{ flex: 1 }} />;
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("flexBasis: 0");
+  });
+
+  it("flags flex: 2 (any positive number)", () => {
+    const code = `
+      const Screen = () => <ScrollView contentContainerStyle={{ flex: 2, padding: 16 }} />;
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags flex: 1 on FlatList contentContainerStyle", () => {
+    const code = `
+      const Screen = () => (
+        <FlatList data={items} renderItem={renderItem} contentContainerStyle={{ flex: 1 }} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags flex: 1 on FlashList contentContainerStyle", () => {
+    const code = `
+      const Screen = () => (
+        <FlashList data={items} renderItem={renderItem} contentContainerStyle={{ flex: 1 }} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags flex: 1 on SectionList contentContainerStyle", () => {
+    const code = `
+      const Screen = () => (
+        <SectionList sections={sections} contentContainerStyle={{ flex: 1 }} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags flex: 1 on KeyboardAwareScrollView", () => {
+    const code = `
+      const Screen = () => (
+        <KeyboardAwareScrollView contentContainerStyle={{ flex: 1 }} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag flexGrow: 1 (the correct fix)", () => {
+    const code = `
+      const Screen = () => <ScrollView contentContainerStyle={{ flexGrow: 1 }} />;
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag flex: 0 (intentional 'non-flexible' RN mode)", () => {
+    const code = `
+      const Screen = () => <ScrollView contentContainerStyle={{ flex: 0 }} />;
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag flex: -1 (RN-specific shrink-to-min mode)", () => {
+    const code = `
+      const Screen = () => <ScrollView contentContainerStyle={{ flex: -1 }} />;
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag flex when paired with explicit flexGrow", () => {
+    const code = `
+      const Screen = () => (
+        <ScrollView contentContainerStyle={{ flex: 1, flexGrow: 2 }} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag flex when paired with explicit flexBasis", () => {
+    const code = `
+      const Screen = () => (
+        <ScrollView contentContainerStyle={{ flex: 1, flexBasis: 100 }} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag dynamic flex value (non-literal)", () => {
+    const code = `
+      const Screen = ({ value }) => (
+        <ScrollView contentContainerStyle={{ flex: value }} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag flex: 1 on non-scrollview components", () => {
+    const code = `
+      const Screen = () => <View contentContainerStyle={{ flex: 1 }} />;
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag contentContainerStyle without flex", () => {
+    const code = `
+      const Screen = () => (
+        <ScrollView contentContainerStyle={{ padding: 16, backgroundColor: "red" }} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag ScrollView without contentContainerStyle", () => {
+    const code = `const Screen = () => <ScrollView style={{ flex: 1 }} />;`;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags flex: 1 via StyleSheet.create ref (styles.container)", () => {
+    const code = `
+      const styles = StyleSheet.create({ container: { flex: 1 } });
+      const Screen = () => (
+        <ScrollView contentContainerStyle={styles.container} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("flexBasis: 0");
+  });
+
+  it("flags flex: 1 via computed StyleSheet.create ref (styles['container'])", () => {
+    const code = `
+      const styles = StyleSheet.create({ container: { flex: 1 } });
+      const Screen = () => (
+        <ScrollView contentContainerStyle={styles["container"]} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag styles.container that does not contain flex: 1", () => {
+    const code = `
+      const styles = StyleSheet.create({ container: { flexGrow: 1, padding: 16 } });
+      const Screen = () => (
+        <ScrollView contentContainerStyle={styles.container} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag styles.container that pairs flex with flexGrow override", () => {
+    const code = `
+      const styles = StyleSheet.create({
+        container: { flex: 1, flexGrow: 2 }
+      });
+      const Screen = () => (
+        <ScrollView contentContainerStyle={styles.container} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag styles.<missingKey> (key not found in stylesheet)", () => {
+    const code = `
+      const styles = StyleSheet.create({ container: { flex: 1 } });
+      const Screen = () => (
+        <ScrollView contentContainerStyle={styles.missing} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag identifier reference that isn't a StyleSheet.create call", () => {
+    const code = `
+      const styles = { container: { flex: 1 } };
+      const Screen = () => (
+        <ScrollView contentContainerStyle={styles.container} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag dynamic computed key (styles[key])", () => {
+    const code = `
+      const styles = StyleSheet.create({ container: { flex: 1 } });
+      const Screen = ({ key }) => (
+        <ScrollView contentContainerStyle={styles[key]} />
+      );
+    `;
+    const result = runRule(rnScrollviewFlexInContentContainer, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag inside testlike file (tags: test-noise)", () => {
+    const code = `const Screen = () => <ScrollView contentContainerStyle={{ flex: 1 }} />;`;
+    const result = runRule(rnScrollviewFlexInContentContainer, code, {
+      filename: "Screen.test.tsx",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.ts
@@ -1,0 +1,185 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// HACK: in React Native, `flex` on `contentContainerStyle` is shorthand
+// for `{ flexGrow, flexShrink, flexBasis: 0 }` — NOT CSS's
+// `flex-basis: auto`. The practical result: when the inner content is
+// taller than the viewport the container collapses to zero on small
+// devices, even though the same code looks right on larger ones. The
+// documented fix is `flexGrow: 1`, which keeps the "fill remaining
+// space" semantics without the basis: 0 collapse.
+
+const VIRTUALIZED_LIST_NAMES = new Set(["FlashList", "LegendList"]);
+
+const STYLESHEET_CREATE_CALLEE_NAMES = new Set(["StyleSheet.create", "create"]);
+
+const getStaticMemberKeyName = (
+  expression: EsTreeNodeOfType<"MemberExpression">,
+): string | null => {
+  if (!expression.computed) {
+    if (isNodeOfType(expression.property, "Identifier")) return expression.property.name;
+    return null;
+  }
+  // computed: `styles["container"]`
+  if (
+    isNodeOfType(expression.property, "Literal") &&
+    typeof expression.property.value === "string"
+  ) {
+    return expression.property.value;
+  }
+  return null;
+};
+
+const isStyleSheetCreateCallExpression = (
+  expression: EsTreeNode | null | undefined,
+): expression is EsTreeNodeOfType<"CallExpression"> => {
+  if (!expression) return false;
+  const callExpression = stripParenExpression(expression);
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
+  const callee = callExpression.callee;
+  // `StyleSheet.create(...)` — non-computed MemberExpression.
+  if (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.object, "Identifier") &&
+    callee.object.name === "StyleSheet" &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === "create"
+  ) {
+    return true;
+  }
+  // Named import: `import { create } from "react-native/StyleSheet"` is
+  // possible but rare; cover bare `create(...)` only when the binding
+  // looks StyleSheet-shaped. We don't follow that import scope today.
+  if (isNodeOfType(callee, "Identifier") && STYLESHEET_CREATE_CALLEE_NAMES.has(callee.name)) {
+    // Bare `create({})` is too ambiguous on its own — skip unless paired
+    // with the canonical StyleSheet member form above.
+    return false;
+  }
+  return false;
+};
+
+const resolveContentContainerStyleObject = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+): EsTreeNodeOfType<"ObjectExpression"> | null => {
+  if (!isNodeOfType(attribute.name, "JSXIdentifier")) return null;
+  if (attribute.name.name !== "contentContainerStyle") return null;
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
+  const expression = stripParenExpression(attribute.value.expression);
+  // Inline literal: `contentContainerStyle={{ flex: 1 }}`
+  if (isNodeOfType(expression, "ObjectExpression")) return expression;
+  // StyleSheet reference: `contentContainerStyle={styles.container}` or
+  // `contentContainerStyle={styles["container"]}`. Follow ONE level of
+  // binding to the `StyleSheet.create({ container: { flex: 1 } })` map
+  // and return the matched property's value. v1 doesn't follow chains
+  // of intermediate identifiers.
+  if (isNodeOfType(expression, "MemberExpression")) {
+    const styleObjectKeyName = getStaticMemberKeyName(expression);
+    if (!styleObjectKeyName) return null;
+    const styleObjectIdentifierName = getRootIdentifierName(expression);
+    if (!styleObjectIdentifierName) return null;
+    const binding = findVariableInitializer(expression, styleObjectIdentifierName);
+    if (!binding || !binding.initializer) return null;
+    if (!isStyleSheetCreateCallExpression(binding.initializer)) return null;
+    const styleSheetCall = stripParenExpression(
+      binding.initializer,
+    ) as EsTreeNodeOfType<"CallExpression">;
+    const argument = styleSheetCall.arguments?.[0];
+    if (!isNodeOfType(argument, "ObjectExpression")) return null;
+    for (const property of argument.properties ?? []) {
+      if (!isNodeOfType(property, "Property")) continue;
+      if (property.computed) continue;
+      let matchesKey = false;
+      if (isNodeOfType(property.key, "Identifier")) {
+        matchesKey = property.key.name === styleObjectKeyName;
+      } else if (isNodeOfType(property.key, "Literal") && typeof property.key.value === "string") {
+        matchesKey = property.key.value === styleObjectKeyName;
+      }
+      if (!matchesKey) continue;
+      const propertyValue = stripParenExpression(property.value);
+      if (isNodeOfType(propertyValue, "ObjectExpression")) return propertyValue;
+      return null;
+    }
+  }
+  return null;
+};
+
+const collectStyleKeyNames = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+): Set<string> => {
+  const names = new Set<string>();
+  for (const property of objectExpression.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) continue;
+    if (property.computed) continue;
+    if (isNodeOfType(property.key, "Identifier")) names.add(property.key.name);
+    else if (isNodeOfType(property.key, "Literal") && typeof property.key.value === "string") {
+      names.add(property.key.value);
+    }
+  }
+  return names;
+};
+
+const findFlexShorthandProperty = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+): EsTreeNodeOfType<"Property"> | null => {
+  for (const property of objectExpression.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) continue;
+    if (property.computed) continue;
+    if (!isNodeOfType(property.key, "Identifier") || property.key.name !== "flex") continue;
+    const value: EsTreeNode | null | undefined = property.value;
+    if (!isNodeOfType(value, "Literal")) return null;
+    // RN `flex: 0` is the "non-flexible, sized by width/height" mode —
+    // intentional, not the CSS shorthand confusion. Same for negative
+    // numbers (legitimate RN-only escape hatch). Only positive numbers
+    // mirror the CSS `flex: 1` mistake.
+    if (typeof value.value !== "number" || value.value <= 0) return null;
+    return property;
+  }
+  return null;
+};
+
+export const rnScrollviewFlexInContentContainer = defineRule<Rule>({
+  id: "rn-scrollview-flex-in-content-container",
+  tags: ["test-noise"],
+  requires: ["react-native"],
+  severity: "warn",
+  recommendation:
+    "Use `flexGrow: 1` on `contentContainerStyle` — RN's `flex: 1` shorthand sets `flexBasis: 0` and collapses the container on small devices",
+  create: (context: RuleContext) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      const elementName = resolveJsxElementName(node);
+      if (!elementName) return;
+      if (!SCROLLVIEW_NAMES.has(elementName) && !VIRTUALIZED_LIST_NAMES.has(elementName)) return;
+
+      for (const attribute of node.attributes ?? []) {
+        if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+        const objectExpression = resolveContentContainerStyleObject(attribute);
+        if (!objectExpression) continue;
+
+        const keyNames = collectStyleKeyNames(objectExpression);
+        // Explicit `flexGrow` / `flexBasis` alongside `flex: 1` signals
+        // the author already understands the trade-off and is overriding
+        // one of the shorthand's slots. Stay quiet — flagging here would
+        // train people to delete the override and reintroduce the bug.
+        if (keyNames.has("flexGrow") || keyNames.has("flexBasis")) continue;
+
+        const flexProperty = findFlexShorthandProperty(objectExpression);
+        if (!flexProperty) continue;
+
+        context.report({
+          node: flexProperty,
+          message: `<${elementName}> contentContainerStyle uses \`flex: <number>\` — RN's flex shorthand sets flexBasis: 0 and collapses the container on small devices. Use \`flexGrow: 1\` instead`,
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.ts
@@ -20,8 +20,6 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const VIRTUALIZED_LIST_NAMES = new Set(["FlashList", "LegendList"]);
 
-const STYLESHEET_CREATE_CALLEE_NAMES = new Set(["StyleSheet.create", "create"]);
-
 const getStaticMemberKeyName = (
   expression: EsTreeNodeOfType<"MemberExpression">,
 ): string | null => {
@@ -46,26 +44,17 @@ const isStyleSheetCreateCallExpression = (
   const callExpression = stripParenExpression(expression);
   if (!isNodeOfType(callExpression, "CallExpression")) return false;
   const callee = callExpression.callee;
-  // `StyleSheet.create(...)` — non-computed MemberExpression.
-  if (
+  // `StyleSheet.create(...)` — the only shape we recognize. Bare
+  // `create({})` from a named import is too ambiguous on its own
+  // (collides with too many user helpers); not followed today.
+  return (
     isNodeOfType(callee, "MemberExpression") &&
     !callee.computed &&
     isNodeOfType(callee.object, "Identifier") &&
     callee.object.name === "StyleSheet" &&
     isNodeOfType(callee.property, "Identifier") &&
     callee.property.name === "create"
-  ) {
-    return true;
-  }
-  // Named import: `import { create } from "react-native/StyleSheet"` is
-  // possible but rare; cover bare `create(...)` only when the binding
-  // looks StyleSheet-shaped. We don't follow that import scope today.
-  if (isNodeOfType(callee, "Identifier") && STYLESHEET_CREATE_CALLEE_NAMES.has(callee.name)) {
-    // Bare `create({})` is too ambiguous on its own — skip unless paired
-    // with the canonical StyleSheet member form above.
-    return false;
-  }
-  return false;
+  );
 };
 
 const resolveContentContainerStyleObject = (


### PR DESCRIPTION
## Why

Catches three React Native perf footguns grounded in Peter Piekarczyk's measured benchmarks ([peterp.me](https://www.peterp.me/)). All three reproduce real production bugs Peter shipped fixes for.

### `rn-prefer-pressable-over-gesture-detector`

Every `<GestureDetector>` registers a native handler on mount. Replacing `Gesture.Tap()`-only surfaces with `<Pressable>` cut bottom-sheet mount time from **778ms → 453ms** on Android (100 instances mounted in one frame).

Before:
```tsx
<GestureDetector gesture={Gesture.Tap().onStart(onPress)}>
  <Animated.View />
</GestureDetector>
```

After:
```tsx
<Pressable onPress={onPress} />
// or, with animated press feedback:
<AnimatedPressable onPress={onPress} />
// where: const AnimatedPressable = createCSSAnimatedComponent(Pressable);
```

### `rn-list-missing-estimated-item-size`

`<FlashList>` / `<LegendList>` use `estimatedItemSize` directly in their initial-container-pool formula. Without it the engine guesses; when the real rows are much larger than the default, the visible viewport flashes blank cells until the engine measures and re-allocates.

Before:
```tsx
<FlashList data={items} renderItem={renderItem} />
```

After:
```tsx
<FlashList data={items} renderItem={renderItem} estimatedItemSize={64} />
```

### `rn-scrollview-flex-in-content-container`

In React Native, `flex: <number>` is shorthand for `{ flexGrow, flexShrink, flexBasis: 0 }` — NOT CSS's `flex-basis: auto`. The practical result: `contentContainerStyle={{ flex: 1 }}` collapses scroll content on small devices. `flexGrow: 1` keeps the "fill remaining space" semantics without the `basis: 0` collapse.

Before:
```tsx
<ScrollView contentContainerStyle={{ flex: 1 }}>...</ScrollView>
```

After:
```tsx
<ScrollView contentContainerStyle={{ flexGrow: 1 }}>...</ScrollView>
```

## What changed

- Added `rn-prefer-pressable-over-gesture-detector`: detects `<GestureDetector gesture={Gesture.Tap()...}>` (inline OR variable-extracted via binding analysis) with no multi-tap, gesture composition (`Race`/`Simultaneous`/`Exclusive`), or `simultaneousWithExternalGesture`. Scoped to `react-native-gesture-handler` imports.
- Added `rn-list-missing-estimated-item-size`: detects `<FlashList>` / `<LegendList>` without `estimatedItemSize` or `estimatedListSize`. Scoped to imports from `@shopify/flash-list` / `@legendapp/list`. Skips empty-data placeholders and abstract wrappers.
- Added `rn-scrollview-flex-in-content-container`: detects `contentContainerStyle={{ flex: <positive-num> }}` on ScrollView family + FlashList/LegendList. Resolves `styles.container` references one level via `StyleSheet.create({...})` (including computed `styles["container"]`). Skips `flex: 0`/`-1` (RN-only modes), `flex` paired with explicit `flexGrow`/`flexBasis` override.
- All three: `warn` severity, gated by `react-native` capability, tagged `test-noise` (auto-skips `.test.tsx`).

## Eval results

RDE was attempted with `--take 3 --runner local` and abandoned after 5 minutes (sequential `git clone` + `npm install` per repo, no Vercel sandbox credentials available locally). The detector surfaces are narrow enough that the **52 co-located tests** (covering happy paths, every documented v1 valid case, aliased / namespaced imports, and the binding-analysis paths) carry the validation weight. Re-running through RDE before merge is recommended.

## Test plan

- `pnpm exec vp test run src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.test.ts src/plugin/rules/react-native/rn-list-missing-estimated-item-size.test.ts src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.test.ts` → 52 passed
- `pnpm --filter oxlint-plugin-react-doctor typecheck` → passes (`291 rules` registered)
- `npx vp fmt --check` → clean
- `npx vp lint` → clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive linter rules and registry wiring with broad test coverage; no runtime or security surface, only possible new warnings in RN apps.
> 
> **Overview**
> Adds **three** new React Native **warn** rules (gated on `react-native`, tagged `test-noise`) and wires them into the generated **`rule-registry`**.
> 
> **`rn-prefer-pressable-over-gesture-detector`** nudges tap-only **`GestureDetector`** usage from **`react-native-gesture-handler`** toward **`Pressable`**, with AST analysis of inline or one-hop variable **`Gesture.Tap()`** chains (skipping pan/pinch/race, external-gesture composition, and non-literal **`numberOfTaps`**).
> 
> **`rn-list-missing-estimated-item-size`** flags **`FlashList`** / **`LegendList`** from **`@shopify/flash-list`** and **`@legendapp/list`** when **`data`** is present but neither **`estimatedItemSize`** nor **`estimatedListSize`** is set, including aliased imports; it skips empty **`data`**, wrappers without **`data`**, and non-canonical imports.
> 
> **`rn-scrollview-flex-in-content-container`** warns on positive literal **`flex`** in **`contentContainerStyle`** for scroll/list components (including one-level **`StyleSheet.create`** resolution), unless **`flexGrow`** / **`flexBasis`** is also set.
> 
> Each rule ships with a co-located test file (~52 cases total).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9acbf39cfbb32ef375bca57f0de4550ab63ff0a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->