### PR TITLE
fix(oxlint-plugin): allowlist public client keys in no-secrets-in-client-code

### DIFF
--- a/.changeset/allowlist-public-client-keys.md
+++ b/.changeset/allowlist-public-client-keys.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Stop flagging known public client keys in `no-secrets-in-client-code`. Keys that vendors design to ship in the browser bundle — RevenueCat public SDK keys (`appl_`/`goog_`/`amzn_`/`strp_`), Stripe/Clerk publishable keys (`pk_live_`/`pk_test_`), Supabase publishable keys (`sb_publishable_`), PostHog project keys (`phc_`), Stytch public tokens (`public-token-`), and Mapbox public access tokens (`pk.`) — are now allowlisted, so the variable-name heuristic no longer reports them as hardcoded secrets. Ambiguous shapes that can be either public or sensitive (Google/Firebase `AIza…` browser keys, and bare Supabase `anon`/`service_role` JWTs) are intentionally still flagged.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
@@ -56,37 +56,22 @@ export const SECRET_PATTERNS = [
   /^sk-[a-zA-Z0-9]{32,}$/,
 ];
 
-// Public, client-safe keys that vendors *design* to ship in the browser
-// bundle. Each carries a non-secret, type-identifying prefix that is
-// distinct from the same vendor's secret key — RevenueCat public
-// `appl_`/`goog_`/`amzn_`/`strp_` vs secret `sk_`; Stripe/Clerk
-// publishable `pk_` vs secret `sk_`; Supabase `sb_publishable_` vs
-// `sb_secret_`; Mapbox public `pk.` vs secret `sk.`; PostHog project
-// `phc_` vs personal `phx_`; Stytch `public-token-` vs `secret-`. A
-// literal matching one of these is intentionally publishable, so the
-// rule must not flag it as a leaked secret via either the secret-shape
-// patterns or the variable-name heuristic. Anchored at the start and
-// written with linear-time constructs (no nested quantifiers) so a long
-// literal can't trigger catastrophic backtracking; every prefix is
-// unique to a vendor's *public* key and never collides with that
-// vendor's secret shape.
-//
-// Intentionally excluded — ambiguous formats that can be public OR
-// sensitive depending on configuration, so flagging stays the safe
-// default: Google/Firebase browser keys (`AIza…`, the same shape as
-// unrestricted server keys) and bare Supabase JWTs (`eyJ…`, whose public
-// `anon` and secret `service_role` variants are indistinguishable by
-// shape; the new `sb_publishable_` format above is the safe opt-in).
+// Public, client-safe keys designed to ship in the browser, each with a
+// prefix distinct from the same vendor's secret key (RevenueCat `appl_`
+// vs `sk_`, Supabase `sb_publishable_` vs `sb_secret_`, …); a literal
+// matching one must never be flagged. Ambiguous shapes are omitted so they
+// stay flagged: Google `AIza…` (also unrestricted server keys) and Supabase
+// `anon`/`service_role` JWTs (`eyJ…`, indistinguishable by shape).
 export const PUBLIC_CLIENT_KEY_PATTERNS = [
-  /^appl_/, // RevenueCat public SDK key (Apple)
-  /^goog_/, // RevenueCat public SDK key (Google)
-  /^amzn_/, // RevenueCat public SDK key (Amazon)
-  /^strp_/, // RevenueCat public SDK key (Stripe)
-  /^pk_(?:live|test)_/, // Stripe / Clerk publishable key
-  /^sb_publishable_/, // Supabase publishable key (new format)
-  /^phc_/, // PostHog project (client) API key
+  /^appl_/, // RevenueCat (Apple)
+  /^goog_/, // RevenueCat (Google)
+  /^amzn_/, // RevenueCat (Amazon)
+  /^strp_/, // RevenueCat (Stripe)
+  /^pk_(?:live|test)_/, // Stripe / Clerk publishable
+  /^sb_publishable_/, // Supabase publishable
+  /^phc_/, // PostHog project key
   /^public-token-(?:live|test)-/, // Stytch public token
-  /^pk\.eyJ/, // Mapbox public access token (pk. + JWT)
+  /^pk\.eyJ/, // Mapbox public token
 ];
 
 export const SECRET_VARIABLE_PATTERN = /(?:api_?key|secret|token|password|credential|auth)/i;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
@@ -56,6 +56,39 @@ export const SECRET_PATTERNS = [
   /^sk-[a-zA-Z0-9]{32,}$/,
 ];
 
