### PR TITLE
fix(react-doctor): unref stdin so an inherited pipe/socket can't keep the CLI alive

### DIFF
--- a/.changeset/unref-stdin.md
+++ b/.changeset/unref-stdin.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Unref `process.stdin` at CLI startup so an inherited stdin pipe/socket can no longer keep the event loop alive after a scan completes. Previously `react-doctor --json` (and other one-shot runs) could finish the scan and flush the full report yet never exit when launched by a parent that holds the stdin write-end open (eval runners, CI harnesses, editor integrations) — Node kept the loop alive on the idle `Socket fd=0`. Interactive prompts are unaffected because `prompts`' `readline` interface re-refs stdin on demand.

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -6,10 +6,15 @@ import { exitGracefully } from "./utils/exit-gracefully.js";
 import { handleError } from "./utils/handle-error.js";
 import { isJsonModeActive, writeJsonErrorReport } from "./utils/json-mode.js";
 import { stripUnknownCliFlags } from "./utils/strip-unknown-cli-flags.js";
+import { unrefStdin } from "./utils/unref-stdin.js";
 import { VERSION } from "./utils/version.js";
 
 process.on("SIGINT", exitGracefully);
 process.on("SIGTERM", exitGracefully);
+
+// Stop an inherited stdin pipe/socket from keeping the one-shot CLI
+// alive after the scan completes (see `unref-stdin.ts`).
+unrefStdin();
 
 const program = new Command()
   .name("react-doctor")

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -11,9 +11,6 @@ import { VERSION } from "./utils/version.js";
 
 process.on("SIGINT", exitGracefully);
 process.on("SIGTERM", exitGracefully);
-
-// Stop an inherited stdin pipe/socket from keeping the one-shot CLI
-// alive after the scan completes (see `unref-stdin.ts`).
 unrefStdin();
 
 const program = new Command()

--- a/packages/react-doctor/src/cli/utils/unref-stdin.ts
+++ b/packages/react-doctor/src/cli/utils/unref-stdin.ts
@@ -1,0 +1,24 @@
+// HACK: react-doctor is a one-shot CLI, but Node keeps the event loop
+// alive for as long as `process.stdin` (fd 0) is an open pipe or
+// socket — even though the only thing that ever reads stdin is an
+// interactive prompt. When the CLI is spawned by a parent that holds
+// the stdin write-end open (eval runners, CI harnesses, editor
+// integrations), the scan finishes and the `--json` report flushes,
+// yet the process never exits: the inherited `Socket fd=0` refs the
+// loop. Some Node versions / stdin fd types ref the socket merely on
+// access (the bundled `import process from "node:process"` facade
+// materializes the lazy `process.stdin` getter), so the hang is not
+// always reproducible, but unref-ing up front makes an idle stdin
+// incapable of holding the process open in every case.
+//
+// Interactive prompts are unaffected: `prompts` builds a
+// `readline.createInterface({ input: process.stdin })`, whose
+// `resume()` (and `setRawMode(true)` on a TTY) re-refs stdin for the
+// lifetime of the prompt and releases it on close.
+//
+// File / `/dev/null` stdin resolves to an `fs.ReadStream` that has no
+// `unref` (and never holds the loop open anyway), hence the optional
+// call.
+export const unrefStdin = (): void => {
+  process.stdin.unref?.();
+};

--- a/packages/react-doctor/tests/helpers/stub-process-stdin-property.ts
+++ b/packages/react-doctor/tests/helpers/stub-process-stdin-property.ts
@@ -1,0 +1,20 @@
+/**
+ * Test helper that overrides a single `process.stdin` property (e.g.
+ * `isTTY`, `unref`) for the duration of one test and returns a restore
+ * function the caller should run in `afterEach`. `process.stdin`
+ * exposes these as non-writable getters / inherited methods, so the
+ * override goes through `Object.defineProperty`; restore reinstates the
+ * original own-descriptor, or deletes the own property when stdin had
+ * none (the value was inherited from the prototype).
+ */
+export const stubProcessStdinProperty = (property: string, value: unknown): (() => void) => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process.stdin, property);
+  Object.defineProperty(process.stdin, property, { value, configurable: true });
+  return () => {
+    if (originalDescriptor) {
+      Object.defineProperty(process.stdin, property, originalDescriptor);
+    } else {
+      delete (process.stdin as unknown as Record<string, unknown>)[property];
+    }
+  };
+};

