### PR TITLE
feat: order the diagnostics dump by rule priority

### DIFF
--- a/.github/workflows/publish-any-commit.yml
+++ b/.github/workflows/publish-any-commit.yml
@@ -1,0 +1,47 @@
+name: Publish Any Commit
+
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22.18.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Publish packages (retry on transient failures)
+        run: |
+          max_attempts=4
+          attempt=1
+          while [ "$attempt" -le "$max_attempts" ]; do
+            if pnpm dlx pkg-pr-new publish \
+              ./packages/react-doctor \
+              ./packages/oxlint-plugin-react-doctor \
+              ./packages/eslint-plugin-react-doctor; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              exit 1
+            fi
+
+            sleep_seconds=$((2 ** attempt))
+            echo "pkg-pr-new publish failed on attempt ${attempt}/${max_attempts}; retrying in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
+            attempt=$((attempt + 1))
+          done

--- a/packages/core/src/calculate-score.ts
+++ b/packages/core/src/calculate-score.ts
@@ -1,36 +1,28 @@
 import { gzipSync } from "node:zlib";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import { FETCH_TIMEOUT_MS, SCORE_API_URL } from "./constants.js";
-import type { Diagnostic, ProjectInfo, RulePriority, ScoreResult } from "./types/index.js";
+import type { Diagnostic, ProjectInfo, ScoreResult } from "./types/index.js";
 
-const RULE_TIERS = new Set(["P0", "P1", "P2", "P3"]);
+// Score API response shape, including the optional per-rule `priority`/`tier`
+// payload. `Schema.Struct` ignores unknown fields, so extra keys (e.g.
+// `stored`) pass through harmlessly.
+const RulePrioritySchema = Schema.Struct({
+  priority: Schema.NullOr(Schema.Number),
+  tier: Schema.Literals(["P0", "P1", "P2", "P3"]),
+});
 
-const parseRulePriorities = (value: unknown): Record<string, RulePriority> | undefined => {
-  if (typeof value !== "object" || value === null) return undefined;
-  const rules: Record<string, RulePriority> = {};
-  for (const [ruleKey, info] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof info !== "object" || info === null) continue;
-    const priority = Reflect.get(info, "priority");
-    const tier = Reflect.get(info, "tier");
-    if (
-      (typeof priority === "number" || priority === null) &&
-      typeof tier === "string" &&
-      RULE_TIERS.has(tier)
-    ) {
-      rules[ruleKey] = { priority, tier: tier as RulePriority["tier"] };
-    }
-  }
-  return Object.keys(rules).length > 0 ? rules : undefined;
-};
+const ScoreApiResponseSchema = Schema.Struct({
+  score: Schema.Number,
+  label: Schema.String,
+  rules: Schema.optional(Schema.Record(Schema.String, RulePrioritySchema)),
+});
 
-const parseScoreResult = (value: unknown): ScoreResult | null => {
-  if (typeof value !== "object" || value === null) return null;
-  if (!("score" in value) || !("label" in value)) return null;
-  const scoreValue = Reflect.get(value, "score");
-  const labelValue = Reflect.get(value, "label");
-  if (typeof scoreValue !== "number" || typeof labelValue !== "string") return null;
-  const rules = parseRulePriorities(Reflect.get(value, "rules"));
-  return { score: scoreValue, label: labelValue, ...(rules ? { rules } : {}) };
-};
+// Decode the score API response; any shape mismatch drops the whole result to
+// null, so a malformed payload simply falls back to "no score" (and severity
+// ordering at render time) rather than throwing.
+const parseScoreResult = (value: unknown): ScoreResult | null =>
+  Option.getOrNull(Schema.decodeUnknownOption(ScoreApiResponseSchema)(value));
 
 const stripFilePaths = (diagnostics: Diagnostic[]): Omit<Diagnostic, "filePath">[] =>
   diagnostics.map(({ filePath: _filePath, ...rest }) => rest);

