### PR TITLE
perf(lint): run oxlint file batches across a bounded worker pool

### DIFF
--- a/.changeset/parallel-lint-batches.md
+++ b/.changeset/parallel-lint-batches.md
@@ -1,0 +1,13 @@
+---
+"react-doctor": patch
+---
+
+perf(lint): run oxlint file batches across a bounded worker pool
+
+Large repos previously linted their file batches one subprocess at a
+time, leaving most CPU cores idle during the scan. Batches now fan out
+across a pool sized to the machine's available parallelism (capped to
+keep many-core CI boxes from reintroducing the memory-pressure cliff the
+batching guards against). Set `REACT_DOCTOR_LINT_CONCURRENCY` to tune the
+pool — `1` restores the previous sequential behavior, higher values opt a
+memory-rich runner into more parallelism.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -45,6 +45,16 @@ export const SPAWN_ARGS_MAX_LENGTH_CHARS = 24_000;
 // vs the hard-cap perf cliffs they prevent.
 export const OXLINT_MAX_FILES_PER_BATCH = 100;
 
+// HACK: ceiling on how many oxlint batch subprocesses run concurrently.
+// `spawnLintBatches` fans batches across CPU cores (one subprocess per
+// pool worker), but each subprocess holds up to OXLINT_MAX_FILES_PER_BATCH
+// (= 100) files in oxlint's native binding — the same memory pressure
+// the batching guards against. Capping the default pool keeps a many-core
+// CI box from spawning dozens of processes at once and reintroducing the
+// SIGABRT-under-memory-pressure cliff (#84). Memory-rich runners raise it
+// past the cap via REACT_DOCTOR_LINT_CONCURRENCY.
+export const LINT_BATCH_CONCURRENCY_MAX = 8;
+
 export const DEFAULT_BRANCH_CANDIDATES = ["main", "master"];
 
 // JSON-format oxlint / eslint configs react-doctor can fold into the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,8 @@ export * from "./summarize-diagnostics.js";
 export * from "./validate-config-types.js";
 export * from "./utils/dedupe-diagnostics.js";
 export * from "./utils/group-by.js";
+export * from "./utils/map-with-concurrency.js";
+export * from "./utils/resolve-lint-concurrency.js";
 export * from "./utils/match-glob-pattern.js";
 export * from "./utils/resolve-github-actions-score-metadata.js";
 export * from "./utils/to-relative-path.js";

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -5,6 +5,8 @@ import {
 import type { Diagnostic, ProjectInfo } from "../../types/index.js";
 import { isSplittableReactDoctorError } from "../../errors.js";
 import { dedupeDiagnostics } from "../../utils/dedupe-diagnostics.js";
+import { mapWithConcurrency } from "../../utils/map-with-concurrency.js";
+import { resolveLintConcurrency } from "../../utils/resolve-lint-concurrency.js";
 import { parseOxlintOutput } from "./parse-output.js";
 import { spawnOxlint } from "./spawn-oxlint.js";
 
@@ -19,17 +21,20 @@ export interface SpawnLintBatchesInput {
 }
 
 /**
- * Runs every prebuilt file batch through oxlint, with binary-split
+ * Runs every prebuilt file batch through oxlint, fanning batches
+ * across a bounded worker pool (`resolveLintConcurrency`) so large
+ * repos saturate the available cores instead of spending the scan
+ * awaiting one subprocess at a time. Each batch keeps the binary-split
  * retry on the splittable error classes (timeout / output-too-large /
- * OOM / killed by signal). When a single-file batch still fails with
- * a splittable error, the file is recorded into a dropped-files list
+ * OOM / killed by signal). When a single-file batch still fails with a
+ * splittable error, the file is recorded into a dropped-files list
  * (surfaced via `onPartialFailure`) so JSON-mode consumers see WHICH
  * files were skipped instead of silently losing them.
  *
  * Errors that aren't splittable (oxlint config crash, JS plugin
- * resolution failure, etc.) propagate to the caller — the
- * `runOxlint` retry-without-extends fallback re-spawns this loop
- * with a slimmer config in that case.
+ * resolution failure, etc.) reject the pool and propagate to the
+ * caller — the `runOxlint` retry-without-extends fallback re-spawns
+ * this loop with a slimmer config in that case.
  */
 export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Diagnostic[]> => {
   const {
@@ -43,7 +48,6 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
   } = input;
   const totalFileCount = fileBatches.reduce((sum, batch) => sum + batch.length, 0);
 
-  const allDiagnostics: Diagnostic[] = [];
   // HACK: tracks files whose smallest splittable batch (down to a
   // single file) still failed with a splittable error — surfaced via
   // `onPartialFailure` so JSON consumers see WHICH files were dropped
@@ -85,40 +89,51 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     }
   };
 
