### PR TITLE
fix(core): clamp React-major capability loop to prevent hang/OOM

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -13,12 +13,13 @@ export const JSX_FILE_PATTERN = /\.(tsx|jsx)$/;
 export const MILLISECONDS_PER_SECOND = 1000;
 
 // Upper bound for the `react:<major>` capability loop in
-// `buildCapabilities`. React majors are small; an unvalidated
-// package.json spec like `"react": "20240101"` would otherwise drive
-// the loop to tens of millions of iterations (hang / OOM). No rule
-// gates on a major above this, so clamping is lossless for real
-// projects — bump when a rule starts requiring a newer React major.
-export const LATEST_KNOWN_REACT_MAJOR = 19;
+// `buildCapabilities`, clamping an unvalidated package.json spec like
+// `"react": "20240101"` that would otherwise drive the loop to tens of
+// millions of iterations (hang / OOM). Set generously — React ships
+// ~one major a year and is probably only gonna be around for another
+// 10 yrs, so 30 is plenty of headroom; any unused `react:<n>` capability
+// strings above the latest real major are harmless.
+export const LATEST_KNOWN_REACT_MAJOR = 30;
 
 // Lowest React major react-doctor emits a `react:<major>` capability
 // for (rules gate on `react:17`+ at the floor).

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -12,6 +12,18 @@ export const JSX_FILE_PATTERN = /\.(tsx|jsx)$/;
 
 export const MILLISECONDS_PER_SECOND = 1000;
 
+// Upper bound for the `react:<major>` capability loop in
+// `buildCapabilities`. React majors are small; an unvalidated
+// package.json spec like `"react": "20240101"` would otherwise drive
+// the loop to tens of millions of iterations (hang / OOM). No rule
+// gates on a major above this, so clamping is lossless for real
+// projects — bump when a rule starts requiring a newer React major.
+export const LATEST_KNOWN_REACT_MAJOR = 19;
+
+// Lowest React major react-doctor emits a `react:<major>` capability
+// for (rules gate on `react:17`+ at the floor).
+export const EARLIEST_GATED_REACT_MAJOR = 17;
+
 export const ERROR_PREVIEW_LENGTH_CHARS = 200;
 
 export const PERFECT_SCORE = 100;

--- a/packages/core/src/runners/oxlint/capabilities.ts
+++ b/packages/core/src/runners/oxlint/capabilities.ts
@@ -1,4 +1,5 @@
 import type { ProjectInfo } from "../../types/index.js";
+import { EARLIEST_GATED_REACT_MAJOR, LATEST_KNOWN_REACT_MAJOR } from "../../constants.js";
 import {
   isReactAtLeast,
   isTailwindAtLeast,
@@ -26,7 +27,12 @@ export const buildCapabilities = (project: ProjectInfo): ReadonlySet<string> => 
 
   const reactMajor = project.reactMajorVersion;
   if (reactMajor !== null) {
-    for (let major = 17; major <= reactMajor; major++) {
+    // Clamp the upper bound: `reactMajor` is parsed from an arbitrary
+    // package.json version string and can be implausibly large (e.g. a
+    // date-like typo `"20240101"`), which would otherwise turn this loop
+    // into a multi-minute hang / OOM.
+    const cappedReactMajor = Math.min(reactMajor, LATEST_KNOWN_REACT_MAJOR);
+    for (let major = EARLIEST_GATED_REACT_MAJOR; major <= cappedReactMajor; major++) {
       capabilities.add(`react:${major}`);
     }
     // Minor-version-pinned capabilities for APIs introduced after a


### PR DESCRIPTION
## Summary
- `buildCapabilities` looped `for (major = 17; major <= reactMajor; …)` where `reactMajor` is parsed from an arbitrary `package.json` version. A date-like typo or hostile value (`"react": "20240101"`) drove tens of millions of iterations + GBs of `Set` — a multi-minute hang / OOM that runs on **every** lint before oxlint spawns (reachable in untrusted-PR CI).
- Clamps the loop's upper bound to `LATEST_KNOWN_REACT_MAJOR` (new constant). Lossless for real projects since no rule gates on a major above it.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (core)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive bound on capability generation; behavior for normal React versions is unchanged and no auth or data paths are touched.
> 
> **Overview**
> **Prevents oxlint capability setup from hanging or OOMing** when `package.json` declares an implausibly large React major (e.g. a date-like `"20240101"`).
> 
> `buildCapabilities` now caps the `react:<major>` loop with `LATEST_KNOWN_REACT_MAJOR` (30) and uses shared `EARLIEST_GATED_REACT_MAJOR` (17) instead of magic numbers. Real projects are unaffected because no rules gate above that ceiling; extra capability strings are harmless.
> 
> This runs on every lint before oxlint spawns, so the fix matters for untrusted-PR CI as well as local typos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4728418039c3ba78892137d352bb76acb79dfb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->