--- a/packages/core/src/calculate-score.ts
+++ b/packages/core/src/calculate-score.ts
@@ -1,6 +1,26 @@
 import { gzipSync } from "node:zlib";
 import { FETCH_TIMEOUT_MS, SCORE_API_URL } from "./constants.js";
-import type { Diagnostic, ProjectInfo, ScoreResult } from "./types/index.js";
+import type { Diagnostic, ProjectInfo, RulePriority, ScoreResult } from "./types/index.js";
+
+const RULE_TIERS = new Set(["P0", "P1", "P2", "P3"]);
+
+const parseRulePriorities = (value: unknown): Record<string, RulePriority> | undefined => {
+  if (typeof value !== "object" || value === null) return undefined;
+  const rules: Record<string, RulePriority> = {};
+  for (const [ruleKey, info] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof info !== "object" || info === null) continue;
+    const priority = Reflect.get(info, "priority");
+    const tier = Reflect.get(info, "tier");
+    if (
+      (typeof priority === "number" || priority === null) &&
+      typeof tier === "string" &&
+      RULE_TIERS.has(tier)
+    ) {
+      rules[ruleKey] = { priority, tier: tier as RulePriority["tier"] };
+    }
+  }
+  return Object.keys(rules).length > 0 ? rules : undefined;
+};
 
 const parseScoreResult = (value: unknown): ScoreResult | null => {
   if (typeof value !== "object" || value === null) return null;
@@ -8,7 +28,8 @@ const parseScoreResult = (value: unknown): ScoreResult | null => {
   const scoreValue = Reflect.get(value, "score");
   const labelValue = Reflect.get(value, "label");
   if (typeof scoreValue !== "number" || typeof labelValue !== "string") return null;
-  return { score: scoreValue, label: labelValue };
+  const rules = parseRulePriorities(Reflect.get(value, "rules"));
+  return { score: scoreValue, label: labelValue, ...(rules ? { rules } : {}) };
 };
 
 const stripFilePaths = (diagnostics: Diagnostic[]): Omit<Diagnostic, "filePath">[] =>

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -47,4 +47,4 @@ export type { PromptMultiselectChoiceState, PromptMultiselectContext } from "./p
 // `core/src/project-info/internal-rn-dependency-names.ts`;
 // rule-side consumers import from the plugin package directly.
 // See that file for the duplication rationale.
-export type { ScoreResult } from "./score.js";
+export type { ScoreResult, RulePriority, RuleTier } from "./score.js";

--- a/packages/core/src/types/score.ts
+++ b/packages/core/src/types/score.ts
@@ -3,8 +3,8 @@ export type RuleTier = "P0" | "P1" | "P2" | "P3";
 export interface RulePriority {
   // Intrinsic end-user value of the rule, 0-100, or null when the rule isn't
   // ranked yet. Higher = more worth fixing first.
-  priority: number | null;
-  tier: RuleTier;
+  readonly priority: number | null;
+  readonly tier: RuleTier;
 }
 
 export interface ScoreResult {
@@ -14,5 +14,5 @@ export interface ScoreResult {
   // Present when the score API ranks the violated rules; used to order the
   // diagnostics dump most-valuable-first. Absent under `--no-score` or when the
   // API is unreachable, in which case rendering falls back to severity order.
-  rules?: Record<string, RulePriority>;
+  readonly rules?: Readonly<Record<string, RulePriority>>;
 }

--- a/packages/core/src/types/score.ts
+++ b/packages/core/src/types/score.ts
@@ -1,4 +1,18 @@
+export type RuleTier = "P0" | "P1" | "P2" | "P3";
+
+export interface RulePriority {
+  // Intrinsic end-user value of the rule, 0-100, or null when the rule isn't
+  // ranked yet. Higher = more worth fixing first.
+  priority: number | null;
+  tier: RuleTier;
+}
+
 export interface ScoreResult {
   score: number;
   label: string;
+  // Per-rule priority returned by the score API, keyed by `<plugin>/<rule>`.
+  // Present when the score API ranks the violated rules; used to order the
+  // diagnostics dump most-valuable-first. Absent under `--no-score` or when the
+  // API is unreachable, in which case rendering falls back to severity order.
+  rules?: Record<string, RulePriority>;
 }

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -8,7 +8,7 @@ import {
   MILLISECONDS_PER_SECOND,
   RULE_NAME_COLUMN_WIDTH_CHARS,
 } from "@react-doctor/core";
-import type { Diagnostic } from "@react-doctor/core";
+import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { indentMultilineText } from "./indent-multiline-text.js";
 
 const POINTER = isUnicodeSupported() ? "›" : ">";
@@ -21,8 +21,45 @@ const SEVERITY_ORDER: Record<Diagnostic["severity"], number> = {
 const colorizeBySeverity = (text: string, severity: Diagnostic["severity"]): string =>
   severity === "error" ? highlighter.error(text) : highlighter.warn(text);
 
-const sortByImportance = (diagnosticGroups: [string, Diagnostic[]][]): [string, Diagnostic[]][] =>
-  diagnosticGroups.toSorted(([, diagnosticsA], [, diagnosticsB]) => {
+// Build a `<plugin>/<rule>` -> priority lookup from the score API's per-rule
+// payload (merged across scans). Rules the API didn't rank — or every rule when
+// the score is unavailable — are simply absent and fall back to severity order.
+export const buildRulePriorityMap = (
+  scores: ReadonlyArray<ScoreResult | null>,
+): ReadonlyMap<string, number> => {
+  const rulePriority = new Map<string, number>();
+  for (const score of scores) {
+    if (!score?.rules) continue;
+    for (const [ruleKey, info] of Object.entries(score.rules)) {
+      if (typeof info.priority === "number") rulePriority.set(ruleKey, info.priority);
+    }
+  }
+  return rulePriority;
+};
+
+// Effective sort weight for a rule group: its API-returned priority, or a
+// severity-based midpoint when the rule isn't ranked (or the score is offline).
+// With no priorities at all this degrades to the previous error-before-warning
+// ordering (error 55 sorts ahead of warning 35).
+const effectivePriority = (
+  ruleKey: string,
+  diagnostics: Diagnostic[],
+  rulePriority: ReadonlyMap<string, number> | undefined,
+): number => {
+  const known = rulePriority?.get(ruleKey);
+  if (known !== undefined) return known;
+  return diagnostics[0].severity === "error" ? 55 : 35;
+};
+
+const sortByImportance = (
+  diagnosticGroups: [string, Diagnostic[]][],
+  rulePriority?: ReadonlyMap<string, number>,
+): [string, Diagnostic[]][] =>
+  diagnosticGroups.toSorted(([ruleKeyA, diagnosticsA], [ruleKeyB, diagnosticsB]) => {
+    const priorityDelta =
+      effectivePriority(ruleKeyB, diagnosticsB, rulePriority) -
+      effectivePriority(ruleKeyA, diagnosticsA, rulePriority);
+    if (priorityDelta !== 0) return priorityDelta;
     const severityDelta =
       SEVERITY_ORDER[diagnosticsA[0].severity] - SEVERITY_ORDER[diagnosticsB[0].severity];
     if (severityDelta !== 0) return severityDelta;
@@ -103,7 +140,20 @@ const buildCompactRuleGroupLine = (
 const getWorstSeverity = (diagnostics: Diagnostic[]): Diagnostic["severity"] =>
   diagnostics.some((diagnostic) => diagnostic.severity === "error") ? "error" : "warning";
 
-const buildCategoryDiagnosticGroups = (diagnostics: Diagnostic[]): CategoryDiagnosticGroup[] => {
+// A category leads with its most valuable rule. `ruleGroups` are already
+// priority-sorted, so the first one is the category's top.
+const categoryTopPriority = (
+  categoryGroup: CategoryDiagnosticGroup,
+  rulePriority: ReadonlyMap<string, number> | undefined,
+): number => {
+  const [topRuleKey, topDiagnostics] = categoryGroup.ruleGroups[0];
+  return effectivePriority(topRuleKey, topDiagnostics, rulePriority);
+};
+
+const buildCategoryDiagnosticGroups = (
+  diagnostics: Diagnostic[],
+  rulePriority?: ReadonlyMap<string, number>,
+): CategoryDiagnosticGroup[] => {
   const categoryGroups = groupBy(diagnostics, (diagnostic) => diagnostic.category);
   return [...categoryGroups.entries()]
     .map(([category, categoryDiagnostics]) => {
@@ -114,10 +164,14 @@ const buildCategoryDiagnosticGroups = (diagnostics: Diagnostic[]): CategoryDiagn
       return {
         category,
         diagnostics: categoryDiagnostics,
-        ruleGroups: sortByImportance([...ruleGroups.entries()]),
+        ruleGroups: sortByImportance([...ruleGroups.entries()], rulePriority),
       };
     })
     .toSorted((categoryGroupA, categoryGroupB) => {
+      const priorityDelta =
+        categoryTopPriority(categoryGroupB, rulePriority) -
+        categoryTopPriority(categoryGroupA, rulePriority);
+      if (priorityDelta !== 0) return priorityDelta;
       const severityDelta =
         SEVERITY_ORDER[getWorstSeverity(categoryGroupA.diagnostics)] -
         SEVERITY_ORDER[getWorstSeverity(categoryGroupB.diagnostics)];
@@ -178,8 +232,11 @@ const buildVerboseRuleGroupLines = (
   return lines;
 };
 
-const buildDefaultDiagnosticsLines = (diagnostics: Diagnostic[]): ReadonlyArray<string> => {
-  const categoryGroups = buildCategoryDiagnosticGroups(diagnostics);
+const buildDefaultDiagnosticsLines = (
+  diagnostics: Diagnostic[],
+  rulePriority?: ReadonlyMap<string, number>,
+): ReadonlyArray<string> => {
+  const categoryGroups = buildCategoryDiagnosticGroups(diagnostics, rulePriority);
   const lines: string[] = [];
   for (const categoryGroup of categoryGroups) {
     lines.push(buildCompactCategoryLine(categoryGroup));
@@ -198,17 +255,18 @@ export const printDiagnostics = (
   diagnostics: Diagnostic[],
   isVerbose: boolean,
   rootDirectory: string,
+  rulePriority?: ReadonlyMap<string, number>,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     let lines: ReadonlyArray<string>;
     if (!isVerbose) {
-      lines = buildDefaultDiagnosticsLines(diagnostics);
+      lines = buildDefaultDiagnosticsLines(diagnostics, rulePriority);
     } else {
       const ruleGroups = groupBy(
         diagnostics,
         (diagnostic) => `${diagnostic.plugin}/${diagnostic.rule}`,
       );
-      const sortedRuleGroups = sortByImportance([...ruleGroups.entries()]);
+      const sortedRuleGroups = sortByImportance([...ruleGroups.entries()], rulePriority);
       const ruleNameColumnWidth = computeRuleNameColumnWidth(
         sortedRuleGroups.map(([ruleKey]) => ruleKey),
       );

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -9,7 +9,7 @@ import {
 } from "@react-doctor/core";
 import type { Diagnostic, InspectResult, ReactDoctorConfig, ScoreResult } from "@react-doctor/core";
 import { colorizeByScore } from "./colorize-by-score.js";
-import { printDiagnostics } from "./render-diagnostics.js";
+import { buildRulePriorityMap, printDiagnostics } from "./render-diagnostics.js";
 import { printSummary } from "./render-summary.js";
 
 const SUMMARY_BAR_WIDTH_CHARS = 20;
@@ -95,7 +95,12 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
 
     if (surfaceDiagnostics.length > 0) {
       yield* Console.log("");
-      yield* printDiagnostics(surfaceDiagnostics, verbose, "");
+      yield* printDiagnostics(
+        surfaceDiagnostics,
+        verbose,
+        "",
+        buildRulePriorityMap(completedScans.map((scan) => scan.result.score)),
+      );
     }
 
     const aggregateScore = computeAggregateScore(completedScans);

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -22,7 +22,7 @@ import type {
 import { makeNoopConsole } from "./cli/utils/noop-console.js";
 import { printAgentGuidance } from "./cli/utils/render-agent-guidance.js";
 import { isCiOrCodingAgentEnvironment } from "./cli/utils/is-ci-environment.js";
-import { printDiagnostics } from "./cli/utils/render-diagnostics.js";
+import { buildRulePriorityMap, printDiagnostics } from "./cli/utils/render-diagnostics.js";
 import { isNonInteractiveEnvironment } from "./cli/utils/is-non-interactive-environment.js";
 import { printProjectDetection } from "./cli/utils/render-project-detection.js";
 import {
@@ -418,7 +418,12 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
     }
 
     yield* Console.log("");
-    yield* printDiagnostics([...surfaceDiagnostics], options.verbose, directory);
+    yield* printDiagnostics(
+      [...surfaceDiagnostics],
+      options.verbose,
+      directory,
+      buildRulePriorityMap([score]),
+    );
     if (options.isNonInteractiveEnvironment && options.outputSurface !== "prComment") {
       yield* printAgentGuidance();
     }


### PR DESCRIPTION
## What

`npx react-doctor` now lists rule-groups (and categories) **by priority, most-valuable-first**, instead of ordering purely by severity. A single P0 (security / crash / legal a11y) leads the dump even when a low-value rule has hundreds of occurrences — so users see *what to fix first*, not just *what's most frequent*.

## How

The score API already returns an intrinsic `priority`/`tier` per violated rule. This PR threads that through to rendering:

- **`core`**: `ScoreResult` gains `rules?: Record<string, RulePriority>` (+ `RuleTier`); `parseScoreResult` captures the `rules` field the API returns.
- **CLI** (`render-diagnostics.ts`): `sortByImportance` and category ordering sort by `effectivePriority` — API priority desc. Unranked rules fall back to a severity midpoint; **with no score (`--no-score` / API unreachable) ordering degrades to the previous error-before-warning + count order**, so there's no regression offline.
- `inspect.ts` and `render-multi-project-summary.ts` build a `<plugin>/<rule>` → priority map (`buildRulePriorityMap`) from the in-band score and pass it to the renderer.

No priority table is duplicated in this repo — the values arrive over the score API (single source of truth lives in the engine).

## Cross-repo dependency

The ordering engages once the score API (`/api/score`) returns the `rules` field — that's a companion change on the website side. Until it's deployed, the CLI falls back to severity ordering (no regression).

## Validation

- typecheck 8/8, lint clean.
- With priorities: `no-eval` (P0, 1×) leads; `no-barrel-import` (P3, 200×) sinks to the bottom.
- Without a score: identical to prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing CLI ordering and score response parsing; behavior depends on the score API shipping `rules`, though fallbacks avoid breakage when it is absent.
> 
> **Overview**
> The CLI **diagnostics dump** now sorts rule groups and categories by **score API per-rule priority** (highest first), so high-value issues like P0 security rules surface ahead of noisy low-tier findings. **`ScoreResult`** gains optional `rules` keyed by `<plugin>/<rule>` with `priority` and `tier`; **`parseScoreResult`** switches to Effect **`Schema`** decoding of that payload (invalid responses still become `null`).
> 
> **`buildRulePriorityMap`** merges priorities from one or many scans; **`printDiagnostics`** uses them in compact and verbose modes. Unranked rules or missing scores keep the old behavior via severity-based stand-ins (error before warning, then count).
> 
> A new **`.github/workflows/publish-any-commit.yml`** builds the monorepo and publishes preview packages with **`pkg-pr-new`**, including exponential backoff retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb2edbc689d3793962e9ec2e330ec34828a34f85. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->