### PR TITLE
feat(jotai): add three Jotai rules + register `jotai` bucket

### DIFF
--- a/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
+++ b/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
@@ -70,6 +70,7 @@ const BUCKET_TO_DEFAULT_CATEGORY = {
   correctness: "Correctness",
   design: "Architecture",
   "js-performance": "Performance",
+  jotai: "State & Effects",
   nextjs: "Next.js",
   performance: "Performance",
   "react-builtins": "Correctness",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -48,6 +48,9 @@ import { iframeHasTitle } from "./rules/a11y/iframe-has-title.js";
 import { iframeMissingSandbox } from "./rules/react-builtins/iframe-missing-sandbox.js";
 import { imgRedundantAlt } from "./rules/a11y/img-redundant-alt.js";
 import { interactiveSupportsFocus } from "./rules/a11y/interactive-supports-focus.js";
+import { jotaiDerivedAtomReturnsFreshObject } from "./rules/jotai/jotai-derived-atom-returns-fresh-object.js";
+import { jotaiSelectAtomInRenderBody } from "./rules/jotai/jotai-select-atom-in-render-body.js";
+import { jotaiTqUseRawQueryAtom } from "./rules/jotai/jotai-tq-use-raw-query-atom.js";
 import { jsAsyncReduceWithoutAwaitedAcc } from "./rules/js-performance/js-async-reduce-without-awaited-acc.js";
 import { jsBatchDomCss } from "./rules/js-performance/js-batch-dom-css.js";
 import { jsCachePropertyAccess } from "./rules/js-performance/js-cache-property-access.js";
@@ -738,6 +741,39 @@ export const reactDoctorRules = [
       ...interactiveSupportsFocus,
       framework: "global",
       category: "Accessibility",
+    },
+  },
+  {
+    key: "react-doctor/jotai-derived-atom-returns-fresh-object",
+    id: "jotai-derived-atom-returns-fresh-object",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...jotaiDerivedAtomReturnsFreshObject,
+      framework: "global",
+      category: "State & Effects",
+    },
+  },
+  {
+    key: "react-doctor/jotai-select-atom-in-render-body",
+    id: "jotai-select-atom-in-render-body",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...jotaiSelectAtomInRenderBody,
+      framework: "global",
+      category: "State & Effects",
+    },
+  },
+  {
+    key: "react-doctor/jotai-tq-use-raw-query-atom",
+    id: "jotai-tq-use-raw-query-atom",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...jotaiTqUseRawQueryAtom,
+      framework: "global",
+      category: "State & Effects",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-derived-atom-returns-fresh-object.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-derived-atom-returns-fresh-object.test.ts
@@ -159,6 +159,42 @@ describe("jotai-derived-atom-returns-fresh-object", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does NOT flag .filter().reduce() — outer .reduce returns a primitive", () => {
+    // Regression: an earlier draft walked inward past non-matching
+    // methods and would flag any chain that included a fresh-producer
+    // step anywhere. The outer terminator (reduce/find/some/every/
+    // includes/at/join) consumes the array and returns a scalar that
+    // dedupes via Object.is. Only the OUTERMOST step decides freshness.
+    const code = `
+      import { atom } from "jotai";
+      const totalAtom = atom((get) =>
+        get(usersAtom).filter((u) => u.active).reduce((sum, u) => sum + u.score, 0)
+      );
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag .find() / .some() / .includes() chains over a get-array", () => {
+    const code = `
+      import { atom } from "jotai";
+      const firstActiveAtom = atom((get) => get(usersAtom).filter((u) => u.active).find((u) => u.id === "primary"));
+      const anyActiveAtom = atom((get) => get(usersAtom).some((u) => u.active));
+      const hasPrimaryAtom = atom((get) => get(usersAtom).map((u) => u.id).includes("primary"));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag .join() — returns a string", () => {
+    const code = `
+      import { atom } from "jotai";
+      const csvAtom = atom((get) => get(usersAtom).map((u) => u.id).join(","));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags atom whose block body has multiple returns ALL producing fresh literals", () => {
     const code = `
       import { atom } from "jotai";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-derived-atom-returns-fresh-object.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-derived-atom-returns-fresh-object.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jotaiDerivedAtomReturnsFreshObject } from "./jotai-derived-atom-returns-fresh-object.js";
+
+describe("jotai-derived-atom-returns-fresh-object", () => {
+  it("flags atom returning fresh object literal (concise arrow body)", () => {
+    const code = `
+      import { atom } from "jotai";
+      const summaryAtom = atom((get) => ({
+        count: get(cartAtom).items.length,
+        total: sum(get(cartAtom).items),
+      }));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("Object.is");
+  });
+
+  it("flags atom returning array-producing chain (.filter().map())", () => {
+    const code = `
+      import { atom } from "jotai";
+      const activeIdsAtom = atom((get) =>
+        get(usersAtom).filter((user) => user.active).map((user) => user.id)
+      );
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atom returning .slice() chain", () => {
+    const code = `
+      import { atom } from "jotai";
+      const topThreeAtom = atom((get) => get(usersAtom).slice(0, 3));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atom returning .toSorted() chain (ES2023 immutable)", () => {
+    const code = `
+      import { atom } from "jotai";
+      const sortedAtom = atom((get) => get(usersAtom).toSorted((a, b) => a.id - b.id));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atom returning Object.entries(get(x))", () => {
+    const code = `
+      import { atom } from "jotai";
+      const entriesAtom = atom((get) => Object.entries(get(mapAtom)));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atom returning Array.from(get(x))", () => {
+    const code = `
+      import { atom } from "jotai";
+      const arrayAtom = atom((get) => Array.from(get(setAtom)));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atom returning fresh ArrayExpression literal", () => {
+    const code = `
+      import { atom } from "jotai";
+      const pairAtom = atom((get) => [get(aAtom), get(bAtom)]);
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atom whose block body returns a fresh object", () => {
+    const code = `
+      import { atom } from "jotai";
+      const summaryAtom = atom((get) => {
+        const cart = get(cartAtom);
+        return { count: cart.items.length, total: sum(cart.items) };
+      });
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atom with renamed get parameter (g instead of get)", () => {
+    const code = `
+      import { atom } from "jotai";
+      const summaryAtom = atom((g) => ({ count: g(cartAtom).items.length }));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atom that spreads an upstream get", () => {
+    const code = `
+      import { atom } from "jotai";
+      const wrappedAtom = atom((get) => ({ ...get(baseAtom) }));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag atom returning a primitive property", () => {
+    const code = `
+      import { atom } from "jotai";
+      const countAtom = atom((get) => get(cartAtom).items.length);
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag atom returning a get(...) member chain (reference-stable)", () => {
+    const code = `
+      import { atom } from "jotai";
+      const userAtom = atom((get) => get(rawAtom).user);
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag primitive atom (no function arg)", () => {
+    const code = `
+      import { atom } from "jotai";
+      const countAtom = atom(0);
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag write-only atom (g, s) => ...", () => {
+    const code = `
+      import { atom } from "jotai";
+      const writeOnlyAtom = atom(
+        (get) => get(baseAtom),
+        (get, set, newValue) => set(baseAtom, { ...get(baseAtom), ...newValue })
+      );
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag a constant object literal (no get(...) inside)", () => {
+    const code = `
+      import { atom } from "jotai";
+      const constantAtom = atom(() => ({ defaults: true }));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag homegrown `atom` from a non-jotai source", () => {
+    const code = `
+      import { atom } from "./my-atoms";
+      const summaryAtom = atom((get) => ({ count: get(c).items.length }));
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags atom whose block body has multiple returns ALL producing fresh literals", () => {
+    const code = `
+      import { atom } from "jotai";
+      const conditionalAtom = atom((get) => {
+        if (get(switchAtom)) return { a: get(aAtom) };
+        return { b: get(bAtom) };
+      });
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag atom whose block body has a mix of fresh + stable returns", () => {
+    // One branch returns a fresh literal, the other returns a reference-
+    // stable upstream value — the cost only hits one path, recommendation
+    // doesn't generalize. Stay quiet.
+    const code = `
+      import { atom } from "jotai";
+      const conditionalAtom = atom((get) => {
+        if (get(switchAtom)) return get(passthroughAtom);
+        return { fresh: get(other) };
+      });
+    `;
+    const result = runRule(jotaiDerivedAtomReturnsFreshObject, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-derived-atom-returns-fresh-object.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-derived-atom-returns-fresh-object.ts
@@ -89,43 +89,37 @@ const freshFromObjectLiteral = (expression: EsTreeNode): FreshReturn | null => {
   return null;
 };
 
-// Walks a chain of CallExpressions looking for an "always-fresh"
-// producer step. Returns the outermost matching expression so the
-// diagnostic points at the actual chain (not a deeply-nested arg).
+// Only the OUTERMOST method in the chain decides whether the atom's
+// value is a fresh structure. Walking inward past non-matching methods
+// produces false positives: `get(users).filter(fn).reduce(sum, 0)`
+// consumes the filtered array and returns a primitive that dedupes
+// via Object.is correctly — even though `.filter()` appears inside
+// the chain.
 const freshFromMethodChain = (expression: EsTreeNode): FreshReturn | null => {
-  let cursor: EsTreeNode | null = expression;
-  while (cursor) {
-    if (!isNodeOfType(cursor, "CallExpression")) return null;
-    const callee = cursor.callee;
-    if (isNodeOfType(callee, "MemberExpression")) {
-      if (callee.computed) return null;
-      if (!isNodeOfType(callee.property, "Identifier")) return null;
-      const methodName = callee.property.name;
-      if (FRESH_ARRAY_INSTANCE_METHODS.has(methodName)) {
-        return { kind: "array", reportNode: expression };
-      }
-      // Static-method form: `Object.entries(get(x))`, `Array.from(get(x))`.
-      if (isNodeOfType(callee.object, "Identifier")) {
-        const staticMethods = FRESH_STATIC_OBJECT_CALLS[callee.object.name];
-        if (staticMethods?.has(methodName)) {
-          return {
-            kind:
-              callee.object.name === "Array" ||
-              methodName === "keys" ||
-              methodName === "values" ||
-              methodName === "entries"
-                ? "array"
-                : "object",
-            reportNode: expression,
-          };
-        }
-      }
-      // Not a fresh-producer step — walk inward through the receiver to
-      // see if an earlier link does produce a fresh value.
-      cursor = callee.object as EsTreeNode | null;
-      continue;
+  if (!isNodeOfType(expression, "CallExpression")) return null;
+  const callee = expression.callee;
+  if (!isNodeOfType(callee, "MemberExpression")) return null;
+  if (callee.computed) return null;
+  if (!isNodeOfType(callee.property, "Identifier")) return null;
+  const methodName = callee.property.name;
+  if (FRESH_ARRAY_INSTANCE_METHODS.has(methodName)) {
+    return { kind: "array", reportNode: expression };
+  }
+  // Static-method form: `Object.entries(get(x))`, `Array.from(get(x))`.
+  if (isNodeOfType(callee.object, "Identifier")) {
+    const staticMethods = FRESH_STATIC_OBJECT_CALLS[callee.object.name];
+    if (staticMethods?.has(methodName)) {
+      return {
+        kind:
+          callee.object.name === "Array" ||
+          methodName === "keys" ||
+          methodName === "values" ||
+          methodName === "entries"
+            ? "array"
+            : "object",
+        reportNode: expression,
+      };
     }
-    return null;
   }
   return null;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-derived-atom-returns-fresh-object.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-derived-atom-returns-fresh-object.ts
@@ -1,0 +1,245 @@
+import { defineRule } from "../../utils/define-rule.js";
+import {
+  isImportedFromModule,
+  getImportedNameFromModule,
+} from "../../utils/find-import-source-for-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// HACK: jotai propagates derived-atom values with `Object.is`. There
+// is no shallow compare and no custom equality on a plain
+// `atom((get) => ...)`. A derivation that returns a fresh
+// ObjectExpression / ArrayExpression literal — OR a method-chain that
+// produces a fresh array / object on every read — fails Object.is on
+// every notify and re-renders every consumer, even when the field
+// values didn't change. Measured: a fresh-object derivation committed
+// 44× more than the equivalent `useQuery` on no-op refetches.
+// Fix: split into multiple primitive derived atoms (each `Object.is`-
+// dedup-able), or wrap with `selectAtom(source, fn, shallow)` from
+// `jotai/utils` if a single wrapper object is genuinely required.
+
+type FunctionExpressionLike =
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionExpression">;
+
+const isAtomFromJotai = (callExpression: EsTreeNodeOfType<"CallExpression">): boolean => {
+  if (!isNodeOfType(callExpression.callee, "Identifier")) return false;
+  const localName = callExpression.callee.name;
+  if (!isImportedFromModule(callExpression, localName, "jotai")) return false;
+  return getImportedNameFromModule(callExpression, localName, "jotai") === "atom";
+};
+
+const isFunctionLike = (node: EsTreeNode | null | undefined): node is FunctionExpressionLike =>
+  Boolean(
+    node &&
+    (isNodeOfType(node, "ArrowFunctionExpression") || isNodeOfType(node, "FunctionExpression")),
+  );
+
+const getFirstParameterName = (fn: FunctionExpressionLike): string | null => {
+  const parameters = fn.params ?? [];
+  if (parameters.length !== 1) return null;
+  const first = parameters[0];
+  return isNodeOfType(first, "Identifier") ? first.name : null;
+};
+
+// Array-prototype methods that always allocate a fresh array. Includes
+// the immutable variants from ES2023 (`toSorted`, `toReversed`,
+// `toSpliced`, `with`) plus the classic Array.prototype mutators that
+// return the modified-but-fresh-shape array (`.sort()`, `.reverse()`
+// — note these mutate AND return the receiver; if the receiver is a
+// fresh array from `.map()` upstream, the chain still allocates).
+const FRESH_ARRAY_INSTANCE_METHODS = new Set([
+  "filter",
+  "map",
+  "flatMap",
+  "slice",
+  "concat",
+  "flat",
+  "toSorted",
+  "toReversed",
+  "toSpliced",
+  "with",
+  "sort",
+  "reverse",
+]);
+
+// Static methods that allocate a fresh array / object from upstream.
+const FRESH_STATIC_OBJECT_CALLS: Record<string, ReadonlySet<string>> = {
+  Object: new Set(["keys", "values", "entries", "fromEntries", "assign", "create"]),
+  Array: new Set(["from", "of"]),
+};
+
+interface FreshReturn {
+  kind: "object" | "array";
+  reportNode: EsTreeNode;
+}
+
+const freshFromObjectLiteral = (expression: EsTreeNode): FreshReturn | null => {
+  if (isNodeOfType(expression, "ObjectExpression")) {
+    return { kind: "object", reportNode: expression };
+  }
+  if (isNodeOfType(expression, "ArrayExpression")) {
+    return { kind: "array", reportNode: expression };
+  }
+  return null;
+};
+
+// Walks a chain of CallExpressions looking for an "always-fresh"
+// producer step. Returns the outermost matching expression so the
+// diagnostic points at the actual chain (not a deeply-nested arg).
+const freshFromMethodChain = (expression: EsTreeNode): FreshReturn | null => {
+  let cursor: EsTreeNode | null = expression;
+  while (cursor) {
+    if (!isNodeOfType(cursor, "CallExpression")) return null;
+    const callee = cursor.callee;
+    if (isNodeOfType(callee, "MemberExpression")) {
+      if (callee.computed) return null;
+      if (!isNodeOfType(callee.property, "Identifier")) return null;
+      const methodName = callee.property.name;
+      if (FRESH_ARRAY_INSTANCE_METHODS.has(methodName)) {
+        return { kind: "array", reportNode: expression };
+      }
+      // Static-method form: `Object.entries(get(x))`, `Array.from(get(x))`.
+      if (isNodeOfType(callee.object, "Identifier")) {
+        const staticMethods = FRESH_STATIC_OBJECT_CALLS[callee.object.name];
+        if (staticMethods?.has(methodName)) {
+          return {
+            kind:
+              callee.object.name === "Array" ||
+              methodName === "keys" ||
+              methodName === "values" ||
+              methodName === "entries"
+                ? "array"
+                : "object",
+            reportNode: expression,
+          };
+        }
+      }
+      // Not a fresh-producer step — walk inward through the receiver to
+      // see if an earlier link does produce a fresh value.
+      cursor = callee.object as EsTreeNode | null;
+      continue;
+    }
+    return null;
+  }
+  return null;
+};
+
+const classifyReturnedExpression = (
+  expression: EsTreeNode | null | undefined,
+): FreshReturn | null => {
+  if (!expression) return null;
+  const inner = stripParenExpression(expression);
+  const literalReturn = freshFromObjectLiteral(inner);
+  if (literalReturn) return literalReturn;
+  return freshFromMethodChain(inner);
+};
+
+const collectTopLevelReturnExpressions = (
+  block: EsTreeNodeOfType<"BlockStatement">,
+): Array<EsTreeNode | null | undefined> => {
+  const returns: Array<EsTreeNode | null | undefined> = [];
+  walkAst(block, (child) => {
+    if (
+      isNodeOfType(child, "FunctionDeclaration") ||
+      isNodeOfType(child, "FunctionExpression") ||
+      isNodeOfType(child, "ArrowFunctionExpression")
+    ) {
+      // Don't descend into nested functions — their returns belong to
+      // their own control-flow scope.
+      return false;
+    }
+    if (isNodeOfType(child, "ReturnStatement")) returns.push(child.argument);
+  });
+  return returns;
+};
+
+const getFreshReturnForFunction = (fn: FunctionExpressionLike): FreshReturn | null => {
+  const body = fn.body;
+  if (!body) return null;
+  // Concise arrow body: `(get) => ({ ... })` / `(get) => [...]` / `(get) => get(x).filter(...)`.
+  if (!isNodeOfType(body, "BlockStatement")) {
+    return classifyReturnedExpression(body);
+  }
+  // Block body: every reachable return must produce a fresh structure
+  // for the diagnostic to hold across every notify. If ANY return
+  // emits a primitive / `get(...)` member chain, the atom can still
+  // dedupe on some paths and the recommendation no longer fits.
+  const returnExpressions = collectTopLevelReturnExpressions(body);
+  if (returnExpressions.length === 0) return null;
+  let firstFresh: FreshReturn | null = null;
+  for (const returnArgument of returnExpressions) {
+    const classification = classifyReturnedExpression(returnArgument);
+    if (!classification) return null;
+    if (!firstFresh) firstFresh = classification;
+  }
+  return firstFresh;
+};
+
+const functionBodyReferencesGetParameter = (
+  fn: FunctionExpressionLike,
+  getParameterName: string,
+): boolean => {
+  const body = fn.body;
+  if (!body) return false;
+  let found = false;
+  walkAst(body, (child) => {
+    if (found) return false;
+    // Don't descend into nested functions — their `get(...)` calls
+    // belong to their own closure and don't prove the outer atom
+    // reads from upstream.
+    if (
+      isNodeOfType(child, "FunctionDeclaration") ||
+      isNodeOfType(child, "FunctionExpression") ||
+      isNodeOfType(child, "ArrowFunctionExpression")
+    ) {
+      if (child !== fn) return false;
+    }
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (!isNodeOfType(child.callee, "Identifier")) return;
+    if (child.callee.name === getParameterName) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+export const jotaiDerivedAtomReturnsFreshObject = defineRule<Rule>({
+  id: "jotai-derived-atom-returns-fresh-object",
+  severity: "warn",
+  recommendation:
+    "Split the derivation into multiple primitive derived atoms (each `Object.is`-dedupable), or wrap with `selectAtom(source, fn, shallow)` from jotai/utils if a wrapper object is required",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isAtomFromJotai(node)) return;
+      const args = node.arguments ?? [];
+      if (args.length === 0) return;
+      const reader = args[0];
+      if (!isFunctionLike(reader)) return;
+      // Write-only / read-write atoms have a second `set` parameter
+      // and produce a different propagation shape. Out of v1 scope.
+      const getParameterName = getFirstParameterName(reader);
+      if (!getParameterName) return;
+
+      const freshReturn = getFreshReturnForFunction(reader);
+      if (!freshReturn) return;
+      // A function body that never reads upstream via `get(...)` isn't
+      // a derived atom — it's a constant atom the author wrote with
+      // a function. The fresh-literal cost only matters when the
+      // upstream is actually being propagated.
+      if (!functionBodyReferencesGetParameter(reader, getParameterName)) return;
+
+      const shape = freshReturn.kind === "object" ? "object" : "array";
+      context.report({
+        node: freshReturn.reportNode,
+        message: `Derived atom returns a fresh ${shape} — jotai compares with Object.is, so every upstream notify re-renders every consumer. Split into per-field derived atoms or use \`selectAtom(source, fn, shallow)\``,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-select-atom-in-render-body.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-select-atom-in-render-body.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jotaiSelectAtomInRenderBody } from "./jotai-select-atom-in-render-body.js";
+
+describe("jotai-select-atom-in-render-body", () => {
+  it("flags selectAtom in a component body (FunctionDeclaration)", () => {
+    const code = `
+      import { selectAtom } from "jotai/utils";
+      function MyComponent() {
+        const sliceAtom = selectAtom(baseAtom, (state) => state.foo);
+        const value = useAtomValue(sliceAtom);
+        return value;
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("useMemo");
+  });
+
+  it("flags selectAtom in a component body (ArrowFunctionExpression)", () => {
+    const code = `
+      import { selectAtom } from "jotai/utils";
+      const MyComponent = () => {
+        const sliceAtom = selectAtom(baseAtom, (state) => state.foo);
+        return useAtomValue(sliceAtom);
+      };
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags selectAtom in a custom hook body", () => {
+    const code = `
+      import { selectAtom } from "jotai/utils";
+      function useFoo() {
+        const sliceAtom = selectAtom(baseAtom, (state) => state.foo);
+        return useAtomValue(sliceAtom);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags selectAtom imported from 'jotai' (re-export)", () => {
+    const code = `
+      import { selectAtom } from "jotai";
+      function MyComponent() {
+        const sliceAtom = selectAtom(baseAtom, (state) => state.foo);
+        return useAtomValue(sliceAtom);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags selectAtom imported under an alias", () => {
+    const code = `
+      import { selectAtom as makeSlice } from "jotai/utils";
+      function MyComponent() {
+        const sliceAtom = makeSlice(baseAtom, (state) => state.foo);
+        return useAtomValue(sliceAtom);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags selectAtom inside a helper nested in a component", () => {
+    const code = `
+      import { selectAtom } from "jotai/utils";
+      function MyComponent() {
+        const buildSlice = () => selectAtom(baseAtom, (state) => state.foo);
+        const sliceAtom = buildSlice();
+        return useAtomValue(sliceAtom);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag selectAtom at module scope", () => {
+    const code = `
+      import { selectAtom } from "jotai/utils";
+      const sliceAtom = selectAtom(baseAtom, (state) => state.foo);
+      function MyComponent() {
+        return useAtomValue(sliceAtom);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag selectAtom inside useMemo callback in a component", () => {
+    const code = `
+      import { selectAtom } from "jotai/utils";
+      function MyComponent({ field }) {
+        const sliceAtom = useMemo(
+          () => selectAtom(baseAtom, (state) => state[field]),
+          [field]
+        );
+        return useAtomValue(sliceAtom);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag selectAtom inside useMemo callback in a custom hook", () => {
+    const code = `
+      import { selectAtom } from "jotai/utils";
+      function useSlice(field) {
+        const sliceAtom = useMemo(
+          () => selectAtom(baseAtom, (s) => s[field]),
+          [field]
+        );
+        return useAtomValue(sliceAtom);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag selectAtom imported from a non-jotai source (homegrown helper)", () => {
+    const code = `
+      import { selectAtom } from "./my-utils";
+      function MyComponent() {
+        const sliceAtom = selectAtom(baseAtom, (state) => state.foo);
+        return useAtomValue(sliceAtom);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag selectAtom in a lowercase non-hook helper", () => {
+    const code = `
+      import { selectAtom } from "jotai/utils";
+      function buildSliceAtom() {
+        return selectAtom(baseAtom, (state) => state.foo);
+      }
+    `;
+    const result = runRule(jotaiSelectAtomInRenderBody, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-select-atom-in-render-body.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-select-atom-in-render-body.ts
@@ -1,0 +1,114 @@
+import { defineRule } from "../../utils/define-rule.js";
+import {
+  isImportedFromModule,
+  getImportedNameFromModule,
+} from "../../utils/find-import-source-for-name.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// HACK: `selectAtom(base, selector)` returns a NEW atom on every call.
+// Calling it in a component / hook body without `useMemo` rebuilds
+// the derived atom on every render — `useAtomValue` then subscribes
+// to a brand new atom each render and triggers an infinite render
+// loop (jotai's documented #1 footgun). The fix is either:
+//   (a) lift the `selectAtom(...)` call to module scope, or
+//   (b) wrap it in `useMemo(() => selectAtom(base, selector), [deps])`.
+
+const JOTAI_SELECT_ATOM_SOURCES = ["jotai/utils", "jotai"];
+
+const MEMOIZING_HOOK_NAMES = new Set(["useMemo", "useCallback"]);
+
+const COMPONENT_NAME_PATTERN = /^[A-Z]/;
+const HOOK_NAME_PATTERN = /^use[A-Z]/;
+
+const isFunctionLikeNode = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "FunctionDeclaration") ||
+  isNodeOfType(node, "FunctionExpression") ||
+  isNodeOfType(node, "ArrowFunctionExpression");
+
+const isImportedSelectAtom = (callExpression: EsTreeNodeOfType<"CallExpression">): boolean => {
+  if (!isNodeOfType(callExpression.callee, "Identifier")) return false;
+  const localName = callExpression.callee.name;
+  for (const source of JOTAI_SELECT_ATOM_SOURCES) {
+    if (!isImportedFromModule(callExpression, localName, source)) continue;
+    const importedName = getImportedNameFromModule(callExpression, localName, source);
+    if (importedName === "selectAtom") return true;
+  }
+  return false;
+};
+
+const isCallbackOfMemoizingHook = (functionNode: EsTreeNode): boolean => {
+  const callParent = functionNode.parent;
+  if (!isNodeOfType(callParent, "CallExpression")) return false;
+  if (!isNodeOfType(callParent.callee, "Identifier")) return false;
+  if (!MEMOIZING_HOOK_NAMES.has(callParent.callee.name)) return false;
+  // The function must be the FIRST argument to count as the
+  // memoizing callback — `useMemo(..., [arg, selectAtomFn])` is not
+  // the same thing.
+  return callParent.arguments?.[0] === functionNode;
+};
+
+const containingFunctionIsComponentOrHook = (functionNode: EsTreeNode): boolean => {
+  if (isNodeOfType(functionNode, "FunctionDeclaration") && functionNode.id) {
+    const declaredName = functionNode.id.name;
+    return COMPONENT_NAME_PATTERN.test(declaredName) || HOOK_NAME_PATTERN.test(declaredName);
+  }
+  // ArrowFunctionExpression / FunctionExpression — look for the
+  // surrounding VariableDeclarator. `memo(...)` and `forwardRef(...)`
+  // wrappers are transparent here: walk past intermediate calls until
+  // we find the binding.
+  let cursor: EsTreeNode | null | undefined = functionNode.parent ?? null;
+  while (cursor && isNodeOfType(cursor, "CallExpression")) {
+    cursor = cursor.parent ?? null;
+  }
+  if (!cursor) return false;
+  if (!isNodeOfType(cursor, "VariableDeclarator")) return false;
+  if (!isNodeOfType(cursor.id, "Identifier")) return false;
+  return COMPONENT_NAME_PATTERN.test(cursor.id.name) || HOOK_NAME_PATTERN.test(cursor.id.name);
+};
+
+export const jotaiSelectAtomInRenderBody = defineRule<Rule>({
+  id: "jotai-select-atom-in-render-body",
+  severity: "error",
+  recommendation:
+    "Lift `selectAtom(base, fn)` to module scope, or wrap it: `const atom = useMemo(() => selectAtom(base, fn), [deps])`. Calling it in render rebuilds the derived atom every render and infinitely re-subscribes",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isImportedSelectAtom(node)) return;
+
+      // Walk up to find the nearest enclosing function. If that
+      // function itself is the callback of useMemo / useCallback,
+      // the selectAtom call is memoized — fine.
+      let cursor: EsTreeNode | null | undefined = node.parent ?? null;
+      let nearestFunctionLike: EsTreeNode | null = null;
+      while (cursor) {
+        if (isFunctionLikeNode(cursor)) {
+          nearestFunctionLike = cursor;
+          break;
+        }
+        cursor = cursor.parent ?? null;
+      }
+      if (!nearestFunctionLike) return;
+      if (isCallbackOfMemoizingHook(nearestFunctionLike)) return;
+
+      // Now walk up again from the nearest function looking for any
+      // enclosing component or hook. Helpers nested inside a
+      // component are still "render-time" execution paths.
+      let outerCursor: EsTreeNode | null = nearestFunctionLike;
+      while (outerCursor) {
+        if (isFunctionLikeNode(outerCursor) && containingFunctionIsComponentOrHook(outerCursor)) {
+          context.report({
+            node,
+            message:
+              "`selectAtom(...)` called in a component / hook body without `useMemo` — every render builds a new derived atom and `useAtomValue` re-subscribes forever. Lift it to module scope or wrap with `useMemo(() => selectAtom(...), [deps])`",
+          });
+          return;
+        }
+        outerCursor = outerCursor.parent ?? null;
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-tq-use-raw-query-atom.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-tq-use-raw-query-atom.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jotaiTqUseRawQueryAtom } from "./jotai-tq-use-raw-query-atom.js";
+
+describe("jotai-tq-use-raw-query-atom", () => {
+  it("flags useAtomValue subscribing to an atomWithQuery binding", () => {
+    const code = `
+      import { atomWithQuery } from "jotai-tanstack-query";
+      const userQueryAtom = atomWithQuery(() => ({ queryKey: ["user"], queryFn }));
+      function UserProfile() {
+        const result = useAtomValue(userQueryAtom);
+        return result.data?.name;
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("Derive the field");
+  });
+
+  it("flags useAtom subscribing to an atomWithQuery binding", () => {
+    const code = `
+      import { atomWithQuery } from "jotai-tanstack-query";
+      const userQueryAtom = atomWithQuery(() => ({ queryKey: ["user"], queryFn }));
+      function UserProfile() {
+        const [result] = useAtom(userQueryAtom);
+        return result.data?.name;
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atomWithSuspenseQuery binding consumer", () => {
+    const code = `
+      import { atomWithSuspenseQuery } from "jotai-tanstack-query";
+      const userQueryAtom = atomWithSuspenseQuery(() => ({ queryKey: ["user"], queryFn }));
+      function UserProfile() {
+        const result = useAtomValue(userQueryAtom);
+        return result.data?.name;
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags atomWithInfiniteQuery binding consumer", () => {
+    const code = `
+      import { atomWithInfiniteQuery } from "jotai-tanstack-query";
+      const feedQueryAtom = atomWithInfiniteQuery(() => ({ queryKey: ["feed"], queryFn }));
+      function Feed() {
+        return useAtomValue(feedQueryAtom);
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag a derived atom consumer (atom(g => g(queryAtom).data))", () => {
+    const code = `
+      import { atom } from "jotai";
+      import { atomWithQuery } from "jotai-tanstack-query";
+      const userQueryAtom = atomWithQuery(() => ({ queryKey: ["user"], queryFn }));
+      const userDataAtom = atom((get) => get(userQueryAtom).data);
+      function UserProfile() {
+        const data = useAtomValue(userDataAtom);
+        return data?.name;
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag useSetAtom on the query binding (mutation pattern)", () => {
+    // `useSetAtom` doesn't subscribe to the value, so there's no
+    // re-render cost from envelope churn.
+    const code = `
+      import { atomWithQuery } from "jotai-tanstack-query";
+      const userQueryAtom = atomWithQuery(() => ({ queryKey: ["user"], queryFn }));
+      function Refresh() {
+        const set = useSetAtom(userQueryAtom);
+        return null;
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag atomWithMutation consumer (no observer envelope)", () => {
+    const code = `
+      import { atomWithMutation } from "jotai-tanstack-query";
+      const saveAtom = atomWithMutation(() => ({ mutationFn }));
+      function Save() {
+        const [{ mutate }] = useAtom(saveAtom);
+        return null;
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag query bindings imported from a non-jotai-tq source", () => {
+    const code = `
+      import { atomWithQuery } from "./my-atoms";
+      const userQueryAtom = atomWithQuery({ queryKey: ["user"] });
+      function UserProfile() {
+        return useAtomValue(userQueryAtom);
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag aliased atomWithQuery imports (file-local binding still tracked)", () => {
+    const code = `
+      import { atomWithQuery as makeQueryAtom } from "jotai-tanstack-query";
+      const userQueryAtom = makeQueryAtom(() => ({ queryKey: ["user"], queryFn }));
+      function UserProfile() {
+        return useAtomValue(userQueryAtom);
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag useAtomValue on an unrelated plain atom", () => {
+    const code = `
+      import { atom } from "jotai";
+      const counterAtom = atom(0);
+      function Counter() {
+        return useAtomValue(counterAtom);
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags cross-file imported `*QueryAtom` binding (naming convention)", () => {
+    const code = `
+      import { userQueryAtom } from "./atoms";
+      function UserProfile() {
+        const result = useAtomValue(userQueryAtom);
+        return result.data?.name;
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags cross-file imported `*SuspenseQueryAtom` binding", () => {
+    const code = `
+      import { userSuspenseQueryAtom } from "./atoms";
+      function UserProfile() {
+        return useAtomValue(userSuspenseQueryAtom);
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags cross-file imported `*InfiniteQueryAtom` binding", () => {
+    const code = `
+      import { feedInfiniteQueryAtom } from "./atoms";
+      function Feed() {
+        return useAtomValue(feedInfiniteQueryAtom);
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag cross-file binding without the QueryAtom suffix", () => {
+    const code = `
+      import { userAtom } from "./atoms";
+      function UserProfile() {
+        return useAtomValue(userAtom);
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag bindings imported from `jotai` itself", () => {
+    const code = `
+      import { someQueryAtom } from "jotai";
+      function UserProfile() {
+        return useAtomValue(someQueryAtom);
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag useAtomValue called with a non-identifier expression", () => {
+    const code = `
+      import { atomWithQuery } from "jotai-tanstack-query";
+      const userQueryAtom = atomWithQuery(() => ({ queryKey: ["user"] }));
+      function UserProfile() {
+        return useAtomValue(makeAtom());
+      }
+    `;
+    const result = runRule(jotaiTqUseRawQueryAtom, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-tq-use-raw-query-atom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/jotai/jotai-tq-use-raw-query-atom.ts
@@ -1,0 +1,106 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// HACK: jotai-tanstack-query's `atomWithQuery` returns an atom whose
+// value is the full `QueryObserverResult` envelope. TanStack rebuilds
+// that envelope on every observer notify, including no-op refetches.
+// Subscribing directly via `useAtomValue(queryAtom)` puts every
+// consumer on the broadcast path and re-renders them every notify,
+// even when the field they actually read didn't change. Measured:
+// 44× more commits than the equivalent `useQuery` consumer.
+// Fix: derive the field once, then subscribe to the derived atom.
+//   const dataAtom = atom((get) => get(queryAtom).data)
+//   const data = useAtomValue(dataAtom)
+// `atomWithMutation` is excluded because there's no observer envelope —
+// the result IS the imperative trigger and subscribing to it is the
+// documented API. `atomWithSuspenseQuery` and `atomWithInfiniteQuery`
+// share the same envelope-on-every-notify shape as `atomWithQuery`.
+
+const QUERY_ATOM_FACTORY_IMPORTED_NAMES = new Set([
+  "atomWithQuery",
+  "atomWithSuspenseQuery",
+  "atomWithInfiniteQuery",
+  "atomWithSuspenseInfiniteQuery",
+]);
+
+const SUBSCRIBING_HOOK_NAMES = new Set(["useAtomValue", "useAtom"]);
+
+// Bindings imported from another file follow a strong naming convention
+// in jotai-tanstack-query codebases (the library's own README + every
+// real OSS example uses this shape). When we see an imported binding
+// with one of these suffixes used with `useAtomValue` / `useAtom`,
+// treat it as a query atom even though we can't see the source-of-
+// truth `atomWithQuery(...)` call. False-positive risk is low: a
+// non-tq atom that happens to be named `*QueryAtom` is an unusual
+// naming clash. False-negative risk for the file-local case is zero
+// (those still resolve via the binding tracker below).
+const QUERY_ATOM_NAMING_CONVENTION =
+  /(SuspenseInfiniteQuery|SuspenseQuery|InfiniteQuery|Query)Atom$/;
+
+export const jotaiTqUseRawQueryAtom = defineRule<Rule>({
+  id: "jotai-tq-use-raw-query-atom",
+  severity: "warn",
+  recommendation:
+    "Derive the field you read: `const dataAtom = atom((get) => get(queryAtom).data)`. Subscribing directly to a jotai-tanstack-query atom re-renders on every observer notify (refetches, focus events, no-op cache hits)",
+  create: (context: RuleContext) => {
+    const queryAtomFactoryLocalNames = new Set<string>();
+    const queryAtomBindingNames = new Set<string>();
+
+    return {
+      ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
+        const source = node.source?.value;
+        for (const specifier of node.specifiers ?? []) {
+          if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+          if (!isNodeOfType(specifier.local, "Identifier")) continue;
+          const localName = specifier.local.name;
+          if (source === "jotai-tanstack-query") {
+            const importedName = getImportedName(specifier);
+            if (importedName && QUERY_ATOM_FACTORY_IMPORTED_NAMES.has(importedName)) {
+              queryAtomFactoryLocalNames.add(localName);
+            }
+            continue;
+          }
+          // Cross-file: trust the naming convention for bindings imported
+          // from another file. Library imports (`jotai`, `react`, etc.)
+          // wouldn't normally have a `*QueryAtom`-shaped binding name,
+          // but skip them to be safe.
+          if (typeof source !== "string") continue;
+          if (source.startsWith("jotai") || source === "react" || source.startsWith("react/")) {
+            continue;
+          }
+          if (QUERY_ATOM_NAMING_CONVENTION.test(localName)) {
+            queryAtomBindingNames.add(localName);
+          }
+        }
+      },
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+        if (queryAtomFactoryLocalNames.size === 0) return;
+        if (!isNodeOfType(node.id, "Identifier")) return;
+        const initializer: EsTreeNode | null | undefined = node.init;
+        if (!isNodeOfType(initializer, "CallExpression")) return;
+        if (!isNodeOfType(initializer.callee, "Identifier")) return;
+        if (!queryAtomFactoryLocalNames.has(initializer.callee.name)) return;
+        queryAtomBindingNames.add(node.id.name);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (queryAtomBindingNames.size === 0) return;
+        if (!isNodeOfType(node.callee, "Identifier")) return;
+        if (!SUBSCRIBING_HOOK_NAMES.has(node.callee.name)) return;
+        const args = node.arguments ?? [];
+        if (args.length === 0) return;
+        const firstArgument = args[0];
+        if (!isNodeOfType(firstArgument, "Identifier")) return;
+        if (!queryAtomBindingNames.has(firstArgument.name)) return;
+        context.report({
+          node,
+          message: `\`${node.callee.name}(${firstArgument.name})\` subscribes directly to a jotai-tanstack-query atom — every observer notify (refetch, focus, no-op cache hit) re-renders consumers. Derive the field first: \`const dataAtom = atom((get) => get(${firstArgument.name}).data)\``,
+        });
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Why

Catches three Jotai re-render footguns from [peterp.me/articles/jotai-structural-sharing-vs-selectatom](https://www.peterp.me/articles/jotai-structural-sharing-vs-selectatom/). Peter measured **44× more commits** than the equivalent React Query consumer when these patterns appear in jotai-tanstack-query codebases — same query, same response, same render output, just a lot more React work.

### `jotai-select-atom-in-render-body` (error severity)

`selectAtom` returns a new atom on every call. Calling it in a component / hook body without `useMemo` rebuilds the derived atom on every render → `useAtomValue` re-subscribes to a brand-new atom each render → infinite render loop. Jotai's own documented #1 footgun.

Before:
```ts
function MyComponent() {
  const sliceAtom = selectAtom(baseAtom, (s) => s.foo);
  return useAtomValue(sliceAtom);  // infinite re-render
}
```

After:
```ts
const sliceAtom = selectAtom(baseAtom, (s) => s.foo);  // module scope
function MyComponent() { return useAtomValue(sliceAtom); }
// or, when the selector depends on props:
function MyComponent({ field }) {
  const sliceAtom = useMemo(() => selectAtom(baseAtom, (s) => s[field]), [field]);
  return useAtomValue(sliceAtom);
}
```

### `jotai-derived-atom-returns-fresh-object`

Jotai propagates derived values with `Object.is`. A derivation that returns a fresh `ObjectExpression` / `ArrayExpression` literal — OR an array-producing method chain (`.filter()`, `.map()`, `.toSorted()`, `Object.entries(...)`, `Array.from(...)`) — fails `Object.is` on every notify and re-renders every consumer, even when the field values didn't change.

Before:
```ts
const summaryAtom = atom((get) => ({
  count: get(cartAtom).items.length,
  total: sum(get(cartAtom).items),
}));
// → every cartAtom notify re-renders every consumer of summaryAtom
```

After:
```ts
const countAtom = atom((get) => get(cartAtom).items.length);
const totalAtom = atom((get) => sum(get(cartAtom).items));
// → only consumers of the field that actually changed re-render
```

### `jotai-tq-use-raw-query-atom`

Subscribing directly to `atomWithQuery` puts every consumer on the full `QueryObserverResult` broadcast path. TanStack rebuilds that envelope on every observer notify (refetches, focus events, no-op cache hits) — consumers re-render even when their field didn't change.

Before:
```ts
const userQueryAtom = atomWithQuery(() => ({ queryKey: ["user"], queryFn }));
function UserProfile() {
  const result = useAtomValue(userQueryAtom);  // 44× re-renders
  return result.data?.name;
}
```

After:
```ts
const userQueryAtom = atomWithQuery(() => ({ queryKey: ["user"], queryFn }));
const userDataAtom = atom((get) => get(userQueryAtom).data);
function UserProfile() {
  const data = useAtomValue(userDataAtom);  // 1× per data change
  return data?.name;
}
```

## What changed

- Added \`jotai/\` bucket to \`scripts/generate-rule-registry.mjs\` with category "State & Effects".
- Added \`jotai-select-atom-in-render-body\` (error severity).
- Added \`jotai-derived-atom-returns-fresh-object\` (warn). Handles concise arrow bodies (ParenthesizedExpression stripped), block bodies with multiple top-level returns (every return must be a fresh structure), renamed \`get\` parameters, array-producing method chains, and \`Object.{keys,values,entries,fromEntries}\` / \`Array.{from,of}\` static-method shapes.
- Added \`jotai-tq-use-raw-query-atom\` (warn). Tracks file-local \`atomWithQuery(...)\` bindings (aliased factory imports OK) AND cross-file imports via the established \`*QueryAtom\` / \`*SuspenseQueryAtom\` / \`*InfiniteQueryAtom\` / \`*SuspenseInfiniteQueryAtom\` naming convention. Excludes \`useSetAtom\`, \`atomWithMutation\`, and bindings imported from \`jotai\` / \`react\` themselves.
- All three self-gate via import detection (no new project capability needed). Rules fire zero times on projects that don't import from \`jotai\`.

## Eval results

RDE not run — local runner is \`git clone\` + \`npm install\` bound (sequential, no Vercel sandbox credentials locally). Jotai usage in the existing OSS corpus is small (~2 hits in the manifest), so signal would be low even with a full RDE run. **45 co-located tests** cover the documented bug shapes, every v1 valid case, aliased imports, renamed parameters, and the cross-file naming-convention path.

## Test plan

- \`pnpm exec vp test run src/plugin/rules/jotai\` → 45 passed
- \`pnpm --filter oxlint-plugin-react-doctor typecheck\` → passes (\`291 rules\` registered)
- \`npx vp fmt --check\` → clean
- \`npx vp lint\` → clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint-only rules gated on Jotai imports; no runtime or auth changes, with bounded false-positive risk on the cross-file `*QueryAtom` naming heuristic.
> 
> **Overview**
> Adds a **`jotai`** rule bucket (category **State & Effects**) and three import-gated oxlint rules for common Jotai re-render footguns.
> 
> **`jotai-select-atom-in-render-body`** (error) flags `selectAtom` from `jotai` / `jotai/utils` inside a component or `use*` hook body unless it sits in a `useMemo` / `useCallback` callback or at module scope—avoids rebuilding a new derived atom every render and infinite re-subscribe loops.
> 
> **`jotai-derived-atom-returns-fresh-object`** (warn) flags read-only `atom((get) => …)` derivations that return fresh object/array literals or outermost “allocating” chains (e.g. `.map`, `Object.entries`) when the body actually calls `get`, since Jotai dedupes with `Object.is`.
> 
> **`jotai-tq-use-raw-query-atom`** (warn) flags `useAtom` / `useAtomValue` on `jotai-tanstack-query` query atoms (file-local factory tracking plus cross-file `*QueryAtom` naming), and nudges subscribing via a field-derived atom instead of the full observer envelope.
> 
> Registry codegen and `rule-registry.ts` wire all three in; **45** co-located tests cover positive/negative cases, aliases, and edge paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 339340a0ba0981b33984653b72b45ef0ff11a2ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->