### PR TITLE
fix(cli): tolerate install dependency command failures

### DIFF
--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -237,7 +237,8 @@ const formatDependencyInstallMessage = (result: InstallReactDoctorDependencyResu
     return "Skipped dev dependency install: devDependencies field is not an object.";
   }
   if (result.dependencyReason === "install-command-failed") {
-    const installCommand = result.installCommand ?? `npm install --save-dev ${DOCTOR_PACKAGE_NAME}@latest`;
+    const installCommand =
+      result.installCommand ?? `npm install --save-dev ${DOCTOR_PACKAGE_NAME}@latest`;
     return `Skipped dev dependency install: package manager command failed. Run manually: ${installCommand}`;
   }
   return "Skipped dev dependency install: package.json missing or invalid.";

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -55,7 +55,11 @@ interface InstallReactDoctorDependencyOptions {
 
 interface InstallReactDoctorDependencyResult {
   readonly dependencyStatus: "created" | "existing" | "skipped";
-  readonly dependencyReason?: "missing-or-invalid-package-json" | "invalid-dev-dependencies";
+  readonly dependencyReason?:
+    | "missing-or-invalid-package-json"
+    | "invalid-dev-dependencies"
+    | "install-command-failed";
+  readonly installCommand?: string;
 }
 
 const PACKAGE_MANAGER_LOCKFILES = [
@@ -151,6 +155,9 @@ const defaultInstallDependencyRunner = (input: InstallReactDoctorDependencyRunne
   });
 };
 
+const formatInstallCommand = (input: InstallReactDoctorDependencyRunnerInput): string =>
+  [input.command, ...input.args].join(" ");
+
 const installReactDoctorDependency = async (
   options: InstallReactDoctorDependencyOptions,
 ): Promise<InstallReactDoctorDependencyResult> => {
@@ -170,7 +177,15 @@ const installReactDoctorDependency = async (
   }
 
   const runnerInput = buildInstallCommand(options.projectRoot);
-  await (options.runner ?? defaultInstallDependencyRunner)(runnerInput);
+  try {
+    await (options.runner ?? defaultInstallDependencyRunner)(runnerInput);
+  } catch {
+    return {
+      dependencyStatus: "skipped",
+      dependencyReason: "install-command-failed",
+      installCommand: formatInstallCommand(runnerInput),
+    };
+  }
   return { dependencyStatus: "created" };
 };
 
@@ -220,6 +235,10 @@ const formatDependencyInstallMessage = (result: InstallReactDoctorDependencyResu
   }
   if (result.dependencyReason === "invalid-dev-dependencies") {
     return "Skipped dev dependency install: devDependencies field is not an object.";
+  }
+  if (result.dependencyReason === "install-command-failed") {
+    const installCommand = result.installCommand ?? `npm install --save-dev ${DOCTOR_PACKAGE_NAME}@latest`;
+    return `Skipped dev dependency install: package manager command failed. Run manually: ${installCommand}`;
   }
   return "Skipped dev dependency install: package.json missing or invalid.";
 };

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -299,6 +299,38 @@ describe("runInstallReactDoctor", () => {
     ]);
   });
 
+  it("does not fail setup when the package manager install command fails", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, {
+      scripts: {},
+    });
+
+    await runInstallReactDoctorForTest({
+      yes: true,
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      detectedAgents: ["cursor"],
+      gitHookPath: null,
+      installDependencyRunner: (input) => {
+        dependencyInstallCalls.push(input);
+        throw new Error("npm install failed");
+      },
+    });
+
+    expect(process.exitCode).toBe(0);
+    expect(dependencyInstallCalls).toEqual([
+      {
+        command: "npm",
+        args: ["install", "--save-dev", "react-doctor@latest"],
+        cwd: fixture.projectRoot,
+      },
+    ]);
+    expect(readFixturePackageJson(fixture.projectRoot).scripts).toEqual({
+      doctor: "npx react-doctor@latest",
+    });
+    expect(readFixturePackageJson(fixture.projectRoot)).not.toHaveProperty("devDependencies");
+  });
+
   it("detects the package manager from an ancestor package.json", async () => {
     writeValidSkill(fixture.sourceDir);
     writePackageJson(fixture.projectRoot, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treat `react-doctor install` dev-dependency package-manager failures as non-fatal
- Show the exact manual install command to retry when the package-manager step fails
- Add regression coverage for a failing dependency install runner

## Testing
- `nr build`
- `nr test install-react-doctor.test.ts` in `packages/react-doctor`
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format`
- `nr smoke:json-report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a10ac448-a79a-4db6-8930-0664da8d5f62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a10ac448-a79a-4db6-8930-0664da8d5f62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

