### PR TITLE
feat(cli): pair verbose diagnostics with per-rule fix-recipe URLs

### DIFF
--- a/.changeset/verbose-rule-prompt-urls.md
+++ b/.changeset/verbose-rule-prompt-urls.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Pair each error and warning in `--verbose` output with its canonical per-rule fix recipe at `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md`. Every rule group now prints a `Fix recipe:` line (also written into the verbose diagnostics dump), so the `/doctor` playbook can fetch the reviewer-tested recipe on demand and apply the canonical fix instead of improvising per diagnostic.

--- a/.changeset/verbose-rule-prompt-urls.md
+++ b/.changeset/verbose-rule-prompt-urls.md
@@ -1,5 +1,0 @@
----
-"react-doctor": patch
----
-
-Pair each error and warning in `--verbose` output with its canonical per-rule fix recipe at `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md`. Every rule group now prints a `Fix recipe:` line (also written into the verbose diagnostics dump), so the `/doctor` playbook can fetch the reviewer-tested recipe on demand and apply the canonical fix instead of improvising per diagnostic.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -48,6 +48,11 @@ export const SCORE_API_URL = "https://www.react.doctor/api/score";
 
 export const SHARE_BASE_URL = "https://www.react.doctor/share";
 
+// Base URL for the per-rule fix recipes the `/doctor` playbook fetches
+// on demand. The full URL for one rule is
+// `<base>/<plugin>/<rule>.md` (see `buildRulePromptUrl`).
+export const PROMPTS_RULES_BASE_URL = "https://www.react.doctor/prompts/rules";
+
 export const FETCH_TIMEOUT_MS = 10_000;
 
 export const GITHUB_VIEWER_PERMISSION_TIMEOUT_MS = 2_000;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,6 +65,7 @@ export * from "./resolve-lint-include-paths.js";
 export * from "./run-oxlint.js";
 export * from "./summarize-diagnostics.js";
 export * from "./validate-config-types.js";
+export * from "./utils/build-rule-prompt-url.js";
 export * from "./utils/dedupe-diagnostics.js";
 export * from "./utils/group-by.js";
 export * from "./utils/match-glob-pattern.js";

--- a/packages/core/src/utils/build-rule-prompt-url.ts
+++ b/packages/core/src/utils/build-rule-prompt-url.ts
@@ -1,0 +1,10 @@
+import { PROMPTS_RULES_BASE_URL } from "../constants.js";
+
+/**
+ * Canonical URL for a rule's reviewer-tested fix recipe, served at
+ * `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md`. The
+ * `/doctor` playbook fetches it on demand so each fix follows the
+ * canonical recipe instead of being improvised per diagnostic.
+ */
+export const buildRulePromptUrl = (plugin: string, rule: string): string =>
+  `${PROMPTS_RULES_BASE_URL}/${plugin}/${rule}.md`;

--- a/packages/core/tests/build-rule-prompt-url.test.ts
+++ b/packages/core/tests/build-rule-prompt-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildRulePromptUrl, PROMPTS_RULES_BASE_URL } from "@react-doctor/core";
+
+describe("buildRulePromptUrl", () => {
+  it("builds the canonical per-rule fix-recipe URL from plugin and rule", () => {
+    expect(buildRulePromptUrl("react-doctor", "no-array-index-key")).toBe(
+      `${PROMPTS_RULES_BASE_URL}/react-doctor/no-array-index-key.md`,
+    );
+  });
+
+  it("preserves non-react-doctor plugin namespaces", () => {
+    expect(buildRulePromptUrl("jsx-a11y", "alt-text")).toBe(
+      "https://www.react.doctor/prompts/rules/jsx-a11y/alt-text.md",
+    );
+  });
+});

