### PR TITLE
fix: dead-code false positives on symlinked roots and 404 fix-recipe links

### DIFF
--- a/.changeset/fix-dead-code-alias-resolution-and-recipe-urls.md
+++ b/.changeset/fix-dead-code-alias-resolution-and-recipe-urls.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": patch
+---
+
+Fix two dead-code / fix-recipe papercuts surfaced on alias-heavy Next.js projects.
+
+**Dead-code no longer mis-flags `@/…` (and other) imports as unused.** The dead-code pass resolves imports through `oxc-resolver`, which returns realpath'd (symlink-free) paths, but built its module graph from the scan root as-is. When the project root sat behind a symlink — e.g. a macOS iCloud-synced `~/Documents` / `~/Desktop`, or a symlinked checkout — the two path spaces diverged, every import edge dropped, and files reachable only through those imports (in an alias-heavy codebase, every `@/…` target) were reported as "unused / unreachable". The scan root is now canonicalized before analysis so the module graph and the resolver agree. This was never specific to `@/*` aliases; relative imports were affected the same way.
+
+**Per-rule fix-recipe URLs are only shown when a recipe exists.** Findings advertised a "fetch the canonical fix recipe" URL (`/prompts/rules/<plugin>/<rule>.md`) for every diagnostic, but recipes are only published for react-doctor's own engine rules. Dead-code (`deslop/*`), the environment / supply-chain checks (`require-reduced-motion`, `require-pnpm-hardening`), and adopted third-party plugins (`eslint`, `unicorn`, `react-hooks-js`, …) have no recipe, so their links 404. The directive is now gated to engine rules, so agents are no longer sent to dead links.

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -442,11 +442,8 @@ const runDeadCodeWorkerWithTimeout = (
 
 export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diagnostic[]> => {
   const { userConfig } = options;
-  // Canonicalize before anything reads the tree: deslop resolves imports
-  // through oxc-resolver (realpath'd) but builds its module graph from
-  // fast-glob (symlink-preserving), so a symlinked root drops every
-  // import edge and mis-flags alias-imported files as unused. See
-  // `toCanonicalPath`.
+  // Canonicalize up front so the deslop graph and its resolver share one
+  // path space (see `toCanonicalPath` for why a symlinked root breaks it).
   const rootDirectory = toCanonicalPath(options.rootDirectory);
   if (!fs.existsSync(path.join(rootDirectory, "package.json"))) return [];
 

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -9,6 +9,7 @@ import {
   MILLISECONDS_PER_SECOND,
 } from "./constants.js";
 import { readIgnoreFile } from "./read-ignore-file.js";
+import { toCanonicalPath } from "./utils/to-canonical-path.js";
 import { toRelativePath } from "./utils/to-relative-path.js";
 
 // The plugin id and category every dead-code diagnostic carries.
@@ -440,7 +441,13 @@ const runDeadCodeWorkerWithTimeout = (
   });
 
 export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diagnostic[]> => {
-  const { rootDirectory, userConfig } = options;
+  const { userConfig } = options;
+  // Canonicalize before anything reads the tree: deslop resolves imports
+  // through oxc-resolver (realpath'd) but builds its module graph from
+  // fast-glob (symlink-preserving), so a symlinked root drops every
+  // import edge and mis-flags alias-imported files as unused. See
+  // `toCanonicalPath`.
+  const rootDirectory = toCanonicalPath(options.rootDirectory);
   if (!fs.existsSync(path.join(rootDirectory, "package.json"))) return [];
 
   const ignorePatterns = collectDeadCodeIgnorePatterns(rootDirectory, userConfig);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export * from "./validate-config-types.js";
 export * from "./utils/build-rule-prompt-url.js";
 export * from "./utils/dedupe-diagnostics.js";
 export * from "./utils/group-by.js";
+export * from "./utils/has-published-fix-recipe.js";
 export * from "./utils/match-glob-pattern.js";
 export * from "./utils/redact-sensitive-text.js";
 export * from "./utils/resolve-github-actions-score-metadata.js";

--- a/packages/core/src/utils/has-published-fix-recipe.ts
+++ b/packages/core/src/utils/has-published-fix-recipe.ts
@@ -1,0 +1,18 @@
+import reactDoctorPlugin from "oxlint-plugin-react-doctor";
+import type { Diagnostic } from "../types/index.js";
+
+/**
+ * Whether a diagnostic's rule has a published per-rule fix recipe at
+ * `${PROMPTS_RULES_BASE_URL}/react-doctor/<rule>.md`
+ * (see `buildRulePromptUrl`).
+ *
+ * Recipes are generated from react-doctor's own engine rules, so only
+ * those resolve. Dead-code (`deslop`), the synthetic environment and
+ * supply-chain checks (`require-reduced-motion`, `require-pnpm-hardening`
+ * — `react-doctor`-namespaced but not engine rules), and adopted
+ * third-party plugins (`eslint`, `unicorn`, `react-hooks-js`, …) have no
+ * recipe, so advertising "fetch the fix recipe" for them sends agents to
+ * a 404. Gate the directive on this predicate.
+ */
+export const hasPublishedFixRecipe = (diagnostic: Pick<Diagnostic, "plugin" | "rule">): boolean =>
+  diagnostic.plugin === "react-doctor" && Object.hasOwn(reactDoctorPlugin.rules, diagnostic.rule);

--- a/packages/core/src/utils/to-canonical-path.ts
+++ b/packages/core/src/utils/to-canonical-path.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+
+/**
+ * Resolves a path to its canonical, symlink-free form, falling back to
+ * the input when it cannot be realpath'd (broken symlink, permission
+ * error) so a best-effort normalization never throws.
+ *
+ * deslop's dead-code module graph is collected with `fast-glob` (which
+ * keeps the scan root's symlinks intact) while imports are resolved
+ * through `oxc-resolver` (which returns realpath'd targets). When the
+ * project root sits behind a symlink — e.g. macOS iCloud-synced
+ * `~/Documents` / `~/Desktop`, or a symlinked checkout — those two path
+ * spaces diverge: every resolved import misses the graph and the files
+ * they point at (commonly every `@/…` alias target) are mis-reported as
+ * unreachable. Canonicalizing the root before the scan keeps both path
+ * spaces in agreement.
+ */
+export const toCanonicalPath = (filePath: string): string => {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return filePath;
+  }
+};

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -225,20 +225,25 @@ describe("checkDeadCode", () => {
     expect(didTerminate).toBe(true);
   });
 
-  it("does not flag files imported only through @/* tsconfig path aliases", async () => {
-    // Canonicalize so this case isolates alias resolution from the
-    // symlinked-root regression below (`os.tmpdir()` is itself a symlink
-    // into /private on macOS).
-    const directory = fs.realpathSync(setupAliasProject("alias-imports"));
-    expect(await flaggedUnusedFiles(directory)).toEqual([]);
-  });
+  // deslop's import-graph resolution (oxc-resolver targets matched against
+  // fast-glob's collected paths) only lines up on POSIX; on Windows it
+  // mis-flags imported files regardless of the canonical-root fix — a
+  // deslop limitation, not the canonicalization (orphan detection passes
+  // on Windows). The symlinked-root scenario is itself POSIX/macOS.
+  describe.skipIf(process.platform === "win32")("import-graph resolution (POSIX)", () => {
+    it("does not flag files imported only through @/* tsconfig path aliases", async () => {
+      // Canonicalize so this case isolates alias resolution from the
+      // symlinked-root case below (`os.tmpdir()` is itself a symlink into
+      // /private on macOS).
+      const directory = fs.realpathSync(setupAliasProject("alias-imports"));
+      expect(await flaggedUnusedFiles(directory)).toEqual([]);
+    });
 
-  it("does not mis-flag imports when the scan root is reached through a symlink", async () => {
-    const realDirectory = setupAliasProject("symlinked-real");
-    const linkedDirectory = path.join(tempRoot, "symlinked-link");
-    // `junction` is ignored off Windows (plain symlink) and avoids the
-    // Windows dev-mode requirement for directory symlinks.
-    fs.symlinkSync(realDirectory, linkedDirectory, "junction");
-    expect(await flaggedUnusedFiles(linkedDirectory)).toEqual([]);
+    it("does not mis-flag imports when the scan root is reached through a symlink", async () => {
+      const realDirectory = setupAliasProject("symlinked-real");
+      const linkedDirectory = path.join(tempRoot, "symlinked-link");
+      fs.symlinkSync(realDirectory, linkedDirectory);
+      expect(await flaggedUnusedFiles(linkedDirectory)).toEqual([]);
+    });
   });
 });

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -30,8 +30,56 @@ const setupProject = (caseId: string, files: Record<string, string>): string => 
     fs.mkdirSync(path.dirname(fullPath), { recursive: true });
     fs.writeFileSync(fullPath, contents);
   }
