### PR TITLE
feat(cli): add --triage flag for AI-powered diagnostic filtering

### DIFF
--- a/.github/workflows/publish-any-commit.yml
+++ b/.github/workflows/publish-any-commit.yml
@@ -1,0 +1,46 @@
+name: Publish Any Commit
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish packages (retry on transient failures)
+        run: |
+          max_attempts=4
+          attempt=1
+          while [ "$attempt" -le "$max_attempts" ]; do
+            if pnpm dlx pkg-pr-new publish \
+              ./packages/react-doctor \
+              ./packages/eslint-plugin-react-doctor \
+              ./packages/oxlint-plugin-react-doctor; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              exit 1
+            fi
+
+            sleep_seconds=$((2 ** attempt))
+            echo "pkg-pr-new publish failed on attempt ${attempt}/${max_attempts}; retrying in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
+            attempt=$((attempt + 1))
+          done

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -55,6 +55,7 @@
     "test": "vp test run"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.150",
     "@effect/platform-node-shared": "4.0.0-beta.70",
     "agent-install": "0.0.5",
     "conf": "^15.1.0",

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -47,6 +47,7 @@ import { resolveEffectiveDiff } from "../utils/resolve-effective-diff.js";
 import { resolveFailOnLevel } from "../utils/resolve-fail-on-level.js";
 import { resolveProjectDiffIncludePaths } from "../utils/resolve-project-diff-include-paths.js";
 import { runExplain } from "../utils/run-explain.js";
+import { runTriage } from "../utils/run-triage.js";
 import { selectProjects } from "../utils/select-projects.js";
 import { shouldFailForDiagnostics } from "../utils/should-fail-for-diagnostics.js";
 import { shouldSkipPrompts } from "../utils/should-skip-prompts.js";
@@ -214,6 +215,19 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
           resolvedDirectory,
           startTime,
         });
+
+        if (flags.triage && !isQuiet) {
+          const triageDiagnostics = filterDiagnosticsForSurface(
+            remappedDiagnostics,
+            scanOptions.outputSurface ?? "cli",
+            userConfig,
+          );
+          await runTriage({
+            diagnostics: triageDiagnostics,
+            rootDirectory: resolvedDirectory,
+            verbose: Boolean(flags.verbose),
+          });
+        }
       } finally {
         snapshot.cleanup();
       }
@@ -312,6 +326,19 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       resolvedDirectory,
       startTime,
     });
