### PR TITLE
feat(rn): hint Reanimated .get()/.set() on react-compiler immutability findings

### DIFF
--- a/packages/core/src/project-info/discover-project.ts
+++ b/packages/core/src/project-info/discover-project.ts
@@ -13,6 +13,8 @@ import { getDependencyDeclaration } from "./utils/get-dependency-declaration.js"
 import { hasReactNativeWorkspaceAnywhere } from "./has-react-native-workspace-anywhere.js";
 import { hasPreact } from "./has-preact.js";
 import { hasTanStackQuery } from "./has-tanstack-query.js";
+import { someWorkspacePackageJson } from "./some-workspace-package-json.js";
+import { isPackageJsonReanimatedAware } from "./utils/is-package-json-reanimated-aware.js";
 import { readPackageJson } from "./read-package-json.js";
 import { isCatalogReference, resolveCatalogVersion } from "./resolve-catalog-version.js";
 import { resolveEffectiveReactMajor } from "./resolve-effective-react-major.js";
@@ -157,6 +159,13 @@ export const discoverProject = (directory: string): ProjectInfo => {
     framework === "react-native" ||
     hasReactNativeWorkspaceAnywhere(directory, packageJson);
 
+  // Only walk for reanimated once we already know it's an RN project —
+  // reanimated implies React Native, so a web project can never declare
+  // it, and this skips the workspace walk entirely for web monorepos.
+  const hasReanimated =
+    hasReactNativeWorkspace &&
+    someWorkspacePackageJson(directory, packageJson, isPackageJsonReanimatedAware);
+
   const projectInfo: ProjectInfo = {
     rootDirectory: directory,
     projectName,
@@ -169,6 +178,7 @@ export const discoverProject = (directory: string): ProjectInfo => {
     hasTanStackQuery: hasTanStackQuery(packageJson),
     hasPreact: hasPreact(packageJson),
     hasReactNativeWorkspace,
+    hasReanimated,
     sourceFileCount,
   };
   cachedProjectInfos.set(directory, projectInfo);

--- a/packages/core/src/project-info/has-react-native-workspace-anywhere.ts
+++ b/packages/core/src/project-info/has-react-native-workspace-anywhere.ts
@@ -1,8 +1,5 @@
-import path from "node:path";
 import type { PackageJson } from "../types/index.js";
-import { getWorkspacePatterns } from "./get-workspace-patterns.js";
-import { readPackageJson } from "./read-package-json.js";
-import { resolveWorkspaceDirectories } from "./resolve-workspace-directories.js";
+import { someWorkspacePackageJson } from "./some-workspace-package-json.js";
 import { isPackageJsonReactNativeAware } from "./utils/is-package-json-react-native-aware.js";
 
 // True when the root manifest or any workspace package inside
@@ -23,21 +20,5 @@ import { isPackageJsonReactNativeAware } from "./utils/is-package-json-react-nat
 export const hasReactNativeWorkspaceAnywhere = (
   rootDirectory: string,
   rootPackageJson: PackageJson,
-): boolean => {
-  if (isPackageJsonReactNativeAware(rootPackageJson)) return true;
-
-  const patterns = getWorkspacePatterns(rootDirectory, rootPackageJson);
-  if (patterns.length === 0) return false;
-
-  const visitedDirectories = new Set<string>();
-  for (const pattern of patterns) {
-    const directories = resolveWorkspaceDirectories(rootDirectory, pattern);
-    for (const workspaceDirectory of directories) {
-      if (visitedDirectories.has(workspaceDirectory)) continue;
-      visitedDirectories.add(workspaceDirectory);
-      const workspacePackageJson = readPackageJson(path.join(workspaceDirectory, "package.json"));
-      if (isPackageJsonReactNativeAware(workspacePackageJson)) return true;
-    }
-  }
-  return false;
-};
+): boolean =>
+  someWorkspacePackageJson(rootDirectory, rootPackageJson, isPackageJsonReactNativeAware);

--- a/packages/core/src/project-info/some-workspace-package-json.ts
+++ b/packages/core/src/project-info/some-workspace-package-json.ts
@@ -1,0 +1,33 @@
+import path from "node:path";
+import type { PackageJson } from "../types/index.js";
+import { getWorkspacePatterns } from "./get-workspace-patterns.js";
+import { readPackageJson } from "./read-package-json.js";
+import { resolveWorkspaceDirectories } from "./resolve-workspace-directories.js";
+
+// True when the root manifest or any workspace package inside
+// `rootDirectory` satisfies `predicate`. One short-circuiting walk of the
+// workspace globs (`getWorkspacePatterns` + `resolveWorkspaceDirectories`),
+// shared by the React Native and Reanimated project gates so both resolve
+// workspaces identically.
+export const someWorkspacePackageJson = (
+  rootDirectory: string,
+  rootPackageJson: PackageJson,
+  predicate: (packageJson: PackageJson) => boolean,
+): boolean => {
+  if (predicate(rootPackageJson)) return true;
+
+  const patterns = getWorkspacePatterns(rootDirectory, rootPackageJson);
+  if (patterns.length === 0) return false;
+
+  const visitedDirectories = new Set<string>();
+  for (const pattern of patterns) {
+    const directories = resolveWorkspaceDirectories(rootDirectory, pattern);
+    for (const workspaceDirectory of directories) {
+      if (visitedDirectories.has(workspaceDirectory)) continue;
+      visitedDirectories.add(workspaceDirectory);
+      const workspacePackageJson = readPackageJson(path.join(workspaceDirectory, "package.json"));
+      if (predicate(workspacePackageJson)) return true;
+    }
+  }
+  return false;
+};

--- a/packages/core/src/project-info/utils/is-package-json-reanimated-aware.ts
+++ b/packages/core/src/project-info/utils/is-package-json-reanimated-aware.ts
@@ -1,0 +1,18 @@
+import type { PackageJson } from "../../types/index.js";
+
+// `react-native-reanimated` ships `.get()` / `.set()` accessors as the
+// React Compiler-compatible alternative to `.value`. Detecting the
+// dependency keeps the React Compiler `immutability` hint scoped to
+// projects that can actually act on it. Checks the same four sections as
+// the React Native gate so a reanimated dep in any section counts.
+const REANIMATED_DEPENDENCY_NAME = "react-native-reanimated";
+
+export const isPackageJsonReanimatedAware = (packageJson: PackageJson): boolean => {
+  const allDependencies = {
+    ...packageJson.peerDependencies,
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+    ...packageJson.optionalDependencies,
+  };
+  return Object.hasOwn(allDependencies, REANIMATED_DEPENDENCY_NAME);
+};

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -8,6 +8,7 @@ import type {
 import { ERROR_PREVIEW_LENGTH_CHARS, SOURCE_FILE_PATTERN } from "../../constants.js";
 import { OxlintOutputUnparseable, ReactDoctorError } from "../../errors.js";
 import { buildNoSecretsRecommendation } from "../../utils/build-no-secrets-recommendation.js";
+import { appendReanimatedSharedValueHint } from "../../utils/append-reanimated-shared-value-hint.js";
 import { shouldSuppressLocalUseHookDiagnostic } from "./should-suppress-local-use-hook-diagnostic.js";
 
 const FILEPATH_WITH_LOCATION_PATTERN = /\S+\.\w+:\d+:\d+[\s\S]*$/;
@@ -74,7 +75,10 @@ const cleanDiagnosticMessage = (
 ): CleanedDiagnostic => {
   if (plugin === "react-hooks-js") {
     const rawMessage = message.replace(FILEPATH_WITH_LOCATION_PATTERN, "").trim();
-    return { message: REACT_COMPILER_MESSAGE, help: rawMessage || help };
+    return {
+      message: REACT_COMPILER_MESSAGE,
+      help: appendReanimatedSharedValueHint(rawMessage || help, rule, project),
+    };
   }
   const cleaned = message.replace(FILEPATH_WITH_LOCATION_PATTERN, "").trim();
   return {

--- a/packages/core/src/types/project-info.ts
+++ b/packages/core/src/types/project-info.ts
@@ -44,6 +44,13 @@ export interface ProjectInfo {
    * — no `rn-*` rules load for the project at all.
    */
   hasReactNativeWorkspace: boolean;
+  /**
+   * `true` when the project (or any of its workspace packages) declares
+   * `react-native-reanimated`. Lets diagnostics surface reanimated's
+   * Compiler-compatible `.get()` / `.set()` accessors only where they
+   * apply, instead of on every React Native project.
+   */
+  hasReanimated: boolean;
   sourceFileCount: number;
 }
 

--- a/packages/core/src/utils/append-reanimated-shared-value-hint.ts
+++ b/packages/core/src/utils/append-reanimated-shared-value-hint.ts
@@ -4,8 +4,9 @@ import type { ProjectInfo } from "../types/index.js";
 // pattern `sharedValue.value = ...` because the Compiler treats hook
 // return values as immutable. The generic "move the modification into the
 // hook" suggestion can't be satisfied for a library-owned value, so point
-// React Native users at Reanimated's Compiler-compliant `.get()` / `.set()`
-// accessors instead. Gated to RN projects so web scans never surface it.
+// users at Reanimated's Compiler-compliant `.get()` / `.set()` accessors
+// instead. Gated to projects that actually depend on react-native-reanimated
+// so the hint never appears where it can't apply.
 // Docs: https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support
 const REANIMATED_SHARED_VALUE_HINT =
   "If this is a Reanimated shared value, prefer its React Compiler-compatible `.get()` / `.set()` accessors over `.value` — https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support";
@@ -16,7 +17,7 @@ export const appendReanimatedSharedValueHint = (
   project: ProjectInfo,
 ): string => {
   if (rule !== "immutability") return help;
-  if (!project.hasReactNativeWorkspace) return help;
+  if (!project.hasReanimated) return help;
   if (!help) return REANIMATED_SHARED_VALUE_HINT;
   return `${help}\n\n${REANIMATED_SHARED_VALUE_HINT}`;
 };

--- a/packages/core/src/utils/append-reanimated-shared-value-hint.ts
+++ b/packages/core/src/utils/append-reanimated-shared-value-hint.ts
@@ -1,0 +1,22 @@
+import type { ProjectInfo } from "../types/index.js";
+
+// React Compiler's `immutability` rule fires on the canonical Reanimated
+// pattern `sharedValue.value = ...` because the Compiler treats hook
+// return values as immutable. The generic "move the modification into the
+// hook" suggestion can't be satisfied for a library-owned value, so point
+// React Native users at Reanimated's Compiler-compliant `.get()` / `.set()`
+// accessors instead. Gated to RN projects so web scans never surface it.
+// Docs: https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support
+const REANIMATED_SHARED_VALUE_HINT =
+  "If this is a Reanimated shared value, prefer its React Compiler-compatible `.get()` / `.set()` accessors over `.value` — https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support";
+
+export const appendReanimatedSharedValueHint = (
+  help: string,
+  rule: string,
+  project: ProjectInfo,
+): string => {
+  if (rule !== "immutability") return help;
+  if (!project.hasReactNativeWorkspace) return help;
+  if (!help) return REANIMATED_SHARED_VALUE_HINT;
+  return `${help}\n\n${REANIMATED_SHARED_VALUE_HINT}`;
+};

--- a/packages/core/tests/append-reanimated-shared-value-hint.test.ts
+++ b/packages/core/tests/append-reanimated-shared-value-hint.test.ts
@@ -22,6 +22,7 @@ const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
   hasReactCompiler: true,
   hasTanStackQuery: false,
   hasReactNativeWorkspace: true,
+  hasReanimated: true,
   sourceFileCount: 10,
   ...overrides,
 });
@@ -46,7 +47,7 @@ const buildOxlintStdout = (code: string, message: string): string =>
   });
 
 describe("appendReanimatedSharedValueHint", () => {
-  it("appends the .get()/.set() hint for immutability findings in RN projects", () => {
+  it("appends the .get()/.set() hint for immutability findings when reanimated is installed", () => {
     const help = appendReanimatedSharedValueHint(
       REACT_COMPILER_IMMUTABILITY_HELP,
       "immutability",
@@ -63,11 +64,11 @@ describe("appendReanimatedSharedValueHint", () => {
     expect(help.startsWith("\n")).toBe(false);
   });
 
-  it("leaves help untouched for non-RN projects", () => {
+  it("leaves help untouched when reanimated is not installed", () => {
     const help = appendReanimatedSharedValueHint(
       REACT_COMPILER_IMMUTABILITY_HELP,
       "immutability",
-      buildProject({ hasReactNativeWorkspace: false, framework: "vite" }),
+      buildProject({ hasReanimated: false }),
     );
     expect(help).toBe(REACT_COMPILER_IMMUTABILITY_HELP);
   });
@@ -96,14 +97,14 @@ describe("parseOxlintOutput react-hooks-js immutability messaging", () => {
     expect(diagnostic.help).toContain(REANIMATED_DOCS_ANCHOR);
   });
 
-  it("does not surface the hint for web projects", () => {
+  it("does not surface the hint when reanimated is not installed", () => {
     const stdout = buildOxlintStdout(
       "react-hooks-js(immutability)",
       REACT_COMPILER_IMMUTABILITY_HELP,
     );
     const [diagnostic] = parseOxlintOutput(
       stdout,
-      buildProject({ hasReactNativeWorkspace: false, framework: "vite" }),
+      buildProject({ hasReanimated: false }),
       ROOT_DIRECTORY,
     );
 

--- a/packages/core/tests/append-reanimated-shared-value-hint.test.ts
+++ b/packages/core/tests/append-reanimated-shared-value-hint.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { ProjectInfo } from "@react-doctor/core";
+import { appendReanimatedSharedValueHint } from "../src/utils/append-reanimated-shared-value-hint.js";
+import { parseOxlintOutput } from "../src/runners/oxlint/parse-output.js";
+
+const ROOT_DIRECTORY = "/home/user/app";
+
+const REACT_COMPILER_IMMUTABILITY_HELP =
+  "This value cannot be modified\n\nModifying a value returned from a hook is not allowed. Consider moving the modification into the hook where the value is constructed.";
+
+const REANIMATED_DOCS_ANCHOR =
+  "https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support";
+
+const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
+  rootDirectory: ROOT_DIRECTORY,
+  projectName: "app",
+  reactVersion: "19.2.0",
+  reactMajorVersion: 19,
+  tailwindVersion: null,
+  framework: "expo",
+  hasTypeScript: true,
+  hasReactCompiler: true,
+  hasTanStackQuery: false,
+  hasReactNativeWorkspace: true,
+  sourceFileCount: 10,
+  ...overrides,
+});
+
+const buildOxlintStdout = (code: string, message: string): string =>
+  JSON.stringify({
+    diagnostics: [
+      {
+        message,
+        code,
+        severity: "error",
+        causes: [],
+        url: "",
+        help: "",
+        filename: "src/components/SpinningIcon.tsx",
+        labels: [{ label: "", span: { offset: 0, length: 1, line: 23, column: 5 } }],
+        related: [],
+      },
+    ],
+    number_of_files: 1,
+    number_of_rules: 1,
+  });
+
+describe("appendReanimatedSharedValueHint", () => {
+  it("appends the .get()/.set() hint for immutability findings in RN projects", () => {
+    const help = appendReanimatedSharedValueHint(
+      REACT_COMPILER_IMMUTABILITY_HELP,
+      "immutability",
+      buildProject(),
+    );
+    expect(help).toContain(REACT_COMPILER_IMMUTABILITY_HELP);
+    expect(help).toContain("`.get()` / `.set()`");
+    expect(help).toContain(REANIMATED_DOCS_ANCHOR);
+  });
+
+  it("returns just the hint when the upstream help is empty", () => {
+    const help = appendReanimatedSharedValueHint("", "immutability", buildProject());
+    expect(help).toContain("`.get()` / `.set()`");
+    expect(help.startsWith("\n")).toBe(false);
+  });
+
+  it("leaves help untouched for non-RN projects", () => {
+    const help = appendReanimatedSharedValueHint(
+      REACT_COMPILER_IMMUTABILITY_HELP,
+      "immutability",
+      buildProject({ hasReactNativeWorkspace: false, framework: "vite" }),
+    );
+    expect(help).toBe(REACT_COMPILER_IMMUTABILITY_HELP);
+  });
+
+  it("leaves help untouched for other react-hooks-js rules", () => {
+    const help = appendReanimatedSharedValueHint(
+      REACT_COMPILER_IMMUTABILITY_HELP,
+      "refs",
+      buildProject(),
+    );
+    expect(help).toBe(REACT_COMPILER_IMMUTABILITY_HELP);
+  });
+});
+
+describe("parseOxlintOutput react-hooks-js immutability messaging", () => {
+  it("surfaces the Reanimated accessor hint end-to-end for RN projects", () => {
+    const stdout = buildOxlintStdout(
+      "react-hooks-js(immutability)",
+      REACT_COMPILER_IMMUTABILITY_HELP,
+    );
+    const [diagnostic] = parseOxlintOutput(stdout, buildProject(), ROOT_DIRECTORY);
+
+    expect(diagnostic.message).toBe("React Compiler can't optimize this code");
+    expect(diagnostic.category).toBe("React Compiler");
+    expect(diagnostic.help).toContain("`.get()` / `.set()`");
+    expect(diagnostic.help).toContain(REANIMATED_DOCS_ANCHOR);
+  });
+
+  it("does not surface the hint for web projects", () => {
+    const stdout = buildOxlintStdout(
+      "react-hooks-js(immutability)",
+      REACT_COMPILER_IMMUTABILITY_HELP,
+    );
+    const [diagnostic] = parseOxlintOutput(
+      stdout,
+      buildProject({ hasReactNativeWorkspace: false, framework: "vite" }),
+      ROOT_DIRECTORY,
+    );
+
+    expect(diagnostic.help).not.toContain("`.get()` / `.set()`");
+  });
+
+  it("does not surface the hint for other React Compiler rules", () => {
+    const stdout = buildOxlintStdout("react-hooks-js(refs)", "Cannot access ref during render");
+    const [diagnostic] = parseOxlintOutput(stdout, buildProject(), ROOT_DIRECTORY);
+
+    expect(diagnostic.help).not.toContain("`.get()` / `.set()`");
+  });
+});

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1077,6 +1077,86 @@ describe("discoverProject — hasReactNativeWorkspace", () => {
   });
 });
 
+describe("discoverProject — hasReanimated", () => {
+  it("is true when the entry-point Expo app declares `react-native-reanimated`", () => {
+    const projectDirectory = path.join(tempDirectory, "reanimated-self");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "spinning-app",
+        dependencies: {
+          react: "^19.0.0",
+          expo: "^51.0.0",
+          "react-native-reanimated": "~3.16.0",
+        },
+      }),
+    );
+
+    const projectInfo = discoverProject(projectDirectory);
+    expect(projectInfo.hasReanimated).toBe(true);
+  });
+
+  it("is true when a workspace sibling declares `react-native-reanimated` (web-rooted monorepo)", () => {
+    const rootDirectory = path.join(tempDirectory, "reanimated-monorepo");
+    const mobileDirectory = path.join(rootDirectory, "apps", "mobile");
+    fs.mkdirSync(mobileDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(rootDirectory, "package.json"),
+      JSON.stringify({
+        name: "reanimated-monorepo",
+        dependencies: { next: "^14.0.0", react: "^19.0.0", "react-dom": "^19.0.0" },
+        workspaces: ["apps/*"],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(mobileDirectory, "package.json"),
+      JSON.stringify({
+        name: "mobile",
+        dependencies: {
+          react: "^19.0.0",
+          "react-native": "0.76.0",
+          "react-native-reanimated": "^3.16.0",
+        },
+      }),
+    );
+
+    const projectInfo = discoverProject(rootDirectory);
+    expect(projectInfo.hasReanimated).toBe(true);
+  });
+
+  it("is false for a React Native project that does not depend on reanimated", () => {
+    const projectDirectory = path.join(tempDirectory, "rn-without-reanimated");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "plain-rn-app",
+        dependencies: { react: "^19.0.0", "react-native": "0.76.0" },
+      }),
+    );
+
+    const projectInfo = discoverProject(projectDirectory);
+    expect(projectInfo.hasReactNativeWorkspace).toBe(true);
+    expect(projectInfo.hasReanimated).toBe(false);
+  });
+
+  it("is false for a web project (the reanimated walk is gated behind React Native)", () => {
+    const projectDirectory = path.join(tempDirectory, "web-no-reanimated");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "web-app",
+        dependencies: { next: "^14.0.0", react: "^19.0.0", "react-dom": "^19.0.0" },
+      }),
+    );
+
+    const projectInfo = discoverProject(projectDirectory);
+    expect(projectInfo.hasReanimated).toBe(false);
+  });
+});
+
 describe("formatFrameworkName", () => {
   it("formats known frameworks", () => {
     expect(formatFrameworkName("nextjs")).toBe("Next.js");

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -34,6 +34,7 @@ const sampleProject: ProjectInfo = {
   hasReactCompiler: false,
   hasTanStackQuery: false,
   hasReactNativeWorkspace: false,
+  hasReanimated: false,
   sourceFileCount: 1,
 };
 

--- a/packages/core/tests/services/linter.test.ts
+++ b/packages/core/tests/services/linter.test.ts
@@ -17,6 +17,7 @@ const sampleProject: ProjectInfo = {
   hasReactCompiler: false,
   hasTanStackQuery: false,
   hasReactNativeWorkspace: false,
+  hasReanimated: false,
   sourceFileCount: 1,
 };
 

--- a/packages/core/tests/services/project.test.ts
+++ b/packages/core/tests/services/project.test.ts
@@ -17,6 +17,7 @@ const sampleProject: ProjectInfo = {
   hasReactCompiler: false,
   hasTanStackQuery: false,
   hasReactNativeWorkspace: false,
+  hasReanimated: false,
   sourceFileCount: 1,
 };
 

--- a/packages/react-doctor/tests/build-json-report.test.ts
+++ b/packages/react-doctor/tests/build-json-report.test.ts
@@ -13,6 +13,7 @@ const SAMPLE_PROJECT: ProjectInfo = {
   hasReactCompiler: false,
   hasTanStackQuery: false,
   hasReactNativeWorkspace: false,
+  hasReanimated: false,
   sourceFileCount: 42,
 };
 

--- a/packages/react-doctor/tests/regressions/_helpers.ts
+++ b/packages/react-doctor/tests/regressions/_helpers.ts
@@ -110,6 +110,7 @@ export interface BuildTestProjectOptions {
   framework?: ProjectInfo["framework"];
   hasReactCompiler?: boolean;
   hasTanStackQuery?: boolean;
+  hasReanimated?: boolean;
   reactMajorVersion?: number | null;
   hasTypeScript?: boolean;
   tailwindVersion?: string | null;
@@ -136,6 +137,7 @@ export const buildTestProject = (options: BuildTestProjectOptions): ProjectInfo 
     hasReactCompiler: options.hasReactCompiler ?? false,
     hasTanStackQuery: options.hasTanStackQuery ?? false,
     hasReactNativeWorkspace: framework === "expo" || framework === "react-native",
+    hasReanimated: options.hasReanimated ?? false,
     sourceFileCount: 0,
   };
 };

--- a/packages/react-doctor/tests/to-json-report.test.ts
+++ b/packages/react-doctor/tests/to-json-report.test.ts
@@ -28,6 +28,7 @@ const buildDiagnoseResult = (): DiagnoseResult => ({
     hasReactCompiler: false,
     hasTanStackQuery: false,
     hasReactNativeWorkspace: false,
+    hasReanimated: false,
     sourceFileCount: 12,
   },
   elapsedMilliseconds: 321,


### PR DESCRIPTION
## Why

`react-hooks-js/immutability` — the upstream React Compiler rule — fires on the canonical Reanimated `sharedValue.value = ...` pattern, because React Compiler treats values returned from hooks as immutable and skips optimizing the component. The rule's generic advice ("move the modification into the hook where the value is constructed") is impossible to follow for a library-owned `SharedValue`, so React Native users hit a dead end (and sometimes file upstream issues — see #544).

Reanimated ships `.get()` / `.set()` accessors specifically as the React Compiler-compatible API. react-doctor now surfaces that alternative directly in the diagnostic's help text.

Before:

```tsx
const rotation = useSharedValue(0);
useEffect(() => {
  // react-hooks-js/immutability ERROR — generic, non-actionable hint
  rotation.value = withRepeat(withTiming(360), -1);
}, [rotation]);
```

After:

```tsx
const rotation = useSharedValue(0);
useEffect(() => {
  // React Compiler-compatible accessor; clears the finding
  rotation.set(withRepeat(withTiming(360), -1));
}, [rotation]);
```

The diagnostic help now ends with an actionable pointer:

```text
React Compiler can't optimize this code
→ Modifying a value returned from a hook is not allowed. ...

  If this is a Reanimated shared value, prefer its React Compiler-compatible
  `.get()` / `.set()` accessors over `.value` —
  https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support
```

## What changed

- Added `appendReanimatedSharedValueHint` util in `@react-doctor/core` and wired it into the `react-hooks-js` branch of `parseOxlintOutput`.
- Appends the Reanimated `.get()` / `.set()` hint to the help text of the `immutability` diagnostic only.
- Gated to `rule === "immutability"` **and** React Native projects (`project.hasReactNativeWorkspace`) — the other ~15 React Compiler rules and web/Next/Vite scans are untouched.
- Phrased conditionally ("If this is a Reanimated shared value…") so it stays accurate even when an immutability finding isn't a `SharedValue`.
- **Severity deliberately unchanged.** The reporter's original "false positive / downgrade to WARN" framing was retracted in their follow-up: the finding is genuinely actionable (Compiler does skip the component), and the parser has no AST to tell a `SharedValue` mutation apart from any other illegal hook-return mutation, so a blanket downgrade would silence real errors.
- Adds unit + end-to-end (`parseOxlintOutput`) tests for RN/web gating and rule gating.

## Eval results

RDE not run — this is a deterministic help-text transformation on an existing upstream diagnostic, not a new AST/heuristic rule, so there is no detection surface to measure for noise. Behavior is covered by the new unit + parser integration tests instead.

## Test plan

- `pnpm --filter @react-doctor/core exec vp test run append-reanimated-shared-value-hint` — 7 passed
- `pnpm test` — full suite green (core 353, react-doctor 1378 passed / 12 skipped)
- `pnpm typecheck` — 8/8
- `pnpm lint` + `pnpm format:check` — clean

> Note: this branch also carries a pre-existing commit (`9a05ef20` "fix: copy should say scanning files", a 1-line `run-inspect.ts` change) that isn't on `main` yet and is unrelated to this change. It will drop out of this diff automatically if it lands via another PR first.

Closes #544

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to project metadata detection and optional diagnostic help text; no runtime behavior, auth, or data handling.
> 
> **Overview**
> Adds **`hasReanimated`** to project discovery (root or any workspace declares `react-native-reanimated`, only after the project is treated as React Native) and refactors workspace walks through shared **`someWorkspacePackageJson`**, so RN and Reanimated detection use the same monorepo traversal.
> 
> For **`react-hooks-js` / `immutability`** React Compiler diagnostics, **`parseOxlintOutput`** now appends conditional help pointing at Reanimated’s **`.get()` / `.set()`** accessors when **`hasReanimated`** is true, without changing severity or other Compiler rules. **`ProjectInfo`** and test fixtures gain the new flag; unit and parser tests cover gating and end-to-end help text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0816f8558ce6a02bac408488e1c418a9fd6f4ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->