### PR TITLE
fix(ci): serialize @dev snapshot publish to avoid npm 409 conflict

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,8 @@ jobs:
 
   publish-dev:
     name: Publish @dev snapshot
+    needs: publish
+    if: ${{ !cancelled() && needs.publish.result != 'failure' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -91,4 +93,14 @@ jobs:
       - name: Publish to npm under the dev tag
         env:
           NPM_CONFIG_PROVENANCE: true
-        run: pnpm publish --recursive --tag dev --no-git-checks --access public
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm publish --recursive --tag dev --no-git-checks --access public; then
+              exit 0
+            fi
+            backoff_seconds=$((attempt * 15))
+            echo "Dev publish attempt ${attempt} failed; retrying in ${backoff_seconds}s (already-published versions are skipped by pnpm)"
+            sleep "${backoff_seconds}"
+          done
+          echo "Dev publish failed after 3 attempts"
+          exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `Publish` workflow failed with:

```
npm error code E409
npm error 409 Conflict - PUT https://registry.npmjs.org/oxlint-plugin-react-doctor - Failed to save packument.
A common cause is if you try to publish a new package before the previous package has been fully processed.
```

## Root cause

`.github/workflows/publish.yml` defines two jobs that **both trigger on `push: [main]`**:

- `publish` → `changeset publish` publishes the real versions (e.g. `oxlint-plugin-react-doctor@0.2.13`)
- `publish-dev` → publishes a snapshot (`oxlint-plugin-react-doctor@0.2.13-dev.<sha>`)

Both jobs publish the **same fixed package group** (`react-doctor`, `eslint-plugin-react-doctor`, `oxlint-plugin-react-doctor`, per `.changeset/config.json`). When a `chore: version packages` PR merge lands on `main` (commit `bed4b27`), both jobs run **in parallel** and issue concurrent `PUT` requests to the same packument. npm serializes packument writes per package and rejects the second concurrent write with `409 Conflict`.

The workflow-level `concurrency` group only prevents overlapping *workflow runs* — it does **not** serialize the two *jobs* inside a single run.

## Fix

- `publish-dev` now `needs: publish`, so the dev snapshot is published **after** the changesets publish completes. The two jobs can no longer write the same packument concurrently. The `if: ${{ !cancelled() && needs.publish.result != 'failure' }}` guard keeps the dev snapshot running on normal pushes (where `publish` is a no-op that just manages the release PR) while skipping it if the real publish genuinely fails.
- Added a bounded 3-attempt retry with linear backoff around the dev publish to absorb any residual transient registry hiccup. `pnpm publish --recursive` skips versions already on the registry, so retries are safe and won't attempt to overwrite successfully published packages.

## Notes

YAML validated locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c550f405-d669-4ac4-a951-398c9e459f50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c550f405-d669-4ac4-a951-398c9e459f50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

