### PR TITLE
Add enterprise hint for missing scores

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -46,6 +46,8 @@ export const SCORE_BAR_WIDTH_CHARS = 50;
 
 export const SCORE_API_URL = "https://www.react.doctor/api/score";
 
+export const ENTERPRISE_CONTACT_URL = "https://react.doctor/enterprise";
+
 export const SHARE_BASE_URL = "https://www.react.doctor/share";
 
 // Base URL for the per-rule fix recipes the `/doctor` playbook fetches

--- a/packages/react-doctor/src/cli/utils/build-no-score-message.ts
+++ b/packages/react-doctor/src/cli/utils/build-no-score-message.ts
@@ -1,0 +1,11 @@
+import { ENTERPRISE_CONTACT_URL } from "@react-doctor/core";
+
+const ENTERPRISE_CONTACT_HINT = `Want something custom to your company? Contact us at ${ENTERPRISE_CONTACT_URL}.`;
+
+export const buildNoScoreMessage = (isScoreDisabled: boolean): string => {
+  const reason = isScoreDisabled
+    ? "Score disabled by --no-score."
+    : "Score unavailable (could not reach the score API).";
+
+  return `${reason} ${ENTERPRISE_CONTACT_HINT}`;
+};

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -20,6 +20,7 @@ import type {
   ScoreResult,
 } from "@react-doctor/core";
 import { makeNoopConsole } from "./cli/utils/noop-console.js";
+import { buildNoScoreMessage } from "./cli/utils/build-no-score-message.js";
 import { printAgentGuidance } from "./cli/utils/render-agent-guidance.js";
 import { isCiOrCodingAgentEnvironment } from "./cli/utils/is-ci-environment.js";
 import { printDiagnostics } from "./cli/utils/render-diagnostics.js";
@@ -343,9 +344,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
     if (didDeadCodeFail) skippedChecks.push("dead-code");
     const hasSkippedChecks = skippedChecks.length > 0;
 
-    const noScoreMessage = options.noScore
-      ? "Score disabled by --no-score."
-      : "Score unavailable (could not reach the score API).";
+    const noScoreMessage = buildNoScoreMessage(options.noScore);
 
     const skippedCheckReasons: Record<string, string> = {};
     if (didLintFail && lintFailureReason !== null) {

--- a/packages/react-doctor/tests/build-no-score-message.test.ts
+++ b/packages/react-doctor/tests/build-no-score-message.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+import { ENTERPRISE_CONTACT_URL } from "@react-doctor/core";
+import { buildNoScoreMessage } from "../src/cli/utils/build-no-score-message.js";
+
+describe("buildNoScoreMessage", () => {
+  it("points --no-score users to enterprise contact", () => {
+    expect(buildNoScoreMessage(true)).toBe(
+      `Score disabled by --no-score. Want something custom to your company? Contact us at ${ENTERPRISE_CONTACT_URL}.`,
+    );
+  });
+
+  it("points score API failures to enterprise contact", () => {
+    expect(buildNoScoreMessage(false)).toBe(
+      `Score unavailable (could not reach the score API). Want something custom to your company? Contact us at ${ENTERPRISE_CONTACT_URL}.`,
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared enterprise contact URL constant.
- Show an enterprise contact hint when scoring is disabled with `--no-score` or unavailable because the score API cannot be reached.
- Add focused tests for the no-score message wording.

## Testing
- `corepack pnpm --package @antfu/ni dlx nr build`
- `corepack pnpm --package @antfu/ni dlx nr test build-no-score-message.test.ts` (from `packages/react-doctor`)
- `corepack pnpm --package @antfu/ni dlx nr test`
- `corepack pnpm --package @antfu/ni dlx nr lint`
- `corepack pnpm --package @antfu/ni dlx nr typecheck`
- `corepack pnpm --package @antfu/ni dlx nr format`
- `corepack pnpm --package @antfu/ni dlx nr smoke:json-report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-031c5db6-544a-43ab-ac73-2cf2b5153662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-031c5db6-544a-43ab-ac73-2cf2b5153662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