+// Public, client-safe keys that vendors *design* to ship in the browser
+// bundle. Each carries a non-secret, type-identifying prefix that is
+// distinct from the same vendor's secret key — RevenueCat public
+// `appl_`/`goog_`/`amzn_`/`strp_` vs secret `sk_`; Stripe/Clerk
+// publishable `pk_` vs secret `sk_`; Supabase `sb_publishable_` vs
+// `sb_secret_`; Mapbox public `pk.` vs secret `sk.`; PostHog project
+// `phc_` vs personal `phx_`; Stytch `public-token-` vs `secret-`. A
+// literal matching one of these is intentionally publishable, so the
+// rule must not flag it as a leaked secret via either the secret-shape
+// patterns or the variable-name heuristic. Anchored at the start and
+// written with linear-time constructs (no nested quantifiers) so a long
+// literal can't trigger catastrophic backtracking; every prefix is
+// unique to a vendor's *public* key and never collides with that
+// vendor's secret shape.
+//
+// Intentionally excluded — ambiguous formats that can be public OR
+// sensitive depending on configuration, so flagging stays the safe
+// default: Google/Firebase browser keys (`AIza…`, the same shape as
+// unrestricted server keys) and bare Supabase JWTs (`eyJ…`, whose public
+// `anon` and secret `service_role` variants are indistinguishable by
+// shape; the new `sb_publishable_` format above is the safe opt-in).
+export const PUBLIC_CLIENT_KEY_PATTERNS = [
+  /^appl_/, // RevenueCat public SDK key (Apple)
+  /^goog_/, // RevenueCat public SDK key (Google)
+  /^amzn_/, // RevenueCat public SDK key (Amazon)
+  /^strp_/, // RevenueCat public SDK key (Stripe)
+  /^pk_(?:live|test)_/, // Stripe / Clerk publishable key
+  /^sb_publishable_/, // Supabase publishable key (new format)
+  /^phc_/, // PostHog project (client) API key
+  /^public-token-(?:live|test)-/, // Stytch public token
+  /^pk\.eyJ/, // Mapbox public access token (pk. + JWT)
+];
+
 export const SECRET_VARIABLE_PATTERN = /(?:api_?key|secret|token|password|credential|auth)/i;
 
 export const SECRET_TOOLING_FILE_PATTERN = /(?:^|\/)[^/]+\.config\.[cm]?[jt]s$/;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -1,4 +1,5 @@
 import {
+  PUBLIC_CLIENT_KEY_PATTERNS,
   SECRET_FALSE_POSITIVE_SUFFIXES,
   SECRET_MIN_LENGTH_CHARS,
   SECRET_PATTERNS,
@@ -44,6 +45,18 @@ export const noSecretsInClientCode = defineRule<Rule>({
 
         const variableName = node.id.name;
         const literalValue = node.init.value;
+
+        // Known public, client-safe keys (RevenueCat `appl_`, Stripe/Clerk
+        // publishable `pk_`, Supabase `sb_publishable_`, Mapbox `pk.`,
+        // PostHog `phc_`, Stytch `public-token-`) are designed to ship in the
+        // browser bundle. Short-circuit before both detectors so an
+        // intentionally-publishable literal is never reported as a leaked
+        // secret — neither the variable-name heuristic nor the secret-shape
+        // patterns should fire on it.
+        if (PUBLIC_CLIENT_KEY_PATTERNS.some((pattern) => pattern.test(literalValue))) {
+          return;
+        }
+
         const isServerOnlyScope = isInsideServerOnlyScope(node);
 
         const trailingSuffix = getIdentifierTrailingWord(variableName);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -46,13 +46,8 @@ export const noSecretsInClientCode = defineRule<Rule>({
         const variableName = node.id.name;
         const literalValue = node.init.value;
 
-        // Known public, client-safe keys (RevenueCat `appl_`, Stripe/Clerk
-        // publishable `pk_`, Supabase `sb_publishable_`, Mapbox `pk.`,
-        // PostHog `phc_`, Stytch `public-token-`) are designed to ship in the
-        // browser bundle. Short-circuit before both detectors so an
-        // intentionally-publishable literal is never reported as a leaked
-        // secret — neither the variable-name heuristic nor the secret-shape
-        // patterns should fire on it.
+        // Public, client-safe keys ship in the browser by design; skip
+        // them before either detector can flag them.
         if (PUBLIC_CLIENT_KEY_PATTERNS.some((pattern) => pattern.test(literalValue))) {
           return;
         }

--- a/packages/react-doctor/tests/regressions/no-secrets-in-client-code.test.ts
+++ b/packages/react-doctor/tests/regressions/no-secrets-in-client-code.test.ts
@@ -558,4 +558,37 @@ export default {};
     expect(secretIssues).toHaveLength(1);
     expect(secretIssues[0].message).toContain("Hardcoded secret detected");
   });
+
+  it("does not flag known public client keys that are designed to ship in the browser", async () => {
+    const projectDir = setupReactProject(tempRoot, "public-client-keys-allowlisted", {
+      files: {
+        "src/payments.tsx": `const revenueCatApiKey = "appl_FIXTUREkey1234567890abcdef";
+const stripeApiKey = "pk_test_FIXTUREkey1234567890abcdef";
+const supabaseApiKey = "sb_publishable_FIXTUREkey1234567890";
+
+export const Payments = () => (
+  <div>{revenueCatApiKey}{stripeApiKey}{supabaseApiKey}</div>
+);
+`,
+      },
+    });
+
+    await expect(getSecretIssues(projectDir)).resolves.toEqual([]);
+  });
+
+  it("still flags a real secret literal even when a public client key sits beside it", async () => {
+    const projectDir = setupReactProject(tempRoot, "public-key-with-real-secret", {
+      files: {
+        "src/payments.tsx": `const revenueCatApiKey = "appl_FIXTUREkey1234567890abcdef";
+const stripeKey = "sk\\u005ftest_FIXTUREsecret1234567890";
+
+export const Payments = () => <div>{revenueCatApiKey}{stripeKey}</div>;
+`,
+      },
+    });
+
+    const secretIssues = await getSecretIssues(projectDir);
+    expect(secretIssues).toHaveLength(1);
+    expect(secretIssues[0].message).toContain("Hardcoded secret detected");
+  });
 });


### PR DESCRIPTION
## Why

`no-secrets-in-client-code` flagged public, client-safe SDK keys (e.g. RevenueCat `appl_…`) as hardcoded secrets.

These keys are *designed* to ship in the browser bundle — RevenueCat / Stripe / Supabase / etc. publishable keys carry a type-identifying prefix that is distinct from the vendor's secret key. The rule's variable-name heuristic matches on the *variable name* (`apiKey`, `token`, …) regardless of the value, so an intentionally-public key in a client file was reported as a leak.

Before — reported `Possible hardcoded secret in "revenueCatApiKey"`:

```tsx
const revenueCatApiKey = "appl_QKLmVFiscBxRYOaeTdZFTulz";
```

After — no diagnostic (`appl_` is a known public client-key prefix):

```tsx
const revenueCatApiKey = "appl_QKLmVFiscBxRYOaeTdZFTulz";
```

## What changed

- Added `PUBLIC_CLIENT_KEY_PATTERNS` to the plugin's security constants (sibling of `SECRET_PATTERNS`).
- `no-secrets-in-client-code` short-circuits before **both** detectors (variable-name heuristic and secret-shape patterns) when a literal matches a known public prefix.
- Allowlisted: RevenueCat `appl_`/`goog_`/`amzn_`/`strp_`, Stripe/Clerk `pk_(live|test)_`, Supabase `sb_publishable_`, PostHog `phc_`, Stytch `public-token-(live|test)-`, Mapbox `pk.eyJ`.
- Still flagged on purpose — ambiguous shapes that can be public *or* sensitive: Google/Firebase `AIza…` (same shape as unrestricted server keys) and bare Supabase `anon`/`service_role` JWTs (`eyJ…`, indistinguishable by shape).
- Adds regression tests: public keys are not flagged; a real `sk_test_` secret beside a public key is still flagged.
- Changeset: `react-doctor` patch.

## Eval results

RDE not run. This change only **narrows** the rule — it suppresses findings for specific public-key value prefixes and cannot emit new diagnostics — so there is no false-positive surface to sweep; the RDE harness/manifests aren't set up in this worktree. Can run it on request.

## Test plan

- `vp test run tests/regressions/no-secrets-in-client-code.test.ts` — 31 passed (2 new)
- `pnpm test` — 7/7 tasks, 1422 passed
- `pnpm typecheck` — 8/8
- `pnpm lint` / `pnpm format:check` — clean
- `pnpm smoke:json-report` — OK

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows lint diagnostics only; does not weaken detection for known secret prefixes or ambiguous Google/Supabase shapes.
> 
> **Overview**
> The `no-secrets-in-client-code` rule no longer reports literals that match **known public, browser-shipped** key prefixes (RevenueCat `appl_`/`goog_`/etc., Stripe/Clerk `pk_live_`/`pk_test_`, Supabase `sb_publishable_`, PostHog `phc_`, Stytch `public-token-`, Mapbox `pk.eyJ…`). A new `PUBLIC_CLIENT_KEY_PATTERNS` list is checked **before** both the variable-name heuristic and secret-shape detectors, so names like `revenueCatApiKey` stop producing false positives when the value is intentionally public.
> 
> **Ambiguous** shapes stay flagged: Google/Firebase `AIza…` and bare Supabase JWT-style `anon`/`service_role` values. Regression tests confirm allowlisted keys are silent and real secrets (e.g. `sk_test_`) still fire when mixed with public keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438dc22f63de427a1aead74139320702380c4d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->