### PR TITLE
fix(cli): write diagnostics dump with owner-only permissions

### DIFF
--- a/packages/react-doctor/src/cli/utils/write-diagnostics-directory.ts
+++ b/packages/react-doctor/src/cli/utils/write-diagnostics-directory.ts
@@ -8,7 +8,9 @@ import { formatRuleSummary, sortRuleGroupsByImportance } from "./render-diagnost
 
 export const writeDiagnosticsDirectory = (diagnostics: Diagnostic[]): string => {
   const outputDirectory = join(tmpdir(), `react-doctor-${randomUUID()}`);
-  mkdirSync(outputDirectory, { recursive: true });
+  // Owner-only (0700/0600): the dump holds source snippets + absolute
+  // paths and lives in a world-listable tmp dir on shared/CI hosts.
+  mkdirSync(outputDirectory, { recursive: true, mode: 0o700 });
 
   const ruleGroups = groupBy(
     diagnostics,
@@ -18,10 +20,14 @@ export const writeDiagnosticsDirectory = (diagnostics: Diagnostic[]): string => 
 
   for (const [ruleKey, ruleDiagnostics] of sortedRuleGroups) {
     const fileName = ruleKey.replace(/\//g, "--") + ".txt";
-    writeFileSync(join(outputDirectory, fileName), formatRuleSummary(ruleKey, ruleDiagnostics));
+    writeFileSync(join(outputDirectory, fileName), formatRuleSummary(ruleKey, ruleDiagnostics), {
+      mode: 0o600,
+    });
   }
 
-  writeFileSync(join(outputDirectory, "diagnostics.json"), JSON.stringify(diagnostics));
+  writeFileSync(join(outputDirectory, "diagnostics.json"), JSON.stringify(diagnostics), {
+    mode: 0o600,
+  });
 
   return outputDirectory;
 };


### PR DESCRIPTION
## Summary
- `writeDiagnosticsDirectory` wrote `diagnostics.json` (source snippets + absolute paths) under a world-listable tmp dir with default umask (typically world-readable).
- Now creates the directory `0700` and files `0600` (local info-disclosure hardening on shared/CI hosts).

## Test plan
- [ ] `pnpm typecheck`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized filesystem permission change with no behavior change beyond access control on temp diagnostic files.
> 
> **Overview**
> Hardens the temporary diagnostics dump written by `writeDiagnosticsDirectory` so only the owning user can read it on shared or CI machines.
> 
> The dump (rule `.txt` files plus `diagnostics.json` with snippets and absolute paths) still lands under `tmpdir()`, but the directory is now created with **mode `0700`** and each file with **`0600`**, instead of relying on the default umask (often world-readable). A short comment documents why.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a828bd1abd2f0ff4a530ed8a30566c04df345c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->