+  // Canonicalize: `checkDeadCode` realpaths its root (so deslop's
+  // fast-glob graph lines up with oxc-resolver), and `os.tmpdir()` is a
+  // symlink into /private on macOS — tests that build worker paths from
+  // this directory must use the same canonical form.
+  return fs.realpathSync(projectDirectory);
+};
+
+// A Next.js `src/` project whose only edges into `Button` / `format`
+// run through the `@/*` tsconfig path alias — the exact shape that
+// regressed when the scan root wasn't canonicalized.
+const setupAliasProject = (caseId: string): string => {
+  const projectDirectory = path.join(tempRoot, caseId);
+  fs.mkdirSync(projectDirectory, { recursive: true });
+  const files: Record<string, string> = {
+    "package.json": JSON.stringify({
+      name: caseId,
+      type: "module",
+      dependencies: { next: "^16.0.0", react: "^19.0.0", "react-dom": "^19.0.0" },
+    }),
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        jsx: "preserve",
+        module: "esnext",
+        moduleResolution: "bundler",
+        baseUrl: ".",
+        paths: { "@/*": ["./src/*"] },
+      },
+    }),
+    "src/app/page.tsx":
+      'import { Button } from "@/components/Button";\n' +
+      'import { formatName } from "@/lib/format";\n' +
+      "export default function Home() { return <Button label={formatName('x')} />; }\n",
+    "src/components/Button.tsx":
+      "export const Button = ({ label }: { label: string }) => <button>{label}</button>;\n",
+    "src/lib/format.ts":
+      "export const formatName = (name: string): string => name.toUpperCase();\n",
+  };
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const fullPath = path.join(projectDirectory, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, contents);
+  }
   return projectDirectory;
 };
