### PR TITLE
fix(oxlint-plugin): skip js-tosorted-immutable on React Native/Expo (Hermes)

### DIFF
--- a/.changeset/tosorted-immutable-hermes.md
+++ b/.changeset/tosorted-immutable-hermes.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Stop `js-tosorted-immutable` from firing in React Native / Expo projects. Hermes (the default RN/Expo JS engine) hasn't shipped the ES2023 change-array-by-copy methods, so the rule's recommended `array.toSorted()` rewrite of `[...array].sort()` crashed at runtime with `TypeError: undefined is not a function`. The rule now carries `disabledBy: ["react-native"]`, so it only fires on projects whose engine supports `toSorted()`.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-tosorted-immutable.ts
@@ -9,6 +9,12 @@ export const jsTosortedImmutable = defineRule<Rule>({
   id: "js-tosorted-immutable",
   tags: ["test-noise"],
   severity: "warn",
+  // Hermes (the default React Native / Expo JS engine) hasn't shipped
+  // the ES2023 change-array-by-copy methods, so `array.toSorted()`
+  // throws `undefined is not a function` at runtime. Recommending it in
+  // an RN/Expo project would turn working `[...array].sort()` code into
+  // a crash, so the gate drops this rule there. See issue #543.
+  disabledBy: ["react-native"],
   recommendation:
     "Use `array.toSorted()` (ES2023) instead of `[...array].sort()` for immutable sorting without the spread allocation",
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/tests/regressions/js-performance-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/js-performance-rules.test.ts
@@ -1363,3 +1363,56 @@ describe("async-parallel", () => {
     expect(hits).toHaveLength(0);
   });
 });
+
+describe("issue #543: js-tosorted-immutable is gated off for React Native / Expo (Hermes)", () => {
+  // Hermes — the default RN/Expo JS engine — hasn't shipped the ES2023
+  // change-array-by-copy methods, so `array.toSorted()` throws at
+  // runtime. Recommending it (and `--fix`-ing to it) turns working
+  // `[...array].sort()` code into a crash, so the rule must not fire in
+  // a React Native / Expo project. It stays on for web projects, where
+  // every modern engine supports `toSorted()`.
+  const SPREAD_SORT_SOURCE = `
+    export const sortCards = (
+      cardType: Array<{ id: string }>,
+      preferred: string | null,
+    ) =>
+      preferred
+        ? [...cardType].sort(
+            (first, second) =>
+              (second.id === preferred ? 1 : 0) - (first.id === preferred ? 1 : 0),
+          )
+        : cardType;
+  `;
+
+  it("flags [...array].sort() in a non-React-Native project", async () => {
+    const projectDir = setupReactProject(tempRoot, "tosorted-web-project", {
+      files: { "src/sort-cards.ts": SPREAD_SORT_SOURCE },
+    });
+
+    const hits = await collectRuleHits(projectDir, "js-tosorted-immutable");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("toSorted()");
+  });
+
+  it("does not flag [...array].sort() in an Expo project (Hermes lacks toSorted)", async () => {
+    const projectDir = setupReactProject(tempRoot, "tosorted-expo-project", {
+      files: { "src/sort-cards.ts": SPREAD_SORT_SOURCE },
+    });
+
+    const hits = await collectRuleHits(projectDir, "js-tosorted-immutable", {
+      framework: "expo",
+    });
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag [...array].sort() in a bare React Native project either", async () => {
+    const projectDir = setupReactProject(tempRoot, "tosorted-rn-project", {
+      files: { "src/sort-cards.ts": SPREAD_SORT_SOURCE },
+    });
+
+    const hits = await collectRuleHits(projectDir, "js-tosorted-immutable", {
+      framework: "react-native",
+    });
+    expect(hits).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Why

Catches a false positive that turns working React Native / Expo code into a runtime crash. Fixes #543.

`js-tosorted-immutable` is a `global` rule that recommends rewriting `[...array].sort()` as `array.toSorted()`. Hermes — the default JS engine in current Expo/RN SDKs — hasn't shipped the ES2023 change-array-by-copy methods, so applying the suggestion (manually or via `--fix`) throws `TypeError: undefined is not a function` at runtime. TypeScript happily type-checks it (`lib: ["esnext"]`), so nothing catches it before the device does.

Before (what the rule pushed RN users toward — crashes on Hermes):

```ts
const sorted = preferred
  ? cardType.toSorted((a, b) => (b.id === preferred ? 1 : 0) - (a.id === preferred ? 1 : 0))
  : cardType;
// ERROR  TypeError: undefined is not a function
```

After (rule no longer fires in RN/Expo, so the working spread-sort is left alone):

```ts
const sorted = preferred
  ? [...cardType].sort((a, b) => (b.id === preferred ? 1 : 0) - (a.id === preferred ? 1 : 0))
  : cardType;
```

## What changed

- Gated `js-tosorted-immutable` with `disabledBy: ["react-native"]`.
- The rule now only fires where the engine supports `toSorted()` (web). It no-ops in Expo, React Native, and monorepos that contain an RN workspace — reusing the `react-native` capability `buildCapabilities` already emits.
- Mirrors the existing `disabledBy: ["react-compiler"]` pattern on the `jsx-no-new-*-as-prop` rules — no new infrastructure and no codegen change (the registry imports the rule object, so `disabledBy` flows straight into `createOxlintConfig`'s gate).
- Scope check: the other `toSorted`/`toReversed`/`toSpliced`/`with` references in the codebase are detection sets (`FRESH_ARRAY_METHODS`, `DERIVING_ARRAY_METHODS`), not suggestions, so `js-tosorted-immutable` is the only rule that needed gating.
- Adds regression tests (flagged on web; suppressed on Expo and bare React Native) and a patch changeset.

## Eval results

RDE not run. This change can only narrow an existing rule — it removes diagnostics in RN/Expo projects and changes nothing on web — so it cannot introduce new false positives. The project-capability gate is deterministic and is covered by the end-to-end regression tests below.

## Test plan

- `pnpm exec vp test run tests/regressions/js-performance-rules.test.ts` — 60 passed (incl. 3 new issue #543 cases)
- `pnpm exec turbo run typecheck --filter=react-doctor --filter=oxlint-plugin-react-doctor` — pass
- `pnpm exec vp lint <changed files>` — pass
- `pnpm exec vp fmt --check <changed files>` — pass

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows when one lint rule runs; web behavior unchanged and only removes unsafe suggestions on RN/Expo.
> 
> **Overview**
> Fixes a **false positive** where `js-tosorted-immutable` pushed React Native / Expo apps toward `array.toSorted()`, which **Hermes does not implement**, so fixes could crash at runtime while `[...array].sort()` still works.
> 
> The rule now sets **`disabledBy: ["react-native"]`**, reusing the existing project-capability gate (same pattern as other `disabledBy` rules). It **still runs on web**; it is **off for Expo, bare React Native, and RN workspaces**. Regression tests cover web vs Expo vs RN, plus a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a41698ba649fe27b06ce1d1478401ee86c1c414. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->