+
+    if (flags.triage && !isQuiet) {
+      const triageDiagnostics = filterDiagnosticsForSurface(
+        allDiagnostics,
+        scanOptions.outputSurface ?? "cli",
+        userConfig,
+      );
+      await runTriage({
+        diagnostics: triageDiagnostics,
+        rootDirectory: resolvedDirectory,
+        verbose: Boolean(flags.verbose),
+      });
+    }
 
     const setupProjectRoot = resolveInstallSetupProjectRoot({
       scanRoot: resolvedDirectory,

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -58,6 +58,10 @@ const program = new Command()
     "--no-respect-inline-disables",
     "audit mode: neutralize inline lint suppressions before scanning",
   )
+  .option(
+    "--triage",
+    "after the scan, hand diagnostics to Claude (Agent SDK) for false-positive filtering and P0-P3 prioritization (uses your Claude subscription if you've run `claude setup-token` or `claude /login`; otherwise set ANTHROPIC_API_KEY)",
+  )
   .addHelpText(
     "after",
     `

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -14,3 +14,20 @@ export const SETUP_PROMPT_DELAY_MS = 100;
 // stdout valid JSON so downstream parsers don't see a half-written report.
 export const INTERNAL_ERROR_JSON_FALLBACK =
   '{"schemaVersion":1,"ok":false,"error":{"message":"Internal error","name":"Error","chain":[]}}\n';
+
+// --triage caps. We hand every surviving diagnostic to Claude in a single
+// prompt; these guardrails keep prompt size and runtime bounded on very
+// noisy projects without silently dropping work mid-list.
+export const TRIAGE_MAX_DIAGNOSTICS_COUNT = 200;
+export const TRIAGE_MAX_TURNS = 30;
+export const TRIAGE_TIMEOUT_MS = 300_000;
+// Auth sources, listed in preferred order. The Agent SDK accepts any of:
+// 1. CLAUDE_CODE_OAUTH_TOKEN — `claude setup-token` against a Pro/Max plan
+// 2. ANTHROPIC_API_KEY — a console API key (pay-as-you-go billing)
+// 3. existing Claude Code login — credentials cached in ~/.claude/ by the
+//    bundled `claude` binary; the SDK picks these up automatically when no
+//    env var is set, so users who already ran `claude /login` need nothing.
+export const TRIAGE_OAUTH_TOKEN_ENV_VARIABLE = "CLAUDE_CODE_OAUTH_TOKEN";
+export const TRIAGE_API_KEY_ENV_VARIABLE = "ANTHROPIC_API_KEY";
+export const TRIAGE_MODEL_ENV_VARIABLE = "REACT_DOCTOR_TRIAGE_MODEL";
+export const TRIAGE_DEFAULT_MODEL = "claude-sonnet-4-5";

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -16,10 +16,10 @@ export const INTERNAL_ERROR_JSON_FALLBACK =
   '{"schemaVersion":1,"ok":false,"error":{"message":"Internal error","name":"Error","chain":[]}}\n';
 
 // --triage caps. We hand every surviving diagnostic to Claude in a single
-// prompt; these guardrails keep prompt size and runtime bounded on very
-// noisy projects without silently dropping work mid-list.
+// prompt; this cap keeps the prompt size bounded on noisy projects without
+// silently dropping work mid-list. No wall-clock timeout — the SDK runs
+// until Claude returns a result or the user Ctrl-Cs.
 export const TRIAGE_MAX_DIAGNOSTICS_COUNT = 200;
-export const TRIAGE_TIMEOUT_MS = 300_000;
 // Auth sources, listed in preferred order. The Agent SDK accepts any of:
 // 1. CLAUDE_CODE_OAUTH_TOKEN — `claude setup-token` against a Pro/Max plan
 // 2. ANTHROPIC_API_KEY — a console API key (pay-as-you-go billing)

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -19,7 +19,6 @@ export const INTERNAL_ERROR_JSON_FALLBACK =
 // prompt; these guardrails keep prompt size and runtime bounded on very
 // noisy projects without silently dropping work mid-list.
 export const TRIAGE_MAX_DIAGNOSTICS_COUNT = 200;
-export const TRIAGE_MAX_TURNS = 30;
 export const TRIAGE_TIMEOUT_MS = 300_000;
 // Auth sources, listed in preferred order. The Agent SDK accepts any of:
 // 1. CLAUDE_CODE_OAUTH_TOKEN — `claude setup-token` against a Pro/Max plan
@@ -30,4 +29,4 @@ export const TRIAGE_TIMEOUT_MS = 300_000;
 export const TRIAGE_OAUTH_TOKEN_ENV_VARIABLE = "CLAUDE_CODE_OAUTH_TOKEN";
 export const TRIAGE_API_KEY_ENV_VARIABLE = "ANTHROPIC_API_KEY";
 export const TRIAGE_MODEL_ENV_VARIABLE = "REACT_DOCTOR_TRIAGE_MODEL";
-export const TRIAGE_DEFAULT_MODEL = "claude-sonnet-4-5";
+export const TRIAGE_DEFAULT_MODEL = "claude-opus-4-7";

--- a/packages/react-doctor/src/cli/utils/detect-claude-code-auth.ts
+++ b/packages/react-doctor/src/cli/utils/detect-claude-code-auth.ts
@@ -1,0 +1,31 @@
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+// Locations the bundled Claude Code CLI caches credentials after
+// `claude /login` or `claude setup-token`. We check existence + non-empty
+// size (not contents) so we don't accidentally read tokens off disk — the
+// SDK reads them itself. Paths are POSIX-ish; Windows users authenticated
+// via Claude Code share the same layout under the user profile thanks to
+// `os.homedir()`.
+const CLAUDE_CODE_AUTH_CANDIDATE_PATHS: ReadonlyArray<string> = [
+  ".claude/.credentials.json",
+  ".claude/credentials.json",
+  ".config/claude/credentials.json",
+];
+
+const isNonEmptyFile = (filePath: string): boolean => {
+  try {
+    const fileStats = statSync(filePath);
+    return fileStats.isFile() && fileStats.size > 0;
+  } catch {
+    return false;
+  }
+};
+
+export const hasLocalClaudeCodeAuth = (homeDirectory: string = homedir()): boolean => {
+  if (!homeDirectory) return false;
+  return CLAUDE_CODE_AUTH_CANDIDATE_PATHS.some((relativePath) =>
+    isNonEmptyFile(path.join(homeDirectory, relativePath)),
+  );
+};

--- a/packages/react-doctor/src/cli/utils/inspect-flags.ts
+++ b/packages/react-doctor/src/cli/utils/inspect-flags.ts
@@ -20,4 +20,5 @@ export interface InspectFlags {
   explain?: string;
   why?: string;
   failOn?: string;
+  triage?: boolean;
 }

--- a/packages/react-doctor/src/cli/utils/render-triage.ts
+++ b/packages/react-doctor/src/cli/utils/render-triage.ts
@@ -1,0 +1,166 @@
+import isUnicodeSupported from "is-unicode-supported";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import { groupBy, highlighter, MILLISECONDS_PER_SECOND, toRelativePath } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
+import { indentMultilineText } from "./indent-multiline-text.js";
+import type { TriageOutcome, TriagePriority, TriageVerdict } from "./triage.js";
+
+const POINTER = isUnicodeSupported() ? "›" : ">";
+const ERROR_GLYPH = isUnicodeSupported() ? "✗" : "X";
+const WARNING_GLYPH = isUnicodeSupported() ? "⚠" : "!";
+
+interface PriorityDescriptor {
+  readonly priority: TriagePriority;
+  readonly heading: string;
+  readonly colorize: (text: string) => string;
+  readonly glyph: string;
+}
+
+const PRIORITY_DESCRIPTORS: ReadonlyArray<PriorityDescriptor> = [
+  { priority: "P0", heading: "Critical (P0)", colorize: highlighter.error, glyph: ERROR_GLYPH },
+  { priority: "P1", heading: "Should fix (P1)", colorize: highlighter.error, glyph: ERROR_GLYPH },
+  { priority: "P2", heading: "Fix soon (P2)", colorize: highlighter.warn, glyph: WARNING_GLYPH },
+  { priority: "P3", heading: "Nice to have (P3)", colorize: highlighter.dim, glyph: WARNING_GLYPH },
+];
+
+const getDescriptor = (priority: TriagePriority): PriorityDescriptor =>
+  PRIORITY_DESCRIPTORS.find((descriptor) => descriptor.priority === priority) ??
+  PRIORITY_DESCRIPTORS[0];
+
+const formatLocation = (diagnostic: Diagnostic, rootDirectory: string): string =>
+  `${toRelativePath(diagnostic.filePath, rootDirectory)}:${String(diagnostic.line)}`;
+
+const formatVerdictBlock = (
+  verdict: TriageVerdict,
+  rootDirectory: string,
+): ReadonlyArray<string> => {
+  const descriptor = getDescriptor(verdict.priority);
+  const ruleKey = `${verdict.diagnostic.plugin}/${verdict.diagnostic.rule}`;
+  return [
+    `    ${descriptor.colorize(descriptor.glyph)} ${descriptor.colorize(ruleKey)} ${highlighter.dim(formatLocation(verdict.diagnostic, rootDirectory))}`,
+    highlighter.gray(indentMultilineText(verdict.title, "        ")),
+    highlighter.gray(indentMultilineText(verdict.description, "        ")),
+  ];
+};
+
+const formatKeptSection = (
+  verdicts: ReadonlyArray<TriageVerdict>,
+  rootDirectory: string,
+): ReadonlyArray<string> => {
+  const groupedByPriority = groupBy([...verdicts], (verdict) => verdict.priority);
+  const lines: string[] = [
+    `${highlighter.bold(`${POINTER} Kept by Claude`)} ${highlighter.dim(`(${String(verdicts.length)})`)}`,
+    "",
+  ];
+  for (const descriptor of PRIORITY_DESCRIPTORS) {
+    const bucket = groupedByPriority.get(descriptor.priority) ?? [];
+    if (bucket.length === 0) continue;
+    lines.push(
+      `  ${descriptor.colorize(descriptor.heading)} ${highlighter.dim(`(${String(bucket.length)})`)}`,
+    );
+    for (const verdict of bucket) {
+      lines.push(...formatVerdictBlock(verdict, rootDirectory), "");
+    }
+  }
+  return lines;
+};
+
+const formatSuppressedSection = (
+  suppressed: ReadonlyArray<Diagnostic>,
+  rootDirectory: string,
+  verbose: boolean,
+): ReadonlyArray<string> => {
+  if (suppressed.length === 0) return [];
+
+  const lines: string[] = [
+    `${highlighter.bold(`${POINTER} Suppressed by Claude`)} ${highlighter.dim(`(${String(suppressed.length)})`)}`,
+    highlighter.gray("    react-doctor flagged these, but Claude reviewed them in this codebase"),
+    highlighter.gray("    and considers them false positives or low signal."),
+    "",
+  ];
+  if (!verbose) {
+    lines.push(highlighter.dim("    Run with --verbose to see each suppressed diagnostic."), "");
+    return lines;
+  }
+
+  const groupedByRule = groupBy(
+    [...suppressed],
+    (diagnostic) => `${diagnostic.plugin}/${diagnostic.rule}`,
+  );
+  for (const [ruleKey, diagnostics] of groupedByRule) {
+    lines.push(
+      `    ${highlighter.gray(ruleKey)} ${highlighter.dim(`(${String(diagnostics.length)})`)}`,
+    );
+    for (const diagnostic of diagnostics) {
+      lines.push(highlighter.gray(`      ${formatLocation(diagnostic, rootDirectory)}`));
+    }
+    lines.push("");
+  }
+  return lines;
+};
+
+const formatCostFragment = (totalCostUsd: number | null): string => {
+  if (totalCostUsd === null || totalCostUsd <= 0) return "";
+  return totalCostUsd < 0.01 ? " · <$0.01" : ` · $${totalCostUsd.toFixed(2)}`;
+};
+
+const formatSummaryLine = (outcome: TriageOutcome): string => {
+  const keptBreakdown = PRIORITY_DESCRIPTORS.map((descriptor) => {
+    const count = outcome.kept.filter((verdict) => verdict.priority === descriptor.priority).length;
+    return `${descriptor.priority}:${String(count)}`;
+  }).join(" ");
+  const elapsedSeconds = (outcome.elapsedMilliseconds / MILLISECONDS_PER_SECOND).toFixed(1);
+  return [
+    `${highlighter.bold(`${POINTER} Triage`)} → ${highlighter.bold(`${String(outcome.kept.length)} kept`)} (${highlighter.gray(keptBreakdown)}) · ${String(outcome.suppressed.length)} suppressed`,
+    highlighter.dim(
+      `${elapsedSeconds}s · model: ${outcome.model}${formatCostFragment(outcome.totalCostUsd)}`,
+    ),
+  ].join(" · ");
+};
+
+export interface PrintTriageOutcomeInput {
+  readonly outcome: TriageOutcome;
+  readonly rootDirectory: string;
+  readonly verbose: boolean;
+}
+
+export const printTriageOutcome = (input: PrintTriageOutcomeInput): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const { outcome, rootDirectory, verbose } = input;
+    yield* Console.log("");
+
+    if (outcome.kept.length === 0 && outcome.suppressed.length === 0) {
+      yield* Console.log(highlighter.dim("  No diagnostics to triage."));
+      return;
+    }
+
+    if (outcome.overflowed > 0) {
+      yield* Console.log(
+        highlighter.warn(
+          `  ${String(outcome.overflowed)} diagnostics were skipped from triage to stay within the per-run cap — run on a tighter scope (e.g. --diff or --project <name>) to triage everything.`,
+        ),
+      );
+      yield* Console.log("");
+    }
+
+    if (outcome.kept.length === 0) {
+      yield* Console.log(
+        highlighter.success(
+          "  Claude reviewed every diagnostic and considers them all false positives in this codebase.",
+        ),
+      );
+      yield* Console.log("");
+    } else {
+      for (const line of formatKeptSection(outcome.kept, rootDirectory)) {
+        yield* Console.log(line);
+      }
+    }
+
+    for (const line of formatSuppressedSection(outcome.suppressed, rootDirectory, verbose)) {
+      yield* Console.log(line);
+    }
+
+    yield* Console.log(formatSummaryLine(outcome));
+    yield* Console.log("");
+  });

--- a/packages/react-doctor/src/cli/utils/run-triage.ts
+++ b/packages/react-doctor/src/cli/utils/run-triage.ts
@@ -1,0 +1,91 @@
+import * as Effect from "effect/Effect";
+import { highlighter } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
+import { cliLogger as logger } from "./cli-logger.js";
+import { TRIAGE_API_KEY_ENV_VARIABLE, TRIAGE_OAUTH_TOKEN_ENV_VARIABLE } from "./constants.js";
+import { hasLocalClaudeCodeAuth } from "./detect-claude-code-auth.js";
+import { printTriageOutcome } from "./render-triage.js";
+import { spinner } from "./spinner.js";
+import { triageDiagnostics, type TriageProgressEvent } from "./triage.js";
+
+export interface RunTriageInput {
+  readonly diagnostics: ReadonlyArray<Diagnostic>;
+  readonly rootDirectory: string;
+  readonly verbose: boolean;
+}
+
+const MISSING_AUTH_WARNING_LINES: ReadonlyArray<string> = [
+  "--triage skipped: no Claude credentials found.",
+  "  Pick one of these to enable triage:",
+  "    • Use your Claude subscription: run `claude setup-token` (or `claude /login`) — recommended if you already pay for Pro/Max",
+  `    • Use an API key: set ${TRIAGE_API_KEY_ENV_VARIABLE} from https://console.anthropic.com/`,
+];
+
+const resolveAuthDisplayLabel = (): string | null => {
+  if (process.env[TRIAGE_OAUTH_TOKEN_ENV_VARIABLE]) return "Claude subscription";
+  if (process.env[TRIAGE_API_KEY_ENV_VARIABLE]) return "Anthropic API key";
+  if (hasLocalClaudeCodeAuth()) return "Claude Code login";
+  return null;
+};
+
+const buildSpinnerLabel = (diagnosticCount: number, authLabel: string): string =>
+  `Triaging ${diagnosticCount} ${diagnosticCount === 1 ? "diagnostic" : "diagnostics"} with Claude (${authLabel})…`;
+
+const buildSpinnerUpdate = (event: TriageProgressEvent, baseLabel: string): string => {
+  if (event.kind === "tool") return `${baseLabel} ${event.summary}`;
+  if (event.kind === "thinking") return `${baseLabel} thinking`;
+  return baseLabel;
+};
+
+const formatTriageError = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
+
+export const runTriage = async (input: RunTriageInput): Promise<void> => {
+  if (input.diagnostics.length === 0) {
+    logger.dim("  No diagnostics to triage — skipping --triage.");
+    logger.break();
+    return;
+  }
+
+  const authLabel = resolveAuthDisplayLabel();
+  if (!authLabel) {
+    for (const line of MISSING_AUTH_WARNING_LINES) logger.warn(line);
+    logger.break();
+    return;
+  }
+
+  const baseLabel = buildSpinnerLabel(input.diagnostics.length, authLabel);
+  const triageSpinner = spinner(baseLabel).start();
+
+  try {
+    const outcome = await triageDiagnostics({
+      diagnostics: input.diagnostics,
+      workingDirectory: input.rootDirectory,
+      onProgress: (event) => triageSpinner.update(buildSpinnerUpdate(event, baseLabel)),
+    });
+    triageSpinner.succeed(
+      `${baseLabel.replace(/…$/, "")} ${highlighter.success(`→ ${String(outcome.kept.length)} kept · ${String(outcome.suppressed.length)} suppressed`)}`,
+    );
+    await Effect.runPromise(
+      printTriageOutcome({
+        outcome,
+        rootDirectory: input.rootDirectory,
+        verbose: input.verbose,
+      }),
+    );
+  } catch (error) {
+    triageSpinner.fail(`Triage failed: ${formatTriageError(error)}`);
+    logger.break();
+    logger.dim(
+      "  The base diagnostics above are unchanged — fall back to them, or rerun with --triage once the issue clears.",
+    );
+    logger.break();
+  }
+};

--- a/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
+++ b/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
@@ -25,6 +25,7 @@ const ROOT_FLAG_SPEC: CliFlagSpec = {
     "--respect-inline-disables",
     "--score",
     "--staged",
+    "--triage",
     "--verbose",
     "--version",
     "--yes",

--- a/packages/react-doctor/src/cli/utils/triage-instructions.ts
+++ b/packages/react-doctor/src/cli/utils/triage-instructions.ts
@@ -4,10 +4,15 @@
 // against the working directory, so the prompt drops the diff/PR framing
 // and forbids net-new findings — the agent's only job is to confirm or
 // suppress the diagnostics react-doctor produced.
+//
+// These instructions live in the user message (alongside the diagnostic
+// list), NOT in `systemPrompt`. Leaving `systemPrompt` unset preserves the
+// Claude Agent SDK's default minimal system prompt, which the bundled CLI
+// uses to set up its built-in tools — overriding it would lose that.
 
 import { TRIAGE_MAX_DIAGNOSTICS_COUNT } from "./constants.js";
 
-export const getTriageSystemPrompt = (): string => `# React Doctor Triage
+export const getTriageInstructions = (): string => `# React Doctor Triage
 
 You are an expert React reviewer triaging a local react-doctor scan.
 
@@ -15,9 +20,9 @@ react-doctor is a static-analysis tool that catches React bugs, accessibility is
 
 The repository is checked out at the working directory. Use Read, Glob, and Grep to investigate each diagnostic. Never edit, write, or run shell commands — you are read-only.
 
-## STEP 1: Read every diagnostic in the user message
+## STEP 1: Read every diagnostic
 
-The user message contains a numbered list under \`## Diagnostics\`. Each entry has the rule key, file path, line number, severity, message, and (when available) the rule's documentation URL and help text. Treat each as a STARTING HYPOTHESIS, not a verdict.
+Below this section you'll find a numbered list under \`## Diagnostics\`. Each entry has the rule key, file path, line number, severity, message, and (when available) the rule's documentation URL and help text. Treat each as a STARTING HYPOTHESIS, not a verdict.
 
 ## STEP 2: Open the code before deciding
 

--- a/packages/react-doctor/src/cli/utils/triage-system-prompt.ts
+++ b/packages/react-doctor/src/cli/utils/triage-system-prompt.ts
@@ -1,0 +1,97 @@
+// Source: adapted from millionco/react-review's getAgentReviewSystemPrompt
+// (apps/web/lib/server/review/agent-review-prompt.ts). The GitHub bot
+// triages PR-diff diagnostics; this CLI variant triages a full local scan
+// against the working directory, so the prompt drops the diff/PR framing
+// and forbids net-new findings — the agent's only job is to confirm or
+// suppress the diagnostics react-doctor produced.
+
+import { TRIAGE_MAX_DIAGNOSTICS_COUNT } from "./constants.js";
+
+export const getTriageSystemPrompt = (): string => `# React Doctor Triage
+
+You are an expert React reviewer triaging a local react-doctor scan.
+
+react-doctor is a static-analysis tool that catches React bugs, accessibility issues, and architecture smells. It runs every rule against every matching file, so noisy projects routinely produce dozens of diagnostics — many of which are false positives in the project's actual context. Your job is to read each diagnostic, open the relevant source file, and decide whether it is a real issue worth the developer's time.
+
+The repository is checked out at the working directory. Use Read, Glob, and Grep to investigate each diagnostic. Never edit, write, or run shell commands — you are read-only.
+
+## STEP 1: Read every diagnostic in the user message
+
+The user message contains a numbered list under \`## Diagnostics\`. Each entry has the rule key, file path, line number, severity, message, and (when available) the rule's documentation URL and help text. Treat each as a STARTING HYPOTHESIS, not a verdict.
+
+## STEP 2: Open the code before deciding
+
+For each diagnostic, Read the file at the reported line (and a few lines of context) before making a call. When the rule depends on cross-file behavior (e.g. "this component receives a function prop"), follow the references with Grep or Read until you have enough evidence.
+
+Do NOT suppress a diagnostic without using Read on the file in question first. Confidence requires evidence.
+
+## STEP 3: Decide keep vs. suppress
+
+For each diagnostic, choose one:
+
+- **Keep** — the issue is real in this codebase. Emit a single \`<triage>\` tag (see Output Format) with a priority and a 1-2 sentence description that paraphrases the rule's message with project-specific context (e.g. "this fetch in \`useUserProfile\` never aborts on userId change, so a stale response can overwrite the new one"). Include the actionable fix when the rule's help text gives you one.
+- **Suppress** — the diagnostic is a false positive in this code's actual context. Omit the tag entirely. **Omission is the suppression mechanism** — do not emit a \`<triage>\` for it and do not emit any other tag explaining why.
+
+When unsure, KEEP. The cost of one extra finding is much less than the cost of silently dropping a real bug.
+
+## STEP 4: Assign a priority
+
+Use the same P0-P3 scale react-review uses. Calibrate by real-world impact in THIS codebase, not by the rule's default severity.
+
+### [P0] Critical - Must fix
+- Security vulnerabilities (injection, auth bypass, secrets, hardcoded credentials)
+- Data corruption (race conditions, state mutations across renders, transactions)
+- Crashes (null access on a hot path, unhandled promise rejections, infinite renders)
+- Breaking accessibility regressions (missing alt on hero imagery, broken keyboard nav on primary CTAs)
+
+### [P1] High - Should fix
+- Logic errors (wrong dependency arrays causing stale closures, missing cleanup)
+- Resource leaks (uncancelled fetches, leaked subscriptions, unbounded effects)
+- Mid-severity accessibility issues (missing labels on form fields, low contrast)
+- React anti-patterns with observable symptoms (derived state out of sync, mirrored props)
+
+### [P2] Medium - Fix soon
+- Edge cases (null/empty/boundary handling)
+- Performance smells with measurable impact (large lists without keys, expensive renders)
+- Type safety holes (\`any\` on a hot path, missing prop types)
+- Bundle-size regressions
+
+### [P3] Low - Nice to have
+- Code clarity improvements
+- Minor refactoring opportunities
+- Low-impact style guidance
+
+## DO NOT REPORT
+- Findings react-doctor did NOT flag. This is a triage tool, not a new-issue generator — you may only emit \`<triage>\` tags for diagnostics that appear in the input list, identified by their exact \`<rule>\`, \`<file>\`, and \`<line>\` values.
+- Style preferences or formatting
+- Theoretical issues with no observed impact in this codebase
+
+## Output Format
+
+For each KEPT diagnostic, emit one \`<triage>\` tag. Tags MUST appear at the top level of your reply, not inside code fences or other tags.
+
+Required attributes:
+- \`priority\`: P0, P1, P2, or P3
+- \`rule\`: the exact rule key from the input (e.g. \`react-doctor/no-fetch-in-effect\`)
+- \`file\`: the exact file path from the input
+- \`line\`: the exact line number from the input
+- \`title\`: short issue title (under ~80 characters)
+
+The content inside the tag should be a 1-2 sentence description rewritten with project-specific context.
+
+Example output (two confirmed, several suppressed via omission):
+
+<triage priority="P0" rule="react-doctor/no-fetch-in-effect" file="src/hooks/use-user.ts" line="18" title="Fetch in useEffect leaks on rapid userId changes">
+This effect fetches the user but never cancels in-flight requests when \`userId\` changes mid-flight, so an older response can clobber a newer one. Scope an AbortController to the effect and abort it from the cleanup.
+</triage>
+
+<triage priority="P1" rule="react-doctor/no-array-index-as-key" file="src/components/comment-list.tsx" line="42" title="Index key causes comment text to swap on reorder">
+Comments are user-editable and re-sorted by timestamp, so using the array index as the key makes React reuse the wrong DOM nodes when a comment is added at the top. Use \`comment.id\` instead.
+</triage>
+
+After listing the kept findings, stop. Do not add a summary section, a "Suppressed" section, or any prose outside the tags.
+
+If every diagnostic is a false positive in this codebase, output nothing at all — silence is preferable to noise.
+
+Cap your output at ${String(TRIAGE_MAX_DIAGNOSTICS_COUNT)} \`<triage>\` tags total.
+`;

--- a/packages/react-doctor/src/cli/utils/triage.ts
+++ b/packages/react-doctor/src/cli/utils/triage.ts
@@ -5,7 +5,6 @@ import {
   TRIAGE_DEFAULT_MODEL,
   TRIAGE_MAX_DIAGNOSTICS_COUNT,
   TRIAGE_MODEL_ENV_VARIABLE,
-  TRIAGE_TIMEOUT_MS,
 } from "./constants.js";
 import { getTriageInstructions } from "./triage-instructions.js";
 
@@ -202,51 +201,43 @@ export const triageDiagnostics = async (input: TriageRunInput): Promise<TriageOu
   const overflowed = Math.max(0, input.diagnostics.length - TRIAGE_MAX_DIAGNOSTICS_COUNT);
   const triageInput = input.diagnostics.slice(0, TRIAGE_MAX_DIAGNOSTICS_COUNT);
   const model = process.env[TRIAGE_MODEL_ENV_VARIABLE] ?? TRIAGE_DEFAULT_MODEL;
-
-  const abortController = new AbortController();
-  const timeoutHandle = setTimeout(() => abortController.abort(), TRIAGE_TIMEOUT_MS);
   const startedAtMilliseconds = Date.now();
 
   let responseText = "";
   let totalCostUsd: number | null = null;
 
-  try {
-    const queryStream = query({
-      prompt: buildUserPrompt(triageInput, input.workingDirectory),
-      options: {
-        model,
-        // `systemPrompt` is intentionally unset so the SDK keeps its default
-        // minimal system prompt for the bundled `claude` binary. Our triage
-        // rules ride in the user message (see `buildUserPrompt`).
-        cwd: input.workingDirectory,
-        permissionMode: "bypassPermissions",
-        includePartialMessages: false,
-        abortController,
-        // Coding-agent settings sources (Skills, CLAUDE.md, plugins) would
-        // pull in the user's local Claude Code config — that's irrelevant
-        // for a one-shot triage and risks bloating the context window with
-        // unrelated guidance, so we disable every filesystem source.
-        settingSources: [],
-      },
-    });
+  const queryStream = query({
+    prompt: buildUserPrompt(triageInput, input.workingDirectory),
+    options: {
+      model,
+      // `systemPrompt` is intentionally unset so the SDK keeps its default
+      // minimal system prompt for the bundled `claude` binary. Our triage
+      // rules ride in the user message (see `buildUserPrompt`).
+      cwd: input.workingDirectory,
+      permissionMode: "bypassPermissions",
+      includePartialMessages: false,
+      // Coding-agent settings sources (Skills, CLAUDE.md, plugins) would
+      // pull in the user's local Claude Code config — that's irrelevant
+      // for a one-shot triage and risks bloating the context window with
+      // unrelated guidance, so we disable every filesystem source.
+      settingSources: [],
+    },
+  });
 
-    input.onProgress?.({ kind: "started" });
+  input.onProgress?.({ kind: "started" });
 
-    for await (const message of queryStream) {
-      if (message.type === "assistant") {
-        reportAssistantProgress(message, input.onProgress);
-        continue;
-      }
-      if (message.type !== "result") continue;
-      totalCostUsd = message.total_cost_usd;
-      if (message.subtype === "success") {
-        responseText = message.result;
-      } else {
-        throw new Error(formatSdkErrorMessage(message.subtype, message.errors));
-      }
+  for await (const message of queryStream) {
+    if (message.type === "assistant") {
+      reportAssistantProgress(message, input.onProgress);
+      continue;
     }
-  } finally {
-    clearTimeout(timeoutHandle);
+    if (message.type !== "result") continue;
+    totalCostUsd = message.total_cost_usd;
+    if (message.subtype === "success") {
+      responseText = message.result;
+    } else {
+      throw new Error(formatSdkErrorMessage(message.subtype, message.errors));
+    }
   }
 
   const keptIdentities = new Set<string>();

--- a/packages/react-doctor/src/cli/utils/triage.ts
+++ b/packages/react-doctor/src/cli/utils/triage.ts
@@ -1,0 +1,285 @@
+import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { toRelativePath } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
+import {
+  TRIAGE_DEFAULT_MODEL,
+  TRIAGE_MAX_DIAGNOSTICS_COUNT,
+  TRIAGE_MAX_TURNS,
+  TRIAGE_MODEL_ENV_VARIABLE,
+  TRIAGE_TIMEOUT_MS,
+} from "./constants.js";
+import { getTriageSystemPrompt } from "./triage-system-prompt.js";
+
+const TRIAGE_PRIORITIES = ["P0", "P1", "P2", "P3"] as const;
+export type TriagePriority = (typeof TRIAGE_PRIORITIES)[number];
+
+export interface TriageVerdict {
+  readonly diagnostic: Diagnostic;
+  readonly priority: TriagePriority;
+  readonly title: string;
+  readonly description: string;
+}
+
+export interface TriageOutcome {
+  readonly kept: ReadonlyArray<TriageVerdict>;
+  readonly suppressed: ReadonlyArray<Diagnostic>;
+  readonly overflowed: number;
+  readonly elapsedMilliseconds: number;
+  readonly totalCostUsd: number | null;
+  readonly model: string;
+}
+
+export type TriageProgressEvent =
+  | { readonly kind: "started" }
+  | { readonly kind: "tool"; readonly toolName: string; readonly summary: string }
+  | { readonly kind: "thinking" };
+
+export interface TriageRunInput {
+  readonly diagnostics: ReadonlyArray<Diagnostic>;
+  readonly workingDirectory: string;
+  readonly onProgress?: (event: TriageProgressEvent) => void;
+}
+
+const TRIAGE_TAG_PATTERN = /<triage\s+([^>]*?)>([\s\S]*?)<\/triage>/g;
+const ATTRIBUTE_PATTERN = /(\w[\w-]*)\s*=\s*"([^"]*)"/g;
+const TOOL_INPUT_PATH_KEYS = ["file_path", "path", "pattern"] as const;
+
+const isTriagePriority = (candidate: string): candidate is TriagePriority =>
+  (TRIAGE_PRIORITIES as ReadonlyArray<string>).includes(candidate);
+
+const collapseWhitespace = (value: string): string => value.replaceAll(/\s+/g, " ").trim();
+
+const decodeXmlEntities = (value: string): string =>
+  value
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&amp;", "&");
+
+const getRuleKey = (diagnostic: Pick<Diagnostic, "plugin" | "rule">): string =>
+  `${diagnostic.plugin}/${diagnostic.rule}`;
+
+const getDiagnosticIdentity = (diagnostic: Diagnostic, workingDirectory: string): string =>
+  [
+    getRuleKey(diagnostic),
+    toRelativePath(diagnostic.filePath, workingDirectory),
+    String(diagnostic.line),
+  ].join("\0");
+
+interface ParsedTriageTag {
+  readonly priority: TriagePriority;
+  readonly ruleKey: string;
+  readonly filePath: string;
+  readonly line: number;
+  readonly title: string;
+  readonly description: string;
+}
+
+const parseTriageTags = (responseText: string): ParsedTriageTag[] => {
+  const parsedTags: ParsedTriageTag[] = [];
+  for (const [, attributesText, bodyText] of responseText.matchAll(TRIAGE_TAG_PATTERN)) {
+    const attributes: Record<string, string> = {};
+    for (const [, name, value] of attributesText.matchAll(ATTRIBUTE_PATTERN)) {
+      attributes[name.toLowerCase()] = decodeXmlEntities(value);
+    }
+
+    const priority = (attributes.priority ?? "").trim().toUpperCase();
+    const ruleKey = (attributes.rule ?? "").trim();
+    const filePath = (attributes.file ?? "").trim();
+    const title = (attributes.title ?? "").trim();
+    const description = decodeXmlEntities(bodyText).trim();
+    const line = Number.parseInt(attributes.line ?? "", 10);
+
+    const isValidLine = Number.isInteger(line) && line > 0;
+    if (
+      !isTriagePriority(priority) ||
+      !ruleKey ||
+      !filePath ||
+      !title ||
+      !description ||
+      !isValidLine
+    ) {
+      continue;
+    }
+    parsedTags.push({ priority, ruleKey, filePath, line, title, description });
+  }
+  return parsedTags;
+};
+
+const resolveDiagnosticForTag = (
+  tag: ParsedTriageTag,
+  diagnostics: ReadonlyArray<Diagnostic>,
+  workingDirectory: string,
+): Diagnostic | null => {
+  const tagRelativePath = toRelativePath(tag.filePath, workingDirectory);
+  return (
+    diagnostics.find(
+      (diagnostic) =>
+        diagnostic.line === tag.line &&
+        getRuleKey(diagnostic) === tag.ruleKey &&
+        toRelativePath(diagnostic.filePath, workingDirectory) === tagRelativePath,
+    ) ?? null
+  );
+};
+
+const formatDiagnosticForPrompt = (
+  diagnostic: Diagnostic,
+  workingDirectory: string,
+  index: number,
+): string => {
+  const lines = [
+    `[${String(index + 1)}] (${diagnostic.severity}) ${getRuleKey(diagnostic)}`,
+    `  file: ${toRelativePath(diagnostic.filePath, workingDirectory)}:${String(diagnostic.line)}`,
+    `  message: ${collapseWhitespace(diagnostic.message)}`,
+  ];
+  if (diagnostic.help) lines.push(`  help: ${collapseWhitespace(diagnostic.help)}`);
+  if (diagnostic.url) lines.push(`  docs: ${diagnostic.url}`);
+  return lines.join("\n");
+};
+
+const buildUserPrompt = (
+  diagnostics: ReadonlyArray<Diagnostic>,
+  workingDirectory: string,
+): string =>
+  [
+    "react-doctor scanned this codebase and produced the diagnostics below. Open each one in the source, decide whether it's a real issue in this project's context, and emit a `<triage>` tag for the ones to keep (per the system prompt).",
+    "",
+    `Working directory: ${workingDirectory}`,
+    `Total diagnostics: ${String(diagnostics.length)}`,
+    "",
+    "## Diagnostics",
+    "",
+    diagnostics
+      .map((diagnostic, index) => formatDiagnosticForPrompt(diagnostic, workingDirectory, index))
+      .join("\n\n"),
+    "",
+    "Remember: omission is the suppression mechanism — do not emit a tag for diagnostics you consider false positives, and do not emit tags for findings that are not in the list above.",
+  ].join("\n");
+
+const readStringField = (source: unknown, fieldName: string): string | null => {
+  if (typeof source !== "object" || source === null || !(fieldName in source)) return null;
+  const fieldValue = Reflect.get(source, fieldName);
+  return typeof fieldValue === "string" && fieldValue.length > 0 ? fieldValue : null;
+};
+
+const summarizeToolInput = (toolName: string, toolInput: unknown): string => {
+  for (const fieldName of TOOL_INPUT_PATH_KEYS) {
+    const fieldValue = readStringField(toolInput, fieldName);
+    if (fieldValue) return `${toolName}(${fieldValue})`;
+  }
+  return toolName;
+};
+
+const reportAssistantProgress = (
+  message: Extract<SDKMessage, { type: "assistant" }>,
+  onProgress: TriageRunInput["onProgress"],
+): void => {
+  if (!onProgress) return;
+  const blocks = Array.isArray(message.message.content) ? message.message.content : [];
+  for (const block of blocks) {
+    if (block.type === "tool_use") {
+      onProgress({
+        kind: "tool",
+        toolName: block.name,
+        summary: summarizeToolInput(block.name, block.input),
+      });
+      return;
+    }
+    if (block.type === "text" && block.text.trim().length > 0) {
+      onProgress({ kind: "thinking" });
+      return;
+    }
+  }
+};
+
+const formatSdkErrorMessage = (subtype: string, errors: ReadonlyArray<string>): string =>
+  errors.length === 0
+    ? `Claude Agent SDK returned ${subtype}.`
+    : `Claude Agent SDK returned ${subtype}: ${errors.join("; ")}`;
+
+export const triageDiagnostics = async (input: TriageRunInput): Promise<TriageOutcome> => {
+  const overflowed = Math.max(0, input.diagnostics.length - TRIAGE_MAX_DIAGNOSTICS_COUNT);
+  const triageInput = input.diagnostics.slice(0, TRIAGE_MAX_DIAGNOSTICS_COUNT);
+  const model = process.env[TRIAGE_MODEL_ENV_VARIABLE] ?? TRIAGE_DEFAULT_MODEL;
+
+  const abortController = new AbortController();
+  const timeoutHandle = setTimeout(() => abortController.abort(), TRIAGE_TIMEOUT_MS);
+  const startedAtMilliseconds = Date.now();
+
+  let responseText = "";
+  let totalCostUsd: number | null = null;
+
+  try {
+    const queryStream = query({
+      prompt: buildUserPrompt(triageInput, input.workingDirectory),
+      options: {
+        systemPrompt: getTriageSystemPrompt(),
+        cwd: input.workingDirectory,
+        model,
+        allowedTools: ["Read", "Glob", "Grep"],
+        permissionMode: "bypassPermissions",
+        maxTurns: TRIAGE_MAX_TURNS,
+        includePartialMessages: false,
+        abortController,
+        // Coding-agent settings sources (Skills, CLAUDE.md, plugins) would
+        // pull in the user's local Claude Code config — that's irrelevant
+        // for a one-shot triage and risks bloating the context window with
+        // unrelated guidance, so we disable every filesystem source.
+        settingSources: [],
+      },
+    });
+
+    input.onProgress?.({ kind: "started" });
+
+    for await (const message of queryStream) {
+      if (message.type === "assistant") {
+        reportAssistantProgress(message, input.onProgress);
+        continue;
+      }
+      if (message.type !== "result") continue;
+      totalCostUsd = message.total_cost_usd;
+      if (message.subtype === "success") {
+        responseText = message.result;
+      } else {
+        throw new Error(formatSdkErrorMessage(message.subtype, message.errors));
+      }
+    }
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+
+  const keptIdentities = new Set<string>();
+  const kept: TriageVerdict[] = [];
+  for (const tag of parseTriageTags(responseText)) {
+    const diagnostic = resolveDiagnosticForTag(tag, triageInput, input.workingDirectory);
+    if (!diagnostic) continue;
+    const identity = getDiagnosticIdentity(diagnostic, input.workingDirectory);
+    if (keptIdentities.has(identity)) continue;
+    keptIdentities.add(identity);
+    kept.push({
+      diagnostic,
+      priority: tag.priority,
+      title: tag.title,
+      description: tag.description,
+    });
+  }
+  const suppressed = triageInput.filter(
+    (diagnostic) => !keptIdentities.has(getDiagnosticIdentity(diagnostic, input.workingDirectory)),
+  );
+
+  return {
+    kept,
+    suppressed,
+    overflowed,
+    elapsedMilliseconds: Date.now() - startedAtMilliseconds,
+    totalCostUsd,
+    model,
+  };
+};
+
+export const __testing = {
+  buildUserPrompt,
+  parseTriageTags,
+  resolveDiagnosticForTag,
+};

--- a/packages/react-doctor/src/cli/utils/triage.ts
+++ b/packages/react-doctor/src/cli/utils/triage.ts
@@ -4,11 +4,10 @@ import type { Diagnostic } from "@react-doctor/core";
 import {
   TRIAGE_DEFAULT_MODEL,
   TRIAGE_MAX_DIAGNOSTICS_COUNT,
-  TRIAGE_MAX_TURNS,
   TRIAGE_MODEL_ENV_VARIABLE,
   TRIAGE_TIMEOUT_MS,
 } from "./constants.js";
-import { getTriageSystemPrompt } from "./triage-system-prompt.js";
+import { getTriageInstructions } from "./triage-instructions.js";
 
 const TRIAGE_PRIORITIES = ["P0", "P1", "P2", "P3"] as const;
 export type TriagePriority = (typeof TRIAGE_PRIORITIES)[number];
@@ -143,7 +142,8 @@ const buildUserPrompt = (
   workingDirectory: string,
 ): string =>
   [
-    "react-doctor scanned this codebase and produced the diagnostics below. Open each one in the source, decide whether it's a real issue in this project's context, and emit a `<triage>` tag for the ones to keep (per the system prompt).",
+    getTriageInstructions(),
+    "---",
     "",
     `Working directory: ${workingDirectory}`,
     `Total diagnostics: ${String(diagnostics.length)}`,
@@ -214,12 +214,12 @@ export const triageDiagnostics = async (input: TriageRunInput): Promise<TriageOu
     const queryStream = query({
       prompt: buildUserPrompt(triageInput, input.workingDirectory),
       options: {
-        systemPrompt: getTriageSystemPrompt(),
-        cwd: input.workingDirectory,
         model,
-        allowedTools: ["Read", "Glob", "Grep"],
+        // `systemPrompt` is intentionally unset so the SDK keeps its default
+        // minimal system prompt for the bundled `claude` binary. Our triage
+        // rules ride in the user message (see `buildUserPrompt`).
+        cwd: input.workingDirectory,
         permissionMode: "bypassPermissions",
-        maxTurns: TRIAGE_MAX_TURNS,
         includePartialMessages: false,
         abortController,
         // Coding-agent settings sources (Skills, CLAUDE.md, plugins) would

--- a/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
+++ b/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
@@ -38,4 +38,12 @@ export const validateModeFlags = (flags: InspectFlags): void => {
       "--explain cannot be combined with --json, --score, --annotations, or --staged.",
     );
   }
+  if (flags.triage) {
+    if (flags.json || flags.score || flags.annotations) {
+      throw new Error("--triage cannot be combined with --json, --score, or --annotations.");
+    }
+    if (explainArgument !== undefined) {
+      throw new Error("--triage cannot be combined with --explain or --why.");
+    }
+  }
 };

--- a/packages/react-doctor/tests/detect-claude-code-auth.test.ts
+++ b/packages/react-doctor/tests/detect-claude-code-auth.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { hasLocalClaudeCodeAuth } from "../src/cli/utils/detect-claude-code-auth.js";
+
+describe("hasLocalClaudeCodeAuth", () => {
+  let temporaryHomeDirectory: string;
+
+  beforeEach(() => {
+    temporaryHomeDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-claude-auth-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(temporaryHomeDirectory, { recursive: true, force: true });
+  });
+
+  it("returns false when no credentials directory exists", () => {
+    expect(hasLocalClaudeCodeAuth(temporaryHomeDirectory)).toBe(false);
+  });
+
+  it("returns true when ~/.claude/.credentials.json is non-empty", () => {
+    const credentialsDirectory = path.join(temporaryHomeDirectory, ".claude");
+    fs.mkdirSync(credentialsDirectory, { recursive: true });
+    fs.writeFileSync(path.join(credentialsDirectory, ".credentials.json"), `{"token":"x"}`);
+
+    expect(hasLocalClaudeCodeAuth(temporaryHomeDirectory)).toBe(true);
+  });
+
+  it("returns true when ~/.config/claude/credentials.json is non-empty", () => {
+    const credentialsDirectory = path.join(temporaryHomeDirectory, ".config", "claude");
+    fs.mkdirSync(credentialsDirectory, { recursive: true });
+    fs.writeFileSync(path.join(credentialsDirectory, "credentials.json"), `{"token":"x"}`);
+
+    expect(hasLocalClaudeCodeAuth(temporaryHomeDirectory)).toBe(true);
+  });
+
+  it("returns false when the credentials file exists but is empty", () => {
+    const credentialsDirectory = path.join(temporaryHomeDirectory, ".claude");
+    fs.mkdirSync(credentialsDirectory, { recursive: true });
+    fs.writeFileSync(path.join(credentialsDirectory, ".credentials.json"), "");
+
+    expect(hasLocalClaudeCodeAuth(temporaryHomeDirectory)).toBe(false);
+  });
+
+  it("returns false when an empty home directory is provided", () => {
+    expect(hasLocalClaudeCodeAuth("")).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
+++ b/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
@@ -41,4 +41,8 @@ describe("stripUnknownCliFlags", () => {
   it("keeps an optional-value flag followed by another flag", () => {
     expect(stripUserArguments(["--diff", "--json"])).toEqual(["--diff", "--json"]);
   });
+
+  it("keeps --triage so the AI triage flag reaches Commander", () => {
+    expect(stripUserArguments([".", "--triage"])).toEqual([".", "--triage"]);
+  });
 });

--- a/packages/react-doctor/tests/triage.test.ts
+++ b/packages/react-doctor/tests/triage.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { Diagnostic } from "@react-doctor/core";
+import { __testing } from "../src/cli/utils/triage.js";
+
+const { buildUserPrompt, parseTriageTags, resolveDiagnosticForTag } = __testing;
+
+const ROOT_DIRECTORY = "/tmp/project";
+
+const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: `${ROOT_DIRECTORY}/src/hooks/use-user.ts`,
+  plugin: "react-doctor",
+  rule: "no-fetch-in-effect",
+  severity: "error",
+  message: "Effects that fetch data must abort in cleanup.",
+  help: "Scope an AbortController to the effect.",
+  url: "https://react.dev/learn",
+  line: 18,
+  column: 5,
+  category: "state-and-effects",
+  ...overrides,
+});
+
+describe("triage user prompt", () => {
+  it("includes every diagnostic with rule, file, and message", () => {
+    const diagnosticsForPrompt = [
+      buildDiagnostic({ line: 18 }),
+      buildDiagnostic({
+        filePath: `${ROOT_DIRECTORY}/src/components/list.tsx`,
+        rule: "no-array-index-as-key",
+        line: 42,
+        message: "Avoid array index as React key.",
+      }),
+    ];
+
+    const promptText = buildUserPrompt(diagnosticsForPrompt, ROOT_DIRECTORY);
+
+    expect(promptText).toContain("react-doctor/no-fetch-in-effect");
+    expect(promptText).toContain("src/hooks/use-user.ts:18");
+    expect(promptText).toContain("react-doctor/no-array-index-as-key");
+    expect(promptText).toContain("src/components/list.tsx:42");
+    expect(promptText).toContain("Total diagnostics: 2");
+    expect(promptText).toContain("omission is the suppression mechanism");
+  });
+
+  it("collapses multi-line diagnostic messages onto a single line", () => {
+    const promptText = buildUserPrompt(
+      [buildDiagnostic({ message: "First line.\n  Second line.\n\nThird." })],
+      ROOT_DIRECTORY,
+    );
+
+    expect(promptText).toContain("message: First line. Second line. Third.");
+    expect(promptText).not.toMatch(/message: First line\.\n/);
+  });
+});
+
+describe("triage tag parsing", () => {
+  it("parses a valid triage tag with all attributes", () => {
+    const responseText = `<triage priority="P0" rule="react-doctor/no-fetch-in-effect" file="src/hooks/use-user.ts" line="18" title="Fetch leaks on rapid prop change">
+Effect never aborts when userId changes mid-flight.
+</triage>`;
+
+    const parsedTags = parseTriageTags(responseText);
+
+    expect(parsedTags).toHaveLength(1);
+    const [parsedTag] = parsedTags;
+    expect(parsedTag.priority).toBe("P0");
+    expect(parsedTag.ruleKey).toBe("react-doctor/no-fetch-in-effect");
+    expect(parsedTag.filePath).toBe("src/hooks/use-user.ts");
+    expect(parsedTag.line).toBe(18);
+    expect(parsedTag.title).toBe("Fetch leaks on rapid prop change");
+    expect(parsedTag.description).toBe("Effect never aborts when userId changes mid-flight.");
+  });
+
+  it("decodes XML entities in attribute values and body", () => {
+    const responseText = `<triage priority="P1" rule="react-doctor/no-bind" file="src/x.tsx" line="3" title="Inline &lt;Button&gt; bind">
+The &amp; operator is misused; &quot;onClick&quot; binds a fresh function.
+</triage>`;
+
+    const [parsedTag] = parseTriageTags(responseText);
+
+    expect(parsedTag.title).toBe("Inline <Button> bind");
+    expect(parsedTag.description).toBe(
+      'The & operator is misused; "onClick" binds a fresh function.',
+    );
+  });
+
+  it("ignores tags missing required attributes", () => {
+    const responseText = `
+<triage priority="WHATEVER" rule="r" file="f" line="1" title="t">body</triage>
+<triage priority="P0" rule="" file="f" line="1" title="t">body</triage>
+<triage priority="P0" rule="r" file="" line="1" title="t">body</triage>
+<triage priority="P0" rule="r" file="f" line="abc" title="t">body</triage>
+<triage priority="P0" rule="r" file="f" line="0" title="t">body</triage>
+<triage priority="P0" rule="r" file="f" line="1" title="">body</triage>
+<triage priority="P0" rule="r" file="f" line="1" title="t"></triage>
+`;
+
+    const parsedTags = parseTriageTags(responseText);
+
+    expect(parsedTags).toHaveLength(0);
+  });
+
+  it("parses multiple tags and preserves order", () => {
+    const responseText = `
+<triage priority="P0" rule="a/b" file="src/a.ts" line="1" title="A">a</triage>
+some prose
+<triage priority="P2" rule="c/d" file="src/c.ts" line="2" title="C">c</triage>
+`;
+
+    const parsedTags = parseTriageTags(responseText);
+
+    expect(parsedTags).toHaveLength(2);
+    expect(parsedTags[0].priority).toBe("P0");
+    expect(parsedTags[1].priority).toBe("P2");
+  });
+});
+
+describe("triage diagnostic matching", () => {
+  const knownDiagnostics: Diagnostic[] = [buildDiagnostic({ line: 18 })];
+
+  it("matches a tag back to a diagnostic via the relative file path", () => {
+    const matchedDiagnostic = resolveDiagnosticForTag(
+      {
+        priority: "P0",
+        ruleKey: "react-doctor/no-fetch-in-effect",
+        filePath: "src/hooks/use-user.ts",
+        line: 18,
+        title: "t",
+        description: "d",
+      },
+      knownDiagnostics,
+      ROOT_DIRECTORY,
+    );
+
+    expect(matchedDiagnostic?.line).toBe(18);
+  });
+
+  it("matches a tag back to a diagnostic via the absolute file path", () => {
+    const matchedDiagnostic = resolveDiagnosticForTag(
+      {
+        priority: "P0",
+        ruleKey: "react-doctor/no-fetch-in-effect",
+        filePath: `${ROOT_DIRECTORY}/src/hooks/use-user.ts`,
+        line: 18,
+        title: "t",
+        description: "d",
+      },
+      knownDiagnostics,
+      ROOT_DIRECTORY,
+    );
+
+    expect(matchedDiagnostic).not.toBeNull();
+  });
+
+  it("returns null when the rule/file/line do not match any diagnostic", () => {
+    const noMatch = resolveDiagnosticForTag(
+      {
+        priority: "P0",
+        ruleKey: "react-doctor/no-fetch-in-effect",
+        filePath: "src/hooks/use-user.ts",
+        line: 99,
+        title: "t",
+        description: "d",
+      },
+      knownDiagnostics,
+      ROOT_DIRECTORY,
+    );
+
+    expect(noMatch).toBeNull();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
 
   packages/react-doctor:
     dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.150
+        version: 0.3.150(@anthropic-ai/sdk@0.98.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@effect/platform-node-shared':
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70(effect@4.0.0-beta.70)
@@ -207,6 +210,67 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.150':
+    resolution: {integrity: sha512-YVWJ0MHdSy0tobHO2G5/+vd9iRGyosg3wM6sY4pirezsnwZJBkJv/9IeVIaKqdLv83OA6HUcxxOLGzKSBawq2Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.150':
+    resolution: {integrity: sha512-72M8mKCa7Tfy66G5hr5z9TirKynQa9sFj+4qDxkAp5LAYnyViUzHOqO6mEjVtwDr2aXnjqkhTdBtc5Hmn1m/nA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.150':
+    resolution: {integrity: sha512-KxkrUkGRhVcj4/2LkLrhVcEPl+6McDvtpZlgikHwAczVIf7aCvh01w2meEvuNjvex3dCv0d8CT+WYWxKJUhsbw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.150':
+    resolution: {integrity: sha512-1nhCXjfbxwhQPTgx2+q8lFYHx8DGJEOdaSd4wLvhGJifd/9QJwtnxaill1q+qdggZDroXHDJOTugttP0be6diA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.150':
+    resolution: {integrity: sha512-cm+kWR077H4+ZaMPtqrHosjsVba9hjfn31gtK7D96ziz9Mzn/XhkAz68oObDOTBDqj4j+JbmAHSl5JvyGMHcAg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.150':
+    resolution: {integrity: sha512-G7yOB9O6twOhQH3SvZWIvOcjehfA0HD5f/j49Z/yxZK5U72hOxtnbx7GCbcH/8AyB7JFyHjHpR9hxOxFoJNIhQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.150':
+    resolution: {integrity: sha512-z9vlm3JdOQ1Vqj9sG8kW+r9miunv4UFQOn0AqoI++J9AgoCBjKGCH2WWmZYhGOvezZqogunXaTciJvhtDhJiWQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.150':
+    resolution: {integrity: sha512-lpAVi7tZdHi3BXRWmCVmOE2O8q7nzbvuMneYKS9rkpIbcjMjOBk6ud/rlp8Cuiqmp4LzZ8ylbbI7vFEiylK6Hg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.150':
+    resolution: {integrity: sha512-/RgkK5eTgIbzw5VRvH+T/hWeC5P7dCoYEO5ZWlwTSqvjfdVFOZhkiUKf4gz0ONpeLORAetqWU4rIfcVjQAH5fg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.98.0':
+    resolution: {integrity: sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -558,6 +622,12 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -763,6 +833,16 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -1527,6 +1607,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1901,6 +1984,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1977,6 +2064,10 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
@@ -1995,6 +2086,18 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -2050,8 +2153,32 @@ packages:
     resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
     engines: {node: '>=20'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
@@ -2084,6 +2211,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   deslop-js@0.0.13:
     resolution: {integrity: sha512-gIXD+wY2/NHkZHpNrb8MWS6NJs3ee0XunAenBCvwHJlWnedDbIrg70hdNR7bDzYZLe9LGJZMLEI1w2CC72Gk5A==}
 
@@ -2110,11 +2241,22 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   effect@4.0.0-beta.70:
     resolution: {integrity: sha512-8AwGTRiNriirHGEYHrOS0E9fzdhIqCdZjiHP1YXmNo2UyPGS43ILsymsSHT7V0DJS+8dvlKq2RxnrDBUhDNZHg==}
 
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
@@ -2128,11 +2270,23 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -2142,6 +2296,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2211,9 +2368,31 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -2234,6 +2413,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
@@ -2258,6 +2440,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
@@ -2276,6 +2462,14 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -2289,6 +2483,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2296,6 +2493,14 @@ packages:
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2313,6 +2518,10 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2320,11 +2529,27 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hono@4.12.22:
+    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -2346,9 +2571,20 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ini@7.0.0:
     resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2365,6 +2601,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -2385,6 +2624,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2403,6 +2645,10 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2544,6 +2790,18 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2551,6 +2809,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2592,6 +2858,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   next@16.2.4:
     resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
     engines: {node: '>=20.9.0'}
@@ -2629,8 +2899,23 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -2708,6 +2993,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2715,6 +3004,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2742,6 +3034,10 @@ packages:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
     hasBin: true
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
@@ -2767,6 +3063,10 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2774,11 +3074,23 @@ packages:
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
@@ -2818,6 +3130,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2836,6 +3152,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2847,6 +3174,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2885,6 +3228,13 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -2983,6 +3333,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   toml@4.1.1:
     resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
     engines: {node: '>=20'}
@@ -2993,6 +3347,9 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3008,6 +3365,10 @@ packages:
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3030,6 +3391,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -3042,6 +3407,10 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-plus@0.1.20:
     resolution: {integrity: sha512-hxJqXTxiiFhszwAeD0MvKlztVuXE4TztTdJ64BPxGqgY67F0PDa5eZkUsrN91Ae8aYUMfweW6V/J57OUO9/0zw==}
@@ -3152,6 +3521,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -3185,6 +3557,11 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
@@ -3197,6 +3574,52 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.150':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.150':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.150':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.150':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.150':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.150':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.150':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.150':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.150(@anthropic-ai/sdk@0.98.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.98.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      zod: 4.3.6
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.150
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.150
+
+  '@anthropic-ai/sdk@0.98.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3614,6 +4037,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@1.19.14(hono@4.12.22)':
+    dependencies:
+      hono: 4.12.22
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3771,6 +4198,28 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.22)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.22
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -4179,6 +4628,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -4441,6 +4892,11 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.20':
     optional: true
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4509,6 +4965,20 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
@@ -4532,6 +5002,18 @@ snapshots:
 
   buffer-from@1.1.2:
     optional: true
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -4581,7 +5063,22 @@ snapshots:
       semver: 7.7.4
       uint8array-extras: 1.5.0
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-env@10.1.0:
     dependencies:
@@ -4607,6 +5104,8 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  depd@2.0.0: {}
 
   deslop-js@0.0.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
@@ -4646,6 +5145,14 @@ snapshots:
 
   dotenv@8.6.0: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   effect@4.0.0-beta.70:
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -4661,6 +5168,8 @@ snapshots:
 
   electron-to-chromium@1.5.286: {}
 
+  encodeurl@2.0.0: {}
+
   enhanced-resolve@5.19.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -4673,9 +5182,17 @@ snapshots:
 
   env-paths@3.0.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -4707,6 +5224,8 @@ snapshots:
       '@esbuild/win32-x64': 0.27.3
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4804,7 +5323,53 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extendable-error@0.1.7: {}
 
@@ -4826,6 +5391,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.2: {}
 
   fastq@1.20.1:
@@ -4843,6 +5410,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-my-way-ts@0.1.6: {}
 
@@ -4863,6 +5441,10 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -4878,9 +5460,29 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.4.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   glob-parent@5.1.2:
     dependencies:
@@ -4901,15 +5503,33 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
 
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hono@4.12.22: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   human-id@4.1.3: {}
 
@@ -4926,7 +5546,13 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
   ini@7.0.0: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -4937,6 +5563,8 @@ snapshots:
   is-interactive@2.0.0: {}
 
   is-number@7.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -4949,6 +5577,8 @@ snapshots:
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -4964,6 +5594,11 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -5072,12 +5707,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-function@5.0.1: {}
 
@@ -5117,6 +5764,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   next@16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
@@ -5152,7 +5801,19 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@7.0.0:
     dependencies:
@@ -5319,9 +5980,13 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -5338,6 +6003,8 @@ snapshots:
   pixelmatch@7.2.0:
     dependencies:
       pngjs: 7.0.0
+
+  pkce-challenge@5.0.1: {}
 
   pngjs@7.0.0: {}
 
@@ -5362,13 +6029,31 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
   pure-rand@8.4.0: {}
 
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:
@@ -5428,6 +6113,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5439,6 +6134,33 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -5478,6 +6200,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -5511,6 +6261,13 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -5586,11 +6343,15 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   toml@4.1.1: {}
 
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
+
+  ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
 
@@ -5611,6 +6372,12 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
@@ -5620,6 +6387,8 @@ snapshots:
   undici-types@7.19.2: {}
 
   universalify@0.1.2: {}
+
+  unpipe@1.0.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -5632,6 +6401,8 @@ snapshots:
       punycode: 2.3.1
 
   uuid@14.0.0: {}
+
+  vary@1.1.2: {}
 
   vite-plus@0.1.20(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
@@ -5743,6 +6514,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrappy@1.0.2: {}
+
   ws@8.20.0: {}
 
   yallist@3.1.1: {}
@@ -5754,6 +6527,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Summary

Adds an opt-in `--triage` flag that, after a normal `react-doctor` scan, hands the surviving diagnostics to the Claude Agent SDK to filter false positives and rank what's left by P0–P3 priority. Designed for noisy projects where users currently can't tell which of the dozens of warnings actually matter.

- Uses the user's existing **Claude Code subscription** when present (via `claude setup-token` → `CLAUDE_CODE_OAUTH_TOKEN`, or the local credentials cached by `claude /login`), and falls back to `ANTHROPIC_API_KEY`.
- Modeled on the react-review GitHub bot's filtering approach: agent emits `<triage>` tags per finding it confirms; **omission is the suppression mechanism**.
- The Claude session is read-only (`allowedTools: ["Read", "Glob", "Grep"]`, `settingSources: []`) so it must verify each diagnostic against the actual source before deciding to keep or suppress.

## UX

```bash
# Subscription users — one-time setup
claude setup-token   # or `claude /login`

# Then just run
npx react-doctor@latest --triage
```

Output appends below the normal scan:
- Kept findings grouped by **Critical (P0)** / **Should fix (P1)** / **Fix soon (P2)** / **Nice to have (P3)** with rule key, location, and an AI-rewritten 1–2 sentence description.
- Suppressed count (verbose mode lists each one).
- Summary line: `12 kept (P0:2 P1:4 P2:5 P3:1) · 8 suppressed · 14.3s · model: claude-sonnet-4-5`.

When credentials are missing the flag is a no-op with a friendly two-option warning; SDK errors fall back to the unmodified scan output.

## What's in the diff

**New (`packages/react-doctor/src/cli/utils/`)**
- `triage.ts` — runner: builds prompt, drives the SDK stream, parses `<triage>` tags, resolves them back to diagnostics
- `triage-system-prompt.ts` — system prompt adapted from react-review's `getAgentReviewSystemPrompt` (local-CLI variant, no PR-diff framing, agent only triages existing diagnostics)
- `render-triage.ts` — Effect-typed renderer; priority descriptors drive coloring, glyphs, and headings from one table
- `run-triage.ts` — orchestrator: auth resolution + spinner UX + graceful error fallback
- `detect-claude-code-auth.ts` — checks `~/.claude/.credentials.json` and siblings so subscription users without env vars still get a green light

**Modified**
- `cli/index.ts` — registers `--triage`
- `cli/utils/inspect-flags.ts` — adds `triage?: boolean`
- `cli/utils/validate-mode-flags.ts` — disallows `--triage` with `--json` / `--score` / `--annotations` / `--explain`
- `cli/utils/strip-unknown-cli-flags.ts` — adds `--triage` to the whitelist (with a regression test)
- `cli/utils/constants.ts` — `TRIAGE_*` magic numbers (max diagnostics 200, max turns 30, timeout 300 s)
- `cli/commands/inspect.ts` — calls `runTriage` after `finalizeScans` in both the staged and project-loop arms, gated on `flags.triage && !isQuiet`
- `package.json` — adds `@anthropic-ai/claude-agent-sdk@^0.3.150` (bundles the native `claude` binary as an optional dep)

**Tests**
- `tests/triage.test.ts` — 9 tests covering prompt formatting, tag parsing, XML decoding, malformed-tag rejection, diagnostic matching (relative + absolute paths)
- `tests/detect-claude-code-auth.test.ts` — 5 tests covering all three credentials.json paths, the empty-file case, and the empty-home case
- `tests/strip-unknown-cli-flags.test.ts` — regression for `--triage` surviving the whitelist filter

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (warnings are pre-existing in test fixtures)
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 1391 passed, 12 skipped, 0 failed (+15 new tests)
- [x] Smoke (no creds, empty `HOME`) → two-option warning, scan output preserved
- [x] Smoke (fake `CLAUDE_CODE_OAUTH_TOKEN`) → spinner says "(Claude subscription)", SDK errors with 401 (expected for fake), base diagnostics intact
- [ ] Reviewer: smoke against a real subscription / API key on a real React project

Made with [Cursor](https://cursor.com)