### PR TITLE
feat(cli): combine install setup prompts

### DIFF
--- a/packages/react-doctor/src/cli/commands/install.ts
+++ b/packages/react-doctor/src/cli/commands/install.ts
@@ -1,6 +1,6 @@
 import * as Effect from "effect/Effect";
 import { handleError } from "../utils/handle-error.js";
-import { runInstallSkill } from "../utils/install-skill.js";
+import { runInstallReactDoctor } from "../utils/install-react-doctor.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
 
 interface InstallCommandOptions {
@@ -28,7 +28,7 @@ export const installAction = async (
   Effect.runSync(printBrandedHeader);
   try {
     const parentOptions = command?.parent?.opts?.();
-    await runInstallSkill({
+    await runInstallReactDoctor({
       yes: options.yes ?? parentOptions?.yes,
       dryRun: options.dryRun,
       agentHooks: options.agentHooks,

--- a/packages/react-doctor/src/cli/utils/cli-logger.ts
+++ b/packages/react-doctor/src/cli/utils/cli-logger.ts
@@ -5,7 +5,7 @@ import { highlighter } from "@react-doctor/core";
 /**
  * Thin synchronous façade over Effect's `Console` module. Used by
  * the imperative CLI helper files (`select-projects`, `run-explain`,
- * `install-skill`, the legacy paths in `cli/commands/inspect.ts`)
+ * `install-react-doctor`, the legacy paths in `cli/commands/inspect.ts`)
  * that aren't yet Effect-typed. Every call drains into a single
  * `Console.*` Effect via `Effect.runSync`, so the underlying logging
  * pipeline is identical to the canonical `yield* Console.log(...)`
@@ -23,7 +23,7 @@ export const cliLogger = {
   //   dim   → gray
   //   success → green
   // Bugbot regression #432: without these, warning / error / info
-  // messages from `install-skill.ts`, `resolve-diff-mode.ts`, and
+  // messages from `install-react-doctor.ts`, `resolve-diff-mode.ts`, and
   // `resolve-fail-on-level.ts` rendered as plain uncolored text.
   warn: (message: string): void => {
     Effect.runSync(Console.warn(highlighter.warn(message)));

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -25,6 +25,11 @@ import { prompts } from "./prompts.js";
 import { shouldSkipPrompts } from "./should-skip-prompts.js";
 import { spinner } from "./spinner.js";
 
+const SETUP_OPTION_GIT_HOOK = "git-hook";
+const SETUP_OPTION_AGENT_HOOKS = "agent-hooks";
+const SETUP_OPTION_WORKFLOW = "workflow";
+const SETUP_OPTION_SKIP = "skip";
+
 const CONFIG_ONLY_GIT_HOOK_KINDS = new Set([
   GitHookKind.Ghooks,
   GitHookKind.GitHooksJs,
@@ -249,7 +254,7 @@ const installReactDoctorPackageSetup = async (
   }
 };
 
-interface InstallSkillOptions {
+interface InstallReactDoctorOptions {
   yes?: boolean;
   dryRun?: boolean;
   agentHooks?: boolean;
@@ -262,6 +267,7 @@ interface InstallSkillOptions {
   installDependencyRunner?: (
     input: InstallReactDoctorDependencyRunnerInput,
   ) => void | Promise<void>;
+  prompt?: typeof prompts;
 }
 
 const getSkillSourceDirectory = (): string => {
@@ -269,7 +275,36 @@ const getSkillSourceDirectory = (): string => {
   return path.join(distDirectory, "skills", SKILL_NAME);
 };
 
-export const runInstallSkill = async (options: InstallSkillOptions = {}): Promise<void> => {
+const canInstallNativeAgentHooks = (agents: readonly SkillAgentType[]): boolean =>
+  agents.some((agent) => agent === "claude-code" || agent === "cursor");
+
+const buildWorkflowContent = (): string =>
+  [
+    "name: React Doctor",
+    "",
+    "on:",
+    "  pull_request:",
+    "    branches: [main]",
+    "",
+    "permissions:",
+    "  contents: read",
+    "  pull-requests: write",
+    "",
+    "jobs:",
+    "  react-doctor:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "      - uses: millionco/react-doctor@main",
+    "        with:",
+    "          github-token: ${{ secrets.GITHUB_TOKEN }}",
+    "          diff: main",
+    "",
+  ].join("\n");
+
+export const runInstallReactDoctor = async (
+  options: InstallReactDoctorOptions = {},
+): Promise<void> => {
   const requestedProjectRoot = options.projectRoot ?? process.cwd();
   const projectRoot = findNearestPackageDirectory(requestedProjectRoot) ?? requestedProjectRoot;
   const sourceDir = options.sourceDir ?? getSkillSourceDirectory();
@@ -301,11 +336,12 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
   const gitHookPath = gitHookTarget?.hookPath;
   const promptOptions =
     options.onPromptCancel === undefined ? {} : { onCancel: options.onPromptCancel };
+  const prompt = options.prompt ?? prompts;
 
   const selectedAgents: SkillAgentType[] = skipPrompts
     ? detectedAgents
     : ((
-        await prompts(
+        await prompt(
           {
             type: "multiselect",
             name: "agents",
@@ -324,26 +360,89 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
 
   if (selectedAgents.length === 0) return;
 
+  const workflowsDirectory = path.join(projectRoot, ".github", "workflows");
+  const workflowTargetPath = path.join(workflowsDirectory, "react-doctor.yml");
+  const hasExistingWorkflows = existsSync(workflowsDirectory);
+  const canInstallWorkflow = !existsSync(workflowTargetPath);
+  const setupActionChoices = [
+    ...(gitHookPath === null || gitHookPath === undefined
+      ? []
+      : [
+          {
+            title: "Pre-commit hook",
+            description: "Check staged changes before each commit",
+            value: SETUP_OPTION_GIT_HOOK,
+            selected: true,
+          },
+        ]),
+    ...(canInstallNativeAgentHooks(selectedAgents)
+      ? [
+          {
+            title: "Agent hooks",
+            description: "Ask Claude Code or Cursor to scan after code edits",
+            value: SETUP_OPTION_AGENT_HOOKS,
+            selected: Boolean(options.agentHooks),
+          },
+        ]
+      : []),
+    ...(canInstallWorkflow
+      ? [
+          {
+            title: "GitHub Actions workflow",
+            description: "Scan pull requests in CI",
+            value: SETUP_OPTION_WORKFLOW,
+            selected: hasExistingWorkflows,
+          },
+        ]
+      : []),
+  ];
+  const setupChoices =
+    setupActionChoices.length === 0
+      ? []
+      : [
+          {
+            title: "Skip optional setup",
+            description: "Install only the agent skill and package setup",
+            value: SETUP_OPTION_SKIP,
+            selected: false,
+          },
+          ...setupActionChoices,
+        ];
+  const selectedSetupOptions: string[] =
+    skipPrompts || setupChoices.length === 0
+      ? []
+      : ((
+          await prompt<"setupOptions">(
+            {
+              type: "multiselect",
+              name: "setupOptions",
+              message: "Select additional React Doctor setup:",
+              choices: setupChoices,
+              instructions: false,
+            },
+            promptOptions,
+          )
+        ).setupOptions ?? []);
+  const selectedSetupActions = selectedSetupOptions.filter(
+    (setupOption) => setupOption !== SETUP_OPTION_SKIP,
+  );
+  const didSkipOptionalSetup =
+    selectedSetupActions.length === 0 && selectedSetupOptions.includes(SETUP_OPTION_SKIP);
+
   const shouldInstallGitHook =
     gitHookPath !== null &&
     gitHookPath !== undefined &&
     (Boolean(options.yes) ||
-      (!skipPrompts &&
-        Boolean(
-          (
-            await prompts<"installGitHook">(
-              {
-                type: "confirm",
-                name: "installGitHook",
-                message: "Check for issues before each commit?",
-                initial: true,
-              },
-              promptOptions,
-            )
-          ).installGitHook,
-        )));
+      (!didSkipOptionalSetup && selectedSetupActions.includes(SETUP_OPTION_GIT_HOOK)));
 
-  const shouldInstallAgentHooks = Boolean(options.agentHooks);
+  const shouldInstallAgentHooks =
+    Boolean(options.agentHooks) ||
+    (!didSkipOptionalSetup && selectedSetupActions.includes(SETUP_OPTION_AGENT_HOOKS));
+  const shouldInstallWorkflow =
+    !skipPrompts &&
+    !didSkipOptionalSetup &&
+    canInstallWorkflow &&
+    selectedSetupActions.includes(SETUP_OPTION_WORKFLOW);
 
   if (options.dryRun) {
     logger.log(`Dry run — would install ${SKILL_NAME} skill for:`);
@@ -358,6 +457,9 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
     }
     if (shouldInstallAgentHooks) {
       logger.dim("  Agent hooks: Claude Code / Cursor when selected");
+    }
+    if (shouldInstallWorkflow) {
+      logger.dim(`  GitHub Actions workflow: ${path.relative(projectRoot, workflowTargetPath)}`);
     }
     return;
   }
@@ -430,55 +532,19 @@ export const runInstallSkill = async (options: InstallSkillOptions = {}): Promis
     }
   }
 
-  const workflowsDirectory = path.join(projectRoot, ".github", "workflows");
-  const workflowTargetPath = path.join(workflowsDirectory, "react-doctor.yml");
-  if (!existsSync(workflowTargetPath) && !skipPrompts) {
-    const hasExistingWorkflows = existsSync(workflowsDirectory);
-    const { shouldInstallWorkflow } = await prompts<"shouldInstallWorkflow">(
-      {
-        type: "confirm",
-        name: "shouldInstallWorkflow",
-        message: "Add a GitHub Actions workflow to scan PRs?",
-        initial: hasExistingWorkflows,
-      },
-      promptOptions,
-    );
-    if (shouldInstallWorkflow) {
-      if (!hasExistingWorkflows) {
-        mkdirSync(workflowsDirectory, { recursive: true });
-      }
-      const workflowSpinner = spinner("Adding GitHub Actions workflow...").start();
-      try {
-        const workflowContent = [
-          "name: React Doctor",
-          "",
-          "on:",
-          "  pull_request:",
-          "    branches: [main]",
-          "",
-          "permissions:",
-          "  contents: read",
-          "  pull-requests: write",
-          "",
-          "jobs:",
-          "  react-doctor:",
-          "    runs-on: ubuntu-latest",
-          "    steps:",
-          "      - uses: actions/checkout@v4",
-          "      - uses: millionco/react-doctor@main",
-          "        with:",
-          "          github-token: ${{ secrets.GITHUB_TOKEN }}",
-          "          diff: main",
-          "",
-        ].join("\n");
-        writeFileSync(workflowTargetPath, workflowContent);
-        workflowSpinner.succeed(
-          `GitHub Actions workflow added at ${path.relative(projectRoot, workflowTargetPath)}.`,
-        );
-      } catch (error) {
-        workflowSpinner.fail("Failed to add GitHub Actions workflow.");
-        throw error;
-      }
+  if (shouldInstallWorkflow) {
+    if (!hasExistingWorkflows) {
+      mkdirSync(workflowsDirectory, { recursive: true });
+    }
+    const workflowSpinner = spinner("Adding GitHub Actions workflow...").start();
+    try {
+      writeFileSync(workflowTargetPath, buildWorkflowContent());
+      workflowSpinner.succeed(
+        `GitHub Actions workflow added at ${path.relative(projectRoot, workflowTargetPath)}.`,
+      );
+    } catch (error) {
+      workflowSpinner.fail("Failed to add GitHub Actions workflow.");
+      throw error;
     }
   }
 };

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -29,7 +29,6 @@ const SETUP_OPTION_GIT_HOOK = "git-hook";
 const SETUP_OPTION_AGENT_HOOKS = "agent-hooks";
 const SETUP_OPTION_WORKFLOW = "workflow";
 const SETUP_OPTION_SKIP = "skip";
-const SETUP_OPTION_SKILL_PREFIX = "skill:";
 
 const CONFIG_ONLY_GIT_HOOK_KINDS = new Set([
   GitHookKind.Ghooks,
@@ -279,18 +278,6 @@ const getSkillSourceDirectory = (): string => {
 const canInstallNativeAgentHooks = (agents: readonly SkillAgentType[]): boolean =>
   agents.some((agent) => agent === "claude-code" || agent === "cursor");
 
-const getSkillSetupOption = (agent: SkillAgentType): string =>
-  `${SETUP_OPTION_SKILL_PREFIX}${agent}`;
-
-const getSkillSetupOptionAgent = (
-  setupOption: string,
-  detectedAgents: readonly SkillAgentType[],
-): SkillAgentType | null => {
-  if (!setupOption.startsWith(SETUP_OPTION_SKILL_PREFIX)) return null;
-  const requestedAgent = setupOption.slice(SETUP_OPTION_SKILL_PREFIX.length);
-  return detectedAgents.find((detectedAgent) => detectedAgent === requestedAgent) ?? null;
-};
-
 const buildWorkflowContent = (): string =>
   [
     "name: React Doctor",
@@ -351,17 +338,33 @@ export const runInstallReactDoctor = async (
     options.onPromptCancel === undefined ? {} : { onCancel: options.onPromptCancel };
   const prompt = options.prompt ?? prompts;
 
+  const selectedAgents: SkillAgentType[] = skipPrompts
+    ? detectedAgents
+    : ((
+        await prompt(
+          {
+            type: "multiselect",
+            name: "agents",
+            message: `Install the ${highlighter.info(`/${SKILL_NAME}`)} skill for:`,
+            choices: detectedAgents.map((agent) => ({
+              title: getSkillAgentConfig(agent).displayName,
+              value: agent,
+              selected: true,
+            })),
+            instructions: false,
+            min: 1,
+          },
+          promptOptions,
+        )
+      ).agents ?? []);
+
+  if (selectedAgents.length === 0) return;
+
   const workflowsDirectory = path.join(projectRoot, ".github", "workflows");
   const workflowTargetPath = path.join(workflowsDirectory, "react-doctor.yml");
   const hasExistingWorkflows = existsSync(workflowsDirectory);
   const canInstallWorkflow = !existsSync(workflowTargetPath);
   const setupActionChoices = [
-    ...detectedAgents.map((agent) => ({
-      title: `${getSkillAgentConfig(agent).displayName} skill`,
-      description: `Install the ${highlighter.info(`/${SKILL_NAME}`)} skill`,
-      value: getSkillSetupOption(agent),
-      selected: true,
-    })),
     ...(gitHookPath === null || gitHookPath === undefined
       ? []
       : [
@@ -372,7 +375,7 @@ export const runInstallReactDoctor = async (
             selected: true,
           },
         ]),
-    ...(canInstallNativeAgentHooks(detectedAgents)
+    ...(canInstallNativeAgentHooks(selectedAgents)
       ? [
           {
             title: "Agent hooks",
@@ -398,41 +401,33 @@ export const runInstallReactDoctor = async (
       ? []
       : [
           {
-            title: "Skip setup",
-            description: "Do not install skills, hooks, or workflow",
+            title: "Skip optional setup",
+            description: "Install only the agent skill and package setup",
             value: SETUP_OPTION_SKIP,
             selected: false,
           },
           ...setupActionChoices,
         ];
-  let selectedSetupOptions: string[];
-  if (skipPrompts) {
-    selectedSetupOptions = detectedAgents.map(getSkillSetupOption);
-  } else if (setupChoices.length === 0) {
-    selectedSetupOptions = [];
-  } else {
-    const setupAnswers = await prompt<"setupOptions">(
-      {
-        type: "multiselect",
-        name: "setupOptions",
-        message: "Select React Doctor setup:",
-        choices: setupChoices,
-        instructions: false,
-      },
-      promptOptions,
-    );
-    selectedSetupOptions = setupAnswers.setupOptions ?? [];
-  }
+  const selectedSetupOptions: string[] =
+    skipPrompts || setupChoices.length === 0
+      ? []
+      : ((
+          await prompt<"setupOptions">(
+            {
+              type: "multiselect",
+              name: "setupOptions",
+              message: "Select additional React Doctor setup:",
+              choices: setupChoices,
+              instructions: false,
+            },
+            promptOptions,
+          )
+        ).setupOptions ?? []);
   const selectedSetupActions = selectedSetupOptions.filter(
     (setupOption) => setupOption !== SETUP_OPTION_SKIP,
   );
   const didSkipOptionalSetup =
     selectedSetupActions.length === 0 && selectedSetupOptions.includes(SETUP_OPTION_SKIP);
-  const selectedAgents: SkillAgentType[] = [];
-  for (const setupAction of selectedSetupActions) {
-    const selectedAgent = getSkillSetupOptionAgent(setupAction, detectedAgents);
-    if (selectedAgent !== null) selectedAgents.push(selectedAgent);
-  }
 
   const shouldInstallGitHook =
     gitHookPath !== null &&
@@ -448,24 +443,15 @@ export const runInstallReactDoctor = async (
     !didSkipOptionalSetup &&
     canInstallWorkflow &&
     selectedSetupActions.includes(SETUP_OPTION_WORKFLOW);
-  const shouldInstallPackageSetup =
-    selectedAgents.length > 0 || shouldInstallGitHook || shouldInstallAgentHooks;
-  const didSelectSetup = shouldInstallPackageSetup || shouldInstallWorkflow;
-
-  if (!didSelectSetup || didSkipOptionalSetup) return;
 
   if (options.dryRun) {
-    logger.log(`Dry run — would install React Doctor setup:`);
-    if (selectedAgents.length > 0) {
-      logger.dim(
-        `  Skill: ${selectedAgents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ")}`,
-      );
+    logger.log(`Dry run — would install ${SKILL_NAME} skill for:`);
+    for (const agent of selectedAgents) {
+      logger.dim(`  - ${getSkillAgentConfig(agent).displayName}`);
     }
-    if (shouldInstallPackageSetup) {
-      logger.dim(`  Source: ${sourceDir}`);
-      logger.dim("  Package script: doctor (or react-doctor if doctor exists)");
-      logger.dim("  Dev dependency: react-doctor");
-    }
+    logger.dim(`  Source: ${sourceDir}`);
+    logger.dim("  Package script: doctor (or react-doctor if doctor exists)");
+    logger.dim("  Dev dependency: react-doctor");
     if (shouldInstallGitHook) {
       logger.dim(`  Git hook: ${gitHookPath}`);
     }
@@ -478,41 +464,37 @@ export const runInstallReactDoctor = async (
     return;
   }
 
-  if (selectedAgents.length > 0) {
-    const installSpinner = spinner(`Installing ${SKILL_NAME} skill...`).start();
-    try {
-      const installResult = await installSkillsFromSource({
-        source: sourceDir,
-        agents: selectedAgents,
-        cwd: projectRoot,
-        mode: "copy",
-      });
+  const installSpinner = spinner(`Installing ${SKILL_NAME} skill...`).start();
+  try {
+    const installResult = await installSkillsFromSource({
+      source: sourceDir,
+      agents: selectedAgents,
+      cwd: projectRoot,
+      mode: "copy",
+    });
 
-      if (installResult.skills.length === 0) {
-        throw new Error(
-          `Could not parse ${SKILL_MANIFEST_FILE} for ${SKILL_NAME} (missing or invalid frontmatter).`,
-        );
-      }
-      if (installResult.failed.length > 0) {
-        throw new Error(
-          installResult.failed
-            .map((failure) => `${getSkillAgentConfig(failure.agent).displayName}: ${failure.error}`)
-            .join("\n"),
-        );
-      }
-
-      installSpinner.succeed(
-        `${SKILL_NAME} skill installed for ${selectedAgents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ")}.`,
+    if (installResult.skills.length === 0) {
+      throw new Error(
+        `Could not parse ${SKILL_MANIFEST_FILE} for ${SKILL_NAME} (missing or invalid frontmatter).`,
       );
-    } catch (error) {
-      installSpinner.fail(`Failed to install ${SKILL_NAME} skill.`);
-      throw error;
     }
+    if (installResult.failed.length > 0) {
+      throw new Error(
+        installResult.failed
+          .map((failure) => `${getSkillAgentConfig(failure.agent).displayName}: ${failure.error}`)
+          .join("\n"),
+      );
+    }
+
+    installSpinner.succeed(
+      `${SKILL_NAME} skill installed for ${selectedAgents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ")}.`,
+    );
+  } catch (error) {
+    installSpinner.fail(`Failed to install ${SKILL_NAME} skill.`);
+    throw error;
   }
 
-  if (shouldInstallPackageSetup) {
-    await installReactDoctorPackageSetup(projectRoot, options.installDependencyRunner);
-  }
+  await installReactDoctorPackageSetup(projectRoot, options.installDependencyRunner);
 
   if (shouldInstallGitHook && gitHookTarget !== null && gitHookTarget !== undefined) {
     const hookSpinner = spinner("Installing React Doctor pre-commit hook...").start();
@@ -535,7 +517,7 @@ export const runInstallReactDoctor = async (
     try {
       const hookResult = installReactDoctorAgentHooks({
         projectRoot,
-        agents: selectedAgents.length > 0 ? selectedAgents : detectedAgents,
+        agents: selectedAgents,
       });
       if (hookResult.installedAgents.length === 0) {
         hookSpinner.succeed("No supported native agent hook targets selected.");

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -29,6 +29,7 @@ const SETUP_OPTION_GIT_HOOK = "git-hook";
 const SETUP_OPTION_AGENT_HOOKS = "agent-hooks";
 const SETUP_OPTION_WORKFLOW = "workflow";
 const SETUP_OPTION_SKIP = "skip";
+const SETUP_OPTION_SKILL_PREFIX = "skill:";
 
 const CONFIG_ONLY_GIT_HOOK_KINDS = new Set([
   GitHookKind.Ghooks,
@@ -278,6 +279,18 @@ const getSkillSourceDirectory = (): string => {
 const canInstallNativeAgentHooks = (agents: readonly SkillAgentType[]): boolean =>
   agents.some((agent) => agent === "claude-code" || agent === "cursor");
 
+const getSkillSetupOption = (agent: SkillAgentType): string =>
+  `${SETUP_OPTION_SKILL_PREFIX}${agent}`;
+
+const getSkillSetupOptionAgent = (
+  setupOption: string,
+  detectedAgents: readonly SkillAgentType[],
+): SkillAgentType | null => {
+  if (!setupOption.startsWith(SETUP_OPTION_SKILL_PREFIX)) return null;
+  const requestedAgent = setupOption.slice(SETUP_OPTION_SKILL_PREFIX.length);
+  return detectedAgents.find((detectedAgent) => detectedAgent === requestedAgent) ?? null;
+};
+
 const buildWorkflowContent = (): string =>
   [
     "name: React Doctor",
@@ -338,33 +351,17 @@ export const runInstallReactDoctor = async (
     options.onPromptCancel === undefined ? {} : { onCancel: options.onPromptCancel };
   const prompt = options.prompt ?? prompts;
 
-  const selectedAgents: SkillAgentType[] = skipPrompts
-    ? detectedAgents
-    : ((
-        await prompt(
-          {
-            type: "multiselect",
-            name: "agents",
-            message: `Install the ${highlighter.info(`/${SKILL_NAME}`)} skill for:`,
-            choices: detectedAgents.map((agent) => ({
-              title: getSkillAgentConfig(agent).displayName,
-              value: agent,
-              selected: true,
-            })),
-            instructions: false,
-            min: 1,
-          },
-          promptOptions,
-        )
-      ).agents ?? []);
-
-  if (selectedAgents.length === 0) return;
-
   const workflowsDirectory = path.join(projectRoot, ".github", "workflows");
   const workflowTargetPath = path.join(workflowsDirectory, "react-doctor.yml");
   const hasExistingWorkflows = existsSync(workflowsDirectory);
   const canInstallWorkflow = !existsSync(workflowTargetPath);
   const setupActionChoices = [
+    ...detectedAgents.map((agent) => ({
+      title: `${getSkillAgentConfig(agent).displayName} skill`,
+      description: `Install the ${highlighter.info(`/${SKILL_NAME}`)} skill`,
+      value: getSkillSetupOption(agent),
+      selected: true,
+    })),
     ...(gitHookPath === null || gitHookPath === undefined
       ? []
       : [
@@ -375,7 +372,7 @@ export const runInstallReactDoctor = async (
             selected: true,
           },
         ]),
-    ...(canInstallNativeAgentHooks(selectedAgents)
+    ...(canInstallNativeAgentHooks(detectedAgents)
       ? [
           {
             title: "Agent hooks",
@@ -401,33 +398,41 @@ export const runInstallReactDoctor = async (
       ? []
       : [
           {
-            title: "Skip optional setup",
-            description: "Install only the agent skill and package setup",
+            title: "Skip setup",
+            description: "Do not install skills, hooks, or workflow",
             value: SETUP_OPTION_SKIP,
             selected: false,
           },
           ...setupActionChoices,
         ];
-  const selectedSetupOptions: string[] =
-    skipPrompts || setupChoices.length === 0
-      ? []
-      : ((
-          await prompt<"setupOptions">(
-            {
-              type: "multiselect",
-              name: "setupOptions",
-              message: "Select additional React Doctor setup:",
-              choices: setupChoices,
-              instructions: false,
-            },
-            promptOptions,
-          )
-        ).setupOptions ?? []);
+  let selectedSetupOptions: string[];
+  if (skipPrompts) {
+    selectedSetupOptions = detectedAgents.map(getSkillSetupOption);
+  } else if (setupChoices.length === 0) {
+    selectedSetupOptions = [];
+  } else {
+    const setupAnswers = await prompt<"setupOptions">(
+      {
+        type: "multiselect",
+        name: "setupOptions",
+        message: "Select React Doctor setup:",
+        choices: setupChoices,
+        instructions: false,
+      },
+      promptOptions,
+    );
+    selectedSetupOptions = setupAnswers.setupOptions ?? [];
+  }
   const selectedSetupActions = selectedSetupOptions.filter(
     (setupOption) => setupOption !== SETUP_OPTION_SKIP,
   );
   const didSkipOptionalSetup =
     selectedSetupActions.length === 0 && selectedSetupOptions.includes(SETUP_OPTION_SKIP);
+  const selectedAgents: SkillAgentType[] = [];
+  for (const setupAction of selectedSetupActions) {
+    const selectedAgent = getSkillSetupOptionAgent(setupAction, detectedAgents);
+    if (selectedAgent !== null) selectedAgents.push(selectedAgent);
+  }
 
   const shouldInstallGitHook =
     gitHookPath !== null &&
@@ -443,15 +448,24 @@ export const runInstallReactDoctor = async (
     !didSkipOptionalSetup &&
     canInstallWorkflow &&
     selectedSetupActions.includes(SETUP_OPTION_WORKFLOW);
+  const shouldInstallPackageSetup =
+    selectedAgents.length > 0 || shouldInstallGitHook || shouldInstallAgentHooks;
+  const didSelectSetup = shouldInstallPackageSetup || shouldInstallWorkflow;
+
+  if (!didSelectSetup || didSkipOptionalSetup) return;
 
   if (options.dryRun) {
-    logger.log(`Dry run — would install ${SKILL_NAME} skill for:`);
-    for (const agent of selectedAgents) {
-      logger.dim(`  - ${getSkillAgentConfig(agent).displayName}`);
+    logger.log(`Dry run — would install React Doctor setup:`);
+    if (selectedAgents.length > 0) {
+      logger.dim(
+        `  Skill: ${selectedAgents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ")}`,
+      );
     }
-    logger.dim(`  Source: ${sourceDir}`);
-    logger.dim("  Package script: doctor (or react-doctor if doctor exists)");
-    logger.dim("  Dev dependency: react-doctor");
+    if (shouldInstallPackageSetup) {
+      logger.dim(`  Source: ${sourceDir}`);
+      logger.dim("  Package script: doctor (or react-doctor if doctor exists)");
+      logger.dim("  Dev dependency: react-doctor");
+    }
     if (shouldInstallGitHook) {
       logger.dim(`  Git hook: ${gitHookPath}`);
     }
@@ -464,37 +478,41 @@ export const runInstallReactDoctor = async (
     return;
   }
 
-  const installSpinner = spinner(`Installing ${SKILL_NAME} skill...`).start();
-  try {
-    const installResult = await installSkillsFromSource({
-      source: sourceDir,
-      agents: selectedAgents,
-      cwd: projectRoot,
-      mode: "copy",
-    });
+  if (selectedAgents.length > 0) {
+    const installSpinner = spinner(`Installing ${SKILL_NAME} skill...`).start();
+    try {
+      const installResult = await installSkillsFromSource({
+        source: sourceDir,
+        agents: selectedAgents,
+        cwd: projectRoot,
+        mode: "copy",
+      });
 
-    if (installResult.skills.length === 0) {
-      throw new Error(
-        `Could not parse ${SKILL_MANIFEST_FILE} for ${SKILL_NAME} (missing or invalid frontmatter).`,
-      );
-    }
-    if (installResult.failed.length > 0) {
-      throw new Error(
-        installResult.failed
-          .map((failure) => `${getSkillAgentConfig(failure.agent).displayName}: ${failure.error}`)
-          .join("\n"),
-      );
-    }
+      if (installResult.skills.length === 0) {
+        throw new Error(
+          `Could not parse ${SKILL_MANIFEST_FILE} for ${SKILL_NAME} (missing or invalid frontmatter).`,
+        );
+      }
+      if (installResult.failed.length > 0) {
+        throw new Error(
+          installResult.failed
+            .map((failure) => `${getSkillAgentConfig(failure.agent).displayName}: ${failure.error}`)
+            .join("\n"),
+        );
+      }
 
-    installSpinner.succeed(
-      `${SKILL_NAME} skill installed for ${selectedAgents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ")}.`,
-    );
-  } catch (error) {
-    installSpinner.fail(`Failed to install ${SKILL_NAME} skill.`);
-    throw error;
+      installSpinner.succeed(
+        `${SKILL_NAME} skill installed for ${selectedAgents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ")}.`,
+      );
+    } catch (error) {
+      installSpinner.fail(`Failed to install ${SKILL_NAME} skill.`);
+      throw error;
+    }
   }
 
-  await installReactDoctorPackageSetup(projectRoot, options.installDependencyRunner);
+  if (shouldInstallPackageSetup) {
+    await installReactDoctorPackageSetup(projectRoot, options.installDependencyRunner);
+  }
 
   if (shouldInstallGitHook && gitHookTarget !== null && gitHookTarget !== undefined) {
     const hookSpinner = spinner("Installing React Doctor pre-commit hook...").start();
@@ -517,7 +535,7 @@ export const runInstallReactDoctor = async (
     try {
       const hookResult = installReactDoctorAgentHooks({
         projectRoot,
-        agents: selectedAgents,
+        agents: selectedAgents.length > 0 ? selectedAgents : detectedAgents,
       });
       if (hookResult.installedAgents.length === 0) {
         hookSpinner.succeed("No supported native agent hook targets selected.");

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -6,13 +6,13 @@ import { findNearestPackageDirectory, hasDoctorScript } from "./install-doctor-s
 import { isCiOrCodingAgentEnvironment, isCodingAgentEnvironment } from "./is-ci-environment.js";
 import { SETUP_PROMPT_DELAY_MS } from "./constants.js";
 
-export interface InstallSkillRunnerOptions {
+export interface InstallReactDoctorRunnerOptions {
   readonly projectRoot?: string;
   readonly onPromptCancel?: () => void;
 }
 
-export interface InstallSkillRunner {
-  (options: InstallSkillRunnerOptions): Promise<void>;
+export interface InstallReactDoctorRunner {
+  (options: InstallReactDoctorRunnerOptions): Promise<void>;
 }
 
 export interface SetupPromptWait {
@@ -52,7 +52,7 @@ export interface ShouldPromptInstallSetupOptions {
 
 export interface PromptInstallSetupOptions extends ShouldPromptInstallSetupOptions {
   readonly issueCount: number;
-  readonly install?: InstallSkillRunner;
+  readonly install?: InstallReactDoctorRunner;
   readonly select?: SetupPromptSelect;
   readonly wait?: SetupPromptWait;
   readonly warn?: SetupPromptWarningWriter;
@@ -220,7 +220,8 @@ export const promptInstallSetup = async (options: PromptInstallSetupOptions): Pr
       return;
     }
 
-    const install = options.install ?? (await import("./install-skill.js")).runInstallSkill;
+    const install =
+      options.install ?? (await import("./install-react-doctor.js")).runInstallReactDoctor;
     const previousExitCode = process.exitCode;
     let setupExitCode: typeof process.exitCode;
     try {

--- a/packages/react-doctor/tests/install-action.test.ts
+++ b/packages/react-doctor/tests/install-action.test.ts
@@ -4,12 +4,12 @@ import { silenceConsoleForTest } from "./helpers/silence-console.js";
 // HACK: vi.mock is hoisted above the imports it replaces. The mock factory
 // runs before any non-mock import, so we re-import inside each test to get
 // the spied module.
-vi.mock("../src/cli/utils/install-skill.js", () => ({
-  runInstallSkill: vi.fn(),
+vi.mock("../src/cli/utils/install-react-doctor.js", () => ({
+  runInstallReactDoctor: vi.fn(),
 }));
 
 import { installAction } from "../src/cli/commands/install.js";
-import { runInstallSkill } from "../src/cli/utils/install-skill.js";
+import { runInstallReactDoctor } from "../src/cli/utils/install-react-doctor.js";
 
 describe("installAction (Commander action wrapper)", () => {
   let originalExitCode: number | string | undefined;
@@ -19,7 +19,7 @@ describe("installAction (Commander action wrapper)", () => {
     restoreConsole = silenceConsoleForTest();
     originalExitCode = process.exitCode;
     process.exitCode = 0;
-    vi.mocked(runInstallSkill).mockReset();
+    vi.mocked(runInstallReactDoctor).mockReset();
   });
 
   afterEach(() => {
@@ -28,13 +28,13 @@ describe("installAction (Commander action wrapper)", () => {
   });
 
   // Regression guard for H2: installAction translates Commander's `--cwd`
-  // (exposed as `options.cwd`) into `runInstallSkill({ projectRoot })`.
+  // (exposed as `options.cwd`) into `runInstallReactDoctor({ projectRoot })`.
   // Typos in this thin wire-up (e.g. `projectRoot: options.dryRun`) would
-  // silently send the wrong directory to the skill installer.
-  it("forwards --cwd as projectRoot to runInstallSkill", async () => {
+  // silently send the wrong directory to the installer.
+  it("forwards --cwd as projectRoot to runInstallReactDoctor", async () => {
     await installAction({ cwd: "/tmp/some-project", yes: true, dryRun: true });
-    expect(runInstallSkill).toHaveBeenCalledTimes(1);
-    expect(runInstallSkill).toHaveBeenCalledWith({
+    expect(runInstallReactDoctor).toHaveBeenCalledTimes(1);
+    expect(runInstallReactDoctor).toHaveBeenCalledWith({
       yes: true,
       dryRun: true,
       agentHooks: undefined,
@@ -44,8 +44,8 @@ describe("installAction (Commander action wrapper)", () => {
 
   it("falls back to process.cwd() when --cwd is not provided", async () => {
     await installAction({ yes: true });
-    expect(runInstallSkill).toHaveBeenCalledTimes(1);
-    expect(runInstallSkill).toHaveBeenCalledWith({
+    expect(runInstallReactDoctor).toHaveBeenCalledTimes(1);
+    expect(runInstallReactDoctor).toHaveBeenCalledWith({
       yes: true,
       dryRun: undefined,
       agentHooks: undefined,
@@ -55,7 +55,7 @@ describe("installAction (Commander action wrapper)", () => {
 
   it("propagates --yes and --dry-run independently of --cwd", async () => {
     await installAction({ yes: false, dryRun: true, cwd: "/tmp/other" });
-    expect(runInstallSkill).toHaveBeenCalledWith({
+    expect(runInstallReactDoctor).toHaveBeenCalledWith({
       yes: false,
       dryRun: true,
       agentHooks: undefined,
@@ -63,9 +63,9 @@ describe("installAction (Commander action wrapper)", () => {
     });
   });
 
-  it("forwards --agent-hooks to runInstallSkill", async () => {
+  it("forwards --agent-hooks to runInstallReactDoctor", async () => {
     await installAction({ yes: true, agentHooks: true, cwd: "/tmp/agent-hooks" });
-    expect(runInstallSkill).toHaveBeenCalledWith({
+    expect(runInstallReactDoctor).toHaveBeenCalledWith({
       yes: true,
       dryRun: undefined,
       agentHooks: true,
@@ -85,7 +85,7 @@ describe("installAction (Commander action wrapper)", () => {
         },
       },
     );
-    expect(runInstallSkill).toHaveBeenCalledWith({
+    expect(runInstallReactDoctor).toHaveBeenCalledWith({
       yes: true,
       dryRun: true,
       agentHooks: undefined,
@@ -106,7 +106,7 @@ describe("installAction (Commander action wrapper)", () => {
         },
       },
     );
-    expect(runInstallSkill).toHaveBeenCalledWith({
+    expect(runInstallReactDoctor).toHaveBeenCalledWith({
       yes: false,
       dryRun: true,
       agentHooks: undefined,
@@ -127,7 +127,7 @@ describe("installAction (Commander action wrapper)", () => {
         },
       },
     );
-    expect(runInstallSkill).toHaveBeenCalledWith({
+    expect(runInstallReactDoctor).toHaveBeenCalledWith({
       yes: true,
       dryRun: true,
       agentHooks: true,
@@ -136,7 +136,7 @@ describe("installAction (Commander action wrapper)", () => {
   });
 
   it("delegates thrown errors to handleError without re-throwing", async () => {
-    vi.mocked(runInstallSkill).mockRejectedValueOnce(new Error("boom"));
+    vi.mocked(runInstallReactDoctor).mockRejectedValueOnce(new Error("boom"));
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);
     }) as never);

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -2,20 +2,26 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type { Answers, PromptObject } from "prompts";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
-import { runInstallSkill } from "../src/cli/utils/install-skill.js";
-import type { InstallReactDoctorDependencyRunnerInput } from "../src/cli/utils/install-skill.js";
+import {
+  CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+  CODING_AGENT_ENVIRONMENT_VARIABLES,
+} from "../src/cli/utils/is-ci-environment.js";
+import { NON_INTERACTIVE_ENVIRONMENT_VARIABLES } from "../src/cli/utils/is-non-interactive-environment.js";
+import { runInstallReactDoctor } from "../src/cli/utils/install-react-doctor.js";
+import type { InstallReactDoctorDependencyRunnerInput } from "../src/cli/utils/install-react-doctor.js";
 import { setSpinnerSilent } from "../src/cli/utils/spinner.js";
 import { silenceConsoleForTest } from "./helpers/silence-console.js";
 
-interface InstallSkillFixture {
+interface InstallReactDoctorFixture {
   projectRoot: string;
   sourceDir: string;
   cleanup: () => void;
 }
 
-const setupFixture = (): InstallSkillFixture => {
-  const root = mkdtempSync(path.join(tmpdir(), "react-doctor-install-skill-"));
+const setupFixture = (): InstallReactDoctorFixture => {
+  const root = mkdtempSync(path.join(tmpdir(), "react-doctor-install-"));
   const projectRoot = path.join(root, "project");
   const sourceDir = path.join(root, "source");
   mkdirSync(projectRoot, { recursive: true });
@@ -44,7 +50,7 @@ const readFixturePackageJson = (projectRoot: string): Record<string, unknown> =>
 let dependencyInstallCalls: InstallReactDoctorDependencyRunnerInput[] = [];
 
 const installDependencyForTest: NonNullable<
-  Parameters<typeof runInstallSkill>[0]
+  Parameters<typeof runInstallReactDoctor>[0]
 >["installDependencyRunner"] = (input) => {
   dependencyInstallCalls.push(input);
   const packageJson = readFixturePackageJson(input.cwd);
@@ -61,14 +67,81 @@ const installDependencyForTest: NonNullable<
   });
 };
 
-const runInstallSkillForTest = (options: NonNullable<Parameters<typeof runInstallSkill>[0]>) =>
-  runInstallSkill({
+const runInstallReactDoctorForTest = (
+  options: NonNullable<Parameters<typeof runInstallReactDoctor>[0]>,
+) =>
+  runInstallReactDoctor({
     installDependencyRunner: installDependencyForTest,
     ...options,
   });
 
-describe("runInstallSkill", () => {
-  let fixture: InstallSkillFixture;
+interface RunInteractiveInstallReactDoctorForTestOptions {
+  readonly sourceDir: string;
+  readonly projectRoot: string;
+  readonly gitHookPath: string;
+  readonly setupOptions: readonly string[];
+  readonly promptQuestions?: unknown[];
+}
+
+const runInteractiveInstallReactDoctorForTest = async (
+  options: RunInteractiveInstallReactDoctorForTestOptions,
+): Promise<void> => {
+  const originalIsTty = process.stdin.isTTY;
+  const savedEnvironmentValues = new Map<string, string | undefined>();
+  const interactivePromptEnvironmentVariables = new Set([
+    ...NON_INTERACTIVE_ENVIRONMENT_VARIABLES,
+    ...CODING_AGENT_ENVIRONMENT_VARIABLES,
+    ...CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+  ]);
+  const prompt: NonNullable<Parameters<typeof runInstallReactDoctor>[0]>["prompt"] = async <
+    PromptName extends string = string,
+  >(
+    question: PromptObject<PromptName> | PromptObject<PromptName>[],
+  ) => {
+    options.promptQuestions?.push(question);
+    const promptQuestion = Array.isArray(question) ? question[0] : question;
+    const answers: Answers<PromptName> = Object.create(null);
+    const questionName = promptQuestion?.name;
+    if (typeof questionName !== "string") return answers;
+    answers[questionName] = questionName === "agents" ? ["cursor"] : options.setupOptions;
+    return answers;
+  };
+
+  try {
+    for (const environmentVariable of interactivePromptEnvironmentVariables) {
+      savedEnvironmentValues.set(environmentVariable, process.env[environmentVariable]);
+      delete process.env[environmentVariable];
+    }
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+
+    await runInstallReactDoctorForTest({
+      sourceDir: options.sourceDir,
+      projectRoot: options.projectRoot,
+      detectedAgents: ["cursor"],
+      gitHookPath: options.gitHookPath,
+      prompt,
+    });
+  } finally {
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: originalIsTty,
+    });
+    for (const environmentVariable of interactivePromptEnvironmentVariables) {
+      const savedEnvironmentValue = savedEnvironmentValues.get(environmentVariable);
+      if (savedEnvironmentValue === undefined) {
+        delete process.env[environmentVariable];
+      } else {
+        process.env[environmentVariable] = savedEnvironmentValue;
+      }
+    }
+  }
+};
+
+describe("runInstallReactDoctor", () => {
+  let fixture: InstallReactDoctorFixture;
   let originalExitCode: number | string | null | undefined;
   let originalCi: string | undefined;
   let restoreConsole: () => void;
@@ -97,7 +170,7 @@ describe("runInstallSkill", () => {
 
   it("exits with code 1 when the bundled SKILL.md is missing", async () => {
     writePackageJson(fixture.projectRoot, { scripts: {} });
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -112,7 +185,7 @@ describe("runInstallSkill", () => {
   it("exits with code 1 when no agents are detected", async () => {
     writeValidSkill(fixture.sourceDir);
     writePackageJson(fixture.projectRoot, { scripts: {} });
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -135,7 +208,7 @@ describe("runInstallSkill", () => {
       "# Just a heading, no frontmatter\nNothing here.\n",
     );
     await expect(
-      runInstallSkillForTest({
+      runInstallReactDoctorForTest({
         yes: true,
         sourceDir: fixture.sourceDir,
         projectRoot: fixture.projectRoot,
@@ -150,7 +223,7 @@ describe("runInstallSkill", () => {
       "---\nname: react-doctor\n---\n# react-doctor\n",
     );
     await expect(
-      runInstallSkillForTest({
+      runInstallReactDoctorForTest({
         yes: true,
         sourceDir: fixture.sourceDir,
         projectRoot: fixture.projectRoot,
@@ -162,7 +235,7 @@ describe("runInstallSkill", () => {
   it("--dry-run writes nothing, even with valid SKILL.md and detected agents", async () => {
     writeValidSkill(fixture.sourceDir);
     writePackageJson(fixture.projectRoot, { scripts: {} });
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       dryRun: true,
       agentHooks: true,
@@ -185,7 +258,7 @@ describe("runInstallSkill", () => {
       },
     });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -209,7 +282,7 @@ describe("runInstallSkill", () => {
       scripts: {},
     });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -239,7 +312,7 @@ describe("runInstallSkill", () => {
       scripts: {},
     });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: appDirectory,
@@ -261,7 +334,7 @@ describe("runInstallSkill", () => {
     writePackageJson(fixture.projectRoot, { scripts: {} });
 
     await expect(
-      runInstallSkillForTest({
+      runInstallReactDoctorForTest({
         yes: true,
         sourceDir: fixture.sourceDir,
         projectRoot: fixture.projectRoot,
@@ -280,7 +353,7 @@ describe("runInstallSkill", () => {
     const nestedDirectory = path.join(fixture.projectRoot, "src", "components");
     mkdirSync(nestedDirectory, { recursive: true });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: nestedDirectory,
@@ -305,7 +378,7 @@ describe("runInstallSkill", () => {
       },
     });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -329,7 +402,7 @@ describe("runInstallSkill", () => {
       },
     });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -355,7 +428,7 @@ describe("runInstallSkill", () => {
       scripts: {},
     });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -375,7 +448,7 @@ describe("runInstallSkill", () => {
     writeValidSkill(fixture.sourceDir);
     writeFileSync(path.join(fixture.projectRoot, "package.json"), "{ invalid json");
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -393,7 +466,7 @@ describe("runInstallSkill", () => {
 
   it("installs the skill into the universal .agents/skills directory for a universal agent", async () => {
     writeValidSkill(fixture.sourceDir);
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -406,7 +479,7 @@ describe("runInstallSkill", () => {
 
   it("installs the skill into a vendor-specific directory for a non-universal agent", async () => {
     writeValidSkill(fixture.sourceDir);
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -419,7 +492,7 @@ describe("runInstallSkill", () => {
 
   it("installs the skill into .factory/skills for the droid agent (upstream agent-install@0.0.3)", async () => {
     writeValidSkill(fixture.sourceDir);
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -434,7 +507,7 @@ describe("runInstallSkill", () => {
     writeValidSkill(fixture.sourceDir);
     const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -454,7 +527,7 @@ describe("runInstallSkill", () => {
   it("--agent-hooks installs native hooks for selected supported agents", async () => {
     writeValidSkill(fixture.sourceDir);
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       agentHooks: true,
       sourceDir: fixture.sourceDir,
@@ -478,10 +551,84 @@ describe("runInstallSkill", () => {
     expect(existsSync(path.join(fixture.projectRoot, ".codex/hooks.json"))).toBe(false);
   });
 
+  it("prompts once for optional setup and installs only selected options", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const promptQuestions: unknown[] = [];
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = path.join(fixture.projectRoot, ".github/workflows/react-doctor.yml");
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      setupOptions: ["workflow"],
+      promptQuestions,
+    });
+
+    expect(promptQuestions).toHaveLength(2);
+    expect(promptQuestions[1]).toEqual(
+      expect.objectContaining({
+        type: "multiselect",
+        name: "setupOptions",
+        message: "Select additional React Doctor setup:",
+      }),
+    );
+    expect(promptQuestions[1]).toEqual(
+      expect.objectContaining({
+        choices: expect.arrayContaining([
+          expect.objectContaining({ value: "skip" }),
+          expect.objectContaining({ value: "git-hook" }),
+          expect.objectContaining({ value: "agent-hooks" }),
+          expect.objectContaining({ value: "workflow" }),
+        ]),
+      }),
+    );
+    expect(existsSync(hookPath)).toBe(false);
+    expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
+    expect(readFileSync(workflowPath, "utf8")).toContain("name: React Doctor");
+  });
+
+  it("skips optional setup when only the skip option is selected", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = path.join(fixture.projectRoot, ".github/workflows/react-doctor.yml");
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      setupOptions: ["skip"],
+    });
+
+    expect(existsSync(hookPath)).toBe(false);
+    expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
+    expect(existsSync(workflowPath)).toBe(false);
+  });
+
+  it("honors selected setup actions when skip is selected with another option", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = path.join(fixture.projectRoot, ".github/workflows/react-doctor.yml");
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      setupOptions: ["skip", "workflow"],
+    });
+
+    expect(existsSync(hookPath)).toBe(false);
+    expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
+    expect(readFileSync(workflowPath, "utf8")).toContain("name: React Doctor");
+  });
+
   it("--yes does not install native agent hooks unless --agent-hooks is set", async () => {
     writeValidSkill(fixture.sourceDir);
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
@@ -504,7 +651,7 @@ describe("runInstallSkill", () => {
     process.env.CI = "1";
     execFileSync("git", ["init"], { cwd: fixture.projectRoot, stdio: "ignore" });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       yes: true,
       agentHooks: true,
       sourceDir: fixture.sourceDir,
@@ -531,7 +678,7 @@ describe("runInstallSkill", () => {
     process.env.CI = "1";
     execFileSync("git", ["init"], { cwd: fixture.projectRoot, stdio: "ignore" });
 
-    await runInstallSkillForTest({
+    await runInstallReactDoctorForTest({
       agentHooks: true,
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -551,7 +551,7 @@ describe("runInstallReactDoctor", () => {
     expect(existsSync(path.join(fixture.projectRoot, ".codex/hooks.json"))).toBe(false);
   });
 
-  it("prompts once for optional setup and installs only selected options", async () => {
+  it("prompts once for setup and installs only selected options", async () => {
     writeValidSkill(fixture.sourceDir);
     writePackageJson(fixture.projectRoot, { scripts: {} });
     const promptQuestions: unknown[] = [];
@@ -562,27 +562,31 @@ describe("runInstallReactDoctor", () => {
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
       gitHookPath: hookPath,
-      setupOptions: ["workflow"],
+      setupOptions: ["skill:cursor", "workflow"],
       promptQuestions,
     });
 
-    expect(promptQuestions).toHaveLength(2);
-    expect(promptQuestions[1]).toEqual(
+    expect(promptQuestions).toHaveLength(1);
+    expect(promptQuestions[0]).toEqual(
       expect.objectContaining({
         type: "multiselect",
         name: "setupOptions",
-        message: "Select additional React Doctor setup:",
+        message: "Select React Doctor setup:",
       }),
     );
-    expect(promptQuestions[1]).toEqual(
+    expect(promptQuestions[0]).toEqual(
       expect.objectContaining({
         choices: expect.arrayContaining([
           expect.objectContaining({ value: "skip" }),
+          expect.objectContaining({ value: "skill:cursor" }),
           expect.objectContaining({ value: "git-hook" }),
           expect.objectContaining({ value: "agent-hooks" }),
           expect.objectContaining({ value: "workflow" }),
         ]),
       }),
+    );
+    expect(existsSync(path.join(fixture.projectRoot, ".agents/skills/react-doctor/SKILL.md"))).toBe(
+      true,
     );
     expect(existsSync(hookPath)).toBe(false);
     expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
@@ -603,6 +607,7 @@ describe("runInstallReactDoctor", () => {
     });
 
     expect(existsSync(hookPath)).toBe(false);
+    expect(existsSync(path.join(fixture.projectRoot, ".agents"))).toBe(false);
     expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
     expect(existsSync(workflowPath)).toBe(false);
   });
@@ -621,6 +626,7 @@ describe("runInstallReactDoctor", () => {
     });
 
     expect(existsSync(hookPath)).toBe(false);
+    expect(existsSync(path.join(fixture.projectRoot, ".agents"))).toBe(false);
     expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
     expect(readFileSync(workflowPath, "utf8")).toContain("name: React Doctor");
   });

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -551,7 +551,7 @@ describe("runInstallReactDoctor", () => {
     expect(existsSync(path.join(fixture.projectRoot, ".codex/hooks.json"))).toBe(false);
   });
 
-  it("prompts once for setup and installs only selected options", async () => {
+  it("prompts once for optional setup and installs only selected options", async () => {
     writeValidSkill(fixture.sourceDir);
     writePackageJson(fixture.projectRoot, { scripts: {} });
     const promptQuestions: unknown[] = [];
@@ -562,31 +562,27 @@ describe("runInstallReactDoctor", () => {
       sourceDir: fixture.sourceDir,
       projectRoot: fixture.projectRoot,
       gitHookPath: hookPath,
-      setupOptions: ["skill:cursor", "workflow"],
+      setupOptions: ["workflow"],
       promptQuestions,
     });
 
-    expect(promptQuestions).toHaveLength(1);
-    expect(promptQuestions[0]).toEqual(
+    expect(promptQuestions).toHaveLength(2);
+    expect(promptQuestions[1]).toEqual(
       expect.objectContaining({
         type: "multiselect",
         name: "setupOptions",
-        message: "Select React Doctor setup:",
+        message: "Select additional React Doctor setup:",
       }),
     );
-    expect(promptQuestions[0]).toEqual(
+    expect(promptQuestions[1]).toEqual(
       expect.objectContaining({
         choices: expect.arrayContaining([
           expect.objectContaining({ value: "skip" }),
-          expect.objectContaining({ value: "skill:cursor" }),
           expect.objectContaining({ value: "git-hook" }),
           expect.objectContaining({ value: "agent-hooks" }),
           expect.objectContaining({ value: "workflow" }),
         ]),
       }),
-    );
-    expect(existsSync(path.join(fixture.projectRoot, ".agents/skills/react-doctor/SKILL.md"))).toBe(
-      true,
     );
     expect(existsSync(hookPath)).toBe(false);
     expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
@@ -607,7 +603,6 @@ describe("runInstallReactDoctor", () => {
     });
 
     expect(existsSync(hookPath)).toBe(false);
-    expect(existsSync(path.join(fixture.projectRoot, ".agents"))).toBe(false);
     expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
     expect(existsSync(workflowPath)).toBe(false);
   });
@@ -626,7 +621,6 @@ describe("runInstallReactDoctor", () => {
     });
 
     expect(existsSync(hookPath)).toBe(false);
-    expect(existsSync(path.join(fixture.projectRoot, ".agents"))).toBe(false);
     expect(existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
     expect(readFileSync(workflowPath, "utf8")).toContain("name: React Doctor");
   });


### PR DESCRIPTION
## Summary
- Rename the install runner to reflect the full React Doctor setup flow.
- Replace sequential optional install prompts with one multiselect for pre-commit hooks, agent hooks, workflow setup, or skipping optional setup.
- Add coverage for workflow-only, skip-only, and skip-plus-action selections.

## Test plan
- `nr test install-react-doctor.test.ts`
- `nr test install-react-doctor.test.ts install-action.test.ts prompt-install-setup.test.ts`
- `nr typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and naming refactor with preserved --yes/--agent-hooks behavior; expanded tests reduce regression risk for install wiring.
> 
> **Overview**
> Renames the install entry point from **`runInstallSkill`** / **`install-skill`** to **`runInstallReactDoctor`** / **`install-react-doctor`** across the CLI, post-scan setup prompt, and tests so naming matches the full setup flow (skill, package script, dependency, optional integrations).
> 
> **Interactive install** no longer chains separate confirms for pre-commit, agent hooks, and GitHub Actions. After agent multiselect, users get one **“Select additional React Doctor setup”** multiselect (pre-commit, agent hooks, workflow, or skip optional setup). Selection drives what gets installed; choosing only **skip** skips hooks and workflow unless **`--yes`** / **`--agent-hooks`** flags apply. Workflow YAML is centralized in **`buildWorkflowContent()`**, and **`prompt`** is injectable for tests.
> 
> Tests are renamed/updated for the new API, with coverage for workflow-only, skip-only, and skip combined with another option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c5870e46ddc702ac7052efee73f0c3af7000e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->