### PR TITLE
fix(core): always clear oxlint batch progress interval to prevent CLI hang (#599)

### DIFF
--- a/.changeset/fix-staged-progress-interval-leak.md
+++ b/.changeset/fix-staged-progress-interval-leak.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix `react-doctor --staged` (and other scans) hanging after the diagnostics summary is already printed. When an adopted lint config crashed oxlint on the first attempt, the oxlint runner's per-batch progress timer was left running while the scan silently retried with `extends` stripped — so the run finished and printed results, but the orphaned `setInterval` kept the Node event loop alive and the process never returned control to the shell. The batch loop now clears the timer in a `finally`, so it's always cleaned up even when a batch throws. See #599.

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -102,7 +102,7 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     // HACK: tick the progress counter per-file on a timer while the
     // batch subprocess runs, so the UI feels smooth instead of jumping
     // by 100 when each batch completes. The interval is cleared as
-    // soon as the batch resolves — any remaining files in the batch
+    // soon as the batch settles — any remaining files in the batch
     // are counted in one final update.
     let batchFileIndex = 0;
     const progressInterval =
@@ -114,11 +114,20 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
             }
           }, PROGRESS_TICK_INTERVAL_MS)
         : null;
-    const batchDiagnostics = await spawnLintBatch(batch);
-    if (progressInterval !== null) clearInterval(progressInterval);
-    allDiagnostics.push(...batchDiagnostics);
-    scannedFileCount += batch.length;
-    onFileProgress?.(scannedFileCount, totalFileCount);
+    // The interval MUST be cleared even when `spawnLintBatch` rejects
+    // (e.g. an adopted lint config crashes oxlint with a non-splittable
+    // error). It's a ref'd timer, so a leaked one outlives the failed
+    // attempt and keeps the event loop alive after output is printed:
+    // the caller's extends-stripped retry then succeeds, no
+    // `process.exit()` runs, and the CLI hangs forever (issue #599).
+    try {
+      const batchDiagnostics = await spawnLintBatch(batch);
+      allDiagnostics.push(...batchDiagnostics);
+      scannedFileCount += batch.length;
+      onFileProgress?.(scannedFileCount, totalFileCount);
+    } finally {
+      if (progressInterval !== null) clearInterval(progressInterval);
+    }
   }
 
   if (droppedFiles.length > 0 && onPartialFailure) {

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -114,12 +114,9 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
             }
           }, PROGRESS_TICK_INTERVAL_MS)
         : null;
