### PR TITLE
fix(oxlint-plugin): treat fbtee translation tags as transparent in rn-no-raw-text

### DIFF
--- a/.changeset/rn-no-raw-text-fbtee.md
+++ b/.changeset/rn-no-raw-text-fbtee.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Fix a `rn-no-raw-text` false positive on fbtee translation tags. fbtee's `<fbt>` / `<fbs>` (and namespaced children like `<fbt:param>`) are compile-time translation tags that disappear at build time, so text inside `<Text><fbt>…</fbt></Text>` is really rendered inside `<Text>` and is safe on React Native. The rule now treats `fbt` / `fbs` as transparent wrappers when every ancestor up to a text-handling component is also transparent, while still reporting raw text when an `<fbt>` is used outside a `<Text>` boundary. See #581.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
@@ -27,6 +27,10 @@ export const REACT_NATIVE_TEXT_COMPONENT_KEYWORDS = new Set([
   "Body",
 ]);
 
+// fbtee's <fbt> / <fbs> compile-time translation tags should be transparent to
+// React Native text boundaries. Ref: https://github.com/millionco/react-doctor/issues/581
+export const REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS = new Set(["fbt", "fbs"]);
+
 // HACK: Maps (not plain objects) so that an unusual `import { constructor }
 // from "react-native"` (or any other Object.prototype name) doesn't fall
 // through to `Object.prototype.constructor` and falsely report. Symmetric

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
@@ -27,8 +27,20 @@ export const REACT_NATIVE_TEXT_COMPONENT_KEYWORDS = new Set([
   "Body",
 ]);
 
-// fbtee's <fbt> / <fbs> compile-time translation tags should be transparent to
-// React Native text boundaries. Ref: https://github.com/millionco/react-doctor/issues/581
+// Compile-time translation wrappers — fbtee's <fbt> / <fbs> and their
+// namespaced children (<fbt:param>, <fbt:plural>, <fbt:name>, …) — are NOT
+// React Native layout components. A Babel/SWC transform erases them at build
+// time, so their text really renders inside the surrounding <Text>. The
+// rn-no-raw-text rule treats them as *transparent*: raw text inside them is
+// safe only when an enclosing element is a real text component (so a bare
+// <fbt> outside <Text> is still reported).
+//
+// To extend the same behavior to another compile-time / i18n wrapper, add its
+// tag name here — namespaced children are matched by their namespace, so a
+// single entry (e.g. "fbt") covers every "<fbt:*>" child.
+//
+// Ref: https://github.com/millionco/react-doctor/issues/581
+//      https://facebook.github.io/fbt/docs/api_intro
 export const REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS = new Set(["fbt", "fbs"]);
 
 // HACK: Maps (not plain objects) so that an unusual `import { constructor }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -55,7 +55,9 @@ const isTextHandlingComponent = (elementName: string): boolean => {
   return [...REACT_NATIVE_TEXT_COMPONENT_KEYWORDS].some((keyword) => elementName.includes(keyword));
 };
 
