### PR TITLE
fix(core): scope React subproject discovery to skip app-data dirs and bound depth

### DIFF
--- a/.changeset/scope-subproject-discovery.md
+++ b/.changeset/scope-subproject-discovery.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Scope React subproject discovery so running `react-doctor` from a home directory no longer reports unrelated, vendored projects as ambiguous candidates. When the scan root has no `package.json` or workspace manifest, the filesystem crawl now skips OS/editor app-data directories (`AppData`, `Library`, …) and stops descending past a fixed depth. Previously a home-directory scan could surface React packages bundled inside editor installs (e.g. a VS Code extension under `AppData`) alongside real projects, aborting with `Multiple React projects found`. See #545.

--- a/packages/core/src/project-info/discover-react-subprojects.ts
+++ b/packages/core/src/project-info/discover-react-subprojects.ts
@@ -41,6 +41,24 @@ const listManifestWorkspacePackages = (rootDirectory: string): WorkspacePackage[
   return toReactWorkspacePackages(directories);
 };
 
+// Directory names that hold OS- or editor-managed installs rather than user
+// projects. When a scan starts from a home directory (no package.json and no
+// workspace manifest in cwd), the recursive crawl would otherwise descend into
+// these and surface vendored React packages that the user never authored — e.g.
+// VS Code ships a `copilot` extension under `AppData` that declares a React
+// dependency, which made `react-doctor` report ambiguous candidates. See #545.
+const NON_PROJECT_DIRECTORIES = new Set([
+  "AppData", // Windows per-user app data + bundled application installs
+  "Application Data", // legacy Windows app-data junction
+  "Library", // macOS per-user app data, caches, and app installs
+]);
+
+// Backstop for pathological trees: real projects discovered via filesystem
+// fallback (only used when the scan root has no package.json / workspace
+// manifest) sit a few levels down at most. Bounding the depth keeps the crawl
+// from descending deep into vendored installs that escape the name list above.
+const MAX_SCAN_DEPTH = 6;
+
 const discoverReactSubprojectsByFilesystem = (rootDirectory: string): WorkspacePackage[] => {
   const packages: WorkspacePackage[] = [];
   // HACK: stack + .pop() rather than queue + .shift() because Array.shift()
@@ -49,12 +67,15 @@ const discoverReactSubprojectsByFilesystem = (rootDirectory: string): WorkspaceP
   // stack pattern. Result is the same set of directories with a different
   // visit order (depth-first instead of breadth-first), which doesn't
   // matter for the final packages list.
-  const pendingDirectories = [rootDirectory];
+  const pendingDirectories: { directory: string; depth: number }[] = [
+    { directory: rootDirectory, depth: 0 },
+  ];
 
   while (pendingDirectories.length > 0) {
-    const currentDirectory = pendingDirectories.pop();
-    if (!currentDirectory) continue;
+    const current = pendingDirectories.pop();
+    if (!current) continue;
 
+    const { directory: currentDirectory, depth } = current;
     const packageJsonPath = path.join(currentDirectory, "package.json");
     if (isFile(packageJsonPath)) {
       const packageJson = readPackageJson(packageJsonPath);
@@ -64,6 +85,8 @@ const discoverReactSubprojectsByFilesystem = (rootDirectory: string): WorkspaceP
       }
     }
 
+    if (depth >= MAX_SCAN_DEPTH) continue;
+
     const entries = readDirectoryEntries(currentDirectory).toSorted((firstEntry, secondEntry) =>
       firstEntry.name.localeCompare(secondEntry.name),
     );
@@ -72,12 +95,16 @@ const discoverReactSubprojectsByFilesystem = (rootDirectory: string): WorkspaceP
       if (
         !entry.isDirectory() ||
         entry.name.startsWith(".") ||
-        IGNORED_DIRECTORIES.has(entry.name)
+        IGNORED_DIRECTORIES.has(entry.name) ||
+        NON_PROJECT_DIRECTORIES.has(entry.name)
       ) {
         continue;
       }
 
-      pendingDirectories.push(path.join(currentDirectory, entry.name));
+      pendingDirectories.push({
+        directory: path.join(currentDirectory, entry.name),
+        depth: depth + 1,
+      });
     }
   }
 

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -799,6 +799,50 @@ describe("discoverReactSubprojects", () => {
     expect(packages).toContainEqual({ name: "web", directory: subdirectory });
   });
 