--- a/packages/react-doctor/tests/should-skip-prompts.test.ts
+++ b/packages/react-doctor/tests/should-skip-prompts.test.ts
@@ -5,24 +5,7 @@ import {
 } from "../src/cli/utils/is-ci-environment.js";
 import { NON_INTERACTIVE_ENVIRONMENT_VARIABLES } from "../src/cli/utils/is-non-interactive-environment.js";
 import { shouldSkipPrompts } from "../src/cli/utils/should-skip-prompts.js";
-
-interface ProcessStdinTtyHandle {
-  restore: () => void;
-}
-
-const stubProcessStdinIsTty = (value: boolean): ProcessStdinTtyHandle => {
-  const originalDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
-  Object.defineProperty(process.stdin, "isTTY", { value, configurable: true });
-  return {
-    restore: () => {
-      if (originalDescriptor) {
-        Object.defineProperty(process.stdin, "isTTY", originalDescriptor);
-      } else {
-        delete (process.stdin as unknown as { isTTY?: boolean }).isTTY;
-      }
-    },
-  };
-};
+import { stubProcessStdinProperty } from "./helpers/stub-process-stdin-property.js";
 
 // The env vars `isNonInteractiveEnvironment()` consults. Cleared at the
 // start of each test so the helper's result depends only on what the
