### PR TITLE
fix(cli): re-unref stdin after prompts so the CLI doesn't hang

### DIFF
--- a/.changeset/fix-cli-stdin-hang.md
+++ b/.changeset/fix-cli-stdin-hang.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix the CLI hanging after the post-scan prompts. Interactive prompts re-ref stdin via `readline` and never release it on close, undoing the startup `unrefStdin()` and holding the one-shot CLI's event loop open. The shared `prompts` wrapper now re-unrefs stdin once each prompt settles.

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
 import Conf from "conf";
-import basePrompts from "prompts";
+import { prompts } from "./prompts.js";
 import { findNearestPackageDirectory, hasDoctorScript } from "./install-doctor-script.js";
 import { isCiOrCodingAgentEnvironment, isCodingAgentEnvironment } from "./is-ci-environment.js";
 import { SETUP_PROMPT_DELAY_MS } from "./constants.js";
@@ -155,7 +155,7 @@ const defaultWait: SetupPromptWait = (milliseconds) =>
   });
 
 const defaultSelect: SetupPromptSelect = async (message) => {
-  const { setupReactDoctorChoice } = await basePrompts<"setupReactDoctorChoice">(
+  const { setupReactDoctorChoice } = await prompts<"setupReactDoctorChoice">(
     {
       type: "select",
       name: "setupReactDoctorChoice",

--- a/packages/react-doctor/src/cli/utils/prompts.ts
+++ b/packages/react-doctor/src/cli/utils/prompts.ts
@@ -69,10 +69,7 @@ export const prompts = <T extends string = string>(
 ): Promise<Answers<T>> => {
   patchMultiselectToggleAll();
   patchMultiselectSubmit();
-  // `prompts` builds a `readline.createInterface({ input: process.stdin })`,
-  // which `resume()`s stdin and re-refs fd 0 — undoing the startup
-  // `unrefStdin()`. `readline.close()` pauses stdin but never unrefs it, so a
-  // referenced idle stdin would hold this one-shot CLI's event loop open and
-  // hang after the last prompt resolves. Re-unref once the prompt settles.
+  // HACK: each prompt re-refs stdin and never unrefs it on close, so re-unref
+  // once it settles or the one-shot CLI hangs. See `unref-stdin.ts` for why.
   return basePrompts(questions, { onCancel: options.onCancel ?? onCancel }).finally(unrefStdin);
 };

--- a/packages/react-doctor/src/cli/utils/prompts.ts
+++ b/packages/react-doctor/src/cli/utils/prompts.ts
@@ -4,6 +4,7 @@ import type { PromptMultiselectContext } from "@react-doctor/core";
 import { cliLogger as logger } from "./cli-logger.js";
 import { shouldAutoSelectCurrentChoice } from "./should-auto-select-current-choice.js";
 import { shouldSelectAllChoices } from "./should-select-all-choices.js";
+import { unrefStdin } from "./unref-stdin.js";
 
 const require = createRequire(import.meta.url);
 const PROMPTS_MULTISELECT_MODULE_PATH = "prompts/lib/elements/multiselect";
@@ -68,5 +69,10 @@ export const prompts = <T extends string = string>(
 ): Promise<Answers<T>> => {
   patchMultiselectToggleAll();
   patchMultiselectSubmit();
-  return basePrompts(questions, { onCancel: options.onCancel ?? onCancel });
+  // `prompts` builds a `readline.createInterface({ input: process.stdin })`,
+  // which `resume()`s stdin and re-refs fd 0 — undoing the startup
+  // `unrefStdin()`. `readline.close()` pauses stdin but never unrefs it, so a
+  // referenced idle stdin would hold this one-shot CLI's event loop open and
+  // hang after the last prompt resolves. Re-unref once the prompt settles.
+  return basePrompts(questions, { onCancel: options.onCancel ?? onCancel }).finally(unrefStdin);
 };

--- a/packages/react-doctor/src/cli/utils/unref-stdin.ts
+++ b/packages/react-doctor/src/cli/utils/unref-stdin.ts
@@ -11,10 +11,14 @@
 // always reproducible, but unref-ing up front makes an idle stdin
 // incapable of holding the process open in every case.
 //
-// Interactive prompts are unaffected: `prompts` builds a
+// Interactive prompts DEFEAT this up-front unref: `prompts` builds a
 // `readline.createInterface({ input: process.stdin })`, whose
 // `resume()` (and `setRawMode(true)` on a TTY) re-refs stdin for the
-// lifetime of the prompt and releases it on close.
+// lifetime of the prompt. Crucially `readline.close()` only *pauses*
+// stdin on submit/cancel — it never unrefs it — so after the last
+// prompt resolves the re-reffed fd 0 holds the loop open again and the
+// CLI hangs. The `prompts` wrapper therefore re-invokes `unrefStdin`
+// once each prompt settles.
 //
 // File / `/dev/null` stdin resolves to an `fs.ReadStream` that has no
 // `unref` (and never holds the loop open anyway), hence the optional

--- a/packages/react-doctor/tests/prompts.test.ts
+++ b/packages/react-doctor/tests/prompts.test.ts
@@ -1,0 +1,40 @@
+import basePrompts from "prompts";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { prompts } from "../src/cli/utils/prompts.js";
+import { stubProcessStdinProperty } from "./helpers/stub-process-stdin-property.js";
+
+vi.mock("prompts", () => ({ default: vi.fn() }));
+
+describe("prompts wrapper", () => {
+  let restoreStdinUnref: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreStdinUnref?.();
+    restoreStdinUnref = undefined;
+    vi.clearAllMocks();
+  });
+
+  // `prompts` re-refs stdin via `readline.createInterface` and never unrefs it
+  // on close, so without this the one-shot CLI hangs after the last prompt.
+  it("re-unrefs stdin after a prompt resolves", async () => {
+    const unref = vi.fn();
+    restoreStdinUnref = stubProcessStdinProperty("unref", unref);
+    vi.mocked(basePrompts).mockResolvedValue({ shouldCopy: true });
+
+    await prompts({ type: "confirm", name: "shouldCopy", message: "Copy issues?" });
+
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-unrefs stdin even when the prompt rejects", async () => {
+    const unref = vi.fn();
+    restoreStdinUnref = stubProcessStdinProperty("unref", unref);
+    vi.mocked(basePrompts).mockRejectedValue(new Error("prompt failed"));
+
+    await expect(
+      prompts({ type: "confirm", name: "shouldCopy", message: "Copy issues?" }),
+    ).rejects.toThrow("prompt failed");
+
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the CLI hanging after the post-scan prompts (reported: doctor "hanging here" after answering `Set up React Doctor? › Skip` and `Copy issues to clipboard? … no`).

**Root cause:** `react-doctor` is a one-shot CLI with no explicit `process.exit()` — it relies on the event loop draining so it can exit with the correct `process.exitCode`. The startup `unrefStdin()` hack unrefs fd 0 so an idle/inherited stdin can't hold the loop open. But interactive prompts undo that: `prompts@2.4.2` builds a `readline.createInterface({ input: process.stdin })`, which `resume()`s stdin and **re-refs** fd 0. On close, `prompts` calls `setRawMode(false)` + `rl.close()` (which *pauses* stdin) but **never unrefs it**. So after the last prompt resolves, fd 0 is referenced again and keeps the libuv loop alive → the process hangs.

(The existing `unref-stdin.ts` comment even claims prompts "releases [stdin] on close" — that assumption is the bug.)

**Fix:** Re-unref stdin once each prompt settles, centralized in the shared `prompts` wrapper via `.finally(unrefStdin)` (covers resolve *and* reject). The one direct `basePrompts` call (`prompt-install-setup`'s setup prompt) is routed through the same wrapper so every prompt site is covered.

This is environment-dependent (TTY type / Node version), matching "hangs here" for some users but not all — consistent with the existing notes in `unref-stdin.ts`.

## Changes
- `prompts.ts`: re-unref stdin after each prompt settles
- `prompt-install-setup.ts`: route the setup prompt through the shared wrapper instead of `basePrompts` directly
- `tests/prompts.test.ts`: regression tests (unref-after-resolve + unref-after-reject)
- changeset (patch)

## Test plan
- [x] `tests/prompts.test.ts` passes (new)
- [x] `unref-stdin`, `prompt-install-setup`, `copy-issues-to-clipboard`, `resolve-diff-mode`, `inspect-action-setup-prompt` suites pass (54 tests)
- [x] lint passes
- [ ] Manually verify the CLI exits promptly after answering the post-scan prompts in an interactive terminal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small process-lifecycle fix around stdin unref after prompts; no auth, data, or scan logic changes.
> 
> **Overview**
> Fixes the one-shot CLI **hanging after post-scan interactive prompts** (e.g. setup and copy-to-clipboard) when the event loop should drain and exit.
> 
> Startup already calls `unrefStdin()` so idle inherited stdin does not keep the process alive. **`prompts` / readline re-refs `process.stdin` during prompts and does not unref on close**, so the last prompt leaves fd 0 referenced and the CLI stalls. The shared **`prompts` wrapper** now runs **`unrefStdin` in `.finally()`** after each prompt (resolve or reject). The install-setup select path is switched from **`basePrompts` to that wrapper** so every prompt site gets the same behavior. **`unref-stdin.ts`** comments are corrected; **`tests/prompts.test.ts`** covers unref on success and failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70914b4e64d4b77417514bed73477d7e098ff78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->