### PR TITLE
fix(cli): dispatch oxlint-failure hint on structured kind, not message text

### DIFF
--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -16,7 +16,12 @@ import { buildDiagnosticPipeline } from "./build-diagnostic-pipeline.js";
 import { checkPnpmHardening } from "./check-pnpm-hardening.js";
 import { checkReducedMotion } from "./check-reduced-motion.js";
 import { computeJsxIncludePaths } from "./jsx-include-paths.js";
-import { NoReactDependency, ReactDoctorError, type ReactDoctorErrorReason } from "./errors.js";
+import {
+  NoReactDependency,
+  type OxlintUnavailable,
+  ReactDoctorError,
+  type ReactDoctorErrorReason,
+} from "./errors.js";
 import { filterDiagnosticsForSurface } from "./filter-for-surface.js";
 import { resolveLintIncludePaths } from "./resolve-lint-include-paths.js";
 import { Config, type ResolvedConfig } from "./services/config.js";
@@ -77,6 +82,13 @@ export interface InspectOutput {
    * `OxlintUnavailable` with `kind: "native-binding-missing"`).
    */
   readonly lintFailureReasonTag: ReactDoctorErrorReason["_tag"] | null;
+  /**
+   * The `kind` of an `OxlintUnavailable` lint failure
+   * (`binary-not-found` / `native-binding-missing`), or `null` for any
+   * other failure. Lets renderers show the "upgrade Node" hint by
+   * dispatching on structured data instead of matching message text.
+   */
+  readonly lintFailureReasonKind: OxlintUnavailable["kind"] | null;
   readonly lintPartialFailures: ReadonlyArray<string>;
   /** `false` when run-dead-code was disabled, diff/staged mode, or analysis crashed. */
   readonly didDeadCodeFail: boolean;
@@ -252,7 +264,8 @@ export const runInspect = <HooksR = never>(
       didFail: boolean;
       reason: string | null;
       reasonTag: ReactDoctorErrorReason["_tag"] | null;
-    }>({ didFail: false, reason: null, reasonTag: null });
+      reasonKind: OxlintUnavailable["kind"] | null;
+    }>({ didFail: false, reason: null, reasonTag: null, reasonKind: null });
     const deadCodeFailure = yield* Ref.make<{ didFail: boolean; reason: string | null }>({
       didFail: false,
       reason: null,
@@ -289,6 +302,7 @@ export const runInspect = <HooksR = never>(
                 didFail: true,
                 reason: error.message,
                 reasonTag: error.reason._tag,
+                reasonKind: error.reason._tag === "OxlintUnavailable" ? error.reason.kind : null,
               });
               return Stream.empty as Stream.Stream<Diagnostic, never>;
             }),
@@ -393,6 +407,7 @@ export const runInspect = <HooksR = never>(
       didLintFail: lintFailureState.didFail,
       lintFailureReason: lintFailureState.reason,
       lintFailureReasonTag: lintFailureState.reasonTag,
+      lintFailureReasonKind: lintFailureState.reasonKind,
       lintPartialFailures,
       didDeadCodeFail: deadCodeFailureState.didFail,
       deadCodeFailureReason: deadCodeFailureState.reason,

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -9,7 +9,6 @@ import {
   resolveScanTarget,
   restoreLegacyThrow,
   runInspect as runInspectEffect,
-  type ReactDoctorErrorReason,
 } from "@react-doctor/core";
 import { buildRuntimeLayers } from "./cli/utils/build-runtime-layers.js";
 import type {
@@ -251,24 +250,19 @@ const runInspectWithRuntime = async (
   const lintFailureReason = lintBindingMissing
     ? `oxlint native binding not found for Node ${process.version}; expected one matching ${OXLINT_NODE_REQUIREMENT}`
     : output.lintFailureReason;
-  // Tagged-reason dispatch beats string sniffing on lintFailureReason
-  // — the runtime carries lintFailureReasonTag exactly so this
-  // renderer doesn't have to know the format strings the runner
-  // produces.
-  const lintFailureReasonTag: ReactDoctorErrorReason["_tag"] | null = output.lintFailureReasonTag;
-  const isNativeBindingFailure =
-    lintFailureReasonTag === "OxlintUnavailable" || lintFailureReasonTag === "OxlintSpawnFailed";
-
   // The orchestrator already finalized the lint spinner via the
   // Progress service. Print only the supplementary CLI-side hint
-  // (upgrade-Node guidance / failure reason) post-orchestrator.
+  // (upgrade-Node guidance / failure reason) post-orchestrator. Dispatch
+  // on the structured failure kind the runtime carries — never the
+  // message text (see AGENTS.md: renderers dispatch on reason, not
+  // `message.includes(...)`).
   if (
     !options.scoreOnly &&
     !lintBindingMissing &&
     output.didLintFail &&
     lintFailureReason !== null
   ) {
-    if (isNativeBindingFailure && /native binding/.test(lintFailureReason)) {
+    if (output.lintFailureReasonKind === "native-binding-missing") {
       runConsole(
         Console.log(
           highlighter.gray(


### PR DESCRIPTION
## Summary
- `inspect.ts` gated the "upgrade Node" hint on `/native binding/.test(lintFailureReason)` — the message-text sniffing AGENTS.md explicitly forbids (renderers should dispatch on `reason._tag`/structured data).
- Threads the `OxlintUnavailable` `kind` through `InspectOutput.lintFailureReasonKind` and dispatches on `=== "native-binding-missing"`, completing the design the existing `lintFailureReasonTag` started.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (core run-inspect + react-doctor inspect)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to failure metadata and CLI rendering; behavior should match prior intent for native-binding failures without relying on message strings.
> 
> **Overview**
> The inspect orchestrator now exposes **`lintFailureReasonKind`** on `InspectOutput`, populated when lint fails with `OxlintUnavailable` (`binary-not-found` vs `native-binding-missing`); other failures leave it `null`.
> 
> The CLI **stops** gating the gray “upgrade Node” hint on `/native binding/.test(lintFailureReason)` and tag-based checks, and instead shows that hint only when **`lintFailureReasonKind === "native-binding-missing"`**. Other lint failures still print the error message via `Console.error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca98fdea0f9f4a57b35ba686c8d62b0a26eec76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->