@@ -35,7 +18,7 @@ const NON_INTERACTIVE_ENV_VARS = [
 
 describe("shouldSkipPrompts", () => {
   let savedEnv: Record<string, string | undefined>;
-  let ttyHandle: ProcessStdinTtyHandle;
+  let restoreStdinIsTty: () => void;
 
   beforeEach(() => {
     savedEnv = {};
@@ -43,7 +26,7 @@ describe("shouldSkipPrompts", () => {
       savedEnv[envVarName] = process.env[envVarName];
       delete process.env[envVarName];
     }
-    ttyHandle = stubProcessStdinIsTty(true);
+    restoreStdinIsTty = stubProcessStdinProperty("isTTY", true);
   });
 
   afterEach(() => {
@@ -55,7 +38,7 @@ describe("shouldSkipPrompts", () => {
         process.env[envVarName] = previousValue;
       }
     }
-    ttyHandle.restore();
+    restoreStdinIsTty();
   });
 
   it("returns false with an interactive TTY and no other signals", () => {
@@ -75,8 +58,8 @@ describe("shouldSkipPrompts", () => {
   });
 
   it("returns true when stdin is not a TTY", () => {
-    ttyHandle.restore();
-    ttyHandle = stubProcessStdinIsTty(false);
+    restoreStdinIsTty();
+    restoreStdinIsTty = stubProcessStdinProperty("isTTY", false);
     expect(shouldSkipPrompts()).toBe(true);
   });
 

--- a/packages/react-doctor/tests/unref-stdin.test.ts
+++ b/packages/react-doctor/tests/unref-stdin.test.ts
@@ -5,7 +5,7 @@ interface StdinUnrefHandle {
   restore: () => void;
 }
 
-const stubStdinUnref = (unref: unknown): StdinUnrefHandle => {
+const stubStdinUnref = (unref: (() => void) | undefined): StdinUnrefHandle => {
   const originalDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "unref");
   Object.defineProperty(process.stdin, "unref", { value: unref, configurable: true });
   return {

--- a/packages/react-doctor/tests/unref-stdin.test.ts
+++ b/packages/react-doctor/tests/unref-stdin.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { unrefStdin } from "../src/cli/utils/unref-stdin.js";
+
+interface StdinUnrefHandle {
+  restore: () => void;
+}
+
+const stubStdinUnref = (unref: unknown): StdinUnrefHandle => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "unref");
+  Object.defineProperty(process.stdin, "unref", { value: unref, configurable: true });
+  return {
+    restore: () => {
+      if (originalDescriptor) {
+        Object.defineProperty(process.stdin, "unref", originalDescriptor);
+      } else {
+        delete (process.stdin as unknown as { unref?: unknown }).unref;
+      }
+    },
+  };
+};
+
+describe("unrefStdin", () => {
+  let handle: StdinUnrefHandle | undefined;
+
+  afterEach(() => {
+    handle?.restore();
+    handle = undefined;
+  });
+
+  it("unrefs stdin so an inherited pipe/socket can't hold the event loop open", () => {
+    const unref = vi.fn();
+    handle = stubStdinUnref(unref);
+    unrefStdin();
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+
+  // File / `/dev/null` stdin resolves to an `fs.ReadStream` with no `unref`.
+  it("is a no-op when stdin has no unref (file / /dev/null)", () => {
+    handle = stubStdinUnref(undefined);
+    expect(() => unrefStdin()).not.toThrow();
+  });
+});

--- a/packages/react-doctor/tests/unref-stdin.test.ts
+++ b/packages/react-doctor/tests/unref-stdin.test.ts
@@ -1,42 +1,25 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { unrefStdin } from "../src/cli/utils/unref-stdin.js";
-
-interface StdinUnrefHandle {
-  restore: () => void;
-}
-
-const stubStdinUnref = (unref: (() => void) | undefined): StdinUnrefHandle => {
-  const originalDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "unref");
-  Object.defineProperty(process.stdin, "unref", { value: unref, configurable: true });
-  return {
-    restore: () => {
-      if (originalDescriptor) {
-        Object.defineProperty(process.stdin, "unref", originalDescriptor);
-      } else {
-        delete (process.stdin as unknown as { unref?: unknown }).unref;
-      }
-    },
-  };
-};
+import { stubProcessStdinProperty } from "./helpers/stub-process-stdin-property.js";
 
 describe("unrefStdin", () => {
-  let handle: StdinUnrefHandle | undefined;
+  let restoreStdinUnref: (() => void) | undefined;
 
   afterEach(() => {
-    handle?.restore();
-    handle = undefined;
+    restoreStdinUnref?.();
+    restoreStdinUnref = undefined;
   });
 
   it("unrefs stdin so an inherited pipe/socket can't hold the event loop open", () => {
     const unref = vi.fn();
-    handle = stubStdinUnref(unref);
+    restoreStdinUnref = stubProcessStdinProperty("unref", unref);
     unrefStdin();
     expect(unref).toHaveBeenCalledTimes(1);
   });
 
   // File / `/dev/null` stdin resolves to an `fs.ReadStream` with no `unref`.
   it("is a no-op when stdin has no unref (file / /dev/null)", () => {
-    handle = stubStdinUnref(undefined);
+    restoreStdinUnref = stubProcessStdinProperty("unref", undefined);
     expect(() => unrefStdin()).not.toThrow();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`react-doctor --json` finishes the scan and flushes a complete report in ~1s, but the process never exits when launched by a parent that keeps the stdin write-end open (eval runners, CI harnesses, editor integrations). Node keeps the event loop alive on the idle inherited `Socket fd=0` (stdin). This is a pre-existing issue (reproduces on `main` under node 24 and 25), not a branch regression, and it hangs the eval's local runner because each child waits for `exit`.

## Root cause

`react-doctor` is a one-shot CLI that only ever *reads* stdin for interactive prompts. But Node keeps the event loop alive while `process.stdin` (fd 0) is an open pipe/socket. The bundle's `import process from "node:process"` (pulled in transitively) makes the Node ESM facade enumerate the lazy `process.stdin` getter, materializing the socket; on some node versions / stdin fd types that ref keeps the loop open even though nothing is reading. So after the scan completes and the report flushes, the inherited `Socket fd=0` holds the process open indefinitely.

## Fix

Call `process.stdin.unref()` once at CLI startup (`packages/react-doctor/src/cli/index.ts`, alongside the existing `SIGINT`/`SIGTERM` and stdout-`EPIPE` lifecycle hooks), via a small documented `unrefStdin()` util. An idle stdin can no longer hold the process open in any environment.

Interactive prompts are unaffected: `prompts` builds a `readline.createInterface({ input: process.stdin })`, whose `resume()` (plus `setRawMode(true)` on a TTY) re-refs stdin for the lifetime of the prompt and releases it on close. File / `/dev/null` stdin resolves to an `fs.ReadStream` that has no `unref` (and never holds the loop open anyway), hence the optional call (`process.stdin.unref?.()`).

## Verification

- Reproduced the underlying mechanism deterministically by spawning the CLI from a parent that holds an inherited stdin socket open. Demonstrated that an actively-ref'd stdin hangs for 12s without `unref` but exits in ~33ms with `unref`.
- Confirmed `react-doctor --json` still emits valid JSON (283 diagnostics on the `basic-react` fixture) and now exits cleanly under node 22, 24, and 25.
- Verified interactive prompts still keep the loop alive after the startup `unref` (`readline` re-refs stdin; `beforeExit` does not fire while a prompt is open).
- Added a unit test (`tests/unref-stdin.test.ts`) covering both the socket/pipe path (calls `unref`) and the file / `/dev/null` path (no-op when `unref` is absent).
- `pnpm smoke:json-report`, package typecheck, lint, and format check all pass. The full `react-doctor` test suite passes except for one pre-existing, environment-dependent agent-guidance test (`cli-and-output.test.ts`) that fails identically on clean `main` because the cloud-agent shell sets `CURSOR_AGENT`; it is unrelated to this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dab6bf5b-4783-4cec-9da3-44dbda8c1862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dab6bf5b-4783-4cec-9da3-44dbda8c1862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