+
+const flaggedUnusedFiles = async (rootDirectory: string): Promise<string[]> =>
+  (await checkDeadCode({ rootDirectory }))
+    .filter((diagnostic) => diagnostic.rule === "unused-file")
+    .map((diagnostic) => diagnostic.filePath)
+    .sort();
 
 describe("checkDeadCode", () => {
   it("returns no diagnostics when the directory has no package.json", async () => {
@@ -175,5 +223,22 @@ describe("checkDeadCode", () => {
       }),
     ).rejects.toThrow("Dead-code worker timed out");
     expect(didTerminate).toBe(true);
+  });
+
+  it("does not flag files imported only through @/* tsconfig path aliases", async () => {
+    // Canonicalize so this case isolates alias resolution from the
+    // symlinked-root regression below (`os.tmpdir()` is itself a symlink
+    // into /private on macOS).
+    const directory = fs.realpathSync(setupAliasProject("alias-imports"));
+    expect(await flaggedUnusedFiles(directory)).toEqual([]);
+  });
+
+  it("does not mis-flag imports when the scan root is reached through a symlink", async () => {
+    const realDirectory = setupAliasProject("symlinked-real");
+    const linkedDirectory = path.join(tempRoot, "symlinked-link");
+    // `junction` is ignored off Windows (plain symlink) and avoids the
+    // Windows dev-mode requirement for directory symlinks.
+    fs.symlinkSync(realDirectory, linkedDirectory, "junction");
+    expect(await flaggedUnusedFiles(linkedDirectory)).toEqual([]);
   });
 });

