### PR TITLE
Default branch diff prompt to changed files

### DIFF
--- a/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-diff-mode.ts
@@ -36,15 +36,22 @@ export const resolveDiffMode = async (
   if (shouldSkipPrompts) return false;
   if (isQuiet) return false;
 
+  const changedFilesTitle = diffInfo.isCurrentChanges
+    ? `Uncommitted changes (${changedSourceFiles.length})`
+    : `Changed files on ${diffInfo.currentBranch ?? "this branch"} (${changedSourceFiles.length})`;
+  const changedFilesDescription = diffInfo.isCurrentChanges
+    ? "Compare working tree changes against HEAD"
+    : `Compare against ${diffInfo.baseBranch} from the branch merge-base`;
+
   const { scanScope } = await prompts({
     type: "select",
     name: "scanScope",
     message: "Choose what to scan",
     choices: [
-      { title: "Full codebase", value: "full" },
-      { title: `Changed files (${changedSourceFiles.length})`, value: "branch" },
+      { title: "Full codebase", description: "Scan every source file", value: "full" },
+      { title: changedFilesTitle, description: changedFilesDescription, value: "branch" },
     ],
-    initial: 0,
+    initial: diffInfo.isCurrentChanges ? 0 : 1,
   });
   return scanScope === "branch";
 };

--- a/packages/react-doctor/tests/resolve-diff-mode.test.ts
+++ b/packages/react-doctor/tests/resolve-diff-mode.test.ts
@@ -43,6 +43,7 @@ describe("resolveDiffMode (issue #298 messaging)", () => {
   afterEach(() => {
     consoleHandle.restore();
     consoleLogSpy.mockRestore();
+    vi.clearAllMocks();
   });
 
   it("warns with a base-aware message when --diff <base> was passed but the diff could not be computed", async () => {
@@ -70,6 +71,45 @@ describe("resolveDiffMode (issue #298 messaging)", () => {
   it("stays silent in quiet mode regardless of failure shape", async () => {
     await resolveDiffMode(null, "origin/master", true, true);
     expect(consoleHandle.capturedMessages).toHaveLength(0);
+  });
+
+  it("asks whether to scan the full codebase or branch changed files", async () => {
+    vi.mocked(prompts).mockResolvedValue({ scanScope: "branch" });
+
+    const isDiffMode = await resolveDiffMode(
+      buildDiffInfo({
+        currentBranch: "feature/login",
+        baseBranch: "main",
+        changedFiles: ["src/App.tsx", "README.md", "src/hooks.ts"],
+      }),
+      undefined,
+      false,
+      false,
+    );
+
+    expect(isDiffMode).toBe(true);
+    expect(prompts).toHaveBeenCalledWith({
+      type: "select",
+      name: "scanScope",
+      message: "Choose what to scan",
+      choices: [
+        { title: "Full codebase", description: "Scan every source file", value: "full" },
+        {
+          title: "Changed files on feature/login (2)",
+          description: "Compare against main from the branch merge-base",
+          value: "branch",
+        },
+      ],
+      initial: 1,
+    });
+  });
+
+  it("keeps the full scan when the user does not choose branch changed files", async () => {
+    vi.mocked(prompts).mockResolvedValue({ scanScope: "full" });
+
+    const isDiffMode = await resolveDiffMode(buildDiffInfo(), undefined, false, false);
+
+    expect(isDiffMode).toBe(false);
   });
 
   it("uses a specific label for the scope selection prompt", async () => {


### PR DESCRIPTION
## Why

Makes the interactive branch workflow prefer the most relevant scan scope: files changed on the current branch.

When React Doctor detects a branch diff, users usually want to validate the work in that branch against the merge-base. The prompt still allows a full-codebase scan, but the changed-files option is now clearer and selected by default.

Before:

```text
Select
  Full codebase
  Changed files (2)
```

After:

```text
Scan scope
  Full codebase                 Scan every source file
> Changed files on feature (2)  Compare against main from the branch merge-base
```

## What changed

- Clarified the interactive diff-mode prompt copy.
- Shows the current branch and base branch used for merge-base diff scans.
- Defaults branch diff prompts to changed files while keeping uncommitted-current-branch prompts on full scan.
- Adds tests for branch prompt copy, default selection, and opting back into full scan.

## Test plan

- `nr test tests/resolve-diff-mode.test.ts`
- `nr typecheck`

RDE was not run because this is CLI prompt UX, not a React Doctor rule change.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI prompt UX and tests only; no scan engine or security-sensitive logic changes.
> 
> **Overview**
> Improves the interactive **“Choose what to scan”** prompt when React Doctor detects a diff without an explicit `--diff` flag.
> 
> The **changed-files** option now shows branch-aware titles and descriptions (current branch, base branch, merge-base vs uncommitted wording), adds short descriptions on both choices, and **defaults to changed files** for branch diffs while **keeping full codebase** as the default for uncommitted-only changes. Tests cover the new prompt copy, default `initial` index, and opting back into a full scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 546dfda1a469cc8c78ff0da264f999c80ea9b344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->