### PR TITLE
fix(cli): guard startup stdin unref on isTTY so prompts don't exit by themselves

### DIFF
--- a/.changeset/unref-stdin-tty-guard.md
+++ b/.changeset/unref-stdin-tty-guard.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Guard the startup `process.stdin` unref on `process.stdin.isTTY` so interactive prompts no longer exit by themselves. The startup unref (added so one-shot non-interactive runs like `--json` from an eval runner holding the stdin pipe open can exit cleanly) was applied unconditionally, including on a real terminal. On a TTY `prompts` never re-refs the unref'd stdin handle — `readline.createInterface` + `setRawMode(true)` do not re-ref it — so the multiselect ("Select projects") rendered and the CLI then drained the event loop and exited (code 0) before the user could answer. Skipping the unref when stdin is a TTY keeps the one-shot exit fix for non-interactive pipes/sockets while leaving interactive terminals untouched. Adds an in-process behavioral test and a real-PTY CI smoke (`pnpm smoke:tty-prompt`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,11 @@ jobs:
       - name: Smoke test JSON report shape
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '22.18.0' }}
         run: pnpm smoke:json-report
+
+      # Allocates a real pseudo-terminal (`pty.openpty()`) so the CLI sees an
+      # interactive TTY and renders the multiselect prompt, then asserts the
+      # process stays alive waiting for input instead of exiting by itself
+      # (regression guard for #576: unref'd stdin killed interactive prompts).
+      - name: Smoke test interactive TTY prompt
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '22.18.0' }}
+        run: pnpm smoke:tty-prompt

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "changeset": "changeset",
     "version": "changeset version",
     "release": "pnpm build && changeset publish",
-    "smoke:json-report": "node --experimental-strip-types --no-warnings scripts/smoke-json-report.ts"
+    "smoke:json-report": "node --experimental-strip-types --no-warnings scripts/smoke-json-report.ts",
+    "smoke:tty-prompt": "python3 scripts/smoke-tty-prompt.py"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/packages/react-doctor/src/cli/utils/unref-stdin.ts
+++ b/packages/react-doctor/src/cli/utils/unref-stdin.ts
@@ -1,28 +1,28 @@
-// HACK: react-doctor is a one-shot CLI, but Node keeps the event loop
-// alive for as long as `process.stdin` (fd 0) is an open pipe or
-// socket — even though the only thing that ever reads stdin is an
-// interactive prompt. When the CLI is spawned by a parent that holds
-// the stdin write-end open (eval runners, CI harnesses, editor
-// integrations), the scan finishes and the `--json` report flushes,
-// yet the process never exits: the inherited `Socket fd=0` refs the
-// loop. Some Node versions / stdin fd types ref the socket merely on
-// access (the bundled `import process from "node:process"` facade
-// materializes the lazy `process.stdin` getter), so the hang is not
-// always reproducible, but unref-ing up front makes an idle stdin
-// incapable of holding the process open in every case.
+// HACK: react-doctor is a one-shot CLI, but when stdin (fd 0) is an
+// inherited pipe or socket Node keeps the event loop alive for as long
+// as that handle is open — even though the only thing that ever reads
+// stdin is an interactive prompt. When the CLI is spawned by a parent
+// that holds the stdin write-end open (eval runners, CI harnesses,
+// editor integrations), the scan finishes and the `--json` report
+// flushes, yet the process never exits: the inherited `Socket fd=0`
+// refs the loop. Unref-ing fd 0 up front makes an idle pipe/socket
+// incapable of holding the process open.
 //
-// Interactive prompts DEFEAT this up-front unref: `prompts` builds a
-// `readline.createInterface({ input: process.stdin })`, whose
-// `resume()` (and `setRawMode(true)` on a TTY) re-refs stdin for the
-// lifetime of the prompt. Crucially `readline.close()` only *pauses*
-// stdin on submit/cancel — it never unrefs it — so after the last
-// prompt resolves the re-reffed fd 0 holds the loop open again and the
-// CLI hangs. The `prompts` wrapper therefore re-invokes `unrefStdin`
-// once each prompt settles.
+// We MUST NOT unref an interactive TTY. A real terminal is the only
+// case that shows prompts, and `prompts` never re-refs an unref'd stdin
+// handle: its base element does `readline.createInterface(...)` +
+// `setRawMode(true)` but never `resume()`, and none of those re-ref the
+// libuv handle (verified on a real PTY). Unref-ing a TTY therefore lets
+// the event loop drain while a prompt is still waiting for input — the
+// CLI renders the prompt and then exits by itself (code 0) before the
+// user can answer. A TTY is never the "parent holds the pipe open"
+// hang scenario, so guarding on `isTTY` keeps the one-shot exit fix
+// without breaking interactive prompts.
 //
 // File / `/dev/null` stdin resolves to an `fs.ReadStream` that has no
 // `unref` (and never holds the loop open anyway), hence the optional
 // call.
 export const unrefStdin = (): void => {
+  if (process.stdin.isTTY) return;
   process.stdin.unref?.();
 };