-const isTransparentTextWrapper = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
+const isTransparentTextWrapper = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): boolean => {
   const elementName = resolveJsxElementName(openingElement);
   if (elementName && REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(elementName)) return true;
   if (isNodeOfType(openingElement.name, "JSXNamespacedName")) {
@@ -112,10 +114,7 @@ export const rnNoRawText = defineRule<Rule>({
         // narrower scope.
         if (isInsidePlatformOsWebBranch(node)) return;
 
-        if (
-          isTransparentTextWrapper(node.openingElement) &&
-          isInsideTextHandlingComponent(node)
-        ) {
+        if (isTransparentTextWrapper(node.openingElement) && isInsideTextHandlingComponent(node)) {
           return;
         }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -2,6 +2,7 @@ import {
   RAW_TEXT_PREVIEW_MAX_CHARS,
   REACT_NATIVE_TEXT_COMPONENTS,
   REACT_NATIVE_TEXT_COMPONENT_KEYWORDS,
+  REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS,
 } from "../../constants/react-native.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { hasDirective } from "../../utils/has-directive.js";
@@ -54,6 +55,30 @@ const isTextHandlingComponent = (elementName: string): boolean => {
   return [...REACT_NATIVE_TEXT_COMPONENT_KEYWORDS].some((keyword) => elementName.includes(keyword));
 };
 
+const isTransparentTextWrapper = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
+  const elementName = resolveJsxElementName(openingElement);
+  if (elementName && REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(elementName)) return true;
+  if (isNodeOfType(openingElement.name, "JSXNamespacedName")) {
+    return REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(openingElement.name.namespace.name);
+  }
+  return false;
+};
+
+const isInsideTextHandlingComponent = (node: EsTreeNodeOfType<"JSXElement">): boolean => {
+  let parentNode = node.parent;
+  while (parentNode) {
+    if (!isNodeOfType(parentNode, "JSXElement")) {
+      parentNode = parentNode.parent;
+      continue;
+    }
+    const parentElementName = resolveJsxElementName(parentNode.openingElement);
+    if (parentElementName && isTextHandlingComponent(parentElementName)) return true;
+    if (!isTransparentTextWrapper(parentNode.openingElement)) return false;
+    parentNode = parentNode.parent;
+  }
+  return false;
+};
+
 export const rnNoRawText = defineRule<Rule>({
   id: "rn-no-raw-text",
   requires: ["react-native"],
@@ -86,6 +111,13 @@ export const rnNoRawText = defineRule<Rule>({
         // package-level boundary handled by the wrapper — same rationale,
         // narrower scope.
         if (isInsidePlatformOsWebBranch(node)) return;
+
+        if (
+          isTransparentTextWrapper(node.openingElement) &&
+          isInsideTextHandlingComponent(node)
+        ) {
+          return;
+        }
 
         for (const child of node.children ?? []) {
           if (!isRawTextContent(child)) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -50,22 +50,30 @@ const getRawTextDescription = (child: EsTreeNode): string => {
   return "text content";
 };
 
+// Resolves the tag name used for the text-boundary checks. Namespaced JSX tags
+// (fbtee's <fbt:param>, <fbt:plural>, …) resolve to their namespace (`fbt`) so
+// they inherit the transparency of the <fbt> construct they belong to.
+const resolveTextBoundaryName = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): string | null => {
+  if (isNodeOfType(openingElement.name, "JSXNamespacedName")) {
+    return openingElement.name.namespace.name;
+  }
+  return resolveJsxElementName(openingElement);
+};
+
 const isTextHandlingComponent = (elementName: string): boolean => {
   if (REACT_NATIVE_TEXT_COMPONENTS.has(elementName)) return true;
   return [...REACT_NATIVE_TEXT_COMPONENT_KEYWORDS].some((keyword) => elementName.includes(keyword));
 };
 
-const isTransparentTextWrapper = (
-  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
-): boolean => {
-  const elementName = resolveJsxElementName(openingElement);
-  if (elementName && REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(elementName)) return true;
-  if (isNodeOfType(openingElement.name, "JSXNamespacedName")) {
-    return REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(openingElement.name.namespace.name);
-  }
-  return false;
-};
+const isTransparentTextWrapper = (elementName: string | null): boolean =>
+  elementName !== null && REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(elementName);
 
+// Walks ancestors to a real text component, stepping through transparent
+// wrappers. Returns false as soon as a non-transparent, non-text element
+// breaks the chain — so the text boundary is only honored when every link
+// up to the <Text> is itself transparent.
 const isInsideTextHandlingComponent = (node: EsTreeNodeOfType<"JSXElement">): boolean => {
   let parentNode = node.parent;
   while (parentNode) {
@@ -73,9 +81,9 @@ const isInsideTextHandlingComponent = (node: EsTreeNodeOfType<"JSXElement">): bo
       parentNode = parentNode.parent;
       continue;
     }
-    const parentElementName = resolveJsxElementName(parentNode.openingElement);
-    if (parentElementName && isTextHandlingComponent(parentElementName)) return true;
-    if (!isTransparentTextWrapper(parentNode.openingElement)) return false;
+    const parentName = resolveTextBoundaryName(parentNode.openingElement);
+    if (parentName && isTextHandlingComponent(parentName)) return true;
+    if (!isTransparentTextWrapper(parentName)) return false;
     parentNode = parentNode.parent;
   }
   return false;
@@ -104,7 +112,7 @@ export const rnNoRawText = defineRule<Rule>({
       JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
         if (isDomComponentFile) return;
 
-        const elementName = resolveJsxElementName(node.openingElement);
+        const elementName = resolveTextBoundaryName(node.openingElement);
         if (elementName && isTextHandlingComponent(elementName)) return;
 
         // `Platform.OS === "web"` branches deliberately render web markup
@@ -114,7 +122,7 @@ export const rnNoRawText = defineRule<Rule>({
         // narrower scope.
         if (isInsidePlatformOsWebBranch(node)) return;
 
-        if (isTransparentTextWrapper(node.openingElement) && isInsideTextHandlingComponent(node)) {
+        if (isTransparentTextWrapper(elementName) && isInsideTextHandlingComponent(node)) {
           return;
         }
 

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -6,6 +6,11 @@
  *   #93 + #100 — `textComponents` config must allowlist user-defined RN
  *                text wrappers (custom Typography component, member-
  *                expression names like `NativeTabs.Trigger.Label`)
+ *   #183     — `rawTextWrapperComponents` suppresses string-only wrapper
+ *              children
+ *   #581     — fbtee `<fbt>` / `<fbs>` translation tags stay transparent to
+ *              the `<Text>` boundary (so raw text inside them isn't flagged)
+ *   #76      — `@expo/vector-icons` is not treated as a legacy Expo package
  *   #94      — `MotionConfig reducedMotion="user"` must satisfy the
  *              reduced-motion accessibility check (so the rule doesn't
  *              false-positive when handling is delegated to the provider)

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -242,6 +242,72 @@ describe("issue #183: rawTextWrapperComponents suppresses string-only wrapper ch
   });
 });
 
+describe("issue #581: fbtee tags stay transparent inside <Text>", () => {
+  const buildFbteeProject = (projectName: string, appSource: string) =>
+    setupReactProject(tempRoot, projectName, {
+      packageJsonExtras: { dependencies: { react: "^19.0.0", "react-native": "^0.79.0" } },
+      files: { "src/App.tsx": appSource },
+    });
+
+  const getRnNoRawTextDiagnostics = async (projectDirectory: string) => {
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDirectory,
+      project: buildTestProject({
+        rootDirectory: projectDirectory,
+        framework: "react-native",
+      }),
+    });
+    return diagnostics.filter((diagnostic) => diagnostic.rule === "rn-no-raw-text");
+  };
+
+  it("does not report raw text inside <Text><fbt>...</fbt></Text>", async () => {
+    const projectDirectory = buildFbteeProject(
+      "issue-581-fbt-inside-text",
+      `import { Text } from "react-native";
+
+export const App = () => (
+  <Text>
+    <fbt desc="Greeting">Welcome</fbt>
+  </Text>
+);
+`,
+    );
+
+    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("does not report raw text inside namespaced fbtee tags within <Text>", async () => {
+    const projectDirectory = buildFbteeProject(
+      "issue-581-fbt-param-inside-text",
+      `import { Text } from "react-native";
+
+export const App = () => (
+  <Text>
+    <fbt desc="Greeting">
+      <fbt:param name="word">Welcome</fbt:param>
+    </fbt>
+  </Text>
+);
+`,
+    );
+
+    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("still reports raw text when <fbt> is outside <Text>", async () => {
+    const projectDirectory = buildFbteeProject(
+      "issue-581-fbt-outside-text",
+      `export const App = () => <fbt desc="Greeting">Welcome</fbt>;
+`,
+    );
+
+    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
+    expect(diagnostics).toHaveLength(1);
+  });
+});
+
 describe("issue #76: @expo/vector-icons is not treated as a legacy Expo package", () => {
   it("does not flag @expo/vector-icons while still flagging deprecated Expo packages", async () => {
     const projectDir = setupReactProject(tempRoot, "issue-76-vector-icons", {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Catches a `rn-no-raw-text` false positive on fbtee translation tags (#581).

fbtee's `<fbt>` / `<fbs>` (and namespaced children like `<fbt:param>`) are compile-time translation constructs — a Babel/SWC transform erases them at build time, so text inside `<Text><fbt>…</fbt></Text>` really renders inside `<Text>` and is safe on React Native. The rule was treating `<fbt>` like a normal element, so it flagged its child text as "outside a `<Text>`". This pattern is used by the official fbtee Expo template (and was independently hit in production).

Before:

```tsx
import { Text } from "react-native";

// ✗ react-doctor/rn-no-raw-text: Raw "Welcome" outside a <Text> component
<Text>
  <fbt desc="Greeting">Welcome</fbt>
</Text>
```

After:

```tsx
import { Text } from "react-native";

// ✓ no diagnostic — <fbt> is transparent inside <Text>
<Text>
  <fbt desc="Greeting">Welcome</fbt>
</Text>

// ✗ still flagged — <fbt> is NOT a <Text> substitute on its own
<fbt desc="Greeting">Welcome</fbt>
```

## What changed

- Added a `REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS` set (`fbt`, `fbs`) — the single, documented extension point for compile-time / i18n wrappers.
- `rn-no-raw-text` now treats a transparent wrapper's raw text as safe **only when every ancestor up to a real text component is also transparent**, so a bare `<fbt>` outside `<Text>` is still reported.
- Namespaced children (`<fbt:param>`, `<fbt:plural>`, …) inherit transparency via their namespace, so one entry covers every `<fbt:*>` child.
- Consolidated tag-name resolution into a single `resolveTextBoundaryName` helper and gave `isTransparentTextWrapper` the same `string`-name signature as `isTextHandlingComponent`, removing the dual name-resolution path.
- Added regression coverage for #581 (fbt inside `<Text>`, namespaced fbt inside `<Text>`, and fbt outside `<Text>`).

## Eval results

RDE not run: this is a targeted false-positive fix on an existing rule (not a new broad/heuristic rule). Behavior is pinned by end-to-end oxlint regression tests on real React Native fixtures.

## Test plan

- `pnpm exec vp test run rn-and-motion` (in `packages/react-doctor`) — 21 passed, including the three #581 cases
- `pnpm --filter oxlint-plugin-react-doctor typecheck` — pass
- `pnpm lint` — pass (only pre-existing fixture warnings)
- `pnpm format` — pass

Note: a sandbox-only oxc-parser mismatch makes some unrelated `react-builtins` suites fail locally; they pass on every CI runner.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://million-js.slack.com/archives/C0A209N9L3D/p1780088965402029?thread_ts=1780088965.402029&cid=C0A209N9L3D)

<div><a href="https://cursor.com/agents/bc-4881c48f-6e98-5b94-8234-2311e11950d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4881c48f-6e98-5b94-8234-2311e11950d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

