### PR TITLE
fix(cli): avoid dead-code scan freezes

### DIFF
--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -12,7 +12,7 @@ interface CheckDeadCodeOptions {
   /** Loaded react-doctor config — `ignore.files` is forwarded to deslop. */
   readonly userConfig?: ReactDoctorConfig | null;
   readonly deslopJsModuleSpecifier?: string;
-  readonly runWorker?: DeadCodeWorkerRunner;
+  readonly createWorker?: DeadCodeWorkerFactory;
   readonly workerTimeoutMs?: number;
 }
 
@@ -21,11 +21,15 @@ interface DeadCodeWorkerInput {
   readonly tsConfigPath?: string;
   readonly ignorePatterns: ReadonlyArray<string>;
   readonly deslopJsModuleSpecifier: string;
-  readonly timeoutMs: number;
 }
 
-interface DeadCodeWorkerRunner {
-  (input: DeadCodeWorkerInput): Promise<unknown>;
+interface DeadCodeWorkerHandle {
+  readonly result: Promise<unknown>;
+  readonly terminate?: () => void | Promise<unknown>;
+}
+
+interface DeadCodeWorkerFactory {
+  (input: DeadCodeWorkerInput): DeadCodeWorkerHandle;
 }
 
 interface DeadCodeWorkerUnusedFile {
@@ -296,54 +300,31 @@ const buildDeadCodeWorkerError = (workerError: DeadCodeWorkerError): Error => {
   return error;
 };
 
-const runDeadCodeWorker: DeadCodeWorkerRunner = (input) =>
-  new Promise<unknown>((resolve, reject) => {
-    const worker = new Worker(DEAD_CODE_WORKER_SCRIPT, {
-      eval: true,
-      workerData: input,
-    });
-    let didSettle = false;
-    let timeoutHandle: ReturnType<typeof setTimeout>;
+const createDeadCodeWorker: DeadCodeWorkerFactory = (input) => {
+  const worker = new Worker(DEAD_CODE_WORKER_SCRIPT, {
+    eval: true,
+    workerData: input,
+  });
+  let didSettle = false;
 
+  const result = new Promise<unknown>((resolve, reject) => {
     const settle = (callback: () => void): void => {
       if (didSettle) return;
       didSettle = true;
-      clearTimeout(timeoutHandle);
       worker.removeAllListeners();
       callback();
     };
-
-    timeoutHandle = setTimeout(() => {
-      settle(() => {
-        void worker.terminate();
-        reject(
-          new Error(
-            `Dead-code worker timed out after ${input.timeoutMs / MILLISECONDS_PER_SECOND}s.`,
-          ),
-        );
-      });
-    }, input.timeoutMs);
-    timeoutHandle.unref?.();
 
     worker.once("message", (message: unknown) => {
       try {
         const parsedMessage = parseDeadCodeWorkerMessage(message);
         if (parsedMessage.ok) {
-          settle(() => {
-            void worker.terminate();
-            resolve(parsedMessage.result);
-          });
+          settle(() => resolve(parsedMessage.result));
           return;
         }
-        settle(() => {
-          void worker.terminate();
-          reject(buildDeadCodeWorkerError(parsedMessage.error));
-        });
+        settle(() => reject(buildDeadCodeWorkerError(parsedMessage.error)));
       } catch (error) {
-        settle(() => {
-          void worker.terminate();
-          reject(error);
-        });
+        settle(() => reject(error));
       }
     });
 
@@ -357,18 +338,65 @@ const runDeadCodeWorker: DeadCodeWorkerRunner = (input) =>
     });
   });
 
+  return {
+    result,
+    terminate: () => {
+      didSettle = true;
+      worker.removeAllListeners();
+      return worker.terminate();
+    },
+  };
+};
+
+const runDeadCodeWorkerWithTimeout = (
+  handle: DeadCodeWorkerHandle,
+  timeoutMs: number,
+): Promise<unknown> =>
+  new Promise<unknown>((resolve, reject) => {
+    let didSettle = false;
+    const timeoutHandle = setTimeout(() => {
+      if (didSettle) return;
+      didSettle = true;
+      void handle.terminate?.();
+      reject(
+        new Error(`Dead-code worker timed out after ${timeoutMs / MILLISECONDS_PER_SECOND}s.`),
+      );
+    }, timeoutMs);
+    timeoutHandle.unref?.();
+
+    handle.result.then(
+      (value) => {
+        if (didSettle) return;
+        didSettle = true;
+        clearTimeout(timeoutHandle);
+        void handle.terminate?.();
+        resolve(value);
+      },
+      (error: unknown) => {
+        if (didSettle) return;
+        didSettle = true;
+        clearTimeout(timeoutHandle);
+        void handle.terminate?.();
+        reject(error);
+      },
+    );
+  });
+
 export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diagnostic[]> => {
   const { rootDirectory, userConfig } = options;
   if (!fs.existsSync(path.join(rootDirectory, "package.json"))) return [];
 
   const ignorePatterns = collectDeadCodeIgnorePatterns(rootDirectory, userConfig);
-  const rawResult = await (options.runWorker ?? runDeadCodeWorker)({
+  const workerHandle = (options.createWorker ?? createDeadCodeWorker)({
     rootDirectory,
     tsConfigPath: resolveTsConfigPath(rootDirectory),
     ignorePatterns,
     deslopJsModuleSpecifier: options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js"),
-    timeoutMs: options.workerTimeoutMs ?? DEAD_CODE_WORKER_TIMEOUT_MS,
   });
+  const rawResult = await runDeadCodeWorkerWithTimeout(
+    workerHandle,
+    options.workerTimeoutMs ?? DEAD_CODE_WORKER_TIMEOUT_MS,
+  );
   const result = parseDeadCodeWorkerResult(rawResult);
   const toRelative = (filePath: string): string => toRelativeFilePath(rootDirectory, filePath);
   const diagnostics: Diagnostic[] = [];

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -1,17 +1,122 @@
 import fs from "node:fs";
 import path from "node:path";
+import { Worker } from "node:worker_threads";
 import type { Diagnostic, ReactDoctorConfig } from "./types/index.js";
 import { collectIgnorePatterns } from "./collect-ignore-patterns.js";
+import { DEAD_CODE_WORKER_TIMEOUT_MS, MILLISECONDS_PER_SECOND } from "./constants.js";
 import { readIgnoreFile } from "./read-ignore-file.js";
 import { toRelativePath } from "./utils/to-relative-path.js";
 
 interface CheckDeadCodeOptions {
-  rootDirectory: string;
+  readonly rootDirectory: string;
   /** Loaded react-doctor config — `ignore.files` is forwarded to deslop. */
-  userConfig?: ReactDoctorConfig | null;
+  readonly userConfig?: ReactDoctorConfig | null;
+  readonly deslopJsModuleSpecifier?: string;
+  readonly runWorker?: DeadCodeWorkerRunner;
+  readonly workerTimeoutMs?: number;
+}
+
+interface DeadCodeWorkerInput {
+  readonly rootDirectory: string;
+  readonly tsConfigPath?: string;
+  readonly ignorePatterns: ReadonlyArray<string>;
+  readonly deslopJsModuleSpecifier: string;
+  readonly timeoutMs: number;
+}
+
+interface DeadCodeWorkerRunner {
+  (input: DeadCodeWorkerInput): Promise<unknown>;
+}
+
+interface DeadCodeWorkerUnusedFile {
+  readonly path: string;
+}
+
+interface DeadCodeWorkerUnusedExport {
+  readonly path: string;
+  readonly name: string;
+  readonly line: number;
+  readonly column: number;
+  readonly isTypeOnly: boolean;
+}
+
+interface DeadCodeWorkerUnusedDependency {
+  readonly name: string;
+  readonly isDevDependency: boolean;
+}
+
+interface DeadCodeWorkerCircularDependency {
+  readonly files: ReadonlyArray<string>;
+}
+
+interface DeadCodeWorkerResult {
+  readonly unusedFiles: ReadonlyArray<DeadCodeWorkerUnusedFile>;
+  readonly unusedExports: ReadonlyArray<DeadCodeWorkerUnusedExport>;
+  readonly unusedDependencies: ReadonlyArray<DeadCodeWorkerUnusedDependency>;
+  readonly circularDependencies: ReadonlyArray<DeadCodeWorkerCircularDependency>;
+}
+
+interface DeadCodeWorkerError {
+  readonly name?: string;
+  readonly message: string;
+  readonly stack?: string;
+}
+
+interface DeadCodeWorkerSuccessMessage {
+  readonly ok: true;
+  readonly result: unknown;
+}
+
+interface DeadCodeWorkerFailureMessage {
+  readonly ok: false;
+  readonly error: DeadCodeWorkerError;
 }
 
 const TSCONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"];
+
+const DEAD_CODE_WORKER_SCRIPT = `
+const { parentPort, workerData } = require("node:worker_threads");
+
+const normalizeResult = (result) => ({
+  unusedFiles: result.unusedFiles.map((unusedFile) => ({
+    path: unusedFile.path,
+  })),
+  unusedExports: result.unusedExports.map((unusedExport) => ({
+    path: unusedExport.path,
+    name: unusedExport.name,
+    line: unusedExport.line,
+    column: unusedExport.column,
+    isTypeOnly: unusedExport.isTypeOnly,
+  })),
+  unusedDependencies: result.unusedDependencies.map((unusedDependency) => ({
+    name: unusedDependency.name,
+    isDevDependency: unusedDependency.isDevDependency,
+  })),
+  circularDependencies: result.circularDependencies.map((cycle) => ({
+    files: cycle.files,
+  })),
+});
+
+const serializeError = (error) =>
+  error instanceof Error
+    ? { name: error.name, message: error.message, stack: error.stack }
+    : { message: String(error) };
+
+(async () => {
+  try {
+    const { analyze, defineConfig } = await import(workerData.deslopJsModuleSpecifier);
+    const config = {
+      rootDir: workerData.rootDirectory,
+      ...(workerData.tsConfigPath ? { tsConfigPath: workerData.tsConfigPath } : {}),
+      ...(workerData.ignorePatterns.length > 0 ? { ignorePatterns: workerData.ignorePatterns } : {}),
+    };
+    const result = await analyze(defineConfig(config));
+    parentPort.postMessage({ ok: true, result: normalizeResult(result) });
+  } catch (error) {
+    parentPort.postMessage({ ok: false, error: serializeError(error) });
+  }
+})();
+`;
 
 const resolveTsConfigPath = (rootDirectory: string): string | undefined => {
   for (const filename of TSCONFIG_FILENAMES) {
@@ -48,24 +153,223 @@ const toRelativeFilePath = (rootDirectory: string, filePath: string): string => 
   return relative.length > 0 ? relative : filePath.replace(/\\/g, "/");
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseArray = (value: unknown, label: string): unknown[] => {
+  if (!Array.isArray(value)) {
+    throw new Error(`Dead-code worker returned invalid ${label}.`);
+  }
+  return value;
+};
+
+const parseString = (value: unknown, label: string): string => {
+  if (typeof value !== "string") {
+    throw new Error(`Dead-code worker returned invalid ${label}.`);
+  }
+  return value;
+};
+
+const parseNumber = (value: unknown, label: string): number => {
+  if (typeof value !== "number") {
+    throw new Error(`Dead-code worker returned invalid ${label}.`);
+  }
+  return value;
+};
+
+const parseBoolean = (value: unknown, label: string): boolean => {
+  if (typeof value !== "boolean") {
+    throw new Error(`Dead-code worker returned invalid ${label}.`);
+  }
+  return value;
+};
+
+const parseStringArray = (value: unknown, label: string): string[] => {
+  const values = parseArray(value, label);
+  return values.map((entry, index) => parseString(entry, `${label}[${index}]`));
+};
+
+const parseUnusedFiles = (value: unknown): DeadCodeWorkerUnusedFile[] => {
+  const values = parseArray(value, "unusedFiles");
+  const unusedFiles: DeadCodeWorkerUnusedFile[] = [];
+  for (const [index, entry] of values.entries()) {
+    if (!isRecord(entry)) {
+      throw new Error(`Dead-code worker returned invalid unusedFiles[${index}].`);
+    }
+    unusedFiles.push({ path: parseString(entry.path, `unusedFiles[${index}].path`) });
+  }
+  return unusedFiles;
+};
+
+const parseUnusedExports = (value: unknown): DeadCodeWorkerUnusedExport[] => {
+  const values = parseArray(value, "unusedExports");
+  const unusedExports: DeadCodeWorkerUnusedExport[] = [];
+  for (const [index, entry] of values.entries()) {
+    if (!isRecord(entry)) {
+      throw new Error(`Dead-code worker returned invalid unusedExports[${index}].`);
+    }
+    unusedExports.push({
+      path: parseString(entry.path, `unusedExports[${index}].path`),
+      name: parseString(entry.name, `unusedExports[${index}].name`),
+      line: parseNumber(entry.line, `unusedExports[${index}].line`),
+      column: parseNumber(entry.column, `unusedExports[${index}].column`),
+      isTypeOnly: parseBoolean(entry.isTypeOnly, `unusedExports[${index}].isTypeOnly`),
+    });
+  }
+  return unusedExports;
+};
+
+const parseUnusedDependencies = (value: unknown): DeadCodeWorkerUnusedDependency[] => {
+  const values = parseArray(value, "unusedDependencies");
+  const unusedDependencies: DeadCodeWorkerUnusedDependency[] = [];
+  for (const [index, entry] of values.entries()) {
+    if (!isRecord(entry)) {
+      throw new Error(`Dead-code worker returned invalid unusedDependencies[${index}].`);
+    }
+    unusedDependencies.push({
+      name: parseString(entry.name, `unusedDependencies[${index}].name`),
+      isDevDependency: parseBoolean(
+        entry.isDevDependency,
+        `unusedDependencies[${index}].isDevDependency`,
+      ),
+    });
+  }
+  return unusedDependencies;
+};
+
+const parseCircularDependencies = (value: unknown): DeadCodeWorkerCircularDependency[] => {
+  const values = parseArray(value, "circularDependencies");
+  const circularDependencies: DeadCodeWorkerCircularDependency[] = [];
+  for (const [index, entry] of values.entries()) {
+    if (!isRecord(entry)) {
+      throw new Error(`Dead-code worker returned invalid circularDependencies[${index}].`);
+    }
+    circularDependencies.push({
+      files: parseStringArray(entry.files, `circularDependencies[${index}].files`),
+    });
+  }
+  return circularDependencies;
+};
+
+const parseDeadCodeWorkerResult = (value: unknown): DeadCodeWorkerResult => {
+  if (!isRecord(value)) {
+    throw new Error("Dead-code worker returned an invalid result.");
+  }
+  return {
+    unusedFiles: parseUnusedFiles(value.unusedFiles),
+    unusedExports: parseUnusedExports(value.unusedExports),
+    unusedDependencies: parseUnusedDependencies(value.unusedDependencies),
+    circularDependencies: parseCircularDependencies(value.circularDependencies),
+  };
+};
+
+const parseDeadCodeWorkerError = (value: unknown): DeadCodeWorkerError => {
+  if (!isRecord(value) || typeof value.message !== "string") {
+    return { message: "Dead-code worker failed." };
+  }
+  return {
+    ...(typeof value.name === "string" ? { name: value.name } : {}),
+    message: value.message,
+    ...(typeof value.stack === "string" ? { stack: value.stack } : {}),
+  };
+};
+
+const parseDeadCodeWorkerMessage = (
+  value: unknown,
+): DeadCodeWorkerSuccessMessage | DeadCodeWorkerFailureMessage => {
+  if (!isRecord(value)) {
+    throw new Error("Dead-code worker returned an invalid message.");
+  }
+  if (value.ok === true) {
+    return { ok: true, result: value.result };
+  }
+  if (value.ok === false) {
+    return { ok: false, error: parseDeadCodeWorkerError(value.error) };
+  }
+  throw new Error("Dead-code worker returned an invalid status.");
+};
+
+const buildDeadCodeWorkerError = (workerError: DeadCodeWorkerError): Error => {
+  const error = new Error(workerError.message);
+  if (workerError.name !== undefined) error.name = workerError.name;
+  if (workerError.stack !== undefined) error.stack = workerError.stack;
+  return error;
+};
+
+const runDeadCodeWorker: DeadCodeWorkerRunner = (input) =>
+  new Promise<unknown>((resolve, reject) => {
+    const worker = new Worker(DEAD_CODE_WORKER_SCRIPT, {
+      eval: true,
+      workerData: input,
+    });
+    let didSettle = false;
+    let timeoutHandle: ReturnType<typeof setTimeout>;
+
+    const settle = (callback: () => void): void => {
+      if (didSettle) return;
+      didSettle = true;
+      clearTimeout(timeoutHandle);
+      worker.removeAllListeners();
+      callback();
+    };
+
+    timeoutHandle = setTimeout(() => {
+      settle(() => {
+        void worker.terminate();
+        reject(
+          new Error(
+            `Dead-code worker timed out after ${input.timeoutMs / MILLISECONDS_PER_SECOND}s.`,
+          ),
+        );
+      });
+    }, input.timeoutMs);
+    timeoutHandle.unref?.();
+
+    worker.once("message", (message: unknown) => {
+      try {
+        const parsedMessage = parseDeadCodeWorkerMessage(message);
+        if (parsedMessage.ok) {
+          settle(() => {
+            void worker.terminate();
+            resolve(parsedMessage.result);
+          });
+          return;
+        }
+        settle(() => {
+          void worker.terminate();
+          reject(buildDeadCodeWorkerError(parsedMessage.error));
+        });
+      } catch (error) {
+        settle(() => {
+          void worker.terminate();
+          reject(error);
+        });
+      }
+    });
+
+    worker.once("error", (error) => {
+      settle(() => reject(error));
+    });
+
+    worker.once("exit", (exitCode) => {
+      if (exitCode === 0) return;
+      settle(() => reject(new Error(`Dead-code worker exited with code ${exitCode}.`)));
+    });
+  });
+
 export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diagnostic[]> => {
   const { rootDirectory, userConfig } = options;
   if (!fs.existsSync(path.join(rootDirectory, "package.json"))) return [];
 
-  // HACK: lazy-load so a missing/incompatible native oxc binding inside
-  // deslop-js can't crash module evaluation of @react-doctor/core
-  // (which the entire CLI imports). The caller's try/catch then
-  // catches the import failure and degrades gracefully.
-  const { analyze, defineConfig } = await import("deslop-js");
-
   const ignorePatterns = collectDeadCodeIgnorePatterns(rootDirectory, userConfig);
-  const result = await analyze(
-    defineConfig({
-      rootDir: rootDirectory,
-      tsConfigPath: resolveTsConfigPath(rootDirectory),
-      ...(ignorePatterns.length > 0 ? { ignorePatterns } : {}),
-    }),
-  );
+  const rawResult = await (options.runWorker ?? runDeadCodeWorker)({
+    rootDirectory,
+    tsConfigPath: resolveTsConfigPath(rootDirectory),
+    ignorePatterns,
+    deslopJsModuleSpecifier: options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js"),
+    timeoutMs: options.workerTimeoutMs ?? DEAD_CODE_WORKER_TIMEOUT_MS,
+  });
+  const result = parseDeadCodeWorkerResult(rawResult);
   const toRelative = (filePath: string): string => toRelativeFilePath(rootDirectory, filePath);
   const diagnostics: Diagnostic[] = [];
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -101,6 +101,8 @@ export const OXLINT_OUTPUT_MAX_BYTES = 50 * 1024 * 1024;
 // binding is markedly slower than on a developer laptop.
 export const OXLINT_SPAWN_TIMEOUT_MS = 60_000;
 
+export const DEAD_CODE_WORKER_TIMEOUT_MS = 120_000;
+
 // HACK: lookahead cap for JSX opener-span scanning; bounds worst-case
 // work on pathological files. Real openers stay well under this.
 export const JSX_OPENER_SCAN_MAX_LINES = 32;

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -258,32 +258,6 @@ export const runInspect = <HooksR = never>(
       reason: null,
     });
 
-    const shouldRunDeadCode = input.runDeadCode && !isDiffMode;
-
-    const deadCodeFiber = yield* Effect.forkChild(
-      shouldRunDeadCode
-        ? Stream.runCollect(
-            applyPerElementPipeline(
-              deadCodeService
-                .run({ rootDirectory: scanDirectory, userConfig: resolvedConfig.config })
-                .pipe(
-                  Stream.catchTag("ReactDoctorError", (error: ReactDoctorError) =>
-                    Stream.unwrap(
-                      Effect.gen(function* () {
-                        yield* Ref.set(deadCodeFailure, {
-                          didFail: true,
-                          reason: error.message,
-                        });
-                        return Stream.empty as Stream.Stream<Diagnostic, never>;
-                      }),
-                    ),
-                  ),
-                ),
-            ),
-          )
-        : Effect.succeed<Iterable<Diagnostic>>([]),
-    );
-
     const scanProgress = yield* progressService.start("Scanning...");
     const scanStartTime = Date.now();
     let lastReportedTotalFileCount = 0;
@@ -327,11 +301,36 @@ export const runInspect = <HooksR = never>(
     yield* afterLint(lintFailureState.didFail);
 
     if (lintFailureState.didFail) {
-      yield* Fiber.interrupt(deadCodeFiber);
       yield* scanProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
     }
 
-    const deadCodeCollected = lintFailureState.didFail ? [] : yield* Fiber.join(deadCodeFiber);
+    const shouldRunDeadCode = input.runDeadCode && !isDiffMode;
+    const deadCodeCollected =
+      lintFailureState.didFail || !shouldRunDeadCode
+        ? []
+        : yield* scanProgress.update("Analyzing dead code...").pipe(
+            Effect.andThen(
+              Stream.runCollect(
+                applyPerElementPipeline(
+                  deadCodeService
+                    .run({ rootDirectory: scanDirectory, userConfig: resolvedConfig.config })
+                    .pipe(
+                      Stream.catchTag("ReactDoctorError", (error: ReactDoctorError) =>
+                        Stream.unwrap(
+                          Effect.gen(function* () {
+                            yield* Ref.set(deadCodeFailure, {
+                              didFail: true,
+                              reason: error.message,
+                            });
+                            return Stream.empty as Stream.Stream<Diagnostic, never>;
+                          }),
+                        ),
+                      ),
+                    ),
+                ),
+              ),
+            ),
+          );
     const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
 
     const scanElapsedSeconds = ((Date.now() - scanStartTime) / 1000).toFixed(1);

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
-import { checkDeadCode } from "@react-doctor/core";
+import { checkDeadCode } from "../src/check-dead-code.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-check-dead-code-"));
 
@@ -72,5 +72,99 @@ describe("checkDeadCode", () => {
       .map((diagnostic) => diagnostic.filePath);
     expect(flagged.some((entry) => entry.endsWith("gitignored.ts"))).toBe(false);
     expect(flagged.some((entry) => entry.endsWith("configignored.ts"))).toBe(false);
+  });
+
+  it("maps unused exports, dependencies, and cycles from worker results", async () => {
+    const directory = setupProject("worker-result-shapes", {
+      "src/index.ts": "export const used = 1;\n",
+      "src/a.ts": "import './b';\n",
+      "src/b.ts": "import './a';\n",
+    });
+
+    const diagnostics = await checkDeadCode({
+      rootDirectory: directory,
+      runWorker: async () => ({
+        unusedFiles: [],
+        unusedExports: [
+          {
+            path: path.join(directory, "src", "index.ts"),
+            name: "unused",
+            line: 3,
+            column: 14,
+            isTypeOnly: false,
+          },
+          {
+            path: path.join(directory, "src", "index.ts"),
+            name: "UnusedType",
+            line: 4,
+            column: 12,
+            isTypeOnly: true,
+          },
+        ],
+        unusedDependencies: [
+          {
+            name: "left-pad",
+            isDevDependency: false,
+          },
+          {
+            name: "vitest",
+            isDevDependency: true,
+          },
+        ],
+        circularDependencies: [
+          {
+            files: [path.join(directory, "src", "a.ts"), path.join(directory, "src", "b.ts")],
+          },
+        ],
+      }),
+    });
+
+    expect(diagnostics.map((diagnostic) => diagnostic.rule)).toEqual([
+      "unused-export",
+      "unused-type",
+      "unused-dependency",
+      "unused-dev-dependency",
+      "circular-dependency",
+    ]);
+    expect(diagnostics.find((diagnostic) => diagnostic.rule === "unused-type")?.message).toContain(
+      "Unused type export: `UnusedType`",
+    );
+    expect(
+      diagnostics.find((diagnostic) => diagnostic.rule === "circular-dependency")?.message,
+    ).toContain("src/a.ts → src/b.ts");
+  });
+
+  it("rejects malformed worker results instead of silently dropping diagnostics", async () => {
+    const directory = setupProject("malformed-worker-result", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+
+    await expect(
+      checkDeadCode({
+        rootDirectory: directory,
+        runWorker: async () => ({
+          unusedFiles: [{ path: 1 }],
+          unusedExports: [],
+          unusedDependencies: [],
+          circularDependencies: [],
+        }),
+      }),
+    ).rejects.toThrow("unusedFiles[0].path");
+  });
+
+  it("times out a stuck worker", async () => {
+    const directory = setupProject("stuck-worker", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const stuckDeslopModule =
+      "data:text/javascript,export const defineConfig = (config) => config; export const analyze = () => new Promise(() => {});";
+
+    await expect(
+      checkDeadCode({
+        rootDirectory: directory,
+        deslopJsModuleSpecifier: stuckDeslopModule,
+        workerTimeoutMs: 1,
+      }),
+    ).rejects.toThrow("Dead-code worker timed out");
   });
 });

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -83,39 +83,41 @@ describe("checkDeadCode", () => {
 
     const diagnostics = await checkDeadCode({
       rootDirectory: directory,
-      runWorker: async () => ({
-        unusedFiles: [],
-        unusedExports: [
-          {
-            path: path.join(directory, "src", "index.ts"),
-            name: "unused",
-            line: 3,
-            column: 14,
-            isTypeOnly: false,
-          },
-          {
-            path: path.join(directory, "src", "index.ts"),
-            name: "UnusedType",
-            line: 4,
-            column: 12,
-            isTypeOnly: true,
-          },
-        ],
-        unusedDependencies: [
-          {
-            name: "left-pad",
-            isDevDependency: false,
-          },
-          {
-            name: "vitest",
-            isDevDependency: true,
-          },
-        ],
-        circularDependencies: [
-          {
-            files: [path.join(directory, "src", "a.ts"), path.join(directory, "src", "b.ts")],
-          },
-        ],
+      createWorker: () => ({
+        result: Promise.resolve({
+          unusedFiles: [],
+          unusedExports: [
+            {
+              path: path.join(directory, "src", "index.ts"),
+              name: "unused",
+              line: 3,
+              column: 14,
+              isTypeOnly: false,
+            },
+            {
+              path: path.join(directory, "src", "index.ts"),
+              name: "UnusedType",
+              line: 4,
+              column: 12,
+              isTypeOnly: true,
+            },
+          ],
+          unusedDependencies: [
+            {
+              name: "left-pad",
+              isDevDependency: false,
+            },
+            {
+              name: "vitest",
+              isDevDependency: true,
+            },
+          ],
+          circularDependencies: [
+            {
+              files: [path.join(directory, "src", "a.ts"), path.join(directory, "src", "b.ts")],
+            },
+          ],
+        }),
       }),
     });
 
@@ -142,11 +144,13 @@ describe("checkDeadCode", () => {
     await expect(
       checkDeadCode({
         rootDirectory: directory,
-        runWorker: async () => ({
-          unusedFiles: [{ path: 1 }],
-          unusedExports: [],
-          unusedDependencies: [],
-          circularDependencies: [],
+        createWorker: () => ({
+          result: Promise.resolve({
+            unusedFiles: [{ path: 1 }],
+            unusedExports: [],
+            unusedDependencies: [],
+            circularDependencies: [],
+          }),
         }),
       }),
     ).rejects.toThrow("unusedFiles[0].path");
@@ -156,15 +160,20 @@ describe("checkDeadCode", () => {
     const directory = setupProject("stuck-worker", {
       "src/index.ts": "export const used = 1;\n",
     });
-    const stuckDeslopModule =
-      "data:text/javascript,export const defineConfig = (config) => config; export const analyze = () => new Promise(() => {});";
+    let didTerminate = false;
 
     await expect(
       checkDeadCode({
         rootDirectory: directory,
-        deslopJsModuleSpecifier: stuckDeslopModule,
+        createWorker: () => ({
+          result: new Promise(() => {}),
+          terminate: () => {
+            didTerminate = true;
+          },
+        }),
         workerTimeoutMs: 1,
       }),
     ).rejects.toThrow("Dead-code worker timed out");
+    expect(didTerminate).toBe(true);
   });
 });

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -18,7 +18,7 @@ import { DeadCode } from "../src/services/dead-code.js";
 import { Files } from "../src/services/files.js";
 import { Git } from "../src/services/git.js";
 import { LintPartialFailures, Linter } from "../src/services/linter.js";
-import { Progress } from "../src/services/progress.js";
+import { Progress, ProgressCapture } from "../src/services/progress.js";
 import { Project } from "../src/services/project.js";
 import { Reporter, ReporterCapture } from "../src/services/reporter.js";
 import { Score } from "../src/services/score.js";
@@ -344,6 +344,64 @@ describe("runInspect — hooks fire in order", () => {
     );
     expect(output.diagnostics).toHaveLength(1);
     expect(events).toEqual(["beforeLint:sample-app", "afterLint:false"]);
+  });
+});
+
+describe("runInspect — scan progress phases", () => {
+  it("runs dead-code after lint and labels it as a separate progress phase", async () => {
+    const phaseEvents: string[] = [];
+    const trackingLinter = Layer.mock(Linter, {
+      run: () =>
+        Stream.unwrap(
+          Effect.sync(() => {
+            phaseEvents.push("lint");
+            return Stream.fromIterable([lintDiagnostic]);
+          }),
+        ),
+    });
+    const trackingDeadCode = Layer.mock(DeadCode, {
+      run: () =>
+        Stream.unwrap(
+          Effect.sync(() => {
+            phaseEvents.push("dead-code");
+            return Stream.fromIterable([deadCodeDiagnostic]);
+          }),
+        ),
+    });
+    const layers = Layer.mergeAll(
+      Project.layerOf(sampleProject),
+      Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
+      Files.layerInMemory(new Map()),
+      trackingLinter,
+      LintPartialFailures.layerLive,
+      trackingDeadCode,
+      Git.layerOf({}),
+      Score.layerOf(null),
+      Progress.layerCapture,
+      Reporter.layerNoop,
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const output = yield* runInspect(baseInput, {
+          afterLint: () =>
+            Effect.sync(() => {
+              phaseEvents.push("afterLint");
+            }),
+        });
+        const progressRef = yield* ProgressCapture;
+        const progressEvents = yield* Ref.get(progressRef);
+        return { output, progressEvents };
+      }).pipe(Effect.provide(layers)),
+    );
+
+    expect(result.output.diagnostics.map((diagnostic) => diagnostic.rule)).toEqual([
+      "no-derived-state",
+      "unused-file",
+    ]);
+    expect(phaseEvents).toEqual(["lint", "afterLint", "dead-code"]);
+    expect(result.progressEvents.map((event) => event.text)).toContain("Scanning...");
+    expect(result.progressEvents.map((event) => event.text)).toContain("Analyzing dead code...");
   });
 });
 

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -10,6 +10,11 @@ export const AGENT_HOOK_TIMEOUT_SECONDS = 120;
 
 export const SETUP_PROMPT_DELAY_MS = 100;
 
+export const SCORE_HEADER_ANIMATION_FRAME_COUNT = 40;
+export const SCORE_HEADER_ANIMATION_FRAME_DELAY_MS = 50;
+export const PERFECT_SCORE_RAINBOW_FRAME_COUNT = 16;
+export const PERFECT_SCORE_RAINBOW_FRAME_DELAY_MS = 50;
+
 // Last-resort fallback when buildJsonReportError itself throws — keeps
 // stdout valid JSON so downstream parsers don't see a half-written report.
 export const INTERNAL_ERROR_JSON_FALLBACK =

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -9,13 +9,15 @@ import {
 } from "@react-doctor/core";
 import type { ScoreResult } from "@react-doctor/core";
 import { colorizeByScore } from "./colorize-by-score.js";
+import {
+  PERFECT_SCORE_RAINBOW_FRAME_COUNT,
+  PERFECT_SCORE_RAINBOW_FRAME_DELAY_MS,
+  SCORE_HEADER_ANIMATION_FRAME_COUNT,
+  SCORE_HEADER_ANIMATION_FRAME_DELAY_MS,
+} from "./constants.js";
 import { isSpinnerInteractive } from "./is-spinner-interactive.js";
 import { isSpinnerSilent } from "./spinner.js";
 
-const SCORE_BAR_ANIMATION_FRAME_COUNT = 40;
-const SCORE_BAR_ANIMATION_FRAME_DELAY_MS = 50;
-const PERFECT_SCORE_RAINBOW_FRAME_COUNT = 16;
-const PERFECT_SCORE_RAINBOW_FRAME_DELAY_MS = 50;
 const RAINBOW_HUE_SHIFT_PER_FRAME = 9;
 const RAINBOW_GRADIENT_WIDTH = 80;
 const RAINBOW_OKLCH_LIGHTNESS = 0.638;
@@ -257,8 +259,8 @@ const printAnimatedScore = (
   Effect.gen(function* () {
     const isPerfectScore = score === PERFECT_SCORE;
 
-    for (let frame = 0; frame <= SCORE_BAR_ANIMATION_FRAME_COUNT; frame += 1) {
-      const progress = easeOutCubic(frame / SCORE_BAR_ANIMATION_FRAME_COUNT);
+    for (let frame = 0; frame <= SCORE_HEADER_ANIMATION_FRAME_COUNT; frame += 1) {
+      const progress = easeOutCubic(frame / SCORE_HEADER_ANIMATION_FRAME_COUNT);
       const animatedScore = Math.round(score * progress);
       if (isPerfectScore) {
         const cursorUp = frame === 0 ? "" : "\x1b[4A";
@@ -271,8 +273,8 @@ const printAnimatedScore = (
             projectName,
           })}`,
         );
-        if (frame < SCORE_BAR_ANIMATION_FRAME_COUNT) {
-          yield* sleep(SCORE_BAR_ANIMATION_FRAME_DELAY_MS);
+        if (frame < SCORE_HEADER_ANIMATION_FRAME_COUNT) {
+          yield* sleep(SCORE_HEADER_ANIMATION_FRAME_DELAY_MS);
         }
         continue;
       }
@@ -285,8 +287,8 @@ const printAnimatedScore = (
       yield* writeScoreHeaderLine(
         `${cursorUp}\r${buildScoreHeaderLine(scoreFaceLine, animatedScoreLine)}\n\r${buildScoreHeaderLine(barFaceLine, animatedBarLine)}\n`,
       );
-      if (frame < SCORE_BAR_ANIMATION_FRAME_COUNT) {
-        yield* sleep(SCORE_BAR_ANIMATION_FRAME_DELAY_MS);
+      if (frame < SCORE_HEADER_ANIMATION_FRAME_COUNT) {
+        yield* sleep(SCORE_HEADER_ANIMATION_FRAME_DELAY_MS);
       }
     }
 

--- a/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
@@ -39,7 +39,7 @@ export const resolveDiffMode = async (
   const { scanScope } = await prompts({
     type: "select",
     name: "scanScope",
-    message: "Select",
+    message: "Choose what to scan",
     choices: [
       { title: "Full codebase", value: "full" },
       { title: `Changed files (${changedSourceFiles.length})`, value: "branch" },

--- a/packages/react-doctor/src/cli/utils/select-projects.ts
+++ b/packages/react-doctor/src/cli/utils/select-projects.ts
@@ -23,7 +23,7 @@ export const selectProjects = async (
   if (packages.length === 0) return [rootDirectory];
   if (packages.length === 1) {
     logger.log(
-      `${highlighter.success("✔")} Select projects to scan ${highlighter.dim("›")} ${packages[0].name}`,
+      `${highlighter.success("✔")} Select projects ${highlighter.dim("›")} ${packages[0].name}`,
     );
     return [packages[0].directory];
   }
@@ -67,7 +67,7 @@ const resolveProjectFlag = (
 
 const printDiscoveredProjects = (packages: WorkspacePackage[]): void => {
   logger.log(
-    `${highlighter.success("✔")} Select projects to scan ${highlighter.dim("›")} ${packages.map((workspacePackage) => workspacePackage.name).join(", ")}`,
+    `${highlighter.success("✔")} Select projects ${highlighter.dim("›")} ${packages.map((workspacePackage) => workspacePackage.name).join(", ")}`,
   );
 };
 
@@ -78,7 +78,7 @@ const promptProjectSelection = async (
   const { selectedDirectories } = await prompts({
     type: "multiselect",
     name: "selectedDirectories",
-    message: "Select projects to scan",
+    message: "Select projects",
     choices: workspacePackages.map((workspacePackage) => ({
       title: workspacePackage.name,
       description: path.relative(rootDirectory, workspacePackage.directory),

--- a/packages/react-doctor/tests/resolve-diff-mode.test.ts
+++ b/packages/react-doctor/tests/resolve-diff-mode.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { DiffInfo } from "@react-doctor/core";
 import { resolveDiffMode } from "../src/cli/utils/resolve-diff-mode.js";
+import { prompts } from "../src/cli/utils/prompts.js";
+
+vi.mock("../src/cli/utils/prompts.js", () => ({
+  prompts: vi.fn(),
+}));
 
 interface ConsoleWarnHandle {
   capturedMessages: string[];
@@ -32,6 +37,7 @@ describe("resolveDiffMode (issue #298 messaging)", () => {
   beforeEach(() => {
     consoleHandle = captureConsoleWarn();
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(prompts).mockResolvedValue({ scanScope: "full" });
   });
 
   afterEach(() => {
@@ -64,5 +70,17 @@ describe("resolveDiffMode (issue #298 messaging)", () => {
   it("stays silent in quiet mode regardless of failure shape", async () => {
     await resolveDiffMode(null, "origin/master", true, true);
     expect(consoleHandle.capturedMessages).toHaveLength(0);
+  });
+
+  it("uses a specific label for the scope selection prompt", async () => {
+    const isDiffMode = await resolveDiffMode(buildDiffInfo(), undefined, false, false);
+
+    expect(isDiffMode).toBe(false);
+    expect(prompts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "scanScope",
+        message: "Choose what to scan",
+      }),
+    );
   });
 });

--- a/packages/react-doctor/tests/select-projects.test.ts
+++ b/packages/react-doctor/tests/select-projects.test.ts
@@ -62,7 +62,10 @@ describe("selectProjects", () => {
 
     expect(selectedDirectories).toEqual([projectDirectory]);
     expect(prompts).not.toHaveBeenCalled();
-    expect(cliLogger.log).toHaveBeenCalledWith(expect.stringContaining("Select projects to scan"));
+    expect(cliLogger.log).toHaveBeenCalledWith(expect.stringContaining("Select projects"));
+    expect(cliLogger.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("Select projects to scan"),
+    );
   });
 
   it("falls through to subproject discovery for a monorepo with no workspace React packages", async () => {
@@ -78,6 +81,30 @@ describe("selectProjects", () => {
 
     expect(selectedDirectories).toEqual([projectDirectory]);
     expect(prompts).not.toHaveBeenCalled();
-    expect(cliLogger.log).toHaveBeenCalledWith(expect.stringContaining("Select projects to scan"));
+    expect(cliLogger.log).toHaveBeenCalledWith(expect.stringContaining("Select projects"));
+    expect(cliLogger.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("Select projects to scan"),
+    );
+  });
+
+  it("uses a concise label for interactive project selection", async () => {
+    const tempDirectory = createTempDirectory();
+    writeJson(path.join(tempDirectory, "package.json"), {
+      name: "workspace",
+      workspaces: ["apps/*"],
+    });
+    const webDirectory = setupReactProject(path.join(tempDirectory, "apps"), "web");
+    setupReactProject(path.join(tempDirectory, "apps"), "docs");
+    vi.mocked(prompts).mockResolvedValue({ selectedDirectories: [webDirectory] });
+
+    const selectedDirectories = await selectProjects(tempDirectory, undefined, false);
+
+    expect(selectedDirectories).toEqual([webDirectory]);
+    expect(prompts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "selectedDirectories",
+        message: "Select projects",
+      }),
+    );
   });
 });

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -131,7 +131,11 @@ export default defineConfig({
   test: {
     testTimeout: TEST_TIMEOUT_MS,
     ...(process.platform === "win32"
-      ? { fileParallelism: false, maxWorkers: WINDOWS_TEST_MAX_WORKERS, pool: "threads" }
+      ? {
+          fileParallelism: false,
+          maxWorkers: WINDOWS_TEST_MAX_WORKERS,
+          poolOptions: { forks: { singleFork: true } },
+        }
       : {}),
   },
 });

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -10,7 +10,7 @@ const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.j
 };
 
 const TEST_TIMEOUT_MS = 30_000;
-const WINDOWS_TEST_MAX_WORKERS = 2;
+const WINDOWS_TEST_MAX_WORKERS = 1;
 
 // HACK: agent-install's parseSkillManifest silently returns `null` when
 // frontmatter is missing or invalid `name:` / `description:` fields,
@@ -130,6 +130,8 @@ export default defineConfig({
   ],
   test: {
     testTimeout: TEST_TIMEOUT_MS,
-    ...(process.platform === "win32" ? { maxWorkers: WINDOWS_TEST_MAX_WORKERS } : {}),
+    ...(process.platform === "win32"
+      ? { fileParallelism: false, maxWorkers: WINDOWS_TEST_MAX_WORKERS }
+      : {}),
   },
 });

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -9,6 +9,9 @@ const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.j
   version: string;
 };
 
+const TEST_TIMEOUT_MS = 30_000;
+const WINDOWS_TEST_MAX_WORKERS = 2;
+
 // HACK: agent-install's parseSkillManifest silently returns `null` when
 // frontmatter is missing or invalid `name:` / `description:` fields,
 // which caused `react-doctor install` to print success while writing
@@ -126,6 +129,7 @@ export default defineConfig({
     },
   ],
   test: {
-    testTimeout: 30_000,
+    testTimeout: TEST_TIMEOUT_MS,
+    ...(process.platform === "win32" ? { maxWorkers: WINDOWS_TEST_MAX_WORKERS } : {}),
   },
 });

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -131,7 +131,7 @@ export default defineConfig({
   test: {
     testTimeout: TEST_TIMEOUT_MS,
     ...(process.platform === "win32"
-      ? { fileParallelism: false, maxWorkers: WINDOWS_TEST_MAX_WORKERS }
+      ? { fileParallelism: false, maxWorkers: WINDOWS_TEST_MAX_WORKERS, pool: "threads" }
       : {}),
   },
 });


### PR DESCRIPTION
## Summary
- run dead-code analysis in a worker thread with timeout and strict result validation so the CLI main thread stays responsive
- separate lint and dead-code progress phases so the spinner does not sit on `Scanning...` during whole-project analysis
- tighten scan prompt copy to `Select projects` and `Choose what to scan`

## Test plan
- `nr test tests/check-dead-code.test.ts tests/services/dead-code.test.ts tests/run-inspect.test.ts` from `packages/core`
- `nr test tests/render-score-header.test.ts tests/select-projects.test.ts tests/resolve-diff-mode.test.ts` from `packages/react-doctor`
- `nr typecheck`
- `node packages/react-doctor/bin/react-doctor.js . --project website --full --no-score`

Note: pre-commit reported staged React Doctor warnings and did not block the commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Worker-based deslop-js execution and stricter result parsing change how dead-code failures surface; inspect timing shifts from parallel to sequential dead-code, which may affect perceived scan duration but reduces main-thread freezes.
> 
> **Overview**
> Dead-code analysis no longer runs **deslop-js** on the main thread. It now runs in a **worker thread** with a **120s timeout**, worker **terminate** on hang, and **strict validation** of worker payloads (malformed results throw instead of being dropped). Tests can inject `createWorker` / `workerTimeoutMs`.
> 
> **Inspect orchestration** runs dead code **after lint** (not in parallel with it) and shows a separate progress line **"Analyzing dead code..."** so the spinner is not stuck on **"Scanning..."** during whole-repo analysis.
> 
> CLI prompts are shortened to **"Select projects"** and **"Choose what to scan"**. Score-header animation timing constants move to shared CLI constants. **Windows** Vitest runs with reduced parallelism in `vite.config.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fa2389c490bf762267805d1bc8bad52b8ab68e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->