### PR TITLE
fix(#591): CLI multi-project wrapper scans

### DIFF
--- a/packages/core/src/resolve-diagnose-target.ts
+++ b/packages/core/src/resolve-diagnose-target.ts
@@ -1,12 +1,21 @@
 import path from "node:path";
 import { AmbiguousProjectError, discoverReactSubprojects, isFile } from "./project-info/index.js";
 
-export const resolveDiagnoseTarget = (directory: string): string | null => {
+export interface ResolveDiagnoseTargetOptions {
+  readonly allowAmbiguous?: boolean;
+}
+
+export const resolveDiagnoseTarget = (
+  directory: string,
+  options: ResolveDiagnoseTargetOptions = {},
+): string | null => {
   if (isFile(path.join(directory, "package.json"))) return directory;
 
   const reactSubprojects = discoverReactSubprojects(directory);
   if (reactSubprojects.length === 0) return null;
   if (reactSubprojects.length === 1) return reactSubprojects[0].directory;
+
+  if (options.allowAmbiguous === true) return null;
 
   const relativeCandidates = reactSubprojects
     .map((subproject) => path.relative(directory, subproject.directory))

--- a/packages/core/src/resolve-diagnose-target.ts
+++ b/packages/core/src/resolve-diagnose-target.ts
@@ -1,20 +1,12 @@
 import path from "node:path";
 import { AmbiguousProjectError, discoverReactSubprojects, isFile } from "./project-info/index.js";
 
-export interface ResolveDiagnoseTargetOptions {
-  readonly allowAmbiguous?: boolean;
-}
-
-export const resolveDiagnoseTarget = (
-  directory: string,
-  options: ResolveDiagnoseTargetOptions = {},
-): string | null => {
+export const resolveDiagnoseTarget = (directory: string): string | null => {
   if (isFile(path.join(directory, "package.json"))) return directory;
 
   const reactSubprojects = discoverReactSubprojects(directory);
   if (reactSubprojects.length === 0) return null;
   if (reactSubprojects.length === 1) return reactSubprojects[0].directory;
-  if (options.allowAmbiguous === true) return null;
 
   const relativeCandidates = reactSubprojects
     .map((subproject) => path.relative(directory, subproject.directory))

--- a/packages/core/src/resolve-diagnose-target.ts
+++ b/packages/core/src/resolve-diagnose-target.ts
@@ -1,12 +1,20 @@
 import path from "node:path";
 import { AmbiguousProjectError, discoverReactSubprojects, isFile } from "./project-info/index.js";
 
-export const resolveDiagnoseTarget = (directory: string): string | null => {
+export interface ResolveDiagnoseTargetOptions {
+  readonly allowAmbiguous?: boolean;
+}
+
+export const resolveDiagnoseTarget = (
+  directory: string,
+  options: ResolveDiagnoseTargetOptions = {},
+): string | null => {
   if (isFile(path.join(directory, "package.json"))) return directory;
 
   const reactSubprojects = discoverReactSubprojects(directory);
   if (reactSubprojects.length === 0) return null;
   if (reactSubprojects.length === 1) return reactSubprojects[0].directory;
+  if (options.allowAmbiguous === true) return null;
 
   const relativeCandidates = reactSubprojects
     .map((subproject) => path.relative(directory, subproject.directory))

--- a/packages/core/src/resolve-scan-target.ts
+++ b/packages/core/src/resolve-scan-target.ts
@@ -27,6 +27,10 @@ export interface ResolvedScanTarget {
   readonly didRedirectViaRootDir: boolean;
 }
 
+export interface ResolveScanTargetOptions {
+  readonly allowAmbiguous?: boolean;
+}
+
 /**
  * The canonical entry-point translation shared by every public shell
  * (`inspect()`, `diagnose()`, and the CLI's `inspectAction`):
@@ -38,7 +42,8 @@ export interface ResolvedScanTarget {
  *      project root, if configured.
  *   4. Walk into a nested React subproject when the requested
  *      directory has no `package.json` of its own (raises
- *      `AmbiguousProjectError` when multiple candidates exist).
+ *      `AmbiguousProjectError` when multiple candidates exist unless
+ *      the caller opts into keeping the wrapper directory).
  *
  * Throws `ProjectNotFoundError` when neither the requested directory
  * nor any discoverable nested project has a `package.json`.
@@ -50,17 +55,19 @@ export interface ResolvedScanTarget {
  * via its own cache). Routing through `resolveScanTarget` keeps every
  * shell in agreement on what "the scan directory" means.
  */
-export const resolveScanTarget = (requestedDirectory: string): ResolvedScanTarget => {
+export const resolveScanTarget = (
+  requestedDirectory: string,
+  options: ResolveScanTargetOptions = {},
+): ResolvedScanTarget => {
   const absoluteRequested = path.resolve(requestedDirectory);
   const loadedConfig = loadConfigWithSource(absoluteRequested);
   const userConfig = loadedConfig?.config ?? null;
   const configSourceDirectory = loadedConfig?.sourceDirectory ?? null;
   const redirectedDirectory = resolveConfigRootDir(userConfig, configSourceDirectory);
   const directoryAfterRedirect = redirectedDirectory ?? absoluteRequested;
-  // `resolveDiagnoseTarget` throws `AmbiguousProjectError` when the
-  // requested directory has multiple React subprojects; let it
-  // propagate to the caller.
-  const resolved = resolveDiagnoseTarget(directoryAfterRedirect);
+  const resolved = resolveDiagnoseTarget(directoryAfterRedirect, {
+    allowAmbiguous: options.allowAmbiguous,
+  });
   const resolvedDirectory = resolved ?? directoryAfterRedirect;
 
   if (!isDirectory(resolvedDirectory)) {

--- a/packages/core/src/resolve-scan-target.ts
+++ b/packages/core/src/resolve-scan-target.ts
@@ -1,14 +1,12 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { loadConfigWithSource } from "./load-config.js";
-import {
-  AmbiguousProjectError,
-  isDirectory,
-  NotADirectoryError,
-  ProjectNotFoundError,
-} from "./project-info/index.js";
+import { isDirectory, NotADirectoryError, ProjectNotFoundError } from "./project-info/index.js";
 import { resolveConfigRootDir } from "./resolve-config-root-dir.js";
-import { resolveDiagnoseTarget } from "./resolve-diagnose-target.js";
+import {
+  resolveDiagnoseTarget,
+  type ResolveDiagnoseTargetOptions,
+} from "./resolve-diagnose-target.js";
 import type { ReactDoctorConfig } from "./types/index.js";
 
 export interface ResolvedScanTarget {
@@ -32,23 +30,6 @@ export interface ResolvedScanTarget {
   readonly didRedirectViaRootDir: boolean;
 }
 
-export interface ResolveScanTargetOptions {
-  readonly allowAmbiguous?: boolean;
-}
-
-const resolveTargetDirectory = (
-  directory: string,
-  options: ResolveScanTargetOptions,
-): string | null => {
-  try {
-    return resolveDiagnoseTarget(directory);
-  } catch (error) {
-    if (options.allowAmbiguous === true && error instanceof AmbiguousProjectError) {
-      return null;
-    }
-    throw error;
-  }
-};
 
 /**
  * The canonical entry-point translation shared by every public shell
@@ -76,7 +57,7 @@ const resolveTargetDirectory = (
  */
 export const resolveScanTarget = (
   requestedDirectory: string,
-  options: ResolveScanTargetOptions = {},
+  options: ResolveDiagnoseTargetOptions = {},
 ): ResolvedScanTarget => {
   const absoluteRequested = path.resolve(requestedDirectory);
   const loadedConfig = loadConfigWithSource(absoluteRequested);
@@ -84,8 +65,8 @@ export const resolveScanTarget = (
   const configSourceDirectory = loadedConfig?.sourceDirectory ?? null;
   const redirectedDirectory = resolveConfigRootDir(userConfig, configSourceDirectory);
   const directoryAfterRedirect = redirectedDirectory ?? absoluteRequested;
-  const resolved = resolveTargetDirectory(directoryAfterRedirect, options);
-  const resolvedDirectory = resolved ?? directoryAfterRedirect;
+  const resolvedDirectory =
+    resolveDiagnoseTarget(directoryAfterRedirect, options) ?? directoryAfterRedirect;
 
   if (!isDirectory(resolvedDirectory)) {
     throw existsSync(resolvedDirectory)

--- a/packages/core/src/resolve-scan-target.ts
+++ b/packages/core/src/resolve-scan-target.ts
@@ -30,7 +30,6 @@ export interface ResolvedScanTarget {
   readonly didRedirectViaRootDir: boolean;
 }
 
-
 /**
  * The canonical entry-point translation shared by every public shell
  * (`inspect()`, `diagnose()`, and the CLI's `inspectAction`):

--- a/packages/core/src/resolve-scan-target.ts
+++ b/packages/core/src/resolve-scan-target.ts
@@ -1,7 +1,12 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { loadConfigWithSource } from "./load-config.js";
-import { isDirectory, NotADirectoryError, ProjectNotFoundError } from "./project-info/index.js";
+import {
+  AmbiguousProjectError,
+  isDirectory,
+  NotADirectoryError,
+  ProjectNotFoundError,
+} from "./project-info/index.js";
 import { resolveConfigRootDir } from "./resolve-config-root-dir.js";
 import { resolveDiagnoseTarget } from "./resolve-diagnose-target.js";
 import type { ReactDoctorConfig } from "./types/index.js";
@@ -30,6 +35,20 @@ export interface ResolvedScanTarget {
 export interface ResolveScanTargetOptions {
   readonly allowAmbiguous?: boolean;
 }
+
+const resolveTargetDirectory = (
+  directory: string,
+  options: ResolveScanTargetOptions,
+): string | null => {
+  try {
+    return resolveDiagnoseTarget(directory);
+  } catch (error) {
+    if (options.allowAmbiguous === true && error instanceof AmbiguousProjectError) {
+      return null;
+    }
+    throw error;
+  }
+};
 
 /**
  * The canonical entry-point translation shared by every public shell
@@ -65,9 +84,7 @@ export const resolveScanTarget = (
   const configSourceDirectory = loadedConfig?.sourceDirectory ?? null;
   const redirectedDirectory = resolveConfigRootDir(userConfig, configSourceDirectory);
   const directoryAfterRedirect = redirectedDirectory ?? absoluteRequested;
-  const resolved = resolveDiagnoseTarget(directoryAfterRedirect, {
-    allowAmbiguous: options.allowAmbiguous,
-  });
+  const resolved = resolveTargetDirectory(directoryAfterRedirect, options);
   const resolvedDirectory = resolved ?? directoryAfterRedirect;
 
   if (!isDirectory(resolvedDirectory)) {

--- a/packages/core/tests/resolve-scan-target.test.ts
+++ b/packages/core/tests/resolve-scan-target.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { AmbiguousProjectError, resolveScanTarget } from "../src/index.js";
+
+const tempDirectories: string[] = [];
+
+const createTempDirectory = (): string => {
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-resolve-target-"));
+  tempDirectories.push(tempDirectory);
+  return tempDirectory;
+};
+
+const writeJson = (filePath: string, contents: unknown): void => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(contents, null, 2));
+};
+
+const writeReactProject = (parentDirectory: string, projectName: string): string => {
+  const projectDirectory = path.join(parentDirectory, projectName);
+  writeJson(path.join(projectDirectory, "package.json"), {
+    name: projectName,
+    dependencies: {
+      react: "^19.0.0",
+      "react-dom": "^19.0.0",
+    },
+  });
+  return projectDirectory;
+};
+
+describe("resolveScanTarget", () => {
+  afterEach(() => {
+    for (const tempDirectory of tempDirectories.splice(0)) {
+      fs.rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("can keep an ambiguous wrapper directory for multi-project CLI scans", () => {
+    const wrapperDirectory = createTempDirectory();
+    writeReactProject(wrapperDirectory, "frontend");
+    writeReactProject(wrapperDirectory, "mobile");
+
+    expect(() => resolveScanTarget(wrapperDirectory)).toThrow(AmbiguousProjectError);
+
+    const scanTarget = resolveScanTarget(wrapperDirectory, { allowAmbiguous: true });
+    expect(scanTarget.resolvedDirectory).toBe(wrapperDirectory);
+  });
+});

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -134,7 +134,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
   try {
     validateModeFlags(flags);
 
-    const scanTarget = resolveScanTarget(requestedDirectory);
+    const scanTarget = resolveScanTarget(requestedDirectory, { allowAmbiguous: true });
     const userConfig = scanTarget.userConfig;
     const resolvedDirectory = scanTarget.resolvedDirectory;
     setJsonReportDirectory(resolvedDirectory);

--- a/packages/react-doctor/src/cli/utils/select-projects.ts
+++ b/packages/react-doctor/src/cli/utils/select-projects.ts
@@ -1,9 +1,9 @@
-import { existsSync } from "node:fs";
 import path from "node:path";
 import type { WorkspacePackage } from "@react-doctor/core";
 import {
   discoverReactSubprojects,
   highlighter,
+  isFile,
   isMonorepoRoot,
   listWorkspacePackages,
 } from "@react-doctor/core";
@@ -15,7 +15,7 @@ export const selectProjects = async (
   projectFlag: string | undefined,
   skipPrompts: boolean,
 ): Promise<string[]> => {
-  const hasRootPackageJson = existsSync(path.join(rootDirectory, "package.json"));
+  const hasRootPackageJson = isFile(path.join(rootDirectory, "package.json"));
   let packages = listWorkspacePackages(rootDirectory);
   if (packages.length === 0 && (!hasRootPackageJson || isMonorepoRoot(rootDirectory))) {
     packages = discoverReactSubprojects(rootDirectory);

--- a/packages/react-doctor/src/cli/utils/select-projects.ts
+++ b/packages/react-doctor/src/cli/utils/select-projects.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
 import type { WorkspacePackage } from "@react-doctor/core";
 import {
@@ -14,9 +15,9 @@ export const selectProjects = async (
   projectFlag: string | undefined,
   skipPrompts: boolean,
 ): Promise<string[]> => {
+  const hasRootPackageJson = existsSync(path.join(rootDirectory, "package.json"));
   let packages = listWorkspacePackages(rootDirectory);
-  if (packages.length === 0) {
-    if (!isMonorepoRoot(rootDirectory)) return [rootDirectory];
+  if (packages.length === 0 && (!hasRootPackageJson || isMonorepoRoot(rootDirectory))) {
     packages = discoverReactSubprojects(rootDirectory);
   }
 

--- a/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
+++ b/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { resolveScanTarget } from "@react-doctor/core";
 import type { InspectResult } from "@react-doctor/core";
 import { inspectAction } from "../src/cli/commands/inspect.js";
 import { promptInstallSetup } from "../src/cli/utils/prompt-install-setup.js";
@@ -139,6 +140,7 @@ describe("inspectAction setup prompt", () => {
 
     await inspectAction(rootDirectory, { diff: true, lint: false });
 
+    expect(resolveScanTarget).toHaveBeenCalledWith(rootDirectory, { allowAmbiguous: true });
     expect(inspect).toHaveBeenCalledTimes(1);
     expect(inspect).toHaveBeenCalledWith(
       webDirectory,

--- a/packages/react-doctor/tests/select-projects.test.ts
+++ b/packages/react-doctor/tests/select-projects.test.ts
@@ -107,4 +107,17 @@ describe("selectProjects", () => {
       }),
     );
   });
+
+  it("discovers nested React projects when a wrapper directory has no package.json", async () => {
+    const tempDirectory = createTempDirectory();
+    const frontendDirectory = setupReactProject(tempDirectory, "frontend");
+    const mobileDirectory = setupReactProject(tempDirectory, "mobile");
+
+    const selectedDirectories = await selectProjects(tempDirectory, undefined, true);
+
+    expect(selectedDirectories.toSorted()).toEqual([frontendDirectory, mobileDirectory].toSorted());
+    expect(prompts).not.toHaveBeenCalled();
+    expect(cliLogger.log).toHaveBeenCalledWith(expect.stringContaining("frontend"));
+    expect(cliLogger.log).toHaveBeenCalledWith(expect.stringContaining("mobile"));
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- allow the CLI scan-target path to keep ambiguous wrapper directories for multi-project scans
- keep `resolveDiagnoseTarget` single-purpose by handling the CLI ambiguity opt-in at the scan-target boundary
- discover nested React projects from wrapper directories without a root package.json using the existing `isFile` helper
- add regression coverage for issue #591's frontend/mobile wrapper shape

## Testing

- `pnpm --package @antfu/ni dlx nr test tests/resolve-scan-target.test.ts` (from `packages/core`)
- `pnpm --package @antfu/ni dlx nr test tests/select-projects.test.ts tests/inspect-action-setup-prompt.test.ts` (from `packages/react-doctor`)
- `pnpm --package @antfu/ni dlx nr test`
- `pnpm --package @antfu/ni dlx nr lint`
- `pnpm --package @antfu/ni dlx nr typecheck`
- `pnpm --package @antfu/ni dlx nr format`
- `pnpm --package @antfu/ni dlx nr smoke:json-report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0d4028a-2ba9-4937-abe5-446bcc52a264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0d4028a-2ba9-4937-abe5-446bcc52a264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