-  let scannedFileCount = 0;
-  for (const batch of fileBatches) {
-    // HACK: tick the progress counter per-file on a timer while the
-    // batch subprocess runs, so the UI feels smooth instead of jumping
-    // by 100 when each batch completes. The interval is cleared as
-    // soon as the batch resolves — any remaining files in the batch
-    // are counted in one final update.
-    let batchFileIndex = 0;
-    const progressInterval =
-      onFileProgress && batch.length > 1
-        ? setInterval(() => {
-            if (batchFileIndex < batch.length) {
-              batchFileIndex += 1;
-              onFileProgress(scannedFileCount + batchFileIndex, totalFileCount);
-            }
-          }, PROGRESS_TICK_INTERVAL_MS)
-        : null;
-    const batchDiagnostics = await spawnLintBatch(batch);
-    if (progressInterval !== null) clearInterval(progressInterval);
-    allDiagnostics.push(...batchDiagnostics);
-    scannedFileCount += batch.length;
-    onFileProgress?.(scannedFileCount, totalFileCount);
-  }
+  // Progress reports off a single shared accumulator so the counter
+  // stays monotonic even though batches now finish out of order across
+  // the pool. A timer simulates per-file ticks up to (never past) the
+  // final file so the spinner stays smooth while subprocesses are in
+  // flight; each completed batch snaps the counter to the real
+  // completed-file total.
+  let completedFileCount = 0;
+  let simulatedFileCount = 0;
+  const progressTicker =
+    onFileProgress && totalFileCount > 1
+      ? setInterval(() => {
+          if (simulatedFileCount < totalFileCount - 1) {
+            simulatedFileCount += 1;
+            onFileProgress(Math.max(completedFileCount, simulatedFileCount), totalFileCount);
+          }
+        }, PROGRESS_TICK_INTERVAL_MS)
+      : null;
+  progressTicker?.unref?.();
 
-  if (droppedFiles.length > 0 && onPartialFailure) {
-    const previewFiles = droppedFiles.slice(0, OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT).join(", ");
-    const remainderHint =
-      droppedFiles.length > OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT
-        ? `, +${droppedFiles.length - OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT} more`
-        : "";
-    const reasonHint = firstDropReason ? ` — first failure: ${firstDropReason}` : "";
-    onPartialFailure(
-      `${droppedFiles.length} file(s) failed to lint and were skipped (${previewFiles}${remainderHint})${reasonHint}`,
+  try {
+    const diagnosticsPerBatch = await mapWithConcurrency(
+      fileBatches,
+      resolveLintConcurrency(),
+      async (batch) => {
+        const batchDiagnostics = await spawnLintBatch(batch);
+        completedFileCount += batch.length;
+        simulatedFileCount = Math.max(simulatedFileCount, completedFileCount);
+        onFileProgress?.(completedFileCount, totalFileCount);
+        return batchDiagnostics;
+      },
     );
+
+    if (droppedFiles.length > 0 && onPartialFailure) {
+      const previewFiles = droppedFiles.slice(0, OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT).join(", ");
+      const remainderHint =
+        droppedFiles.length > OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT
+          ? `, +${droppedFiles.length - OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT} more`
+          : "";
+      const reasonHint = firstDropReason ? ` — first failure: ${firstDropReason}` : "";
+      onPartialFailure(
+        `${droppedFiles.length} file(s) failed to lint and were skipped (${previewFiles}${remainderHint})${reasonHint}`,
+      );
+    }
+    return dedupeDiagnostics(diagnosticsPerBatch.flat());
+  } finally {
+    if (progressTicker !== null) clearInterval(progressTicker);
   }
-  return dedupeDiagnostics(allDiagnostics);
 };

--- a/packages/core/src/utils/map-with-concurrency.ts
+++ b/packages/core/src/utils/map-with-concurrency.ts
@@ -1,0 +1,35 @@
+/**
+ * Maps `mapItem` over `items` with at most `concurrencyLimit` calls
+ * in flight at once, preserving result order. A minimal Promise-based
+ * worker pool: `concurrencyLimit` workers each pull the next index off
+ * a shared cursor until the list drains.
+ *
+ * The oxlint runner uses it to fan a project's file batches across CPU
+ * cores instead of awaiting one subprocess at a time. Plain async code
+ * (not Effect) because the runner it serves — `spawnLintBatches` →
+ * `spawnOxlint` — is plain async around `child_process.spawn`.
+ */
+export const mapWithConcurrency = async <Item, Result>(
+  items: ReadonlyArray<Item>,
+  concurrencyLimit: number,
+  mapItem: (item: Item, index: number) => Promise<Result>,
+): Promise<Result[]> => {
+  const results = new Array<Result>(items.length);
+  let nextIndex = 0;
+
+  const runWorker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapItem(items[currentIndex], currentIndex);
+    }
+  };
+
+  const workerCount = Math.max(1, Math.min(Math.floor(concurrencyLimit), items.length));
+  const workers: Promise<void>[] = [];
+  for (let workerIndex = 0; workerIndex < workerCount; workerIndex += 1) {
+    workers.push(runWorker());
+  }
+  await Promise.all(workers);
+  return results;
+};

