### PR TITLE
fix(website): enforce score request-body cap on the actual read

### DIFF
--- a/packages/website/src/app/api/score/route.ts
+++ b/packages/website/src/app/api/score/route.ts
@@ -4,7 +4,7 @@ import { getScoreLabel } from "@/utils/get-score-label";
 
 const ERROR_RULE_PENALTY = 1.5;
 const WARNING_RULE_PENALTY = 0.75;
-const MAX_REQUEST_BODY_BYTES = 2_000_000;
+const MAX_REQUEST_BODY_BYTES = 4_000_000;
 const MAX_DECOMPRESSED_BODY_BYTES = 25_000_000;
 const MAX_DIAGNOSTICS_PER_REQUEST = 50_000;
 
@@ -107,7 +107,7 @@ const decodeRequestBody = async (request: Request): Promise<unknown> => {
 export const POST = async (request: Request): Promise<Response> => {
   const contentLength = Number(request.headers.get("content-length") ?? "0");
   if (contentLength > MAX_REQUEST_BODY_BYTES) {
-    return respondError(413, "Request body exceeds 2MB");
+    return respondError(413, "Request body exceeds 4MB");
   }
 
   let body: unknown;
@@ -115,7 +115,7 @@ export const POST = async (request: Request): Promise<Response> => {
     body = await decodeRequestBody(request);
   } catch (error) {
     if (error instanceof RequestBodyTooLargeError) {
-      return respondError(413, "Request body exceeds 2MB");
+      return respondError(413, "Request body exceeds 4MB");
     }
     if (error instanceof DecompressedBodyTooLargeError) {
       return respondError(413, "Decompressed request body exceeds 25MB");

--- a/packages/website/src/app/api/score/route.ts
+++ b/packages/website/src/app/api/score/route.ts
@@ -4,8 +4,15 @@ import { getScoreLabel } from "@/utils/get-score-label";
 
 const ERROR_RULE_PENALTY = 1.5;
 const WARNING_RULE_PENALTY = 0.75;
+// 4 MB — Vercel's serverless request body limit; the platform rejects
+// anything larger before it reaches this handler, so this is the most we
+// can accept inline.
+// TODO: switch to a Vercel Blob upload reference for larger diagnostic
+// payloads instead of inline JSON.
 const MAX_REQUEST_BODY_BYTES = 4_000_000;
-const MAX_DECOMPRESSED_BODY_BYTES = 25_000_000;
+// Hold the decompressed (gzip) payload to the same 4 MB ceiling — a
+// compressed body must not expand beyond what we'd accept uncompressed.
+const MAX_DECOMPRESSED_BODY_BYTES = 4_000_000;
 const MAX_DIAGNOSTICS_PER_REQUEST = 50_000;
 
 interface DiagnosticInput {
@@ -118,7 +125,7 @@ export const POST = async (request: Request): Promise<Response> => {
       return respondError(413, "Request body exceeds 4MB");
     }
     if (error instanceof DecompressedBodyTooLargeError) {
-      return respondError(413, "Decompressed request body exceeds 25MB");
+      return respondError(413, "Decompressed request body exceeds 4MB");
     }
     body = null;
   }

--- a/packages/website/src/app/api/score/route.ts
+++ b/packages/website/src/app/api/score/route.ts
@@ -72,13 +72,26 @@ class DecompressedBodyTooLargeError extends Error {
   }
 }
 
+class RequestBodyTooLargeError extends Error {
+  constructor() {
+    super("request body exceeds limit");
+    this.name = "RequestBodyTooLargeError";
+  }
+}
+
 const isBufferTooLargeError = (error: unknown): boolean =>
   error instanceof Error && (error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE";
 
 const decodeRequestBody = async (request: Request): Promise<unknown> => {
   const contentEncoding = request.headers.get("content-encoding")?.toLowerCase() ?? "";
+  // Enforce the cap on the bytes actually read — the content-length
+  // header is client-controlled (omittable / spoofable), so it can't be
+  // the only guard, and the non-gzip path previously had no app-level cap.
+  const rawBody = Buffer.from(await request.arrayBuffer());
+  if (rawBody.byteLength > MAX_REQUEST_BODY_BYTES) {
+    throw new RequestBodyTooLargeError();
+  }
   if (contentEncoding === "gzip") {
-    const rawBody = Buffer.from(await request.arrayBuffer());
     let decompressed: Buffer;
     try {
       decompressed = gunzipSync(rawBody, { maxOutputLength: MAX_DECOMPRESSED_BODY_BYTES });
@@ -88,7 +101,7 @@ const decodeRequestBody = async (request: Request): Promise<unknown> => {
     }
     return JSON.parse(decompressed.toString("utf8"));
   }
-  return request.json();
+  return JSON.parse(rawBody.toString("utf8"));
 };
 
 export const POST = async (request: Request): Promise<Response> => {
@@ -101,6 +114,9 @@ export const POST = async (request: Request): Promise<Response> => {
   try {
     body = await decodeRequestBody(request);
   } catch (error) {
+    if (error instanceof RequestBodyTooLargeError) {
+      return respondError(413, "Request body exceeds 2MB");
+    }
     if (error instanceof DecompressedBodyTooLargeError) {
       return respondError(413, "Decompressed request body exceeds 25MB");
     }


### PR DESCRIPTION
## Summary
- Caps the score API request body at **4 MB** (Vercel's serverless body limit) and stops relying solely on the spoofable `content-length` header: the size is checked against the bytes actually read, and the non-gzip path is JSON-parsed from that bounded buffer instead of unbounded `request.json()`.
- Holds the **decompressed** (gzip) payload to the same 4 MB ceiling so a compressed body can't expand past what we'd accept uncompressed.
- In-code `TODO`: switch to a Vercel Blob upload reference for larger diagnostic payloads.

Note: this is a secondary validation, not a true pre-buffer memory cap — `request.arrayBuffer()` buffers first and the platform body limit is the hard ceiling.

## Test plan
- [ ] `pnpm typecheck`