--- a/packages/react-doctor/tests/unref-stdin-live.test.ts
+++ b/packages/react-doctor/tests/unref-stdin-live.test.ts
@@ -1,0 +1,112 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+
+// Live smoke test: spawn a real Node process that runs the actual
+// `unrefStdin()` against a real OS stdin pipe handle, then mimics exactly
+// what `prompts` does when a prompt opens (readline interface + keypress
+// listener). The regression we guard against is #576: unconditionally
+// unref-ing stdin let the event loop drain while an interactive prompt was
+// still waiting for input, so the CLI rendered the prompt and then exited
+// by itself (code 0) before the user could answer.
+//
+// The bug only fires when `process.stdin.isTTY` is true, so the probe forces
+// that branch. A real OS pipe is a faithful stand-in for a TTY socket here:
+// both are libuv stream handles, and whether the handle is ref'd is the only
+// thing that decides if the loop stays alive.
+
+// If the prompt is still running this long after it rendered, the event loop
+// is being held open correctly. The regression exits within ~70ms of render.
+const STAY_ALIVE_WINDOW_MS = 750;
+const PROMPT_OPEN_MARKER = "PROMPT_OPEN";
+
+const currentDirectory = dirname(fileURLToPath(import.meta.url));
+const unrefStdinSourceUrl = pathToFileURL(
+  join(currentDirectory, "../src/cli/utils/unref-stdin.ts"),
+).href;
+
+// Older Node needs the flag; Node >= 23.6 strips types by default.
+const nodeStripTypesArgs = process.features.typescript ? [] : ["--experimental-strip-types"];
+
+const probeScript = `
+import * as readline from "node:readline";
+import { unrefStdin } from ${JSON.stringify(unrefStdinSourceUrl)};
+
+const wantInteractiveTty = process.argv[2] === "tty";
+Object.defineProperty(process.stdin, "isTTY", { value: wantInteractiveTty, configurable: true });
+
+unrefStdin();
+
+const readlineInterface = readline.createInterface({ input: process.stdin, escapeCodeTimeout: 50 });
+readline.emitKeypressEvents(process.stdin, readlineInterface);
+process.stdin.on("keypress", () => {});
+
+process.stdout.write(${JSON.stringify(`${PROMPT_OPEN_MARKER}\n`)});
+`;
+
+interface LiveProbeResult {
+  readonly didExitByItself: boolean;
+  readonly stdout: string;
+}
+
+let probeDirectory: string;
+let probeScriptPath: string;
+
+const runPromptProbe = (stdinMode: "tty" | "pipe"): Promise<LiveProbeResult> =>
+  new Promise((resolve) => {
+    const child = spawn(process.execPath, [...nodeStripTypesArgs, probeScriptPath, stdinMode], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+
+    let didSettle = false;
+    const stayAliveTimer = setTimeout(() => {
+      if (didSettle) return;
+      didSettle = true;
+      child.kill();
+      resolve({ didExitByItself: false, stdout });
+    }, STAY_ALIVE_WINDOW_MS);
+
+    child.on("exit", () => {
+      if (didSettle) return;
+      didSettle = true;
+      clearTimeout(stayAliveTimer);
+      resolve({ didExitByItself: true, stdout });
+    });
+  });
+
+describe("unrefStdin (live)", () => {
+  beforeAll(() => {
+    probeDirectory = mkdtempSync(join(tmpdir(), "react-doctor-unref-stdin-"));
+    probeScriptPath = join(probeDirectory, "prompt-keepalive-probe.ts");
+    writeFileSync(probeScriptPath, probeScript);
+  });
+
+  afterAll(() => {
+    rmSync(probeDirectory, { recursive: true, force: true });
+  });
+
+  it("keeps the event loop alive while an interactive (TTY) prompt waits for input", async () => {
+    const result = await runPromptProbe("tty");
+    expect(result.stdout).toContain(PROMPT_OPEN_MARKER);
+    // The actual regression guard: the process must NOT die by itself while a
+    // prompt is open. If this flips to true, an interactive prompt renders and
+    // exits before the user can answer (the #576 unconditional-unref bug).
+    expect(result.didExitByItself).toBe(false);
+  });
+
+  it("still exits on its own when stdin is a non-interactive pipe (one-shot runs)", async () => {
+    const result = await runPromptProbe("pipe");
+    expect(result.stdout).toContain(PROMPT_OPEN_MARKER);
+    // Preserves the original #576 fix: a parent-held stdin pipe must not keep
+    // a finished one-shot run (e.g. `--json` from an eval runner) alive.
+    expect(result.didExitByItself).toBe(true);
+  });
+});

--- a/packages/react-doctor/tests/unref-stdin.test.ts
+++ b/packages/react-doctor/tests/unref-stdin.test.ts
@@ -4,21 +4,37 @@ import { stubProcessStdinProperty } from "./helpers/stub-process-stdin-property.
 
 describe("unrefStdin", () => {
   let restoreStdinUnref: (() => void) | undefined;
+  let restoreStdinIsTty: (() => void) | undefined;
 
   afterEach(() => {
     restoreStdinUnref?.();
     restoreStdinUnref = undefined;
+    restoreStdinIsTty?.();
+    restoreStdinIsTty = undefined;
   });
 
   it("unrefs stdin so an inherited pipe/socket can't hold the event loop open", () => {
+    restoreStdinIsTty = stubProcessStdinProperty("isTTY", false);
     const unref = vi.fn();
     restoreStdinUnref = stubProcessStdinProperty("unref", unref);
     unrefStdin();
     expect(unref).toHaveBeenCalledTimes(1);
   });
 
+  // An interactive TTY is the only case that shows prompts; unref-ing it
+  // lets the loop drain while a prompt waits for input (the CLI renders
+  // the prompt and then exits by itself), so it must be left ref'd.
+  it("does not unref an interactive TTY (regression: prompts must not die by themselves)", () => {
+    restoreStdinIsTty = stubProcessStdinProperty("isTTY", true);
+    const unref = vi.fn();
+    restoreStdinUnref = stubProcessStdinProperty("unref", unref);
+    unrefStdin();
+    expect(unref).not.toHaveBeenCalled();
+  });
+
   // File / `/dev/null` stdin resolves to an `fs.ReadStream` with no `unref`.
   it("is a no-op when stdin has no unref (file / /dev/null)", () => {
+    restoreStdinIsTty = stubProcessStdinProperty("isTTY", false);
     restoreStdinUnref = stubProcessStdinProperty("unref", undefined);
     expect(() => unrefStdin()).not.toThrow();
   });

--- a/scripts/smoke-tty-prompt.py
+++ b/scripts/smoke-tty-prompt.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Smoke test: the interactive multiselect prompt must survive in a real TTY.
+
+Regression guard for #576. The CLI unrefs `process.stdin` at startup so
+one-shot non-interactive runs (e.g. `--json` launched by an eval runner that
+holds the stdin pipe open) can exit cleanly. The fix MUST NOT unref an
+interactive TTY: `prompts` never re-refs an unref'd stdin handle, so unref-ing
+a terminal lets the event loop drain while the prompt is still waiting for
+input — the CLI renders the prompt and then exits by itself (code 0) before
+the user can answer.
+
+A real terminal is the only environment that exposes this bug (`isTTY` gates
+the unref), so this test allocates a genuine pseudo-terminal with
+`pty.openpty()` — Node has no built-in PTY and the `script(1)` utility needs
+the parent's stdin to itself be a TTY, which CI runners don't provide. Python's
+`pty` module is preinstalled on every GitHub-hosted runner (Linux + macOS) and
+needs no native build.
+
+Verdict:
+  PASS  -> the prompt rendered AND the process was still alive when we killed
+           it at the timeout (the TTY held the event loop open, as it must).
+  FAIL  -> the process exited on its own (the #576 regression: "dies by
+           itself"), or the prompt never rendered (setup/environment problem).
+"""
+
+import json
+import os
+import pty
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CLI_BINARY_PATH = os.path.join(REPOSITORY_ROOT, "packages", "react-doctor", "dist", "cli.js")
+
+# If the prompt is still open this long after the CLI started, the event loop
+# is being held open correctly. The regression self-exits within ~100ms of the
+# prompt rendering, so this window has a wide safety margin for slow CI cold
+# starts.
+STAY_ALIVE_WINDOW_SECONDS = 6.0
+PROMPT_MARKER = "Select projects"
+
+# Env vars that make `shouldSkipPrompts()` short-circuit to non-interactive
+# (so the multiselect would never render). CI sets CI / GITHUB_ACTIONS, and a
+# coding agent may set CURSOR_AGENT etc., so we strip the full set the CLI
+# consults to force the genuine interactive code path. Keep in sync with
+# `is-non-interactive-environment.ts` + `is-ci-environment.ts`.
+NON_INTERACTIVE_ENVIRONMENT_VARIABLES = (
+    "CI",
+    "GITHUB_ACTIONS",
+    "GITLAB_CI",
+    "BUILDKITE",
+    "JENKINS_URL",
+    "TF_BUILD",
+    "CODEBUILD_BUILD_ID",
+    "TEAMCITY_VERSION",
+    "BITBUCKET_BUILD_NUMBER",
+    "CIRCLECI",
+    "TRAVIS",
+    "DRONE",
+    "GIT_DIR",
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CURSOR_AGENT",
+    "CODEX_CI",
+    "CODEX_SANDBOX",
+    "CODEX_SANDBOX_NETWORK_DISABLED",
+    "OPENCODE",
+    "GOOSE_TERMINAL",
+    "AGENT_SESSION_ID",
+    "AMP_THREAD_ID",
+    "AGENT_THREAD_ID",
+    "AGENT",
+)
+
+
+def fail(message):
+    print(f"Smoke FAIL: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def resolve_node_binary():
+    node_path = shutil.which("node")
+    if node_path is None:
+        fail("`node` not found on PATH.")
+    return node_path
+
+
+NODE_BINARY_PATH = resolve_node_binary()
+
+
+def write_package_json(directory, contents):
+    os.makedirs(directory, exist_ok=True)
+    with open(os.path.join(directory, "package.json"), "w", encoding="utf-8") as handle:
+        json.dump(contents, handle)
+
+
+def create_workspace_fixture(root_directory):
+    """A minimal monorepo with two React packages so the CLI shows the
+    multiselect "Select projects" prompt (>= 2 workspace packages with a React
+    dependency)."""
+    write_package_json(
+        root_directory,
+        {"name": "rd-tty-smoke-root", "private": True, "version": "0.0.0", "workspaces": ["packages/*"]},
+    )
+    for package_name in ("app-a", "app-b"):
+        package_directory = os.path.join(root_directory, "packages", package_name)
+        write_package_json(
+            package_directory,
+            {"name": package_name, "version": "0.0.0", "dependencies": {"react": "18.3.1"}},
+        )
+        source_directory = os.path.join(package_directory, "src")
+        os.makedirs(source_directory, exist_ok=True)
+        with open(os.path.join(source_directory, "index.tsx"), "w", encoding="utf-8") as handle:
+            handle.write("export const Component = () => null;\n")
+
+
+def run_prompt_in_pty(fixture_directory):
+    child_environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in NON_INTERACTIVE_ENVIRONMENT_VARIABLES
+    }
+    child_environment["FORCE_COLOR"] = "0"
+
+    master_fd, slave_fd = pty.openpty()
+    process = subprocess.Popen(
+        [NODE_BINARY_PATH, CLI_BINARY_PATH, fixture_directory, "--no-lint", "--no-dead-code", "--no-score"],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        env=child_environment,
+        close_fds=True,
+    )
+    os.close(slave_fd)
+
+    captured_output = b""
+    deadline = time.time() + STAY_ALIVE_WINDOW_SECONDS
+    while time.time() < deadline and process.poll() is None:
+        readable, _, _ = select.select([master_fd], [], [], 0.2)
+        if not readable:
+            continue
+        try:
+            chunk = os.read(master_fd, 4096)
+        except OSError:
+            chunk = b""
+        if chunk:
+            captured_output += chunk
+    os.close(master_fd)
+
+    exited_by_itself = process.poll() is not None
+    if not exited_by_itself:
+        process.send_signal(signal.SIGKILL)
+        process.wait()
+
+    return exited_by_itself, captured_output.decode("utf-8", "replace")
+
+
+def main():
+    if not os.path.isfile(CLI_BINARY_PATH):
+        fail(f"Built CLI missing at {CLI_BINARY_PATH}. Run `pnpm build` first.")
+
+    fixture_directory = tempfile.mkdtemp(prefix="react-doctor-tty-smoke-")
+    try:
+        create_workspace_fixture(fixture_directory)
+        exited_by_itself, output = run_prompt_in_pty(fixture_directory)
+    finally:
+        shutil.rmtree(fixture_directory, ignore_errors=True)
+
+    prompt_rendered = PROMPT_MARKER in output
+
+    if not prompt_rendered:
+        print(output[:1000], file=sys.stderr)
+        fail(
+            f'The "{PROMPT_MARKER}" prompt never rendered in the PTY — the CLI '
+            "did not reach interactive project selection (env/setup problem)."
+        )
+
+    if exited_by_itself:
+        print(output[:1000], file=sys.stderr)
+        fail(
+            "The CLI exited on its own while an interactive prompt was open "
+            "(the #576 unref-stdin regression: prompts die by themselves)."
+        )
+
+    print(
+        f'Smoke OK: "{PROMPT_MARKER}" prompt rendered in a real PTY and the '
+        "process stayed alive waiting for input (held the event loop open)."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Interactive prompts (e.g. the `Select projects` multiselect) render and then the CLI **exits by itself** (code 0) before the user can answer. This is a prod regression — reproduced on `react-doctor@latest` (v0.2.13).

**Root cause:** the startup `process.stdin.unref()` (#576, kept by #586) is applied unconditionally. On a real TTY, `prompts` never re-refs the unref'd stdin handle (`readline.createInterface` + `setRawMode(true)` do **not** re-ref the libuv handle — verified on a real PTY), so once the prompt awaits input there's nothing keeping the event loop alive and Node drains and exits.

**Fix:** skip the unref when `process.stdin.isTTY`. This preserves the one-shot exit behavior for non-interactive pipes/sockets (eval runners, CI, editor integrations — the only case the unref was ever for) while leaving interactive terminals untouched.

> Note on #586: it assumed `prompts` re-refs stdin and added a post-prompt `.finally(unrefStdin)`. On a real PTY that premise doesn't hold (the prompt dies *before* settling, and `readline.close()` releases a TTY stdin cleanly with no hang), so #586 does not actually fix the death. With this guard, #586's `.finally(unrefStdin)` becomes a harmless no-op on a TTY — left in place here; happy to remove it in a follow-up if preferred.

## Changes
- `unref-stdin.ts`: `if (process.stdin.isTTY) return;` guard + corrected comment.
- `unref-stdin.test.ts`: added the `does not unref an interactive TTY` regression case.
- `unref-stdin-live.test.ts`: new in-process subprocess behavioral test.
- `scripts/smoke-tty-prompt.py` + `pnpm smoke:tty-prompt` + CI step: real-PTY smoke that renders the prompt in a pseudo-terminal and asserts the process stays alive waiting for input.

## Test plan
- [x] `pnpm --filter react-doctor test` (16 tests incl. live test pass; #586's `prompts.test.ts` still passes)
- [x] `pnpm --filter react-doctor typecheck`
- [x] `pnpm smoke:tty-prompt` (real PTY: `Smoke OK`)
- [x] Verified the smoke + live test FAIL against the regressed (unconditional-unref) build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted CLI stdin lifecycle change with strong regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a production regression where interactive CLI prompts (e.g. **Select projects**) appeared and the process **exited immediately** (code 0) before input.
> 
> Startup `unrefStdin()` now **skips** `process.stdin.unref()` when `process.stdin.isTTY`, so real terminals keep stdin ref'd while prompts wait. **Non-TTY** pipes/sockets still get the startup unref so one-shot runs (e.g. `--json` with a parent holding stdin open) can exit cleanly.
> 
> Adds regression coverage: unit test for the TTY branch, a live subprocess probe mimicking `prompts` + readline, and a **real PTY** smoke (`pnpm smoke:tty-prompt`) wired into CI on Ubuntu/Node 22.18.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4b75986c9c1510bbe61ab8f9bdf8811f222ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->