-    // The interval MUST be cleared even when `spawnLintBatch` rejects
-    // (e.g. an adopted lint config crashes oxlint with a non-splittable
-    // error). It's a ref'd timer, so a leaked one outlives the failed
-    // attempt and keeps the event loop alive after output is printed:
-    // the caller's extends-stripped retry then succeeds, no
-    // `process.exit()` runs, and the CLI hangs forever (issue #599).
+    // Clear in `finally` so a rejected batch (e.g. an adopted lint config
+    // crashing oxlint) can't leak this ref'd timer — a leak keeps the event
+    // loop alive and hangs the CLI after output prints (issue #599).
     try {
       const batchDiagnostics = await spawnLintBatch(batch);
       allDiagnostics.push(...batchDiagnostics);

--- a/packages/core/tests/spawn-batches.test.ts
+++ b/packages/core/tests/spawn-batches.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression test for issue #599 — `react-doctor --staged` hangs after
+ * printing results.
+ *
+ * `spawnLintBatches` starts a ref'd `setInterval` progress timer for each
+ * multi-file batch and used to clear it on a statement that only ran once
+ * `await spawnLintBatch(batch)` had *resolved*. When a batch instead
+ * rejects with a non-splittable error (e.g. an adopted lint config
+ * crashing oxlint), that statement was skipped and the timer leaked. The
+ * caller (`runOxlint`) then silently retried with `extends` stripped and
+ * succeeded, so the scan finished and printed output — but the orphaned
+ * timer kept the Node event loop alive and the CLI never exited (the CLI
+ * relies on natural event-loop drain + `process.exitCode`, not on
+ * `process.exit()`).
+ *
+ * The fix wraps the batch in `try/finally`, so the timer is cleared on
+ * BOTH the resolve and reject paths. We assert that by instrumenting
+ * `setInterval` / `clearInterval` around a `spawnLintBatches` call whose
+ * batch is forced to reject, and confirming no interval survives.
+ */
+
+import { describe, expect, it } from "vite-plus/test";
+import type { ProjectInfo } from "@react-doctor/core";
+import { spawnLintBatches } from "../src/runners/oxlint/spawn-batches.js";
+
+type IntervalHandle = ReturnType<typeof setInterval>;
+
+const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
+  rootDirectory: "/tmp/app",
+  projectName: "app",
+  reactVersion: "19.2.0",
+  reactMajorVersion: 19,
+  tailwindVersion: null,
+  framework: "unknown",
+  hasTypeScript: true,
+  hasReactCompiler: false,
+  hasTanStackQuery: false,
+  hasReactNativeWorkspace: false,
+  hasReanimated: false,
+  preactVersion: null,
+  preactMajorVersion: null,
+  sourceFileCount: 2,
+  ...overrides,
+});
+
+/**
+ * Runs `fn` with `setInterval` / `clearInterval` instrumented so the test
+ * can assert no progress timer outlives the call. Globals are always
+ * restored and any survivor is force-cleared in `finally`, so a
+ * regression here can't hang the test process itself.
+ */
+const trackIntervals = async (
+  fn: () => Promise<void>,
+): Promise<{ created: number; leaked: number }> => {
+  const realSetInterval = globalThis.setInterval;
+  const realClearInterval = globalThis.clearInterval;
+  const live = new Set<IntervalHandle>();
+  let created = 0;
+  let leaked = 0;
+
+  globalThis.setInterval = ((...args: Parameters<typeof setInterval>) => {
+    const handle = realSetInterval(...args);
+    live.add(handle);
+    created += 1;
+    return handle;
+  }) as typeof setInterval;
+  globalThis.clearInterval = ((handle?: IntervalHandle) => {
+    if (handle !== undefined) live.delete(handle);
+    realClearInterval(handle);
+  }) as typeof clearInterval;
+
+  try {
+    await fn();
+  } finally {
+    globalThis.setInterval = realSetInterval;
+    globalThis.clearInterval = realClearInterval;
+    leaked = live.size;
+    for (const handle of live) realClearInterval(handle);
+  }
+
+  return { created, leaked };
+};
+
+// A multi-file batch so the progress interval is actually created
+// (`batch.length > 1`), with `onFileProgress` wired — the human inspect
+// path always passes it. Both are preconditions for the leak.
+const fileBatches = [["src/a.tsx", "src/b.tsx"]];
+
+describe("issue #599: spawnLintBatches never leaks its progress interval", () => {
+  it("clears the progress timer when a multi-file batch rejects with a non-splittable error", async () => {
+    // `baseArgs` make `spawnOxlint` run `node -e <script> …files`. The
+    // script writes to stderr and exits 0 → empty stdout + non-empty
+    // stderr → a non-splittable `OxlintSpawnFailed`, exactly how an
+    // adopted lint config crashing oxlint surfaces. `spawnLintBatch`
+    // re-throws it, so the whole call rejects before the post-`await`
+    // cleanup the old code relied on.
+    const { created, leaked } = await trackIntervals(async () => {
+      await expect(
+        spawnLintBatches({
+          baseArgs: ["-e", "process.stderr.write('boom')"],
+          fileBatches,
+          rootDirectory: process.cwd(),
+          nodeBinaryPath: process.execPath,
+          project: buildProject(),
+          onFileProgress: () => {},
+          spawnTimeoutMs: 30_000,
+        }),
+      ).rejects.toThrow(/Failed to run oxlint/);
+    });
+
+    expect(created).toBeGreaterThanOrEqual(1);
+    expect(leaked).toBe(0);
+  });
+
+  it("clears the progress timer on the success path too", async () => {
+    const oxlintJson = JSON.stringify({ diagnostics: [] });
+    const { created, leaked } = await trackIntervals(async () => {
+      const diagnostics = await spawnLintBatches({
+        baseArgs: ["-e", `process.stdout.write(${JSON.stringify(oxlintJson)})`],
+        fileBatches,
+        rootDirectory: process.cwd(),
+        nodeBinaryPath: process.execPath,
+        project: buildProject(),
+        onFileProgress: () => {},
+        spawnTimeoutMs: 30_000,
+      });
+      expect(diagnostics).toEqual([]);
+    });
+
+    expect(created).toBeGreaterThanOrEqual(1);
+    expect(leaked).toBe(0);
+  });
+});

