### PR TITLE
fix(oxlint-plugin): record param-default/computed-key references; fix exhaustive-deps FP

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/ts-type-position-keys.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/ts-type-position-keys.ts
@@ -1,0 +1,18 @@
+// AST child keys that hold TypeScript type-position nodes — type
+// annotations, type parameters/arguments, and the heritage type lists
+// (`implements`, `extends X<T>` type args). Reference-collecting walkers
+// skip these so identifiers that appear ONLY in a type are never
+// recorded as runtime value references (they're erased at compile time).
+//
+// Single source of truth — consumed by the scope analyzer, the
+// closure-capture walk, and the reference-name collector so the three
+// can't drift on which keys are type-only.
+export const TYPE_POSITION_CHILD_KEYS: ReadonlySet<string> = new Set([
+  "implements",
+  "returnType",
+  "superTypeArguments",
+  "superTypeParameters",
+  "typeAnnotation",
+  "typeArguments",
+  "typeParameters",
+]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { exhaustiveDeps } from "./exhaustive-deps.js";
+
+describe("react-builtins/exhaustive-deps — regressions", () => {
+  // A module-scope constant used only as a parameter default is stable
+  // across renders, so it must NOT be reported as a missing dependency.
+  // Previously a manual (unfiltered) param-default walk added it
+  // unconditionally; the scope analyzer now records the reference so the
+  // normal module-scope filter excludes it.
+  it("does not flag a module-scope constant used as a parameter default", () => {
+    const code = `
+      const SOME_MODULE_CONST = { a: 1 };
+      function MyComponent() {
+        return useCallback((opts = SOME_MODULE_CONST) => opts, []);
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+    expect(messages).not.toContain("SOME_MODULE_CONST");
+  });
+
+  // Regression guard for the other direction: a genuine component-scope
+  // value used as a parameter default is still reported when omitted from
+  // the dependency array (the fix must not silence real findings).
+  it("still flags a component-scope value used as a parameter default", () => {
+    const code = `
+      function MyComponent({ value }) {
+        return useCallback((opts = value) => opts, []);
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+    expect(messages).toContain("value");
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -325,35 +325,13 @@ const collectCaptureDepKeys = (callback: EsTreeNode, scopes: ScopeAnalysis): Cap
     if (!depKey) continue;
     keys.add(depKey);
   }
-  const functionParams = (callback as { params?: ReadonlyArray<EsTreeNode> }).params ?? [];
-  for (const param of functionParams) {
-    if (!isNodeOfType(param, "AssignmentPattern")) continue;
-    const visitDefaultValue = (node: EsTreeNode): void => {
-      if (isNodeOfType(node, "Identifier") || isNodeOfType(node, "MemberExpression")) {
-        const depKey = stringifyMemberChain(node);
-        if (depKey) keys.add(depKey);
-      }
-      const reference = scopes.referenceFor(node);
-      if (reference?.resolvedSymbol) {
-        const symbol = reference.resolvedSymbol;
-        if (!isOutsideAllFunctions(symbol)) {
-          const depKey = computeDepKey(reference);
-          if (depKey) keys.add(depKey);
-        }
-      }
-      const record = node as unknown as Record<string, unknown>;
-      for (const key of Object.keys(record)) {
-        if (key === "parent") continue;
-        const child = record[key];
-        if (Array.isArray(child)) {
-          for (const item of child) if (isAstNode(item)) visitDefaultValue(item);
-        } else if (isAstNode(child)) {
-          visitDefaultValue(child);
-        }
-      }
-    };
-    visitDefaultValue(param.right as EsTreeNode);
-  }
+  // Parameter default values and computed destructuring keys are now
+  // recorded as references by the scope analyzer, so `closureCaptures`
+  // already collects them through the SAME filtered path as the body
+  // above (module-scope / stable values excluded). A separate manual
+  // param walk used to live here and added every default-value name
+  // unconditionally — which mis-reported module constants like
+  // `(opts = SOME_CONST) => …` as missing deps.
   return { keys, stableCapturedNames };
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/semantic/closure-captures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/semantic/closure-captures.ts
@@ -1,18 +1,10 @@
 import type { EsTreeNode } from "../utils/es-tree-node.js";
 import type { ReferenceDescriptor, ScopeAnalysis } from "./scope-analysis.js";
 import { isDescendantScope } from "./scope-analysis.js";
+import { TYPE_POSITION_CHILD_KEYS } from "../constants/ts-type-position-keys.js";
 import { isAstDescendant } from "../utils/is-ast-descendant.js";
 import { isAstNode } from "../utils/is-ast-node.js";
 import { isFunctionLike } from "../utils/is-function-like.js";
-
-const TYPE_ONLY_CHILD_KEYS: ReadonlySet<string> = new Set([
-  "implements",
-  "returnType",
-  "superTypeArguments",
-  "typeAnnotation",
-  "typeArguments",
-  "typeParameters",
-]);
 
 // True if `inner` is a descendant of `outer` (or equal) in the AST
 // tree. Used to filter references inside `functionNode`.
@@ -69,7 +61,7 @@ export const closureCaptures = (
     const record = node as unknown as Record<string, unknown>;
     for (const key of Object.keys(record)) {
       if (key === "parent") continue;
-      if (TYPE_ONLY_CHILD_KEYS.has(key)) continue;
+      if (TYPE_POSITION_CHILD_KEYS.has(key)) continue;
       const child = record[key];
       if (Array.isArray(child)) {
         for (const item of child) if (isAstNode(item)) visit(item);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/semantic/scope-analysis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/semantic/scope-analysis.ts
@@ -1,5 +1,6 @@
 import type { EsTreeNode } from "../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../utils/es-tree-node-of-type.js";
+import { TYPE_POSITION_CHILD_KEYS } from "../constants/ts-type-position-keys.js";
 import { isAstNode } from "../utils/is-ast-node.js";
 import { isFunctionLike } from "../utils/is-function-like.js";
 import { isNodeOfType } from "../utils/is-node-of-type.js";
@@ -625,6 +626,50 @@ const setNodeScope = (node: EsTreeNode, state: BuilderState): void => {
   state.nodeScope.set(node, state.currentScope);
 };
 
+// Records references that live in the reference-bearing sub-parts of a
+// function parameter pattern: default-value expressions (`(a = expr) =>`)
+// and computed destructuring keys (`({ [k]: v }) =>`). The function-like
+// handler binds the parameter NAMES but walks only the body, so without
+// this the identifiers in defaults / computed keys would never be
+// recorded as references — leaving closure-capture and exhaustive-deps
+// analysis blind to them (e.g. misclassifying a module constant used as
+// a default). References are parked on the current (function) scope.
+const walkParameterReferences = (pattern: EsTreeNode, state: BuilderState): void => {
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    walkParameterReferences(pattern.left as EsTreeNode, state);
+    const defaultValue = (pattern.right as EsTreeNode | null) ?? null;
+    if (defaultValue) walk(defaultValue, state);
+    return;
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    for (const property of pattern.properties) {
+      const propertyNode = property as EsTreeNode;
+      if (isNodeOfType(propertyNode, "RestElement")) {
+        walkParameterReferences((propertyNode as { argument: EsTreeNode }).argument, state);
+        continue;
+      }
+      if (!isNodeOfType(propertyNode, "Property")) continue;
+      const propertyDetail = propertyNode as {
+        computed?: boolean;
+        key: EsTreeNode;
+        value: EsTreeNode;
+      };
+      if (propertyDetail.computed) walk(propertyDetail.key, state);
+      walkParameterReferences(propertyDetail.value, state);
+    }
+    return;
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    for (const element of pattern.elements) {
+      if (element) walkParameterReferences(element as EsTreeNode, state);
+    }
+    return;
+  }
+  if (isNodeOfType(pattern, "RestElement")) {
+    walkParameterReferences(pattern.argument as EsTreeNode, state);
+  }
+};
+
 // Single-pass walker. For each node we:
 //   1) Open a scope if appropriate.
 //   2) Bind any declarations to the active scope (with hoisting).
@@ -666,11 +711,12 @@ const walk = (node: EsTreeNode, state: BuilderState): void => {
       });
       tagAsBinding(state, node.id as EsTreeNode);
     }
-    handleFunctionParameters(
-      (node as { params: ReadonlyArray<EsTreeNode> }).params ?? [],
-      fnScope,
-      state,
-    );
+    const functionParams = (node as { params: ReadonlyArray<EsTreeNode> }).params ?? [];
+    handleFunctionParameters(functionParams, fnScope, state);
+    // Record references inside parameter default values and computed
+    // destructuring keys (the handler above binds names but doesn't walk
+    // these reference-bearing sub-expressions).
+    for (const param of functionParams) walkParameterReferences(param, state);
     // Walk the body inline; if it's a BlockStatement, we mark it so the
     // BlockStatement handler doesn't push a duplicate scope.
     const body = (node as { body: EsTreeNode }).body;
@@ -739,6 +785,7 @@ const walk = (node: EsTreeNode, state: BuilderState): void => {
     const nodeRecord = node as unknown as Record<string, unknown>;
     for (const key of Object.keys(nodeRecord)) {
       if (key === "parent") continue;
+      if (TYPE_POSITION_CHILD_KEYS.has(key)) continue;
       const child = nodeRecord[key];
       if (Array.isArray(child)) {
         for (const item of child) if (isAstNode(item)) walk(item, state);
@@ -851,6 +898,7 @@ const walk = (node: EsTreeNode, state: BuilderState): void => {
   const nodeRecord = node as unknown as Record<string, unknown>;
   for (const key of Object.keys(nodeRecord)) {
     if (key === "parent") continue;
+    if (TYPE_POSITION_CHILD_KEYS.has(key)) continue;
     const child = nodeRecord[key];
     if (Array.isArray(child)) {
       for (const item of child) if (isAstNode(item)) walk(item, state);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-reference-identifier-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-reference-identifier-names.ts
@@ -1,16 +1,8 @@
+import { TYPE_POSITION_CHILD_KEYS } from "../constants/ts-type-position-keys.js";
 import { collectPatternNames } from "./collect-pattern-names.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isAstNode } from "./is-ast-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
-
-const TYPE_POSITION_KEYS = new Set([
-  "typeAnnotation",
-  "typeParameters",
-  "typeArguments",
-  "returnType",
-  "superTypeArguments",
-  "superTypeParameters",
-]);
 
 const collectScopedReferencesInPattern = (
   pattern: EsTreeNode | null | undefined,
@@ -110,7 +102,7 @@ const collectScopedReferenceIdentifierNames = (
   if (typeof node.type === "string" && node.type.startsWith("TS")) return;
   for (const [key, child] of Object.entries(node)) {
     if (key === "parent") continue;
-    if (TYPE_POSITION_KEYS.has(key)) continue;
+    if (TYPE_POSITION_CHILD_KEYS.has(key)) continue;
     if (Array.isArray(child)) {
       for (const item of child) {
         if (isAstNode(item)) collectScopedReferenceIdentifierNames(item, into, shadowed);


### PR DESCRIPTION
## Summary
- `scope-analysis` now records references in parameter **default values** and **computed destructuring keys** (previously it bound the param names but never walked these sub-expressions, leaving closure-capture / exhaustive-deps blind to them).
- Consolidated the TS type-position child-key skip-set into one source of truth (`constants/ts-type-position-keys.ts`), used by `scope-analysis`, `closure-captures`, and `collect-reference-identifier-names` (which previously had two divergent copies), and applied it in the scope walk so type-only identifiers aren't recorded as value references.
- Because `closureCaptures` now picks up param defaults through the **filtered** path, removed `exhaustive-deps`' separate manual param-default walk whose unconditional add mis-reported module constants (`(opts = SOME_CONST) => …, []`) as missing deps.
- Adds `exhaustive-deps.regressions.test.ts` (FP gone; genuine component-scope default still flagged).

## Test plan
- [ ] `pnpm typecheck`
- [ ] `cd packages/oxlint-plugin-react-doctor && pnpm test` (no new failures vs baseline; +2 regression tests)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared semantic analysis (scope references and closure capture) used by exhaustive-deps; behavior is narrowed with regression tests but other rules depending on the same paths could shift slightly.
> 
> **Overview**
> Fixes **exhaustive-deps** false positives when a **module-scope** constant appears only in a hook callback’s **parameter default** (e.g. `(opts = SOME_CONST) => …` with `[]`), while keeping real misses for **component-scope** defaults.
> 
> The scope analyzer now records references in parameter **default expressions** and **computed destructuring keys** via `walkParameterReferences`, so `closureCaptures` sees them with the same module-scope / stability filters as the callback body. The rule’s separate manual param-default walk was removed because it added every default name unconditionally.
> 
> Type-only AST child keys are centralized in `TYPE_POSITION_CHILD_KEYS` and applied in the scope walk (plus existing consumers), so type-position identifiers are not treated as runtime value references; `superTypeParameters` is aligned across walkers that previously diverged.
> 
> Regression tests cover the module-constant FP and that component-scope defaults are still reported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8251c9a835c7834b27831259c3a0f5b21e37fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->