### PR TITLE
fix(api): surface lint failures via diagnose().skippedChecks

### DIFF
--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -97,10 +97,20 @@ const outputToDiagnoseResult = (
     console.error("Lint failed:", output.lintFailureReason);
   }
 
+  // Mirror the CLI's skipped-check accounting (react-doctor/src/inspect.ts
+  // → finalizeAndRender) so programmatic consumers and toJsonReport() see
+  // a failed lint / dead-code pass instead of a false "all clear".
   const skippedChecks: string[] = [];
+  if (output.didLintFail) skippedChecks.push("lint");
+  if (output.didDeadCodeFail) skippedChecks.push("dead-code");
+
   const skippedCheckReasons: Record<string, string> = {};
+  if (output.didLintFail && output.lintFailureReason !== null) {
+    skippedCheckReasons.lint = output.lintFailureReason;
+  } else if (output.lintPartialFailures.length > 0) {
+    skippedCheckReasons["lint:partial"] = output.lintPartialFailures.join("; ");
+  }
   if (output.didDeadCodeFail && output.deadCodeFailureReason !== null) {
-    skippedChecks.push("dead-code");
     skippedCheckReasons["dead-code"] = output.deadCodeFailureReason;
   }
 


### PR DESCRIPTION
## Summary
- `diagnose()` / `diagnoseProjects()` previously only pushed `"dead-code"` to `skippedChecks`. A recoverable lint failure (e.g. oxlint native binding missing / spawn failure, which the orchestrator folds into `didLintFail`) was therefore reported as a clean, complete scan to programmatic consumers and `toJsonReport()`.
- Now mirrors the CLI's `finalizeAndRender` accounting: pushes `"lint"` (plus `skippedCheckReasons.lint` / `lint:partial`) whenever `output.didLintFail`.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (api + core + react-doctor)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small mapping change in diagnose result shaping with no auth or data-path impact.
> 
> **Overview**
> **`diagnose()` / `diagnoseProjects()`** now report lint failures the same way the CLI does: when `output.didLintFail` is set, **`skippedChecks`** includes `"lint"` and **`skippedCheckReasons`** can carry `lint`, `lint:partial`, or existing dead-code entries.
> 
> Previously only dead-code failures were reflected in **`skippedChecks`**, so API consumers and **`toJsonReport()`** could treat a scan as complete even when lint never ran (e.g. oxlint spawn / native binding errors). Stderr mirroring for `"Lint failed:"` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9584bc92e5ac4abf45cdd30a101c6b4feb8e4b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->