### PR TITLE
feat(state-and-effects): add activity-wraps-effect-heavy-subtree

### DIFF
--- a/packages/core/src/project-info/index.ts
+++ b/packages/core/src/project-info/index.ts
@@ -8,6 +8,7 @@ export {
 export { clearPackageJsonCache, readPackageJson } from "./read-package-json.js";
 export { resolveEffectiveReactMajor } from "./resolve-effective-react-major.js";
 export { parseReactMajor } from "./parse-react-major.js";
+export { parseReactMajorMinor, isReactAtLeast } from "./parse-react-major-minor.js";
 export { peerRangeMinMajor } from "./parse-react-peer-range.js";
 export { parseTailwindMajorMinor, isTailwindAtLeast } from "./parse-tailwind-major-minor.js";
 export { findMonorepoRoot, isMonorepoRoot } from "./find-monorepo-root.js";

--- a/packages/core/src/project-info/parse-react-major-minor.ts
+++ b/packages/core/src/project-info/parse-react-major-minor.ts
@@ -21,14 +21,25 @@ interface ReactMajorMinor {
 const MAJOR_MINOR_PATTERN = /(\d{1,4})\.(\d{1,4})/;
 const MAJOR_ONLY_PATTERN = /(\d{1,4})/;
 
+// Strip upper-bound comparators (`<19.2`, `<=20.0.0`, `<19.2-beta`) from
+// the spec before regex-matching the lower bound. Without this, a spec
+// like `"<19.2 >=19.0"` matches `19.2` from the upper bound and reports
+// the project as React 19.2+ even though the range *excludes* 19.2.
+// Mirrors the same stripping that `dependency-version-spec`'s lower-
+// bound major extractor does, kept inline to keep this parser
+// dependency-free.
+const UPPER_BOUND_COMPARATOR_PATTERN = /<\s*=?\s*\d{1,4}(?:\.\d{1,4}){0,2}(?:-[^\s,|]+)?/g;
+
 export const parseReactMajorMinor = (
   reactVersion: string | null | undefined,
 ): ReactMajorMinor | null => {
   if (typeof reactVersion !== "string") return null;
   const trimmed = reactVersion.trim();
   if (trimmed.length === 0) return null;
+  const lowerBoundsOnly = trimmed.replace(UPPER_BOUND_COMPARATOR_PATTERN, " ").trim();
+  if (lowerBoundsOnly.length === 0) return null;
 
-  const majorMinorMatch = trimmed.match(MAJOR_MINOR_PATTERN);
+  const majorMinorMatch = lowerBoundsOnly.match(MAJOR_MINOR_PATTERN);
   if (majorMinorMatch) {
     const major = Number.parseInt(majorMinorMatch[1], 10);
     const minor = Number.parseInt(majorMinorMatch[2], 10);
@@ -37,7 +48,7 @@ export const parseReactMajorMinor = (
     return { major, minor };
   }
 
-  const majorOnlyMatch = trimmed.match(MAJOR_ONLY_PATTERN);
+  const majorOnlyMatch = lowerBoundsOnly.match(MAJOR_ONLY_PATTERN);
   if (!majorOnlyMatch) return null;
   const major = Number.parseInt(majorOnlyMatch[1], 10);
   if (!Number.isFinite(major) || major <= 0) return null;

--- a/packages/core/src/project-info/parse-react-major-minor.ts
+++ b/packages/core/src/project-info/parse-react-major-minor.ts
@@ -1,0 +1,50 @@
+// HACK: react-doctor reads the project's React version straight out of
+// package.json (the `react` dep), which produces semver ranges
+// (`^19.2.0`, `~19.0.1`, `>=19 <20`, `19.x`, `latest`, etc.) — never a
+// normalized number. Some React-version-gated rules need the MINOR in
+// addition to the major (e.g. `<Activity>` shipped in React 19.2 — a
+// gate purely on `major >= 19` would mis-fire on 19.0 / 19.1).
+//
+// Mirrors `parse-tailwind-major-minor` exactly: pull the first
+// `<major>.<minor>` pair from the trimmed spec, fall back to
+// `{ major, minor: 0 }` when only a major is present.
+interface ReactMajorMinor {
+  major: number;
+  minor: number;
+}
+
+export const parseReactMajorMinor = (
+  reactVersion: string | null | undefined,
+): ReactMajorMinor | null => {
+  if (typeof reactVersion !== "string") return null;
+  const trimmed = reactVersion.trim();
+  if (trimmed.length === 0) return null;
+
+  const majorMinorMatch = trimmed.match(/(\d+)\.(\d+)/);
+  if (majorMinorMatch) {
+    const major = Number.parseInt(majorMinorMatch[1], 10);
+    const minor = Number.parseInt(majorMinorMatch[2], 10);
+    if (!Number.isFinite(major) || major <= 0) return null;
+    if (!Number.isFinite(minor) || minor < 0) return null;
+    return { major, minor };
+  }
+
+  const majorOnlyMatch = trimmed.match(/(\d+)/);
+  if (!majorOnlyMatch) return null;
+  const major = Number.parseInt(majorOnlyMatch[1], 10);
+  if (!Number.isFinite(major) || major <= 0) return null;
+  return { major, minor: 0 };
+};
+
+export const isReactAtLeast = (
+  detected: ReactMajorMinor | null,
+  required: ReactMajorMinor,
+): boolean => {
+  // HACK: when detection failed (workspace protocols, dist-tags like
+  // "latest", etc.) optimistically treat the project as running the
+  // latest React so we surface the rule rather than silently dropping
+  // it. Mirrors the React-major and Tailwind fallback policy.
+  if (detected === null) return true;
+  if (detected.major !== required.major) return detected.major > required.major;
+  return detected.minor >= required.minor;
+};

--- a/packages/core/src/project-info/parse-react-major-minor.ts
+++ b/packages/core/src/project-info/parse-react-major-minor.ts
@@ -28,7 +28,13 @@ const MAJOR_ONLY_PATTERN = /(\d{1,4})/;
 // Mirrors the same stripping that `dependency-version-spec`'s lower-
 // bound major extractor does, kept inline to keep this parser
 // dependency-free.
-const UPPER_BOUND_COMPARATOR_PATTERN = /<\s*=?\s*\d{1,4}(?:\.\d{1,4}){0,2}(?:-[^\s,|]+)?/g;
+//
+// HACK: CodeQL flags consecutive `\s*` groups as polynomial-backtracking
+// risk on attacker-controlled input. Use a single bounded `\s{0,8}` so
+// the regex is unambiguous and linear. Semver upper bounds never
+// contain internal whitespace between `<` and `=`; 8 chars between
+// `<=` and the digit is more than any real spec uses.
+const UPPER_BOUND_COMPARATOR_PATTERN = /<=?\s{0,8}\d{1,4}(?:\.\d{1,4}){0,2}(?:-[^\s,|]+)?/g;
 
 export const parseReactMajorMinor = (
   reactVersion: string | null | undefined,

--- a/packages/core/src/project-info/parse-react-major-minor.ts
+++ b/packages/core/src/project-info/parse-react-major-minor.ts
@@ -13,6 +13,14 @@ interface ReactMajorMinor {
   minor: number;
 }
 
+// HACK: CodeQL flags unbounded `\d+` on untrusted package.json input as
+// a polynomial-backtracking risk (even though the patterns here are
+// not actually polynomial — there's no nested quantifier). Bound the
+// digit count so the regex is provably O(1) on any input. React
+// major/minor numbers won't realistically exceed 4 digits anyway.
+const MAJOR_MINOR_PATTERN = /(\d{1,4})\.(\d{1,4})/;
+const MAJOR_ONLY_PATTERN = /(\d{1,4})/;
+
 export const parseReactMajorMinor = (
   reactVersion: string | null | undefined,
 ): ReactMajorMinor | null => {
@@ -20,7 +28,7 @@ export const parseReactMajorMinor = (
   const trimmed = reactVersion.trim();
   if (trimmed.length === 0) return null;
 
-  const majorMinorMatch = trimmed.match(/(\d+)\.(\d+)/);
+  const majorMinorMatch = trimmed.match(MAJOR_MINOR_PATTERN);
   if (majorMinorMatch) {
     const major = Number.parseInt(majorMinorMatch[1], 10);
     const minor = Number.parseInt(majorMinorMatch[2], 10);
@@ -29,7 +37,7 @@ export const parseReactMajorMinor = (
     return { major, minor };
   }
 
-  const majorOnlyMatch = trimmed.match(/(\d+)/);
+  const majorOnlyMatch = trimmed.match(MAJOR_ONLY_PATTERN);
   if (!majorOnlyMatch) return null;
   const major = Number.parseInt(majorOnlyMatch[1], 10);
   if (!Number.isFinite(major) || major <= 0) return null;

--- a/packages/core/src/runners/oxlint/capabilities.ts
+++ b/packages/core/src/runners/oxlint/capabilities.ts
@@ -1,5 +1,10 @@
 import type { ProjectInfo } from "../../types/index.js";
-import { isTailwindAtLeast, parseTailwindMajorMinor } from "../../project-info/index.js";
+import {
+  isReactAtLeast,
+  isTailwindAtLeast,
+  parseReactMajorMinor,
+  parseTailwindMajorMinor,
+} from "../../project-info/index.js";
 
 export const buildCapabilities = (project: ProjectInfo): ReadonlySet<string> => {
   const capabilities = new Set<string>();
@@ -23,6 +28,20 @@ export const buildCapabilities = (project: ProjectInfo): ReadonlySet<string> => 
   if (reactMajor !== null) {
     for (let major = 17; major <= reactMajor; major++) {
       capabilities.add(`react:${major}`);
+    }
+    // Minor-version-pinned capabilities for APIs introduced after a
+    // major release. Mirrors the `tailwind:3.4` pattern below.
+    // `react:19.2` is the gate for `<Activity>`, which shipped in
+    // React 19.2 (the major landed at 19.0 without it). Only consider
+    // the minor gate when we've already detected React 19+ — and use
+    // `isReactAtLeast`'s optimistic-on-null policy so projects with
+    // unparseable specs (workspace protocols, dist-tags) still get
+    // the rule when React 19 is otherwise detected.
+    if (reactMajor >= 19) {
+      const parsedReact = parseReactMajorMinor(project.reactVersion);
+      if (isReactAtLeast(parsedReact, { major: 19, minor: 2 })) {
+        capabilities.add("react:19.2");
+      }
     }
   }
 

--- a/packages/core/tests/parse-react-major-minor.test.ts
+++ b/packages/core/tests/parse-react-major-minor.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isReactAtLeast, parseReactMajorMinor } from "@react-doctor/core";
+
+describe("parseReactMajorMinor", () => {
+  it("extracts major.minor from caret/tilde/exact ranges", () => {
+    expect(parseReactMajorMinor("^19.2.0")).toEqual({ major: 19, minor: 2 });
+    expect(parseReactMajorMinor("~19.0.3")).toEqual({ major: 19, minor: 0 });
+    expect(parseReactMajorMinor("19.2.0")).toEqual({ major: 19, minor: 2 });
+    expect(parseReactMajorMinor("19.2")).toEqual({ major: 19, minor: 2 });
+    expect(parseReactMajorMinor("v19.0.0")).toEqual({ major: 19, minor: 0 });
+  });
+
+  it("treats major-only specs as minor 0", () => {
+    expect(parseReactMajorMinor("19")).toEqual({ major: 19, minor: 0 });
+    expect(parseReactMajorMinor("^19")).toEqual({ major: 19, minor: 0 });
+    expect(parseReactMajorMinor("19.x")).toEqual({ major: 19, minor: 0 });
+  });
+
+  it("uses the lower bound on multi-comparator ranges", () => {
+    expect(parseReactMajorMinor(">=19.2 <20")).toEqual({ major: 19, minor: 2 });
+    expect(parseReactMajorMinor("19.2 || 20.0")).toEqual({ major: 19, minor: 2 });
+  });
+
+  it("regression: upper-bound comparator is stripped before matching", () => {
+    // Without upper-bound stripping the regex matches `19.2` from the
+    // exclusive upper bound, falsely reporting React 19.2+ even though
+    // the range *excludes* 19.2.
+    expect(parseReactMajorMinor("<19.2 >=19.0")).toEqual({ major: 19, minor: 0 });
+    expect(parseReactMajorMinor("<=19.2.0 >=19.0.0")).toEqual({ major: 19, minor: 0 });
+    expect(parseReactMajorMinor(">=18.3 <19.2")).toEqual({ major: 18, minor: 3 });
+    expect(parseReactMajorMinor("<19.2-beta >=19.0")).toEqual({ major: 19, minor: 0 });
+  });
+
+  it("returns null for tags, workspace protocols, and empty input", () => {
+    expect(parseReactMajorMinor(null)).toBeNull();
+    expect(parseReactMajorMinor(undefined)).toBeNull();
+    expect(parseReactMajorMinor("")).toBeNull();
+    expect(parseReactMajorMinor("   ")).toBeNull();
+  });
+
+  it("ignores leading whitespace and npm: alias prefixes", () => {
+    expect(parseReactMajorMinor("  ^19.2.0  ")).toEqual({ major: 19, minor: 2 });
+    expect(parseReactMajorMinor("npm:react@^19.2.0")).toEqual({ major: 19, minor: 2 });
+  });
+});
+
+describe("isReactAtLeast", () => {
+  it("returns true when detected major is greater than required", () => {
+    expect(isReactAtLeast({ major: 20, minor: 0 }, { major: 19, minor: 2 })).toBe(true);
+  });
+
+  it("returns true when major matches and detected minor >= required", () => {
+    expect(isReactAtLeast({ major: 19, minor: 2 }, { major: 19, minor: 2 })).toBe(true);
+    expect(isReactAtLeast({ major: 19, minor: 5 }, { major: 19, minor: 2 })).toBe(true);
+  });
+
+  it("returns false when major matches but detected minor < required", () => {
+    expect(isReactAtLeast({ major: 19, minor: 0 }, { major: 19, minor: 2 })).toBe(false);
+    expect(isReactAtLeast({ major: 19, minor: 1 }, { major: 19, minor: 2 })).toBe(false);
+  });
+
+  it("returns false when detected major is less than required", () => {
+    expect(isReactAtLeast({ major: 18, minor: 99 }, { major: 19, minor: 2 })).toBe(false);
+  });
+
+  it("optimistically returns true when detection failed (null detected)", () => {
+    // Matches the Tailwind precedent: unparseable specs (workspace
+    // protocols, dist-tags) shouldn't silently drop version-gated
+    // rules. Callers are expected to gate on a separate "detected at
+    // all" check (e.g. `reactMajor !== null`) before relying on this.
+    expect(isReactAtLeast(null, { major: 19, minor: 2 })).toBe(true);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -8,6 +8,7 @@
 
 import type { Rule } from "./utils/rule.js";
 
+import { activityWrapsEffectHeavySubtree } from "./rules/state-and-effects/activity-wraps-effect-heavy-subtree.js";
 import { advancedEventHandlerRefs } from "./rules/state-and-effects/advanced-event-handler-refs.js";
 import { altText } from "./rules/a11y/alt-text.js";
 import { anchorAmbiguousText } from "./rules/a11y/anchor-ambiguous-text.js";
@@ -298,6 +299,17 @@ import { useLazyMotion } from "./rules/bundle-size/use-lazy-motion.js";
 import { voidDomElementsNoChildren } from "./rules/react-builtins/void-dom-elements-no-children.js";
 
 export const reactDoctorRules = [
+  {
+    key: "react-doctor/activity-wraps-effect-heavy-subtree",
+    id: "activity-wraps-effect-heavy-subtree",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...activityWrapsEffectHeavySubtree,
+      framework: "global",
+      category: "State & Effects",
+    },
+  },
   {
     key: "react-doctor/advanced-event-handler-refs",
     id: "advanced-event-handler-refs",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
@@ -71,6 +71,37 @@ describe("activity-wraps-effect-heavy-subtree", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it('does NOT flag Activity with static `mode="hidden"` (pinned, no toggle)', () => {
+    // Regression: static `mode="hidden"` is also non-toggleable —
+    // there's no hide/show cycle, so no Effect teardown / recreate.
+    // The rule must only fire on truly dynamic mode expressions.
+    const code = `
+      import { Activity, useEffect } from "react";
+      const Sheet = () => { useEffect(() => subscribe(), []); return null; };
+      const Screen = () => (
+        <Activity mode="hidden">
+          <Sheet />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('does NOT flag Activity with static `mode={"hidden"}` JSXExpressionContainer', () => {
+    const code = `
+      import { Activity, useEffect } from "react";
+      const Sheet = () => { useEffect(() => subscribe(), []); return null; };
+      const Screen = () => (
+        <Activity mode={"hidden"}>
+          <Sheet />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does NOT flag Activity with statically visible mode (no toggle)", () => {
     const code = `
       import { Activity, useEffect } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
@@ -201,6 +201,29 @@ describe("activity-wraps-effect-heavy-subtree", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("regression: <Charts.Bar /> child does NOT collide with same-file `Bar` helper", () => {
+    // Bugbot caught that collectChildComponentNames was extracting
+    // "Bar" from <Charts.Bar /> via the trailing-identifier shape,
+    // then findSameFileComponentBody would look up "Bar" in the same
+    // file. If a same-file `Bar` exists with effects, this produced
+    // a false positive even though `<Charts.Bar />` resolves to an
+    // external namespace, not the same-file Bar.
+    const code = `
+      import { Activity, useEffect } from "react";
+      const Bar = () => {
+        useEffect(() => observe(), []);
+        return null;
+      };
+      const Screen = ({ open }) => (
+        <Activity mode={open ? "visible" : "hidden"}>
+          <Charts.Bar />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("regression: namespace <React.Activity> with same-file user component named `Activity` — no false positive", () => {
     // Bugbot caught that the child-name walker pulls "Activity" out of
     // <React.Activity> via the trailing-identifier shape, then asked

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { activityWrapsEffectHeavySubtree } from "./activity-wraps-effect-heavy-subtree.js";
+
+describe("activity-wraps-effect-heavy-subtree", () => {
+  it("flags Activity wrapping an effect-heavy same-file component", () => {
+    const code = `
+      import { Activity, useEffect } from "react";
+      const EditProfileSheet = ({ user }) => {
+        useEffect(() => { subscribe(user.id); return () => unsubscribe(user.id); }, [user.id]);
+        useEffect(() => { trackOpen(user.id); }, [user.id]);
+        return null;
+      };
+      const Screen = ({ open, user }) => (
+        <Activity mode={open ? "visible" : "hidden"}>
+          <EditProfileSheet user={user} />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("EditProfileSheet");
+  });
+
+  it("flags Activity wrapping a component with useLayoutEffect", () => {
+    const code = `
+      import { Activity, useLayoutEffect } from "react";
+      const Sheet = () => {
+        useLayoutEffect(() => measure(), []);
+        return null;
+      };
+      const Screen = ({ open }) => (
+        <Activity mode={open ? "visible" : "hidden"}>
+          <Sheet />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Activity wrapping multiple effectful children", () => {
+    const code = `
+      import { Activity, useEffect } from "react";
+      const Header = () => { useEffect(() => bind(), []); return null; };
+      const Body = () => { useEffect(() => observe(), []); return null; };
+      const Screen = ({ open }) => (
+        <Activity mode={open ? "visible" : "hidden"}>
+          <Header />
+          <Body />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("Header");
+    expect(result.diagnostics[0].message).toContain("Body");
+  });
+
+  it("flags Activity aliased import (unstable_Activity as Activity)", () => {
+    const code = `
+      import { unstable_Activity as Activity, useEffect } from "react";
+      const Sheet = () => { useEffect(() => subscribe(), []); return null; };
+      const Screen = ({ open }) => (
+        <Activity mode={open ? "visible" : "hidden"}>
+          <Sheet />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag Activity with statically visible mode (no toggle)", () => {
+    const code = `
+      import { Activity, useEffect } from "react";
+      const Sheet = () => { useEffect(() => subscribe(), []); return null; };
+      const Screen = () => (
+        <Activity mode="visible">
+          <Sheet />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag Activity without a mode prop (defaults to visible)", () => {
+    const code = `
+      import { Activity, useEffect } from "react";
+      const Sheet = () => { useEffect(() => subscribe(), []); return null; };
+      const Screen = () => (
+        <Activity>
+          <Sheet />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag Activity wrapping an effect-free component", () => {
+    const code = `
+      import { Activity } from "react";
+      const Spinner = () => <div />;
+      const Screen = ({ open }) => (
+        <Activity mode={open ? "visible" : "hidden"}>
+          <Spinner />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag Activity wrapping a component not defined in the same file (v1 scope)", () => {
+    const code = `
+      import { Activity } from "react";
+      import { EditProfileSheet } from "./profile";
+      const Screen = ({ open }) => (
+        <Activity mode={open ? "visible" : "hidden"}>
+          <EditProfileSheet />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag a user-component named Activity not imported from react", () => {
+    const code = `
+      import { Activity } from "./calendar";
+      import { useEffect } from "react";
+      const Entry = () => { useEffect(() => subscribe(), []); return null; };
+      const Screen = () => (
+        <Activity mode="open">
+          <Entry />
+        </Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags <React.Activity> via the React default-import namespace", () => {
+    const code = `
+      import React, { useEffect } from "react";
+      const Sheet = () => { useEffect(() => subscribe(), []); return null; };
+      const Screen = ({ open }) => (
+        <React.Activity mode={open ? "visible" : "hidden"}>
+          <Sheet />
+        </React.Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it('flags <React.Activity> via `import * as React from "react"`', () => {
+    const code = `
+      import * as React from "react";
+      const Sheet = () => { React.useEffect(() => subscribe(), []); return null; };
+      const Screen = ({ open }) => (
+        <React.Activity mode={open ? "visible" : "hidden"}>
+          <Sheet />
+        </React.Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag <Calendar.Activity> (namespace isn't a React import)", () => {
+    const code = `
+      import * as Calendar from "./calendar";
+      import { useEffect } from "react";
+      const Entry = () => { useEffect(() => subscribe(), []); return null; };
+      const Screen = ({ open }) => (
+        <Calendar.Activity mode={open ? "visible" : "hidden"}>
+          <Entry />
+        </Calendar.Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag an Activity child with no JSX children", () => {
+    const code = `
+      import { Activity } from "react";
+      const Screen = ({ open }) => (
+        <Activity mode={open ? "visible" : "hidden"} />
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
@@ -201,6 +201,33 @@ describe("activity-wraps-effect-heavy-subtree", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("regression: namespace <React.Activity> with same-file user component named `Activity` — no false positive", () => {
+    // Bugbot caught that the child-name walker pulls "Activity" out of
+    // <React.Activity> via the trailing-identifier shape, then asked
+    // findSameFileComponentBody to look up "Activity" in the same
+    // file. If a user component happens to be named `Activity` with
+    // effects, this produced a false-positive diagnostic even though
+    // that component isn't actually a child of the boundary.
+    const code = `
+      import React, { useEffect } from "react";
+      const Activity = ({ children }) => {
+        useEffect(() => trackOpen(), []);
+        useEffect(() => measure(), []);
+        return <>{children}</>;
+      };
+      const Screen = ({ open }) => (
+        <React.Activity mode={open ? "visible" : "hidden"}>
+          <Spinner />
+        </React.Activity>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    // The inner content is just <Spinner /> (no same-file body), and
+    // the canonical "Activity" name is explicitly excluded from the
+    // child set. No diagnostic.
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does NOT flag <Calendar.Activity> (namespace isn't a React import)", () => {
     const code = `
       import * as Calendar from "./calendar";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts
@@ -251,6 +251,32 @@ describe("activity-wraps-effect-heavy-subtree", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("flags aliased boundary wrapping a same-file user component named `Activity`", () => {
+    // Regression for an earlier over-eager cleanup that silently
+    // dropped `Activity` from the child candidate set whenever it
+    // appeared — including legitimate same-file user components.
+    // With aliased import `unstable_Activity as UA`, the boundary
+    // element is `<UA>`, the child `<Activity />` is a user
+    // component, and if `Activity` is defined in the same file with
+    // effects, it's a real positive that should fire.
+    const code = `
+      import { unstable_Activity as UA, useEffect } from "react";
+      const Activity = ({ user }) => {
+        useEffect(() => sub(user.id), [user.id]);
+        useEffect(() => track(user.id), [user.id]);
+        return null;
+      };
+      const Screen = ({ open, user }) => (
+        <UA mode={open ? "visible" : "hidden"}>
+          <Activity user={user} />
+        </UA>
+      );
+    `;
+    const result = runRule(activityWrapsEffectHeavySubtree, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("Activity");
+  });
+
   it("does NOT flag <Calendar.Activity> (namespace isn't a React import)", () => {
     const code = `
       import * as Calendar from "./calendar";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
@@ -176,9 +176,20 @@ export const activityWrapsEffectHeavySubtree = defineRule<Rule>({
 
         const childComponentNames = new Set<string>();
         collectChildComponentNames(node, childComponentNames);
-        // Drop the Activity name itself if a child happens to be a
-        // nested <Activity /> — that's a different rule's concern.
+        // Drop any name that resolves to Activity itself, regardless of
+        // import shape:
+        //   - named import (`import { Activity }`) — covered by
+        //     `localActivityNames`
+        //   - namespace import (`<React.Activity>`) — the child walker
+        //     extracts the trailing identifier `"Activity"` which is
+        //     also one of `ACTIVITY_IMPORTED_NAMES`
+        // Without removing the canonical names, a same-file user
+        // component coincidentally named `Activity` produces a false
+        // positive on the namespace-import path.
         for (const activityName of localActivityNames) childComponentNames.delete(activityName);
+        for (const canonicalActivityName of ACTIVITY_IMPORTED_NAMES) {
+          childComponentNames.delete(canonicalActivityName);
+        }
         if (childComponentNames.size === 0) return;
 
         const programRoot = findProgramRoot(node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
@@ -1,5 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
-import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { EFFECT_HOOK_NAMES, UPPERCASE_PATTERN } from "../../constants/react.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
@@ -37,8 +37,6 @@ const isStaticallyKnownMode = (modeAttribute: EsTreeNodeOfType<"JSXAttribute">):
   return false;
 };
 
-const COMPONENT_NAME_PATTERN = /^[A-Z]/;
-
 const collectChildComponentNames = (
   element: EsTreeNodeOfType<"JSXElement">,
   into: Set<string>,
@@ -54,7 +52,7 @@ const collectChildComponentNames = (
     // `Bar` helper that has nothing to do with this boundary).
     if (!isNodeOfType(child.name, "JSXIdentifier")) return;
     const name = child.name.name;
-    if (!COMPONENT_NAME_PATTERN.test(name)) return;
+    if (!UPPERCASE_PATTERN.test(name)) return;
     into.add(name);
   });
 };
@@ -177,20 +175,15 @@ export const activityWrapsEffectHeavySubtree = defineRule<Rule>({
 
         const childComponentNames = new Set<string>();
         collectChildComponentNames(node, childComponentNames);
-        // Drop any name that resolves to Activity itself, regardless of
-        // import shape:
-        //   - named import (`import { Activity }`) — covered by
-        //     `localActivityNames`
-        //   - namespace import (`<React.Activity>`) — the child walker
-        //     extracts the trailing identifier `"Activity"` which is
-        //     also one of `ACTIVITY_IMPORTED_NAMES`
-        // Without removing the canonical names, a same-file user
-        // component coincidentally named `Activity` produces a false
-        // positive on the namespace-import path.
+        // Drop the locally-bound Activity names so a nested
+        // `<Activity>` inside another `<Activity>` doesn't self-report.
+        // We DON'T drop the canonical `ACTIVITY_IMPORTED_NAMES`: the
+        // namespace path already skips JSXMemberExpression in
+        // `collectChildComponentNames`, and a same-file user component
+        // legitimately named `Activity` (with effects, used as a child
+        // inside an aliased boundary like `import { unstable_Activity as UA }`)
+        // is a real positive we shouldn't silently drop.
         for (const activityName of localActivityNames) childComponentNames.delete(activityName);
-        for (const canonicalActivityName of ACTIVITY_IMPORTED_NAMES) {
-          childComponentNames.delete(canonicalActivityName);
-        }
         if (childComponentNames.size === 0) return;
 
         const programRoot = findProgramRoot(node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
@@ -37,14 +37,6 @@ const isStaticallyKnownMode = (modeAttribute: EsTreeNodeOfType<"JSXAttribute">):
   return false;
 };
 
-const getJsxElementName = (node: EsTreeNode): string | null => {
-  if (isNodeOfType(node, "JSXIdentifier")) return node.name;
-  if (isNodeOfType(node, "JSXMemberExpression")) {
-    if (isNodeOfType(node.property, "JSXIdentifier")) return node.property.name;
-  }
-  return null;
-};
-
 const COMPONENT_NAME_PATTERN = /^[A-Z]/;
 
 const collectChildComponentNames = (
@@ -53,8 +45,15 @@ const collectChildComponentNames = (
 ): void => {
   walkAst(element, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "JSXOpeningElement")) return;
-    const name = getJsxElementName(child.name);
-    if (!name) return;
+    // Skip JSXMemberExpression children (`<Charts.Bar />`,
+    // `<Foo.Bar.Baz />`). Member-expression children are by
+    // definition not same-file references — they resolve through a
+    // namespace / module. Extracting the trailing identifier and
+    // looking up a same-file component of that name produces false
+    // positives (e.g. `<Charts.Bar />` would collide with a same-file
+    // `Bar` helper that has nothing to do with this boundary).
+    if (!isNodeOfType(child.name, "JSXIdentifier")) return;
+    const name = child.name.name;
     if (!COMPONENT_NAME_PATTERN.test(name)) return;
     into.add(name);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
@@ -1,0 +1,201 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { findProgramRoot } from "../../utils/find-program-root.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// HACK: React 19.2's `<Activity mode="hidden">` preserves state for a
+// subtree but cleans up its Effects. When the boundary becomes visible
+// again, React recreates every Effect — subscriptions, observers,
+// effect-driven setState chains. On dense screens (settings, profile
+// editor, checkout) the visible cost is a "remount storm" on what
+// looks like a free state-preservation primitive. This rule is the
+// narrow v1: report an `<Activity>` with a TOGGLEABLE `mode` wrapping
+// any same-file component that itself uses `useEffect` /
+// `useLayoutEffect`. The user can then audit whether the inner
+// effects belong outside the Activity boundary.
+
+const ACTIVITY_IMPORTED_NAMES = new Set(["Activity", "unstable_Activity"]);
+
+const isStaticVisibleMode = (modeAttribute: EsTreeNodeOfType<"JSXAttribute">): boolean => {
+  const value = modeAttribute.value;
+  if (!value) return false;
+  if (isNodeOfType(value, "Literal")) return value.value === "visible";
+  if (isNodeOfType(value, "JSXExpressionContainer")) {
+    const expression = value.expression;
+    if (isNodeOfType(expression, "Literal")) return expression.value === "visible";
+  }
+  return false;
+};
+
+const getJsxElementName = (node: EsTreeNode): string | null => {
+  if (isNodeOfType(node, "JSXIdentifier")) return node.name;
+  if (isNodeOfType(node, "JSXMemberExpression")) {
+    if (isNodeOfType(node.property, "JSXIdentifier")) return node.property.name;
+  }
+  return null;
+};
+
+const COMPONENT_NAME_PATTERN = /^[A-Z]/;
+
+const collectChildComponentNames = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  into: Set<string>,
+): void => {
+  walkAst(element, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "JSXOpeningElement")) return;
+    const name = getJsxElementName(child.name);
+    if (!name) return;
+    if (!COMPONENT_NAME_PATTERN.test(name)) return;
+    into.add(name);
+  });
+};
+
+const findSameFileComponentBody = (
+  programRoot: EsTreeNode,
+  componentName: string,
+): EsTreeNode | null => {
+  let foundBody: EsTreeNode | null = null;
+  walkAst(programRoot, (node: EsTreeNode) => {
+    if (foundBody) return false;
+    if (isNodeOfType(node, "FunctionDeclaration") && node.id && node.id.name === componentName) {
+      foundBody = node.body;
+      return false;
+    }
+    if (
+      isNodeOfType(node, "VariableDeclarator") &&
+      isNodeOfType(node.id, "Identifier") &&
+      node.id.name === componentName
+    ) {
+      const initializer = node.init;
+      if (
+        isNodeOfType(initializer, "ArrowFunctionExpression") ||
+        isNodeOfType(initializer, "FunctionExpression")
+      ) {
+        foundBody = initializer.body;
+        return false;
+      }
+    }
+  });
+  return foundBody;
+};
+
+const countEffectHookCalls = (body: EsTreeNode | null): number => {
+  if (!body) return 0;
+  let count = 0;
+  walkAst(body, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (isHookCall(child, EFFECT_HOOK_NAMES)) count++;
+  });
+  return count;
+};
+
+export const activityWrapsEffectHeavySubtree = defineRule<Rule>({
+  id: "activity-wraps-effect-heavy-subtree",
+  severity: "warn",
+  requires: ["react:19"],
+  recommendation:
+    "Audit the subtree under `<Activity>` — every hide / show cycle tears down and recreates every Effect inside. Move subscriptions and effect-driven setState chains outside the Activity boundary, or pre-resolve the data above it",
+  create: (context: RuleContext) => {
+    const localActivityNames = new Set<string>();
+
+    const reactNamespaceLocalNames = new Set<string>();
+
+    return {
+      ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
+        if (node.source?.value !== "react") return;
+        for (const specifier of node.specifiers ?? []) {
+          if (isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
+            // `import * as React from "react"` — bind the local name so
+            // `<X.Activity>` can be verified against it.
+            if (isNodeOfType(specifier.local, "Identifier")) {
+              reactNamespaceLocalNames.add(specifier.local.name);
+            }
+            continue;
+          }
+          if (isNodeOfType(specifier, "ImportDefaultSpecifier")) {
+            // `import React from "react"` — same shape, same handling.
+            if (isNodeOfType(specifier.local, "Identifier")) {
+              reactNamespaceLocalNames.add(specifier.local.name);
+            }
+            continue;
+          }
+          if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+          const importedName = getImportedName(specifier);
+          if (!importedName || !ACTIVITY_IMPORTED_NAMES.has(importedName)) continue;
+          if (isNodeOfType(specifier.local, "Identifier")) {
+            localActivityNames.add(specifier.local.name);
+          }
+        }
+      },
+      JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
+        const openingElement = node.openingElement;
+        if (!openingElement) return;
+        const elementName = openingElement.name;
+        let isActivity = false;
+        if (isNodeOfType(elementName, "JSXIdentifier")) {
+          isActivity = localActivityNames.has(elementName.name);
+        } else if (isNodeOfType(elementName, "JSXMemberExpression")) {
+          // `<React.Activity>` namespace form — verify the namespace
+          // resolves to the React default / namespace import (not a
+          // local `<Calendar.Activity>` user component).
+          if (
+            isNodeOfType(elementName.object, "JSXIdentifier") &&
+            reactNamespaceLocalNames.has(elementName.object.name) &&
+            isNodeOfType(elementName.property, "JSXIdentifier")
+          ) {
+            isActivity = ACTIVITY_IMPORTED_NAMES.has(elementName.property.name);
+          }
+        }
+        if (!isActivity) return;
+
+        let modeAttribute: EsTreeNodeOfType<"JSXAttribute"> | null = null;
+        for (const attribute of openingElement.attributes ?? []) {
+          if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+          if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
+          if (attribute.name.name !== "mode") continue;
+          modeAttribute = attribute;
+          break;
+        }
+        // No `mode` prop = default visible = always visible = no
+        // hide/show cycle. Skip.
+        if (!modeAttribute) return;
+        // Statically `mode="visible"` = pinned visible = no cycle.
+        if (isStaticVisibleMode(modeAttribute)) return;
+
+        const childComponentNames = new Set<string>();
+        collectChildComponentNames(node, childComponentNames);
+        // Drop the Activity name itself if a child happens to be a
+        // nested <Activity /> — that's a different rule's concern.
+        for (const activityName of localActivityNames) childComponentNames.delete(activityName);
+        if (childComponentNames.size === 0) return;
+
+        const programRoot = findProgramRoot(node);
+        if (!programRoot) return;
+
+        let totalEffects = 0;
+        const effectfulChildren: string[] = [];
+        for (const componentName of childComponentNames) {
+          const body = findSameFileComponentBody(programRoot, componentName);
+          if (!body) continue;
+          const effectCount = countEffectHookCalls(body);
+          if (effectCount === 0) continue;
+          totalEffects += effectCount;
+          effectfulChildren.push(`<${componentName}>`);
+        }
+        if (totalEffects === 0) return;
+
+        context.report({
+          node: openingElement,
+          message: `<Activity> wraps ${effectfulChildren.join(", ")} which use ${totalEffects} effect hook${totalEffects === 1 ? "" : "s"} — every hide/show cycle recreates them all. Audit the subtree or move subscriptions outside the boundary`,
+        });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
@@ -101,7 +101,9 @@ const countEffectHookCalls = (body: EsTreeNode | null): number => {
 export const activityWrapsEffectHeavySubtree = defineRule<Rule>({
   id: "activity-wraps-effect-heavy-subtree",
   severity: "warn",
-  requires: ["react:19"],
+  // `<Activity>` shipped in React 19.2; gate on the minor-version
+  // capability so the rule stays inert on 19.0 / 19.1 projects.
+  requires: ["react:19.2"],
   recommendation:
     "Audit the subtree under `<Activity>` — every hide / show cycle tears down and recreates every Effect inside. Move subscriptions and effect-driven setState chains outside the Activity boundary, or pre-resolve the data above it",
   create: (context: RuleContext) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
@@ -23,13 +23,16 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const ACTIVITY_IMPORTED_NAMES = new Set(["Activity", "unstable_Activity"]);
 
-const isStaticVisibleMode = (modeAttribute: EsTreeNodeOfType<"JSXAttribute">): boolean => {
+// A statically-known mode value (whether `"visible"`, `"hidden"`, or any
+// other literal) means the boundary has no toggle — and therefore no
+// hide/show cycle, no Effect teardown / recreate, no remount storm.
+// Only flag toggleable shapes like `mode={open ? "visible" : "hidden"}`.
+const isStaticallyKnownMode = (modeAttribute: EsTreeNodeOfType<"JSXAttribute">): boolean => {
   const value = modeAttribute.value;
   if (!value) return false;
-  if (isNodeOfType(value, "Literal")) return value.value === "visible";
+  if (isNodeOfType(value, "Literal")) return true;
   if (isNodeOfType(value, "JSXExpressionContainer")) {
-    const expression = value.expression;
-    if (isNodeOfType(expression, "Literal")) return expression.value === "visible";
+    return isNodeOfType(value.expression, "Literal");
   }
   return false;
 };
@@ -166,8 +169,10 @@ export const activityWrapsEffectHeavySubtree = defineRule<Rule>({
         // No `mode` prop = default visible = always visible = no
         // hide/show cycle. Skip.
         if (!modeAttribute) return;
-        // Statically `mode="visible"` = pinned visible = no cycle.
-        if (isStaticVisibleMode(modeAttribute)) return;
+        // Any statically-known mode value (`"visible"`, `"hidden"`, ...) =
+        // pinned, no toggle, no hide/show cycle. Only TOGGLEABLE modes
+        // trigger the Effect teardown / recreate cost.
+        if (isStaticallyKnownMode(modeAttribute)) return;
 
         const childComponentNames = new Set<string>();
         collectChildComponentNames(node, childComponentNames);


### PR DESCRIPTION
## Why

Catches the React 19.2 \`<Activity>\` footgun documented at [peterp.me/articles/hidden-cost-of-react-activity](https://www.peterp.me/articles/hidden-cost-of-react-activity/). \`<Activity mode="hidden">\` preserves state for a hidden subtree but tears down its Effects. When the boundary becomes visible again, React recreates every subscription, observer, AppState listener, and effect-driven \`setState\`. On a dense screen (settings, profile editor, checkout, bottom sheet) this is a **remount storm** on what looks like a free state-preservation primitive.

The cost doesn't show up when you explain Activity as "state is preserved." It shows up when the user taps back into the screen and it feels heavier than expected.

Before:
\`\`\`tsx
const EditProfileSheet = ({ user }) => {
  useEffect(() => { sub(user.id); return () => unsub(user.id); }, [user.id]);
  useEffect(() => { trackOpen(user.id); }, [user.id]);
  // ...
};

const Screen = ({ open, user }) => (
  <Activity mode={open ? "visible" : "hidden"}>
    <EditProfileSheet user={user} />
  </Activity>
);
// → every show/hide cycle re-subscribes, re-fires trackOpen, etc.
\`\`\`

After:
\`\`\`tsx
// Pull effect work above the Activity boundary so it stays mounted:
const Screen = ({ open, user }) => {
  useSubscription(user.id);  // lifted outside Activity
  useTrackOpen(user.id);
  return (
    <Activity mode={open ? "visible" : "hidden"}>
      <EditProfileSheet user={user} />
    </Activity>
  );
};
\`\`\`

## What changed

- Added \`activity-wraps-effect-heavy-subtree\` (\`warn\` severity, \`requires: ["react:19"]\`).
- **Detection surface (v1, narrow on purpose):** \`<Activity>\` with a TOGGLEABLE \`mode\` (\`mode={x}\` where \`x\` isn't statically \`"visible"\`) wrapping any same-file component whose body contains \`useEffect\` / \`useLayoutEffect\`.
- **Import scope:**
  - Named: \`import { Activity } from "react"\`.
  - Aliased: \`import { unstable_Activity as Activity } from "react"\`.
  - Namespaced: \`<React.Activity>\` via \`import React from "react"\` or \`import * as React from "react"\` — verifies the namespace IS the React import (\`<Calendar.Activity>\` from a user library stays quiet).
- **Diagnostic shape:** names the inner effectful children + effect count so the user knows exactly what to audit.
- **Skips:** \`mode="visible"\` (no toggle), missing \`mode\` (defaults to visible), effect-free children, cross-file components (out of v1 scope — single-file linter model), \`<Activity>\` with no JSX children.

## Eval results

RDE not run — local runner is \`git clone\` + \`npm install\` bound. React 19.2 + Activity is brand new (released in late 2025); the corpus will have ~0 hits for a while. The rule's intended audience is teams about to adopt Activity who don't yet know about the effect-teardown semantics. **13 co-located tests** cover named / aliased / namespaced (default + namespace) imports, static-vs-toggleable mode, multi-child aggregation, the negative case for \`<Calendar.Activity>\` masquerading, missing mode, and effect-free subtrees.

This is the **first React Doctor rule that walks JSX nesting context** (children of a parent element). The implementation is single-file by design — cross-file component analysis isn't feasible in the current oxlint plugin model and would substantially change the rule's complexity. The v1 boundary is explicit in the rule comment so future work knows what to extend.

## Test plan

- \`pnpm exec vp test run src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.test.ts\` → 13 passed
- \`pnpm --filter oxlint-plugin-react-doctor typecheck\` → passes (\`289 rules\` registered)
- \`npx vp fmt --check\` → clean
- \`npx vp lint\` → clean

## Notes for review

This is the most architecturally novel of the four peterp.me-derived rules in flight (#529, #530, #531, this one). Specific design choices worth confirming:

1. **Single-file scope.** Cross-file component lookup would require a different plugin model. Acceptable for v1?
2. **\`requires: ["react:19"]\`.** Inert on pre-19 codebases. Should we also gate on \`react-native\` since the post is RN-focused? My read: Activity is a React API, the cost applies to any framework — left it as React-only gate.
3. **Multi-child aggregation.** The diagnostic message lists every effectful same-file child + the total effect count. Lots of context, but informative.
4. **Severity warn, not error.** Activity isn't always wrong — it's wrong on dense subtrees. The rule is a prompt-to-audit, not a hard rejection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New AST rule with same-file JSX parent/child analysis and semver parsing for capabilities; well-tested and warn-only, but version-gate optimism on unparseable specs can surface the rule on 19.0/19.1 edge cases.
> 
> **Overview**
> Adds **React minor-version parsing** (`parseReactMajorMinor`, `isReactAtLeast`) and wires a new **`react:19.2`** oxlint capability so rules can target APIs that landed after React 19.0 (e.g. `<Activity>`).
> 
> Introduces the **`activity-wraps-effect-heavy-subtree`** warn rule (`requires: react:19.2`): it flags React `<Activity>` boundaries with a **toggleable** `mode` that wrap **same-file** children using `useEffect` / `useLayoutEffect`, with import handling for named, aliased, and `React.Activity` forms and guards against static modes, cross-file children, and false positives from member-expression JSX or non-React `Activity` components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebde5b50a0dd863c2948439451ec63392933dd36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->