### PR TITLE
perf(oxlint-plugin): memoize getDownstreamRefs — ~24% faster scans, 14 lines

### DIFF
--- a/.changeset/memoize-downstream-refs.md
+++ b/.changeset/memoize-downstream-refs.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+Speed up scans of effect-heavy codebases by memoizing `getDownstreamRefs` in the State & Effects rule helpers. `ascend()` re-descended the same large definition subtrees on every recursion step, so the seven effect rules (led by `no-pass-data-to-parent`) blew up superlinearly on big components with many `useEffect`s — re-walking and re-scoping identical bodies across recursion, across effects, and across rules. Caching the downstream-reference lookup per Program node (a `WeakMap` keyed on the per-`Program` analysis singleton, GC-bound with the file) collapses that to a single descent.
+
+On an 866-file Next.js app this cut ~9s (~24%) off a full scan — the worst rule on the largest file (a 1,159-line component with 10 effects) dropped from ~9.5s to ~0.18s, and the hot lint batch from ~13.5s to ~2.5s. Diagnostics are byte-identical (verified by a SHA-256 fingerprint over every diagnostic before/after); the cache only stores arrays callers already read and never mutate.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
@@ -92,12 +92,26 @@ export const getRef = (analysis: ProgramAnalysis, identifier: EsTreeNode): Refer
   return null;
 };
 
+// Memoize per (analysis, node). `analysis` is the per-Program singleton
+// (get-program-analysis.ts), so this WeakMap is stable for the file and
+// self-cleaning (GC'd with the Program). Without it, ascend() re-descends
+// the same large definition subtrees on every recursion step -> superlinear.
+const downstreamRefsCache = new WeakMap<ProgramAnalysis, WeakMap<EsTreeNode, Reference[]>>();
+
 export const getDownstreamRefs = (analysis: ProgramAnalysis, node: EsTreeNode): Reference[] => {
+  let perNode = downstreamRefsCache.get(analysis);
+  if (!perNode) {
+    perNode = new WeakMap();
+    downstreamRefsCache.set(analysis, perNode);
+  }
+  const cached = perNode.get(node);
+  if (cached) return cached;
   const refs: Reference[] = [];
   for (const identifier of findDownstreamNodes(node, "Identifier")) {
     const ref = getRef(analysis, identifier);
     if (ref) refs.push(ref);
   }
+  perNode.set(node, refs);
   return refs;
 };
 


### PR DESCRIPTION
## What

Memoize `getDownstreamRefs` in the State & Effects rule helpers so `ascend()` stops re-descending the same definition subtrees on every recursion step.

**14 added lines, one file, no API/output change.**

```ts
const downstreamRefsCache = new WeakMap<ProgramAnalysis, WeakMap<EsTreeNode, Reference[]>>();

export const getDownstreamRefs = (analysis, node) => {
  let perNode = downstreamRefsCache.get(analysis);
  if (!perNode) { perNode = new WeakMap(); downstreamRefsCache.set(analysis, perNode); }
  const cached = perNode.get(node);
  if (cached) return cached;
  // ...existing descent...
  perNode.set(node, refs);
  return refs;
};
```

## Why

Found via a measure-first performance investigation of a 50–90s scan on a real 866-file Next.js app.

The scan time decomposes (median-of-3, `--no-score`, raised batch timeout) as:

| phase | time |
|---|---|
| lint (oxlint, 9 sequential batches) | ~24.8s |
| dead-code | ~12.6s |
| fixed overhead (discovery/git/listing/config) | ~0.3s |

The lint phase was dominated by **one rule on one file**: `no-pass-data-to-parent` on a 1,159-line component with 10 `useEffect`s — that single 100-file batch took ~13.5s (~51% of all lint time). A V8 `--prof` showed `ascend()` at **43.4% of all ticks, 97.9% from nested `ascend → ascend` recursion**.

Root cause: `ascend()` calls `getDownstreamRefs(analysis, defBody)` on every recursion step, and `getDownstreamRefs` re-runs `findDownstreamNodes()`/`descend()` over the **entire** definition subtree plus an O(all-scopes) scope scan per identifier — every time. `getProgramAnalysis` already memoizes the eslint-scope analysis per `Program`, but this lookup wasn't memoized, so the same large bodies were re-walked across recursion, across the file's 10 effects, and across the **7 effect rules** that share these helpers → superlinear blowup.

(The seeded suspect — React Compiler / `react-hooks-js` — was **not** the cost: removing all 16 of its rules moved the hot batch only ~2.3%.)

## Impact (measured, two independent reproductions)

- Worst rule on the hot file: **~9.5s → ~0.18s** (~52×)
- Hot lint batch: **~13.5s → ~2.5s** (~5.4×)
- **Full scan: ~9s / ~24% faster** (36.6s → 27.9s on a 16-core box; the lint phase itself drops ~40%)
- Diagnostics **byte-identical** — verified by a SHA-256 fingerprint over every diagnostic (`filePath|plugin|rule|severity|line|column|message`) before/after: `2068 → 2068` issues, identical hash, empty diff. No dropped batches, no extra memory pressure (peak RSS +0.9%, noise).

## Safety

- `WeakMap` keyed on the per-`Program` `ProgramAnalysis` singleton → no cross-file bleed, GC-bound with the file, no leak.
- Every consumer of the returned array (`ast.ts`, `react.ts`, `no-event-handler.ts`, `no-reset-all-state-on-prop-change.ts`) only **reads** it (`for...of` / `.some` / `.filter` / `.flatMap`) — none mutate — so returning the shared reference can't change results.
- Future-proofing note (optional follow-up): a future rule that sorts/pushes into a `getDownstreamRefs` result would silently corrupt the cache; a defensive `Object.freeze`/copy would remove that footgun.

## Tests

- `typecheck`: clean (322 rules generated, 0 errors)
- `state-and-effects` suite: 214/214 pass
- Full plugin suite: only the **38 pre-existing `react-builtins` failures** remain (identical `38 failed / 82 passed / 13 skipped` on a clean `main` — unrelated to this change)

## Follow-up (not in this PR)

Overlapping dead-code with lint in `run-inspect.ts` (they currently run sequentially despite a "concurrent fibers" comment) stacks additively and would hide the ~12.6s dead-code phase under the longer lint phase — a separate ~14-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)