+  it("skips OS/editor app-data directories during filesystem recursion", () => {
+    // Repro for #545: a home-directory scan must not surface React packages
+    // vendored inside editor installs (here, a VS Code extension under AppData).
+    const rootDirectory = path.join(tempDirectory, "home-with-appdata");
+    const editorExtension = path.join(
+      rootDirectory,
+      "AppData",
+      "Local",
+      "Programs",
+      "Microsoft VS Code",
+      "resources",
+      "app",
+      "extensions",
+      "copilot",
+    );
+    const realProject = path.join(rootDirectory, "Downloads", "my-app", "frontend");
+    fs.mkdirSync(editorExtension, { recursive: true });
+    fs.mkdirSync(realProject, { recursive: true });
+    fs.writeFileSync(
+      path.join(editorExtension, "package.json"),
+      JSON.stringify({ name: "copilot", dependencies: { react: "^18.0.0" } }),
+    );
+    fs.writeFileSync(
+      path.join(realProject, "package.json"),
+      JSON.stringify({ name: "frontend", dependencies: { react: "^19.0.0" } }),
+    );
+
+    const packages = discoverReactSubprojects(rootDirectory);
+    expect(packages).toEqual([{ name: "frontend", directory: realProject }]);
+  });
+
+  it("does not descend past the maximum scan depth during filesystem recursion", () => {
+    const rootDirectory = path.join(tempDirectory, "deeply-vendored");
+    const tooDeep = path.join(rootDirectory, "a", "b", "c", "d", "e", "f", "g");
+    fs.mkdirSync(tooDeep, { recursive: true });
+    fs.writeFileSync(
+      path.join(tooDeep, "package.json"),
+      JSON.stringify({ name: "too-deep", dependencies: { react: "^19.0.0" } }),
+    );
+
+    const packages = discoverReactSubprojects(rootDirectory);
+    expect(packages).toHaveLength(0);
+  });
+
   it("prefers pnpm workspace packages over filesystem recursion", () => {
     const rootDirectory = path.join(tempDirectory, "pnpm-workspace-preferred");
     const workspaceDirectory = path.join(rootDirectory, "apps", "web");


### PR DESCRIPTION
Fixes #545.

## Root cause

Running `npx react-doctor` from a home directory (no `package.json` / workspace manifest in cwd) falls through to `discoverReactSubprojectsByFilesystem`, which recursively walks the **entire** home tree with no depth bound and only prunes dotfiles + build artifacts (`IGNORED_DIRECTORIES`). It therefore descends ~9 levels into editor internals like `AppData\Local\Programs\Microsoft VS Code\…\extensions\copilot`, whose `package.json` declares a React dependency (`hasReactDependency` matches any of `react`/`react-native`/`next`/`preact`). Combined with the user's real `Downloads` projects, that yielded 4 candidates, and `resolveDiagnoseTarget` throws `AmbiguousProjectError` — aborting the run with `Multiple React projects found`.

## Fix

In the filesystem-fallback crawl (`packages/core/src/project-info/discover-react-subprojects.ts`):

- **Skip OS/editor app-data directories** — `AppData`, `Application Data`, `Library`. This prunes the VS Code extension branch (and similar vendored installs) at the top level. The reported false positive lived under `AppData`.
- **Bound the crawl depth** (`MAX_SCAN_DEPTH = 6`) as a backstop against pathological vendored trees that escape the name list. Projects discovered via the filesystem fallback realistically sit only a few levels down.

Both guards apply *only* to the filesystem fallback (used when the scan root has no manifest); manifest/workspace resolution is unchanged, and the shared `IGNORED_DIRECTORIES` set is untouched so in-project source scans are unaffected.

## Tests

Added two cases to `discover-project.test.ts`:
- A home-directory layout with a React package vendored under `AppData/.../extensions/copilot` plus a real `Downloads/.../frontend` — only the real project is returned (direct #545 repro).
- A React package nested past `MAX_SCAN_DEPTH` is not discovered.

All 73 tests in `discover-project.test.ts` pass; `typecheck` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Discovery-only change in the filesystem fallback path; workspace/manifest resolution is untouched, with targeted tests for the new guards.
> 
> **Overview**
> Fixes **#545** by tightening the **filesystem-only** React subproject crawl used when the scan root has no `package.json` or workspace manifest.
> 
> The recursive walk now **skips** OS/editor app-data directory names (`AppData`, `Application Data`, `Library`) so vendored React packages inside editor installs are not counted as user projects. It also **caps descent at depth 6** so deeply nested vendored trees are not discovered. Manifest-based workspace discovery is unchanged.
> 
> Tests cover a home-directory layout with a fake VS Code extension under `AppData` plus a real app under `Downloads`, and a React package beyond the depth limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4178493f5f8e9840284ab0556de35dd6cb72eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->