--- a/packages/core/tests/spawn-batches.test.ts
+++ b/packages/core/tests/spawn-batches.test.ts
@@ -1,22 +1,14 @@
 /**
- * Regression test for issue #599 — `react-doctor --staged` hangs after
+ * Regression test for issue #599 — `react-doctor --staged` hung after
  * printing results.
  *
- * `spawnLintBatches` starts a ref'd `setInterval` progress timer for each
- * multi-file batch and used to clear it on a statement that only ran once
- * `await spawnLintBatch(batch)` had *resolved*. When a batch instead
- * rejects with a non-splittable error (e.g. an adopted lint config
- * crashing oxlint), that statement was skipped and the timer leaked. The
- * caller (`runOxlint`) then silently retried with `extends` stripped and
- * succeeded, so the scan finished and printed output — but the orphaned
- * timer kept the Node event loop alive and the CLI never exited (the CLI
- * relies on natural event-loop drain + `process.exitCode`, not on
- * `process.exit()`).
- *
- * The fix wraps the batch in `try/finally`, so the timer is cleared on
- * BOTH the resolve and reject paths. We assert that by instrumenting
- * `setInterval` / `clearInterval` around a `spawnLintBatches` call whose
- * batch is forced to reject, and confirming no interval survives.
+ * `spawnLintBatches` starts a ref'd `setInterval` progress timer per
+ * multi-file batch and used to clear it only after `await spawnLintBatch`
+ * resolved. When a batch rejects with a non-splittable error (an adopted
+ * lint config crashing oxlint), that line was skipped and the timer
+ * leaked — and because the caller silently retries and the CLI exits via
+ * event-loop drain rather than `process.exit()`, the process hung. The
+ * fix clears the timer in a `finally`.
  */
 
 import { describe, expect, it } from "vite-plus/test";
@@ -40,87 +32,50 @@ const project: ProjectInfo = {
   sourceFileCount: 2,
 };
 
