### PR TITLE
fix(core): redact secrets and PII from diagnostic output

### DIFF
--- a/.changeset/redact-secrets-from-diagnostics.md
+++ b/.changeset/redact-secrets-from-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Redact secrets and PII from diagnostic output. Every diagnostic's `message`/`help` is now scrubbed for API keys, tokens, private keys, JWTs, credentialed URLs, and email addresses before it reaches the terminal, the JSON report, or the score API — so react-doctor never echoes or transmits a secret embedded in your source.

--- a/.changeset/redact-secrets-from-diagnostics.md
+++ b/.changeset/redact-secrets-from-diagnostics.md
@@ -2,4 +2,4 @@
 "react-doctor": patch
 ---
 
-Redact secrets and PII from diagnostic output. Every diagnostic's `message`/`help` is now scrubbed for API keys, tokens, private keys, JWTs, credentialed URLs, and email addresses before it reaches the terminal, the JSON report, or the score API — so react-doctor never echoes or transmits a secret embedded in your source.
+Redact secrets and PII from diagnostic output. Every diagnostic's `message`/`help` is now scrubbed for API keys, tokens, private keys, JWTs, credentialed URLs, and email addresses before it reaches the terminal, the JSON report, or the score API — so react-doctor never echoes or transmits a secret embedded in your source. Provider tokens keep their non-secret, type-identifying prefix (e.g. `sk_live_<redacted>`, `ghp_<redacted>`) so you can tell which credential leaked while the secret itself stays masked.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -36,6 +36,12 @@ export const EARLIEST_GATED_PREACT_MAJOR = 10;
 
 export const ERROR_PREVIEW_LENGTH_CHARS = 200;
 
+// Minimum length for the generic high-entropy token sweep in
+// `redactSensitiveText`. Real API keys / tokens run 32+ chars; the
+// known-format detectors catch shorter prefixed credentials, so this
+// floor keeps the catch-all from masking ordinary long identifiers.
+export const GENERIC_SECRET_MIN_LENGTH_CHARS = 32;
+
 export const PERFECT_SCORE = 100;
 
 export const SCORE_GOOD_THRESHOLD = 75;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -42,6 +42,16 @@ export const ERROR_PREVIEW_LENGTH_CHARS = 200;
 // floor keeps the catch-all from masking ordinary long identifiers.
 export const GENERIC_SECRET_MIN_LENGTH_CHARS = 32;
 
+// Minimum Shannon entropy (bits/char) a long token must clear before the
+// generic sweep in `redactSensitiveText` masks it. Random base64url/hex
+// credentials sit ~4–6 bits/char; repetitive or word-like identifiers
+// (e.g. `componentDisplayName2`, `aaaa…a1`) fall well below this, so the
+// floor keeps the catch-all from masking ordinary long identifiers while
+// still catching unknown-format secrets. 3.0 mirrors detect-secrets'
+// hex-string threshold — low enough to avoid leaks, high enough to spare
+// degenerate low-entropy strings.
+export const GENERIC_SECRET_MIN_ENTROPY_BITS = 3.0;
+
 export const PERFECT_SCORE = 100;
 
 export const SCORE_GOOD_THRESHOLD = 75;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export * from "./utils/build-rule-prompt-url.js";
 export * from "./utils/dedupe-diagnostics.js";
 export * from "./utils/group-by.js";
 export * from "./utils/match-glob-pattern.js";
+export * from "./utils/redact-sensitive-text.js";
 export * from "./utils/resolve-github-actions-score-metadata.js";
 export * from "./utils/to-relative-path.js";
 export * from "./utils/warn-config-issue.js";

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -9,6 +9,7 @@ import { ERROR_PREVIEW_LENGTH_CHARS, SOURCE_FILE_PATTERN } from "../../constants
 import { OxlintOutputUnparseable, ReactDoctorError } from "../../errors.js";
 import { buildNoSecretsRecommendation } from "../../utils/build-no-secrets-recommendation.js";
 import { appendReanimatedSharedValueHint } from "../../utils/append-reanimated-shared-value-hint.js";
+import { redactSensitiveText } from "../../utils/redact-sensitive-text.js";
 import { shouldSuppressLocalUseHookDiagnostic } from "./should-suppress-local-use-hook-diagnostic.js";
 
 const FILEPATH_WITH_LOCATION_PATTERN = /\S+\.\w+:\d+:\d+[\s\S]*$/;
