### PR TITLE
feat(oxlint-plugin): add no-prop-types rule (React 19)

### DIFF
--- a/.changeset/no-prop-types.md
+++ b/.changeset/no-prop-types.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Add the `no-prop-types` architecture rule. React 19 removed runtime `propTypes` validation entirely — React no longer reads `Component.propTypes`, so invalid props that used to log a console warning now pass silently. The rule flags `Component.propTypes = { ... }` assignments and `static propTypes` class fields on component-cased identifiers, and is version-gated to React 19+ (`requires: ["react:19"]`) so projects where `propTypes` still runs stay quiet. It steers users toward TypeScript prop types plus explicit runtime validation. See #460.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -183,6 +183,7 @@ import { noPermanentWillChange } from "./rules/performance/no-permanent-will-cha
 import { noPolymorphicChildren } from "./rules/correctness/no-polymorphic-children.js";
 import { noPreventDefault } from "./rules/correctness/no-prevent-default.js";
 import { noPropCallbackInEffect } from "./rules/state-and-effects/no-prop-callback-in-effect.js";
+import { noPropTypes } from "./rules/architecture/no-prop-types.js";
 import { noPureBlackBackground } from "./rules/design/no-pure-black-background.js";
 import { noReactChildren } from "./rules/react-builtins/no-react-children.js";
 import { noReactDomDeprecatedApis } from "./rules/architecture/no-react-dom-deprecated-apis.js";
@@ -2239,6 +2240,17 @@ export const reactDoctorRules = [
       ...noPropCallbackInEffect,
       framework: "global",
       category: "State & Effects",
+    },
+  },
+  {
+    key: "react-doctor/no-prop-types",
+    id: "no-prop-types",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noPropTypes,
+      framework: "global",
+      category: "Architecture",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-prop-types.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-prop-types.ts
@@ -1,0 +1,91 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { isUppercaseName } from "../../utils/is-uppercase-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// HACK: React 19 removed runtime `propTypes` validation entirely —
+// React no longer reads `Component.propTypes`, so invalid props that
+// used to log a console warning now pass silently. The fix is the same
+// across both component shapes (function and class): move the contract
+// to TypeScript types and add explicit runtime checks only where data
+// can actually be invalid. Detection targets two idioms:
+//
+//   Component.propTypes = { value: PropTypes.number };   // assignment
+//   class Component { static propTypes = { ... }; }       // class field
+//
+// The uppercase-receiver heuristic (mirrors `no-default-props`) keeps
+// the rule conservative: only a Capitalized identifier / class name is
+// treated as a component, so `config.propTypes = …` on a lowercase
+// object is never flagged. The whole rule is version-gated on
+// `react:19` so pre-19 projects — where `propTypes` still runs — stay
+// quiet.
+const PROP_TYPES_PROPERTY = "propTypes";
+
+const isPropTypesKey = (key: EsTreeNode | null | undefined, computed: boolean): boolean => {
+  if (!key) return false;
+  if (computed) return isNodeOfType(key, "Literal") && key.value === PROP_TYPES_PROPERTY;
+  return isNodeOfType(key, "Identifier") && key.name === PROP_TYPES_PROPERTY;
+};
+
+const getComponentNameFromPropTypesAssignment = (left: EsTreeNode): string | null => {
+  if (!isNodeOfType(left, "MemberExpression")) return null;
+  if (!isPropTypesKey(left.property, Boolean(left.computed))) return null;
+  if (!isNodeOfType(left.object, "Identifier")) return null;
+  if (!isUppercaseName(left.object.name)) return null;
+  return left.object.name;
+};
+
+const getComponentNameFromClassProperty = (
+  node: EsTreeNodeOfType<"PropertyDefinition">,
+): string | null => {
+  if (!node.static) return null;
+  if (!isPropTypesKey(node.key, Boolean(node.computed))) return null;
+
+  const classBody = node.parent;
+  if (!isNodeOfType(classBody, "ClassBody")) return null;
+  const classNode = classBody.parent;
+  if (!classNode) return null;
+
+  if (
+    (isNodeOfType(classNode, "ClassDeclaration") || isNodeOfType(classNode, "ClassExpression")) &&
+    classNode.id?.name &&
+    isUppercaseName(classNode.id.name)
+  ) {
+    return classNode.id.name;
+  }
+
+  if (!isNodeOfType(classNode, "ClassExpression")) return null;
+  const declarator = classNode.parent;
+  if (!isNodeOfType(declarator, "VariableDeclarator")) return null;
+  if (!isNodeOfType(declarator.id, "Identifier")) return null;
+  if (!isUppercaseName(declarator.id.name)) return null;
+  return declarator.id.name;
+};
+
+const buildMessage = (componentName: string): string =>
+  `${componentName}.propTypes — React 19 no longer runs \`propTypes\` checks, so invalid props pass silently. Move the prop contract to TypeScript types and add explicit runtime validation only where data can actually be invalid`;
+
+export const noPropTypes = defineRule<Rule>({
+  id: "no-prop-types",
+  requires: ["react:19"],
+  tags: ["test-noise"],
+  severity: "warn",
+  recommendation:
+    "React 19 removed runtime `propTypes` validation — React no longer reads `Component.propTypes`, so invalid props pass silently. Describe props with TypeScript types and move any required runtime validation to explicit checks (or schema parsing) in component code. Only enabled on projects detected as React 19+.",
+  create: (context: RuleContext) => ({
+    AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
+      if (node.operator !== "=") return;
+      const componentName = getComponentNameFromPropTypesAssignment(node.left);
+      if (!componentName) return;
+      context.report({ node: node.left, message: buildMessage(componentName) });
+    },
+    PropertyDefinition(node: EsTreeNodeOfType<"PropertyDefinition">) {
+      const componentName = getComponentNameFromClassProperty(node);
+      if (!componentName) return;
+      context.report({ node: node.key, message: buildMessage(componentName) });
+    },
+  }),
+});

