### PR TITLE
Add Discord link to CLI error help

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -145,7 +145,7 @@ export const STAGED_FILES_PROJECT_CONFIG_FILENAMES = [
 
 export const CANONICAL_GITHUB_URL = "https://github.com/millionco/react-doctor";
 
-export const CANONICAL_DISCORD_URL = "https://discord.gg/tB3FfF9cwb";
+export const CANONICAL_DISCORD_URL = "https://react.doctor/discord";
 
 export const SKILL_NAME = "react-doctor";
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -145,6 +145,8 @@ export const STAGED_FILES_PROJECT_CONFIG_FILENAMES = [
 
 export const CANONICAL_GITHUB_URL = "https://github.com/millionco/react-doctor";
 
+export const CANONICAL_DISCORD_URL = "https://discord.gg/tB3FfF9cwb";
+
 export const SKILL_NAME = "react-doctor";
 
 // HACK: cap on combined stdout+stderr bytes per oxlint batch. Above

--- a/packages/react-doctor/src/cli/utils/handle-error.ts
+++ b/packages/react-doctor/src/cli/utils/handle-error.ts
@@ -1,6 +1,7 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import {
+  CANONICAL_DISCORD_URL,
   CANONICAL_GITHUB_URL,
   formatErrorChain,
   formatReactDoctorError,
@@ -99,6 +100,9 @@ const handleErrorEffect = (error: unknown): Effect.Effect<void> =>
       highlighter.error(
         `If the problem persists, please open this prefilled issue: ${buildErrorIssueUrl(error)}`,
       ),
+    );
+    yield* Console.error(
+      highlighter.error(`You can also ask for help in Discord: ${CANONICAL_DISCORD_URL}`),
     );
     yield* Console.error("");
     yield* Console.error(highlighter.error(formatErrorForReport(error)));

--- a/packages/react-doctor/tests/handle-error.test.ts
+++ b/packages/react-doctor/tests/handle-error.test.ts
@@ -63,7 +63,7 @@ describe("handleError", () => {
     }
 
     expect(errorMessages.join("\n")).toContain(
-      "You can also ask for help in Discord: https://discord.gg/tB3FfF9cwb",
+      "You can also ask for help in Discord: https://react.doctor/discord",
     );
     expect(process.exitCode).toBe(1);
   });

--- a/packages/react-doctor/tests/handle-error.test.ts
+++ b/packages/react-doctor/tests/handle-error.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
-import { buildErrorIssueUrl } from "../src/cli/utils/handle-error.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { buildErrorIssueUrl, handleError } from "../src/cli/utils/handle-error.js";
 
 const OTLP_ENDPOINT_ENVIRONMENT_VARIABLE = "REACT_DOCTOR_OTLP_ENDPOINT";
 const OTLP_AUTH_HEADER_ENVIRONMENT_VARIABLE = "REACT_DOCTOR_OTLP_AUTH_HEADER";
@@ -10,8 +10,10 @@ interface EnvironmentSnapshot {
 
 describe("handleError", () => {
   let savedEnvironment: EnvironmentSnapshot;
+  let savedExitCode: number | string | undefined;
 
   beforeEach(() => {
+    savedExitCode = process.exitCode;
     savedEnvironment = {
       [OTLP_ENDPOINT_ENVIRONMENT_VARIABLE]: process.env[OTLP_ENDPOINT_ENVIRONMENT_VARIABLE],
       [OTLP_AUTH_HEADER_ENVIRONMENT_VARIABLE]: process.env[OTLP_AUTH_HEADER_ENVIRONMENT_VARIABLE],
@@ -21,6 +23,7 @@ describe("handleError", () => {
   });
 
   afterEach(() => {
+    process.exitCode = savedExitCode;
     for (const [environmentVariableName, value] of Object.entries(savedEnvironment)) {
       if (value === undefined) {
         delete process.env[environmentVariableName];
@@ -45,5 +48,23 @@ describe("handleError", () => {
     expect(body).toContain("OTLP exporter enabled: yes");
     expect(body).toContain("trace/span link, if exported:");
     expect(body).not.toContain("secret-token");
+  });
+
+  it("suggests Discord when printing an error", () => {
+    const errorMessages: string[] = [];
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation((...messages) => {
+      errorMessages.push(messages.join(" "));
+    });
+
+    try {
+      handleError(new Error("boom"), { shouldExit: false });
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+
+    expect(errorMessages.join("\n")).toContain(
+      "You can also ask for help in Discord: https://discord.gg/tB3FfF9cwb",
+    );
+    expect(process.exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared canonical Discord support URL using `https://react.doctor/discord`.
- Print the Discord support link in the CLI error handler alongside the prefilled GitHub issue link.
- Cover the error output guidance with a focused test.

## Testing
- `npx --package @antfu/ni nr build`
- `npx --package @antfu/ni nr test tests/handle-error.test.ts` (from `packages/react-doctor`)
- `npx --package @antfu/ni nr typecheck`
- `npx --package @antfu/ni nr format:check`
- `npx --package @antfu/ni nr lint`
- `npx --package @antfu/ni nr test`
- `npx --package @antfu/ni nr smoke:json-report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad82bf48-8e2f-4b04-8858-5b40e1984b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad82bf48-8e2f-4b04-8858-5b40e1984b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