--- a/packages/core/src/utils/resolve-lint-concurrency.ts
+++ b/packages/core/src/utils/resolve-lint-concurrency.ts
@@ -1,0 +1,30 @@
+import os from "node:os";
+import { LINT_BATCH_CONCURRENCY_MAX } from "../constants.js";
+
+/**
+ * Resolves how many oxlint batch subprocesses `spawnLintBatches` runs
+ * at once. Defaults to the machine's available parallelism, clamped to
+ * `LINT_BATCH_CONCURRENCY_MAX` so a many-core CI box doesn't spawn
+ * dozens of oxlint processes simultaneously — each holds up to
+ * `OXLINT_MAX_FILES_PER_BATCH` files in oxlint's native binding, the
+ * very memory pressure the batching guards against.
+ *
+ * `REACT_DOCTOR_LINT_CONCURRENCY` overrides the pool size for
+ * hand-tuned runs: `1` forces the legacy one-batch-at-a-time behavior;
+ * a higher number opts a memory-rich runner into more parallelism than
+ * the default cap. Non-numeric or sub-1 values fall back to the
+ * derived default. Mirrors the env-override pattern
+ * `REACT_DOCTOR_OXLINT_SPAWN_TIMEOUT_MS` already uses in `spawn-oxlint.ts`.
+ */
+export const resolveLintConcurrency = (): number => {
+  const override = process.env["REACT_DOCTOR_LINT_CONCURRENCY"];
+  if (override !== undefined) {
+    const parsed = Number(override);
+    if (Number.isFinite(parsed) && parsed >= 1) {
+      return Math.floor(parsed);
+    }
+  }
+  const availableParallelism =
+    typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length;
+  return Math.max(1, Math.min(availableParallelism, LINT_BATCH_CONCURRENCY_MAX));
+};

