### PR TITLE
fix(cli): default --fail-on to none (advisory)

### DIFF
--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -38,7 +38,7 @@ const program = new Command()
   .option("--staged", "scan only staged (git index) files for pre-commit hooks")
   .option(
     "--fail-on <level>",
-    "exit with error code on diagnostics: error, warning, none (default: error)",
+    "exit with error code on diagnostics: error, warning, none (default: none)",
   )
   .option("--annotations", "output diagnostics as GitHub Actions annotations")
   .option(

--- a/packages/react-doctor/src/cli/utils/resolve-fail-on-level.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-fail-on-level.ts
@@ -14,8 +14,11 @@ export const resolveFailOnLevel = (
 ): FailOnLevel => {
   const sourceValue = flags.failOn ?? userConfig?.failOn ?? DEFAULT_FAIL_ON_LEVEL;
   if (isValidFailOnLevel(sourceValue)) return sourceValue;
+  // Fail closed: an invalid threshold falls back to the documented
+  // default ("error") so a typo (`--fail-on warn`) can't silently
+  // disable the CI gate and let hard errors pass.
   logger.warn(
-    `Invalid failOn level "${sourceValue}". Expected one of: error, warning, none. Falling back to "none".`,
+    `Invalid failOn level "${sourceValue}". Expected one of: error, warning, none. Falling back to "${DEFAULT_FAIL_ON_LEVEL}".`,
   );
-  return "none";
+  return DEFAULT_FAIL_ON_LEVEL;
 };

--- a/packages/react-doctor/src/cli/utils/resolve-fail-on-level.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-fail-on-level.ts
@@ -3,7 +3,11 @@ import { cliLogger as logger } from "./cli-logger.js";
 import type { InspectFlags } from "./inspect-flags.js";
 
 const VALID_FAIL_ON_LEVELS = new Set<FailOnLevel>(["error", "warning", "none"]);
-const DEFAULT_FAIL_ON_LEVEL: FailOnLevel = "error";
+// react-doctor is advisory by default: a bare run reports diagnostics +
+// a score but does not fail the process. Opt in to a CI gate with
+// `--fail-on error|warning` (or `failOn` in config; the GitHub Action
+// passes its own `fail-on` input). The GitHub Action default is separate.
+const DEFAULT_FAIL_ON_LEVEL: FailOnLevel = "none";
 
 const isValidFailOnLevel = (level: string): level is FailOnLevel =>
   VALID_FAIL_ON_LEVELS.has(level as FailOnLevel);
@@ -14,9 +18,8 @@ export const resolveFailOnLevel = (
 ): FailOnLevel => {
   const sourceValue = flags.failOn ?? userConfig?.failOn ?? DEFAULT_FAIL_ON_LEVEL;
   if (isValidFailOnLevel(sourceValue)) return sourceValue;
-  // Fail closed: an invalid threshold falls back to the documented
-  // default ("error") so a typo (`--fail-on warn`) can't silently
-  // disable the CI gate and let hard errors pass.
+  // An invalid threshold resolves to the default (advisory "none") and
+  // warns, rather than guessing a stricter level the user didn't ask for.
   logger.warn(
     `Invalid failOn level "${sourceValue}". Expected one of: error, warning, none. Falling back to "${DEFAULT_FAIL_ON_LEVEL}".`,
   );


### PR DESCRIPTION
## Summary
- react-doctor is advisory by default: a bare `react-doctor` run (or `inspect()`) reports diagnostics + a score without failing the process. `DEFAULT_FAIL_ON_LEVEL` is now `"none"` (was `"error"`), so both the unspecified default **and** the invalid-value fallback are non-blocking.
- Opt in to a CI gate with `--fail-on error|warning` (or `failOn` in config). The **GitHub Action is unaffected** — it passes its own `fail-on` input (default `error`), so existing CI gating keeps working.
- Updates the `--fail-on` help text to `(default: none)`.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default CLI exit-on-diagnostics behavior from error to none, which can surprise CI/scripts that relied on implicit failure without passing --fail-on.
> 
> **Overview**
> **Changes the default exit behavior** so a plain `react-doctor` run reports diagnostics and a score but **does not fail the process** unless you opt in.
> 
> The resolved `--fail-on` / `failOn` default moves from **`error` to `none`**, and the `--fail-on` help text is updated to match. `resolveFailOnLevel` now documents that advisory-by-default is intentional (CI gates via `--fail-on` or config; GitHub Action keeps its own default). On an invalid level, it still falls back to the default—now **`none`**—with a warning that interpolates `DEFAULT_FAIL_ON_LEVEL` instead of a hardcoded string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db8a414c5a4dce5ef15da71459a53a789249da7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->