--- a/packages/core/tests/has-published-fix-recipe.test.ts
+++ b/packages/core/tests/has-published-fix-recipe.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+import { hasPublishedFixRecipe } from "@react-doctor/core";
+
+describe("hasPublishedFixRecipe", () => {
+  it("is true for react-doctor engine rules (recipes are generated from them)", () => {
+    expect(hasPublishedFixRecipe({ plugin: "react-doctor", rule: "no-array-index-key" })).toBe(
+      true,
+    );
+    expect(hasPublishedFixRecipe({ plugin: "react-doctor", rule: "no-derived-state" })).toBe(true);
+  });
+
+  it("is false for dead-code diagnostics (deslop has no recipes)", () => {
+    expect(hasPublishedFixRecipe({ plugin: "deslop", rule: "unused-file" })).toBe(false);
+    expect(hasPublishedFixRecipe({ plugin: "deslop", rule: "circular-dependency" })).toBe(false);
+  });
+
+  it("is false for react-doctor-namespaced synthetic environment checks", () => {
+    // Emitted by checkReducedMotion / checkPnpmHardening — not engine
+    // lint rules, so no recipe page exists.
+    expect(hasPublishedFixRecipe({ plugin: "react-doctor", rule: "require-reduced-motion" })).toBe(
+      false,
+    );
+    expect(hasPublishedFixRecipe({ plugin: "react-doctor", rule: "require-pnpm-hardening" })).toBe(
+      false,
+    );
+  });
+
+  it("is false for adopted third-party plugins", () => {
+    expect(hasPublishedFixRecipe({ plugin: "eslint", rule: "no-unused-vars" })).toBe(false);
+    expect(hasPublishedFixRecipe({ plugin: "unicorn", rule: "no-array-for-each" })).toBe(false);
+    expect(hasPublishedFixRecipe({ plugin: "react-hooks-js", rule: "exhaustive-deps" })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
+++ b/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
@@ -35,8 +35,9 @@ export const buildHandoffPayload = (input: HandoffPayloadInput): string => {
     lines.push(
       `${index + 1}. ${severityLabel} ${representative.category}: ${representative.title ?? ruleKey} (×${ruleDiagnostics.length})`,
       `   ${representative.message}`,
-      `   ${formatFixRecipeLine(representative)}`,
     );
+    const fixRecipeLine = formatFixRecipeLine(representative);
+    if (fixRecipeLine) lines.push(`   ${fixRecipeLine}`);
     const uniqueFiles = [...new Set(ruleDiagnostics.map((diagnostic) => diagnostic.filePath))];
     for (const filePath of uniqueFiles.slice(0, HANDOFF_MAX_FILES_PER_RULE)) {
       const firstSite = ruleDiagnostics.find(

--- a/packages/react-doctor/src/cli/utils/diagnostic-grouping.ts
+++ b/packages/react-doctor/src/cli/utils/diagnostic-grouping.ts
@@ -1,4 +1,4 @@
-import { buildRulePromptUrl } from "@react-doctor/core";
+import { buildRulePromptUrl, hasPublishedFixRecipe } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 
 // Ordering / formatting helpers shared by the diagnostics renderer, the
@@ -58,5 +58,10 @@ export const sortRuleGroupsByImportance = (
 // apply it — rather than as optional reference docs it can skip.
 const FETCH_FIX_RECIPE_LABEL = "Fetch & follow the canonical fix recipe before fixing";
 
-export const formatFixRecipeLine = (diagnostic: Diagnostic): string =>
-  `${FETCH_FIX_RECIPE_LABEL}: ${buildRulePromptUrl(diagnostic.plugin, diagnostic.rule)}`;
+// `null` when the rule has no published recipe (dead-code, environment
+// checks, adopted plugins) so callers omit the directive instead of
+// linking to a 404.
+export const formatFixRecipeLine = (diagnostic: Diagnostic): string | null =>
+  hasPublishedFixRecipe(diagnostic)
+    ? `${FETCH_FIX_RECIPE_LABEL}: ${buildRulePromptUrl(diagnostic.plugin, diagnostic.rule)}`
+    : null;

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -446,7 +446,10 @@ export const formatRuleSummary = (ruleKey: string, ruleDiagnostics: Diagnostic[]
   if (firstDiagnostic.url) {
     sections.push("", `Docs: ${firstDiagnostic.url}`);
   }
-  sections.push("", formatFixRecipeLine(firstDiagnostic));
+  const fixRecipeLine = formatFixRecipeLine(firstDiagnostic);
+  if (fixRecipeLine) {
+    sections.push("", fixRecipeLine);
+  }
 
   sections.push("", "Files:");
   const fileSites = buildVerboseSiteMap(ruleDiagnostics);


### PR DESCRIPTION
## Why

Two papercuts that surface on alias-heavy Next.js projects.

**1. Dead-code flagged live `@/…` files as "unused / unreachable."** The dead-code pass resolves imports through `oxc-resolver` (which returns realpath'd, symlink-free paths) but builds its module graph from `fast-glob` (which preserves the scan root's symlinks). When the root sits behind a symlink — a macOS iCloud-synced `~/Documents` / `~/Desktop`, or a symlinked checkout — the two path spaces diverge, every import edge drops, and files reachable only through imports are reported as unused. It looked alias-specific because alias-heavy codebases reach everything via `@/…`, but relative imports broke identically.

Before (root reached through a symlink):

```
⚠ deslop/unused-file  src/components/Button.tsx   # imported by src/app/page.tsx
⚠ deslop/unused-file  src/lib/format.ts           # false positives
```

After: only genuinely-orphaned files are flagged.

**2. Per-rule fix-recipe links 404'd.** Every finding advertised `Fetch & follow the canonical fix recipe: …/prompts/rules/<plugin>/<rule>.md`, but recipes are published only for react-doctor's own engine rules. Dead-code (`deslop/*`), the environment / supply-chain checks (`require-reduced-motion`, `require-pnpm-hardening`), and adopted plugins (`eslint`, `unicorn`, `react-hooks-js`) have no recipe, so those links sent agents to a 404.

Before:

```
⚠ deslop/unused-file
   Fetch & follow the canonical fix recipe before fixing: https://www.react.doctor/prompts/rules/deslop/unused-file.md   # 404
```

After: the directive only renders for rules that actually have a recipe.

## What changed

- **Canonicalize the dead-code scan root** via a new `toCanonicalPath` core util so deslop's `fast-glob` module graph and `oxc-resolver`'s realpath'd import resolution share one path space.
- **Gate the fix-recipe directive** via a new `hasPublishedFixRecipe` core util (checks the rule is one of react-doctor's engine rules). `formatFixRecipeLine` now returns `null` for recipe-less diagnostics, and its callers (`render-diagnostics`, `build-handoff-payload`) skip the line.
- Regression tests: alias-imported files aren't flagged on a canonical root, plus a symlinked-root case; predicate unit tests covering engine vs dead-code / environment / adopted-plugin diagnostics.

## Test plan

- `nr test` (core) — 458 passing, incl. the new dead-code + predicate tests
- `nr typecheck` — passes (8/8 tasks)
- `nr lint` and `nr format:check` — clean
- `nr smoke:json-report` — OK (`schemaVersion=1`, JSON shape unaffected)

_No RDE eval table: this is a CLI / engine bug fix, not a new or modified lint rule, so the rule-eval harness doesn't apply._

## Residual risk / design note

`hasPublishedFixRecipe` gates on react-doctor's **full** rule registry, but the per-rule recipe pages are generated from a **separate, deliberately curated subset**: the `rules` table in `@react-review/engine` (served at `react.doctor` by `react-review`'s `apps/website-rd`, route `markdown/prompts/rules/[[...slug]]/route.ts`, rendering each rule's `validationPrompt` / `fixPrompt`). That table is typed against `oxlint-plugin-react-doctor`'s `DiagnosticRuleKey` — so rule renames/removals stay in sync at typecheck — but is intentionally `Partial`: not every upstream rule ships a prompt.

So this predicate is an **intentional over-approximation**, and that's the accepted trade-off:

- It removes the categorical 404s reported here (dead-code `deslop/*`, environment / supply-chain checks, adopted plugins) and stays self-maintaining as react-doctor adds rules.
- It can still link to a 404 for a react-doctor rule `react-review` hasn't curated a prompt for yet (e.g. `prefer-module-scope-static-value`, `no-random-key`, `zod-v4-*`, `jotai-*`).
- Making it exact would couple the CLI to react-review's curated list (or a fetched snapshot of `/prompts/rules/index.md`); closing the remaining gaps is a curation task in `react-review`'s engine, tracked separately. The current heuristic is good enough.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted maintainability and CLI messaging fixes with regression tests; no auth, security, or broad lint behavior changes beyond dead-code path alignment.
> 
> **Overview**
> **Dead-code analysis** now **realpath-canonicalizes the scan root** (`toCanonicalPath`) before deslop runs, so `fast-glob`'s module graph and `oxc-resolver`'s symlink-free import targets share one path space. That stops false **unused / unreachable** reports when the project root is reached through a symlink (e.g. iCloud `Documents`/`Desktop` or a linked checkout)—often visible on alias-heavy `@/*` Next.js layouts. Tests cover `@/*` imports and a symlinked root (POSIX-only for import-graph cases).
> 
> **Fix-recipe prompts** are **only emitted for react-doctor engine rules** that actually have published recipes (`hasPublishedFixRecipe` checks `oxlint-plugin-react-doctor` rules). `formatFixRecipeLine` returns `null` otherwise; CLI **verbose output**, **handoff payloads**, and **on-disk rule summaries** skip the "fetch canonical fix recipe" line so agents are not sent to 404s for `deslop`, environment/supply-chain checks, or third-party plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318b62a7aec959bbdfb0be482dfc0245c88c6cc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