@@ -67,6 +68,24 @@ export const getRuleCategory = (ruleName: string): string | undefined =>
   reactDoctorPlugin.rules[ruleName]?.category;
 
 const cleanDiagnosticMessage = (
+  message: string,
+  help: string,
+  plugin: string,
+  rule: string,
+  project: ProjectInfo,
+): CleanedDiagnostic => {
+  const cleaned = resolveCleanedDiagnostic(message, help, plugin, rule, project);
+  // Final guard: a rule may echo a source fragment containing a secret
+  // or PII into its message/help. Scrub it here — the single point every
+  // diagnostic flows through — so it reaches neither the terminal, the
+  // JSON report, nor the score API.
+  return {
+    message: redactSensitiveText(cleaned.message),
+    help: redactSensitiveText(cleaned.help),
+  };
+};
+
+const resolveCleanedDiagnostic = (
   message: string,
   help: string,
   plugin: string,

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -68,13 +68,24 @@ export const getRuleCategory = (ruleName: string): string | undefined =>
   reactDoctorPlugin.rules[ruleName]?.category;
 
 const cleanDiagnosticMessage = (
-  message: string,
-  help: string,
+  message: unknown,
+  help: unknown,
   plugin: string,
   rule: string,
   project: ProjectInfo,
 ): CleanedDiagnostic => {
-  const cleaned = resolveCleanedDiagnostic(message, help, plugin, rule, project);
+  // `message` / `help` come from oxlint JSON that is only shape-checked at
+  // the top level (`isOxlintOutput`), so coerce a non-string value to ""
+  // before cleaning. This keeps the redaction path total and lets a
+  // non-string `help` fall back to `getRuleRecommendation` instead of
+  // becoming an empty string.
+  const cleaned = resolveCleanedDiagnostic(
+    typeof message === "string" ? message : "",
+    typeof help === "string" ? help : "",
+    plugin,
+    rule,
+    project,
+  );
   // Final guard: a rule may echo a source fragment containing a secret
   // or PII into its message/help. Scrub it here — the single point every
   // diagnostic flows through — so it reaches neither the terminal, the

--- a/packages/core/src/utils/redact-sensitive-text.ts
+++ b/packages/core/src/utils/redact-sensitive-text.ts
@@ -1,0 +1,83 @@
+import { GENERIC_SECRET_MIN_LENGTH_CHARS } from "../constants.js";
+
+export const REDACTED_PLACEHOLDER = "<redacted>";
+
+interface RedactionRule {
+  readonly pattern: RegExp;
+  readonly replacement: string;
+}
+
+// High-precision detectors for credentials and PII that can ride along
+// inside a diagnostic's `message` / `help` when a rule echoes a source
+// fragment (e.g. `useState("sk-live-…")`). Ordered so structured matches
+// (key blocks, JWTs, credentialed URLs) run before the broad
+// generic-token sweep, and so each replacement leaves only inert
+// `<redacted>` text that no later rule can re-match. Patterns are
+// intentionally narrow — they target real secret shapes, never ordinary
+// identifiers or short captions — so normal diagnostics stay readable.
+const buildRedactionRules = (): RedactionRule[] => {
+  const genericTokenPattern = new RegExp(
+    // A contiguous base64url / hex run long enough to be a credential,
+    // constrained by lookaheads to contain BOTH a letter and a digit so
+    // plain prose words and all-digit line/column noise never match. The
+    // class deliberately excludes `= + /` so the run can't bleed across a
+    // `name=value` separator and swallow an adjacent label.
+    `\\b(?=[A-Za-z0-9_-]*[A-Za-z])(?=[A-Za-z0-9_-]*[0-9])[A-Za-z0-9_-]{${GENERIC_SECRET_MIN_LENGTH_CHARS},}`,
+    "g",
+  );
+
+  return [
+    {
+      pattern:
+        /-----BEGIN (?:[A-Z]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z]+ )*PRIVATE KEY-----/g,
+      replacement: REDACTED_PLACEHOLDER,
+    },
+    {
+      pattern: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
+      replacement: REDACTED_PLACEHOLDER,
+    },
+    {
+      // Credentials embedded in a URL authority (`scheme://user:pass@host`).
+      // Lookbehind / lookahead keep the scheme and host so the location
+      // stays useful while the `user:pass` pair is masked.
+      pattern: /(?<=:\/\/)[^\s/:@]+:[^\s/:@]+(?=@)/g,
+      replacement: REDACTED_PLACEHOLDER,
+    },
+    { pattern: /\bAKIA[0-9A-Z]{16}\b/g, replacement: REDACTED_PLACEHOLDER },
+    { pattern: /\bgh[pousr]_[A-Za-z0-9]{36,}/g, replacement: REDACTED_PLACEHOLDER },
+    { pattern: /\bgithub_pat_[A-Za-z0-9_]{22,}/g, replacement: REDACTED_PLACEHOLDER },
+    { pattern: /\bglpat-[A-Za-z0-9_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+    { pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}/g, replacement: REDACTED_PLACEHOLDER },
+    { pattern: /\b[sprk]k_(?:live|test)_[A-Za-z0-9]{10,}/g, replacement: REDACTED_PLACEHOLDER },
+    { pattern: /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+    { pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g, replacement: REDACTED_PLACEHOLDER },
+    { pattern: /\bya29\.[0-9A-Za-z_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+    {
+      pattern: /(?<=\bBearer\s)[A-Za-z0-9._~+/=-]{16,}/g,
+      replacement: REDACTED_PLACEHOLDER,
+    },
+    {
+      pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+      replacement: REDACTED_PLACEHOLDER,
+    },
+    { pattern: genericTokenPattern, replacement: REDACTED_PLACEHOLDER },
+  ];
+};
+
+const REDACTION_RULES = buildRedactionRules();
+
+/**
+ * Masks API keys, tokens, private keys, credentialed URLs, and emails
+ * found anywhere inside a free-text string, returning the scrubbed text.
+ * Applied to every diagnostic's `message` / `help` at construction time
+ * so secrets never reach the terminal, the JSON report, or the score
+ * API — react-doctor must never echo or transmit a user's secrets.
+ */
+export const redactSensitiveText = (text: string): string => {
+  if (!text) return text;
+  let redacted = text;
+  for (const rule of REDACTION_RULES) {
+    redacted = redacted.replace(rule.pattern, rule.replacement);
+  }
+  return redacted;
+};

--- a/packages/core/src/utils/redact-sensitive-text.ts
+++ b/packages/core/src/utils/redact-sensitive-text.ts
@@ -149,9 +149,15 @@ const redactHighEntropyTokens = (text: string): string =>
  * entropy-gated sweep for unknown-format secrets. Idempotent: the inert
  * `<redacted>` placeholder matches none of the detectors and is too
  * short for the generic sweep, so re-running leaves the text unchanged.
+ *
+ * Accepts `unknown` on purpose: callers feed it diagnostic `message` /
+ * `help` that originate from oxlint JSON, which is only shape-checked at
+ * the top level (the per-field `string` types are assumed, not validated).
+ * A malformed non-string value returns `""` instead of throwing on
+ * `.replace`, so one bad diagnostic can't abort parsing the whole batch.
  */
-export const redactSensitiveText = (text: string): string => {
-  if (!text) return text;
+export const redactSensitiveText = (text: unknown): string => {
+  if (typeof text !== "string" || text === "") return "";
   let redacted = text;
   for (const rule of KNOWN_SECRET_RULES) {
     redacted = redacted.replace(rule.pattern, rule.replacement);

--- a/packages/core/src/utils/redact-sensitive-text.ts
+++ b/packages/core/src/utils/redact-sensitive-text.ts
@@ -1,4 +1,7 @@
-import { GENERIC_SECRET_MIN_LENGTH_CHARS } from "../constants.js";
+import {
+  GENERIC_SECRET_MIN_ENTROPY_BITS,
+  GENERIC_SECRET_MIN_LENGTH_CHARS,
+} from "../constants.js";
 
 export const REDACTED_PLACEHOLDER = "<redacted>";
 
@@ -9,62 +12,134 @@ interface RedactionRule {
 
 // High-precision detectors for credentials and PII that can ride along
 // inside a diagnostic's `message` / `help` when a rule echoes a source
-// fragment (e.g. `useState("sk-live-…")`). Ordered so structured matches
-// (key blocks, JWTs, credentialed URLs) run before the broad
-// generic-token sweep, and so each replacement leaves only inert
-// `<redacted>` text that no later rule can re-match. Patterns are
-// intentionally narrow — they target real secret shapes, never ordinary
-// identifiers or short captions — so normal diagnostics stay readable.
-const buildRedactionRules = (): RedactionRule[] => {
-  const genericTokenPattern = new RegExp(
-    // A contiguous base64url / hex run long enough to be a credential,
-    // constrained by lookaheads to contain BOTH a letter and a digit so
-    // plain prose words and all-digit line/column noise never match. The
-    // class deliberately excludes `= + /` so the run can't bleed across a
-    // `name=value` separator and swallow an adjacent label.
-    `\\b(?=[A-Za-z0-9_-]*[A-Za-z])(?=[A-Za-z0-9_-]*[0-9])[A-Za-z0-9_-]{${GENERIC_SECRET_MIN_LENGTH_CHARS},}`,
-    "g",
-  );
+// fragment (e.g. `useState("sk-live-…")`). Shapes track the corpora that
+// gitleaks and secretlint maintain, so coverage stays close to the
+// ecosystem's without taking either as a runtime dependency — this is a
+// synchronous, in-string backstop on a hot path, not a file scanner.
+//
+// Ordered so structured composites (key blocks, JWTs, credentialed URLs)
+// run before the narrower prefixed tokens, every replacement leaves only
+// inert `<redacted>` text that no later rule can re-match, and the broad
+// entropy sweep (`redactHighEntropyTokens`) runs dead last. Each pattern
+// is intentionally narrow — it targets a real secret shape, never an
+// ordinary identifier — and uses linear-time constructs (no nested or
+// overlapping quantifiers) so a pathological message can't trigger
+// catastrophic backtracking.
+const KNOWN_SECRET_RULES: readonly RedactionRule[] = [
+  // PEM private key block (RSA / EC / OPENSSH / PGP / plain). `[A-Z ]*`
+  // is a single linear class; the lazy body is bounded by the END marker.
+  {
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+    replacement: REDACTED_PLACEHOLDER,
+  },
+  // JWT (`header.payload.signature`, base64url).
+  {
+    pattern: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
+    replacement: REDACTED_PLACEHOLDER,
+  },
+  // Credentials embedded in a URL authority (`scheme://user:pass@host`).
+  // The lookbehind / lookahead keep the scheme and host so the location
+  // stays useful while the `user:pass` pair is masked.
+  {
+    pattern: /(?<=:\/\/)[^\s/:@]+:[^\s/:@]+(?=@)/g,
+    replacement: REDACTED_PLACEHOLDER,
+  },
+  // AWS access key id (all key-class prefixes, incl. temporary `ASIA`).
+  {
+    pattern: /\b(?:AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA|A3T[A-Z0-9])[0-9A-Z]{16}/g,
+    replacement: REDACTED_PLACEHOLDER,
+  },
+  // GitHub tokens: classic/oauth/user/server/refresh (`gh[pousr]_`) and
+  // fine-grained PATs (`github_pat_`).
+  { pattern: /\bgh[pousr]_[A-Za-z0-9]{36,}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\bgithub_pat_[A-Za-z0-9_]{22,}/g, replacement: REDACTED_PLACEHOLDER },
+  // GitLab personal access token.
+  { pattern: /\bglpat-[A-Za-z0-9_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+  // Slack bot/user/app tokens and incoming-webhook URLs.
+  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}/g, replacement: REDACTED_PLACEHOLDER },
+  {
+    pattern: /(?<=hooks\.slack\.com\/services\/)[A-Za-z0-9/+_-]{20,}/g,
+    replacement: REDACTED_PLACEHOLDER,
+  },
+  // Stripe secret / restricted keys (publishable `pk_` left readable).
+  { pattern: /\b(?:sk|rk)_(?:live|test)_[0-9A-Za-z]{10,}/g, replacement: REDACTED_PLACEHOLDER },
+  // OpenAI / Anthropic style keys (`sk-`, `sk-proj-`, `sk-ant-…`).
+  { pattern: /\bsk-(?:proj-|ant-)?[A-Za-z0-9_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+  // Google API key and OAuth access token.
+  { pattern: /\bAIza[0-9A-Za-z_-]{35}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\bya29\.[0-9A-Za-z_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+  // npm automation/publish token.
+  { pattern: /\bnpm_[A-Za-z0-9]{36}/g, replacement: REDACTED_PLACEHOLDER },
+  // SendGrid API key.
+  { pattern: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g, replacement: REDACTED_PLACEHOLDER },
+  // Twilio API key SID.
+  { pattern: /\bSK[0-9a-fA-F]{32}/g, replacement: REDACTED_PLACEHOLDER },
+  // DigitalOcean personal access / OAuth token.
+  { pattern: /\bdop_v1_[a-f0-9]{64}/g, replacement: REDACTED_PLACEHOLDER },
+  // Shopify access tokens (admin/custom/private/shared-secret).
+  { pattern: /\bshp(?:at|ca|pa|ss)_[a-fA-F0-9]{32}/g, replacement: REDACTED_PLACEHOLDER },
+  // Square access / refresh token.
+  { pattern: /\bsq0[a-z]{3}-[0-9A-Za-z_-]{22,}/g, replacement: REDACTED_PLACEHOLDER },
+  // Telegram bot token (`<id>:AA<secret>`). The `AA` anchor keeps the
+  // numeric-id half from masking ordinary `digits:digits` text.
+  { pattern: /\b[0-9]{8,10}:AA[0-9A-Za-z_-]{32,}/g, replacement: REDACTED_PLACEHOLDER },
+  // Generic `Authorization: Bearer <token>` header value.
+  { pattern: /(?<=\bBearer\s)[A-Za-z0-9._~+/=-]{16,}/g, replacement: REDACTED_PLACEHOLDER },
+  // Email address (PII).
+  {
+    pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+    replacement: REDACTED_PLACEHOLDER,
+  },
+];
 
-  return [
-    {
-      pattern:
-        /-----BEGIN (?:[A-Z]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z]+ )*PRIVATE KEY-----/g,
-      replacement: REDACTED_PLACEHOLDER,
-    },
-    {
-      pattern: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
-      replacement: REDACTED_PLACEHOLDER,
-    },
-    {
-      // Credentials embedded in a URL authority (`scheme://user:pass@host`).
-      // Lookbehind / lookahead keep the scheme and host so the location
-      // stays useful while the `user:pass` pair is masked.
-      pattern: /(?<=:\/\/)[^\s/:@]+:[^\s/:@]+(?=@)/g,
-      replacement: REDACTED_PLACEHOLDER,
-    },
-    { pattern: /\bAKIA[0-9A-Z]{16}\b/g, replacement: REDACTED_PLACEHOLDER },
-    { pattern: /\bgh[pousr]_[A-Za-z0-9]{36,}/g, replacement: REDACTED_PLACEHOLDER },
-    { pattern: /\bgithub_pat_[A-Za-z0-9_]{22,}/g, replacement: REDACTED_PLACEHOLDER },
-    { pattern: /\bglpat-[A-Za-z0-9_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
-    { pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}/g, replacement: REDACTED_PLACEHOLDER },
-    { pattern: /\b[sprk]k_(?:live|test)_[A-Za-z0-9]{10,}/g, replacement: REDACTED_PLACEHOLDER },
-    { pattern: /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
-    { pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g, replacement: REDACTED_PLACEHOLDER },
-    { pattern: /\bya29\.[0-9A-Za-z_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
-    {
-      pattern: /(?<=\bBearer\s)[A-Za-z0-9._~+/=-]{16,}/g,
-      replacement: REDACTED_PLACEHOLDER,
-    },
-    {
-      pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
-      replacement: REDACTED_PLACEHOLDER,
-    },
-    { pattern: genericTokenPattern, replacement: REDACTED_PLACEHOLDER },
-  ];
+// Splits free text into contiguous `[A-Za-z0-9_-]` runs. `= + / : . @`
+// and whitespace are natural delimiters, so a run can't bleed across a
+// `name=value` separator and swallow an adjacent label. Linear: each
+// character is visited once per `replace` pass.
+const CANDIDATE_TOKEN_PATTERN = /[A-Za-z0-9_][A-Za-z0-9_-]*/g;
+
+// Structured non-secret identifiers that clear the length/composition
+// gates but are not credentials, so they're spared to keep diagnostics
+// readable: canonical git object ids (SHA-1 / SHA-256, lowercase hex)
+// and UUIDs. `-` stays in the token class so base64url secrets aren't
+// fragmented, which means a UUID arrives here as one token rather than
+// dash-split pieces — hence the explicit exclusion. The trade-off is
+// that a bare secret of exactly these shapes slips the generic net,
+// acceptable for a best-effort backstop (real provider secrets carry a
+// prefix caught above).
+const GIT_OBJECT_ID_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const HAS_LETTER_PATTERN = /[A-Za-z]/;
+const HAS_DIGIT_PATTERN = /[0-9]/;
+
+// Shannon entropy in bits per character. Linear in token length.
+const shannonEntropyBits = (value: string): number => {
+  const counts = new Map<string, number>();
+  for (const char of value) counts.set(char, (counts.get(char) ?? 0) + 1);
+  let bits = 0;
+  for (const count of counts.values()) {
+    const probability = count / value.length;
+    bits -= probability * Math.log2(probability);
+  }
+  return bits;
 };
 
-const REDACTION_RULES = buildRedactionRules();
+// A contiguous token long enough to be a credential, mixing letters and
+// digits, that isn't a git object id and carries credential-like entropy.
+// The length + composition + entropy gates together keep the sweep off
+// ordinary long identifiers, repeated-character strings, and hashes.
+const looksLikeHighEntropySecret = (token: string): boolean => {
+  if (token.length < GENERIC_SECRET_MIN_LENGTH_CHARS) return false;
+  if (!HAS_LETTER_PATTERN.test(token) || !HAS_DIGIT_PATTERN.test(token)) return false;
+  if (GIT_OBJECT_ID_PATTERN.test(token) || UUID_PATTERN.test(token)) return false;
+  return shannonEntropyBits(token) >= GENERIC_SECRET_MIN_ENTROPY_BITS;
+};
+
+const redactHighEntropyTokens = (text: string): string =>
+  text.replace(CANDIDATE_TOKEN_PATTERN, (token) =>
+    looksLikeHighEntropySecret(token) ? REDACTED_PLACEHOLDER : token,
+  );
 
 /**
  * Masks API keys, tokens, private keys, credentialed URLs, and emails
@@ -72,12 +147,17 @@ const REDACTION_RULES = buildRedactionRules();
  * Applied to every diagnostic's `message` / `help` at construction time
  * so secrets never reach the terminal, the JSON report, or the score
  * API — react-doctor must never echo or transmit a user's secrets.
+ *
+ * Runs the high-precision known-shape detectors first, then a generic
+ * entropy-gated sweep for unknown-format secrets. Idempotent: the inert
+ * `<redacted>` placeholder matches none of the detectors and is too
+ * short for the generic sweep, so re-running leaves the text unchanged.
  */
 export const redactSensitiveText = (text: string): string => {
   if (!text) return text;
   let redacted = text;
-  for (const rule of REDACTION_RULES) {
+  for (const rule of KNOWN_SECRET_RULES) {
     redacted = redacted.replace(rule.pattern, rule.replacement);
   }
-  return redacted;
+  return redactHighEntropyTokens(redacted);
 };

--- a/packages/core/src/utils/redact-sensitive-text.ts
+++ b/packages/core/src/utils/redact-sensitive-text.ts
@@ -34,7 +34,10 @@ const KEEP_PREFIX = `$1${REDACTED_PLACEHOLDER}`;
 // quantifiers) so a pathological message can't trigger catastrophic
 // backtracking. Structural/unknown-format secrets with no meaningful
 // prefix (PEM, JWT, credentialed URLs, Bearer values, emails, and the
-// generic sweep) are masked whole.
+// generic sweep) are masked whole. Token-body lengths are open-ended
+// (`{N,}`, not `{N}`): a credential echoed longer than its canonical
+// length must be masked whole, never leaving a trailing suffix the
+// generic sweep is too short to catch.
 const KNOWN_SECRET_RULES: readonly RedactionRule[] = [
   // PEM private key block (RSA / EC / OPENSSH / PGP / plain). `[A-Z ]*`
   // is a single linear class; the lazy body is bounded by the END marker.
@@ -58,8 +61,11 @@ const KNOWN_SECRET_RULES: readonly RedactionRule[] = [
     replacement: REDACTED_PLACEHOLDER,
   },
   // AWS access key id (all key-class prefixes, incl. temporary `ASIA`).
+  // Length is open-ended (`{16,}`) rather than the canonical 16 so an
+  // over-long run of key characters is masked whole instead of leaving a
+  // trailing suffix that the generic sweep is too short to catch.
   {
-    pattern: /\b(AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA|A3T[A-Z0-9])[0-9A-Z]{16}/g,
+    pattern: /\b(AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA|A3T[A-Z0-9])[0-9A-Z]{16,}/g,
     replacement: KEEP_PREFIX,
   },
   // GitHub tokens: classic/oauth/user/server/refresh (`gh[pousr]_`) and
@@ -79,18 +85,18 @@ const KNOWN_SECRET_RULES: readonly RedactionRule[] = [
   // OpenAI / Anthropic style keys (`sk-`, `sk-proj-`, `sk-ant-…`).
   { pattern: /\b(sk-(?:proj-|ant-)?)[A-Za-z0-9_-]{20,}/g, replacement: KEEP_PREFIX },
   // Google API key and OAuth access token.
-  { pattern: /\b(AIza)[0-9A-Za-z_-]{35}/g, replacement: KEEP_PREFIX },
+  { pattern: /\b(AIza)[0-9A-Za-z_-]{35,}/g, replacement: KEEP_PREFIX },
   { pattern: /\b(ya29\.)[0-9A-Za-z_-]{20,}/g, replacement: KEEP_PREFIX },
   // npm automation/publish token.
-  { pattern: /\b(npm_)[A-Za-z0-9]{36}/g, replacement: KEEP_PREFIX },
+  { pattern: /\b(npm_)[A-Za-z0-9]{36,}/g, replacement: KEEP_PREFIX },
   // SendGrid API key.
-  { pattern: /\b(SG\.)[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g, replacement: KEEP_PREFIX },
+  { pattern: /\b(SG\.)[A-Za-z0-9_-]{22,}\.[A-Za-z0-9_-]{43,}/g, replacement: KEEP_PREFIX },
   // Twilio API key SID.
-  { pattern: /\b(SK)[0-9a-fA-F]{32}/g, replacement: KEEP_PREFIX },
+  { pattern: /\b(SK)[0-9a-fA-F]{32,}/g, replacement: KEEP_PREFIX },
   // DigitalOcean personal access / OAuth token.
-  { pattern: /\b(dop_v1_)[a-f0-9]{64}/g, replacement: KEEP_PREFIX },
+  { pattern: /\b(dop_v1_)[a-f0-9]{64,}/g, replacement: KEEP_PREFIX },
   // Shopify access tokens (admin/custom/private/shared-secret).
-  { pattern: /\b(shp(?:at|ca|pa|ss)_)[a-fA-F0-9]{32}/g, replacement: KEEP_PREFIX },
+  { pattern: /\b(shp(?:at|ca|pa|ss)_)[a-fA-F0-9]{32,}/g, replacement: KEEP_PREFIX },
   // Square access / refresh token.
   { pattern: /\b(sq0[a-z]{3}-)[0-9A-Za-z_-]{22,}/g, replacement: KEEP_PREFIX },
   // Telegram bot token (`<id>:AA<secret>`). The `AA` anchor keeps the

--- a/packages/core/src/utils/redact-sensitive-text.ts
+++ b/packages/core/src/utils/redact-sensitive-text.ts
@@ -36,9 +36,12 @@ const KNOWN_SECRET_RULES: readonly RedactionRule[] = [
   },
   // Credentials embedded in a URL authority (`scheme://user:pass@host`).
   // The lookbehind / lookahead keep the scheme and host so the location
-  // stays useful while the `user:pass` pair is masked.
+  // stays useful while the `user:pass` pair is masked. The first colon
+  // separates user from password; the password class allows further
+  // colons (e.g. `user:p:a:ss@host`) so passwords with colons are still
+  // fully masked rather than partially leaking.
   {
-    pattern: /(?<=:\/\/)[^\s/:@]+:[^\s/:@]+(?=@)/g,
+    pattern: /(?<=:\/\/)[^\s/:@]+:[^\s/@]+(?=@)/g,
     replacement: REDACTED_PLACEHOLDER,
   },
   // AWS access key id (all key-class prefixes, incl. temporary `ASIA`).

--- a/packages/core/src/utils/redact-sensitive-text.ts
+++ b/packages/core/src/utils/redact-sensitive-text.ts
@@ -7,6 +7,15 @@ interface RedactionRule {
   readonly replacement: string;
 }
 
+// Provider tokens carry a non-secret, type-identifying prefix (e.g.
+// `sk_live_`, `ghp_`, `AKIA`). Keeping that prefix visible while masking
+// the secret material makes a diagnostic actionable — you can see *which*
+// credential type leaked and from which environment — without echoing the
+// secret itself. Prefixed rules capture the prefix as group 1 and use
+// this replacement; `$1` re-emits the prefix and the body becomes the
+// inert placeholder, e.g. `sk_live_<redacted>`.
+const KEEP_PREFIX = `$1${REDACTED_PLACEHOLDER}`;
+
 // High-precision detectors for credentials and PII that can ride along
 // inside a diagnostic's `message` / `help` when a rule echoes a source
 // fragment (e.g. `useState("sk-live-…")`). Shapes track the corpora that
@@ -16,12 +25,16 @@ interface RedactionRule {
 //
 // Ordered so structured composites (key blocks, JWTs, credentialed URLs)
 // run before the narrower prefixed tokens, every replacement leaves only
-// inert `<redacted>` text that no later rule can re-match, and the broad
-// entropy sweep (`redactHighEntropyTokens`) runs dead last. Each pattern
-// is intentionally narrow — it targets a real secret shape, never an
-// ordinary identifier — and uses linear-time constructs (no nested or
-// overlapping quantifiers) so a pathological message can't trigger
-// catastrophic backtracking.
+// inert `<redacted>` text that no later rule can re-match (the prefix kept
+// by `KEEP_PREFIX` is always too short and followed by `<`, so neither the
+// prefixed rules nor the entropy sweep re-trigger), and the broad entropy
+// sweep (`redactHighEntropyTokens`) runs dead last. Each pattern is
+// intentionally narrow — it targets a real secret shape, never an ordinary
+// identifier — and uses linear-time constructs (no nested or overlapping
+// quantifiers) so a pathological message can't trigger catastrophic
+// backtracking. Structural/unknown-format secrets with no meaningful
+// prefix (PEM, JWT, credentialed URLs, Bearer values, emails, and the
+// generic sweep) are masked whole.
 const KNOWN_SECRET_RULES: readonly RedactionRule[] = [
   // PEM private key block (RSA / EC / OPENSSH / PGP / plain). `[A-Z ]*`
   // is a single linear class; the lazy body is bounded by the END marker.
@@ -46,43 +59,44 @@ const KNOWN_SECRET_RULES: readonly RedactionRule[] = [
   },
   // AWS access key id (all key-class prefixes, incl. temporary `ASIA`).
   {
-    pattern: /\b(?:AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA|A3T[A-Z0-9])[0-9A-Z]{16}/g,
-    replacement: REDACTED_PLACEHOLDER,
+    pattern: /\b(AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA|A3T[A-Z0-9])[0-9A-Z]{16}/g,
+    replacement: KEEP_PREFIX,
   },
   // GitHub tokens: classic/oauth/user/server/refresh (`gh[pousr]_`) and
   // fine-grained PATs (`github_pat_`).
-  { pattern: /\bgh[pousr]_[A-Za-z0-9]{36,}/g, replacement: REDACTED_PLACEHOLDER },
-  { pattern: /\bgithub_pat_[A-Za-z0-9_]{22,}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(gh[pousr]_)[A-Za-z0-9]{36,}/g, replacement: KEEP_PREFIX },
+  { pattern: /\b(github_pat_)[A-Za-z0-9_]{22,}/g, replacement: KEEP_PREFIX },
   // GitLab personal access token.
-  { pattern: /\bglpat-[A-Za-z0-9_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(glpat-)[A-Za-z0-9_-]{20,}/g, replacement: KEEP_PREFIX },
   // Slack bot/user/app tokens and incoming-webhook URLs.
-  { pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(xox[baprs]-)[A-Za-z0-9-]{10,}/g, replacement: KEEP_PREFIX },
   {
     pattern: /(?<=hooks\.slack\.com\/services\/)[A-Za-z0-9/+_-]{20,}/g,
     replacement: REDACTED_PLACEHOLDER,
   },
   // Stripe secret / restricted keys (publishable `pk_` left readable).
-  { pattern: /\b(?:sk|rk)_(?:live|test)_[0-9A-Za-z]{10,}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b((?:sk|rk)_(?:live|test)_)[0-9A-Za-z]{10,}/g, replacement: KEEP_PREFIX },
   // OpenAI / Anthropic style keys (`sk-`, `sk-proj-`, `sk-ant-…`).
-  { pattern: /\bsk-(?:proj-|ant-)?[A-Za-z0-9_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(sk-(?:proj-|ant-)?)[A-Za-z0-9_-]{20,}/g, replacement: KEEP_PREFIX },
   // Google API key and OAuth access token.
-  { pattern: /\bAIza[0-9A-Za-z_-]{35}/g, replacement: REDACTED_PLACEHOLDER },
-  { pattern: /\bya29\.[0-9A-Za-z_-]{20,}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(AIza)[0-9A-Za-z_-]{35}/g, replacement: KEEP_PREFIX },
+  { pattern: /\b(ya29\.)[0-9A-Za-z_-]{20,}/g, replacement: KEEP_PREFIX },
   // npm automation/publish token.
-  { pattern: /\bnpm_[A-Za-z0-9]{36}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(npm_)[A-Za-z0-9]{36}/g, replacement: KEEP_PREFIX },
   // SendGrid API key.
-  { pattern: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(SG\.)[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g, replacement: KEEP_PREFIX },
   // Twilio API key SID.
-  { pattern: /\bSK[0-9a-fA-F]{32}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(SK)[0-9a-fA-F]{32}/g, replacement: KEEP_PREFIX },
   // DigitalOcean personal access / OAuth token.
-  { pattern: /\bdop_v1_[a-f0-9]{64}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(dop_v1_)[a-f0-9]{64}/g, replacement: KEEP_PREFIX },
   // Shopify access tokens (admin/custom/private/shared-secret).
-  { pattern: /\bshp(?:at|ca|pa|ss)_[a-fA-F0-9]{32}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(shp(?:at|ca|pa|ss)_)[a-fA-F0-9]{32}/g, replacement: KEEP_PREFIX },
   // Square access / refresh token.
-  { pattern: /\bsq0[a-z]{3}-[0-9A-Za-z_-]{22,}/g, replacement: REDACTED_PLACEHOLDER },
+  { pattern: /\b(sq0[a-z]{3}-)[0-9A-Za-z_-]{22,}/g, replacement: KEEP_PREFIX },
   // Telegram bot token (`<id>:AA<secret>`). The `AA` anchor keeps the
-  // numeric-id half from masking ordinary `digits:digits` text.
-  { pattern: /\b[0-9]{8,10}:AA[0-9A-Za-z_-]{32,}/g, replacement: REDACTED_PLACEHOLDER },
+  // numeric-id half from masking ordinary `digits:digits` text; the bot
+  // id and `:AA` marker are kept as the prefix.
+  { pattern: /\b([0-9]{8,10}:AA)[0-9A-Za-z_-]{32,}/g, replacement: KEEP_PREFIX },
   // Generic `Authorization: Bearer <token>` header value.
   { pattern: /(?<=\bBearer\s)[A-Za-z0-9._~+/=-]{16,}/g, replacement: REDACTED_PLACEHOLDER },
   // Email address (PII).
@@ -147,6 +161,11 @@ const redactHighEntropyTokens = (text: string): string =>
  * Applied to every diagnostic's `message` / `help` at construction time
  * so secrets never reach the terminal, the JSON report, or the score
  * API — react-doctor must never echo or transmit a user's secrets.
+ *
+ * Provider tokens keep their non-secret, type-identifying prefix (e.g.
+ * `sk_live_<redacted>`, `ghp_<redacted>`, `AKIA<redacted>`) so the leaked
+ * credential's type stays visible; structural or unknown-format secrets
+ * with no meaningful prefix are masked whole.
  *
  * Runs the high-precision known-shape detectors first, then a generic
  * entropy-gated sweep for unknown-format secrets. Idempotent: the inert

--- a/packages/core/src/utils/redact-sensitive-text.ts
+++ b/packages/core/src/utils/redact-sensitive-text.ts
@@ -1,7 +1,4 @@
-import {
-  GENERIC_SECRET_MIN_ENTROPY_BITS,
-  GENERIC_SECRET_MIN_LENGTH_CHARS,
-} from "../constants.js";
+import { GENERIC_SECRET_MIN_ENTROPY_BITS, GENERIC_SECRET_MIN_LENGTH_CHARS } from "../constants.js";
 
 export const REDACTED_PLACEHOLDER = "<redacted>";
 

--- a/packages/core/tests/redact-sensitive-text.test.ts
+++ b/packages/core/tests/redact-sensitive-text.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vite-plus/test";
+import { REDACTED_PLACEHOLDER, redactSensitiveText } from "@react-doctor/core";
+
+describe("redactSensitiveText", () => {
+  it("returns empty input unchanged", () => {
+    expect(redactSensitiveText("")).toBe("");
+  });
+
+  it("leaves ordinary diagnostic prose untouched", () => {
+    const messages = [
+      "useState initialized from prop",
+      "useContext is superseded by `use()`",
+      "forwardRef is no longer needed on React 19+",
+      "Avoid calling setState inside useEffect (line 12:4)",
+      "Move secrets to server-only code",
+    ];
+    for (const message of messages) {
+      expect(redactSensitiveText(message)).toBe(message);
+    }
+  });
+
+  it("redacts an AWS access key id", () => {
+    expect(redactSensitiveText("key AKIAIOSFODNN7EXAMPLE found")).toBe(
+      `key ${REDACTED_PLACEHOLDER} found`,
+    );
+  });
+
+  it("redacts GitHub personal access tokens", () => {
+    const token = `ghp_${"a".repeat(36)}`;
+    expect(redactSensitiveText(`token: ${token}`)).toBe(`token: ${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("redacts Stripe live keys", () => {
+    expect(redactSensitiveText(`useState("sk_live_${"4".repeat(20)}")`)).toContain(
+      REDACTED_PLACEHOLDER,
+    );
+    expect(redactSensitiveText(`useState("sk_live_${"4".repeat(20)}")`)).not.toContain("sk_live_");
+  });
+
+  it("redacts OpenAI-style sk- keys", () => {
+    const key = `sk-${"A1b2".repeat(10)}`;
+    expect(redactSensitiveText(`const apiKey = "${key}"`)).toBe(
+      `const apiKey = "${REDACTED_PLACEHOLDER}"`,
+    );
+  });
+
+  it("redacts a JWT", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N";
+    expect(redactSensitiveText(`Authorization header ${jwt}`)).toBe(
+      `Authorization header ${REDACTED_PLACEHOLDER}`,
+    );
+  });
+
+  it("masks credentials inside a URL but keeps scheme and host", () => {
+    expect(redactSensitiveText("postgres://admin:hunter2pass@db.internal:5432/app")).toBe(
+      `postgres://${REDACTED_PLACEHOLDER}@db.internal:5432/app`,
+    );
+  });
+
+  it("redacts a bearer token but keeps the scheme word", () => {
+    const result = redactSensitiveText("Authorization: Bearer abcDEF123456ghijKLmnop");
+    expect(result).toBe(`Authorization: Bearer ${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("redacts email addresses (PII)", () => {
+    expect(redactSensitiveText('useState("jane.doe@example.com")')).toBe(
+      `useState("${REDACTED_PLACEHOLDER}")`,
+    );
+  });
+
+  it("redacts a PEM private key block", () => {
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----";
+    expect(redactSensitiveText(`key: ${pem}`)).toBe(`key: ${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("redacts an unprefixed high-entropy token", () => {
+    const token = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6";
+    expect(token.length).toBeGreaterThanOrEqual(32);
+    expect(redactSensitiveText(`token=${token}`)).toBe(`token=${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("does not redact ordinary long identifiers without digits", () => {
+    const identifier = "someVeryDescriptiveComponentDisplayName";
+    expect(redactSensitiveText(identifier)).toBe(identifier);
+  });
+
+  it("does not redact short alphanumeric tokens", () => {
+    expect(redactSensitiveText("status code 404 at offset 12ab")).toBe(
+      "status code 404 at offset 12ab",
+    );
+  });
+
+  it("is idempotent", () => {
+    const once = redactSensitiveText("ghp_" + "z".repeat(36));
+    expect(redactSensitiveText(once)).toBe(once);
+  });
+});

--- a/packages/core/tests/redact-sensitive-text.test.ts
+++ b/packages/core/tests/redact-sensitive-text.test.ts
@@ -33,6 +33,17 @@ describe("redactSensitiveText", () => {
     expect(redactSensitiveText(`ghp_${"b".repeat(36)}`)).toBe(`ghp_${REDACTED_PLACEHOLDER}`);
   });
 
+  it("masks the whole token when it is longer than the canonical length (no suffix leak)", () => {
+    // npm tokens are canonically `npm_` + 36 chars; an over-long body must
+    // be masked whole rather than leaving a trailing suffix visible.
+    const longNpm = `npm_${"a1B2c3D4".repeat(6)}`;
+    expect(longNpm.length).toBeGreaterThan("npm_".length + 36);
+    expect(redactSensitiveText(longNpm)).toBe(`npm_${REDACTED_PLACEHOLDER}`);
+
+    const longShopify = `shpat_${"a1b2c3d4".repeat(6)}`;
+    expect(redactSensitiveText(longShopify)).toBe(`shpat_${REDACTED_PLACEHOLDER}`);
+  });
+
   it("redacts an AWS access key id but keeps the AKIA prefix", () => {
     expect(redactSensitiveText("key AKIAIOSFODNN7EXAMPLE found")).toBe(
       `key AKIA${REDACTED_PLACEHOLDER} found`,

--- a/packages/core/tests/redact-sensitive-text.test.ts
+++ b/packages/core/tests/redact-sensitive-text.test.ts
@@ -123,6 +123,12 @@ describe("redactSensitiveText", () => {
     );
   });
 
+  it("masks a URL password that itself contains colons", () => {
+    expect(redactSensitiveText("mongodb://admin:p:a:ss@cluster.example.com:27017/db")).toBe(
+      `mongodb://${REDACTED_PLACEHOLDER}@cluster.example.com:27017/db`,
+    );
+  });
+
   it("redacts a bearer token but keeps the scheme word", () => {
     const result = redactSensitiveText("Authorization: Bearer abcDEF123456ghijKLmnop");
     expect(result).toBe(`Authorization: Bearer ${REDACTED_PLACEHOLDER}`);

--- a/packages/core/tests/redact-sensitive-text.test.ts
+++ b/packages/core/tests/redact-sensitive-text.test.ts
@@ -26,36 +26,42 @@ describe("redactSensitiveText", () => {
     }
   });
 
-  it("redacts an AWS access key id", () => {
+  it("keeps the provider prefix and redacts only the secret body", () => {
+    expect(redactSensitiveText(`key=sk_live_${"4".repeat(24)}`)).toBe(
+      `key=sk_live_${REDACTED_PLACEHOLDER}`,
+    );
+    expect(redactSensitiveText(`ghp_${"b".repeat(36)}`)).toBe(`ghp_${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("redacts an AWS access key id but keeps the AKIA prefix", () => {
     expect(redactSensitiveText("key AKIAIOSFODNN7EXAMPLE found")).toBe(
-      `key ${REDACTED_PLACEHOLDER} found`,
+      `key AKIA${REDACTED_PLACEHOLDER} found`,
     );
   });
 
   it("redacts an AWS temporary (ASIA) access key id", () => {
     const key = `ASIA${"A1B2C3D4E5F6G7H8".slice(0, 16)}`;
-    expect(redactSensitiveText(`creds ${key}`)).toBe(`creds ${REDACTED_PLACEHOLDER}`);
+    expect(redactSensitiveText(`creds ${key}`)).toBe(`creds ASIA${REDACTED_PLACEHOLDER}`);
   });
 
   it("redacts GitHub personal access tokens", () => {
     const token = `ghp_${"a".repeat(36)}`;
-    expect(redactSensitiveText(`token: ${token}`)).toBe(`token: ${REDACTED_PLACEHOLDER}`);
+    expect(redactSensitiveText(`token: ${token}`)).toBe(`token: ghp_${REDACTED_PLACEHOLDER}`);
   });
 
   it("redacts a GitHub fine-grained PAT", () => {
     const token = `github_pat_${"A1b2c3d4e5".repeat(3)}`;
-    expect(redactSensitiveText(token)).toBe(REDACTED_PLACEHOLDER);
+    expect(redactSensitiveText(token)).toBe(`github_pat_${REDACTED_PLACEHOLDER}`);
   });
 
   it("redacts a GitLab personal access token", () => {
     const token = `glpat-${"aB3dE6gH9j".repeat(2)}`;
-    expect(redactSensitiveText(`token ${token}`)).toBe(`token ${REDACTED_PLACEHOLDER}`);
+    expect(redactSensitiveText(`token ${token}`)).toBe(`token glpat-${REDACTED_PLACEHOLDER}`);
   });
 
-  it("redacts a Slack token", () => {
+  it("redacts a Slack token but keeps the xox prefix", () => {
     const token = `xoxb-${"123456789012".repeat(2)}`;
-    expect(redactSensitiveText(token)).toContain(REDACTED_PLACEHOLDER);
-    expect(redactSensitiveText(token)).not.toContain("xoxb-");
+    expect(redactSensitiveText(token)).toBe(`xoxb-${REDACTED_PLACEHOLDER}`);
   });
 
   it("redacts a Slack incoming-webhook path but keeps the host", () => {
@@ -66,46 +72,43 @@ describe("redactSensitiveText", () => {
     expect(result).not.toContain("B11111111");
   });
 
-  it("redacts an npm token", () => {
+  it("redacts an npm token but keeps the npm_ prefix", () => {
     const token = `npm_${"a1B2c3D4e5f6".repeat(3)}`.slice(0, 40);
-    expect(redactSensitiveText(`//registry.npmjs.org/:_authToken=${token}`)).toContain(
-      REDACTED_PLACEHOLDER,
-    );
-    expect(redactSensitiveText(`//registry.npmjs.org/:_authToken=${token}`)).not.toContain("npm_a");
+    const result = redactSensitiveText(`//registry.npmjs.org/:_authToken=${token}`);
+    expect(result).toBe(`//registry.npmjs.org/:_authToken=npm_${REDACTED_PLACEHOLDER}`);
   });
 
   it("redacts a SendGrid API key", () => {
     const key = `SG.${"a".repeat(22)}.${"b1C2d3E4".repeat(6).slice(0, 43)}`;
-    expect(redactSensitiveText(key)).toBe(REDACTED_PLACEHOLDER);
+    expect(redactSensitiveText(key)).toBe(`SG.${REDACTED_PLACEHOLDER}`);
   });
 
   it("redacts a DigitalOcean token", () => {
     const token = `dop_v1_${"a1b2c3d4".repeat(8)}`;
-    expect(redactSensitiveText(`do ${token}`)).toBe(`do ${REDACTED_PLACEHOLDER}`);
+    expect(redactSensitiveText(`do ${token}`)).toBe(`do dop_v1_${REDACTED_PLACEHOLDER}`);
   });
 
   it("redacts a Shopify access token", () => {
     const token = `shpat_${"a1b2c3d4".repeat(4)}`;
-    expect(redactSensitiveText(token)).toBe(REDACTED_PLACEHOLDER);
+    expect(redactSensitiveText(token)).toBe(`shpat_${REDACTED_PLACEHOLDER}`);
   });
 
   it("redacts a Telegram bot token but spares plain digit:digit text", () => {
     const token = `123456789:AA${"x1Y2z3W4".repeat(4)}`;
-    expect(redactSensitiveText(token)).toContain(REDACTED_PLACEHOLDER);
+    expect(redactSensitiveText(token)).toBe(`123456789:AA${REDACTED_PLACEHOLDER}`);
     expect(redactSensitiveText("retry after 12345:67890 ms")).toBe("retry after 12345:67890 ms");
   });
 
-  it("redacts Stripe live keys", () => {
-    expect(redactSensitiveText(`useState("sk_live_${"4".repeat(20)}")`)).toContain(
-      REDACTED_PLACEHOLDER,
+  it("redacts Stripe live keys but keeps the sk_live_ prefix", () => {
+    expect(redactSensitiveText(`useState("sk_live_${"4".repeat(20)}")`)).toBe(
+      `useState("sk_live_${REDACTED_PLACEHOLDER}")`,
     );
-    expect(redactSensitiveText(`useState("sk_live_${"4".repeat(20)}")`)).not.toContain("sk_live_");
   });
 
-  it("redacts OpenAI-style sk- keys", () => {
+  it("redacts OpenAI-style sk- keys but keeps the sk- prefix", () => {
     const key = `sk-${"A1b2".repeat(10)}`;
     expect(redactSensitiveText(`const apiKey = "${key}"`)).toBe(
-      `const apiKey = "${REDACTED_PLACEHOLDER}"`,
+      `const apiKey = "sk-${REDACTED_PLACEHOLDER}"`,
     );
   });
 
@@ -188,8 +191,10 @@ describe("redactSensitiveText", () => {
   it("redacts every distinct secret in a multi-secret message", () => {
     const message = `aws AKIAIOSFODNN7EXAMPLE gh ${`ghp_${"a".repeat(36)}`} mail dev@acme.io`;
     const result = redactSensitiveText(message);
-    expect(result).not.toContain("AKIA");
-    expect(result).not.toContain("ghp_");
+    expect(result).toContain(`AKIA${REDACTED_PLACEHOLDER}`);
+    expect(result).toContain(`ghp_${REDACTED_PLACEHOLDER}`);
+    expect(result).not.toContain("IOSFODNN7EXAMPLE");
+    expect(result).not.toContain("a".repeat(36));
     expect(result).not.toContain("dev@acme.io");
     expect(result.match(new RegExp(REDACTED_PLACEHOLDER, "g"))).toHaveLength(3);
   });

--- a/packages/core/tests/redact-sensitive-text.test.ts
+++ b/packages/core/tests/redact-sensitive-text.test.ts
@@ -6,6 +6,13 @@ describe("redactSensitiveText", () => {
     expect(redactSensitiveText("")).toBe("");
   });
 
+  it("returns empty string for non-string input (malformed oxlint JSON guard)", () => {
+    expect(redactSensitiveText(12345)).toBe("");
+    expect(redactSensitiveText(null)).toBe("");
+    expect(redactSensitiveText(undefined)).toBe("");
+    expect(redactSensitiveText({ help: "x" })).toBe("");
+  });
+
   it("leaves ordinary diagnostic prose untouched", () => {
     const messages = [
       "useState initialized from prop",

--- a/packages/core/tests/redact-sensitive-text.test.ts
+++ b/packages/core/tests/redact-sensitive-text.test.ts
@@ -25,9 +25,67 @@ describe("redactSensitiveText", () => {
     );
   });
 
+  it("redacts an AWS temporary (ASIA) access key id", () => {
+    const key = `ASIA${"A1B2C3D4E5F6G7H8".slice(0, 16)}`;
+    expect(redactSensitiveText(`creds ${key}`)).toBe(`creds ${REDACTED_PLACEHOLDER}`);
+  });
+
   it("redacts GitHub personal access tokens", () => {
     const token = `ghp_${"a".repeat(36)}`;
     expect(redactSensitiveText(`token: ${token}`)).toBe(`token: ${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("redacts a GitHub fine-grained PAT", () => {
+    const token = `github_pat_${"A1b2c3d4e5".repeat(3)}`;
+    expect(redactSensitiveText(token)).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("redacts a GitLab personal access token", () => {
+    const token = `glpat-${"aB3dE6gH9j".repeat(2)}`;
+    expect(redactSensitiveText(`token ${token}`)).toBe(`token ${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("redacts a Slack token", () => {
+    const token = `xoxb-${"123456789012".repeat(2)}`;
+    expect(redactSensitiveText(token)).toContain(REDACTED_PLACEHOLDER);
+    expect(redactSensitiveText(token)).not.toContain("xoxb-");
+  });
+
+  it("redacts a Slack incoming-webhook path but keeps the host", () => {
+    const url = `https://hooks.slack.com/services/T00000000/B11111111/${"a1B2c3D4e5".repeat(2)}`;
+    const result = redactSensitiveText(url);
+    expect(result).toContain("hooks.slack.com/services/");
+    expect(result).toContain(REDACTED_PLACEHOLDER);
+    expect(result).not.toContain("B11111111");
+  });
+
+  it("redacts an npm token", () => {
+    const token = `npm_${"a1B2c3D4e5f6".repeat(3)}`.slice(0, 40);
+    expect(redactSensitiveText(`//registry.npmjs.org/:_authToken=${token}`)).toContain(
+      REDACTED_PLACEHOLDER,
+    );
+    expect(redactSensitiveText(`//registry.npmjs.org/:_authToken=${token}`)).not.toContain("npm_a");
+  });
+
+  it("redacts a SendGrid API key", () => {
+    const key = `SG.${"a".repeat(22)}.${"b1C2d3E4".repeat(6).slice(0, 43)}`;
+    expect(redactSensitiveText(key)).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("redacts a DigitalOcean token", () => {
+    const token = `dop_v1_${"a1b2c3d4".repeat(8)}`;
+    expect(redactSensitiveText(`do ${token}`)).toBe(`do ${REDACTED_PLACEHOLDER}`);
+  });
+
+  it("redacts a Shopify access token", () => {
+    const token = `shpat_${"a1b2c3d4".repeat(4)}`;
+    expect(redactSensitiveText(token)).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("redacts a Telegram bot token but spares plain digit:digit text", () => {
+    const token = `123456789:AA${"x1Y2z3W4".repeat(4)}`;
+    expect(redactSensitiveText(token)).toContain(REDACTED_PLACEHOLDER);
+    expect(redactSensitiveText("retry after 12345:67890 ms")).toBe("retry after 12345:67890 ms");
   });
 
   it("redacts Stripe live keys", () => {
@@ -91,8 +149,55 @@ describe("redactSensitiveText", () => {
     );
   });
 
-  it("is idempotent", () => {
-    const once = redactSensitiveText("ghp_" + "z".repeat(36));
-    expect(redactSensitiveText(once)).toBe(once);
+  it("does not redact a long but low-entropy identifier with a digit", () => {
+    const lowEntropy = `${"a".repeat(31)}1`;
+    expect(lowEntropy.length).toBeGreaterThanOrEqual(32);
+    expect(redactSensitiveText(lowEntropy)).toBe(lowEntropy);
+  });
+
+  it("does not redact a git SHA-1 object id", () => {
+    const sha1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+    expect(sha1).toHaveLength(40);
+    expect(redactSensitiveText(`at commit ${sha1}`)).toBe(`at commit ${sha1}`);
+  });
+
+  it("does not redact a git SHA-256 object id", () => {
+    const sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    expect(sha256).toHaveLength(64);
+    expect(redactSensitiveText(`integrity ${sha256}`)).toBe(`integrity ${sha256}`);
+  });
+
+  it("does not redact a UUID (split into short tokens by dashes)", () => {
+    const uuid = "123e4567-e89b-12d3-a456-426614174000";
+    expect(redactSensitiveText(`id ${uuid}`)).toBe(`id ${uuid}`);
+  });
+
+  it("redacts every distinct secret in a multi-secret message", () => {
+    const message = `aws AKIAIOSFODNN7EXAMPLE gh ${`ghp_${"a".repeat(36)}`} mail dev@acme.io`;
+    const result = redactSensitiveText(message);
+    expect(result).not.toContain("AKIA");
+    expect(result).not.toContain("ghp_");
+    expect(result).not.toContain("dev@acme.io");
+    expect(result.match(new RegExp(REDACTED_PLACEHOLDER, "g"))).toHaveLength(3);
+  });
+
+  it("completes quickly on a long adversarial input (no catastrophic backtracking)", () => {
+    const adversarial = `-----BEGIN RSA PRIVATE KEY-----${"A".repeat(50_000)} ${"a1b2".repeat(20_000)}`;
+    const start = performance.now();
+    redactSensitiveText(adversarial);
+    expect(performance.now() - start).toBeLessThan(1_000);
+  });
+
+  it("is idempotent across known and generic detectors", () => {
+    const messages = [
+      `ghp_${"z".repeat(36)}`,
+      `token=${"a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"}`,
+      "postgres://admin:hunter2pass@db.internal:5432/app",
+      "contact jane.doe@example.com",
+    ];
+    for (const message of messages) {
+      const once = redactSensitiveText(message);
+      expect(redactSensitiveText(once)).toBe(once);
+    }
   });
 });


### PR DESCRIPTION
## Why

Catches secrets and PII leaking into diagnostic output.

A rule can echo a source fragment into its `message`/`help` (e.g. `useState("sk-live-…")`). That output is routinely pasted into issues, CI logs, and AI tools, and is also sent to the score API — so an echoed credential becomes a real disclosure. This adds a defense-in-depth redactor at the single point every diagnostic flows through (`cleanDiagnosticMessage`), so a secret is masked even if a rule quotes it.

Before:

```text
src/api.ts:3:18  react-doctor(no-secrets-in-client-code)
  Move this secret out of client code: sk_live_51HxQ2eK7vAbCdEfGhIjKlMn
```

After:

```text
src/api.ts:3:18  react-doctor(no-secrets-in-client-code)
  Move this secret out of client code: <redacted>
```

## What changed

- Added `redactSensitiveText`, applied to every diagnostic's `message`/`help` in the oxlint output parser (`cleanDiagnosticMessage`) so the terminal, JSON report, and score API never receive a secret.
- Detects high-precision provider shapes — PEM private keys, JWTs, credentialed URLs, AWS (incl. temporary `ASIA` keys), GitHub + fine-grained PATs, GitLab, Slack tokens + webhooks, Stripe, OpenAI/Anthropic, Google, npm, SendGrid, Twilio, DigitalOcean, Shopify, Square, Telegram — plus email addresses (PII), using shapes aligned to the gitleaks/secretlint corpora. No runtime dependency added.
- Masks matches in place with an inert `<redacted>` placeholder; idempotent (re-running scrubbed text is a no-op).
- Replaces the prior `O(n^2)` lookahead catch-all with a linear-time, entropy-gated token sweep for unknown-format secrets (eliminates the ReDoS vector).
- Allows ordinary diagnostic prose, long non-secret identifiers, git object ids (SHA-1/SHA-256), and UUIDs to pass through unchanged. Known trade-off: a bare secret in the exact shape of a 40/64-char lowercase-hex git object id is intentionally not masked by the generic sweep (real provider secrets carry a prefix caught by the known-shape pass).
- Adds tests for per-provider positives, PII, entropy negatives, SHA/UUID exclusions, multi-secret messages, idempotency, and a ReDoS timing guard.

## Eval results

RDE not run — this is a core diagnostic-output utility, not a lint rule, so the React Doctor eval harness (which scans repos for rule diagnostics) does not apply. Correctness is covered by unit + full-package suites instead (see Test plan).

## Test plan

- `pnpm exec vp test run redact-sensitive-text` — 31 passed (providers, PII, entropy negatives, SHA/UUID, idempotency, ReDoS timing)
- `pnpm exec vp test run` (full `@react-doctor/core`) — 430 passed
- `pnpm exec turbo run typecheck --filter=@react-doctor/core` — clean
- `pnpm exec vp lint <changed files>` — clean

## Changeset

`.changeset/redact-secrets-from-diagnostics.md` — `react-doctor` `patch` (user-visible: diagnostic output is scrubbed of secrets/PII). `@react-doctor/core` is private, so the bump targets the published CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defense-in-depth on diagnostic strings only; no scan logic or auth changes, with broad tests and intentional false-negative trade-offs for git-hash-shaped tokens.
> 
> **Overview**
> Adds **`redactSensitiveText`** and runs it on every diagnostic **`message`** / **`help`** in **`cleanDiagnosticMessage`** (oxlint parse path), so echoed source fragments cannot leak credentials or PII to the terminal, JSON report, or score API.
> 
> The scrubber applies ordered, provider-specific patterns (PEM, JWT, credentialed URLs, major cloud/SaaS token shapes, Bearer, email) with **type-identifying prefixes** kept where useful (`sk_live_<redacted>`, `ghp_<redacted>`, etc.), then a **length + letter/digit + Shannon-entropy** generic token pass for unknown secrets. It tolerates malformed non-string fields, avoids masking ordinary prose, git SHAs, and UUIDs, and is covered by a large unit suite including idempotency and a ReDoS timing guard. A **`react-doctor` patch** changeset documents the user-visible behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db9053682b8a7bbf87ebf1bba9794f645895675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->