### PR TITLE
chore(deps): bump deslop-js to 0.0.14

### DIFF
--- a/.changeset/bump-deslop-js-0-0-14.md
+++ b/.changeset/bump-deslop-js-0-0-14.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Update the dead-code analysis engine (`deslop-js`) to `0.0.14` so the published CLI's unused-file / dead-code detection runs on the latest release. The CLI previously pinned `^0.0.13` while the internal core engine was already on `0.0.14`; this aligns both on a single version and drops the duplicate from the lockfile.

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -58,7 +58,7 @@
     "@effect/platform-node-shared": "4.0.0-beta.70",
     "agent-install": "0.0.5",
     "conf": "^15.1.0",
-    "deslop-js": "^0.0.13",
+    "deslop-js": "^0.0.14",
     "effect": "4.0.0-beta.70",
     "eslint-plugin-react-hooks": "^7.1.1",
     "oxlint": "^1.66.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: ^15.1.0
         version: 15.1.0
       deslop-js:
-        specifier: ^0.0.13
-        version: 0.0.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.0.14
+        version: 0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
@@ -2083,9 +2083,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  deslop-js@0.0.13:
-    resolution: {integrity: sha512-gIXD+wY2/NHkZHpNrb8MWS6NJs3ee0XunAenBCvwHJlWnedDbIrg70hdNR7bDzYZLe9LGJZMLEI1w2CC72Gk5A==}
 
   deslop-js@0.0.14:
     resolution: {integrity: sha512-FY0rNK+mdTozXwNmcJAt5tD9hVOkXEX5ac+Mg77KJvnnsoAh3qIUW64PMnofutjeYz7g1vENMbOcrBmD1v4FlA==}
@@ -4607,18 +4604,6 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
-
-  deslop-js@0.0.13(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
-    dependencies:
-      '@oxc-project/types': 0.132.0
-      fast-glob: 3.3.3
-      minimatch: 10.2.5
-      oxc-parser: 0.132.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   deslop-js@0.0.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:


### PR DESCRIPTION
## Why

The published `react-doctor` package pinned `deslop-js` to `^0.0.13`, while the internal `@react-doctor/core` engine was already on `^0.0.14`. Because caret ranges lock the patch level for `0.0.x` versions, `^0.0.13` never auto-resolves to `0.0.14` — so the lockfile carried *both* copies and the published CLI shipped the older dead-code engine.

`deslop-js` is the engine behind react-doctor's unused-file / dead-code detection. This aligns the published CLI on the latest release (`0.0.14`) and removes the duplicate from the lockfile.

## What changed

- Bumped `deslop-js` `^0.0.13` → `^0.0.14` in `packages/react-doctor/package.json`.
- Regenerated `pnpm-lock.yaml`: both workspace importers now resolve to `0.0.14`; the stale `0.0.13` resolution/snapshot is removed.
- Added a `patch` changeset for `react-doctor` (it's in a `fixed` group, so `eslint-plugin-react-doctor` / `oxlint-plugin-react-doctor` version in lockstep).

`@react-doctor/core` already declared `^0.0.14`, so its manifest is untouched.

## Validation

| Check | Result |
| --- | --- |
| `core` dead-code tests (the code path that invokes `deslop-js`) | 9 passed |
| `react-doctor` dead-code integration test (after `pnpm build`) | 1 passed |
| `pnpm typecheck` | 8/8 successful |
| `pnpm format:check` | clean (1310 files) |

RDE / OSS eval: **not run** — intentionally skipped. This is a dependency version alignment with no new/changed detection surface to evaluate.

## Test plan

- [x] `pnpm --filter @react-doctor/core exec vp test run dead-code`
- [x] `pnpm build && pnpm --filter react-doctor exec vp test run dead-code`
- [x] `pnpm typecheck`
- [x] `pnpm format:check`

## Residual risk

- Low. No source changed; behavior delta is whatever ships in `deslop-js@0.0.14`. The dead-code suites exercise the `analyze`/`defineConfig` API end-to-end and pass on `0.0.14`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only alignment with no application source changes; any behavior change is limited to what ships in `deslop-js@0.0.14`, which existing dead-code tests already exercise.
> 
> **Overview**
> Aligns the published **`react-doctor`** CLI with **`@react-doctor/core`** by bumping **`deslop-js`** from **`^0.0.13`** to **`^0.0.14`** in `packages/react-doctor/package.json`. Under **`0.0.x`** caret rules, the older pin never picked up **`0.0.14`**, so the lockfile had two versions and the shipped CLI could run an older dead-code engine than core.
> 
> **`pnpm-lock.yaml`** now resolves a single **`deslop-js@0.0.14`** (the **`0.0.13`** resolution is removed). A **patch** changeset records the **`react-doctor`** release note for the engine update used for unused-file / dead-code detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ddff9d9c6cc7dacee3615984c28cde1e959e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->