### PR TITLE
feat(react-doctor-lite): PoC in-process engine — dependency graph + worker pool

### DIFF
--- a/packages/react-doctor-lite/README.md
+++ b/packages/react-doctor-lite/README.md
@@ -1,0 +1,140 @@
+# react-doctor-lite (PoC)
+
+A deliberately small re-imagining of the React Doctor engine that drops three
+sources of accidental complexity from `@react-doctor/core`:
+
+1. **oxlint subprocesses → in-process AST walking.** No temp `oxlintrc.json`, no
+   `node <oxlint-bin> --format json`, no stdout parsing, no batched-spawn OOM
+   dance. We parse with `oxc-parser` and run the existing
+   `oxlint-plugin-react-doctor` rules directly.
+2. **`ProjectInfo` boolean soup → a composable dependency graph.** Instead of
+   `hasTanStackQuery` / `hasPreact` / `parseReactMajor` / `detectFramework` and
+   friends, we walk the whole `package.json` graph (monorepo-aware) once and let
+   everything query it: `graph.hasDependency("react", ">=19")`.
+3. **Disk-only entry → first-class programmatic mode.** `diagnose()` accepts an
+   in-memory dependency manifest and in-memory sources, so evals never have to
+   inflate a fake `package.json` on disk.
+
+> This is a proof of concept. It reuses the canonical rules and semantic
+> analysis from `oxlint-plugin-react-doctor` verbatim — it only replaces the
+> _runner_, the _project discovery_, and the _entry API_.
+
+## Why it's faster
+
+`@react-doctor/core` spawns oxlint in **sequential** batches (capped at ~100
+files/batch to avoid OOM on large repos like `supabase/studio`). Sequential
+batches leave most cores idle during the heaviest phase — JS-plugin rule
+evaluation.
+
+`react-doctor-lite` parses and lints in-process and distributes files across a
+**worker-thread pool** with explicit `poolSize` / `batchSize` controls:
+
+```ts
+await diagnose({
+  cwd: "/path/to/large/repo",
+  concurrency: { poolSize: 8, batchSize: 32 },
+});
+```
+
+Because there are no subprocesses, concurrency is a pool of threads instead of a
+queue of `oxlint` processes, and the granularity is per-batch-of-files rather
+than per-spawn.
+
+## Usage
+
+### Disk mode
+
+```ts
+import { diagnose } from "react-doctor-lite";
+
+const result = await diagnose({ cwd: "/path/to/app" });
+console.log(result.diagnostics, result.graph, result.capabilities);
+```
+
+### Programmatic / in-memory mode (no `package.json`, no files on disk)
+
+This is the mode the auto-improving / eval workflows want:
+
+```ts
+import { diagnose } from "react-doctor-lite";
+
+const result = await diagnose({
+  dependencies: {
+    dependencies: { react: "19.0.0", "@tanstack/react-query": "^5" },
+    devDependencies: { typescript: "^5.6.0" },
+  },
+  sources: [{ filePath: "App.tsx", code: "/* ... */" }],
+  rules: { only: ["no-array-index-as-key"] },
+});
+```
+
+### The dependency graph directly
+
+```ts
+import { buildDependencyGraphFromDisk } from "react-doctor-lite";
+
+const graph = buildDependencyGraphFromDisk(process.cwd());
+graph.hasDependency("react", ">=19"); // boolean
+graph.hasDependency("@tanstack/react-query@^5"); // combined specifier form
+graph.getMajor("react"); // lowest installed major across the whole graph
+graph.framework; // "nextjs" | "vite" | ... | "unknown"
+```
+
+## How it maps onto the existing pieces
+
+| Concern | `@react-doctor/core` | `react-doctor-lite` |
+| --- | --- | --- |
+| Rule execution | oxlint subprocess + JSON stdout | `lintSource` — parse once, single tree walk dispatching every rule's visitors |
+| Concurrency | sequential batched `oxlint` spawns | `worker-pool` over `worker_threads`, `poolSize`/`batchSize` knobs |
+| Project discovery | `discover-project.ts` + a dozen boolean helpers | `build-dependency-graph.ts` → one queryable graph |
+| Capability gating | `buildCapabilities(ProjectInfo)` | `buildCapabilities(DependencyGraph)` (same tokens, graph-sourced) |
+| Rule metadata | `requires` / `disabledBy` / `tags` / `framework` | unchanged — reused from `oxlint-plugin-react-doctor` |
+| Entry | `diagnose(directory)` (disk only) | `diagnose({ cwd? , sources?, dependencies? })` |
+
+The capability tokens (`react:19`, `tanstack-query`, `tailwind:3.4`, …) are kept
+identical so the existing rule `requires`/`disabledBy` metadata works without
+changes — the only thing that changed is that the tokens are now _derived from
+graph queries_ instead of bespoke `ProjectInfo` fields.
+
+## Architecture
+
+```
+src/
+  index.ts                      public diagnose() + graph/runner exports
+  types.ts                      shared interfaces
+  constants.ts                  worker-pool thresholds, ignored dirs, framework map
+  dependency-graph/
+    build-dependency-graph.ts   disk walk (monorepo root + workspaces) and in-memory build
+    create-dependency-graph.ts  the queryable graph (hasDependency / getMajor / framework)
+    find-monorepo-root.ts        ancestor climb to a workspace root
+    read-workspace-globs.ts      pnpm-workspace.yaml + package.json#workspaces
+    expand-workspace-glob.ts     prefix/* and prefix/** expansion
+    derive-framework.ts
+    read-package-json.ts
+  capabilities/
+    build-capabilities.ts       graph -> capability token set
+  rules/
+    load-rules.ts               capability-gated rule set (+ overrides) from the plugin
+    should-enable-rule.ts       requires / disabledBy / tags / framework predicate
+  runner/
+    lint-source.ts              single-pass in-process lint of one source
+    lint-sources-in-process.ts  loop over sources
+    run-diagnostics.ts          orchestrator (in-process vs worker pool)
+    worker-pool.ts              worker_threads pool with granular concurrency
+    worker.ts                   worker entry
+    read-source.ts
+  utils/                        focused, one-per-file helpers
+```
+
+## Known PoC limitations
+
+- The worker pool engages only in **built** (`.js`) mode — raw-TS worker threads
+  cannot resolve the `.js`-style import specifiers, so source-mode runs and tiny
+  inputs lint in-process. `pnpm build` then run, or rely on the in-process path.
+- In-memory `sources` always lint in-process (workers read paths from disk).
+- No inline `react-doctor-disable` suppression handling, no scoring, no dead-code
+  pass, no config-file loading, no catalog (`catalog:`) version resolution, and
+  glob negation/brace-expansion in workspace patterns are out of scope.
+- A non-React project is not rejected (core throws `NoReactDependency`); lite
+  simply enables the global rules.
+```

--- a/packages/react-doctor-lite/package.json
+++ b/packages/react-doctor-lite/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "react-doctor-lite",
+  "version": "0.0.0",
+  "private": true,
+  "description": "PoC: a deliberately small, in-process React Doctor engine. No oxlint subprocesses, no oxlintrc temp files, no ad-hoc project-info booleans. Parses with oxc-parser, queries a composable dependency graph, and runs rules over a worker pool with granular concurrency controls.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && cross-env NODE_ENV=production vp pack",
+    "test": "vp test run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "oxc-parser": "^0.132.0",
+    "oxlint-plugin-react-doctor": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/packages/react-doctor-lite/src/capabilities/build-capabilities.ts
+++ b/packages/react-doctor-lite/src/capabilities/build-capabilities.ts
@@ -1,0 +1,66 @@
+import { isReactNativeDependencyName } from "oxlint-plugin-react-doctor";
+import {
+  MIN_GATED_REACT_MAJOR,
+  REACT_COMPILER_DEPENDENCY_NAMES,
+  TANSTACK_QUERY_DEPENDENCY_NAMES,
+} from "../constants.js";
+import type { DependencyGraph } from "../types.js";
+
+const hasReactNativeAnywhere = (graph: DependencyGraph): boolean =>
+  graph.packages.some((node) =>
+    [...node.dependencies.keys()].some((name) => isReactNativeDependencyName(name)),
+  );
+
+// Derives the capability token set the oxlint-plugin-react-doctor rules gate
+// on (`react:19`, `tanstack-query`, `tailwind:3.4`, …) entirely from
+// dependency-graph queries. This is the bridge that lets the existing
+// `requires` / `disabledBy` rule metadata keep working while the underlying
+// detection collapses into the composable graph.
+export const buildCapabilities = (graph: DependencyGraph): Set<string> => {
+  const capabilities = new Set<string>();
+
+  capabilities.add(graph.framework);
+
+  if (
+    graph.framework === "expo" ||
+    graph.framework === "react-native" ||
+    hasReactNativeAnywhere(graph)
+  ) {
+    capabilities.add("react-native");
+  }
+
+  const reactMajor = graph.getMajor("react");
+  if (reactMajor !== null) {
+    for (let major = MIN_GATED_REACT_MAJOR; major <= reactMajor; major++) {
+      capabilities.add(`react:${major}`);
+    }
+    if (reactMajor >= 19 && graph.hasDependency("react", ">=19.2")) {
+      capabilities.add("react:19.2");
+    }
+  }
+
+  if (graph.getMajor("tailwindcss") !== null) {
+    capabilities.add("tailwind");
+    if (graph.hasDependency("tailwindcss", ">=3.4")) {
+      capabilities.add("tailwind:3.4");
+    }
+  }
+
+  if (graph.hasAnyDependency([...REACT_COMPILER_DEPENDENCY_NAMES])) {
+    capabilities.add("react-compiler");
+  }
+  if (graph.hasAnyDependency([...TANSTACK_QUERY_DEPENDENCY_NAMES])) {
+    capabilities.add("tanstack-query");
+  }
+  if (graph.hasDependency("typescript")) {
+    capabilities.add("typescript");
+  }
+  if (graph.hasDependency("preact")) {
+    capabilities.add("preact");
+    if (graph.getVersion("react") === null) {
+      capabilities.add("pure-preact");
+    }
+  }
+
+  return capabilities;
+};

--- a/packages/react-doctor-lite/src/constants.ts
+++ b/packages/react-doctor-lite/src/constants.ts
@@ -1,0 +1,52 @@
+import type { Framework } from "./types.js";
+
+// Below this file count the worker-pool overhead (thread spawn + message
+// serialization) outweighs the parallelism win, so we lint in-process.
+export const WORKER_POOL_MIN_FILES = 24;
+
+// Files handed to a single worker task when the caller does not override it.
+export const DEFAULT_BATCH_SIZE_FILES = 32;
+
+// Directories never worth walking when listing source files on disk.
+export const IGNORED_DIRECTORY_NAMES: ReadonlySet<string> = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "out",
+  "coverage",
+  ".git",
+  ".next",
+  ".turbo",
+  ".cache",
+  ".vercel",
+]);
+
+// Extensions the engine parses as source.
+export const SOURCE_FILE_PATTERN = /\.(?:tsx?|jsx?|mjs|cjs)$/;
+
+// The lowest React major the rule registry gates on (`react:17` … `react:N`).
+export const MIN_GATED_REACT_MAJOR = 17;
+
+export const TANSTACK_QUERY_DEPENDENCY_NAMES: ReadonlySet<string> = new Set([
+  "@tanstack/react-query",
+  "@tanstack/query-core",
+  "react-query",
+]);
+
+export const REACT_COMPILER_DEPENDENCY_NAMES: ReadonlySet<string> = new Set([
+  "babel-plugin-react-compiler",
+  "react-compiler-runtime",
+  "eslint-plugin-react-compiler",
+]);
+
+// Package name -> framework, evaluated in declaration order (first match wins).
+export const FRAMEWORK_DEPENDENCY_NAMES: ReadonlyArray<readonly [string, Framework]> = [
+  ["next", "nextjs"],
+  ["@tanstack/react-start", "tanstack-start"],
+  ["@remix-run/react", "remix"],
+  ["react-scripts", "cra"],
+  ["gatsby", "gatsby"],
+  ["expo", "expo"],
+  ["react-native", "react-native"],
+  ["vite", "vite"],
+];

--- a/packages/react-doctor-lite/src/dependency-graph/build-dependency-graph.ts
+++ b/packages/react-doctor-lite/src/dependency-graph/build-dependency-graph.ts
@@ -1,0 +1,58 @@
+import * as path from "node:path";
+import { createDependencyGraph } from "./create-dependency-graph.js";
+import { expandWorkspaceGlob } from "./expand-workspace-glob.js";
+import { findMonorepoRoot } from "./find-monorepo-root.js";
+import { readPackageJson } from "./read-package-json.js";
+import { readWorkspaceGlobs } from "./read-workspace-globs.js";
+import { mergeDependencySections } from "../utils/merge-dependency-sections.js";
+import type { DependencyGraph, DependencyManifest, PackageNode } from "../types.js";
+
+const toPackageNode = (
+  directory: string,
+  manifest: DependencyManifest,
+  isRoot: boolean,
+): PackageNode => ({
+  name: manifest.name ?? path.basename(directory),
+  directory,
+  isRoot,
+  dependencies: mergeDependencySections(manifest),
+});
+
+// In-memory mode: build a graph straight from a caller-supplied manifest. No
+// filesystem access, so evals never have to inflate a fake `package.json`.
+export const buildDependencyGraphFromManifest = (manifest: DependencyManifest): DependencyGraph =>
+  createDependencyGraph([toPackageNode("", manifest, true)]);
+
+// Disk mode: discover the enclosing workspace root, read it plus every
+// workspace package, and expose the whole graph. Replaces the climbing /
+// catalog-resolving / workspace-walking logic of `discover-project.ts` with a
+// single flat list of nodes.
+export const buildDependencyGraphFromDisk = (cwd: string): DependencyGraph => {
+  const rootDirectory = findMonorepoRoot(cwd);
+  const seenDirectories = new Set<string>();
+  const nodes: PackageNode[] = [];
+
+  const addNode = (directory: string, isRoot: boolean): void => {
+    const resolved = path.resolve(directory);
+    if (seenDirectories.has(resolved)) return;
+    const manifest = readPackageJson(resolved);
+    if (!manifest) return;
+    seenDirectories.add(resolved);
+    nodes.push(toPackageNode(resolved, manifest, isRoot));
+  };
+
+  const rootManifest = readPackageJson(rootDirectory);
+  addNode(rootDirectory, true);
+
+  for (const glob of readWorkspaceGlobs(rootDirectory, rootManifest)) {
+    for (const packageDirectory of expandWorkspaceGlob(rootDirectory, glob)) {
+      addNode(packageDirectory, false);
+    }
+  }
+
+  // Guarantee the scanned directory is represented even when it is neither the
+  // root nor matched by a workspace glob.
+  addNode(cwd, false);
+
+  return createDependencyGraph(nodes);
+};

--- a/packages/react-doctor-lite/src/dependency-graph/create-dependency-graph.ts
+++ b/packages/react-doctor-lite/src/dependency-graph/create-dependency-graph.ts
@@ -1,0 +1,60 @@
+import { deriveFramework } from "./derive-framework.js";
+import { parseDependencyVersion } from "../utils/parse-dependency-version.js";
+import type { ParsedVersion } from "../utils/parse-dependency-version.js";
+import { splitDependencySpecifier } from "../utils/split-dependency-specifier.js";
+import { versionSatisfiesRange } from "../utils/version-satisfies-range.js";
+import type { DependencyGraph, PackageNode } from "../types.js";
+
+const collectConcreteVersions = (
+  packages: ReadonlyArray<PackageNode>,
+  name: string,
+): ParsedVersion[] => {
+  const versions: ParsedVersion[] = [];
+  for (const node of packages) {
+    const spec = node.dependencies.get(name);
+    const parsed = parseDependencyVersion(spec);
+    if (parsed) versions.push(parsed);
+  }
+  return versions;
+};
+
+const lowestVersion = (versions: ReadonlyArray<ParsedVersion>): ParsedVersion | null =>
+  versions.reduce<ParsedVersion | null>(
+    (lowest, current) => (lowest === null || current.major < lowest.major ? current : lowest),
+    null,
+  );
+
+// Builds the composable graph query object from a flat list of package nodes.
+// This is the single replacement for the bespoke `hasTanStackQuery` /
+// `hasPreact` / `parseReactMajor` helpers — every detection becomes a graph
+// query.
+export const createDependencyGraph = (packages: ReadonlyArray<PackageNode>): DependencyGraph => {
+  const isDeclared = (name: string): boolean =>
+    packages.some((node) => node.dependencies.has(name));
+
+  return {
+    packages,
+    framework: deriveFramework(packages),
+    hasDependency(specifier: string, range?: string): boolean {
+      const split = splitDependencySpecifier(specifier);
+      const effectiveRange = range ?? split.range;
+      if (!isDeclared(split.name)) return false;
+      if (!effectiveRange) return true;
+      const lowest = lowestVersion(collectConcreteVersions(packages, split.name));
+      return lowest !== null && versionSatisfiesRange(lowest, effectiveRange);
+    },
+    hasAnyDependency(names: ReadonlyArray<string>): boolean {
+      return names.some((name) => isDeclared(name));
+    },
+    getVersion(name: string): string | null {
+      for (const node of packages) {
+        const spec = node.dependencies.get(name);
+        if (typeof spec === "string") return spec;
+      }
+      return null;
+    },
+    getMajor(name: string): number | null {
+      return lowestVersion(collectConcreteVersions(packages, name))?.major ?? null;
+    },
+  };
+};

--- a/packages/react-doctor-lite/src/dependency-graph/derive-framework.ts
+++ b/packages/react-doctor-lite/src/dependency-graph/derive-framework.ts
@@ -1,0 +1,19 @@
+import { FRAMEWORK_DEPENDENCY_NAMES } from "../constants.js";
+import type { Framework, PackageNode } from "../types.js";
+
+const isDeclaredAnywhere = (packages: ReadonlyArray<PackageNode>, name: string): boolean =>
+  packages.some((node) => node.dependencies.has(name));
+
+// Derives a single framework label from the whole graph. First match in
+// `FRAMEWORK_DEPENDENCY_NAMES` wins; Preact-without-React is the lone special
+// case (Preact-on-Vite stays `vite` but still gets Preact rules via the
+// `preact` capability, mirroring upstream behavior).
+export const deriveFramework = (packages: ReadonlyArray<PackageNode>): Framework => {
+  for (const [name, framework] of FRAMEWORK_DEPENDENCY_NAMES) {
+    if (isDeclaredAnywhere(packages, name)) return framework;
+  }
+  if (isDeclaredAnywhere(packages, "preact") && !isDeclaredAnywhere(packages, "react")) {
+    return "preact";
+  }
+  return "unknown";
+};

--- a/packages/react-doctor-lite/src/dependency-graph/expand-workspace-glob.ts
+++ b/packages/react-doctor-lite/src/dependency-graph/expand-workspace-glob.ts
@@ -1,0 +1,55 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { IGNORED_DIRECTORY_NAMES } from "../constants.js";
+
+const listChildDirectories = (directory: string): string[] => {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isDirectory() && !IGNORED_DIRECTORY_NAMES.has(entry.name))
+    .map((entry) => path.join(directory, entry.name));
+};
+
+const collectDirectoriesRecursively = (directory: string, depth: number): string[] => {
+  if (depth <= 0) return [];
+  const children = listChildDirectories(directory);
+  const collected = [...children];
+  for (const child of children) {
+    collected.push(...collectDirectoriesRecursively(child, depth - 1));
+  }
+  return collected;
+};
+
+const MAX_RECURSIVE_GLOB_DEPTH = 6;
+
+// Expands a single workspace glob into matching directories. Supports the
+// common shapes seen in real monorepos: a literal path, a `prefix/*`
+// single-level wildcard, and a `prefix/**` recursive wildcard. Negations and
+// brace-expansions are intentionally out of scope for the PoC.
+export const expandWorkspaceGlob = (rootDirectory: string, glob: string): string[] => {
+  const normalized = glob.replace(/\\/g, "/").replace(/\/+$/, "");
+
+  if (normalized.endsWith("/**")) {
+    const prefix = normalized.slice(0, -"/**".length);
+    return collectDirectoriesRecursively(
+      path.join(rootDirectory, prefix),
+      MAX_RECURSIVE_GLOB_DEPTH,
+    );
+  }
+
+  if (normalized.endsWith("/*")) {
+    const prefix = normalized.slice(0, -"/*".length);
+    return listChildDirectories(path.join(rootDirectory, prefix));
+  }
+
+  if (!normalized.includes("*")) {
+    const absolute = path.join(rootDirectory, normalized);
+    return fs.existsSync(absolute) ? [absolute] : [];
+  }
+
+  return [];
+};

--- a/packages/react-doctor-lite/src/dependency-graph/find-monorepo-root.ts
+++ b/packages/react-doctor-lite/src/dependency-graph/find-monorepo-root.ts
@@ -1,0 +1,24 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { readPackageJson } from "./read-package-json.js";
+
+const isMonorepoRoot = (directory: string): boolean => {
+  if (fs.existsSync(path.join(directory, "pnpm-workspace.yaml"))) return true;
+  const manifest = readPackageJson(directory);
+  if (!manifest?.workspaces) return false;
+  if (Array.isArray(manifest.workspaces)) return manifest.workspaces.length > 0;
+  return Boolean(manifest.workspaces.packages?.length);
+};
+
+// Climbs ancestors from `startDirectory` looking for a workspace root so a
+// leaf package inherits monorepo-wide dependencies. Returns the start
+// directory itself when no enclosing workspace is found.
+export const findMonorepoRoot = (startDirectory: string): string => {
+  let current = path.resolve(startDirectory);
+  while (true) {
+    if (isMonorepoRoot(current)) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return path.resolve(startDirectory);
+    current = parent;
+  }
+};

--- a/packages/react-doctor-lite/src/dependency-graph/read-package-json.ts
+++ b/packages/react-doctor-lite/src/dependency-graph/read-package-json.ts
@@ -1,0 +1,23 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { DependencyManifest } from "../types.js";
+
+// Reads and parses a `package.json` from a directory. Returns `null` when the
+// file is absent or unparseable rather than throwing — discovery walks treat
+// a missing/broken manifest as "no dependencies declared here".
+export const readPackageJson = (directory: string): DependencyManifest | null => {
+  const manifestPath = path.join(directory, "package.json");
+  let raw: string;
+  try {
+    raw = fs.readFileSync(manifestPath, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+};

--- a/packages/react-doctor-lite/src/dependency-graph/read-workspace-globs.ts
+++ b/packages/react-doctor-lite/src/dependency-graph/read-workspace-globs.ts
@@ -1,0 +1,52 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { DependencyManifest } from "../types.js";
+
+// Pulls the `packages:` entries out of a `pnpm-workspace.yaml` with a
+// deliberately tiny line scanner — the PoC avoids a YAML dependency. Handles
+// the canonical `packages:` block of `- "glob"` items and stops at the next
+// top-level key.
+const readPnpmWorkspaceGlobs = (rootDirectory: string): string[] => {
+  const workspaceFilePath = path.join(rootDirectory, "pnpm-workspace.yaml");
+  let raw: string;
+  try {
+    raw = fs.readFileSync(workspaceFilePath, "utf8");
+  } catch {
+    return [];
+  }
+
+  const globs: string[] = [];
+  let insidePackagesBlock = false;
+  for (const line of raw.split("\n")) {
+    if (/^packages\s*:/.test(line)) {
+      insidePackagesBlock = true;
+      continue;
+    }
+    if (!insidePackagesBlock) continue;
+    const itemMatch = /^\s*-\s*(.+?)\s*$/.exec(line);
+    if (itemMatch) {
+      globs.push(itemMatch[1].replace(/^["']|["']$/g, ""));
+      continue;
+    }
+    // A non-indented, non-list line ends the block.
+    if (/^\S/.test(line)) break;
+  }
+  return globs;
+};
+
+const readManifestWorkspaceGlobs = (manifest: DependencyManifest | null): string[] => {
+  if (!manifest?.workspaces) return [];
+  if (Array.isArray(manifest.workspaces)) return manifest.workspaces;
+  return manifest.workspaces.packages ?? [];
+};
+
+// Resolves the workspace globs for a monorepo root, preferring
+// `pnpm-workspace.yaml` over the `package.json#workspaces` field.
+export const readWorkspaceGlobs = (
+  rootDirectory: string,
+  manifest: DependencyManifest | null,
+): string[] => {
+  const pnpmGlobs = readPnpmWorkspaceGlobs(rootDirectory);
+  if (pnpmGlobs.length > 0) return pnpmGlobs;
+  return readManifestWorkspaceGlobs(manifest);
+};

--- a/packages/react-doctor-lite/src/index.ts
+++ b/packages/react-doctor-lite/src/index.ts
@@ -1,0 +1,41 @@
+import { runDiagnostics } from "./runner/run-diagnostics.js";
+import type { DiagnoseInput, DiagnoseResult } from "./types.js";
+
+// The single public entry point.
+//
+// Disk mode — walk a project on disk:
+//   await diagnose({ cwd: "/path/to/app" })
+//
+// Programmatic mode — no `package.json`, no source files on disk (evals):
+//   await diagnose({
+//     dependencies: { dependencies: { react: "19.0.0" } },
+//     sources: [{ filePath: "App.tsx", code: "..." }],
+//   })
+export const diagnose = async (input: DiagnoseInput = {}): Promise<DiagnoseResult> =>
+  runDiagnostics(input);
+
+export {
+  buildDependencyGraphFromDisk,
+  buildDependencyGraphFromManifest,
+} from "./dependency-graph/build-dependency-graph.js";
+export { createDependencyGraph } from "./dependency-graph/create-dependency-graph.js";
+export { buildCapabilities } from "./capabilities/build-capabilities.js";
+export { loadRules } from "./rules/load-rules.js";
+export { lintSource } from "./runner/lint-source.js";
+
+export type {
+  ConcurrencyOptions,
+  DependencyGraph,
+  DependencyGraphSummary,
+  DependencyManifest,
+  DiagnoseInput,
+  DiagnoseResult,
+  DiagnosticSeverity,
+  Framework,
+  LiteDiagnostic,
+  LiteSource,
+  LoadedRule,
+  PackageNode,
+  RuleSelection,
+  SeverityOverride,
+} from "./types.js";

--- a/packages/react-doctor-lite/src/rules/load-rules.ts
+++ b/packages/react-doctor-lite/src/rules/load-rules.ts
@@ -1,0 +1,85 @@
+import reactDoctorPlugin from "oxlint-plugin-react-doctor";
+import { shouldEnableRule } from "./should-enable-rule.js";
+import type { DiagnosticSeverity, LiteRuleContext, LoadedRule, RuleSelection } from "../types.js";
+import type { RuleVisitors } from "oxlint-plugin-react-doctor";
+
+// The host-rule shape exposed by the plugin's default export. Rules are
+// already wrapped with the semantic-context provider, so `context.scopes` /
+// `context.cfg` build lazily without any work here.
+interface HostRule {
+  severity: "error" | "warn";
+  category?: string;
+  framework?: string;
+  requires?: ReadonlyArray<string>;
+  disabledBy?: ReadonlyArray<string>;
+  tags?: ReadonlyArray<string>;
+  defaultEnabled?: boolean;
+  recommendation?: string;
+  create: (context: LiteRuleContext) => RuleVisitors;
+}
+
+const toDiagnosticSeverity = (severity: "error" | "warn"): DiagnosticSeverity =>
+  severity === "warn" ? "warning" : "error";
+
+const hostRules = reactDoctorPlugin.rules as unknown as Record<string, HostRule>;
+
+const toLoadedRule = (
+  id: string,
+  rule: HostRule,
+  severityOverride: DiagnosticSeverity | undefined,
+): LoadedRule => ({
+  id,
+  key: `react-doctor/${id}`,
+  severity: severityOverride ?? toDiagnosticSeverity(rule.severity),
+  category: rule.category ?? "Correctness",
+  recommendation: rule.recommendation,
+  create: rule.create,
+});
+
+// Reconstructs runnable rules from bare ids and a severity map. Worker threads
+// use this to rebuild the rule set the main thread already gated — visitor
+// functions cannot cross the thread boundary, only ids can.
+export const loadRulesByIds = (
+  ids: ReadonlyArray<string>,
+  severityById: Record<string, DiagnosticSeverity>,
+): LoadedRule[] => {
+  const loaded: LoadedRule[] = [];
+  for (const id of ids) {
+    const rule = hostRules[id];
+    if (rule) loaded.push(toLoadedRule(id, rule, severityById[id]));
+  }
+  return loaded;
+};
+
+export interface LoadRulesInput {
+  capabilities: ReadonlySet<string>;
+  selection?: RuleSelection;
+}
+
+// Resolves the full set of runnable rules for a project: every react-doctor
+// rule, capability-gated, with caller overrides (allowlist, disables, severity
+// remaps, default-disabled opt-in) applied.
+export const loadRules = ({ capabilities, selection = {} }: LoadRulesInput): LoadedRule[] => {
+  const ignoredTags = new Set(selection.ignoreTags ?? []);
+  const onlyIds = selection.only ? new Set(selection.only) : null;
+  const disabledIds = new Set(selection.disable ?? []);
+  const severityOverrides = selection.severity ?? {};
+
+  const loaded: LoadedRule[] = [];
+  for (const [id, rule] of Object.entries(hostRules)) {
+    if (onlyIds && !onlyIds.has(id)) continue;
+    if (disabledIds.has(id)) continue;
+
+    const override = severityOverrides[id];
+    if (override === "off") continue;
+
+    if (rule.defaultEnabled === false && !selection.includeDefaultDisabled && !onlyIds?.has(id)) {
+      continue;
+    }
+
+    if (!shouldEnableRule(rule, capabilities, ignoredTags)) continue;
+
+    loaded.push(toLoadedRule(id, rule, override));
+  }
+  return loaded;
+};

--- a/packages/react-doctor-lite/src/rules/should-enable-rule.ts
+++ b/packages/react-doctor-lite/src/rules/should-enable-rule.ts
@@ -1,0 +1,37 @@
+export interface RuleGate {
+  framework?: string;
+  requires?: ReadonlyArray<string>;
+  disabledBy?: ReadonlyArray<string>;
+  tags?: ReadonlyArray<string>;
+}
+
+// Decides whether a rule is active for a given capability set. Mirrors the
+// `shouldEnableRule` contract from `@react-doctor/core` but folds framework
+// gating into the same predicate: a non-`global` rule needs its framework
+// token in the capability set, every `requires` token must be present, no
+// `disabledBy` token may be present, and no `tags` token may be ignored.
+export const shouldEnableRule = (
+  gate: RuleGate,
+  capabilities: ReadonlySet<string>,
+  ignoredTags: ReadonlySet<string>,
+): boolean => {
+  if (gate.framework && gate.framework !== "global" && !capabilities.has(gate.framework)) {
+    return false;
+  }
+  if (gate.requires) {
+    for (const capability of gate.requires) {
+      if (!capabilities.has(capability)) return false;
+    }
+  }
+  if (gate.disabledBy) {
+    for (const capability of gate.disabledBy) {
+      if (capabilities.has(capability)) return false;
+    }
+  }
+  if (gate.tags) {
+    for (const tag of gate.tags) {
+      if (ignoredTags.has(tag)) return false;
+    }
+  }
+  return true;
+};

--- a/packages/react-doctor-lite/src/runner/lint-source.ts
+++ b/packages/react-doctor-lite/src/runner/lint-source.ts
@@ -1,0 +1,104 @@
+import { parseSync } from "oxc-parser";
+import { attachParentReferences } from "../utils/attach-parent-references.js";
+import { attachSourceLocations } from "../utils/attach-source-locations.js";
+import { isAstNode } from "../utils/is-ast-node.js";
+import { resolveParseLang } from "../utils/resolve-parse-lang.js";
+import type { LiteDiagnostic, LiteRuleContext, LoadedRule } from "../types.js";
+import type { EsTreeNode } from "oxlint-plugin-react-doctor";
+
+export interface LintSourceInput {
+  filePath: string;
+  code: string;
+  rules: ReadonlyArray<LoadedRule>;
+  settings: Readonly<Record<string, unknown>>;
+}
+
+type Visitor = (node: EsTreeNode) => void;
+
+interface NodeWithLoc {
+  loc?: { start?: { line: number; column: number } };
+}
+
+// Lints a single source string entirely in-process: parse once with
+// oxc-parser, wire up parent + loc, build each rule's visitors against a
+// dedicated reporting context, then walk the tree ONCE dispatching every
+// matching visitor. This is the whole runner — no subprocess, no oxlintrc, no
+// stdout JSON parsing.
+export const lintSource = (input: LintSourceInput): LiteDiagnostic[] => {
+  const { filePath, code, rules, settings } = input;
+
+  let program: EsTreeNode;
+  try {
+    const parsed = parseSync(filePath, code, {
+      astType: "ts",
+      lang: resolveParseLang(filePath),
+    });
+    program = parsed.program as unknown as EsTreeNode;
+  } catch {
+    return [];
+  }
+
+  attachParentReferences(program);
+  attachSourceLocations(program, code);
+
+  const diagnostics: LiteDiagnostic[] = [];
+  const enterVisitorsBySelector = new Map<string, Visitor[]>();
+  const exitVisitors: Visitor[] = [];
+
+  for (const rule of rules) {
+    const context: LiteRuleContext = {
+      report: ({ node, message }) => {
+        const position = (node as NodeWithLoc).loc?.start;
+        diagnostics.push({
+          filePath,
+          rule: rule.id,
+          ruleKey: rule.key,
+          severity: rule.severity,
+          category: rule.category,
+          message,
+          recommendation: rule.recommendation,
+          line: position?.line ?? 1,
+          column: position === undefined ? 1 : position.column + 1,
+        });
+      },
+      getFilename: () => filePath,
+      settings,
+    };
+
+    const visitors = rule.create(context);
+    for (const [selector, handler] of Object.entries(visitors)) {
+      if (typeof handler !== "function") continue;
+      if (selector === "Program:exit") {
+        exitVisitors.push(handler as Visitor);
+        continue;
+      }
+      const existing = enterVisitorsBySelector.get(selector);
+      if (existing) existing.push(handler as Visitor);
+      else enterVisitorsBySelector.set(selector, [handler as Visitor]);
+    }
+  }
+
+  const walk = (node: EsTreeNode): void => {
+    const handlers = enterVisitorsBySelector.get(node.type);
+    if (handlers) {
+      for (const handler of handlers) handler(node);
+    }
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const key of Object.keys(nodeRecord)) {
+      if (key === "parent") continue;
+      const child = nodeRecord[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (isAstNode(item)) walk(item);
+        }
+      } else if (isAstNode(child)) {
+        walk(child);
+      }
+    }
+  };
+
+  walk(program);
+  for (const handler of exitVisitors) handler(program);
+
+  return diagnostics;
+};

--- a/packages/react-doctor-lite/src/runner/lint-sources-in-process.ts
+++ b/packages/react-doctor-lite/src/runner/lint-sources-in-process.ts
@@ -1,0 +1,23 @@
+import { lintSource } from "./lint-source.js";
+import type { LiteDiagnostic, LiteSource, LoadedRule } from "../types.js";
+
+export interface LintSourcesInput {
+  sources: ReadonlyArray<LiteSource>;
+  rules: ReadonlyArray<LoadedRule>;
+  settings: Readonly<Record<string, unknown>>;
+}
+
+// Lints a list of in-memory sources sequentially on the current thread. Used
+// directly for small / programmatic inputs and as the per-batch body inside
+// each worker thread.
+export const lintSourcesInProcess = ({
+  sources,
+  rules,
+  settings,
+}: LintSourcesInput): LiteDiagnostic[] => {
+  const diagnostics: LiteDiagnostic[] = [];
+  for (const source of sources) {
+    diagnostics.push(...lintSource({ ...source, rules, settings }));
+  }
+  return diagnostics;
+};

--- a/packages/react-doctor-lite/src/runner/read-source.ts
+++ b/packages/react-doctor-lite/src/runner/read-source.ts
@@ -1,0 +1,12 @@
+import * as fs from "node:fs";
+import type { LiteSource } from "../types.js";
+
+// Reads a file into a `LiteSource`, returning `null` when the read fails so
+// the caller can simply skip unreadable paths.
+export const readSource = (filePath: string): LiteSource | null => {
+  try {
+    return { filePath, code: fs.readFileSync(filePath, "utf8") };
+  } catch {
+    return null;
+  }
+};

--- a/packages/react-doctor-lite/src/runner/run-diagnostics.ts
+++ b/packages/react-doctor-lite/src/runner/run-diagnostics.ts
@@ -1,0 +1,101 @@
+import * as os from "node:os";
+import { lintSourcesInProcess } from "./lint-sources-in-process.js";
+import { readSource } from "./read-source.js";
+import { runWorkerPool } from "./worker-pool.js";
+import { buildCapabilities } from "../capabilities/build-capabilities.js";
+import { DEFAULT_BATCH_SIZE_FILES, WORKER_POOL_MIN_FILES } from "../constants.js";
+import {
+  buildDependencyGraphFromDisk,
+  buildDependencyGraphFromManifest,
+} from "../dependency-graph/build-dependency-graph.js";
+import { createDependencyGraph } from "../dependency-graph/create-dependency-graph.js";
+import { loadRules } from "../rules/load-rules.js";
+import { listSourceFiles } from "../utils/list-source-files.js";
+import type {
+  DependencyGraph,
+  DiagnoseInput,
+  DiagnoseResult,
+  LiteSource,
+  LoadedRule,
+} from "../types.js";
+
+const resolveDependencyGraph = (input: DiagnoseInput): DependencyGraph => {
+  if (input.dependencies) return buildDependencyGraphFromManifest(input.dependencies);
+  if (input.cwd) return buildDependencyGraphFromDisk(input.cwd);
+  return createDependencyGraph([]);
+};
+
+const lintPathsInProcess = (
+  filePaths: ReadonlyArray<string>,
+  rules: ReadonlyArray<LoadedRule>,
+  settings: Record<string, unknown>,
+) => {
+  const sources: LiteSource[] = [];
+  for (const filePath of filePaths) {
+    const source = readSource(filePath);
+    if (source) sources.push(source);
+  }
+  return lintSourcesInProcess({ sources, rules, settings });
+};
+
+// The orchestrator. Resolves the dependency graph, derives capabilities, gates
+// the rule set, enumerates sources, and lints — either in-process (in-memory
+// sources, small inputs, or source-mode execution) or across a worker pool.
+export const runDiagnostics = async (input: DiagnoseInput): Promise<DiagnoseResult> => {
+  const startedAt = performance.now();
+
+  const graph = resolveDependencyGraph(input);
+  const capabilities = buildCapabilities(graph);
+  const rules = loadRules({ capabilities, selection: input.rules });
+  const settings = { ...(input.settings ?? {}) };
+
+  const concurrency = input.concurrency ?? {};
+  const poolSize = concurrency.poolSize ?? os.availableParallelism();
+  const batchSize = concurrency.batchSize ?? DEFAULT_BATCH_SIZE_FILES;
+
+  let scannedFileCount = 0;
+  let ranInWorkerPool = false;
+  let diagnostics;
+
+  if (input.sources) {
+    // In-memory sources never touch disk, so they always lint in-process.
+    scannedFileCount = input.sources.length;
+    diagnostics = lintSourcesInProcess({ sources: input.sources, rules, settings });
+  } else {
+    const filePaths = input.cwd ? listSourceFiles(input.cwd) : [];
+    scannedFileCount = filePaths.length;
+
+    const workerModuleIsBuilt = import.meta.url.endsWith(".js");
+    const useWorkerPool =
+      !concurrency.disableWorkers &&
+      poolSize > 1 &&
+      workerModuleIsBuilt &&
+      filePaths.length >= WORKER_POOL_MIN_FILES;
+
+    if (useWorkerPool) {
+      try {
+        diagnostics = await runWorkerPool({ filePaths, rules, settings, poolSize, batchSize });
+        ranInWorkerPool = true;
+      } catch {
+        diagnostics = lintPathsInProcess(filePaths, rules, settings);
+      }
+    } else {
+      diagnostics = lintPathsInProcess(filePaths, rules, settings);
+    }
+  }
+
+  return {
+    diagnostics,
+    graph: {
+      framework: graph.framework,
+      packageCount: graph.packages.length,
+      reactVersion: graph.getVersion("react"),
+      reactMajor: graph.getMajor("react"),
+    },
+    capabilities: [...capabilities].sort(),
+    enabledRuleCount: rules.length,
+    scannedFileCount,
+    elapsedMilliseconds: Math.round(performance.now() - startedAt),
+    ranInWorkerPool,
+  };
+};

--- a/packages/react-doctor-lite/src/runner/worker-pool.ts
+++ b/packages/react-doctor-lite/src/runner/worker-pool.ts
@@ -1,0 +1,86 @@
+import { Worker } from "node:worker_threads";
+import { chunkArray } from "../utils/chunk-array.js";
+import type { DiagnosticSeverity, LiteDiagnostic, LoadedRule, WorkerTask } from "../types.js";
+
+export interface RunWorkerPoolInput {
+  filePaths: ReadonlyArray<string>;
+  rules: ReadonlyArray<LoadedRule>;
+  settings: Record<string, unknown>;
+  poolSize: number;
+  batchSize: number;
+  // Overrides the resolved worker module URL. Used by tests to point a
+  // source-mode run at the built `dist/worker.js`.
+  workerUrl?: URL;
+}
+
+// The worker module is always a sibling sharing this module's extension —
+// `dist/worker.js` next to the bundled `dist/index.js`, or
+// `src/runner/worker.ts` next to `worker-pool.ts`. Raw-TS execution can't
+// honor the `.js`-style import specifiers inside the worker, which is why the
+// orchestrator only routes here in built (`.js`) mode.
+const resolveWorkerUrl = (): URL => {
+  const moduleUrl = import.meta.url;
+  const extension = moduleUrl.slice(moduleUrl.lastIndexOf("."));
+  return new URL(`./worker${extension}`, moduleUrl);
+};
+
+const buildTask = (
+  filePaths: ReadonlyArray<string>,
+  rules: ReadonlyArray<LoadedRule>,
+  settings: Record<string, unknown>,
+): WorkerTask => {
+  const severityById: Record<string, DiagnosticSeverity> = {};
+  for (const rule of rules) severityById[rule.id] = rule.severity;
+  return {
+    filePaths,
+    enabledRuleIds: rules.map((rule) => rule.id),
+    severityById,
+    settings,
+  };
+};
+
+// Distributes file batches across a fixed pool of worker threads so rule
+// processing actually uses every core, instead of the sequential
+// subprocess-per-batch model. Each idle worker is handed the next pending
+// batch until the queue drains.
+export const runWorkerPool = (input: RunWorkerPoolInput): Promise<LiteDiagnostic[]> => {
+  const { filePaths, rules, settings, poolSize, batchSize } = input;
+  const batches = chunkArray(filePaths, batchSize);
+  const workerUrl = input.workerUrl ?? resolveWorkerUrl();
+  const workerCount = Math.max(1, Math.min(poolSize, batches.length));
+
+  return new Promise<LiteDiagnostic[]>((resolve, reject) => {
+    const diagnostics: LiteDiagnostic[] = [];
+    const workers: Worker[] = [];
+    let nextBatchIndex = 0;
+    let completedBatches = 0;
+    let settled = false;
+
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      for (const worker of workers) void worker.terminate();
+      if (error) reject(error);
+      else resolve(diagnostics);
+    };
+
+    const assignNext = (worker: Worker): void => {
+      if (nextBatchIndex >= batches.length) return;
+      const batch = batches[nextBatchIndex++];
+      worker.postMessage(buildTask(batch, rules, settings));
+    };
+
+    for (let index = 0; index < workerCount; index++) {
+      const worker = new Worker(workerUrl);
+      workers.push(worker);
+      worker.on("message", (batchDiagnostics: LiteDiagnostic[]) => {
+        diagnostics.push(...batchDiagnostics);
+        completedBatches++;
+        if (completedBatches === batches.length) finish();
+        else assignNext(worker);
+      });
+      worker.on("error", finish);
+      assignNext(worker);
+    }
+  });
+};

--- a/packages/react-doctor-lite/src/runner/worker.ts
+++ b/packages/react-doctor-lite/src/runner/worker.ts
@@ -1,0 +1,29 @@
+import { parentPort } from "node:worker_threads";
+import { loadRulesByIds } from "../rules/load-rules.js";
+import { lintSourcesInProcess } from "./lint-sources-in-process.js";
+import { readSource } from "./read-source.js";
+import type { LiteDiagnostic, LiteSource, WorkerTask } from "../types.js";
+
+if (!parentPort) {
+  throw new Error("react-doctor-lite worker must be started inside a worker thread");
+}
+
+const port = parentPort;
+
+// Long-lived worker: rebuild the gated rule set per task (cheap — visitor
+// factories are reused references), read + lint each assigned file, and post
+// the diagnostics back. The pool keeps the worker alive for the next batch.
+port.on("message", (task: WorkerTask) => {
+  const rules = loadRulesByIds(task.enabledRuleIds, task.severityById);
+  const sources: LiteSource[] = [];
+  for (const filePath of task.filePaths) {
+    const source = readSource(filePath);
+    if (source) sources.push(source);
+  }
+  const diagnostics: LiteDiagnostic[] = lintSourcesInProcess({
+    sources,
+    rules,
+    settings: task.settings,
+  });
+  port.postMessage(diagnostics);
+});

--- a/packages/react-doctor-lite/src/types.ts
+++ b/packages/react-doctor-lite/src/types.ts
@@ -1,0 +1,149 @@
+import type { EsTreeNode, RuleVisitors } from "oxlint-plugin-react-doctor";
+
+export type Framework =
+  | "nextjs"
+  | "vite"
+  | "cra"
+  | "remix"
+  | "gatsby"
+  | "expo"
+  | "react-native"
+  | "tanstack-start"
+  | "preact"
+  | "unknown";
+
+export type DiagnosticSeverity = "error" | "warning";
+
+export type SeverityOverride = "error" | "warning" | "off";
+
+// A dependency manifest is the subset of a `package.json` the engine cares
+// about. Disk mode reads these off the filesystem; programmatic mode (evals)
+// passes one directly so no fake `package.json` ever has to be inflated.
+export interface DependencyManifest {
+  name?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  workspaces?: string[] | { packages?: string[] };
+}
+
+// One resolved node in the dependency graph — a single package manifest with
+// its dependency sections flattened into a single concrete-version lookup.
+export interface PackageNode {
+  name: string;
+  directory: string;
+  isRoot: boolean;
+  dependencies: ReadonlyMap<string, string>;
+}
+
+// The composable replacement for the pile of `hasTanStackQuery` /
+// `hasPreact` / `parseReactMajor` booleans. Rules (and capability
+// derivation) query it instead of reading bespoke `ProjectInfo` fields.
+export interface DependencyGraph {
+  readonly packages: ReadonlyArray<PackageNode>;
+  readonly framework: Framework;
+  // `hasDependency("react")` or `hasDependency("react@>=19")` or
+  // `hasDependency("react", ">=19")`. Range is matched against the lowest
+  // installed major across the whole graph (monorepo-safe).
+  hasDependency(specifier: string, range?: string): boolean;
+  hasAnyDependency(names: ReadonlyArray<string>): boolean;
+  getVersion(name: string): string | null;
+  getMajor(name: string): number | null;
+}
+
+export interface DependencyGraphSummary {
+  framework: Framework;
+  packageCount: number;
+  reactVersion: string | null;
+  reactMajor: number | null;
+}
+
+export interface LiteSource {
+  filePath: string;
+  code: string;
+}
+
+export interface LiteDiagnostic {
+  filePath: string;
+  rule: string;
+  ruleKey: string;
+  severity: DiagnosticSeverity;
+  category: string;
+  message: string;
+  recommendation?: string;
+  line: number;
+  column: number;
+}
+
+export interface ConcurrencyOptions {
+  // Number of worker threads. Defaults to `os.availableParallelism()`.
+  poolSize?: number;
+  // Files handed to a single worker task. Larger batches amortize the
+  // per-task message overhead; smaller batches balance load more evenly.
+  batchSize?: number;
+  // Force the synchronous in-process path even when `poolSize > 1`. Used by
+  // tests and tiny programmatic inputs where spawning threads is wasteful.
+  disableWorkers?: boolean;
+}
+
+export interface RuleSelection {
+  // When present, only these bare rule ids run (still capability-gated).
+  only?: ReadonlyArray<string>;
+  disable?: ReadonlyArray<string>;
+  severity?: Record<string, SeverityOverride>;
+  // Behavioral tags to drop wholesale (e.g. "test-noise", "design").
+  ignoreTags?: ReadonlyArray<string>;
+  // Include rules shipped with `defaultEnabled: false`.
+  includeDefaultDisabled?: boolean;
+}
+
+export interface DiagnoseInput {
+  // Root directory for filesystem operations and dependency-graph discovery.
+  // Optional in pure in-memory mode.
+  cwd?: string;
+  // Explicit in-memory sources. When provided, the filesystem is never walked
+  // for source files.
+  sources?: ReadonlyArray<LiteSource>;
+  // Explicit dependency manifest. When provided, no `package.json` is read.
+  dependencies?: DependencyManifest;
+  concurrency?: ConcurrencyOptions;
+  rules?: RuleSelection;
+  // Forwarded to oxlint-plugin-react-doctor rules via `context.settings`.
+  settings?: Record<string, unknown>;
+}
+
+export interface DiagnoseResult {
+  diagnostics: LiteDiagnostic[];
+  graph: DependencyGraphSummary;
+  capabilities: string[];
+  enabledRuleCount: number;
+  scannedFileCount: number;
+  elapsedMilliseconds: number;
+  ranInWorkerPool: boolean;
+}
+
+// Minimal `BaseRuleContext` the oxlint-plugin-react-doctor host rules accept.
+export interface LiteRuleContext {
+  report: (descriptor: { node: EsTreeNode; message: string }) => void;
+  getFilename: () => string;
+  settings: Readonly<Record<string, unknown>>;
+}
+
+// A rule resolved from the plugin registry, capability-gated and ready to run.
+export interface LoadedRule {
+  id: string;
+  key: string;
+  severity: DiagnosticSeverity;
+  category: string;
+  recommendation?: string;
+  create: (context: LiteRuleContext) => RuleVisitors;
+}
+
+// The serializable payload a worker thread needs to lint a batch of files.
+export interface WorkerTask {
+  filePaths: ReadonlyArray<string>;
+  enabledRuleIds: ReadonlyArray<string>;
+  severityById: Record<string, DiagnosticSeverity>;
+  settings: Record<string, unknown>;
+}

--- a/packages/react-doctor-lite/src/utils/attach-parent-references.ts
+++ b/packages/react-doctor-lite/src/utils/attach-parent-references.ts
@@ -1,0 +1,24 @@
+import { isAstNode } from "./is-ast-node.js";
+import type { EsTreeNode } from "oxlint-plugin-react-doctor";
+
+// oxlint sets `node.parent` on every node before invoking JS plugins; the
+// rules walk those links. oxc-parser emits an unparented tree, so we wire the
+// references up once before dispatching visitors.
+export const attachParentReferences = (root: EsTreeNode): void => {
+  const visit = (node: EsTreeNode, parent: EsTreeNode | null): void => {
+    (node as { parent?: EsTreeNode | null }).parent = parent;
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const key of Object.keys(nodeRecord)) {
+      if (key === "parent") continue;
+      const child = nodeRecord[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (isAstNode(item)) visit(item, node);
+        }
+      } else if (isAstNode(child)) {
+        visit(child, node);
+      }
+    }
+  };
+  visit(root, null);
+};

--- a/packages/react-doctor-lite/src/utils/attach-source-locations.ts
+++ b/packages/react-doctor-lite/src/utils/attach-source-locations.ts
@@ -1,0 +1,65 @@
+import { isAstNode } from "./is-ast-node.js";
+import type { EsTreeNode } from "oxlint-plugin-react-doctor";
+
+interface SourcePosition {
+  line: number;
+  column: number;
+}
+
+interface NodeWithOffsets {
+  start?: number;
+  end?: number;
+  loc?: { start: SourcePosition; end: SourcePosition };
+}
+
+const buildLineStartOffsets = (sourceText: string): number[] => {
+  const lineStartOffsets = [0];
+  for (let index = 0; index < sourceText.length; index++) {
+    if (sourceText[index] === "\n") lineStartOffsets.push(index + 1);
+  }
+  return lineStartOffsets;
+};
+
+const offsetToPosition = (
+  offset: number,
+  lineStartOffsets: ReadonlyArray<number>,
+): SourcePosition => {
+  let low = 0;
+  let high = lineStartOffsets.length - 1;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    if (lineStartOffsets[middle] <= offset) low = middle + 1;
+    else high = middle - 1;
+  }
+  const lineIndex = Math.max(0, high);
+  return { line: lineIndex + 1, column: offset - lineStartOffsets[lineIndex] };
+};
+
+// oxc-parser (with `astType: "ts"`) emits byte offsets but no `loc`. Rules and
+// diagnostics want 1-based line / column, so we compute `loc` from the offsets
+// up front — the same thing the oxlint host does at runtime.
+export const attachSourceLocations = (root: EsTreeNode, sourceText: string): void => {
+  const lineStartOffsets = buildLineStartOffsets(sourceText);
+  const visit = (node: EsTreeNode): void => {
+    const withOffsets = node as NodeWithOffsets;
+    if (typeof withOffsets.start === "number" && typeof withOffsets.end === "number") {
+      withOffsets.loc = {
+        start: offsetToPosition(withOffsets.start, lineStartOffsets),
+        end: offsetToPosition(withOffsets.end, lineStartOffsets),
+      };
+    }
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const key of Object.keys(nodeRecord)) {
+      if (key === "parent") continue;
+      const child = nodeRecord[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (isAstNode(item)) visit(item);
+        }
+      } else if (isAstNode(child)) {
+        visit(child);
+      }
+    }
+  };
+  visit(root);
+};

--- a/packages/react-doctor-lite/src/utils/chunk-array.ts
+++ b/packages/react-doctor-lite/src/utils/chunk-array.ts
@@ -1,0 +1,12 @@
+// Splits an array into fixed-size chunks. The final chunk holds the remainder.
+export const chunkArray = <ItemType>(
+  items: ReadonlyArray<ItemType>,
+  chunkSize: number,
+): ItemType[][] => {
+  const safeSize = Math.max(1, Math.floor(chunkSize));
+  const chunks: ItemType[][] = [];
+  for (let index = 0; index < items.length; index += safeSize) {
+    chunks.push(items.slice(index, index + safeSize));
+  }
+  return chunks;
+};

--- a/packages/react-doctor-lite/src/utils/is-ast-node.ts
+++ b/packages/react-doctor-lite/src/utils/is-ast-node.ts
@@ -1,0 +1,6 @@
+import type { EsTreeNode } from "oxlint-plugin-react-doctor";
+
+export const isAstNode = (value: unknown): value is EsTreeNode =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as { type?: unknown }).type === "string";

--- a/packages/react-doctor-lite/src/utils/list-source-files.ts
+++ b/packages/react-doctor-lite/src/utils/list-source-files.ts
@@ -1,0 +1,29 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { IGNORED_DIRECTORY_NAMES, SOURCE_FILE_PATTERN } from "../constants.js";
+
+// Walks a directory tree collecting source files the engine can parse,
+// skipping the usual build / vendor directories. Returns absolute paths.
+export const listSourceFiles = (rootDirectory: string): string[] => {
+  const collected: string[] = [];
+  const walk = (directory: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") && entry.name !== ".") continue;
+      const absolute = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRECTORY_NAMES.has(entry.name)) continue;
+        walk(absolute);
+      } else if (entry.isFile() && SOURCE_FILE_PATTERN.test(entry.name)) {
+        collected.push(absolute);
+      }
+    }
+  };
+  walk(path.resolve(rootDirectory));
+  return collected;
+};

--- a/packages/react-doctor-lite/src/utils/merge-dependency-sections.ts
+++ b/packages/react-doctor-lite/src/utils/merge-dependency-sections.ts
@@ -1,0 +1,21 @@
+import type { DependencyManifest } from "../types.js";
+
+// Flattens every dependency section of a manifest into a single
+// name -> version-spec map. `dependencies` is applied last so a runtime
+// dependency wins over a peer/dev declaration of the same package.
+export const mergeDependencySections = (manifest: DependencyManifest): Map<string, string> => {
+  const merged = new Map<string, string>();
+  const sections = [
+    manifest.optionalDependencies,
+    manifest.peerDependencies,
+    manifest.devDependencies,
+    manifest.dependencies,
+  ];
+  for (const section of sections) {
+    if (!section) continue;
+    for (const [name, spec] of Object.entries(section)) {
+      merged.set(name, spec);
+    }
+  }
+  return merged;
+};

--- a/packages/react-doctor-lite/src/utils/parse-dependency-version.ts
+++ b/packages/react-doctor-lite/src/utils/parse-dependency-version.ts
@@ -1,0 +1,30 @@
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+}
+
+// Matches a whole semver-ish token (`major[.minor[.patch]]`) so the patch
+// segment of `"19.0.0"` is consumed rather than mistaken for a second, lower
+// "version" of `0`. Multi-token ranges (`">=18 <20"`) still yield one match
+// per comparator.
+const VERSION_TOKEN_PATTERN = /(\d+)(?:\.(\d+))?(?:\.\d+)?/g;
+
+// Parses an installed dependency spec (e.g. `"^19.2.0"`, `">=18 <20"`,
+// `"19"`) down to the LOWEST major it could resolve to, plus that major's
+// minor. Non-concrete specs (`"workspace:*"`, `"catalog:"`, `"latest"`,
+// `"*"`) yield `null`. Picking the lowest major keeps range gating
+// conservative — a `">=18 <20"` peer range reports as React 18, never 19.
+export const parseDependencyVersion = (spec: string | null | undefined): ParsedVersion | null => {
+  if (typeof spec !== "string") return null;
+
+  let lowest: ParsedVersion | null = null;
+  for (const match of spec.matchAll(VERSION_TOKEN_PATTERN)) {
+    const major = Number(match[1]);
+    const minor = match[2] === undefined ? 0 : Number(match[2]);
+    if (!Number.isFinite(major)) continue;
+    if (lowest === null || major < lowest.major) {
+      lowest = { major, minor };
+    }
+  }
+  return lowest;
+};

--- a/packages/react-doctor-lite/src/utils/resolve-parse-lang.ts
+++ b/packages/react-doctor-lite/src/utils/resolve-parse-lang.ts
@@ -1,0 +1,18 @@
+import * as path from "node:path";
+
+const EXTENSION_TO_LANG: Record<string, "ts" | "tsx" | "js" | "jsx"> = {
+  ".ts": "ts",
+  ".tsx": "tsx",
+  ".js": "jsx",
+  ".jsx": "jsx",
+  ".mjs": "jsx",
+  ".cjs": "jsx",
+  ".mts": "ts",
+  ".cts": "ts",
+};
+
+// Maps a filename to the oxc-parser `lang`. `.js`/`.mjs`/`.cjs` map to `jsx`
+// so JSX in plain JavaScript files still parses — React projects routinely
+// ship `.js` files containing JSX.
+export const resolveParseLang = (filename: string): "ts" | "tsx" | "js" | "jsx" =>
+  EXTENSION_TO_LANG[path.extname(filename).toLowerCase()] ?? "tsx";

--- a/packages/react-doctor-lite/src/utils/split-dependency-specifier.ts
+++ b/packages/react-doctor-lite/src/utils/split-dependency-specifier.ts
@@ -1,0 +1,20 @@
+export interface DependencySpecifier {
+  name: string;
+  range: string | null;
+}
+
+// Splits a combined specifier like `"react@>=19"` or
+// `"@tanstack/react-query@^5"` into its name and range. The range delimiter
+// is the LAST `@` that is not the leading scope marker, so scoped packages
+// without a range (`"@tanstack/react-query"`) parse correctly.
+export const splitDependencySpecifier = (specifier: string): DependencySpecifier => {
+  const scopeOffset = specifier.startsWith("@") ? 1 : 0;
+  const delimiterIndex = specifier.indexOf("@", scopeOffset);
+  if (delimiterIndex === -1) {
+    return { name: specifier, range: null };
+  }
+  return {
+    name: specifier.slice(0, delimiterIndex),
+    range: specifier.slice(delimiterIndex + 1),
+  };
+};

--- a/packages/react-doctor-lite/src/utils/version-satisfies-range.ts
+++ b/packages/react-doctor-lite/src/utils/version-satisfies-range.ts
@@ -1,0 +1,60 @@
+import { parseDependencyVersion } from "./parse-dependency-version.js";
+import type { ParsedVersion } from "./parse-dependency-version.js";
+
+type RangeOperator = ">=" | ">" | "<=" | "<" | "^" | "~" | "=";
+
+interface ParsedRange {
+  operator: RangeOperator;
+  bound: ParsedVersion;
+}
+
+const RANGE_PATTERN = /^\s*(>=|<=|>|<|\^|~|=)?\s*v?(\d+)(?:\.(\d+))?/;
+
+const parseRange = (range: string): ParsedRange | null => {
+  const match = RANGE_PATTERN.exec(range);
+  if (!match) return null;
+  const operator = (match[1] ?? ">=") as RangeOperator;
+  const major = Number(match[2]);
+  const minor = match[3] === undefined ? 0 : Number(match[3]);
+  if (!Number.isFinite(major)) return null;
+  return { operator, bound: { major, minor } };
+};
+
+const compare = (left: ParsedVersion, right: ParsedVersion): number =>
+  left.major !== right.major ? left.major - right.major : left.minor - right.minor;
+
+// Tests whether an installed version satisfies a query range. Only major /
+// minor precision is modeled — that is all the rule capability gates need
+// (`react:19`, `tailwind:3.4`). A bare query (`"19"`) means `">=19"` so
+// `hasDependency("react", "19")` reads naturally as "React 19 or newer".
+export const versionSatisfiesRange = (
+  installed: ParsedVersion | string | null | undefined,
+  range: string,
+): boolean => {
+  const installedVersion =
+    typeof installed === "string" ? parseDependencyVersion(installed) : installed;
+  if (!installedVersion) return false;
+
+  const parsed = parseRange(range);
+  if (!parsed) return false;
+
+  const { operator, bound } = parsed;
+  const ordering = compare(installedVersion, bound);
+
+  switch (operator) {
+    case ">":
+      return ordering > 0;
+    case ">=":
+      return ordering >= 0;
+    case "<":
+      return ordering < 0;
+    case "<=":
+      return ordering <= 0;
+    case "=":
+      return ordering === 0;
+    case "^":
+      return installedVersion.major === bound.major && ordering >= 0;
+    case "~":
+      return installedVersion.major === bound.major && installedVersion.minor >= bound.minor;
+  }
+};

--- a/packages/react-doctor-lite/tests/capabilities.test.ts
+++ b/packages/react-doctor-lite/tests/capabilities.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildCapabilities } from "../src/capabilities/build-capabilities.js";
+import { buildDependencyGraphFromManifest } from "../src/dependency-graph/build-dependency-graph.js";
+
+describe("capability derivation from the dependency graph", () => {
+  it("emits cumulative react majors and framework tokens", () => {
+    const graph = buildDependencyGraphFromManifest({
+      dependencies: { next: "15.0.0", react: "19.2.0" },
+      devDependencies: { typescript: "^5.6.0", tailwindcss: "^3.4.0" },
+    });
+    const capabilities = buildCapabilities(graph);
+
+    expect(capabilities.has("nextjs")).toBe(true);
+    expect(capabilities.has("react:17")).toBe(true);
+    expect(capabilities.has("react:18")).toBe(true);
+    expect(capabilities.has("react:19")).toBe(true);
+    expect(capabilities.has("react:19.2")).toBe(true);
+    expect(capabilities.has("typescript")).toBe(true);
+    expect(capabilities.has("tailwind")).toBe(true);
+    expect(capabilities.has("tailwind:3.4")).toBe(true);
+  });
+
+  it("flags tanstack-query, react-compiler, and react-native", () => {
+    const graph = buildDependencyGraphFromManifest({
+      dependencies: { react: "19.0.0", "@tanstack/react-query": "^5", "react-native": "0.76.0" },
+      devDependencies: { "babel-plugin-react-compiler": "^1" },
+    });
+    const capabilities = buildCapabilities(graph);
+
+    expect(capabilities.has("tanstack-query")).toBe(true);
+    expect(capabilities.has("react-compiler")).toBe(true);
+    expect(capabilities.has("react-native")).toBe(true);
+  });
+
+  it("treats Preact-without-React as pure-preact", () => {
+    const graph = buildDependencyGraphFromManifest({ dependencies: { preact: "10.0.0" } });
+    const capabilities = buildCapabilities(graph);
+    expect(capabilities.has("preact")).toBe(true);
+    expect(capabilities.has("pure-preact")).toBe(true);
+  });
+});

--- a/packages/react-doctor-lite/tests/dependency-graph.test.ts
+++ b/packages/react-doctor-lite/tests/dependency-graph.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildDependencyGraphFromManifest } from "../src/dependency-graph/build-dependency-graph.js";
+import { createDependencyGraph } from "../src/dependency-graph/create-dependency-graph.js";
+import { mergeDependencySections } from "../src/utils/merge-dependency-sections.js";
+import type { PackageNode } from "../src/types.js";
+
+const node = (name: string, dependencies: Record<string, string>): PackageNode => ({
+  name,
+  directory: "",
+  isRoot: false,
+  dependencies: new Map(Object.entries(dependencies)),
+});
+
+describe("dependency graph queries", () => {
+  it("answers presence and range queries in both call shapes", () => {
+    const graph = buildDependencyGraphFromManifest({
+      dependencies: { react: "^19.2.0", "@tanstack/react-query": "^5.59.0" },
+      devDependencies: { typescript: "^5.6.0" },
+    });
+
+    expect(graph.hasDependency("react")).toBe(true);
+    expect(graph.hasDependency("react@>=19")).toBe(true);
+    expect(graph.hasDependency("react", ">=19")).toBe(true);
+    expect(graph.hasDependency("react", ">=20")).toBe(false);
+    expect(graph.hasDependency("react", "^19")).toBe(true);
+    expect(graph.hasDependency("@tanstack/react-query@^5")).toBe(true);
+    expect(graph.hasDependency("svelte")).toBe(false);
+    expect(graph.getMajor("react")).toBe(19);
+    expect(graph.getVersion("react")).toBe("^19.2.0");
+  });
+
+  it("derives framework from dependency names", () => {
+    expect(
+      buildDependencyGraphFromManifest({ dependencies: { next: "15.0.0", react: "19.0.0" } })
+        .framework,
+    ).toBe("nextjs");
+    expect(buildDependencyGraphFromManifest({ dependencies: { preact: "10.0.0" } }).framework).toBe(
+      "preact",
+    );
+    expect(
+      buildDependencyGraphFromManifest({ dependencies: { vite: "6.0.0", react: "19.0.0" } })
+        .framework,
+    ).toBe("vite");
+  });
+
+  it("uses the lowest installed major across a monorepo graph", () => {
+    const graph = createDependencyGraph([
+      node("web", { react: "^19.0.0" }),
+      node("legacy", { react: "^18.2.0" }),
+    ]);
+
+    expect(graph.getMajor("react")).toBe(18);
+    expect(graph.hasDependency("react", ">=19")).toBe(false);
+    expect(graph.hasDependency("react", ">=18")).toBe(true);
+  });
+
+  it("ignores non-concrete specifiers for version math", () => {
+    const graph = createDependencyGraph([node("app", { react: "workspace:*" })]);
+    expect(graph.hasDependency("react")).toBe(true);
+    expect(graph.getMajor("react")).toBeNull();
+    expect(graph.hasDependency("react", ">=19")).toBe(false);
+  });
+
+  it("merges sections with dependencies winning over peers/dev", () => {
+    const merged = mergeDependencySections({
+      peerDependencies: { react: ">=18" },
+      dependencies: { react: "19.0.0" },
+    });
+    expect(merged.get("react")).toBe("19.0.0");
+  });
+});

--- a/packages/react-doctor-lite/tests/diagnose.test.ts
+++ b/packages/react-doctor-lite/tests/diagnose.test.ts
@@ -1,0 +1,87 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { diagnose } from "../src/index.js";
+
+const BAD_LIST =
+  "const App = ({ items }) => items.map((item, index) => <li key={index}>{item}</li>);\n";
+
+describe("diagnose — programmatic in-memory mode", () => {
+  it("runs with no package.json and no files on disk", async () => {
+    const result = await diagnose({
+      dependencies: {
+        dependencies: { react: "19.0.0" },
+        devDependencies: { typescript: "^5.6.0" },
+      },
+      sources: [{ filePath: "App.tsx", code: BAD_LIST }],
+      rules: { only: ["no-array-index-as-key"] },
+    });
+
+    expect(result.graph.reactMajor).toBe(19);
+    expect(result.scannedFileCount).toBe(1);
+    expect(result.ranInWorkerPool).toBe(false);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].rule).toBe("no-array-index-as-key");
+    expect(result.capabilities).toContain("react:19");
+  });
+
+  it("gates framework rules on the supplied dependency graph", async () => {
+    const webOnly = await diagnose({
+      dependencies: { dependencies: { react: "19.0.0" } },
+      sources: [{ filePath: "App.tsx", code: BAD_LIST }],
+    });
+    const reactNative = await diagnose({
+      dependencies: { dependencies: { react: "19.0.0", "react-native": "0.76.0" } },
+      sources: [{ filePath: "App.tsx", code: BAD_LIST }],
+    });
+
+    expect(reactNative.enabledRuleCount).toBeGreaterThan(webOnly.enabledRuleCount);
+  });
+});
+
+describe("diagnose — disk mode", () => {
+  const temporaryDirectories: string[] = [];
+
+  const makeProject = (
+    manifest: Record<string, unknown>,
+    files: Record<string, string>,
+  ): string => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-lite-"));
+    temporaryDirectories.push(directory);
+    fs.writeFileSync(path.join(directory, "package.json"), JSON.stringify(manifest));
+    for (const [relativePath, code] of Object.entries(files)) {
+      fs.writeFileSync(path.join(directory, relativePath), code);
+    }
+    return directory;
+  };
+
+  afterAll(() => {
+    for (const directory of temporaryDirectories) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers sources and dependencies from disk", async () => {
+    const directory = makeProject(
+      {
+        name: "demo",
+        dependencies: { react: "19.0.0" },
+        devDependencies: { typescript: "^5.6.0" },
+      },
+      { "App.tsx": BAD_LIST },
+    );
+
+    const result = await diagnose({
+      cwd: directory,
+      rules: { only: ["no-array-index-as-key"] },
+      concurrency: { disableWorkers: true },
+    });
+
+    expect(result.graph.framework).toBe("unknown");
+    expect(result.graph.reactMajor).toBe(19);
+    expect(result.scannedFileCount).toBe(1);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(path.isAbsolute(result.diagnostics[0].filePath)).toBe(true);
+  });
+});

--- a/packages/react-doctor-lite/tests/lint-source.test.ts
+++ b/packages/react-doctor-lite/tests/lint-source.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildCapabilities } from "../src/capabilities/build-capabilities.js";
+import { buildDependencyGraphFromManifest } from "../src/dependency-graph/build-dependency-graph.js";
+import { loadRules } from "../src/rules/load-rules.js";
+import { lintSource } from "../src/runner/lint-source.js";
+
+const reactGraph = buildDependencyGraphFromManifest({
+  dependencies: { react: "19.0.0" },
+  devDependencies: { typescript: "^5.6.0" },
+});
+
+describe("in-process single-pass lint", () => {
+  it("flags a known rule with line / column from oxc offsets", () => {
+    const rules = loadRules({
+      capabilities: buildCapabilities(reactGraph),
+      selection: { only: ["no-array-index-as-key"] },
+    });
+    expect(rules).toHaveLength(1);
+
+    const diagnostics = lintSource({
+      filePath: "App.tsx",
+      code: "const App = ({ items }) => items.map((item, index) => <li key={index}>{item}</li>);\n",
+      rules,
+      settings: {},
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].rule).toBe("no-array-index-as-key");
+    expect(diagnostics[0].ruleKey).toBe("react-doctor/no-array-index-as-key");
+    expect(diagnostics[0].line).toBe(1);
+    expect(diagnostics[0].column).toBeGreaterThan(0);
+  });
+
+  it("returns nothing for clean source", () => {
+    const rules = loadRules({
+      capabilities: buildCapabilities(reactGraph),
+      selection: { only: ["no-array-index-as-key"] },
+    });
+    const diagnostics = lintSource({
+      filePath: "App.tsx",
+      code: "const App = ({ items }) => items.map((item) => <li key={item.id}>{item.name}</li>);\n",
+      rules,
+      settings: {},
+    });
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("runs many rules in a single tree walk", () => {
+    const rules = loadRules({ capabilities: buildCapabilities(reactGraph) });
+    expect(rules.length).toBeGreaterThan(50);
+
+    const diagnostics = lintSource({
+      filePath: "App.tsx",
+      code: "const App = ({ items }) => items.map((item, index) => <li key={index}>{item}</li>);\n",
+      rules,
+      settings: {},
+    });
+    expect(diagnostics.some((diagnostic) => diagnostic.rule === "no-array-index-as-key")).toBe(
+      true,
+    );
+  });
+});

--- a/packages/react-doctor-lite/tests/rule-gating.test.ts
+++ b/packages/react-doctor-lite/tests/rule-gating.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildCapabilities } from "../src/capabilities/build-capabilities.js";
+import { buildDependencyGraphFromManifest } from "../src/dependency-graph/build-dependency-graph.js";
+import { loadRules } from "../src/rules/load-rules.js";
+
+const rulesFor = (dependencies: Record<string, string>) =>
+  loadRules({
+    capabilities: buildCapabilities(buildDependencyGraphFromManifest({ dependencies })),
+  });
+
+describe("framework / capability gating", () => {
+  it("loads framework-specific rules only when the framework is present", () => {
+    const webRules = rulesFor({ react: "19.0.0", vite: "6.0.0" });
+    const nextRules = rulesFor({ react: "19.0.0", next: "15.0.0" });
+
+    const webIds = new Set(webRules.map((rule) => rule.id));
+    const nextOnlyIds = nextRules.filter((rule) => !webIds.has(rule.id));
+
+    expect(nextOnlyIds.length).toBeGreaterThan(0);
+  });
+
+  it("honors severity overrides and disables", () => {
+    const capabilities = buildCapabilities(
+      buildDependencyGraphFromManifest({ dependencies: { react: "19.0.0" } }),
+    );
+
+    const overridden = loadRules({
+      capabilities,
+      selection: {
+        only: ["no-array-index-as-key"],
+        severity: { "no-array-index-as-key": "error" },
+      },
+    });
+    expect(overridden[0].severity).toBe("error");
+
+    const disabled = loadRules({
+      capabilities,
+      selection: { only: ["no-array-index-as-key"], disable: ["no-array-index-as-key"] },
+    });
+    expect(disabled).toHaveLength(0);
+  });
+
+  it("respects ignored tags", () => {
+    const capabilities = buildCapabilities(
+      buildDependencyGraphFromManifest({ dependencies: { react: "19.0.0" } }),
+    );
+    const all = loadRules({ capabilities });
+    const withoutTestNoise = loadRules({ capabilities, selection: { ignoreTags: ["test-noise"] } });
+
+    expect(withoutTestNoise.length).toBeLessThan(all.length);
+  });
+});

--- a/packages/react-doctor-lite/tests/worker-pool.integration.test.ts
+++ b/packages/react-doctor-lite/tests/worker-pool.integration.test.ts
@@ -1,0 +1,50 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import type { diagnose as DiagnoseFn } from "../src/index.js";
+
+// The worker pool only engages in built (`.js`) mode — raw-TS workers cannot
+// resolve the `.js`-style import specifiers. So this test drives the BUILT
+// package (`dist/index.js`) and is skipped when the package has not been built
+// yet. `pnpm test` runs after `build` via turbo, so CI always exercises it.
+const distIndexPath = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+const isBuilt = fs.existsSync(distIndexPath);
+
+const BAD_LIST =
+  "const App = ({ items }) => items.map((item, index) => <li key={index}>{item}</li>);\n";
+
+describe.skipIf(!isBuilt)("worker pool over the built package", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterAll(() => {
+    for (const directory of temporaryDirectories) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("lints a large project across worker threads", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-lite-pool-"));
+    temporaryDirectories.push(directory);
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "pool", dependencies: { react: "19.0.0" } }),
+    );
+    const fileCount = 40;
+    for (let index = 0; index < fileCount; index++) {
+      fs.writeFileSync(path.join(directory, `Component${index}.tsx`), BAD_LIST);
+    }
+
+    const { diagnose } = (await import(distIndexPath)) as { diagnose: typeof DiagnoseFn };
+    const result = await diagnose({
+      cwd: directory,
+      rules: { only: ["no-array-index-as-key"] },
+      concurrency: { poolSize: 4, batchSize: 8 },
+    });
+
+    expect(result.ranInWorkerPool).toBe(true);
+    expect(result.scannedFileCount).toBe(fileCount);
+    expect(result.diagnostics).toHaveLength(fileCount);
+  });
+});

--- a/packages/react-doctor-lite/tsconfig.json
+++ b/packages/react-doctor-lite/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/react-doctor-lite/vite.config.ts
+++ b/packages/react-doctor-lite/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  pack: [
+    {
+      entry: { index: "./src/index.ts", worker: "./src/runner/worker.ts" },
+      deps: {
+        neverBundle: ["oxc-parser", "oxlint-plugin-react-doctor"],
+      },
+      dts: true,
+      target: "node20",
+      platform: "node",
+      fixedExtension: false,
+    },
+  ],
+  test: {
+    testTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,19 @@ importers:
         specifier: ^9.4.0
         version: 9.4.0
 
+  packages/react-doctor-lite:
+    dependencies:
+      oxc-parser:
+        specifier: ^0.132.0
+        version: 0.132.0
+      oxlint-plugin-react-doctor:
+        specifier: workspace:*
+        version: link:../oxlint-plugin-react-doctor
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+
   packages/website:
     dependencies:
       '@vercel/analytics':


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A PoC package, `packages/react-doctor-lite`, that re-imagines the diagnostic engine to remove three sources of accidental complexity discussed for the simplification effort. It **reuses the canonical `oxlint-plugin-react-doctor` rules and semantic analysis verbatim** — only the *runner*, *project discovery*, and *entry API* are reimplemented.

## The three simplifications

### 1. Runner: oxlint subprocesses → in-process AST walking
`@react-doctor/core` writes a temp `oxlintrc.json`, resolves the plugin path, spawns `node <oxlint-bin> --format json` in **sequentially-executed** batches (capped at ~100 files/batch to dodge OOM on large repos like `supabase/studio`), then parses stdout JSON and dedupes. Sequential batches leave cores idle during the heaviest phase.

`react-doctor-lite` parses with `oxc-parser` and walks the AST **once per file**, dispatching every enabled rule's visitors in a single traversal — no subprocess, no oxlintrc, no stdout parsing. Files are distributed across a `worker_threads` pool with explicit knobs:

```ts
await diagnose({ cwd, concurrency: { poolSize: 8, batchSize: 32 } });
```

### 2. Project info: boolean soup → a composable dependency graph
Replaces `hasTanStackQuery` / `hasPreact` / `parseReactMajor` / `detectFramework` / `hasReactNativeWorkspaceAnywhere` (and the rest of `discover-project.ts`) with one monorepo-aware graph that everything queries:

```ts
graph.hasDependency("react", ">=19");      // or hasDependency("react@>=19")
graph.hasDependency("@tanstack/react-query@^5");
graph.getMajor("react");                    // lowest installed major across the graph
graph.framework;                            // "nextjs" | "vite" | ... | "unknown"
```

Capability tokens (`react:19`, `tanstack-query`, `tailwind:3.4`, …) are kept **identical**, so existing rule `requires`/`disabledBy` metadata works unchanged — they're now *derived from graph queries* instead of bespoke `ProjectInfo` fields.

### 3. API: disk-only → first-class programmatic mode
`diagnose()` accepts an in-memory dependency manifest and in-memory sources, so eval / auto-improvement callers never inflate a fake `package.json`:

```ts
await diagnose({
  dependencies: { dependencies: { react: "19.0.0" } },
  sources: [{ filePath: "App.tsx", code: "/* ... */" }],
  rules: { only: ["no-array-index-as-key"] },
});
```

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean.
- **18 tests** pass: dependency graph queries/ranges/monorepo lowest-major, capability derivation, framework/severity/tag gating, single-pass in-process lint, in-memory + disk `diagnose()`, and a worker-pool integration test against the built package (40 files across 4 threads → 40 diagnostics, `ranInWorkerPool: true`).

## Notes / scope

This is intentionally a proof of concept. The worker pool engages only in built (`.js`) mode (raw-TS worker threads can't resolve `.js`-style specifiers; source/tiny inputs lint in-process). Suppressions, scoring, dead-code, config-file loading, `catalog:` resolution, and glob negation/brace-expansion are out of scope for the PoC. A non-React project is not rejected (it just enables the global rules). See the package README for the full architecture map and limitations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f95e2d9f-441b-4308-823b-b24e668da466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f95e2d9f-441b-4308-823b-b24e668da466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

