### PR TITLE
fix(core,cli): plug temp-dir leaks and fix staged path remap

### DIFF
--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -128,8 +128,6 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     return [];
   }
 
-  const configDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-oxlintrc-"));
-  const configPath = path.join(configDirectory, "oxlintrc.json");
   const pluginPath = resolvePluginPath();
   // HACK: pass user lint configs to oxlint as absolute paths. oxlint's
   // docs say `extends` is "resolved relative to the configuration
@@ -169,6 +167,13 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   const restoreDisableDirectives = respectInlineDisables
     ? () => {}
     : await neutralizeDisableDirectives(rootDirectory, includePaths);
+
+  // Created last so any throw in the setup above (plugin resolution,
+  // user-plugin loading) happens before the temp dir exists — nothing
+  // between here and the try can throw, so the finally always owns
+  // cleanup.
+  const configDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-oxlintrc-"));
+  const configPath = path.join(configDirectory, "oxlintrc.json");
 
   try {
     const oxlintBinary = resolveOxlintBinary();

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
@@ -182,7 +182,16 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       }
 
       const tempDirectory = mkdtempSync(path.join(tmpdir(), STAGED_FILES_TEMP_DIR_PREFIX));
-      const snapshot = await materializeStagedFiles(resolvedDirectory, stagedFiles, tempDirectory);
+      // If materialization throws before `snapshot.cleanup` is wired up,
+      // remove the temp dir we just created so it can't leak.
+      const snapshot = await materializeStagedFiles(
+        resolvedDirectory,
+        stagedFiles,
+        tempDirectory,
+      ).catch((error: unknown) => {
+        rmSync(tempDirectory, { recursive: true, force: true });
+        throw error;
+      });
       try {
         const scanResult = await inspect(snapshot.tempDirectory, {
           ...scanOptions,
@@ -193,7 +202,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         const remappedDiagnostics = scanResult.diagnostics.map((diagnostic) => ({
           ...diagnostic,
           filePath: path.isAbsolute(diagnostic.filePath)
-            ? diagnostic.filePath.replaceAll(snapshot.tempDirectory, resolvedDirectory)
+            ? diagnostic.filePath.replaceAll(snapshot.tempDirectory, () => resolvedDirectory)
             : diagnostic.filePath,
         }));
         const remappedInspectResult: InspectResult = {


### PR DESCRIPTION
## Summary
- **run-oxlint:** the oxlintrc temp dir was created before throwing setup steps (plugin resolution, user-plugin load); a throw there leaked the dir. Create it last so the `finally` always owns cleanup.
- **cli staged scan:** clean up the temp dir if `materializeStagedFiles` throws before `snapshot.cleanup` is wired; and remap diagnostic paths with a replacer function (`() => resolvedDirectory`) so a real path containing `$&`/`$1` isn't reinterpreted by `replaceAll`.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Resource-cleanup and string-replacement fixes only; no changes to scan rules, auth, or data handling.
> 
> **Overview**
> Fixes **temporary directory leaks** and a **staged-scan path remap** edge case in the oxlint runner and CLI.
> 
> In **`runOxlint`**, creation of the generated `oxlintrc` temp directory is deferred until after plugin resolution, user-plugin loading, and disable-directive setup. If any of that throws, no orphan directory is left behind; the existing `finally` still removes the dir after the lint run.
> 
> For **`--staged`**, if `materializeStagedFiles` fails before `snapshot.cleanup` exists, the CLI now **`rmSync`s** the staging temp dir in a `.catch` before rethrowing. Diagnostic paths are remapped with `replaceAll(tempPath, () => resolvedDirectory)` instead of a string replacement so paths that contain `$&` / `$1`-style sequences are not misinterpreted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca3c9ee3e1dddbec553620e4abd3be4484409cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->