### PR TITLE
fix(action): default PR runs to the target-branch diff (#527)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: "Workspace project(s) to scan (comma-separated)"
     required: false
   diff:
-    description: "Base branch for diff mode (e.g. main). Only files changed vs this branch are scanned."
+    description: "Base branch for diff mode (e.g. main). Only files changed vs this branch are scanned. Defaults to the PR's target branch on pull_request events; pass `false` to force a full scan."
     required: false
   github-token:
     description: "GitHub token for posting PR comments. When set on pull_request events, findings are posted as a PR comment."
@@ -45,7 +45,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - if: ${{ inputs.diff != '' && github.event_name == 'pull_request' }}
+    - if: ${{ github.event_name == 'pull_request' }}
       shell: bash
       run: |
         case "$DIFF_BASE" in -* ) echo "::error::diff input cannot start with -"; exit 1 ;; esac
@@ -54,7 +54,7 @@ runs:
         git checkout "$HEAD_REF" 2>/dev/null || true
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        DIFF_BASE: ${{ inputs.diff }}
+        DIFF_BASE: ${{ inputs.diff || github.base_ref }}
         HEAD_REF: ${{ github.head_ref }}
 
     - shell: bash
@@ -63,7 +63,7 @@ runs:
         INPUT_DIRECTORY: ${{ inputs.directory }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
         INPUT_PROJECT: ${{ inputs.project }}
-        INPUT_DIFF: ${{ inputs.diff }}
+        INPUT_DIFF: ${{ inputs.diff || github.base_ref }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
         INPUT_FAIL_ON: ${{ inputs.fail-on }}
         INPUT_NO_SCORE: ${{ inputs.no-score }}
@@ -106,6 +106,8 @@ runs:
       shell: bash
       env:
         INPUT_DIRECTORY: ${{ inputs.directory }}
+        INPUT_PROJECT: ${{ inputs.project }}
+        INPUT_DIFF: ${{ inputs.diff || github.base_ref }}
         INPUT_NO_SCORE: ${{ inputs.no-score }}
       run: |
         # HACK: --score is an output-collection step, not a gate. Force
@@ -114,7 +116,13 @@ runs:
         # though the value itself is the only meaningful signal here)
         # don't fail the composite action under `set -e -o pipefail`.
         if [ "${INPUT_NO_SCORE:-false}" = "true" ]; then exit 0; fi
+        # Match the scan step's scope (project + diff) so the captured
+        # score reflects the same files as the diagnostics above. A bare
+        # `--score` re-runs a full project scan, yielding a full-project
+        # score that contradicts the diff-scoped PR comment.
         SCORE_ARGS=("$INPUT_DIRECTORY" "--score" "--fail-on" "none")
+        if [ -n "$INPUT_PROJECT" ]; then SCORE_ARGS+=("--project" "$INPUT_PROJECT"); fi
+        if [ -n "$INPUT_DIFF" ]; then SCORE_ARGS+=("--diff" "$INPUT_DIFF"); fi
         SCORE=$(npx react-doctor@latest "${SCORE_ARGS[@]}" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
         if [[ -n "$SCORE" && "$SCORE" =~ ^[0-9]+$ ]]; then
           echo "score=$SCORE" >> "$GITHUB_OUTPUT"

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -74,11 +74,29 @@ describe("GitHub Action contract", () => {
   });
 
   it("guards diff fetch refs against shell-option injection", () => {
-    const fetchStep = extractStep(readActionYaml(), "DIFF_BASE: ${{ inputs.diff }}");
+    const fetchStep = extractStep(readActionYaml(), "HEAD_REF: ${{ github.head_ref }}");
 
     expect(fetchStep).toContain('case "$DIFF_BASE" in -* )');
     expect(fetchStep).toContain('case "$HEAD_REF" in -* )');
     expect(fetchStep).toContain('git fetch origin "$DIFF_BASE"');
+  });
+
+  it("issue #527: defaults the diff base to the PR target branch on pull_request events", () => {
+    const actionYaml = readActionYaml();
+
+    // `inputs.diff || github.base_ref`: an explicit `diff` wins, otherwise
+    // fall back to the PR's target branch (base_ref is set only on
+    // pull_request events; empty on push -> full scan). Keeps PRs on a
+    // diff scan so they never run the unbounded whole-project dead-code
+    // pass that hangs large repos (issue #527).
+    const resolvedDiff = "${{ inputs.diff || github.base_ref }}";
+    const scanStep = extractStep(actionYaml, "INPUT_FAIL_ON: ${{ inputs.fail-on }}");
+    const scoreStep = extractStep(actionYaml, "- id: score");
+    const fetchStep = extractStep(actionYaml, "HEAD_REF: ${{ github.head_ref }}");
+
+    expect(scanStep).toContain(`INPUT_DIFF: ${resolvedDiff}`);
+    expect(scoreStep).toContain(`INPUT_DIFF: ${resolvedDiff}`);
+    expect(fetchStep).toContain(`DIFF_BASE: ${resolvedDiff}`);
   });
 
   it("demotes design rules from the sticky PR comment via --pr-comment", () => {
@@ -111,6 +129,23 @@ describe("GitHub Action contract", () => {
     expect(restoreExitOnErrorIndex).toBeGreaterThan(captureExitCodesIndex);
     expect(stripAnnotationsIndex).toBeGreaterThan(restoreExitOnErrorIndex);
     expect(restoreScanExitCodeIndex).toBeGreaterThan(stripAnnotationsIndex);
+  });
+
+  it("issue #527: score step mirrors the scan's diff/project scope so it can't re-run a full scan", () => {
+    const actionYaml = readActionYaml();
+    const scoreStep = normalizeWhitespace(extractStep(actionYaml, "- id: score"));
+
+    // Without these, a bare `--score` re-runs a FULL project scan even
+    // when the scan step ran in `--diff` mode, re-triggering the
+    // whole-project dead-code pass that diff mode skips and hanging the
+    // job on large repos.
+    expect(scoreStep).toContain("INPUT_PROJECT: ${{ inputs.project }}");
+    expect(scoreStep).toContain(
+      'if [ -n "$INPUT_DIFF" ]; then SCORE_ARGS+=("--diff" "$INPUT_DIFF"); fi',
+    );
+    expect(scoreStep).toContain(
+      'if [ -n "$INPUT_PROJECT" ]; then SCORE_ARGS+=("--project" "$INPUT_PROJECT"); fi',
+    );
   });
 
   it("forwards --annotations to the CLI when the annotations input is true", () => {


### PR DESCRIPTION
## Summary

On `pull_request` events the action defaults the diff base to the PR's target branch (`inputs.diff || github.base_ref`) and fetches it, so the scan and score steps analyze only the changed files. An explicit `diff` input still wins; `diff: false` forces a full scan. The score step mirrors the scan's `--project`/`--diff` scope so the captured score matches the diff-scoped diagnostics in the PR comment.

## Relationship to #527 (the hang)

The hang itself is fixed at the root by #537 — dead-code analysis now runs in a killable child process with a 120s timeout, so it can't stall the CLI regardless of scan mode. This PR is the complementary improvement: keep PR runs scoped to the diff and make the reported score consistent with the diagnostics shown.

## Why this lives in the action (not the CLI)

`getDiffInfo` calls `Effect.die` on an unresolvable base branch (there is no full-scan fallback). With the default `actions/checkout` only the PR merge ref is present — not the base branch — so a CLI-level "default to `GITHUB_BASE_REF`" would hard-crash on most PRs. The action is the only component that fetches the base, so it can safely diff against it.

## Changes

- `diff-setup` runs on all PRs and fetches `inputs.diff || github.base_ref`, then checks out the head ref.
- scan + score pass `--diff (inputs.diff || github.base_ref)`; the score step also mirrors `--project`.
- Updated the `diff` input description (documents the PR default + `diff: false` escape hatch).
- Contract tests for the PR-target-branch default and the score-step scope.

## Test plan

- `vp test run github-action` — 9 passing
- `pnpm typecheck` (8/8), `pnpm lint`, `pnpm format:check`
- CI `react-doctor` self-test runs the action end-to-end on this PR

## Notes

- Because the action can't read `react-doctor.config.json`, the injected `--diff base_ref` overrides a repo-level `config.diff` on PRs (PR target wins — intended).
- Diff mode needs `actions/checkout` with `fetch-depth: 0` for `merge-base`; without it the scan degrades to a full scan (no longer a hang, thanks to #537).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default CI behavior for all pull_request runs (diff-scoped scans and base-branch fetch) and affects reported scores; explicit `diff` still overrides.
> 
> **Overview**
> On **`pull_request`** workflows, the composite action now treats **`inputs.diff || github.base_ref`** as the diff base: it always runs the fetch/checkout prep step for PRs, and both the scan and **`score`** steps pass that resolved ref into **`--diff`** so only changed files are analyzed unless **`diff`** is set explicitly (or **`false`** for a full scan).
> 
> The **`score`** step also forwards **`--project`** and **`--diff`** like the main scan, so the **`score`** output and sticky comment reflect the same scope as the diagnostics instead of re-running a full-project scan.
> 
> **`action.yml`** documents the new default; **`github-action.test.ts`** adds contract tests for the PR-target default and score-step scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd1fde6464144a0ddbbfb4ad22eac8b347b9ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->