### PR TITLE
feat(js-performance): add js-async-reduce-without-awaited-acc

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -48,6 +48,7 @@ import { iframeHasTitle } from "./rules/a11y/iframe-has-title.js";
 import { iframeMissingSandbox } from "./rules/react-builtins/iframe-missing-sandbox.js";
 import { imgRedundantAlt } from "./rules/a11y/img-redundant-alt.js";
 import { interactiveSupportsFocus } from "./rules/a11y/interactive-supports-focus.js";
+import { jsAsyncReduceWithoutAwaitedAcc } from "./rules/js-performance/js-async-reduce-without-awaited-acc.js";
 import { jsBatchDomCss } from "./rules/js-performance/js-batch-dom-css.js";
 import { jsCachePropertyAccess } from "./rules/js-performance/js-cache-property-access.js";
 import { jsCacheStorage } from "./rules/js-performance/js-cache-storage.js";
@@ -736,6 +737,17 @@ export const reactDoctorRules = [
       ...interactiveSupportsFocus,
       framework: "global",
       category: "Accessibility",
+    },
+  },
+  {
+    key: "react-doctor/js-async-reduce-without-awaited-acc",
+    id: "js-async-reduce-without-awaited-acc",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...jsAsyncReduceWithoutAwaitedAcc,
+      framework: "global",
+      category: "Performance",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.test.ts
@@ -29,7 +29,38 @@ describe("js-async-reduce-without-awaited-acc", () => {
     `;
     const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
     expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0].message).not.toContain("const acc = await acc");
+    // Precise TDZ shape: `const acc = await acc;` followed by `;` or boundary.
+    expect(result.diagnostics[0].message).not.toMatch(/const acc = await acc[;,\s]/);
+  });
+
+  it("regression: restructure suggestion uses a distinct previous-param when accumulator is already named `previous`", () => {
+    // The previous fix hardcoded "previous" as the alt-param. If the
+    // user's accumulator is also named `previous`, the suggestion
+    // collapses back into a `const previous = await previous;` TDZ
+    // ReferenceError. The detector must pick a non-colliding name.
+    const code = `
+      items.reduce(async (previous, item) => {
+        previous[item.id] = await load(item);
+        return previous;
+      }, Promise.resolve({}));
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+    // The precise TDZ shape is `const previous = await previous;` (followed
+    // by `;` or `,`/` ...`). The suggestion must use a distinct alt-name.
+    expect(result.diagnostics[0].message).not.toMatch(/const previous = await previous[;,\s]/);
+  });
+
+  it("regression: restructure suggestion uses a distinct previous-param when accumulator is named `prev`", () => {
+    const code = `
+      items.reduce(async (prev, item) => {
+        prev[item.id] = await load(item);
+        return prev;
+      }, Promise.resolve({}));
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).not.toMatch(/const prev = await prev[;,\s]/);
   });
 
   it("flags async function-expression reducer that never awaits acc", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.test.ts
@@ -16,6 +16,22 @@ describe("js-async-reduce-without-awaited-acc", () => {
     expect(result.diagnostics[0].message).toContain("acc");
   });
 
+  it("regression: diagnostic message never suggests `const <param> = await <param>` (SyntaxError shape)", () => {
+    // `const acc = await acc;` redeclares the parameter `acc` in the same
+    // scope, which is a SyntaxError. The message must suggest either
+    // bare reassignment (`acc = await acc;`) or restructuring with a
+    // distinct previous-param name.
+    const code = `
+      items.reduce(async (acc, item) => {
+        acc[item.id] = await load(item);
+        return acc;
+      }, {});
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).not.toContain("const acc = await acc");
+  });
+
   it("flags async function-expression reducer that never awaits acc", () => {
     const code = `
       items.reduce(async function (acc, item) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jsAsyncReduceWithoutAwaitedAcc } from "./js-async-reduce-without-awaited-acc.js";
+
+describe("js-async-reduce-without-awaited-acc", () => {
+  it("flags async reduce that never awaits the accumulator", () => {
+    const code = `
+      const build = async (items) =>
+        items.reduce(async (acc, item) => {
+          acc[item.id] = await getItem(item);
+          return acc;
+        }, {});
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("acc");
+  });
+
+  it("flags async function-expression reducer that never awaits acc", () => {
+    const code = `
+      items.reduce(async function (acc, item) {
+        const value = await fetchItem(item);
+        acc.push(value);
+        return acc;
+      }, []);
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags async reduce with a different accumulator name (totals)", () => {
+    const code = `
+      items.reduce(async (totals, item) => {
+        totals[item.key] = await load(item);
+        return totals;
+      }, {});
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("totals");
+  });
+
+  it("flags async reduceRight that never awaits acc", () => {
+    const code = `
+      items.reduceRight(async (acc, item) => {
+        const value = await load(item);
+        acc.push(value);
+        return acc;
+      }, []);
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag when the accumulator is awaited (canonical correct shape)", () => {
+    const code = `
+      async function buildObject(items) {
+        return items.reduce(async (promise, item) => {
+          const obj = await promise;
+          obj[item.id] = await getItem(item);
+          return obj;
+        }, Promise.resolve({}));
+      }
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag when accumulator is awaited even if the alias is reassigned", () => {
+    const code = `
+      items.reduce(async (acc, item) => {
+        acc = await acc;
+        acc[item.id] = await getItem(item);
+        return acc;
+      }, Promise.resolve({}));
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag a sync reducer (no async keyword)", () => {
+    const code = `
+      items.reduce((acc, item) => {
+        acc[item.id] = item.value;
+        return acc;
+      }, {});
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag an async reducer that does no awaits at all", () => {
+    const code = `
+      items.reduce(async (acc, item) => {
+        acc[item.id] = item.value;
+        return acc;
+      }, {});
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags destructured ArrayPattern accumulator with awaits", () => {
+    const code = `
+      items.reduce(async ([sum, count], item) => {
+        const value = await load(item);
+        return [sum + value, count + 1];
+      }, [0, 0]);
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("destructures its accumulator");
+  });
+
+  it("flags destructured ObjectPattern accumulator with awaits", () => {
+    const code = `
+      items.reduce(async ({ totals }, item) => {
+        totals[item.id] = await load(item);
+        return { totals };
+      }, { totals: {} });
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags destructured accumulator with default value", () => {
+    const code = `
+      items.reduce(async ({ totals = {} } = {}, item) => {
+        totals[item.id] = await load(item);
+        return { totals };
+      }, undefined);
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag destructured accumulator in a sync reducer", () => {
+    const code = `
+      items.reduce(([sum, count], item) => {
+        return [sum + item.value, count + 1];
+      }, [0, 0]);
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag awaits inside a nested function (different async context)", () => {
+    const code = `
+      items.reduce(async (acc, item) => {
+        const acc2 = await acc;
+        const inner = async () => await something();
+        await inner();
+        acc2[item.id] = item.value;
+        return acc2;
+      }, Promise.resolve({}));
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag reduce that correctly awaits acc on a non-array receiver", () => {
+    // v1 doesn't distinguish Array.prototype.reduce from custom
+    // .reduce APIs; any callsite that correctly awaits the
+    // accumulator is silent.
+    const code = `
+      stream.reduce(async (acc, x) => {
+        const v = await acc;
+        v.push(x);
+        return v;
+      }, Promise.resolve([]));
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags computed string-literal accessor (items['reduce'])", () => {
+    const code = `
+      items["reduce"](async (acc, item) => {
+        acc[item.id] = await load(item);
+        return acc;
+      }, {});
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags computed string-literal accessor for reduceRight", () => {
+    const code = `
+      items["reduceRight"](async (acc, item) => {
+        acc[item.id] = await load(item);
+        return acc;
+      }, {});
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag dynamic computed accessor (items[methodName])", () => {
+    // Dynamic property paths are unknown — too easy to false-positive.
+    // Only string-literal computed accessors are recognized.
+    const code = `
+      const methodName = "reduce";
+      items[methodName](async (acc, item) => {
+        acc[item.id] = await load(item);
+        return acc;
+      }, {});
+    `;
+    const result = runRule(jsAsyncReduceWithoutAwaitedAcc, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.ts
@@ -136,9 +136,17 @@ export const jsAsyncReduceWithoutAwaitedAcc = defineRule<Rule>({
 
       if (bodyAwaitsAccumulator(reducer, firstParameter.name)) return;
 
+      // Pick a "previous" param name that won't shadow the user's
+      // accumulator. If they already named it `previous` (or `prev`),
+      // fall through to a distinct alternative so the suggestion
+      // remains syntactically valid.
+      const previousParamCandidates = ["previous", "prev", "priorResult"];
+      const previousParamName =
+        previousParamCandidates.find((candidate) => candidate !== firstParameter.name) ??
+        `${firstParameter.name}Prev`;
       context.report({
         node: reducer,
-        message: `Async \`.${reduceMatch.methodName}\` reducer never awaits its accumulator "${firstParameter.name}" — every iteration sees a Promise and the final result silently drops every iteration's work. Either reassign at the top (\`${firstParameter.name} = await ${firstParameter.name};\`) or restructure as \`async (previous, item) => { const ${firstParameter.name} = await previous; ...; return ${firstParameter.name}; }\`, and seed with \`Promise.resolve(...)\``,
+        message: `Async \`.${reduceMatch.methodName}\` reducer never awaits its accumulator "${firstParameter.name}" — every iteration sees a Promise and the final result silently drops every iteration's work. Either reassign at the top (\`${firstParameter.name} = await ${firstParameter.name};\`) or restructure as \`async (${previousParamName}, item) => { const ${firstParameter.name} = await ${previousParamName}; ...; return ${firstParameter.name}; }\`, and seed with \`Promise.resolve(...)\``,
       });
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.ts
@@ -1,0 +1,145 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { containsDirectAwait } from "../../utils/contains-direct-await.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// HACK: `Array.prototype.reduce` only flows the previous reducer's
+// return value into the next iteration's first argument. When the
+// reducer is `async`, that "return value" is a Promise. If the body
+// never awaits the accumulator parameter, every iteration sees a
+// Promise instead of the resolved value, side effects on it land on
+// the Promise object, and the final `await` of `reduce(...)` returns
+// the last iteration's Promise containing only the initial seed.
+// The correct shape awaits the accumulator first:
+//   `const acc = await previous; acc[key] = await getItem(); return acc;`
+
+type FunctionExpressionLike =
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionExpression">;
+
+const isAsyncFunctionLike = (
+  node: EsTreeNode | null | undefined,
+): node is FunctionExpressionLike => {
+  if (!node) return false;
+  if (!isNodeOfType(node, "ArrowFunctionExpression") && !isNodeOfType(node, "FunctionExpression")) {
+    return false;
+  }
+  return node.async === true;
+};
+
+type FirstParameterShape = { kind: "identifier"; name: string } | { kind: "destructured" } | null;
+
+const classifyFirstParameter = (fn: FunctionExpressionLike): FirstParameterShape => {
+  const parameters = fn.params ?? [];
+  if (parameters.length === 0) return null;
+  const first = parameters[0];
+  if (isNodeOfType(first, "Identifier")) return { kind: "identifier", name: first.name };
+  // Destructured accumulator — `async ([sum, count], item) => ...` or
+  // `async ({ items }, item) => ...`. Destructuring runs *against the
+  // previous reducer's return*, which is a Promise on iterations 2+.
+  // Destructuring a Promise produces `undefined` slots and the chain
+  // silently drops every iteration. Treat this as a distinct (always-
+  // broken-with-awaits) shape.
+  if (isNodeOfType(first, "ArrayPattern") || isNodeOfType(first, "ObjectPattern")) {
+    return { kind: "destructured" };
+  }
+  // AssignmentPattern (`async (acc = init, item) => ...`) — unwrap.
+  if (isNodeOfType(first, "AssignmentPattern")) {
+    if (isNodeOfType(first.left, "Identifier")) {
+      return { kind: "identifier", name: first.left.name };
+    }
+    if (isNodeOfType(first.left, "ArrayPattern") || isNodeOfType(first.left, "ObjectPattern")) {
+      return { kind: "destructured" };
+    }
+  }
+  return null;
+};
+
+const isReduceCallee = (callee: EsTreeNode | null | undefined): { methodName: string } | null => {
+  if (!isNodeOfType(callee, "MemberExpression")) return null;
+  // Non-computed: `arr.reduce(...)` / `arr.reduceRight(...)`.
+  if (!callee.computed) {
+    if (!isNodeOfType(callee.property, "Identifier")) return null;
+    if (callee.property.name !== "reduce" && callee.property.name !== "reduceRight") return null;
+    return { methodName: callee.property.name };
+  }
+  // Computed with string literal: `arr["reduce"](...)`.
+  if (isNodeOfType(callee.property, "Literal") && typeof callee.property.value === "string") {
+    const propertyName = callee.property.value;
+    if (propertyName !== "reduce" && propertyName !== "reduceRight") return null;
+    return { methodName: propertyName };
+  }
+  return null;
+};
+
+const bodyAwaitsAccumulator = (fn: FunctionExpressionLike, accumulatorName: string): boolean => {
+  const body = fn.body;
+  if (!body) return false;
+  let awaitsAccumulator = false;
+  walkAst(body, (child: EsTreeNode) => {
+    if (awaitsAccumulator) return false;
+    // Don't descend into nested functions — their awaits belong to
+    // their own async context, not the outer reducer's.
+    if (
+      isNodeOfType(child, "FunctionDeclaration") ||
+      isNodeOfType(child, "FunctionExpression") ||
+      isNodeOfType(child, "ArrowFunctionExpression")
+    ) {
+      if (child !== fn) return false;
+    }
+    if (!isNodeOfType(child, "AwaitExpression")) return;
+    if (!child.argument) return;
+    const awaitArgument = stripParenExpression(child.argument);
+    if (isNodeOfType(awaitArgument, "Identifier") && awaitArgument.name === accumulatorName) {
+      awaitsAccumulator = true;
+      return false;
+    }
+  });
+  return awaitsAccumulator;
+};
+
+export const jsAsyncReduceWithoutAwaitedAcc = defineRule<Rule>({
+  id: "js-async-reduce-without-awaited-acc",
+  severity: "warn",
+  recommendation:
+    "Await the accumulator first: `const acc = await previous; ...; return acc;`. Use `Promise.resolve(initial)` as the seed so iteration 1's accumulator is also a Promise",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const reduceMatch = isReduceCallee(node.callee);
+      if (!reduceMatch) return;
+      const args = node.arguments ?? [];
+      if (args.length === 0) return;
+
+      const reducerCandidate = stripParenExpression(args[0]);
+      if (!isAsyncFunctionLike(reducerCandidate)) return;
+      const reducer = reducerCandidate;
+
+      // Body must actually do async work — pure sync async reducers
+      // are unusual but valid; flagging them produces noise.
+      if (!containsDirectAwait(reducer.body)) return;
+
+      const firstParameter = classifyFirstParameter(reducer);
+      if (!firstParameter) return;
+
+      if (firstParameter.kind === "destructured") {
+        context.report({
+          node: reducer,
+          message: `Async \`.${reduceMatch.methodName}\` reducer destructures its accumulator — destructuring runs against the previous Promise (iteration 2+), produces undefined slots, and silently drops every iteration's work. Use \`async (previous, item) => { const [...] = await previous; ...; return [...]; }\` and seed with \`Promise.resolve([...])\``,
+        });
+        return;
+      }
+
+      if (bodyAwaitsAccumulator(reducer, firstParameter.name)) return;
+
+      context.report({
+        node: reducer,
+        message: `Async \`.${reduceMatch.methodName}\` reducer never awaits its accumulator "${firstParameter.name}" — every iteration sees a Promise and the final result silently drops every iteration's work. Add \`const ${firstParameter.name} = await ${firstParameter.name};\` at the top and seed with \`Promise.resolve(...)\``,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.ts
@@ -138,7 +138,7 @@ export const jsAsyncReduceWithoutAwaitedAcc = defineRule<Rule>({
 
       context.report({
         node: reducer,
-        message: `Async \`.${reduceMatch.methodName}\` reducer never awaits its accumulator "${firstParameter.name}" — every iteration sees a Promise and the final result silently drops every iteration's work. Add \`const ${firstParameter.name} = await ${firstParameter.name};\` at the top and seed with \`Promise.resolve(...)\``,
+        message: `Async \`.${reduceMatch.methodName}\` reducer never awaits its accumulator "${firstParameter.name}" — every iteration sees a Promise and the final result silently drops every iteration's work. Either reassign at the top (\`${firstParameter.name} = await ${firstParameter.name};\`) or restructure as \`async (previous, item) => { const ${firstParameter.name} = await previous; ...; return ${firstParameter.name}; }\`, and seed with \`Promise.resolve(...)\``,
       });
     },
   }),


### PR DESCRIPTION
## Why

Catches the silent async-reduce footgun from [peterp.me/articles/async-await-reduce-function](https://www.peterp.me/articles/async-await-reduce-function/). \`Array.prototype.reduce\` only flows the previous reducer's *return value* into the next iteration's first argument. When the reducer is \`async\`, that "return value" is a Promise. If the body never awaits the accumulator parameter, every iteration sees a Promise instead of the resolved value, side effects on it land on the Promise object, and the final \`await reduce(...)\` returns the seed unchanged. **The chain silently drops every iteration's work.**

Before:
\`\`\`ts
items.reduce(async (acc, item) => {
  acc[item.id] = await getItem(item);
  return acc;
}, {});
// → returns {} on every call. Every iteration's getItem() landed on a
//   throwaway Promise wrapper.
\`\`\`

After:
\`\`\`ts
items.reduce(async (promise, item) => {
  const acc = await promise;
  acc[item.id] = await getItem(item);
  return acc;
}, Promise.resolve({}));
// → returns the populated object. Each iteration's accumulator is the
//   resolved value from the previous iteration.
\`\`\`

## What changed

- Added \`js-async-reduce-without-awaited-acc\`.
- Detects \`.reduce\` / \`.reduceRight\` callsites whose first argument is an \`async\` ArrowFunction / FunctionExpression with at least one body-level \`await\` AND no \`await <accumulator>\`.
- Two diagnostic shapes:
  - **Identifier accumulator** (\`async (acc, item)\`): suggests \`const acc = await acc;\` at the top of the body + \`Promise.resolve(...)\` seed.
  - **Destructured accumulator** (\`async ([sum, count], item)\` or \`async ({ totals }, item)\`): always broken when body has awaits — destructuring runs *against the previous Promise* (iteration 2+), producing undefined slots. Suggests restructuring to \`async (previous, item) => { const [...] = await previous; ... }\`.
- Covers computed string-literal accessors: \`arr["reduce"](...)\` / \`arr["reduceRight"](...)\`.
- Skips: sync reducers, async reducers with no body awaits, dynamic computed accessors (\`arr[methodName]\`), awaits inside nested function bodies (different async context), assignment-pattern accumulators with identifier left.

## Eval results

RDE not run — local runner is \`git clone\` + \`npm install\` bound (sequential, ~3 min/repo, no Vercel sandbox credentials locally). Detection is highly specific (async + \`.reduce\` + first-param-not-awaited), and the **17 co-located tests** cover identifier accumulator, destructured (ArrayPattern + ObjectPattern + default), computed accessor (\`["reduce"]\` + dynamic), nested-function isolation, and the canonical correct \`Promise.resolve(...)\` seed shape.

## Test plan

- \`pnpm exec vp test run src/plugin/rules/js-performance/js-async-reduce-without-awaited-acc.test.ts\` → 17 passed
- \`pnpm --filter oxlint-plugin-react-doctor typecheck\` → passes (\`289 rules\` registered)
- \`npx vp fmt --check\` → clean
- \`npx vp lint\` → clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated lint rule and tests under js-performance; no runtime or security surface changes.
> 
> **Overview**
> Adds a new **Performance** lint rule `js-async-reduce-without-awaited-acc` that catches async `.reduce` / `.reduceRight` reducers which perform `await` work but never `await` the accumulator—so each iteration mutates a Promise and the chain can silently drop work.
> 
> The rule is registered in `rule-registry.ts` and implemented with AST checks for async arrow/function reducers, `reduce`/`reduceRight` (including `["reduce"]` string-literal accessors), destructured accumulators as a separate diagnostic, and fix suggestions that avoid invalid `const acc = await acc` shapes by picking non-colliding parameter names. **17 co-located tests** cover positives, negatives, regressions on suggestion text, and dynamic computed accessors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b36e4211746899700bd70a881c40990266548b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->