### PR TITLE
fix(cli): show setup prompt for monorepo scans

### DIFF
--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -315,14 +315,14 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
     const setupProjectRoot = resolveInstallSetupProjectRoot({
       scanRoot: resolvedDirectory,
-      completedScanDirectories: completedScans.map((scan) => scan.directory),
+      scanDirectories: projectDirectories,
     });
     if (setupProjectRoot !== null) {
-      const hasScoredScan = completedScans.some((scan) => scan.result.score !== null);
+      const hasCompletedScan = completedScans.length > 0;
 
       await promptInstallSetup({
         projectRoot: setupProjectRoot,
-        hasScoredScan,
+        hasCompletedScan,
         issueCount: filterDiagnosticsForSurface(
           allDiagnostics,
           scanOptions.outputSurface ?? "cli",
@@ -337,7 +337,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       if (
         shouldShowAgentInstallHint({
           projectRoot: setupProjectRoot,
-          hasScoredScan,
+          hasCompletedScan,
           isJsonMode,
           isScoreOnly,
           isStaged: Boolean(flags.staged),

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -41,7 +41,8 @@ export interface SetupPromptStoreOptions {
 
 export interface ShouldPromptInstallSetupOptions {
   readonly projectRoot: string;
-  readonly hasScoredScan: boolean;
+  readonly hasCompletedScan?: boolean;
+  readonly hasScoredScan?: boolean;
   readonly isJsonMode: boolean;
   readonly isScoreOnly: boolean;
   readonly isStaged: boolean;
@@ -69,7 +70,7 @@ interface SetupPromptGlobalConfig {
 
 export interface ResolveInstallSetupProjectRootOptions {
   readonly scanRoot: string;
-  readonly completedScanDirectories: ReadonlyArray<string>;
+  readonly scanDirectories: ReadonlyArray<string>;
 }
 
 const GLOBAL_CONFIG_PROJECT_NAME = "react-doctor";
@@ -116,7 +117,7 @@ export const disableSetupPrompt = (
 };
 
 export const shouldPromptInstallSetup = (options: ShouldPromptInstallSetupOptions): boolean => {
-  if (!options.hasScoredScan) return false;
+  if (!(options.hasCompletedScan ?? options.hasScoredScan ?? false)) return false;
   if (options.isJsonMode) return false;
   if (options.isScoreOnly) return false;
   if (options.isStaged) return false;
@@ -129,12 +130,12 @@ export const shouldPromptInstallSetup = (options: ShouldPromptInstallSetupOption
 export const resolveInstallSetupProjectRoot = (
   options: ResolveInstallSetupProjectRootOptions,
 ): string | null => {
-  if (options.completedScanDirectories.length === 0) {
+  if (options.scanDirectories.length === 0) {
     return findNearestPackageDirectory(options.scanRoot) ?? options.scanRoot;
   }
 
   const packageDirectories = new Set<string>();
-  for (const scanDirectory of options.completedScanDirectories) {
+  for (const scanDirectory of options.scanDirectories) {
     const packageDirectory =
       findNearestPackageDirectory(scanDirectory, options.scanRoot) ??
       findNearestPackageDirectory(scanDirectory) ??
@@ -142,7 +143,9 @@ export const resolveInstallSetupProjectRoot = (
     packageDirectories.add(packageDirectory);
   }
 
-  if (packageDirectories.size !== 1) return null;
+  if (packageDirectories.size !== 1) {
+    return findNearestPackageDirectory(options.scanRoot, options.scanRoot);
+  }
   return [...packageDirectories][0] ?? null;
 };
 
@@ -240,7 +243,8 @@ export const promptInstallSetup = async (options: PromptInstallSetupOptions): Pr
 
 export interface ShouldShowAgentInstallHintOptions {
   readonly projectRoot: string;
-  readonly hasScoredScan: boolean;
+  readonly hasCompletedScan?: boolean;
+  readonly hasScoredScan?: boolean;
   readonly isJsonMode: boolean;
   readonly isScoreOnly: boolean;
   readonly isStaged: boolean;
@@ -249,7 +253,7 @@ export interface ShouldShowAgentInstallHintOptions {
 }
 
 export const shouldShowAgentInstallHint = (options: ShouldShowAgentInstallHintOptions): boolean => {
-  if (!options.hasScoredScan) return false;
+  if (!(options.hasCompletedScan ?? options.hasScoredScan ?? false)) return false;
   if (options.isJsonMode) return false;
   if (options.isScoreOnly) return false;
   if (options.isStaged) return false;

--- a/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
+++ b/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { InspectResult } from "@react-doctor/core";
+import { inspectAction } from "../src/cli/commands/inspect.js";
+import { promptInstallSetup } from "../src/cli/utils/prompt-install-setup.js";
+import { inspect } from "../src/inspect.js";
+
+const mockState = vi.hoisted(() => ({
+  rootDirectory: "",
+  projectDirectories: [] as string[],
+}));
+
+vi.mock("ora", () => ({
+  default: () => ({
+    text: "",
+    start: function () {
+      return this;
+    },
+    stop: function () {
+      return this;
+    },
+    succeed: () => {},
+    fail: () => {},
+  }),
+}));
+
+vi.mock("@react-doctor/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@react-doctor/core")>();
+  return {
+    ...actual,
+    resolveScanTarget: vi.fn(() => ({
+      resolvedDirectory: mockState.rootDirectory,
+      requestedDirectory: mockState.rootDirectory,
+      userConfig: null,
+      configSourceDirectory: null,
+      didRedirectViaRootDir: false,
+    })),
+    getDiffInfo: vi.fn(async () => ({
+      currentBranch: "feature",
+      baseBranch: "main",
+      changedFiles: ["apps/web/src/App.tsx"],
+      isCurrentChanges: false,
+    })),
+    filterDiagnosticsForSurface: vi.fn((diagnostics) => diagnostics),
+  };
+});
+
+vi.mock("../src/inspect.js", () => ({
+  inspect: vi.fn(
+    async (directory: string): Promise<InspectResult> => ({
+      diagnostics: [],
+      score: null,
+      skippedChecks: [],
+      project: {
+        rootDirectory: directory,
+        projectName: path.basename(directory),
+        reactVersion: "^19.0.0",
+        reactMajorVersion: 19,
+        tailwindVersion: null,
+        framework: "unknown",
+        hasTypeScript: true,
+        hasReactCompiler: false,
+        hasTanStackQuery: false,
+        hasReactNativeWorkspace: false,
+        sourceFileCount: 1,
+      },
+      elapsedMilliseconds: 1,
+    }),
+  ),
+}));
+
+vi.mock("../src/cli/utils/select-projects.js", () => ({
+  selectProjects: vi.fn(async () => mockState.projectDirectories),
+}));
+
+vi.mock("../src/cli/utils/should-skip-prompts.js", () => ({
+  shouldSkipPrompts: vi.fn(() => false),
+}));
+
+vi.mock("../src/cli/utils/render-multi-project-summary.js", async () => {
+  const Effect = await import("effect/Effect");
+  return {
+    printMultiProjectSummary: vi.fn(() => Effect.void),
+  };
+});
+
+vi.mock("../src/cli/utils/copy-issues-to-clipboard.js", () => ({
+  promptCopyIssues: vi.fn(async () => {}),
+}));
+
+vi.mock("../src/cli/utils/prompt-install-setup.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/cli/utils/prompt-install-setup.js")>();
+  return {
+    ...actual,
+    promptInstallSetup: vi.fn(async () => {}),
+    shouldShowAgentInstallHint: vi.fn(() => false),
+  };
+});
+
+const writePackageJson = (directory: string, value: Record<string, unknown>): void => {
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(path.join(directory, "package.json"), `${JSON.stringify(value, null, 2)}\n`);
+};
+
+describe("inspectAction setup prompt", () => {
+  const tempDirectories: string[] = [];
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    mockState.rootDirectory = "";
+    mockState.projectDirectories = [];
+    for (const tempDirectory of tempDirectories.splice(0)) {
+      fs.rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves setup from selected projects, not only completed diff scans", async () => {
+    const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-inspect-action-"));
+    tempDirectories.push(rootDirectory);
+    const webDirectory = path.join(rootDirectory, "apps", "web");
+    const adminDirectory = path.join(rootDirectory, "apps", "admin");
+    writePackageJson(rootDirectory, {
+      name: "monorepo",
+      workspaces: ["apps/*"],
+      scripts: {},
+    });
+    writePackageJson(webDirectory, { name: "web", scripts: {} });
+    writePackageJson(adminDirectory, { name: "admin", scripts: {} });
+
+    mockState.rootDirectory = rootDirectory;
+    mockState.projectDirectories = [webDirectory, adminDirectory];
+
+    await inspectAction(rootDirectory, { diff: true, lint: false });
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(inspect).toHaveBeenCalledWith(
+      webDirectory,
+      expect.objectContaining({
+        includePaths: ["src/App.tsx"],
+      }),
+    );
+    expect(promptInstallSetup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRoot: rootDirectory,
+        hasCompletedScan: true,
+        skipPrompts: false,
+      }),
+    );
+  });
+});

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -104,6 +104,24 @@ describe("shouldPromptInstallSetup", () => {
     ).toBe(true);
   });
 
+  it("prompts after a completed interactive scan even when scoring is unavailable", () => {
+    writePackageJson(fixture.projectRoot, {
+      scripts: {},
+    });
+
+    expect(
+      shouldPromptInstallSetup({
+        projectRoot: fixture.projectRoot,
+        hasCompletedScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        skipPrompts: false,
+        store: { cwd: fixture.configRoot },
+      }),
+    ).toBe(true);
+  });
+
   it("resolves setup to the completed scan package instead of the monorepo root", () => {
     const appDirectory = path.join(fixture.projectRoot, "apps", "web");
     mkdirSync(appDirectory, { recursive: true });
@@ -119,7 +137,7 @@ describe("shouldPromptInstallSetup", () => {
     expect(
       resolveInstallSetupProjectRoot({
         scanRoot: fixture.projectRoot,
-        completedScanDirectories: [appDirectory],
+        scanDirectories: [appDirectory],
       }),
     ).toBe(appDirectory);
   });
@@ -140,12 +158,12 @@ describe("shouldPromptInstallSetup", () => {
     expect(
       resolveInstallSetupProjectRoot({
         scanRoot: fixture.projectRoot,
-        completedScanDirectories: [nestedDirectory],
+        scanDirectories: [nestedDirectory],
       }),
     ).toBe(appDirectory);
   });
 
-  it("skips setup when a scan completed in multiple package roots", () => {
+  it("resolves setup to the scan root when a scan completed in multiple package roots", () => {
     const webDirectory = path.join(fixture.projectRoot, "apps", "web");
     const adminDirectory = path.join(fixture.projectRoot, "apps", "admin");
     mkdirSync(webDirectory, { recursive: true });
@@ -160,7 +178,24 @@ describe("shouldPromptInstallSetup", () => {
     expect(
       resolveInstallSetupProjectRoot({
         scanRoot: fixture.projectRoot,
-        completedScanDirectories: [webDirectory, adminDirectory],
+        scanDirectories: [webDirectory, adminDirectory],
+      }),
+    ).toBe(fixture.projectRoot);
+  });
+
+  it("skips setup for multiple package roots without a package at the scan root", () => {
+    const scanRoot = path.join(fixture.projectRoot, "multi-root");
+    const webDirectory = path.join(scanRoot, "web");
+    const adminDirectory = path.join(scanRoot, "admin");
+    mkdirSync(webDirectory, { recursive: true });
+    mkdirSync(adminDirectory, { recursive: true });
+    writePackageJson(webDirectory, { name: "web" });
+    writePackageJson(adminDirectory, { name: "admin" });
+
+    expect(
+      resolveInstallSetupProjectRoot({
+        scanRoot,
+        scanDirectories: [webDirectory, adminDirectory],
       }),
     ).toBeNull();
   });
@@ -642,6 +677,21 @@ describe("shouldShowAgentInstallHint", () => {
       shouldShowAgentInstallHint({
         projectRoot: fixture.projectRoot,
         hasScoredScan: true,
+        isJsonMode: false,
+        isScoreOnly: false,
+        isStaged: false,
+        isCodingAgent: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true in a coding agent environment after a completed scan without a score", () => {
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+
+    expect(
+      shouldShowAgentInstallHint({
+        projectRoot: fixture.projectRoot,
+        hasCompletedScan: true,
         isJsonMode: false,
         isScoreOnly: false,
         isStaged: false,


### PR DESCRIPTION
## Summary
- Resolve setup prompt targets from selected scan roots so monorepo scans fall back to the workspace root instead of skipping installation.
- Gate setup on completed scans instead of score availability, so score failures do not suppress setup while copy prompting still appears.
- Add focused regression coverage for multi-project diff scans and setup prompt eligibility.

## Test plan
- `nr test tests/inspect-action-setup-prompt.test.ts`
- `nr test tests/prompt-install-setup.test.ts tests/inspect-action-setup-prompt.test.ts`
- `nr typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only prompt gating and project-root resolution; no auth, data, or scan logic changes beyond when/how setup is offered.
> 
> **Overview**
> Fixes post-scan **install setup** targeting and eligibility so monorepos and unscored runs still get the right prompts.
> 
> `inspect` now passes **all selected project directories** into `resolveInstallSetupProjectRoot` (not only packages that finished a diff scan), and uses **`hasCompletedScan`** instead of requiring a score for `promptInstallSetup` and the agent install hint. When selected scans map to **multiple package roots**, setup resolves to the **nearest package at the scan root** (e.g. monorepo root) instead of returning null and skipping install.
> 
> Adds regression tests for multi-app diff scans (`inspectAction`) and for completed-but-unscored scans, multi-root resolution, and agent hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44106d5518b973ec3376906ebf5b54d6e9f52ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->