--- a/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
@@ -24,19 +24,24 @@ const buildIssuesSummary = (input: CopyIssuesInput): string => {
   lines.push(`${input.diagnostics.length} issues found`);
   lines.push("");
 
-  const ruleGroups = groupBy([...input.diagnostics], (diagnostic) => diagnostic.rule);
+  const ruleGroups = groupBy(
+    [...input.diagnostics],
+    (diagnostic) => `${diagnostic.plugin}/${diagnostic.rule}`,
+  );
   const sortedRules = [...ruleGroups.entries()].sort(
     ([, diagnosticsA], [, diagnosticsB]) => diagnosticsB.length - diagnosticsA.length,
   );
 
   const visibleRules = sortedRules.slice(0, MAX_RULES_SHOWN);
-  for (const [rule, ruleDiagnostics] of visibleRules) {
+  for (const [ruleKey, ruleDiagnostics] of visibleRules) {
     const severity = ruleDiagnostics[0].severity;
     const uniqueFiles = [...new Set(ruleDiagnostics.map((diagnostic) => diagnostic.filePath))];
     const shownFiles = uniqueFiles.slice(0, MAX_FILES_PER_RULE);
     const remainingFileCount = uniqueFiles.length - shownFiles.length;
 
-    lines.push(`${severity === "error" ? "ERROR" : "WARN"} ${rule} (×${ruleDiagnostics.length})`);
+    lines.push(
+      `${severity === "error" ? "ERROR" : "WARN"} ${ruleKey} (×${ruleDiagnostics.length})`,
+    );
     lines.push(`  ${ruleDiagnostics[0].message}`);
     lines.push(`  ${formatFixRecipeLine(ruleDiagnostics[0])}`);
     for (const filePath of shownFiles) {

--- a/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
+++ b/packages/react-doctor/src/cli/utils/copy-issues-to-clipboard.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { groupBy } from "@react-doctor/core";
 import { cliLogger as logger } from "./cli-logger.js";
+import { formatFixRecipeLine } from "./render-diagnostics.js";
 import { prompts } from "./prompts.js";
 import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 
@@ -37,6 +38,7 @@ const buildIssuesSummary = (input: CopyIssuesInput): string => {
 
     lines.push(`${severity === "error" ? "ERROR" : "WARN"} ${rule} (×${ruleDiagnostics.length})`);
     lines.push(`  ${ruleDiagnostics[0].message}`);
+    lines.push(`  ${formatFixRecipeLine(ruleDiagnostics[0])}`);
     for (const filePath of shownFiles) {
       const firstSite = ruleDiagnostics.find(
         (diagnostic) => diagnostic.filePath === filePath && diagnostic.line > 0,
@@ -61,11 +63,12 @@ const buildIssuesSummary = (input: CopyIssuesInput): string => {
   lines.push("");
   lines.push("## How to fix");
   lines.push("1. Run `npx react-doctor@latest --verbose` to see full details");
-  lines.push("2. Fix errors first, then warnings. Start with high-count rules.");
-  lines.push("3. Read the code before acting. Treat findings as hypotheses, not commands.");
-  lines.push("4. Fix root causes, not symptoms. Don't suppress rules without evidence.");
-  lines.push("5. Run `npx react-doctor@latest --verbose --diff` after changes to verify.");
-  lines.push("6. Split unrelated fixes into separate PRs.");
+  lines.push("2. For each rule above, fetch & follow its canonical fix recipe URL before fixing.");
+  lines.push("3. Fix errors first, then warnings. Start with high-count rules.");
+  lines.push("4. Read the code before acting. Treat findings as hypotheses, not commands.");
+  lines.push("5. Fix root causes, not symptoms. Don't suppress rules without evidence.");
+  lines.push("6. Run `npx react-doctor@latest --verbose --diff` after changes to verify.");
+  lines.push("7. Split unrelated fixes into separate PRs.");
 
   return lines.join("\n");
 };

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -75,8 +75,7 @@ const grayLine = (text: string): string => highlighter.gray(text);
 // Directive (not a bare label) so the consuming agent treats the URL as
 // a step to perform — fetch the canonical, reviewer-tested recipe and
 // apply it — rather than as optional reference docs it can skip.
-const FETCH_FIX_RECIPE_LABEL =
-  "Fetch & follow the canonical fix recipe before fixing";
+const FETCH_FIX_RECIPE_LABEL = "Fetch & follow the canonical fix recipe before fixing";
 
 export const formatFixRecipeLine = (diagnostic: Diagnostic): string =>
   `${FETCH_FIX_RECIPE_LABEL}: ${buildRulePromptUrl(diagnostic.plugin, diagnostic.rule)}`;

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -2,6 +2,7 @@ import isUnicodeSupported from "is-unicode-supported";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import {
+  buildRulePromptUrl,
   groupBy,
   highlighter,
   MILLISECONDS_PER_SECOND,
@@ -151,6 +152,11 @@ const buildVerboseRuleGroupLines = (
   if (firstDiagnostic.help) {
     lines.push(grayLine(indentMultilineText(`→ ${firstDiagnostic.help}`, "      ")));
   }
+  lines.push(
+    grayLine(
+      `      Fix recipe: ${buildRulePromptUrl(firstDiagnostic.plugin, firstDiagnostic.rule)}`,
+    ),
+  );
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);
   for (const [filePath, sites] of fileSites) {
     if (sites.length > 0) {
@@ -236,6 +242,10 @@ export const formatRuleSummary = (ruleKey: string, ruleDiagnostics: Diagnostic[]
   if (firstDiagnostic.url) {
     sections.push("", `Docs: ${firstDiagnostic.url}`);
   }
+  sections.push(
+    "",
+    `Fix recipe: ${buildRulePromptUrl(firstDiagnostic.plugin, firstDiagnostic.rule)}`,
+  );
 
   sections.push("", "Files:");
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -78,7 +78,7 @@ const grayLine = (text: string): string => highlighter.gray(text);
 const FETCH_FIX_RECIPE_LABEL =
   "Fetch & follow the canonical fix recipe before fixing";
 
-const formatFixRecipeLine = (diagnostic: Diagnostic): string =>
+export const formatFixRecipeLine = (diagnostic: Diagnostic): string =>
   `${FETCH_FIX_RECIPE_LABEL}: ${buildRulePromptUrl(diagnostic.plugin, diagnostic.rule)}`;
 
 const buildCompactRuleGroupLine = (

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -72,6 +72,15 @@ const padRuleNameToColumn = (ruleName: string, columnWidth: number): string => {
 
 const grayLine = (text: string): string => highlighter.gray(text);
 
+// Directive (not a bare label) so the consuming agent treats the URL as
+// a step to perform — fetch the canonical, reviewer-tested recipe and
+// apply it — rather than as optional reference docs it can skip.
+const FETCH_FIX_RECIPE_LABEL =
+  "Fetch & follow the canonical fix recipe before fixing";
+
+const formatFixRecipeLine = (diagnostic: Diagnostic): string =>
+  `${FETCH_FIX_RECIPE_LABEL}: ${buildRulePromptUrl(diagnostic.plugin, diagnostic.rule)}`;
+
 const buildCompactRuleGroupLine = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
@@ -152,11 +161,7 @@ const buildVerboseRuleGroupLines = (
   if (firstDiagnostic.help) {
     lines.push(grayLine(indentMultilineText(`→ ${firstDiagnostic.help}`, "      ")));
   }
-  lines.push(
-    grayLine(
-      `      Fix recipe: ${buildRulePromptUrl(firstDiagnostic.plugin, firstDiagnostic.rule)}`,
-    ),
-  );
+  lines.push(grayLine(`      ${formatFixRecipeLine(firstDiagnostic)}`));
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);
   for (const [filePath, sites] of fileSites) {
     if (sites.length > 0) {
@@ -242,10 +247,7 @@ export const formatRuleSummary = (ruleKey: string, ruleDiagnostics: Diagnostic[]
   if (firstDiagnostic.url) {
     sections.push("", `Docs: ${firstDiagnostic.url}`);
   }
-  sections.push(
-    "",
-    `Fix recipe: ${buildRulePromptUrl(firstDiagnostic.plugin, firstDiagnostic.rule)}`,
-  );
+  sections.push("", formatFixRecipeLine(firstDiagnostic));
 
   sections.push("", "Files:");
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -133,6 +133,7 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
 
     const longestProjectNameLength = Math.max(...entries.map((entry) => entry.projectName.length));
 
+    yield* Console.log("");
     for (const entry of entries) {
       yield* Console.log(buildSummaryLine(entry, longestProjectNameLength));
     }

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -1,6 +1,6 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import { highlighter, SHARE_BASE_URL } from "@react-doctor/core";
+import { highlighter, PROMPTS_RULES_BASE_URL, SHARE_BASE_URL } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { collectAffectedFiles } from "./render-diagnostics.js";
 import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
@@ -44,7 +44,12 @@ const printCountsSummaryLine = (
     if (!isVerbose && totalIssueCount > 0) {
       yield* Console.log(
         highlighter.dim(
-          `  Run ${highlighter.info("npx react-doctor@latest --verbose")} to see details`,
+          `  Run ${highlighter.info("npx react-doctor@latest --verbose")} to see each issue and its fix recipe`,
+        ),
+      );
+      yield* Console.log(
+        highlighter.dim(
+          `  Every rule has a canonical fix recipe — fetch & follow ${highlighter.info(`${PROMPTS_RULES_BASE_URL}/<plugin>/<rule>.md`)} before fixing`,
         ),
       );
     }

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -1,6 +1,6 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import { highlighter, PROMPTS_RULES_BASE_URL, SHARE_BASE_URL } from "@react-doctor/core";
+import { buildRulePromptUrl, highlighter, SHARE_BASE_URL } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { collectAffectedFiles } from "./render-diagnostics.js";
 import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
@@ -42,14 +42,16 @@ const printCountsSummaryLine = (
     );
     yield* Console.log(`  ${issueText}`);
     if (!isVerbose && totalIssueCount > 0) {
+      const exampleDiagnostic =
+        diagnostics.find((diagnostic) => diagnostic.severity === "error") ?? diagnostics[0];
       yield* Console.log(
         highlighter.dim(
-          `  Run ${highlighter.info("npx react-doctor@latest --verbose")} to see each issue and its fix recipe`,
+          `  Run ${highlighter.info("npx react-doctor@latest --verbose")} to list every issue with its fix-recipe URL`,
         ),
       );
       yield* Console.log(
         highlighter.dim(
-          `  Every rule has a canonical fix recipe — fetch & follow ${highlighter.info(`${PROMPTS_RULES_BASE_URL}/<plugin>/<rule>.md`)} before fixing`,
+          `  Each rule links a canonical fix recipe to fetch & follow before fixing, e.g. ${highlighter.info(buildRulePromptUrl(exampleDiagnostic.plugin, exampleDiagnostic.rule))}`,
         ),
       );
     }


### PR DESCRIPTION
## Summary

- In `--verbose` output, every error/warning rule group now prints a `Fix recipe:` line pointing at the canonical per-rule prompt: `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md`.
- The same line is written into the verbose diagnostics dump (`formatRuleSummary`), so the recipe is available whether an agent reads stdout or the dump files.
- This lets the `/doctor` playbook fetch each rule's reviewer-tested recipe on demand and apply the canonical fix instead of improvising per diagnostic.

### Implementation

- `packages/core/src/constants.ts` — new `PROMPTS_RULES_BASE_URL` constant.
- `packages/core/src/utils/build-rule-prompt-url.ts` — new one-utility-per-file helper (`buildRulePromptUrl(plugin, rule)`), exported from the core index.
- `packages/react-doctor/src/cli/utils/render-diagnostics.ts` — emit the `Fix recipe:` line in `buildVerboseRuleGroupLines` and `formatRuleSummary`.
- The URL is emitted for all rule groups regardless of plugin; the playbook fetches on demand, so a rule without a published recipe simply 404s and the agent falls back — matching the documented `<plugin>/<rule>.md` contract.

The default (non-verbose) summary path is unchanged.

## Test plan

- [x] `pnpm --filter react-doctor typecheck`
- [x] New unit test: `packages/core/tests/build-rule-prompt-url.test.ts` (react-doctor + non-react-doctor namespace)
- [x] Format check + lint on changed files (one pre-existing unused-param warning on `printDiagnostics` is unrelated)
- [x] Manual: `node packages/react-doctor/dist/cli.js <fixture> --verbose` shows a `Fix recipe:` line per rule group

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and a small core URL helper only; no scan logic, auth, or data handling changes.
> 
> **Overview**
> Adds a shared **`buildRulePromptUrl`** helper and **`PROMPTS_RULES_BASE_URL`** so every diagnostic can point at a canonical per-rule fix recipe at `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md`.
> 
> **Verbose CLI output**, rule summaries written to the diagnostics dump, and the **clipboard issues summary** now emit a directive line telling consumers to fetch and follow that recipe before fixing (not just optional docs). The default summary’s “run verbose” hint is updated to mention fix-recipe URLs and shows an example link.
> 
> Multi-project summary gets a small formatting tweak (extra blank line before per-project rows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7499a15e46ceb6db86bb3cb294486c983d67dca4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->