-// A multi-file batch so the progress interval is actually created
-// (`batch.length > 1`), with `onFileProgress` wired — the human inspect
-// path always passes it. Both are preconditions for the leak.
-const fileBatches = [["src/a.tsx", "src/b.tsx"]];
-
-// HACK: stand in for the oxlint binary with `node -e <script>`, so each
-// scenario can pick the failure shape (write stderr + exit 0 → empty
-// stdout → a non-splittable `OxlintSpawnFailed`, exactly how an adopted
-// lint config crashing oxlint surfaces) or the success shape (valid JSON
-// on stdout) without a real oxlint install.
-const runBatchesWith = (baseArgs: ReadonlyArray<string>) =>
-  spawnLintBatches({
-    baseArgs,
-    fileBatches,
-    rootDirectory: process.cwd(),
-    nodeBinaryPath: process.execPath,
-    project,
-    onFileProgress: () => {},
-  });
-
-/**
- * Runs `runScenario` with `setInterval` / `clearInterval` instrumented so
- * the test can assert no progress timer outlives the call. Globals are
- * always restored and any survivor is force-cleared in `finally`, so a
- * regression here can't hang the test process itself.
- */
-const trackIntervals = async (runScenario: () => Promise<void>) => {
-  const realSetInterval = globalThis.setInterval;
-  const realClearInterval = globalThis.clearInterval;
-  const liveIntervalHandles = new Set<ReturnType<typeof setInterval>>();
-  let createdCount = 0;
-  let leakedCount = 0;
-
-  // HACK: reassigning the timer globals is the only way to observe the
-  // interval handles the runner creates internally.
-  globalThis.setInterval = (...args: Parameters<typeof setInterval>) => {
-    const handle = realSetInterval(...args);
-    liveIntervalHandles.add(handle);
-    createdCount += 1;
-    return handle;
-  };
-  globalThis.clearInterval = (handle?: ReturnType<typeof setInterval>) => {
-    if (handle !== undefined) liveIntervalHandles.delete(handle);
-    realClearInterval(handle);
-  };
-
-  try {
-    await runScenario();
-  } finally {
-    globalThis.setInterval = realSetInterval;
-    globalThis.clearInterval = realClearInterval;
-    leakedCount = liveIntervalHandles.size;
-    for (const handle of liveIntervalHandles) realClearInterval(handle);
-  }
-
-  return { createdCount, leakedCount };
-};
-
 describe("issue #599: spawnLintBatches never leaks its progress interval", () => {
-  it("clears the progress timer when a multi-file batch rejects with a non-splittable error", async () => {
-    const { createdCount, leakedCount } = await trackIntervals(async () => {
-      await expect(runBatchesWith(["-e", "process.stderr.write('boom')"])).rejects.toThrow(
-        /Failed to run oxlint/,
-      );
-    });
+  it("clears the progress timer when a multi-file batch rejects", async () => {
+    const realSetInterval = globalThis.setInterval;
+    const realClearInterval = globalThis.clearInterval;
+    const liveIntervalHandles = new Set<ReturnType<typeof setInterval>>();
+    let createdCount = 0;
+
+    // HACK: instrument the timer globals to track the handles the runner
+    // creates and clears internally.
+    globalThis.setInterval = (...args: Parameters<typeof setInterval>) => {
+      const handle = realSetInterval(...args);
+      liveIntervalHandles.add(handle);
+      createdCount += 1;
+      return handle;
+    };
+    globalThis.clearInterval = (handle?: ReturnType<typeof setInterval>) => {
+      if (handle !== undefined) liveIntervalHandles.delete(handle);
+      realClearInterval(handle);
+    };
+
+    try {
+      // HACK: `node -e` stands in for the oxlint binary — it writes to
+      // stderr and exits 0, so empty stdout surfaces as a non-splittable
+      // `OxlintSpawnFailed`, exactly like an adopted lint config crashing
+      // oxlint. The batch has >1 file, so the progress interval is created.
+      await expect(
+        spawnLintBatches({
+          baseArgs: ["-e", "process.stderr.write('boom')"],
+          fileBatches: [["src/a.tsx", "src/b.tsx"]],
+          rootDirectory: process.cwd(),
+          nodeBinaryPath: process.execPath,
+          project,
+          onFileProgress: () => {},
+        }),
+      ).rejects.toThrow(/Failed to run oxlint/);
+    } finally {
+      globalThis.setInterval = realSetInterval;
+      globalThis.clearInterval = realClearInterval;
+      // Force-clear any survivor so a regression fails the assertion below
+      // instead of hanging the test process on the leaked timer.
+      for (const handle of liveIntervalHandles) realClearInterval(handle);
+    }
 
     expect(createdCount).toBeGreaterThanOrEqual(1);
-    expect(leakedCount).toBe(0);
-  });
-
-  it("clears the progress timer on the success path too", async () => {
-    const oxlintJson = JSON.stringify({ diagnostics: [] });
-    const { createdCount, leakedCount } = await trackIntervals(async () => {
-      const diagnostics = await runBatchesWith([
-        "-e",
-        `process.stdout.write(${JSON.stringify(oxlintJson)})`,
-      ]);
-      expect(diagnostics).toEqual([]);
-    });
-
-    expect(createdCount).toBeGreaterThanOrEqual(1);
-    expect(leakedCount).toBe(0);
+    expect(liveIntervalHandles.size).toBe(0);
   });
 });

--- a/packages/core/tests/spawn-batches.test.ts
+++ b/packages/core/tests/spawn-batches.test.ts
@@ -23,9 +23,7 @@ import { describe, expect, it } from "vite-plus/test";
 import type { ProjectInfo } from "@react-doctor/core";
 import { spawnLintBatches } from "../src/runners/oxlint/spawn-batches.js";
 
-type IntervalHandle = ReturnType<typeof setInterval>;
-
-const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
+const project: ProjectInfo = {
   rootDirectory: "/tmp/app",
   projectName: "app",
   reactVersion: "19.2.0",
@@ -40,45 +38,6 @@ const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
   preactVersion: null,
   preactMajorVersion: null,
   sourceFileCount: 2,
-  ...overrides,
-});
-
-/**
- * Runs `fn` with `setInterval` / `clearInterval` instrumented so the test
- * can assert no progress timer outlives the call. Globals are always
- * restored and any survivor is force-cleared in `finally`, so a
- * regression here can't hang the test process itself.
- */
-const trackIntervals = async (
-  fn: () => Promise<void>,
-): Promise<{ created: number; leaked: number }> => {
-  const realSetInterval = globalThis.setInterval;
-  const realClearInterval = globalThis.clearInterval;
-  const live = new Set<IntervalHandle>();
-  let created = 0;
-  let leaked = 0;
-
-  globalThis.setInterval = ((...args: Parameters<typeof setInterval>) => {
-    const handle = realSetInterval(...args);
-    live.add(handle);
-    created += 1;
-    return handle;
-  }) as typeof setInterval;
-  globalThis.clearInterval = ((handle?: IntervalHandle) => {
-    if (handle !== undefined) live.delete(handle);
-    realClearInterval(handle);
-  }) as typeof clearInterval;
-
-  try {
-    await fn();
-  } finally {
-    globalThis.setInterval = realSetInterval;
-    globalThis.clearInterval = realClearInterval;
-    leaked = live.size;
-    for (const handle of live) realClearInterval(handle);
-  }
-
-  return { created, leaked };
 };
 
 // A multi-file batch so the progress interval is actually created
@@ -86,48 +45,82 @@ const trackIntervals = async (
 // path always passes it. Both are preconditions for the leak.
 const fileBatches = [["src/a.tsx", "src/b.tsx"]];
 
+// HACK: stand in for the oxlint binary with `node -e <script>`, so each
+// scenario can pick the failure shape (write stderr + exit 0 → empty
+// stdout → a non-splittable `OxlintSpawnFailed`, exactly how an adopted
+// lint config crashing oxlint surfaces) or the success shape (valid JSON
+// on stdout) without a real oxlint install.
+const runBatchesWith = (baseArgs: ReadonlyArray<string>) =>
+  spawnLintBatches({
+    baseArgs,
+    fileBatches,
+    rootDirectory: process.cwd(),
+    nodeBinaryPath: process.execPath,
+    project,
+    onFileProgress: () => {},
+  });
+
+/**
+ * Runs `runScenario` with `setInterval` / `clearInterval` instrumented so
+ * the test can assert no progress timer outlives the call. Globals are
+ * always restored and any survivor is force-cleared in `finally`, so a
+ * regression here can't hang the test process itself.
+ */
+const trackIntervals = async (runScenario: () => Promise<void>) => {
+  const realSetInterval = globalThis.setInterval;
+  const realClearInterval = globalThis.clearInterval;
+  const liveIntervalHandles = new Set<ReturnType<typeof setInterval>>();
+  let createdCount = 0;
+  let leakedCount = 0;
+
+  // HACK: reassigning the timer globals is the only way to observe the
+  // interval handles the runner creates internally.
+  globalThis.setInterval = (...args: Parameters<typeof setInterval>) => {
+    const handle = realSetInterval(...args);
+    liveIntervalHandles.add(handle);
+    createdCount += 1;
+    return handle;
+  };
+  globalThis.clearInterval = (handle?: ReturnType<typeof setInterval>) => {
+    if (handle !== undefined) liveIntervalHandles.delete(handle);
+    realClearInterval(handle);
+  };
+
+  try {
+    await runScenario();
+  } finally {
+    globalThis.setInterval = realSetInterval;
+    globalThis.clearInterval = realClearInterval;
+    leakedCount = liveIntervalHandles.size;
+    for (const handle of liveIntervalHandles) realClearInterval(handle);
+  }
+
+  return { createdCount, leakedCount };
+};
+
 describe("issue #599: spawnLintBatches never leaks its progress interval", () => {
   it("clears the progress timer when a multi-file batch rejects with a non-splittable error", async () => {
-    // `baseArgs` make `spawnOxlint` run `node -e <script> …files`. The
-    // script writes to stderr and exits 0 → empty stdout + non-empty
-    // stderr → a non-splittable `OxlintSpawnFailed`, exactly how an
-    // adopted lint config crashing oxlint surfaces. `spawnLintBatch`
-    // re-throws it, so the whole call rejects before the post-`await`
-    // cleanup the old code relied on.
-    const { created, leaked } = await trackIntervals(async () => {
-      await expect(
-        spawnLintBatches({
-          baseArgs: ["-e", "process.stderr.write('boom')"],
-          fileBatches,
-          rootDirectory: process.cwd(),
-          nodeBinaryPath: process.execPath,
-          project: buildProject(),
-          onFileProgress: () => {},
-          spawnTimeoutMs: 30_000,
-        }),
-      ).rejects.toThrow(/Failed to run oxlint/);
+    const { createdCount, leakedCount } = await trackIntervals(async () => {
+      await expect(runBatchesWith(["-e", "process.stderr.write('boom')"])).rejects.toThrow(
+        /Failed to run oxlint/,
+      );
     });
 
-    expect(created).toBeGreaterThanOrEqual(1);
-    expect(leaked).toBe(0);
+    expect(createdCount).toBeGreaterThanOrEqual(1);
+    expect(leakedCount).toBe(0);
   });
 
   it("clears the progress timer on the success path too", async () => {
     const oxlintJson = JSON.stringify({ diagnostics: [] });
-    const { created, leaked } = await trackIntervals(async () => {
-      const diagnostics = await spawnLintBatches({
-        baseArgs: ["-e", `process.stdout.write(${JSON.stringify(oxlintJson)})`],
-        fileBatches,
-        rootDirectory: process.cwd(),
-        nodeBinaryPath: process.execPath,
-        project: buildProject(),
-        onFileProgress: () => {},
-        spawnTimeoutMs: 30_000,
-      });
+    const { createdCount, leakedCount } = await trackIntervals(async () => {
+      const diagnostics = await runBatchesWith([
+        "-e",
+        `process.stdout.write(${JSON.stringify(oxlintJson)})`,
+      ]);
       expect(diagnostics).toEqual([]);
     });
 
-    expect(created).toBeGreaterThanOrEqual(1);
-    expect(leaked).toBe(0);
+    expect(createdCount).toBeGreaterThanOrEqual(1);
+    expect(leakedCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Why

Catches a process hang: `react-doctor --staged` (and other scans) could finish, print the full diagnostics summary, then never return control to the shell. Fixes #599.

`spawnLintBatches` starts a ref'd `setInterval` progress timer per multi-file batch and used to clear it on a statement that only ran after `await spawnLintBatch(batch)` *resolved*. When a batch instead rejects with a non-splittable error (e.g. an adopted lint config crashing oxlint), that statement was skipped and the timer leaked. The caller (`runOxlint`) then silently retries with `extends` stripped and succeeds, so the scan finishes and prints output — but the orphaned timer keeps the Node event loop alive (the CLI exits via natural event-loop drain + `process.exitCode`, not `process.exit()`), so the process hangs forever.

Before:

```ts
const progressInterval = onFileProgress && batch.length > 1 ? setInterval(...) : null;
const batchDiagnostics = await spawnLintBatch(batch); // throws on a non-splittable error
if (progressInterval !== null) clearInterval(progressInterval); // skipped -> timer leaks
```

After:

```ts
const progressInterval = onFileProgress && batch.length > 1 ? setInterval(...) : null;
try {
  const batchDiagnostics = await spawnLintBatch(batch);
  // ...accumulate diagnostics + final progress tick
} finally {
  if (progressInterval !== null) clearInterval(progressInterval); // always cleared
}
```

## What changed

- Wrapped the per-batch execution in `spawnLintBatches` in `try/finally` so the progress `setInterval` is cleared on both the resolve and reject paths.
- Added a regression test (`packages/core/tests/spawn-batches.test.ts`) that instruments `setInterval`/`clearInterval` and asserts no timer survives when a multi-file batch rejects with a non-splittable error (plus a success-path assertion). Verified it fails against the pre-fix code (`leaked === 1`).
- Added a changeset (`react-doctor: patch`).
- Audited every other Node-side timer (`spawn-oxlint.ts`, `calculate-score.ts`, `check-dead-code.ts`): all already `clearTimeout` in `finally`/both settle paths and `unref()` defensively — this `setInterval` was the only leak.

## Eval results

RDE not run — this is a runner / process-lifecycle fix, not a lint rule, so the rule-eval harness doesn't apply.

## Test plan

- `pnpm --filter @react-doctor/core test` — 40 files / 390 tests pass (incl. the new regression test)
- `pnpm --filter @react-doctor/core typecheck` — clean
- `pnpm exec vp lint packages/core/src/runners/oxlint/spawn-batches.ts packages/core/tests/spawn-batches.test.ts` — clean
- `pnpm exec vp fmt --check` on the changed files — clean
- Confirmed the regression test fails on pre-fix code and passes after the fix

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in the oxlint batch runner with a targeted regression test; no auth, data, or rule behavior changes.
> 
> **Overview**
> Fixes **#599**: scans such as `react-doctor --staged` could print the full summary yet never exit because a per-batch **progress `setInterval`** in `spawnLintBatches` was only cleared after a successful `await spawnLintBatch`. When a batch **rejects** (e.g. adopted lint config crashing oxlint before `runOxlint` retries without `extends`), that clear was skipped, leaving a ref'd timer that kept the Node event loop alive.
> 
> The batch loop now wraps lint work in **`try` / `finally`** so the interval is always cleared on both success and failure. A **regression test** instruments `setInterval` / `clearInterval` and asserts no handle survives when a multi-file batch fails with a non-splittable error; a **patch changeset** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1a0ecb60796428a05de920722a6013241cfc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->