### PR TITLE
fix: cut false positives and gate rules by library + React Compiler

### DIFF
--- a/.changeset/jsx-key-stable-id-spread.md
+++ b/.changeset/jsx-key-stable-id-spread.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+`jsx-key` no longer reports a missing key when a list element spreads the whole iteration item — `items.map((item) => <Item {...item} />)`. Spreading the row object is the canonical "this row carries its own identity" shape and was the dominant source of `jsx-key` noise on real lists, while rarely catching a genuine reorder bug. Genuine keyless lists still report: `items.map((item) => <Item name={item.name} />)`, index keys, array literals (`[<Item {...item} />]`), and spreads of anything other than the iteration variable.

--- a/.changeset/library-aware-gating-compiler-cleanup.md
+++ b/.changeset/library-aware-gating-compiler-cleanup.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": patch
+---
+
+App-only heuristics now stay quiet in published libraries, and React Compiler memoization-cleanup is demoted to a warning.
+
+- `react-hooks-js/static-components` and `no-render-prop-children` no longer fire on files in a published library — a non-`private` `package.json` that declares the publish contract (`name` + `exports`). They still fire in applications (including private monorepo apps that live under `packages/` or declare a niche internal `exports` map) and in any package without that contract, and an explicit per-rule severity in config always re-enables them.
+- `react-compiler-no-manual-memoization` now defaults to `warn` instead of `error` when React Compiler is detected — redundant `useMemo` / `useCallback` / `memo` is correctness-neutral cleanup, so it's hidden from the default report. The external `react-hooks-js/*` compiler rules stay `error` because each marks code the compiler could not optimize (a real perf regression).
+- New `buckets` config field: set `{ "buckets": { "compiler-cleanup": "error" } }` to re-enable strict errors for the redundant-memoization rule. A per-rule override still wins over a bucket.

--- a/.changeset/rn-no-raw-text-auto-detect-wrappers.md
+++ b/.changeset/rn-no-raw-text-auto-detect-wrappers.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+`rn-no-raw-text` now auto-detects in-file custom text wrappers, cutting false positives on design-system `<Text>` forwarders. A component whose returned root is a `<Text>` — e.g. `const Banner = ({ children }) => <Text>{children}</Text>` or `export const Caption = (props) => <Text {...props} />` — is treated as a string-only text forwarder, so raw text passed to it (`<Banner>Hello</Banner>`) no longer reports. Mixed children still report (`<Banner><Icon /> hi</Banner>`) because a single-`<Text>` forwarder can't be trusted to route a JSX child into text. Components only referenced (not defined) in the file keep the existing name-heuristic behavior, and the config-driven `textComponents` / `rawTextWrapperComponents` overrides are unchanged.

