### PR TITLE
fix(action): degrade to full-project scan when PR files are unreadable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,17 +66,25 @@ runs:
           const outputPath = process.env.REACT_DOCTOR_CHANGED_FILES;
           const pullRequest = context.payload.pull_request;
           if (!pullRequest || !outputPath) return;
-
-          const files = await github.paginate(github.rest.pulls.listFiles, {
-            ...context.repo,
-            pull_number: pullRequest.number,
-            per_page: 100,
-          });
+          let files;
+          try {
+            files = await github.paginate(github.rest.pulls.listFiles, {
+              ...context.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+          } catch (error) {
+            core.warning(
+              `React Doctor could not list pull request files (${error.message}). ` +
+                "Scanning the full project instead. Grant the workflow `pull-requests: read` " +
+                "permission to scan only the files changed in the pull request.",
+            );
+            return;
+          }
           const includedStatuses = new Set(["added", "modified", "renamed"]);
           const changedFiles = files
             .filter((file) => includedStatuses.has(file.status))
             .map((file) => file.filename);
-
           fs.writeFileSync(outputPath, changedFiles.join("\n") + (changedFiles.length ? "\n" : ""));
           core.setOutput("path", outputPath);
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -69,6 +69,8 @@ jobs:
 
 React Doctor scans the files changed in the pull request, emits inline annotations, blocks on error-level findings, and updates one sticky PR comment with the score and issue summary. The built-in GitHub token is used automatically; no secret or PAT is required. On forked PRs where GitHub withholds write permissions, the scan and annotations still run, but the sticky comment may be skipped.
 
+**Permissions:** set `permissions: { contents: read, pull-requests: write }` so React Doctor can read the pull request's changed files for a changed-files-only scan and post the sticky summary comment. If `pull-requests: read` is unavailable (for example on fork PRs or with a restricted default token), the action degrades gracefully to a full-project scan instead of failing.
+
 [Add GitHub Action →](https://github.com/marketplace/actions/react-doctor)
 
 ### 4. Configure rules in `react-doctor.config.json`

--- a/packages/react-doctor/tests/github-action-comment.test.ts
+++ b/packages/react-doctor/tests/github-action-comment.test.ts
@@ -282,4 +282,27 @@ describe("render-github-action-comment", () => {
     expect(outputs).toContain("score=");
     expect(outputs).toContain("total-issues=0");
   });
+
+  it("skips the comment without throwing when the report path is empty", () => {
+    const tempDirectory = setupTempDirectory();
+    const commentPath = path.join(tempDirectory, "comment.md");
+
+    expect(() =>
+      execFileSync(process.execPath, [RENDER_SCRIPT_PATH, "", commentPath], { stdio: "pipe" }),
+    ).not.toThrow();
+    expect(fs.existsSync(commentPath)).toBe(false);
+  });
+
+  it("skips the comment without throwing when the report file is missing", () => {
+    const tempDirectory = setupTempDirectory();
+    const reportPath = path.join(tempDirectory, "missing-report.json");
+    const commentPath = path.join(tempDirectory, "comment.md");
+
+    expect(() =>
+      execFileSync(process.execPath, [RENDER_SCRIPT_PATH, reportPath, commentPath], {
+        stdio: "pipe",
+      }),
+    ).not.toThrow();
+    expect(fs.existsSync(commentPath)).toBe(false);
+  });
 });

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -72,6 +72,23 @@ describe("GitHub Action contract", () => {
     expect(actionYaml).not.toContain('git checkout "$HEAD_REF"');
   });
 
+  it("falls back to a full-project scan when listing PR files is not permitted", () => {
+    const prFilesStep = normalizeWhitespace(extractStep(readActionYaml(), "- id: pr-files"));
+
+    expect(prFilesStep).toContain("try {");
+    expect(prFilesStep).toContain("} catch (error) {");
+    expect(prFilesStep).toContain("core.warning(");
+    expect(prFilesStep).toContain("pull-requests: read");
+
+    const catchIndex = prFilesStep.indexOf("} catch (error) {");
+    const returnIndex = prFilesStep.indexOf("return;", catchIndex);
+    const setOutputIndex = prFilesStep.indexOf('core.setOutput("path", outputPath)');
+
+    expect(catchIndex).toBeGreaterThan(-1);
+    expect(returnIndex).toBeGreaterThan(catchIndex);
+    expect(returnIndex).toBeLessThan(setOutputIndex);
+  });
+
   it("runs one JSON scan, captures its status, and passes PR files to the CLI", () => {
     const scanStep = normalizeWhitespace(
       extractStep(readActionYaml(), "INPUT_FAIL_ON: ${{ inputs.fail-on }}"),

--- a/scripts/render-github-action-comment.mjs
+++ b/scripts/render-github-action-comment.mjs
@@ -26,8 +26,12 @@ const appendOutput = (name, value) => {
 };
 
 const readReport = () => {
-  if (!reportPath) throw new Error("Missing report path.");
-  return JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  if (!reportPath || !fs.existsSync(reportPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  } catch {
+    return null;
+  }
 };
 
 const renderLines = (lines) =>
@@ -227,6 +231,13 @@ const buildCommentBody = (report) => {
 };
 
 const report = readReport();
+if (!report) {
+  console.warn(
+    "React Doctor: no scan report was found, so the summary comment was skipped. " +
+      "This usually means the scan step did not run.",
+  );
+  process.exit(0);
+}
 const body = buildCommentBody(report);
 
 if (commentPath) {


### PR DESCRIPTION
## Why

Catches a hard failure when the React Doctor GitHub Action runs on a `pull_request` event whose `GITHUB_TOKEN` lacks `pull-requests: read` — the default restricted token, or fork PRs.

The `pr-files` step calls `github.rest.pulls.listFiles` to compute changed files for diff-scoped scans. Without `pull-requests: read` that request 403s. The call was not wrapped in try/catch, so the step failed. In a composite action a failed step aborts later steps that lack `if: always()`, so `scan` was skipped and never set its `report-file` output; `render` (which has `if: always()`) then threw `Error: Missing report path.`, and the final gate defaulted the empty `SCAN_STATUS` to `1` — failing the job.

Observed in a consumer running `millionco/react-doctor@main`:

```text
RequestError [HttpError]: Resource not accessible by integration   # 403, x-accepted-github-permissions: pull_requests=read
Error: Missing report path.
Process completed with exit code 1.
```

This is a regression from the PR-reporting refactor that switched changed-file detection from git (needs only `contents: read`) to the pulls API (needs `pull-requests: read`).

Before:

```js
const files = await github.paginate(github.rest.pulls.listFiles, {
  ...context.repo,
  pull_number: pullRequest.number,
  per_page: 100,
});
```

After:

```js
let files;
try {
  files = await github.paginate(github.rest.pulls.listFiles, {
    ...context.repo,
    pull_number: pullRequest.number,
    per_page: 100,
  });
} catch (error) {
  core.warning(
    `React Doctor could not list pull request files (${error.message}). ` +
      "Scanning the full project instead. Grant the workflow `pull-requests: read` " +
      "permission to scan only the files changed in the pull request.",
  );
  return;
}
```

## What changed

- `action.yml` `pr-files`: wrap the `listFiles` call in try/catch; on error emit an actionable `core.warning` and `return` so the scan falls back to a full-project scan instead of aborting the composite action.
- `scripts/render-github-action-comment.mjs`: `readReport` now returns `null` for a missing/empty/unreadable report instead of throwing `Missing report path.`; the script then logs a warning and exits `0`, so the `render` step no longer fails the job when no scan ran.
- Tests: `github-action.test.ts` asserts the `pr-files` step now contains the try/catch, `core.warning(`, `pull-requests: read`, and that the catch `return;` precedes `core.setOutput("path", outputPath)`. `github-action-comment.test.ts` adds two cases (empty report path, missing report file) asserting the renderer exits without throwing and writes no comment.
- README: adds a Permissions note — set `permissions: { contents: read, pull-requests: write }` to enable changed-files-only scanning and the sticky comment; otherwise the action degrades to a full-project scan.

## Eval results

RDE not run — this is a GitHub Action / CI resilience fix, not a lint rule, so there is no rule detection surface to evaluate.

## Changeset

None — tooling (`action.yml`, `scripts/`), docs (README), and tests only; no published npm package runtime behavior changes. Matches repo precedent (the prior `feat(action)` PR #604 changed `action.yml` without a changeset).

## Test plan

- `pnpm exec vp test run tests/github-action` — 14 passed (2 files)
- `pnpm typecheck` — 8/8 tasks successful
- `pnpm lint` — pass (only pre-existing `packages/core/tests/fixtures/**` warnings)
- `pnpm format:check` — pass
- `node --check scripts/render-github-action-comment.mjs`; `action.yml` parses with 6 steps

## Residual risk

- On a token without `pull-requests: read`, scans now cover the full project (slower, may surface findings outside the PR diff) rather than the changed files only — intended graceful degradation, surfaced via `core.warning`.
- The sticky PR comment still requires `pull-requests: write`; without it the comment is skipped (pre-existing behavior, unchanged).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/tooling resilience only; intended tradeoff is slower full-repo scans and broader findings when `pull-requests: read` is missing, not runtime package behavior changes.
> 
> **Overview**
> Fixes GitHub Action jobs that **hard-failed** when `GITHUB_TOKEN` cannot call `pulls.listFiles` (missing `pull-requests: read`, e.g. restricted defaults or fork PRs).
> 
> The **`pr-files`** step now **try/catch**es that API call: on failure it emits a **`core.warning`** explaining how to grant `pull-requests: read`, **returns without** writing changed-files output, and lets **`scan`** run a **full-project** scan instead of aborting the composite action.
> 
> **`render-github-action-comment.mjs`** no longer throws on a missing or invalid report path; it **warns and exits 0** so the **`render`** step (`if: always()`) does not fail the workflow when no scan report exists.
> 
> **README** documents recommended **`permissions`** (`contents: read`, `pull-requests: write`) and the **graceful degradation** to full-repo scanning. **Tests** lock in the try/catch/`return` ordering in `action.yml` and the renderer’s no-throw behavior for empty/missing reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6811b2684b3742b91d00f903a7f39380e6976a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->