--- a/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
@@ -346,6 +346,157 @@ export { config };
   });
 });
 
+describe("no-prop-types", () => {
+  it("flags Component.propTypes = { ... } on a function component", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-types-assignment", {
+      files: {
+        "src/Rating.tsx": `import PropTypes from "prop-types";
+
+export function Rating({ value }: { value?: number }) {
+  return <span>{value}</span>;
+}
+
+Rating.propTypes = {
+  value: PropTypes.number,
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types");
+    expect(hits.length).toBe(1);
+    expect(hits[0].message).toContain("Rating");
+    expect(hits[0].message).toContain("React 19");
+  });
+
+  it("flags a static propTypes class field on a class component", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-types-class-static", {
+      files: {
+        "src/Rating.tsx": `import React from "react";
+import PropTypes from "prop-types";
+
+export class Rating extends React.Component<{ value?: number }> {
+  static propTypes = {
+    value: PropTypes.number,
+  };
+  render() {
+    return <span>{this.props.value}</span>;
+  }
+}
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types");
+    expect(hits.length).toBe(1);
+    expect(hits[0].message).toContain("Rating");
+  });
+
+  it("flags a static propTypes field on a class assigned to an uppercase const", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-types-class-expr", {
+      files: {
+        "src/Rating.tsx": `import React from "react";
+import PropTypes from "prop-types";
+
+export const Rating = class extends React.Component<{ value?: number }> {
+  static propTypes = {
+    value: PropTypes.number,
+  };
+  render() {
+    return <span>{this.props.value}</span>;
+  }
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types");
+    expect(hits.length).toBe(1);
+    expect(hits[0].message).toContain("Rating");
+  });
+
+  it('flags a computed Component["propTypes"] = { ... } assignment', async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-types-computed", {
+      files: {
+        "src/Rating.tsx": `import PropTypes from "prop-types";
+
+export function Rating({ value }: { value?: number }) {
+  return <span>{value}</span>;
+}
+
+Rating["propTypes"] = {
+  value: PropTypes.number,
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types");
+    expect(hits.length).toBe(1);
+    expect(hits[0].message).toContain("Rating");
+  });
+
+  it("does not flag TypeScript prop types with destructuring defaults", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-types-modern", {
+      files: {
+        "src/Rating.tsx": `interface Props {
+  value?: number;
+}
+
+export function Rating({ value = 0 }: Props) {
+  return <span>{value}</span>;
+}
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag a propTypes property on a lowercase (non-component) object", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-types-lowercase", {
+      files: {
+        "src/util.ts": `const config = {} as { propTypes?: Record<string, unknown> };
+config.propTypes = { value: 1 };
+export { config };
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag a static propTypes field on a lowercase-named class", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-types-lowercase-class", {
+      files: {
+        "src/validator.ts": `export class validator {
+  static propTypes = { value: 1 };
+}
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("does not flag an instance (non-static) propTypes class field", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-prop-types-instance-field", {
+      files: {
+        "src/Model.ts": `export class Model {
+  propTypes = { value: 1 };
+}
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types");
+    expect(hits).toHaveLength(0);
+  });
+});
+
 describe("version gating", () => {
   it("does NOT flag forwardRef on React 18 projects (migration-hint, suppressed below minMajor)", async () => {
     const projectDir = setupReactProject(tempRoot, "gating-r18-forwardRef", {
@@ -483,6 +634,51 @@ Button.defaultProps = { size: "md" };
 
     const hits = await collectRuleHits(projectDir, "no-default-props", { reactMajorVersion: 19 });
     expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT flag Component.propTypes on React 18 projects (propTypes still runs pre-19)", async () => {
+    const projectDir = setupReactProject(tempRoot, "gating-r18-propTypes", {
+      reactVersion: "^18.3.1",
+      files: {
+        "src/Rating.tsx": `import PropTypes from "prop-types";
+export function Rating({ value }: { value?: number }) { return <span>{value}</span>; }
+Rating.propTypes = { value: PropTypes.number };
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types", { reactMajorVersion: 18 });
+    expect(hits).toHaveLength(0);
+  });
+
+  it("DOES flag Component.propTypes on React 19 projects", async () => {
+    const projectDir = setupReactProject(tempRoot, "gating-r19-propTypes", {
+      reactVersion: "^19.0.0",
+      files: {
+        "src/Rating.tsx": `import PropTypes from "prop-types";
+export function Rating({ value }: { value?: number }) { return <span>{value}</span>; }
+Rating.propTypes = { value: PropTypes.number };
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types", { reactMajorVersion: 19 });
+    expect(hits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT flag Component.propTypes when the React version is unknown", async () => {
+    const projectDir = setupReactProject(tempRoot, "gating-null-propTypes", {
+      reactVersion: "*",
+      files: {
+        "src/Rating.tsx": `import PropTypes from "prop-types";
+export function Rating({ value }: { value?: number }) { return <span>{value}</span>; }
+Rating.propTypes = { value: PropTypes.number };
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-prop-types", { reactMajorVersion: null });
+    expect(hits).toHaveLength(0);
   });
 
   it("does NOT flag react-dom render on React 17 projects (deprecated since 18, not 17)", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Implements the [`no-prop-types` proposal (#460)](https://github.com/millionco/react-doctor/pull/460).

React 19 removed runtime `propTypes` validation **entirely** — React no longer reads `Component.propTypes`. Invalid props that previously logged a `console.error` from the propTypes validators now pass through silently, so a class of input-validation bugs becomes invisible after upgrading. The rule nudges teams to express the prop contract in TypeScript and move any genuinely runtime validation into explicit checks.

Before:

```tsx
import PropTypes from "prop-types";

export function Rating({ value }) {
  return <span>{value}</span>;
}

Rating.propTypes = {
  value: PropTypes.number, // React 19 never runs this — invalid props pass silently
};
```

After:

```tsx
interface Props {
  value?: number;
}

export function Rating({ value = 0 }: Props) {
  return <span>{value}</span>;
}
```

## What changed

- Added the `no-prop-types` rule under `architecture/` (`framework: "global"`, `severity: "warn"`).
- **Version check:** gated with `requires: ["react:19"]`. The capability builder only adds `react:19` when the detected React major is ≥ 19, so React 17/18 projects (where `propTypes` still runs) and projects with an **unknown** React version stay completely quiet. This is the core safeguard the proposal called out.
- Detects two idioms:
  - `Component.propTypes = …` assignments (including computed `Component["propTypes"] = …`).
  - `static propTypes` class fields, on both named classes and class expressions bound to an uppercase `const`.
- Reports only when the receiver is **component-cased** (uppercase first letter), mirroring the sibling `no-default-props` heuristic — `config.propTypes = …` and `class validator { static propTypes }` are not flagged.
- Allows TypeScript prop types, destructuring defaults, instance (non-static) `propTypes` fields, and any lowercase/non-component receiver.
- Registered in the generated rule registry; the ESLint mirror and presets pick it up automatically.
- Added a changeset.

### Note on tags

The auto-generated proposal suggested `["test-noise", "migration-hint"]`. I shipped it with `["test-noise"]` only, matching the closest sibling `no-default-props`. `migration-hint` (fire in test files too) is reserved for **import-based** deprecated-API rules where test files are a primary migration surface (`react-dom/test-utils`); `propTypes`, like `defaultProps`, is a **pattern-based** rule where flagging test fixtures would just add noise. This keeps false positives down, which was the explicit goal.

## False-positive considerations

- Pre-19 / unknown React version → suppressed by the `react:19` capability gate.
- Lowercase / non-component receivers (`config.propTypes`, `class validator`) → not flagged.
- `this.propTypes`, member-chain receivers (`Foo.Bar.propTypes`), compound assignments (`+=`), and dynamic computed keys (`Foo[name]`) → not flagged (conservative).
- Test/story/playground files → skipped via the `test-noise` wrapper.

## Test plan

- `vp test run packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts` — added 7 detector cases (assignment, static class field, class expression, computed key, + 3 negatives) and 3 version-gating cases (18 → none, 19 → flagged, unknown → none). 43/43 pass.
- `pnpm test` — full filtered suite: 1400 passed / 15 skipped.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm smoke:json-report` — all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32fcb156-b99d-45ac-ac27-8e01acf97cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32fcb156-b99d-45ac-ac27-8e01acf97cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