--- a/packages/core/tests/map-with-concurrency.test.ts
+++ b/packages/core/tests/map-with-concurrency.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mapWithConcurrency } from "@react-doctor/core";
+
+const deferred = <Value>() => {
+  let resolve!: (value: Value) => void;
+  const promise = new Promise<Value>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+};
+
+describe("mapWithConcurrency", () => {
+  it("returns an empty array for empty input", async () => {
+    const results = await mapWithConcurrency([], 4, async (item) => item);
+    expect(results).toEqual([]);
+  });
+
+  it("preserves result order even when items resolve out of order", async () => {
+    const results = await mapWithConcurrency([10, 30, 20], 3, async (delayMs, index) => {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      return `${index}:${delayMs}`;
+    });
+    expect(results).toEqual(["0:10", "1:30", "2:20"]);
+  });
+
+  it("never exceeds the concurrency limit of in-flight calls", async () => {
+    const gates = Array.from({ length: 6 }, () => deferred<void>());
+    let activeCount = 0;
+    let peakActiveCount = 0;
+
+    const pending = mapWithConcurrency(gates, 2, async (gate) => {
+      activeCount += 1;
+      peakActiveCount = Math.max(peakActiveCount, activeCount);
+      await gate.promise;
+      activeCount -= 1;
+      return null;
+    });
+
+    // Release gates one at a time; the pool must keep at most 2 alive.
+    for (const gate of gates) {
+      await Promise.resolve();
+      gate.resolve();
+    }
+    await pending;
+    expect(peakActiveCount).toBe(2);
+  });
+
+  it("treats a limit larger than the item count as 'all at once'", async () => {
+    let activeCount = 0;
+    let peakActiveCount = 0;
+    const gates = Array.from({ length: 3 }, () => deferred<void>());
+
+    const pending = mapWithConcurrency(gates, 100, async (gate) => {
+      activeCount += 1;
+      peakActiveCount = Math.max(peakActiveCount, activeCount);
+      await gate.promise;
+      activeCount -= 1;
+      return null;
+    });
+    await Promise.resolve();
+    for (const gate of gates) gate.resolve();
+    await pending;
+    expect(peakActiveCount).toBe(3);
+  });
+
+  it("clamps a sub-1 limit to a single worker", async () => {
+    let activeCount = 0;
+    let peakActiveCount = 0;
+    const gates = Array.from({ length: 3 }, () => deferred<void>());
+
+    const pending = mapWithConcurrency(gates, 0, async (gate) => {
+      activeCount += 1;
+      peakActiveCount = Math.max(peakActiveCount, activeCount);
+      await gate.promise;
+      activeCount -= 1;
+      return null;
+    });
+    await Promise.resolve();
+    for (const gate of gates) gate.resolve();
+    await pending;
+    expect(peakActiveCount).toBe(1);
+  });
+
+  it("propagates a rejection from any worker", async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async (value) => {
+        if (value === 2) throw new Error("boom");
+        return value;
+      }),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/packages/core/tests/resolve-lint-concurrency.test.ts
+++ b/packages/core/tests/resolve-lint-concurrency.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { LINT_BATCH_CONCURRENCY_MAX, resolveLintConcurrency } from "@react-doctor/core";
+
+const ENV_KEY = "REACT_DOCTOR_LINT_CONCURRENCY";
+const originalOverride = process.env[ENV_KEY];
+
+afterEach(() => {
+  if (originalOverride === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = originalOverride;
+  }
+});
+
+describe("resolveLintConcurrency", () => {
+  it("honors a valid numeric override", () => {
+    process.env[ENV_KEY] = "3";
+    expect(resolveLintConcurrency()).toBe(3);
+  });
+
+  it("forces sequential execution when the override is 1", () => {
+    process.env[ENV_KEY] = "1";
+    expect(resolveLintConcurrency()).toBe(1);
+  });
+
+  it("allows an override above the default cap (memory-rich runners)", () => {
+    process.env[ENV_KEY] = String(LINT_BATCH_CONCURRENCY_MAX + 16);
+    expect(resolveLintConcurrency()).toBe(LINT_BATCH_CONCURRENCY_MAX + 16);
+  });
+
+  it("floors a fractional override", () => {
+    process.env[ENV_KEY] = "4.9";
+    expect(resolveLintConcurrency()).toBe(4);
+  });
+
+  it("falls back to the derived default for non-numeric or sub-1 overrides", () => {
+    for (const invalid of ["abc", "0", "-2", ""]) {
+      process.env[ENV_KEY] = invalid;
+      const resolved = resolveLintConcurrency();
+      expect(resolved).toBeGreaterThanOrEqual(1);
+      expect(resolved).toBeLessThanOrEqual(LINT_BATCH_CONCURRENCY_MAX);
+    }
+  });
+
+  it("derives a default within [1, LINT_BATCH_CONCURRENCY_MAX] when no override is set", () => {
+    delete process.env[ENV_KEY];
+    const resolved = resolveLintConcurrency();
+    expect(resolved).toBeGreaterThanOrEqual(1);
+    expect(resolved).toBeLessThanOrEqual(LINT_BATCH_CONCURRENCY_MAX);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

On large repos the lint pass was the long pole, and it was leaving most of the machine idle. `spawnLintBatches` materializes the file list, splits it into ≤`OXLINT_MAX_FILES_PER_BATCH` (100) batches to dodge the oxlint native-binding OOM/SIGABRT cliff (#84), and then ran those batches **one subprocess at a time** in a plain `for` loop. So during rule processing of a repo like supabase/studio (~3,500 source files → ~36 batches), exactly one core did work while the rest sat idle.

This is the first, most self-contained slice of the broader runner/perf cleanup discussed — it banks the parallelism win **today**, without waiting on the larger oxc-parser rearchitecture, and keeps the subprocess isolation + binary-split OOM recovery fully intact.

## What changed

- **`spawnLintBatches` now fans batches across a bounded worker pool** instead of awaiting each subprocess sequentially. Per-batch behavior is unchanged: the binary-split retry on splittable errors (timeout / output-too-large / OOM / killed), the dropped-file accounting, and the `onPartialFailure` summary all carry over verbatim.
- **New `mapWithConcurrency` util** (`utils/map-with-concurrency.ts`) — a minimal, order-preserving Promise worker pool. Plain async (not Effect) because the runner it serves (`spawnLintBatches` → `spawnOxlint` → `child_process.spawn`) is plain async.
- **New `resolveLintConcurrency` util** (`utils/resolve-lint-concurrency.ts`) — defaults the pool to the machine's available parallelism, clamped to `LINT_BATCH_CONCURRENCY_MAX` (8) so a 64-core CI box doesn't spawn 64 oxlint processes at once and reintroduce the very memory pressure the batching guards against. Overridable via **`REACT_DOCTOR_LINT_CONCURRENCY`** (`1` = legacy sequential behavior; higher = opt a memory-rich runner into more parallelism). Mirrors the existing `REACT_DOCTOR_OXLINT_SPAWN_TIMEOUT_MS` env-override pattern.
- **Progress reporting reworked to be concurrency-safe**: a single shared accumulator keeps the scanned-file counter monotonic even though batches now complete out of order, and a timer still simulates smooth per-file ticks (bounded below the final file) while subprocesses are in flight.

## Behavior / safety notes

- Memory ceiling is preserved: peak concurrency is bounded and each subprocess still holds at most a 100-file batch.
- Error propagation is unchanged: a non-splittable error rejects the pool and propagates to `runOxlint`, which still retries once with `extends` stripped.
- `firstDropReason` is now "first observed" rather than "first by batch order" under parallelism — it's only an illustrative example in the partial-failure message, so this is cosmetic.

## Tests

- `map-with-concurrency.test.ts` — order preservation under out-of-order resolution, never exceeding the limit, limit-larger-than-items, sub-1 clamping, rejection propagation.
- `resolve-lint-concurrency.test.ts` — numeric override, `1` forces sequential, override above the cap, fractional flooring, invalid/sub-1 fallback, derived-default bounds.
- Full suite green: `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (1385 passed / 12 pre-existing skips), and `pnpm smoke:json-report`.

## Follow-ups (not in this PR)

The original discussion scoped a larger rearchitecture; this PR deliberately lands only the contained perf win. Tracked separately:

- **`project-info` → dependency graph.** Replace the `hasTanStackQuery` / `hasPreact` / `hasReactDependency`-style conditionals with a walked package.json graph (monorepo-aware) handed to plugins, queried via composable helpers like `dependencyGraph.hasDependency("react@19")`.
- **In-process runner via `oxc-parser` + worker pool.** Drop the temp-`oxlintrc` + spawned-oxlint dance in favor of direct AST parsing and an in-process worker pool, which also makes the granular concurrency knobs first-class rather than subprocess-shaped.
- **Programmatic-run ergonomics.** Make `inspect()`/`diagnose()` accept an in-memory project description so eval harnesses (e.g. the auto-improving RD loop) don't have to inflate a fake `package.json` on disk to satisfy discovery.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a3de8de-23cd-4482-b840-fd8ad4a9ec37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a3de8de-23cd-4482-b840-fd8ad4a9ec37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

