### PR TITLE
Fix React Native raw text wrapper handling

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-callback-per-row.ts
@@ -79,6 +79,13 @@ export const rnListCallbackPerRow = defineRule<Rule>({
   severity: "warn",
   recommendation:
     "Hoist the handler with useCallback at list scope and pass the row id as a primitive prop, so the row's memo() shallow-compare actually hits",
+  triage: {
+    why: "Virtualized lists render many rows, and each inline row handler is a fresh function.",
+    impact:
+      "Fresh per-row closures defeat memoized row components and can add visible scroll or tap jank.",
+    effort: "medium",
+    confidence: "medium",
+  },
   create: (context: RuleContext) => {
     const inspect = (node: EsTreeNode): void => {
       if (!isRenderItemFunction(node)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
@@ -13,6 +13,13 @@ export const rnNoInlineFlatlistRenderitem = defineRule<Rule>({
   severity: "warn",
   recommendation:
     "Extract renderItem to a named function or wrap in useCallback to avoid re-creating on every render",
+  triage: {
+    why: "Virtualized list props are compared by reference across renders.",
+    impact:
+      "A fresh renderItem function can force list internals and memoized rows to do unnecessary work.",
+    effort: "low",
+    confidence: "medium",
+  },
   create: (context: RuleContext) => ({
     JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "renderItem") return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rnNoRawText } from "./rn-no-raw-text.js";
+
+describe("rn-no-raw-text", () => {
+  it("flags raw text directly inside a View", () => {
+    const code = `const App = () => <View>Hello</View>;`;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("outside a <Text>");
+  });
+
+  it("does NOT flag raw text inside Text", () => {
+    const code = `const App = () => <Text>Hello</Text>;`;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag raw text inside same-file Text wrapper components", () => {
+    const code = `
+      const Copy = ({ children }) => <Text>{children}</Text>;
+      const App = () => <View><Copy>Hello</Copy></View>;
+    `;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag raw text inside memoized Text wrapper components", () => {
+    const code = `
+      const Copy = React.memo(({ children }) => <Text>{children}</Text>);
+      const App = () => <View><Copy>Hello</Copy></View>;
+    `;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag raw text inside forwardRef Text wrapper components", () => {
+    const code = `
+      const Copy = forwardRef(({ children }, ref) => <Text ref={ref}>{children}</Text>);
+      const App = () => <View><Copy>Hello</Copy></View>;
+    `;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag raw text inside components that compose local Text wrappers", () => {
+    const code = `
+      const Copy = ({ children }) => <Text>{children}</Text>;
+      const Emphasis = ({ children }) => <Copy>{children}</Copy>;
+      const App = () => <View><Emphasis>Hello</Emphasis></View>;
+    `;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags raw text inside same-file non-Text wrapper components", () => {
+    const code = `
+      const Card = ({ children }) => <View>{children}</View>;
+      const App = () => <Card>Hello</Card>;
+    `;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags raw text inside unknown custom components", () => {
+    const code = `const App = () => <Card>Hello</Card>;`;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
@@ -53,6 +53,35 @@ describe("rn-no-raw-text", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does NOT flag raw text inside function declaration Text wrappers", () => {
+    const code = `
+      function Copy({ children }) {
+        return <Text>{children}</Text>;
+      }
+      const App = () => <View><Copy>Hello</Copy></View>;
+    `;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag raw text inside conditional Text wrappers", () => {
+    const code = `
+      const Copy = ({ children, hidden }) => hidden ? null : <Text>{children}</Text>;
+      const App = () => <View><Copy>Hello</Copy></View>;
+    `;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag raw text inside logical Text wrappers", () => {
+    const code = `
+      const Copy = ({ children, visible }) => visible && <Text>{children}</Text>;
+      const App = () => <View><Copy>Hello</Copy></View>;
+    `;
+    const result = runRule(rnNoRawText, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags raw text inside same-file non-Text wrapper components", () => {
     const code = `
       const Card = ({ children }) => <View>{children}</View>;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -6,19 +6,14 @@ import {
 } from "../../constants/react-native.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { hasDirective } from "../../utils/has-directive.js";
-import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isInsidePlatformOsWebBranch } from "../../utils/is-inside-platform-os-web-branch.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { createLocalTextBoundaryResolver } from "./utils/create-local-text-boundary-resolver.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
-
-const TEXT_WRAPPER_HOC_NAMES = new Set(["memo", "forwardRef"]);
 
 const truncateText = (text: string): string =>
   text.length > RAW_TEXT_PREVIEW_MAX_CHARS
@@ -76,65 +71,6 @@ const isTextHandlingComponent = (elementName: string): boolean => {
 const isTransparentTextWrapper = (elementName: string | null): boolean =>
   elementName !== null && REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(elementName);
 
-const isReactComponentWrapperCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
-  const callee = stripParenExpression(node.callee as EsTreeNode);
-  if (isNodeOfType(callee, "Identifier")) return TEXT_WRAPPER_HOC_NAMES.has(callee.name);
-  if (!isNodeOfType(callee, "MemberExpression")) return false;
-  if (callee.computed || !isNodeOfType(callee.property, "Identifier")) return false;
-  if (!isNodeOfType(callee.object, "Identifier") || callee.object.name !== "React") return false;
-  return TEXT_WRAPPER_HOC_NAMES.has(callee.property.name);
-};
-
-const resolveComponentFunction = (
-  node: EsTreeNode | null,
-):
-  | EsTreeNodeOfType<"ArrowFunctionExpression">
-  | EsTreeNodeOfType<"FunctionExpression">
-  | EsTreeNodeOfType<"FunctionDeclaration">
-  | null => {
-  if (!node) return null;
-  const expression = stripParenExpression(node);
-  if (isFunctionLike(expression)) return expression;
-  if (!isNodeOfType(expression, "CallExpression") || !isReactComponentWrapperCall(expression)) {
-    return null;
-  }
-  const firstArgument = expression.arguments[0];
-  return firstArgument ? resolveComponentFunction(firstArgument as EsTreeNode) : null;
-};
-
-const collectRenderReturnExpressions = (
-  functionNode:
-    | EsTreeNodeOfType<"ArrowFunctionExpression">
-    | EsTreeNodeOfType<"FunctionExpression">
-    | EsTreeNodeOfType<"FunctionDeclaration">,
-): EsTreeNode[] => {
-  if (
-    isNodeOfType(functionNode, "ArrowFunctionExpression") &&
-    !isNodeOfType(functionNode.body, "BlockStatement")
-  ) {
-    return [functionNode.body];
-  }
-
-  if (!functionNode.body) return [];
-
-  const returnExpressions: EsTreeNode[] = [];
-  walkAst(functionNode.body, (node) => {
-    if (node !== functionNode.body && isFunctionLike(node)) return false;
-    if (isNodeOfType(node, "ReturnStatement") && node.argument) {
-      returnExpressions.push(node.argument);
-    }
-  });
-
-  return returnExpressions;
-};
-
-const isNullableRenderExpression = (node: EsTreeNode): boolean => {
-  const expression = stripParenExpression(node);
-  if (isNodeOfType(expression, "Literal"))
-    return expression.value === null || expression.value === false;
-  return isNodeOfType(expression, "Identifier") && expression.name === "undefined";
-};
-
 // Walks ancestors to a real text component, stepping through transparent
 // wrappers. Returns false as soon as a non-transparent, non-text element
 // breaks the chain — so the text boundary is only honored when every link
@@ -175,69 +111,11 @@ export const rnNoRawText = defineRule<Rule>({
     // Expo Router's directive that opts a single file into being rendered
     // in a WebView as DOM rather than on React Native primitives.
     let isDomComponentFile = false;
-    const textWrapperCache = new Map<number, boolean>();
-
-    const isLocalTextWrapperComponent = (
-      symbol: SymbolDescriptor,
-      seenSymbols: Set<number>,
-    ): boolean => {
-      const cachedResult = textWrapperCache.get(symbol.id);
-      if (cachedResult !== undefined) return cachedResult;
-      if (seenSymbols.has(symbol.id)) return false;
-
-      const functionNode = resolveComponentFunction(symbol.initializer);
-      if (!functionNode) {
-        textWrapperCache.set(symbol.id, false);
-        return false;
-      }
-
-      seenSymbols.add(symbol.id);
-      const returnExpressions = collectRenderReturnExpressions(functionNode);
-      const isTextWrapper =
-        returnExpressions.length > 0 &&
-        returnExpressions.every(
-          (expression) =>
-            isNullableRenderExpression(expression) ||
-            isTextBoundaryExpression(expression, seenSymbols),
-        );
-      seenSymbols.delete(symbol.id);
-      textWrapperCache.set(symbol.id, isTextWrapper);
-      return isTextWrapper;
-    };
-
-    const isTextBoundaryElement = (
-      node: EsTreeNodeOfType<"JSXElement">,
-      seenSymbols: Set<number>,
-    ): boolean => {
-      const elementName = resolveTextBoundaryName(node.openingElement);
-      if (elementName && isTextHandlingComponent(elementName)) return true;
-      const nameNode = node.openingElement.name;
-      if (!isNodeOfType(nameNode, "JSXIdentifier")) return false;
-      const symbol = context.scopes.symbolFor(nameNode);
-      return symbol ? isLocalTextWrapperComponent(symbol, seenSymbols) : false;
-    };
-
-    const isTextBoundaryExpression = (node: EsTreeNode, seenSymbols: Set<number>): boolean => {
-      const expression = stripParenExpression(node);
-      if (isNodeOfType(expression, "JSXElement")) {
-        return isTextBoundaryElement(expression, seenSymbols);
-      }
-      if (isNodeOfType(expression, "ConditionalExpression")) {
-        return (
-          (isNullableRenderExpression(expression.consequent) ||
-            isTextBoundaryExpression(expression.consequent, seenSymbols)) &&
-          (isNullableRenderExpression(expression.alternate) ||
-            isTextBoundaryExpression(expression.alternate, seenSymbols))
-        );
-      }
-      if (isNodeOfType(expression, "LogicalExpression") && expression.operator === "&&") {
-        return (
-          isNullableRenderExpression(expression.right) ||
-          isTextBoundaryExpression(expression.right, seenSymbols)
-        );
-      }
-      return false;
-    };
+    const textBoundaryResolver = createLocalTextBoundaryResolver({
+      context,
+      isTextHandlingComponent,
+      resolveTextBoundaryName,
+    });
 
     return {
       Program(programNode: EsTreeNodeOfType<"Program">) {
@@ -247,8 +125,7 @@ export const rnNoRawText = defineRule<Rule>({
         if (isDomComponentFile) return;
 
         const elementName = resolveTextBoundaryName(node.openingElement);
-        if (elementName && isTextHandlingComponent(elementName)) return;
-        if (isTextBoundaryElement(node, new Set())) return;
+        if (textBoundaryResolver.isTextBoundaryElement(node)) return;
 
         // `Platform.OS === "web"` branches deliberately render web markup
         // (raw text, div/span trees, etc.) when the app is bundled by

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -108,7 +108,10 @@ const collectRenderReturnExpressions = (
     | EsTreeNodeOfType<"FunctionExpression">
     | EsTreeNodeOfType<"FunctionDeclaration">,
 ): EsTreeNode[] => {
-  if (isNodeOfType(functionNode, "ArrowFunctionExpression") && !isNodeOfType(functionNode.body, "BlockStatement")) {
+  if (
+    isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(functionNode.body, "BlockStatement")
+  ) {
     return [functionNode.body];
   }
 
@@ -127,7 +130,8 @@ const collectRenderReturnExpressions = (
 
 const isNullableRenderExpression = (node: EsTreeNode): boolean => {
   const expression = stripParenExpression(node);
-  if (isNodeOfType(expression, "Literal")) return expression.value === null || expression.value === false;
+  if (isNodeOfType(expression, "Literal"))
+    return expression.value === null || expression.value === false;
   return isNodeOfType(expression, "Identifier") && expression.name === "undefined";
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -6,13 +6,19 @@ import {
 } from "../../constants/react-native.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { hasDirective } from "../../utils/has-directive.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isInsidePlatformOsWebBranch } from "../../utils/is-inside-platform-os-web-branch.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+const TEXT_WRAPPER_HOC_NAMES = new Set(["memo", "forwardRef"]);
 
 const truncateText = (text: string): string =>
   text.length > RAW_TEXT_PREVIEW_MAX_CHARS
@@ -70,6 +76,61 @@ const isTextHandlingComponent = (elementName: string): boolean => {
 const isTransparentTextWrapper = (elementName: string | null): boolean =>
   elementName !== null && REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(elementName);
 
+const isReactComponentWrapperCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = stripParenExpression(node.callee as EsTreeNode);
+  if (isNodeOfType(callee, "Identifier")) return TEXT_WRAPPER_HOC_NAMES.has(callee.name);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  if (callee.computed || !isNodeOfType(callee.property, "Identifier")) return false;
+  if (!isNodeOfType(callee.object, "Identifier") || callee.object.name !== "React") return false;
+  return TEXT_WRAPPER_HOC_NAMES.has(callee.property.name);
+};
+
+const resolveComponentFunction = (
+  node: EsTreeNode | null,
+):
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | null => {
+  if (!node) return null;
+  const expression = stripParenExpression(node);
+  if (isFunctionLike(expression)) return expression;
+  if (!isNodeOfType(expression, "CallExpression") || !isReactComponentWrapperCall(expression)) {
+    return null;
+  }
+  const firstArgument = expression.arguments[0];
+  return firstArgument ? resolveComponentFunction(firstArgument as EsTreeNode) : null;
+};
+
+const collectRenderReturnExpressions = (
+  functionNode:
+    | EsTreeNodeOfType<"ArrowFunctionExpression">
+    | EsTreeNodeOfType<"FunctionExpression">
+    | EsTreeNodeOfType<"FunctionDeclaration">,
+): EsTreeNode[] => {
+  if (isNodeOfType(functionNode, "ArrowFunctionExpression") && !isNodeOfType(functionNode.body, "BlockStatement")) {
+    return [functionNode.body];
+  }
+
+  if (!functionNode.body) return [];
+
+  const returnExpressions: EsTreeNode[] = [];
+  walkAst(functionNode.body, (node) => {
+    if (node !== functionNode.body && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "ReturnStatement") && node.argument) {
+      returnExpressions.push(node.argument);
+    }
+  });
+
+  return returnExpressions;
+};
+
+const isNullableRenderExpression = (node: EsTreeNode): boolean => {
+  const expression = stripParenExpression(node);
+  if (isNodeOfType(expression, "Literal")) return expression.value === null || expression.value === false;
+  return isNodeOfType(expression, "Identifier") && expression.name === "undefined";
+};
+
 // Walks ancestors to a real text component, stepping through transparent
 // wrappers. Returns false as soon as a non-transparent, non-text element
 // breaks the chain — so the text boundary is only honored when every link
@@ -104,6 +165,69 @@ export const rnNoRawText = defineRule<Rule>({
     // Expo Router's directive that opts a single file into being rendered
     // in a WebView as DOM rather than on React Native primitives.
     let isDomComponentFile = false;
+    const textWrapperCache = new Map<number, boolean>();
+
+    const isLocalTextWrapperComponent = (
+      symbol: SymbolDescriptor,
+      seenSymbols: Set<number>,
+    ): boolean => {
+      const cachedResult = textWrapperCache.get(symbol.id);
+      if (cachedResult !== undefined) return cachedResult;
+      if (seenSymbols.has(symbol.id)) return false;
+
+      const functionNode = resolveComponentFunction(symbol.initializer);
+      if (!functionNode) {
+        textWrapperCache.set(symbol.id, false);
+        return false;
+      }
+
+      seenSymbols.add(symbol.id);
+      const returnExpressions = collectRenderReturnExpressions(functionNode);
+      const isTextWrapper =
+        returnExpressions.length > 0 &&
+        returnExpressions.every(
+          (expression) =>
+            isNullableRenderExpression(expression) ||
+            isTextBoundaryExpression(expression, seenSymbols),
+        );
+      seenSymbols.delete(symbol.id);
+      textWrapperCache.set(symbol.id, isTextWrapper);
+      return isTextWrapper;
+    };
+
+    const isTextBoundaryElement = (
+      node: EsTreeNodeOfType<"JSXElement">,
+      seenSymbols: Set<number>,
+    ): boolean => {
+      const elementName = resolveTextBoundaryName(node.openingElement);
+      if (elementName && isTextHandlingComponent(elementName)) return true;
+      const nameNode = node.openingElement.name;
+      if (!isNodeOfType(nameNode, "JSXIdentifier")) return false;
+      const symbol = context.scopes.symbolFor(nameNode);
+      return symbol ? isLocalTextWrapperComponent(symbol, seenSymbols) : false;
+    };
+
+    const isTextBoundaryExpression = (node: EsTreeNode, seenSymbols: Set<number>): boolean => {
+      const expression = stripParenExpression(node);
+      if (isNodeOfType(expression, "JSXElement")) {
+        return isTextBoundaryElement(expression, seenSymbols);
+      }
+      if (isNodeOfType(expression, "ConditionalExpression")) {
+        return (
+          (isNullableRenderExpression(expression.consequent) ||
+            isTextBoundaryExpression(expression.consequent, seenSymbols)) &&
+          (isNullableRenderExpression(expression.alternate) ||
+            isTextBoundaryExpression(expression.alternate, seenSymbols))
+        );
+      }
+      if (isNodeOfType(expression, "LogicalExpression") && expression.operator === "&&") {
+        return (
+          isNullableRenderExpression(expression.right) ||
+          isTextBoundaryExpression(expression.right, seenSymbols)
+        );
+      }
+      return false;
+    };
 
     return {
       Program(programNode: EsTreeNodeOfType<"Program">) {
@@ -114,6 +238,7 @@ export const rnNoRawText = defineRule<Rule>({
 
         const elementName = resolveTextBoundaryName(node.openingElement);
         if (elementName && isTextHandlingComponent(elementName)) return;
+        if (isTextBoundaryElement(node, new Set())) return;
 
         // `Platform.OS === "web"` branches deliberately render web markup
         // (raw text, div/span trees, etc.) when the app is bundled by

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -160,6 +160,12 @@ export const rnNoRawText = defineRule<Rule>({
   severity: "error",
   recommendation:
     "Wrap text in a `<Text>` component: `<Text>{value}</Text>` — raw strings outside `<Text>` crash on React Native",
+  triage: {
+    why: "React Native only permits strings inside text-rendering components.",
+    impact: "This is a user-visible crash risk, not a style preference.",
+    effort: "low",
+    confidence: "high",
+  },
   create: (context: RuleContext) => {
     // The package-boundary gate (`isReactNativeFileActive`) lives on the
     // rule wrapper applied at registry load — by the time we get here

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
@@ -69,6 +69,13 @@ export const rnPressableSharedValueMutation = defineRule<Rule>({
   severity: "warn",
   recommendation:
     "Wrap in <GestureDetector gesture={Gesture.Tap()...}> so the press animation runs on the UI thread instead of bouncing across the JS bridge",
+  triage: {
+    why: "Press feedback should stay on the Reanimated UI thread instead of bouncing through JS.",
+    impact:
+      "JS-thread shared-value writes in press handlers can make touch feedback stutter on real devices.",
+    effort: "medium",
+    confidence: "medium",
+  },
   create: (context: RuleContext) => {
     const sharedValueBindingsByComponent: Array<Set<string>> = [];
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/utils/create-local-text-boundary-resolver.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/utils/create-local-text-boundary-resolver.ts
@@ -1,0 +1,138 @@
+import { REACT_HOC_NAMES } from "../../../constants/react.js";
+import type { SymbolDescriptor } from "../../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
+import { flattenCalleeName } from "../../../utils/flatten-callee-name.js";
+import { isFunctionLike } from "../../../utils/is-function-like.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../../utils/rule-context.js";
+import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
+import { walkAst } from "../../../utils/walk-ast.js";
+
+export interface LocalTextBoundaryResolverOptions {
+  context: RuleContext;
+  isTextHandlingComponent: (elementName: string) => boolean;
+  resolveTextBoundaryName: (openingElement: EsTreeNodeOfType<"JSXOpeningElement">) => string | null;
+}
+
+export interface LocalTextBoundaryResolver {
+  isTextBoundaryElement: (node: EsTreeNodeOfType<"JSXElement">) => boolean;
+}
+
+const isReactComponentWrapperCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = stripParenExpression(node.callee as EsTreeNode);
+  const calleeName = flattenCalleeName(callee);
+  return calleeName !== null && REACT_HOC_NAMES.has(calleeName);
+};
+
+const resolveComponentFunction = (node: EsTreeNode | null): EsTreeNode | null => {
+  if (!node) return null;
+  const expression = stripParenExpression(node);
+  if (isFunctionLike(expression)) return expression;
+  if (!isNodeOfType(expression, "CallExpression") || !isReactComponentWrapperCall(expression)) {
+    return null;
+  }
+  const firstArgument = expression.arguments[0];
+  return firstArgument ? resolveComponentFunction(firstArgument as EsTreeNode) : null;
+};
+
+const collectRenderReturnExpressions = (functionNode: EsTreeNode): EsTreeNode[] => {
+  if (!isFunctionLike(functionNode)) return [];
+  if (
+    isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(functionNode.body, "BlockStatement")
+  ) {
+    return [functionNode.body];
+  }
+
+  if (!functionNode.body) return [];
+
+  const returnExpressions: EsTreeNode[] = [];
+  walkAst(functionNode.body, (node) => {
+    if (node !== functionNode.body && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "ReturnStatement") && node.argument) {
+      returnExpressions.push(node.argument);
+    }
+  });
+
+  return returnExpressions;
+};
+
+const isNullableRenderExpression = (node: EsTreeNode): boolean => {
+  const expression = stripParenExpression(node);
+  if (isNodeOfType(expression, "Literal"))
+    return expression.value === null || expression.value === false;
+  return isNodeOfType(expression, "Identifier") && expression.name === "undefined";
+};
+
+export const createLocalTextBoundaryResolver = (
+  options: LocalTextBoundaryResolverOptions,
+): LocalTextBoundaryResolver => {
+  const textWrapperCache = new Map<number, boolean>();
+
+  const isLocalTextWrapperComponent = (
+    symbol: SymbolDescriptor,
+    seenSymbols: Set<number>,
+  ): boolean => {
+    const cachedResult = textWrapperCache.get(symbol.id);
+    if (cachedResult !== undefined) return cachedResult;
+    if (seenSymbols.has(symbol.id)) return false;
+
+    const functionNode = resolveComponentFunction(symbol.initializer);
+    if (!functionNode) {
+      textWrapperCache.set(symbol.id, false);
+      return false;
+    }
+
+    seenSymbols.add(symbol.id);
+    const returnExpressions = collectRenderReturnExpressions(functionNode);
+    const isTextWrapper =
+      returnExpressions.length > 0 &&
+      returnExpressions.every(
+        (expression) =>
+          isNullableRenderExpression(expression) ||
+          isTextBoundaryExpression(expression, seenSymbols),
+      );
+    seenSymbols.delete(symbol.id);
+    textWrapperCache.set(symbol.id, isTextWrapper);
+    return isTextWrapper;
+  };
+
+  const isTextBoundaryElement = (
+    node: EsTreeNodeOfType<"JSXElement">,
+    seenSymbols: Set<number>,
+  ): boolean => {
+    const elementName = options.resolveTextBoundaryName(node.openingElement);
+    if (elementName && options.isTextHandlingComponent(elementName)) return true;
+    const nameNode = node.openingElement.name;
+    if (!isNodeOfType(nameNode, "JSXIdentifier")) return false;
+    const symbol = options.context.scopes.symbolFor(nameNode);
+    return symbol ? isLocalTextWrapperComponent(symbol, seenSymbols) : false;
+  };
+
+  const isTextBoundaryExpression = (node: EsTreeNode, seenSymbols: Set<number>): boolean => {
+    const expression = stripParenExpression(node);
+    if (isNodeOfType(expression, "JSXElement")) {
+      return isTextBoundaryElement(expression, seenSymbols);
+    }
+    if (isNodeOfType(expression, "ConditionalExpression")) {
+      return (
+        (isNullableRenderExpression(expression.consequent) ||
+          isTextBoundaryExpression(expression.consequent, seenSymbols)) &&
+        (isNullableRenderExpression(expression.alternate) ||
+          isTextBoundaryExpression(expression.alternate, seenSymbols))
+      );
+    }
+    if (isNodeOfType(expression, "LogicalExpression") && expression.operator === "&&") {
+      return (
+        isNullableRenderExpression(expression.right) ||
+        isTextBoundaryExpression(expression.right, seenSymbols)
+      );
+    }
+    return false;
+  };
+
+  return {
+    isTextBoundaryElement: (node) => isTextBoundaryElement(node, new Set()),
+  };
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/redux-useselector-inline-derivation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/redux-useselector-inline-derivation.ts
@@ -149,9 +149,17 @@ export const reduxUseselectorInlineDerivation = defineRule<Rule>({
   id: "redux-useselector-inline-derivation",
   severity: "warn",
   category: "Performance",
+  tags: ["state-management"],
   disabledBy: ["react-compiler"],
   recommendation:
     "Select the raw slice and derive with `useMemo`, or use `createSelector` from `reselect`.",
+  triage: {
+    why: "React Redux re-runs the selector on store updates and compares the returned value by reference.",
+    impact:
+      "Inline collection derivation returns a fresh reference and can re-render the screen even when the underlying slice did not change.",
+    effort: "medium",
+    confidence: "high",
+  },
   create: (context: RuleContext) => {
     let aliases: ReadonlySet<string> = new Set<string>();
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/redux-useselector-returns-new-collection.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/redux-useselector-returns-new-collection.ts
@@ -65,9 +65,16 @@ export const reduxUseselectorReturnsNewCollection = defineRule<Rule>({
   id: "redux-useselector-returns-new-collection",
   severity: "warn",
   category: "Performance",
+  tags: ["state-management"],
   disabledBy: ["react-compiler"],
   recommendation:
     "Return a primitive, split into multiple useSelector calls, or pass `shallowEqual` from `react-redux` as the second argument.",
+  triage: {
+    why: "React Redux compares selector results by reference unless you pass an equality function.",
+    impact: "Fresh objects or arrays make the component re-render on every store update.",
+    effort: "low",
+    confidence: "high",
+  },
   create: (context: RuleContext) => {
     let aliases: ReadonlySet<string> = new Set<string>();
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/rule.ts
@@ -15,6 +15,13 @@ export type RuleFramework =
   | "tanstack-query"
   | "preact";
 
+export interface RuleTriage {
+  why?: string;
+  impact?: string;
+  effort?: "low" | "medium" | "high";
+  confidence?: "low" | "medium" | "high";
+}
+
 export interface Rule {
   // Public-facing rule identifier — what users put in their oxlint config
   // (`react-doctor/<id>`) and what shows up in diagnostic output. Owned by
@@ -57,5 +64,6 @@ export interface Rule {
   // `forbid-component-props` flagging `className`, etc.).
   defaultEnabled?: boolean;
   recommendation?: string;
+  triage?: RuleTriage;
   create: (context: RuleContext) => RuleVisitors;
 }

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -33,7 +33,6 @@ import {
 } from "../utils/json-mode.js";
 import { printAnnotations } from "../utils/print-annotations.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
-import { promptCopyIssues } from "../utils/copy-issues-to-clipboard.js";
 import { readChangedFilesFrom } from "../utils/read-changed-files-from.js";
 import { printMultiProjectSummary } from "../utils/render-multi-project-summary.js";
 import {
@@ -369,15 +368,6 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       ) {
         printAgentInstallHint();
       }
-    }
-
-    if (!skipPrompts && !isQuiet && allDiagnostics.length > 0) {
-      const lastScan = completedScans[completedScans.length - 1];
-      await promptCopyIssues({
-        diagnostics: allDiagnostics,
-        score: lastScan?.result.score ?? null,
-        projectName: lastScan?.result.project.projectName ?? path.basename(resolvedDirectory),
-      });
     }
   } catch (error) {
     if (isJsonMode) {

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -25,7 +25,7 @@ const program = new Command()
     "--no-dead-code",
     "skip dead-code analysis (unused files / exports / dependencies, circular imports)",
   )
-  .option("--verbose", "show every rule and per-file details (default shows top 3 rules)")
+  .option("--verbose", "show every rule, explanation, opt-out hint, and per-file details")
   .option("--score", "output only the score")
   .option("--json", "output a single structured JSON report (suppresses other output)")
   .option("--json-compact", "with --json, emit compact JSON (no indentation)")
@@ -70,6 +70,10 @@ const program = new Command()
 ${highlighter.dim("Configuration:")}
   Place a ${highlighter.info("react-doctor.config.json")} (or ${highlighter.info('"reactDoctor"')} key in your package.json) in the project root.
   CLI flags always override config values. See the README for the full schema.
+
+${highlighter.dim("Low-noise workflows:")}
+  Use ${highlighter.info("--staged")} for pre-commit cleanup, ${highlighter.info("--diff")} for branch cleanup, and ${highlighter.info("--fail-on error")} to gate only user-impacting issues.
+  Disable a noisy rule with ${highlighter.info('{ "rules": { "react-doctor/<rule>": "off" } }')} or hide families per surface with ${highlighter.info("surfaces")}.
 
 ${highlighter.dim("Learn more:")}
   ${highlighter.info(CANONICAL_GITHUB_URL)}

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -1,15 +1,22 @@
+import path from "node:path";
 import isUnicodeSupported from "is-unicode-supported";
+import reactDoctorPlugin from "oxlint-plugin-react-doctor";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import {
   buildRulePromptUrl,
   groupBy,
   highlighter,
+  MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE,
+  MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
   MILLISECONDS_PER_SECOND,
+  OUTPUT_DETAIL_WRAP_WIDTH_CHARS,
   RULE_NAME_COLUMN_WIDTH_CHARS,
 } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+import { buildHiddenDiagnosticsSummary } from "./build-hidden-diagnostics-summary.js";
 import { indentMultilineText } from "./indent-multiline-text.js";
+import { wrapIndentedText } from "./wrap-indented-text.js";
 
 const POINTER = isUnicodeSupported() ? "›" : ">";
 
@@ -20,6 +27,11 @@ const SEVERITY_ORDER: Record<Diagnostic["severity"], number> = {
 
 const colorizeBySeverity = (text: string, severity: Diagnostic["severity"]): string =>
   severity === "error" ? highlighter.error(text) : highlighter.warn(text);
+
+const getDiagnosticTriage = (diagnostic: Diagnostic) => {
+  if (diagnostic.plugin !== "react-doctor") return null;
+  return reactDoctorPlugin.rules[diagnostic.rule]?.triage ?? null;
+};
 
 // Build a `<plugin>/<rule>` -> priority lookup from the score API's per-rule
 // payload (merged across scans). Rules the API didn't rank — or every rule when
@@ -117,6 +129,12 @@ const FETCH_FIX_RECIPE_LABEL = "Fetch & follow the canonical fix recipe before f
 export const formatFixRecipeLine = (diagnostic: Diagnostic): string =>
   `${FETCH_FIX_RECIPE_LABEL}: ${buildRulePromptUrl(diagnostic.plugin, diagnostic.rule)}`;
 
+const formatOptOutLine = (diagnostic: Diagnostic): string =>
+  `Config opt-out: { "rules": { "${diagnostic.plugin}/${diagnostic.rule}": "off" } }`;
+
+const formatAbsoluteFilePath = (filePath: string, rootDirectory: string): string =>
+  path.isAbsolute(filePath) ? filePath : path.join(rootDirectory, filePath);
+
 const buildCompactRuleGroupLine = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
@@ -206,26 +224,41 @@ const buildVerboseRuleGroupLines = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
   ruleNameColumnWidth: number,
+  rootDirectory: string,
 ): ReadonlyArray<string> => {
   const lines: string[] = [];
   lines.push(buildCompactRuleGroupLine(ruleKey, ruleDiagnostics, ruleNameColumnWidth));
   const firstDiagnostic = ruleDiagnostics[0];
+  const triage = getDiagnosticTriage(firstDiagnostic);
   lines.push(grayLine(indentMultilineText(firstDiagnostic.message, "      ")));
   if (firstDiagnostic.help) {
     lines.push(grayLine(indentMultilineText(`→ ${firstDiagnostic.help}`, "      ")));
   }
+  if (triage?.why) {
+    lines.push(grayLine(indentMultilineText(`Why: ${triage.why}`, "      ")));
+  }
+  if (triage?.impact) {
+    lines.push(grayLine(indentMultilineText(`Impact: ${triage.impact}`, "      ")));
+  }
+  if (triage?.confidence || triage?.effort) {
+    const confidence = triage.confidence ?? "medium";
+    const effort = triage.effort ?? "medium";
+    lines.push(grayLine(`      Confidence: ${confidence}; effort: ${effort}`));
+  }
   lines.push(grayLine(`      ${formatFixRecipeLine(firstDiagnostic)}`));
+  lines.push(grayLine(`      ${formatOptOutLine(firstDiagnostic)}`));
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);
   for (const [filePath, sites] of fileSites) {
+    const displayFilePath = formatAbsoluteFilePath(filePath, rootDirectory);
     if (sites.length > 0) {
       for (const site of sites) {
-        lines.push(grayLine(`      ${filePath}:${site.line}`));
+        lines.push(grayLine(`      ${displayFilePath}:${site.line}`));
         if (site.suppressionHint) {
           lines.push(grayLine(`        ↳ ${site.suppressionHint}`));
         }
       }
     } else {
-      lines.push(grayLine(`      ${filePath}`));
+      lines.push(grayLine(`      ${displayFilePath}`));
     }
   }
   lines.push("");
@@ -237,10 +270,42 @@ const buildDefaultDiagnosticsLines = (
   rulePriority?: ReadonlyMap<string, number>,
 ): ReadonlyArray<string> => {
   const categoryGroups = buildCategoryDiagnosticGroups(diagnostics, rulePriority);
+  const visibleCategoryGroups = categoryGroups.slice(0, MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE);
+  const hiddenDiagnostics = categoryGroups
+    .slice(MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE)
+    .flatMap((categoryGroup) => categoryGroup.diagnostics);
   const lines: string[] = [];
-  for (const categoryGroup of categoryGroups) {
+  for (const categoryGroup of visibleCategoryGroups) {
     lines.push(buildCompactCategoryLine(categoryGroup));
+    const visibleRuleGroups = categoryGroup.ruleGroups.slice(
+      0,
+      MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
+    );
+    const hiddenRuleGroups = categoryGroup.ruleGroups.slice(
+      MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE,
+    );
+    hiddenDiagnostics.push(...hiddenRuleGroups.flatMap(([, ruleDiagnostics]) => ruleDiagnostics));
+    const ruleNameColumnWidth = computeRuleNameColumnWidth(
+      visibleRuleGroups.map(([ruleKey]) => ruleKey),
+    );
+    for (const [ruleKey, ruleDiagnostics] of visibleRuleGroups) {
+      lines.push(buildCompactRuleGroupLine(ruleKey, ruleDiagnostics, ruleNameColumnWidth));
+    }
   }
+  const hiddenSummary = buildHiddenDiagnosticsSummary(hiddenDiagnostics);
+  if (hiddenSummary.length > 0) {
+    const hiddenParts = hiddenSummary.map((part) => colorizeBySeverity(part.text, part.severity));
+    lines.push(`  ${hiddenParts.join(highlighter.dim(", "))}`);
+  }
+  lines.push(
+    grayLine(
+      wrapIndentedText(
+        "Showing the highest-signal findings first. Run with --verbose for every file, or --staged to focus on the next commit.",
+        "  ",
+        OUTPUT_DETAIL_WRAP_WIDTH_CHARS,
+      ),
+    ),
+  );
   lines.push("");
   return lines;
 };
@@ -271,7 +336,7 @@ export const printDiagnostics = (
         sortedRuleGroups.map(([ruleKey]) => ruleKey),
       );
       lines = sortedRuleGroups.flatMap(([ruleKey, ruleDiagnostics]) =>
-        buildVerboseRuleGroupLines(ruleKey, ruleDiagnostics, ruleNameColumnWidth),
+        buildVerboseRuleGroupLines(ruleKey, ruleDiagnostics, ruleNameColumnWidth, rootDirectory),
       );
     }
     for (const line of lines) {
@@ -288,6 +353,7 @@ export const formatElapsedTime = (elapsedMilliseconds: number): string => {
 
 export const formatRuleSummary = (ruleKey: string, ruleDiagnostics: Diagnostic[]): string => {
   const firstDiagnostic = ruleDiagnostics[0];
+  const triage = getDiagnosticTriage(firstDiagnostic);
 
   const sections = [
     `Rule: ${ruleKey}`,
@@ -301,10 +367,23 @@ export const formatRuleSummary = (ruleKey: string, ruleDiagnostics: Diagnostic[]
   if (firstDiagnostic.help) {
     sections.push("", `Suggestion: ${firstDiagnostic.help}`);
   }
+  if (triage?.why) {
+    sections.push("", `Why: ${triage.why}`);
+  }
+  if (triage?.impact) {
+    sections.push("", `Impact: ${triage.impact}`);
+  }
+  if (triage?.confidence || triage?.effort) {
+    sections.push(
+      "",
+      `Confidence: ${triage.confidence ?? "medium"}`,
+      `Effort: ${triage.effort ?? "medium"}`,
+    );
+  }
   if (firstDiagnostic.url) {
     sections.push("", `Docs: ${firstDiagnostic.url}`);
   }
-  sections.push("", formatFixRecipeLine(firstDiagnostic));
+  sections.push("", formatFixRecipeLine(firstDiagnostic), formatOptOutLine(firstDiagnostic));
 
   sections.push("", "Files:");
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);

--- a/packages/react-doctor/tests/render-diagnostics.test.ts
+++ b/packages/react-doctor/tests/render-diagnostics.test.ts
@@ -65,7 +65,7 @@ describe("printDiagnostics", () => {
 
     const output = stripAnsi(printedLines.join("\n"));
     expect(output).toContain("Why: React Native only permits strings");
-    expect(output).toContain("Impact: This can crash the screen.");
+    expect(output).toContain("Impact: This is a user-visible crash risk");
     expect(output).toContain("Confidence: high; effort: low");
     expect(output).toContain('{ "rules": { "react-doctor/rn-no-raw-text": "off" } }');
     expect(output).toContain("/repo/src/app.tsx:1");

--- a/packages/react-doctor/tests/render-diagnostics.test.ts
+++ b/packages/react-doctor/tests/render-diagnostics.test.ts
@@ -1,0 +1,73 @@
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { printDiagnostics } from "../src/cli/utils/render-diagnostics.js";
+import { buildDiagnostic } from "./regressions/_helpers.js";
+
+const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
+
+const stripAnsi = (text: string): string => text.replace(ANSI_ESCAPE_PATTERN, "");
+
+describe("printDiagnostics", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  const printedLines: string[] = [];
+
+  beforeEach(() => {
+    printedLines.length = 0;
+    consoleLogSpy = vi.spyOn(globalThis.console, "log").mockImplementation((line = "") => {
+      printedLines.push(String(line));
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it("caps default output to top categories and rules with a hidden summary", async () => {
+    const diagnostics = [
+      buildDiagnostic({ category: "Correctness", rule: "a", severity: "error" }),
+      buildDiagnostic({ category: "Correctness", rule: "b", severity: "error" }),
+      buildDiagnostic({ category: "Correctness", rule: "c", severity: "error" }),
+      buildDiagnostic({ category: "Correctness", rule: "d", severity: "error" }),
+      buildDiagnostic({ category: "Performance", rule: "perf", severity: "warning" }),
+      buildDiagnostic({ category: "Architecture", rule: "arch", severity: "warning" }),
+      buildDiagnostic({ category: "React Native", rule: "rn", severity: "warning" }),
+      buildDiagnostic({ category: "Security", rule: "sec", severity: "warning" }),
+      buildDiagnostic({ category: "Accessibility", rule: "a11y", severity: "warning" }),
+    ];
+
+    await Effect.runPromise(printDiagnostics(diagnostics, false, "/repo"));
+
+    const output = stripAnsi(printedLines.join("\n"));
+    expect(output).toContain("Correctness");
+    expect(output).toContain("react-doctor/a");
+    expect(output).toContain("react-doctor/c");
+    expect(output).not.toContain("react-doctor/d");
+    expect(output).toContain("more error");
+    expect(output).toContain("more warning");
+    expect(output).toContain("--staged");
+  });
+
+  it("prints verbose triage metadata, opt-out help, and absolute paths", async () => {
+    await Effect.runPromise(
+      printDiagnostics(
+        [
+          buildDiagnostic({
+            rule: "rn-no-raw-text",
+            message: "Raw text outside Text",
+            help: "Wrap it in Text",
+            filePath: "src/app.tsx",
+          }),
+        ],
+        true,
+        "/repo",
+      ),
+    );
+
+    const output = stripAnsi(printedLines.join("\n"));
+    expect(output).toContain("Why: React Native only permits strings");
+    expect(output).toContain("Impact: This can crash the screen.");
+    expect(output).toContain("Confidence: high; effort: low");
+    expect(output).toContain('{ "rules": { "react-doctor/rn-no-raw-text": "off" } }');
+    expect(output).toContain("/repo/src/app.tsx:1");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rebased onto latest `main`.
- Fix the `rn-no-raw-text` false positive for same-file React Native text wrapper components, including `memo` / `forwardRef` wrappers, function declarations, composed wrappers, and conditional/logical text-boundary returns.
- Extract local text-boundary detection into a focused React Native resolver that reuses shared React HOC/callee utilities.
- Reduce issue overload in default CLI output by showing capped, highest-signal category/rule groups first and summarizing hidden errors/warnings instead of dumping every category equally.
- Preserve the main-branch score-priority ranking path and layer the capped output on top of it.
- Add optional rule triage metadata (`why`, `impact`, `effort`, `confidence`) as rule metadata only; no public Diagnostic / JSON schema changes.
- Show human-facing education, confidence/effort, absolute file paths, and config opt-out snippets in verbose output by looking up React Doctor rule metadata at render time.
- Remove the post-scan copy-to-clipboard prompt from the main inspect flow.
- Improve low-noise workflow help text for `--staged`, `--diff`, `--fail-on error`, rule opt-outs, and surface filtering.
- Add triage metadata to high-signal React Native and state-management re-render rules (`rn-*` list/press rules and React Redux selector rules) rather than introducing speculative noisy detectors.

## Thermos review
- Fixed: plugin-boundary leak risk by keeping triage lookup in the renderer and scoping it to `react-doctor/*` diagnostics only.
- Fixed: extracted the embedded `rn-no-raw-text` mini analyzer into `create-local-text-boundary-resolver` and reused shared React HOC/callee helpers.
- Added coverage for function-declaration wrappers, conditional wrappers, and logical wrappers.

## Testing
- Passed: `pnpm --filter oxlint-plugin-react-doctor exec vp test run src/plugin/rules/react-native/rn-no-raw-text.test.ts src/plugin/rules/state-and-effects/redux-useselector-returns-new-collection.test.ts src/plugin/rules/state-and-effects/redux-useselector-inline-derivation.test.ts`
- Passed: `pnpm --filter react-doctor exec vp test run tests/render-diagnostics.test.ts`
- Passed: `pnpm format:check`
- Passed: `pnpm lint`
- Passed: `pnpm typecheck`
- Passed: `pnpm test`
- Passed: `pnpm smoke:json-report`
- Known/package-wide failure: `pnpm --filter oxlint-plugin-react-doctor test` still fails in unrelated React built-in fixture suites (`jsx-no-new-array-as-prop`, `jsx-no-new-function-as-prop`, `jsx-no-new-object-as-prop`, `no-array-index-key`, `no-multi-comp`); focused touched-rule tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b822b72-36b5-421b-8e91-c7f4f7046b35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b822b72-36b5-421b-8e91-c7f4f7046b35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