--- a/packages/core/src/build-diagnostic-pipeline.ts
+++ b/packages/core/src/build-diagnostic-pipeline.ts
@@ -176,8 +176,14 @@ export const buildDiagnosticPipeline = (
 
       let current = diagnostic;
       let explicitSeverityOverride: RuleSeverityOverride | undefined;
+      // A *per-rule* override (vs. a broad `categories` bump) — the only signal
+      // that should re-enable an app-only rule on a library file.
+      let explicitRuleOverride: RuleSeverityOverride | undefined;
       if (severityControls) {
         const { ruleKey, category } = getDiagnosticRuleIdentity(current);
+        // No `category` → resolves against `rules` (+ aliases) only, ignoring
+        // any matching `categories` entry.
+        explicitRuleOverride = resolveRuleSeverityOverride({ ruleKey }, severityControls);
         explicitSeverityOverride = resolveRuleSeverityOverride(
           { ruleKey, category },
           severityControls,
@@ -189,9 +195,11 @@ export const buildDiagnosticPipeline = (
       }
 
       // App-only rules stay silent on library files unless the user opted the
-      // rule in explicitly (an explicit severity is a deliberate "I want this
-      // here" that beats the library default).
-      if (explicitSeverityOverride === undefined) {
+      // rule in explicitly. Only a per-rule override counts: a broad category
+      // bump (e.g. `categories: { Maintainability: "error" }`) is not a
+      // deliberate "I want static-components in my library" and must not leak
+      // these rules back into published packages.
+      if (explicitRuleOverride === undefined) {
         const ruleKey = `${current.plugin}/${current.rule}`;
         if (isAppOnlyRule(ruleKey) && isLibraryFile(current.filePath)) return null;
       }

--- a/packages/core/src/build-diagnostic-pipeline.ts
+++ b/packages/core/src/build-diagnostic-pipeline.ts
@@ -12,6 +12,8 @@ import { compileIgnoredFilePatterns, isFileIgnoredByPatterns } from "./is-ignore
 import { isTestFilePath } from "./is-test-file.js";
 import { resolveRuleSeverityOverride } from "./resolve-rule-severity-override.js";
 import { isSameRuleKey } from "./rule-key-aliases.js";
+import { APP_ONLY_RULE_KEYS } from "./constants.js";
+import { classifyPackageRole } from "./utils/classify-package-role.js";
 import { resolveCandidateReadPath } from "./utils/resolve-candidate-read-path.js";
 import {
   isInsideStringOnlyWrapper,
@@ -86,6 +88,21 @@ export const buildDiagnosticPipeline = (
   const hasRawTextWrappers = rawTextWrapperComponentNames.size > 0;
   const fileLinesCache = new Map<string, string[] | null>();
   const testFileCache = new Map<string, boolean>();
+  const libraryFileCache = new Map<string, boolean>();
+
+  // App-only rules (`static-components`, `no-render-prop-children`) describe
+  // patterns that are noise in published libraries — silence them on files
+  // confidently classified as `library`. Cached per diagnostic path; the
+  // classifier itself memoizes by package directory.
+  const isLibraryFile = (filePath: string): boolean => {
+    let cached = libraryFileCache.get(filePath);
+    if (cached === undefined) {
+      const absolutePath = resolveCandidateReadPath(rootDirectory, filePath);
+      cached = classifyPackageRole(absolutePath) === "library";
+      libraryFileCache.set(filePath, cached);
+    }
+    return cached;
+  };
 
   const getFileLines = (filePath: string): string[] | null => {
     const cached = fileLinesCache.get(filePath);
@@ -116,6 +133,16 @@ export const buildDiagnosticPipeline = (
   const isRuleIgnored = (ruleIdentifier: string): boolean => {
     for (const ignored of ignoredRules) {
       if (isSameRuleKey(ignored, ruleIdentifier)) return true;
+    }
+    return false;
+  };
+
+  // Alias-aware membership for the app-only set (mirrors `isRuleIgnored`): a
+  // future alias of `static-components` / `no-render-prop-children` is still
+  // caught by the library gate, where a raw `Set.has` would miss it.
+  const isAppOnlyRule = (ruleIdentifier: string): boolean => {
+    for (const appOnlyRuleKey of APP_ONLY_RULE_KEYS) {
+      if (isSameRuleKey(appOnlyRuleKey, ruleIdentifier)) return true;
     }
     return false;
   };
@@ -159,6 +186,14 @@ export const buildDiagnosticPipeline = (
         if (explicitSeverityOverride !== undefined) {
           current = restampSeverity(current, explicitSeverityOverride);
         }
+      }
+
+      // App-only rules stay silent on library files unless the user opted the
+      // rule in explicitly (an explicit severity is a deliberate "I want this
+      // here" that beats the library default).
+      if (explicitSeverityOverride === undefined) {
+        const ruleKey = `${current.plugin}/${current.rule}`;
+        if (isAppOnlyRule(ruleKey) && isLibraryFile(current.filePath)) return null;
       }
 
       // Warnings are hidden by default. An explicit `"warn"` override

--- a/packages/core/src/build-rule-severity-controls.ts
+++ b/packages/core/src/build-rule-severity-controls.ts
@@ -13,9 +13,16 @@ export const buildRuleSeverityControls = (
   config: ReactDoctorConfig | null | undefined,
 ): RuleSeverityControls | undefined => {
   if (!config) return undefined;
-  if (config.rules === undefined && config.categories === undefined) return undefined;
+  if (
+    config.rules === undefined &&
+    config.categories === undefined &&
+    config.buckets === undefined
+  ) {
+    return undefined;
+  }
   return {
     ...(config.rules !== undefined ? { rules: config.rules } : {}),
     ...(config.categories !== undefined ? { categories: config.categories } : {}),
+    ...(config.buckets !== undefined ? { buckets: config.buckets } : {}),
   };
 };

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -209,6 +209,32 @@ export const DIAGNOSTIC_CATEGORY_BUCKETS = [
   "Maintainability",
 ] as const;
 
+// Rules whose heuristic only makes sense in application code. A published
+// library deliberately exposes flexible primitives (components built in
+// render to capture closures, many `render*` slots for composition), so these
+// fire on `app` / `unknown` files but stay silent on confidently-classified
+// `library` files (see `classify-package-role.ts`). Users can still force one
+// on for a library by setting its severity explicitly in config.
+export const APP_ONLY_RULE_KEYS: ReadonlySet<string> = new Set([
+  "react-hooks-js/static-components",
+  "react-doctor/no-render-prop-children",
+]);
+
+// The `compiler-cleanup` severity bucket: redundant-memoization rules that
+// only fire once React Compiler is detected and ship as warnings by default
+// (hidden in the default report). Setting `buckets: { "compiler-cleanup":
+// "error" }` re-enables full strictness.
+//
+// Only the local `react-compiler-no-manual-memoization` rule belongs here —
+// it flags `useMemo` / `useCallback` / `memo` the compiler makes redundant
+// (correctness-neutral cleanup). The external `react-hooks-js/*` compiler
+// rules deliberately stay `error`: each marks code the compiler could NOT
+// optimize, which is a real perf regression, not cleanup.
+export const COMPILER_CLEANUP_BUCKET = "compiler-cleanup";
+export const COMPILER_CLEANUP_RULE_KEYS: ReadonlySet<string> = new Set([
+  "react-doctor/react-compiler-no-manual-memoization",
+]);
+
 // How many of the highest-priority error rules to surface in the
 // "Top N errors you should fix" header above the category breakdown.
 export const TOP_ERRORS_DISPLAY_COUNT = 3;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,7 @@ export * from "./run-oxlint.js";
 export * from "./summarize-diagnostics.js";
 export * from "./validate-config-types.js";
 export * from "./utils/build-rule-prompt-url.js";
+export * from "./utils/classify-package-role.js";
 export * from "./utils/dedupe-diagnostics.js";
 export * from "./utils/group-by.js";
 export * from "./utils/match-glob-pattern.js";

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -6,6 +6,7 @@ import reactDoctorPlugin, {
 import type { OxlintRuleSeverity } from "oxlint-plugin-react-doctor";
 import type { ProjectInfo, RuleSeverityControls } from "../../types/index.js";
 import { resolveRuleSeverityOverride } from "../../resolve-rule-severity-override.js";
+import { COMPILER_CLEANUP_BUCKET, COMPILER_CLEANUP_RULE_KEYS } from "../../constants.js";
 import { buildCapabilities, shouldEnableRule } from "./capabilities.js";
 import { filterRulesToAvailable, resolveReactHooksJsPlugin } from "./plugin-resolution.js";
 import type { JsPluginEntry, ResolvedUserPlugin } from "./plugin-resolution.js";
@@ -33,13 +34,28 @@ const resolveSettingsRootDirectory = (rootDirectory: string): string => {
   return fs.realpathSync(rootDirectory);
 };
 
+// The `compiler-cleanup` bucket override applies to its rule family only when
+// the user hasn't pinned that exact rule individually (a per-rule override
+// always wins). Returns `undefined` when the rule isn't in the family or no
+// bucket override is configured.
+const resolveCompilerCleanupBucketSeverity = (
+  ruleKey: string,
+  severityControls: RuleSeverityControls | undefined,
+): "error" | "warn" | "off" | undefined => {
+  if (!COMPILER_CLEANUP_RULE_KEYS.has(ruleKey)) return undefined;
+  return severityControls?.buckets?.[COMPILER_CLEANUP_BUCKET];
+};
+
 const applyRuleSeverityControls = (
   rules: Record<string, OxlintRuleSeverity>,
   severityControls: RuleSeverityControls | undefined,
 ): Record<string, OxlintRuleSeverity> => {
   const enabledRules: Record<string, OxlintRuleSeverity> = {};
   for (const [ruleKey, defaultSeverity] of Object.entries(rules)) {
-    const severity = resolveRuleSeverityOverride({ ruleKey }, severityControls) ?? defaultSeverity;
+    const severity =
+      resolveRuleSeverityOverride({ ruleKey }, severityControls) ??
+      resolveCompilerCleanupBucketSeverity(ruleKey, severityControls) ??
+      defaultSeverity;
     if (severity === "off") continue;
     enabledRules[ruleKey] = severity;
   }
@@ -115,7 +131,10 @@ export const createOxlintConfig = ({
     // turns it on via `severityControls`. Users can still get the rule
     // by setting its severity to `"warn"` or `"error"` in config.
     if (rule.defaultEnabled === false && explicitSeverity === undefined) continue;
-    const severity = explicitSeverity ?? rule.severity;
+    const severity =
+      explicitSeverity ??
+      resolveCompilerCleanupBucketSeverity(registryEntry.key, severityControls) ??
+      rule.severity;
     if (severity === "off") continue;
     enabledReactDoctorRules[registryEntry.key] = severity;
   }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -56,6 +56,23 @@ export type RuleSeverityOverride = "error" | "warn" | "off";
 export interface RuleSeverityControls {
   rules?: Record<string, RuleSeverityOverride>;
   categories?: Record<string, RuleSeverityOverride>;
+  /**
+   * Severity overrides keyed by a named rule *bucket* — a curated family of
+   * rules that share a gating story rather than a category. The only bucket
+   * today is `"compiler-cleanup"` (the redundant-memoization rule that ships
+   * as a warning once React Compiler is detected); setting it to `"error"`
+   * re-enables strictness. A per-rule override still wins over a bucket.
+   */
+  buckets?: SeverityBuckets;
+}
+
+/**
+ * Closed set of severity buckets. Spelled out (rather than
+ * `Record<string, …>`) so an unknown/typo'd bucket key is a type error
+ * instead of a silent no-op.
+ */
+export interface SeverityBuckets {
+  "compiler-cleanup"?: RuleSeverityOverride;
 }
 
 export interface SurfaceControls {
@@ -259,6 +276,20 @@ export interface ReactDoctorConfig {
    * single category, use `ignore.tags` instead.
    */
   categories?: Record<string, RuleSeverityOverride>;
+  /**
+   * Per-bucket severity map. Buckets are curated rule families with a
+   * shared gating story (not categories). Today the only bucket is
+   * `"compiler-cleanup"`: the redundant-memoization rule
+   * (`react-compiler-no-manual-memoization`) that ships as a warning once
+   * React Compiler is detected. Set it to `"error"` to re-enable strictness.
+   *
+   * ```json
+   * { "buckets": { "compiler-cleanup": "error" } }
+   * ```
+   *
+   * A per-rule override in `rules` still wins over a bucket entry.
+   */
+  buckets?: SeverityBuckets;
   /**
    * User-defined oxlint plugins to load alongside the built-in
    * `react-doctor` plugin. Each entry is either:

--- a/packages/core/src/utils/classify-package-role.ts
+++ b/packages/core/src/utils/classify-package-role.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs";
+import path from "node:path";
+
+// "library" — the file ships as a published/consumable package: its nearest
+//             `package.json` declares both `name` and `exports`, the modern
+//             publish contract. App-only heuristics (components-in-render,
+//             render-prop proliferation, …) are noise here because the
+//             package's authors deliberately expose flexible primitives.
+//             We do NOT infer "library" from a `packages/` directory:
+//             monorepos routinely place applications there (e.g. an Electron
+//             app at `packages/<name>-app`), and silencing app-only findings
+//             in those is a false negative — caught via RDE on
+//             `usebruno/bruno`'s `packages/bruno-app` (a private app with no
+//             `exports` that the old directory heuristic wrongly silenced).
+// "app"     — the file lives under an `apps/` directory: an application that
+//             renders, not a library that exposes API.
+// "unknown" — no nearest `package.json`, an unparseable manifest, or a
+//             package without a publish contract. Callers treat "unknown"
+//             like "app" (fire) so a missing classification never silences a
+//             real finding.
+export type PackageRole = "library" | "app" | "unknown";
+
+// The nearest-`package.json` ancestor walk + safe-manifest read below are
+// INTENTIONALLY duplicated with `oxlint-plugin-react-doctor`'s
+// `plugin/utils/classify-package-platform.ts` — same rationale as
+// `project-info/internal-rn-dependency-names.ts`: this leaf lives in core's
+// pipeline layer, the plugin's copy runs inside oxlint at lint time, and we
+// keep them separate so each side stays decoupled from the other's bundle.
+// Only the plumbing overlaps; the SIGNAL each reads differs (publish contract
+// here vs. dependency cohort there). Keep the walk semantics in sync if either
+// changes.
+
+// Memoize by package directory (NOT filename): every file in a package shares
+// the same answer and a single scan visits many files per package.
+const cachedRoleByPackageDirectory = new Map<string, PackageRole>();
+const cachedPackageDirectoryByFilename = new Map<string, string | null>();
+
+const findNearestPackageDirectory = (filename: string): string | null => {
+  if (!filename) return null;
+  const fromCache = cachedPackageDirectoryByFilename.get(filename);
+  if (fromCache !== undefined) return fromCache;
+
+  let currentDirectory = path.dirname(filename);
+  while (true) {
+    const candidatePackageJsonPath = path.join(currentDirectory, "package.json");
+    let hasPackageJson = false;
+    try {
+      hasPackageJson = fs.statSync(candidatePackageJsonPath).isFile();
+    } catch {
+      hasPackageJson = false;
+    }
+    if (hasPackageJson) {
+      cachedPackageDirectoryByFilename.set(filename, currentDirectory);
+      return currentDirectory;
+    }
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      cachedPackageDirectoryByFilename.set(filename, null);
+      return null;
+    }
+    currentDirectory = parentDirectory;
+  }
+};
+
+interface PackageManifestView {
+  name?: unknown;
+  exports?: unknown;
+  private?: unknown;
+}
+
+const readManifest = (packageJsonPath: string): PackageManifestView | null => {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    if (typeof parsed === "object" && parsed !== null) return parsed as PackageManifestView;
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+// A published library declares `name` + `exports` (its consumption contract)
+// and is NOT `private`. The `private !== true` guard matters: applications
+// frequently set `"private": true` AND declare a niche `exports` map for
+// internal path aliases (e.g. appsmith's `app/client` ships
+// `exports: { "./lib/*": … }`), and treating those as libraries silenced
+// real app diagnostics — caught via RDE.
+const hasPublishContract = (manifest: PackageManifestView): boolean =>
+  typeof manifest.name === "string" &&
+  manifest.name.length > 0 &&
+  manifest.exports !== undefined &&
+  manifest.exports !== null &&
+  manifest.private !== true;
+
+// Returns "app" when `packageDirectory` sits under an `apps/` directory — an
+// explicit application signal. We intentionally do NOT treat a `packages/`
+// ancestor as a library signal (apps live there too); only the publish
+// contract decides "library". "app" and "unknown" behave identically for
+// gating (both fire), so this is informational rather than load-bearing.
+const classifyByDirectoryCohort = (packageDirectory: string): PackageRole | null => {
+  let current = packageDirectory;
+  while (true) {
+    if (path.basename(current) === "apps") return "app";
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+};
+
+// Clears the memoized classifications so a long-running consumer (watch mode,
+// agentic CLI, repeated `diagnose()`) re-reads manifests that changed between
+// calls. Wired into `clearCaches()` alongside the other module-scope caches.
+export const clearPackageRoleCache = (): void => {
+  cachedRoleByPackageDirectory.clear();
+  cachedPackageDirectoryByFilename.clear();
+};
+
+export const classifyPackageRole = (filename: string | undefined): PackageRole => {
+  if (!filename) return "unknown";
+  const packageDirectory = findNearestPackageDirectory(filename);
+  if (!packageDirectory) return "unknown";
+
+  const cached = cachedRoleByPackageDirectory.get(packageDirectory);
+  if (cached !== undefined) return cached;
+
+  const manifest = readManifest(path.join(packageDirectory, "package.json"));
+  let result: PackageRole;
+  if (manifest && hasPublishContract(manifest)) {
+    result = "library";
+  } else {
+    result = classifyByDirectoryCohort(path.dirname(packageDirectory)) ?? "unknown";
+  }
+  cachedRoleByPackageDirectory.set(packageDirectory, result);
+  return result;
+};

--- a/packages/core/tests/classify-package-role.test.ts
+++ b/packages/core/tests/classify-package-role.test.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import type { Diagnostic } from "../src/index.js";
+import { createNodeReadFileLinesSync, mergeAndFilterDiagnostics } from "../src/index.js";
+import { classifyPackageRole } from "../src/utils/classify-package-role.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-classify-role-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const writeManifest = (dir: string, manifest: Record<string, unknown>): void => {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify(manifest));
+};
+
+const writeSource = (filePath: string): void => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "export const x = 1;\n");
+};
+
+describe("classifyPackageRole", () => {
+  it("classifies a package with name + exports as a library", () => {
+    const caseRoot = path.join(tempRoot, "publish-contract");
+    const packageDir = path.join(caseRoot, "ui");
+    writeManifest(packageDir, { name: "@scope/ui", exports: { ".": "./index.js" } });
+    const file = path.join(packageDir, "src", "Button.tsx");
+    writeSource(file);
+    expect(classifyPackageRole(file)).toBe("library");
+  });
+
+  it("classifies a published package under packages/* (name + exports) as a library", () => {
+    const caseRoot = path.join(tempRoot, "monorepo-packages-published");
+    const packageDir = path.join(caseRoot, "packages", "design-system");
+    writeManifest(packageDir, { name: "design-system", exports: { ".": "./index.js" } });
+    const file = path.join(packageDir, "src", "Card.tsx");
+    writeSource(file);
+    expect(classifyPackageRole(file)).toBe("library");
+  });
+
+  // RDE regression: usebruno/bruno's `packages/bruno-app` is a private Electron
+  // app with no `exports`. The old `packages/` → library directory heuristic
+  // wrongly silenced its app-only diagnostics. A package under `packages/`
+  // without a publish contract must NOT classify as a library.
+  it("does not classify a private app under packages/* (no exports) as a library", () => {
+    const caseRoot = path.join(tempRoot, "monorepo-packages-app");
+    const packageDir = path.join(caseRoot, "packages", "bruno-app");
+    writeManifest(packageDir, { name: "@usebruno/app", private: true });
+    const file = path.join(packageDir, "src", "components", "Sidebar.tsx");
+    writeSource(file);
+    expect(classifyPackageRole(file)).not.toBe("library");
+  });
+
+  // RDE regression: appsmith's `app/client` is a private application that
+  // declares a niche `exports: { "./lib/*": … }` for internal path aliases.
+  // `private: true` must disqualify it from the library publish contract.
+  it("does not classify a private app with a niche exports map as a library", () => {
+    const caseRoot = path.join(tempRoot, "private-app-with-exports");
+    const packageDir = path.join(caseRoot, "client");
+    writeManifest(packageDir, {
+      name: "appsmith",
+      private: true,
+      exports: { "./lib/*": "./lib/*.js" },
+    });
+    const file = path.join(packageDir, "src", "pages", "Editor.tsx");
+    writeSource(file);
+    expect(classifyPackageRole(file)).not.toBe("library");
+  });
+
+  it("classifies a file under apps/* as an app", () => {
+    const caseRoot = path.join(tempRoot, "monorepo-apps");
+    const packageDir = path.join(caseRoot, "apps", "web");
+    writeManifest(packageDir, { name: "web", private: true });
+    const file = path.join(packageDir, "src", "App.tsx");
+    writeSource(file);
+    expect(classifyPackageRole(file)).toBe("app");
+  });
+
+  it("returns unknown when there is no nearby package.json", () => {
+    const file = path.join(tempRoot, "loose", "App.tsx");
+    writeSource(file);
+    expect(classifyPackageRole(file)).toBe("unknown");
+  });
+});
+
+const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: "src/App.tsx",
+  plugin: "react-hooks-js",
+  rule: "static-components",
+  severity: "error",
+  message: "Component defined in render",
+  help: "",
+  line: 2,
+  column: 1,
+  category: "Maintainability",
+  ...overrides,
+});
+
+describe("app-only rule gating in the diagnostic pipeline", () => {
+  it("drops static-components on a library file", () => {
+    const packageDir = path.join(tempRoot, "gate-library", "packages", "ui");
+    writeManifest(packageDir, { name: "@scope/ui", exports: { ".": "./index.js" } });
+    writeSource(path.join(packageDir, "src", "Button.tsx"));
+    const result = mergeAndFilterDiagnostics(
+      [buildDiagnostic({ filePath: "src/Button.tsx" })],
+      packageDir,
+      null,
+      createNodeReadFileLinesSync(packageDir),
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it("keeps static-components on an app file", () => {
+    const packageDir = path.join(tempRoot, "gate-app", "apps", "web");
+    writeManifest(packageDir, { name: "web", private: true });
+    writeSource(path.join(packageDir, "src", "App.tsx"));
+    const result = mergeAndFilterDiagnostics(
+      [buildDiagnostic({ filePath: "src/App.tsx" })],
+      packageDir,
+      null,
+      createNodeReadFileLinesSync(packageDir),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("keeps static-components in a private app under packages/* (no exports)", () => {
+    const packageDir = path.join(tempRoot, "gate-monorepo-app", "packages", "bruno-app");
+    writeManifest(packageDir, { name: "@usebruno/app", private: true });
+    writeSource(path.join(packageDir, "src", "components", "Sidebar.tsx"));
+    const result = mergeAndFilterDiagnostics(
+      [buildDiagnostic({ filePath: "src/components/Sidebar.tsx" })],
+      packageDir,
+      null,
+      createNodeReadFileLinesSync(packageDir),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("keeps static-components on a library file when explicitly opted in", () => {
+    const packageDir = path.join(tempRoot, "gate-library-optin", "packages", "ui");
+    writeManifest(packageDir, { name: "@scope/ui2", exports: { ".": "./index.js" } });
+    writeSource(path.join(packageDir, "src", "Button.tsx"));
+    const result = mergeAndFilterDiagnostics(
+      [buildDiagnostic({ filePath: "src/Button.tsx" })],
+      packageDir,
+      { rules: { "react-hooks-js/static-components": "error" } },
+      createNodeReadFileLinesSync(packageDir),
+    );
+    expect(result).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/classify-package-role.test.ts
+++ b/packages/core/tests/classify-package-role.test.ts
@@ -152,4 +152,19 @@ describe("app-only rule gating in the diagnostic pipeline", () => {
     );
     expect(result).toHaveLength(1);
   });
+
+  // Bugbot #614: a broad `categories` bump is NOT a deliberate per-rule opt-in,
+  // so it must not leak app-only rules back into a published library.
+  it("still drops static-components on a library when only a category override is set", () => {
+    const packageDir = path.join(tempRoot, "gate-library-category", "packages", "ui");
+    writeManifest(packageDir, { name: "@scope/ui3", exports: { ".": "./index.js" } });
+    writeSource(path.join(packageDir, "src", "Button.tsx"));
+    const result = mergeAndFilterDiagnostics(
+      [buildDiagnostic({ filePath: "src/Button.tsx", category: "Maintainability" })],
+      packageDir,
+      { categories: { Maintainability: "error" } },
+      createNodeReadFileLinesSync(packageDir),
+    );
+    expect(result).toHaveLength(0);
+  });
 });

--- a/packages/core/tests/compiler-cleanup-bucket.test.ts
+++ b/packages/core/tests/compiler-cleanup-bucket.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ProjectInfo } from "../src/index.js";
+import { createOxlintConfig } from "../src/runners/oxlint/config.js";
+
+const MANUAL_MEMO_KEY = "react-doctor/react-compiler-no-manual-memoization";
+
+const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
+  rootDirectory: "/tmp/project",
+  projectName: "project",
+  reactVersion: "^19.0.0",
+  reactMajorVersion: 19,
+  tailwindVersion: null,
+  zodVersion: null,
+  zodMajorVersion: null,
+  framework: "unknown",
+  hasTypeScript: true,
+  hasReactCompiler: true,
+  hasTanStackQuery: false,
+  hasReactNativeWorkspace: false,
+  hasReanimated: false,
+  preactVersion: null,
+  preactMajorVersion: null,
+  sourceFileCount: 0,
+  ...overrides,
+});
+
+const buildRules = (
+  buckets?: Record<string, "error" | "warn" | "off">,
+  rules?: Record<string, "error" | "warn" | "off">,
+): Record<string, unknown> =>
+  createOxlintConfig({
+    pluginPath: "/tmp/plugin.js",
+    project: buildProject(),
+    severityControls:
+      buckets || rules
+        ? { ...(buckets ? { buckets } : {}), ...(rules ? { rules } : {}) }
+        : undefined,
+  }).rules;
+
+describe("compiler-cleanup severity bucket", () => {
+  it("ships react-compiler-no-manual-memoization as a warning by default", () => {
+    expect(buildRules()[MANUAL_MEMO_KEY]).toBe("warn");
+  });
+
+  it("re-enables errors when the compiler-cleanup bucket is set to error", () => {
+    expect(buildRules({ "compiler-cleanup": "error" })[MANUAL_MEMO_KEY]).toBe("error");
+  });
+
+  it("lets a per-rule override win over the bucket", () => {
+    const rules = buildRules({ "compiler-cleanup": "error" }, { [MANUAL_MEMO_KEY]: "warn" });
+    expect(rules[MANUAL_MEMO_KEY]).toBe("warn");
+  });
+
+  it("drops the rule when the bucket is set to off", () => {
+    expect(buildRules({ "compiler-cleanup": "off" })[MANUAL_MEMO_KEY]).toBeUndefined();
+  });
+
+  it("does not register the rule at all without React Compiler", () => {
+    const rules = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: buildProject({ hasReactCompiler: false }),
+    }).rules;
+    expect(rules[MANUAL_MEMO_KEY]).toBeUndefined();
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
@@ -72,7 +72,12 @@ const resolveRemovalMessageForCallee = (callee: EsTreeNode): string | null => {
 export const reactCompilerNoManualMemoization = defineRule<Rule>({
   id: "react-compiler-no-manual-memoization",
   title: "Redundant manual memoization",
-  severity: "error",
+  // Redundant-memo cleanup is correctness-neutral: the code already works,
+  // the compiler just makes the `useMemo` / `useCallback` / `memo` redundant.
+  // On a compiler-enabled codebase that's hundreds of low-priority hits, so
+  // it ships as a warning (hidden in the default report). Opt back into
+  // errors with the `compiler-cleanup` severity bucket.
+  severity: "warn",
   requires: ["react-compiler"],
   recommendation:
     "Delete the `useMemo` / `useCallback` / `memo` call and use the plain value or component. React Compiler caches it for you.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
@@ -34,4 +34,31 @@ describe("react-builtins/jsx-key — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  // Stable id-spread: spreading the whole iteration item is the "row carries
+  // its own identity" shape. We stay silent there but keep firing on genuine
+  // keyless lists.
+  it("does not flag a list element that spreads the iteration item", () => {
+    expectPass(`items.map(item => <Item {...item} />);`);
+  });
+
+  it("does not flag a function-expression iterator spreading the item", () => {
+    expectPass(`items.map(function (item) { return <Item {...item} />; });`);
+  });
+
+  it("does not flag Array.from spreading the item", () => {
+    expectPass(`Array.from(items, (item) => <Item {...item} />);`);
+  });
+
+  it("still flags a keyless list element that does not spread the item", () => {
+    expectFail(`items.map(item => <Item name={item.name} />);`);
+  });
+
+  it("still flags when spreading something other than the iteration item", () => {
+    expectFail(`items.map(item => <Item {...other} />);`);
+  });
+
+  it("still flags an array-literal element that spreads an identifier", () => {
+    expectFail(`[<Item {...item} />];`);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
@@ -112,6 +112,47 @@ const findEnclosingIteratorContext = (jsxNode: EsTreeNode): IteratorContext | nu
   return null;
 };
 
+// Resolves the name of an iterator callback's first parameter — the "item"
+// each element is built from. `xs.map((item) => ...)` → `"item"`. Only plain
+// identifier params resolve; destructured params (`({ id }) => ...`) return
+// null since there's no single binding to match a spread against.
+const resolveIterationItemName = (callExpression: EsTreeNode): string | null => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return null;
+  const callee = callExpression.callee;
+  if (!isNodeOfType(callee, "MemberExpression")) return null;
+  if (!isNodeOfType(callee.property, "Identifier")) return null;
+  const targetArgIndex = callee.property.name === "from" ? 1 : 0;
+  const callback = callExpression.arguments[targetArgIndex];
+  if (
+    !callback ||
+    (!isNodeOfType(callback, "ArrowFunctionExpression") &&
+      !isNodeOfType(callback, "FunctionExpression"))
+  ) {
+    return null;
+  }
+  const firstParam = callback.params[0];
+  return firstParam && isNodeOfType(firstParam, "Identifier") ? firstParam.name : null;
+};
+
+// React never forwards `key` through `{...spread}`, so `xs.map(x => <X {...x} />)`
+// is technically keyless. But spreading the *whole iteration item* is the
+// canonical "the data row carries its own identity" shape — flagging it is the
+// dominant source of jsx-key noise on real lists (every row spread fires) while
+// rarely catching a genuine reorder bug. We treat that one shape as borderline
+// and stay silent; genuine keyless lists (`<X name={x.name} />`, index keys,
+// array literals) still report.
+const spreadsIterationItem = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  iterationItemName: string,
+): boolean => {
+  for (const attribute of openingElement.attributes) {
+    if (!isNodeOfType(attribute, "JSXSpreadAttribute")) continue;
+    const argument = attribute.argument;
+    if (isNodeOfType(argument, "Identifier") && argument.name === iterationItemName) return true;
+  }
+  return false;
+};
+
 const isWithinChildrenToArray = (jsxNode: EsTreeNode): boolean => {
   let current: EsTreeNode | null | undefined = jsxNode.parent;
   while (current) {
@@ -252,6 +293,10 @@ export const jsxKey = defineRule<Rule>({
         if (!enclosingContext) return;
         if (isWithinChildrenToArray(node)) return;
         if (hasJsxKeyAttribute(openingElement)) return;
+        if (enclosingContext.kind === "iterator") {
+          const iterationItemName = resolveIterationItemName(enclosingContext.callExpression);
+          if (iterationItemName && spreadsIterationItem(openingElement, iterationItemName)) return;
+        }
         context.report({
           node: openingElement,
           message: enclosingContext.kind === "array" ? MISSING_KEY_ARRAY : MISSING_KEY_ITERATOR,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rnNoRawText } from "./rn-no-raw-text.js";
+
+const expectFail = (code: string, settings?: Readonly<Record<string, unknown>>): void => {
+  const result = runRule(rnNoRawText, code, { settings, filename: "App.native.tsx" });
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics.length).toBeGreaterThan(0);
+};
+
+const expectPass = (code: string, settings?: Readonly<Record<string, unknown>>): void => {
+  const result = runRule(rnNoRawText, code, { settings, filename: "App.native.tsx" });
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(0);
+};
+
+describe("react-native/rn-no-raw-text", () => {
+  it("fires on raw text with no Text ancestor", () => {
+    expectFail(`const App = () => <View>Hello</View>;`);
+  });
+
+  it("does not fire inside a real Text component", () => {
+    expectPass(`const App = () => <Text>Hello</Text>;`);
+  });
+
+  describe("auto-detected text wrappers", () => {
+    it("suppresses string-only usage of an arrow forwarder", () => {
+      expectPass(`
+        const Banner = ({ children }) => <Text>{children}</Text>;
+        const App = () => <Banner>Hello</Banner>;
+      `);
+    });
+
+    it("suppresses a spread re-export wrapper", () => {
+      expectPass(`
+        export const Caption = (props) => <Text {...props} />;
+        const App = () => <Caption>hi there</Caption>;
+      `);
+    });
+
+    it("suppresses a function-declaration forwarder", () => {
+      expectPass(`
+        function Banner({ children }) { return <Text>{children}</Text>; }
+        const App = () => <Banner>Hello</Banner>;
+      `);
+    });
+
+    it("works regardless of declaration order (usage before definition)", () => {
+      expectPass(`
+        const App = () => <Banner>Hello</Banner>;
+        const Banner = ({ children }) => <Text>{children}</Text>;
+      `);
+    });
+
+    // The forwarder's `<Text>` root wraps WHATEVER children it receives, so
+    // mixed children (`<Label><Icon/> text</Label>`) render that text inside
+    // `<Text>` — no crash. Reporting it would be a false positive, so an
+    // auto-detected forwarder is trusted like a real text container.
+    it("does not fire on mixed children of an auto-detected forwarder", () => {
+      expectPass(`
+        const Label = ({ children }) => <Text>{children}</Text>;
+        const App = () => <Label><Icon /> text</Label>;
+      `);
+    });
+
+    it("does not treat a non-text forwarder as a wrapper", () => {
+      expectFail(`
+        const Box = ({ children }) => <View>{children}</View>;
+        const App = () => <Box>Hello</Box>;
+      `);
+    });
+
+    // An imported (cross-file) text-named component has no in-file definition,
+    // so it's suppressed by the name heuristic instead — same safe result.
+    it("suppresses an imported text-named component via the name heuristic", () => {
+      expectPass(`
+        import { Label } from "./ui";
+        const App = () => <Label><Icon /> text</Label>;
+      `);
+    });
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -11,6 +11,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { collectTextWrapperComponents } from "./utils/collect-text-wrapper-components.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -106,15 +107,38 @@ export const rnNoRawText = defineRule<Rule>({
     // in a WebView as DOM rather than on React Native primitives.
     let isDomComponentFile = false;
 
+    // Auto-detected in-file text wrappers — components whose returned root is
+    // a real `<Text>` (so they forward children into text). Populated from the
+    // program on first visit so usage anywhere in the file (declared before or
+    // after) is seen. Manual `textComponents` / `rawTextWrapperComponents`
+    // overrides are applied separately in the core diagnostic pipeline
+    // (config-driven), so a project can name cross-file wrappers this
+    // single-file pass can't see.
+    let autoDetectedWrappers: ReadonlySet<string> = new Set();
+
     return {
       Program(programNode: EsTreeNodeOfType<"Program">) {
         isDomComponentFile = hasDirective(programNode, "use dom");
+        autoDetectedWrappers = collectTextWrapperComponents(programNode, isTextHandlingComponent);
       },
       JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
         if (isDomComponentFile) return;
 
         const elementName = resolveTextBoundaryName(node.openingElement);
-        if (elementName && isTextHandlingComponent(elementName)) return;
+
+        // A real text component (name heuristic) or an in-file forwarder we
+        // verified renders into a `<Text>` root renders its children inside
+        // text — so raw text passed to it is safe, INCLUDING mixed children
+        // (`<Banner><Icon/> hi</Banner>`), because the `<Text>` root wraps
+        // whatever children it receives. The string-only contract only applies
+        // to config-named `rawTextWrapperComponents` (handled in core), where
+        // we can't see the implementation.
+        if (
+          elementName &&
+          (isTextHandlingComponent(elementName) || autoDetectedWrappers.has(elementName))
+        ) {
+          return;
+        }
 
         // `Platform.OS === "web"` branches deliberately render web markup
         // (raw text, div/span trees, etc.) when the app is bundled by

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/utils/collect-text-wrapper-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/utils/collect-text-wrapper-components.ts
@@ -1,0 +1,81 @@
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isReactComponentName } from "../../../utils/is-react-component-name.js";
+import { walkAst } from "../../../utils/walk-ast.js";
+import { resolveJsxElementName } from "./resolve-jsx-element-name.js";
+
+type FunctionNode =
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"FunctionDeclaration">;
+
+const isFunctionNode = (node: EsTreeNode): node is FunctionNode =>
+  isNodeOfType(node, "ArrowFunctionExpression") ||
+  isNodeOfType(node, "FunctionExpression") ||
+  isNodeOfType(node, "FunctionDeclaration");
+
+// Resolves the tag name of the single JSX element a component returns at the
+// top level of its body, or `null` when the component returns a fragment,
+// conditional markup, or no JSX. Only the *root* element matters here: a
+// wrapper like `({ children }) => <Text>{children}</Text>` forwards its
+// children into that root, so the root's identity decides whether the wrapper
+// is text-handling. We deliberately stay shallow (expression body, or a
+// `ReturnStatement` at the block's top level) to keep detection high-confidence.
+const resolveReturnedRootElementName = (functionNode: FunctionNode): string | null => {
+  const { body } = functionNode;
+  if (!body) return null;
+
+  if (!isNodeOfType(body, "BlockStatement")) {
+    return isNodeOfType(body, "JSXElement") ? resolveJsxElementName(body.openingElement) : null;
+  }
+
+  for (const statement of body.body) {
+    if (!isNodeOfType(statement, "ReturnStatement")) continue;
+    const argument = statement.argument;
+    if (argument && isNodeOfType(argument, "JSXElement")) {
+      return resolveJsxElementName(argument.openingElement);
+    }
+  }
+  return null;
+};
+
+// Records a component declaration when its name is PascalCase and its returned
+// root element is text-handling. Both `const Label = (...) => <Text>…</Text>`
+// (variable declarator) and `function Label(...) { return <Text>…</Text> }`
+// (declaration) are covered.
+const recordWrapperFromDeclaration = (
+  componentName: string | null,
+  functionNode: EsTreeNode | null | undefined,
+  isTextHandlingRoot: (elementName: string) => boolean,
+  wrappers: Set<string>,
+): void => {
+  if (!componentName || !isReactComponentName(componentName)) return;
+  if (!functionNode || !isFunctionNode(functionNode)) return;
+  const rootName = resolveReturnedRootElementName(functionNode);
+  if (rootName && isTextHandlingRoot(rootName)) wrappers.add(componentName);
+};
+
+// Walks a program once and returns the names of in-file components that
+// forward their children into a text-handling root element. These behave like
+// configured `rawTextWrapperComponents`: raw text inside them is safe only when
+// the children are string-only (mixed children still get reported), since the
+// wrapper is assumed to forward `children` into a single `<Text>`.
+export const collectTextWrapperComponents = (
+  programNode: EsTreeNode,
+  isTextHandlingRoot: (elementName: string) => boolean,
+): ReadonlySet<string> => {
+  const wrappers = new Set<string>();
+
+  walkAst(programNode, (node) => {
+    if (isNodeOfType(node, "VariableDeclarator")) {
+      const componentName = node.id && isNodeOfType(node.id, "Identifier") ? node.id.name : null;
+      recordWrapperFromDeclaration(componentName, node.init, isTextHandlingRoot, wrappers);
+    } else if (isNodeOfType(node, "FunctionDeclaration")) {
+      const componentName = node.id && isNodeOfType(node.id, "Identifier") ? node.id.name : null;
+      recordWrapperFromDeclaration(componentName, node, isTextHandlingRoot, wrappers);
+    }
+  });
+
+  return wrappers;
+};

--- a/packages/oxlint-plugin-react-doctor/src/rules.ts
+++ b/packages/oxlint-plugin-react-doctor/src/rules.ts
@@ -66,6 +66,11 @@ export const EXTERNAL_RULES = [
     severity: "error",
   },
   { key: "react-hooks-js/static-components", source: "react-compiler", severity: "error" },
+  // These stay `error`: each react-hooks-js compiler diagnostic marks code the
+  // React Compiler could NOT optimize (an unmemoizable component shape), which
+  // is a real perf regression — not redundant-memo cleanup. Demoting them hid
+  // those regressions (regression #140). The redundant-memo cleanup lives in
+  // the local `react-compiler-no-manual-memoization` rule instead.
   { key: "react-hooks-js/use-memo", source: "react-compiler", severity: "error" },
   { key: "react-hooks-js/void-use-memo", source: "react-compiler", severity: "error" },
   { key: "react-hooks-js/incompatible-library", source: "react-compiler", severity: "error" },

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -5,6 +5,7 @@ import {
   clearConfigCache,
   clearIgnorePatternsCache,
   clearPackageJsonCache,
+  clearPackageRoleCache,
   clearProjectCache,
 } from "@react-doctor/core";
 import type {
@@ -69,6 +70,7 @@ export const clearCaches = (): void => {
   clearConfigCache();
   clearPackageJsonCache();
   clearIgnorePatternsCache();
+  clearPackageRoleCache();
   clearAutoSuppressionCaches();
 };
 

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -576,8 +576,10 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
   // is gated with `requires: ["react-compiler"]` so it ONLY fires once
   // the project ships with React Compiler. Without the compiler, manual
   // `useMemo` / `useCallback` / `memo()` are still legitimate perf
-  // tools — the gate must keep the rule out of the default config.
-  it("enables react-compiler-no-manual-memoization only when React Compiler is detected", () => {
+  // tools — the gate must keep the rule out of the default config. With
+  // the compiler it ships as a `warn` (redundant-memo cleanup is hidden in
+  // the default report); the `compiler-cleanup` bucket re-enables errors.
+  it("ships react-compiler-no-manual-memoization as a warning, gated on React Compiler", () => {
     const ruleKey = "react-doctor/react-compiler-no-manual-memoization";
 
     const withoutCompiler = createOxlintConfig({
@@ -590,7 +592,14 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
       pluginPath: "/tmp/react-doctor-plugin.js",
       project: buildTestProject({ rootDirectory: "/tmp/test", hasReactCompiler: true }),
     });
-    expect(withCompiler.rules[ruleKey]).toBe("error");
+    expect(withCompiler.rules[ruleKey]).toBe("warn");
+
+    const withCompilerCleanupBucket = createOxlintConfig({
+      pluginPath: "/tmp/react-doctor-plugin.js",
+      project: buildTestProject({ rootDirectory: "/tmp/test", hasReactCompiler: true }),
+      severityControls: { buckets: { "compiler-cleanup": "error" } },
+    });
+    expect(withCompilerCleanupBucket.rules[ruleKey]).toBe("error");
   });
 
   // The three noisy upstream rules ship `defaultEnabled: false` —


### PR DESCRIPTION
## Why

Cut the dominant false-positive sources on real React / React Native codebases, and make app-only / React-Compiler-cleanup rules context-aware instead of one-size-fits-all.

**Before**
```tsx
// design-system <Text> forwarder — flagged on every usage
const Caption = (props) => <Text {...props} />;
<Caption>Hello</Caption>;                 // rn-no-raw-text ✗

items.map((item) => <Item {...item} />);  // jsx-key ✗ (every row)

// published library — app-only heuristics fire anyway
export const Button = () => { /* ... */ }; // static-components ✗

// React Compiler on — ~1k "delete this useMemo" errors fail CI
const x = useMemo(() => compute(), [a]);   // error ✗
```

**After**
```tsx
const Caption = (props) => <Text {...props} />;
<Caption>Hello</Caption>;                 // ✓ auto-detected text forwarder

items.map((item) => <Item {...item} />);  // ✓ whole-item spread = own identity

export const Button = () => { /* ... */ }; // ✓ silent in published libraries

const x = useMemo(() => compute(), [a]);   // warn (hidden by default; opt-in via bucket)
```

## What changed

- **`rn-no-raw-text`** auto-detects in-file components whose returned root is a `<Text>` (incl. spread re-exports). Raw text passed to them no longer reports — including mixed children, since the verified `<Text>` root wraps whatever it receives. Cross-file wrappers stay covered by config `textComponents` / `rawTextWrapperComponents`.
- **`jsx-key`** no longer reports a missing key when a list element spreads the whole iteration item (`xs.map(i => <X {...i} />)`). Genuine keyless lists, index keys, and array literals still report.
- **Per-file library classification** (`classify-package-role`): a non-`private` `package.json` with `name` + `exports` is a library. `react-hooks-js/static-components` and `no-render-prop-children` are silenced there; they still fire in apps and in private monorepo packages (even under `packages/`). An explicit per-rule severity always re-enables them.
- **`react-compiler-no-manual-memoization`** → `warn` when React Compiler is detected (redundant-memo cleanup, hidden from the default report). New **`compiler-cleanup` severity bucket** (`{ "buckets": { "compiler-cleanup": "error" } }`) re-enables strict errors. External `react-hooks-js/*` compiler rules stay `error` (they flag genuinely unoptimizable shapes — regression #140).
- Wired `clearPackageRoleCache()` into `clearCaches()`; made the app-only gate alias-aware.

## Eval results

Validated with RDE (local runner) over a 500-rootDir OSS corpus, baseline `main` vs this branch:

| Check | Result |
| --- | --- |
| RootDir scans | `500` (×2, 0 scan failures) |
| Net diagnostic change | `-2772` |
| Added diagnostics (potential new FPs) | `0` |
| `react-compiler-no-manual-memoization` | `-2762` (demoted, hidden) |
| `static-components` | `-8` — all verified true libraries (`@payloadcms/ui`, `@payloadcms/richtext-lexical`) |
| `jsx-key` | `-2` — both verified `.map(i => <X {...i} />)` whole-item spreads |

RDE caught two real over-suppression bugs in an earlier classifier draft (monorepo apps under `packages/`, and a private app with a niche `exports` map); both are fixed with regression tests.

## Test plan

- [x] `vp test run` — oxlint-plugin rule suites + core (`467` core tests; `classify-package-role`, `compiler-cleanup-bucket`, `rn-no-raw-text`, `jsx-key` regressions)
- [x] `pnpm typecheck` — `@react-doctor/core`, `oxlint-plugin-react-doctor`, `react-doctor`
- [x] `vp check` — lint + format on all touched files
- [x] `scan-resilience` + `architecture-rules` regressions updated/green
- [x] RDE corpus parity (500 rootDirs): net `-2772`, `0` added
- [x] Changesets added (`patch`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which diagnostics surface (library gating, severity demotion, heuristic exceptions); misclassification could hide real app-only or key issues, though explicit per-rule overrides and conservative unknown→app behavior limit that.
> 
> **Overview**
> Reduces **false positives** and adds **context-aware rule gating** across lint rules and the diagnostic pipeline.
> 
> **Rule behavior:** **`jsx-key`** stays silent when a mapped list element spreads the **whole** iteration variable (`<Item {...item} />`); other keyless list shapes still report. **`rn-no-raw-text`** auto-detects in-file components whose return root is **`<Text>`** (including spread forwarders) and treats raw string children as safe; config **`textComponents`** / **`rawTextWrapperComponents`** unchanged.
> 
> **Pipeline & config:** New **`classifyPackageRole`** marks published packages (`name` + **`exports`**, not **`private`**) as libraries—**not** from `packages/` alone. **`react-hooks-js/static-components`** and **`no-render-prop-children`** are dropped on library files unless a **per-rule** severity override opts in (category bumps do not). **`react-compiler-no-manual-memoization`** defaults to **`warn`** when React Compiler is on; new **`buckets.compiler-cleanup`** can restore **`error`**. **`react-hooks-js/*`** compiler rules remain **`error`**.
> 
> **Infra:** **`clearPackageRoleCache()`** hooks into **`clearCaches()`**; patch changesets and regression tests cover classifier edge cases and bucket precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7282f04f63c4ff797ddfb075bbbc207e56980c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->