### PR TITLE
feat(cli): align CLI with clig.dev and 12-factor guidelines

### DIFF
--- a/.changeset/cli-color-version-help.md
+++ b/.changeset/cli-color-version-help.md
@@ -1,0 +1,10 @@
+---
+"react-doctor": minor
+---
+
+Align the CLI with the clig.dev and 12-factor CLI guidelines:
+
+- `--color` / `--no-color` flags force or disable colored output, with app-specific `REACT_DOCTOR_NO_COLOR` / `REACT_DOCTOR_FORCE_COLOR` env overrides. Flags win over env vars, which win over picocolors' built-in `NO_COLOR` / `FORCE_COLOR` / `TERM` / TTY detection; the preference is resolved before parsing so it reaches every surface (scan report, branded header, score, prompts, errors).
+- `react-doctor --help` and `react-doctor install --help` now lead with worked examples and link to where to report feedback.
+- New `react-doctor version` subcommand prints the version with Node and platform info (e.g. `react-doctor/0.2.14 darwin-arm64 node-v24.14.0`); `-v` / `-V` / `--version` stay terse for scripts.
+- `react-doctor help` and `react-doctor help <command>` now show help instead of failing by trying to scan a directory named "help".

--- a/packages/core/src/highlighter.ts
+++ b/packages/core/src/highlighter.ts
@@ -9,3 +9,23 @@ export const highlighter = {
   gray: pc.gray,
   bold: pc.bold,
 };
+
+/**
+ * Override picocolors' automatic color detection. picocolors decides
+ * once, at import time, from `NO_COLOR` / `FORCE_COLOR` / `TERM` / TTY.
+ * This lets the CLI honor an explicit `--color` / `--no-color` flag
+ * (clig.dev, Output: "Disable color … if the user requested it") by
+ * swapping in a fresh set of formatters. Call it before any colored
+ * output is produced. Every call site reads `highlighter.<method>` at
+ * call time, so reassigning the properties propagates everywhere.
+ */
+export const setColorEnabled = (enabled: boolean): void => {
+  const colors = pc.createColors(enabled);
+  highlighter.error = colors.red;
+  highlighter.warn = colors.yellow;
+  highlighter.info = colors.cyan;
+  highlighter.success = colors.green;
+  highlighter.dim = colors.dim;
+  highlighter.gray = colors.gray;
+  highlighter.bold = colors.bold;
+};

--- a/packages/react-doctor/src/cli/commands/version.ts
+++ b/packages/react-doctor/src/cli/commands/version.ts
@@ -1,0 +1,15 @@
+import { VERSION } from "../utils/version.js";
+
+/**
+ * oclif-style version line. 12-factor CLI Apps (#3, "What version am I
+ * on?"): the `version` command is the primary place users grab debugging
+ * info, so it carries the Node runtime and platform alongside the CLI
+ * version. The `-v` / `-V` / `--version` flags stay terse (just the
+ * number) so scripts can parse them.
+ */
+export const buildVersionString = (): string =>
+  `react-doctor/${VERSION} ${process.platform}-${process.arch} node-${process.version}`;
+
+export const versionAction = (): void => {
+  process.stdout.write(`${buildVersionString()}\n`);
+};

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -103,7 +103,11 @@ const program = new Command()
     "--changed-files-from <file>",
     "internal: scan source files listed in a newline-delimited changed-files file",
   )
-  .option("--no-score", "skip the score API and the share URL")
+  .option("--no-score", "skip the score API, the share URL, and crash reporting")
+  .option(
+    "--no-telemetry",
+    "alias for --no-score (skip the score API, share URL, and crash reporting)",
+  )
   .option("--staged", "scan only staged (git index) files for pre-commit hooks")
   .option(
     "--fail-on <level>",

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -3,9 +3,13 @@ import { CANONICAL_GITHUB_URL, highlighter } from "@react-doctor/core";
 import { initializeSentry } from "../instrument.js";
 import { inspectAction } from "./commands/inspect.js";
 import { installAction } from "./commands/install.js";
+import { versionAction } from "./commands/version.js";
+import { applyColorPreference } from "./utils/apply-color-preference.js";
+import { NODE_ARGUMENT_COUNT } from "./utils/constants.js";
 import { exitGracefully } from "./utils/exit-gracefully.js";
 import { handleError } from "./utils/handle-error.js";
 import { isJsonModeActive, writeJsonErrorReport } from "./utils/json-mode.js";
+import { normalizeHelpInvocation } from "./utils/normalize-help-command.js";
 import { reportErrorToSentry } from "./utils/report-error.js";
 import { stripUnknownCliFlags } from "./utils/strip-unknown-cli-flags.js";
 import { unrefStdin } from "./utils/unref-stdin.js";
@@ -16,6 +20,58 @@ initializeSentry();
 process.on("SIGINT", exitGracefully);
 process.on("SIGTERM", exitGracefully);
 unrefStdin();
+
+const formatExampleLines = (
+  examples: ReadonlyArray<readonly [command: string, description: string]>,
+): string => {
+  const width = Math.max(...examples.map(([command]) => command.length));
+  return examples
+    .map(
+      ([command, description]) =>
+        `  $ ${command.padEnd(width)}  ${highlighter.dim(`# ${description}`)}`,
+    )
+    .join("\n");
+};
+
+// clig.dev (Help): "Lead with examples." Epilogs are functions, not
+// pre-built strings, so they render after `applyColorPreference` runs and
+// honor `--no-color` in a TTY.
+const renderRootHelpEpilog = (): string => `
+${highlighter.dim("Examples:")}
+${formatExampleLines([
+  ["react-doctor", "scan the current project"],
+  ["react-doctor ./apps/web", "scan a specific directory"],
+  ["react-doctor --diff main", "scan only files changed vs. main"],
+  ["react-doctor --staged", "scan staged files (pre-commit hook)"],
+  ["react-doctor --fail-on warning", "exit non-zero on warnings (CI gate)"],
+  ["react-doctor --json > report.json", "write a machine-readable report"],
+  ["react-doctor --explain src/App.tsx:42", "explain why a rule fired there"],
+  ["react-doctor install", "set up the agent skill and git hook"],
+])}
+
+${highlighter.dim("Configuration:")}
+  Place a ${highlighter.info("react-doctor.config.json")} (or ${highlighter.info('"reactDoctor"')} key in your package.json) in the project root.
+  CLI flags always override config values. See the README for the full schema.
+
+${highlighter.dim("Feedback & bug reports:")}
+  ${highlighter.info(`${CANONICAL_GITHUB_URL}/issues`)}
+
+${highlighter.dim("Learn more:")}
+  ${highlighter.info(CANONICAL_GITHUB_URL)}
+`;
+
+const renderInstallHelpEpilog = (): string => `
+${highlighter.dim("Examples:")}
+${formatExampleLines([
+  ["react-doctor install", "interactive setup"],
+  ["react-doctor install --yes", "non-interactive; all detected agents"],
+  ["react-doctor install --dry-run", "preview without writing files"],
+  ["react-doctor install --agent-hooks", "also install native agent hooks"],
+])}
+
+${highlighter.dim("Learn more:")}
+  ${highlighter.info(CANONICAL_GITHUB_URL)}
+`;
 
 const program = new Command()
   .name("react-doctor")
@@ -74,17 +130,9 @@ const program = new Command()
   )
   .option("--warnings", "show warning-severity diagnostics (errors always show)")
   .option("--no-warnings", "hide warning-severity diagnostics (default)")
-  .addHelpText(
-    "after",
-    `
-${highlighter.dim("Configuration:")}
-  Place a ${highlighter.info("react-doctor.config.json")} (or ${highlighter.info('"reactDoctor"')} key in your package.json) in the project root.
-  CLI flags always override config values. See the README for the full schema.
-
-${highlighter.dim("Learn more:")}
-  ${highlighter.info(CANONICAL_GITHUB_URL)}
-`,
-  );
+  .option("--color", "force colored output")
+  .option("--no-color", "disable colored output (also honors NO_COLOR)")
+  .addHelpText("after", renderRootHelpEpilog);
 
 program.action(inspectAction);
 
@@ -96,7 +144,15 @@ program
   .option("--dry-run", "show what would be installed without writing files")
   .option("--agent-hooks", "install native non-blocking agent hooks for Claude Code and Cursor")
   .option("-c, --cwd <cwd>", "working directory", process.cwd())
+  .option("--color", "force colored output")
+  .option("--no-color", "disable colored output (also honors NO_COLOR)")
+  .addHelpText("after", renderInstallHelpEpilog)
   .action(installAction);
+
+program
+  .command("version")
+  .description("show the version with Node and platform info")
+  .action(versionAction);
 
 // HACK: when stdout is piped into a process that closes early (e.g.
 // `react-doctor . | head`), Node throws an uncaught EPIPE on the next
@@ -105,7 +161,26 @@ process.stdout.on("error", (error: NodeJS.ErrnoException) => {
   if (error.code === "EPIPE") process.exit(0);
 });
 
-program.parseAsync(stripUnknownCliFlags(process.argv)).catch(async (error: unknown) => {
+const knownCommands = program.commands.flatMap((command) => [command.name(), ...command.aliases()]);
+const argv = normalizeHelpInvocation(stripUnknownCliFlags(process.argv), knownCommands);
+
+// HACK: Commander allows only one short flag on `--version` (we use `-v`),
+// so honor `-V` by scanning argv ourselves and printing the terse version
+// before Commander parses. Stop at `--` so it isn't read as a passthrough.
+const userArguments = process.argv.slice(NODE_ARGUMENT_COUNT);
+const endOfOptionsIndex = userArguments.indexOf("--");
+const optionArguments =
+  endOfOptionsIndex === -1 ? userArguments : userArguments.slice(0, endOfOptionsIndex);
+if (optionArguments.includes("-V")) {
+  process.stdout.write(`${VERSION}\n`);
+  process.exit(0);
+}
+
+// Color must be resolved before Commander parses so the choice reaches
+// help output too.
+applyColorPreference(argv);
+
+program.parseAsync(argv).catch(async (error: unknown) => {
   await reportErrorToSentry(error);
   if (isJsonModeActive()) {
     writeJsonErrorReport(error);

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -5,7 +5,6 @@ import { inspectAction } from "./commands/inspect.js";
 import { installAction } from "./commands/install.js";
 import { versionAction } from "./commands/version.js";
 import { applyColorPreference } from "./utils/apply-color-preference.js";
-import { NODE_ARGUMENT_COUNT } from "./utils/constants.js";
 import { exitGracefully } from "./utils/exit-gracefully.js";
 import { handleError } from "./utils/handle-error.js";
 import { isJsonModeActive, writeJsonErrorReport } from "./utils/json-mode.js";
@@ -167,13 +166,11 @@ const knownCommands = program.commands.flatMap((command) => [command.name(), ...
 const strippedArgv = stripUnknownCliFlags(process.argv);
 
 // HACK: Commander allows only one short flag on `--version` (we use `-v`),
-// so honor `-V` by scanning argv ourselves and printing the terse version
-// before Commander parses. Stop at `--` so it isn't read as a passthrough.
-const userArguments = process.argv.slice(NODE_ARGUMENT_COUNT);
-const endOfOptionsIndex = userArguments.indexOf("--");
-const optionArguments =
-  endOfOptionsIndex === -1 ? userArguments : userArguments.slice(0, endOfOptionsIndex);
-if (optionArguments.includes("-V")) {
+// so honor `-V` ourselves before Commander parses. `stripUnknownCliFlags`
+// drops a standalone unknown `-V` but keeps one that's an option value, so
+// "present in raw argv yet stripped out" means it was passed as a real flag
+// (not e.g. `--cwd -V`).
+if (process.argv.includes("-V") && !strippedArgv.includes("-V")) {
   process.stdout.write(`${VERSION}\n`);
   process.exit(0);
 }

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -152,6 +152,8 @@ program
 program
   .command("version")
   .description("show the version with Node and platform info")
+  .option("--color", "force colored output")
+  .option("--no-color", "disable colored output (also honors NO_COLOR)")
   .action(versionAction);
 
 // HACK: when stdout is piped into a process that closes early (e.g.
@@ -162,7 +164,7 @@ process.stdout.on("error", (error: NodeJS.ErrnoException) => {
 });
 
 const knownCommands = program.commands.flatMap((command) => [command.name(), ...command.aliases()]);
-const argv = normalizeHelpInvocation(stripUnknownCliFlags(process.argv), knownCommands);
+const strippedArgv = stripUnknownCliFlags(process.argv);
 
 // HACK: Commander allows only one short flag on `--version` (we use `-v`),
 // so honor `-V` by scanning argv ourselves and printing the terse version
@@ -176,9 +178,13 @@ if (optionArguments.includes("-V")) {
   process.exit(0);
 }
 
-// Color must be resolved before Commander parses so the choice reaches
-// help output too.
-applyColorPreference(argv);
+// Resolve color from the stripped argv (before help-normalization drops
+// trailing tokens like `react-doctor help --no-color`) so the choice
+// reaches help output too.
+applyColorPreference(strippedArgv);
+
+// 12-factor (#1): map `help` / `help <command>` to Commander's `--help`.
+const argv = normalizeHelpInvocation(strippedArgv, knownCommands);
 
 program.parseAsync(argv).catch(async (error: unknown) => {
   await reportErrorToSentry(error);

--- a/packages/react-doctor/src/cli/utils/apply-color-preference.ts
+++ b/packages/react-doctor/src/cli/utils/apply-color-preference.ts
@@ -1,0 +1,33 @@
+import { setColorEnabled } from "@react-doctor/core";
+
+/**
+ * Resolve an explicit color preference from `--color` / `--no-color` or the
+ * app-specific `REACT_DOCTOR_NO_COLOR` / `REACT_DOCTOR_FORCE_COLOR` env vars
+ * (clig.dev Output; 12-factor #6), overriding picocolors' own
+ * `NO_COLOR` / `FORCE_COLOR` / `TERM` / TTY detection. Flags win over env
+ * vars; with neither set, picocolors' detection stands.
+ *
+ * Scanning argv directly (not Commander's parsed options) applies the
+ * preference once, before Commander parses, so it reaches every later path.
+ * The scan stops at `--` so a trailing positional can't flip it.
+ */
+export const applyColorPreference = (
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): void => {
+  let enabled: boolean | undefined;
+  for (const argument of argv) {
+    if (argument === "--") break;
+    // Last flag wins, matching how most CLIs resolve conflicting toggles.
+    if (argument === "--no-color") enabled = false;
+    else if (argument === "--color") enabled = true;
+  }
+
+  if (enabled === undefined) {
+    // Treat empty values as unset, matching the `NO_COLOR` convention.
+    if (env.REACT_DOCTOR_NO_COLOR) enabled = false;
+    else if (env.REACT_DOCTOR_FORCE_COLOR) enabled = true;
+  }
+
+  if (enabled !== undefined) setColorEnabled(enabled);
+};

--- a/packages/react-doctor/src/cli/utils/apply-color-preference.ts
+++ b/packages/react-doctor/src/cli/utils/apply-color-preference.ts
@@ -7,9 +7,12 @@ import { setColorEnabled } from "@react-doctor/core";
  * `NO_COLOR` / `FORCE_COLOR` / `TERM` / TTY detection. Flags win over env
  * vars; with neither set, picocolors' detection stands.
  *
- * Scanning argv directly (not Commander's parsed options) applies the
- * preference once, before Commander parses, so it reaches every later path.
- * The scan stops at `--` so a trailing positional can't flip it.
+ * A resolved preference is mirrored onto the standard `NO_COLOR` /
+ * `FORCE_COLOR` env vars in addition to our picocolors highlighter, so
+ * libraries with their own color stacks (the `ora` spinner, `prompts`)
+ * honor it too rather than only the scan report. Scanning argv directly
+ * (not Commander's parsed options) applies the preference before Commander
+ * parses, so it reaches every later path. The scan stops at `--`.
  */
 export const applyColorPreference = (
   argv: readonly string[],
@@ -29,5 +32,14 @@ export const applyColorPreference = (
     else if (env.REACT_DOCTOR_FORCE_COLOR) enabled = true;
   }
 
-  if (enabled !== undefined) setColorEnabled(enabled);
+  if (enabled === undefined) return;
+
+  if (enabled) {
+    env.FORCE_COLOR = "1";
+    delete env.NO_COLOR;
+  } else {
+    env.NO_COLOR = "1";
+    delete env.FORCE_COLOR;
+  }
+  setColorEnabled(enabled);
 };

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -2,6 +2,11 @@
 // (128 + signal number). Used by exit-gracefully.ts on SIGINT/SIGTERM.
 export const SIGINT_EXIT_CODE = 130;
 
+// Length of the `[node, script]` prefix that precedes user arguments in
+// `process.argv`. Shared by the argv processors (flag stripping, help
+// normalization, the `-V` alias).
+export const NODE_ARGUMENT_COUNT = 2;
+
 export const STAGED_FILES_TEMP_DIR_PREFIX = "react-doctor-staged-";
 
 export const GIT_HOOK_EXECUTABLE_MODE = 0o755;

--- a/packages/react-doctor/src/cli/utils/inspect-flags.ts
+++ b/packages/react-doctor/src/cli/utils/inspect-flags.ts
@@ -9,6 +9,7 @@ export interface InspectFlags {
   score?: boolean;
   json?: boolean;
   jsonCompact?: boolean;
+  telemetry?: boolean;
   yes?: boolean;
   full?: boolean;
   annotations?: boolean;

--- a/packages/react-doctor/src/cli/utils/normalize-help-command.ts
+++ b/packages/react-doctor/src/cli/utils/normalize-help-command.ts
@@ -12,8 +12,10 @@ import { NODE_ARGUMENT_COUNT } from "./constants.js";
  *   `react-doctor help install` -> `react-doctor install --help`
  *
  * Only a *leading* `help` token is rewritten, so a flag value such as
- * `--project help` is never mistaken for the help command. An unknown
- * target (`help bogus`) falls back to root help rather than erroring.
+ * `--project help` is never mistaken for the help command. The target is
+ * the first non-flag token after `help`, so intervening flags like
+ * `help --no-color install` still resolve to `install`. An unknown target
+ * (`help bogus`) falls back to root help rather than erroring.
  */
 export const normalizeHelpInvocation = (
   argv: readonly string[],
@@ -23,7 +25,7 @@ export const normalizeHelpInvocation = (
   const userArguments = argv.slice(NODE_ARGUMENT_COUNT);
   if (userArguments[0] !== "help") return [...argv];
 
-  const target = userArguments[1];
+  const target = userArguments.slice(1).find((argument) => !argument.startsWith("-"));
   if (target !== undefined && knownCommands.includes(target)) {
     return [...nodeArguments, target, "--help"];
   }

--- a/packages/react-doctor/src/cli/utils/normalize-help-command.ts
+++ b/packages/react-doctor/src/cli/utils/normalize-help-command.ts
@@ -1,0 +1,31 @@
+import { NODE_ARGUMENT_COUNT } from "./constants.js";
+
+/**
+ * 12-factor CLI Apps (#1, "Great help is essential"): `mycli help` and
+ * `mycli help <command>` must display help. Commander doesn't wire this
+ * up once the root command has its own default action plus a positional
+ * argument — it treats a leading `help` as the `[directory]` to scan,
+ * which then errors with "No React project found in ./help".
+ *
+ * We rewrite the argv up front so the existing `--help` paths handle it:
+ *   `react-doctor help`         -> `react-doctor --help`
+ *   `react-doctor help install` -> `react-doctor install --help`
+ *
+ * Only a *leading* `help` token is rewritten, so a flag value such as
+ * `--project help` is never mistaken for the help command. An unknown
+ * target (`help bogus`) falls back to root help rather than erroring.
+ */
+export const normalizeHelpInvocation = (
+  argv: readonly string[],
+  knownCommands: readonly string[],
+): string[] => {
+  const nodeArguments = argv.slice(0, NODE_ARGUMENT_COUNT);
+  const userArguments = argv.slice(NODE_ARGUMENT_COUNT);
+  if (userArguments[0] !== "help") return [...argv];
+
+  const target = userArguments[1];
+  if (target !== undefined && knownCommands.includes(target)) {
+    return [...nodeArguments, target, "--help"];
+  }
+  return [...nodeArguments, "--help"];
+};

--- a/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
@@ -33,7 +33,7 @@ export const resolveCliInspectOptions = (
     respectInlineDisables: flags.respectInlineDisables,
     warnings: flags.warnings ?? (wantsWarningGate ? true : undefined),
     scoreOnly: flags.score === true,
-    noScore: flags.score === false || (userConfig?.noScore ?? false),
+    noScore: flags.score === false || flags.telemetry === false || (userConfig?.noScore ?? false),
     isCi: isCiEnvironment(),
     silent: Boolean(flags.json),
     outputSurface: flags.prComment ? "prComment" : "cli",

--- a/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
+++ b/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
@@ -1,3 +1,5 @@
+import { NODE_ARGUMENT_COUNT } from "./constants.js";
+
 interface CliFlagSpec {
   readonly longOptionsWithoutValues: ReadonlySet<string>;
   readonly longOptionsWithRequiredValues: ReadonlySet<string>;
@@ -6,17 +8,17 @@ interface CliFlagSpec {
   readonly shortOptionsWithRequiredValues: ReadonlySet<string>;
 }
 
-const NODE_ARGUMENT_COUNT = 2;
-
 const ROOT_FLAG_SPEC: CliFlagSpec = {
   longOptionsWithoutValues: new Set([
     "--annotations",
+    "--color",
     "--dead-code",
     "--full",
     "--help",
     "--json",
     "--json-compact",
     "--lint",
+    "--no-color",
     "--no-dead-code",
     "--no-lint",
     "--no-respect-inline-disables",
@@ -44,7 +46,14 @@ const ROOT_FLAG_SPEC: CliFlagSpec = {
 };
 
 const INSTALL_FLAG_SPEC: CliFlagSpec = {
-  longOptionsWithoutValues: new Set(["--agent-hooks", "--dry-run", "--help", "--yes"]),
+  longOptionsWithoutValues: new Set([
+    "--agent-hooks",
+    "--color",
+    "--dry-run",
+    "--help",
+    "--no-color",
+    "--yes",
+  ]),
   longOptionsWithRequiredValues: new Set(["--cwd"]),
   longOptionsWithOptionalValues: new Set(),
   shortOptionsWithoutValues: new Set(["-h", "-y"]),

--- a/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
+++ b/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
@@ -60,9 +60,18 @@ const INSTALL_FLAG_SPEC: CliFlagSpec = {
   shortOptionsWithRequiredValues: new Set(["-c"]),
 };
 
+const VERSION_FLAG_SPEC: CliFlagSpec = {
+  longOptionsWithoutValues: new Set(["--color", "--help", "--no-color"]),
+  longOptionsWithRequiredValues: new Set(),
+  longOptionsWithOptionalValues: new Set(),
+  shortOptionsWithoutValues: new Set(["-h"]),
+  shortOptionsWithRequiredValues: new Set(),
+};
+
 const COMMAND_FLAG_SPECS = new Map<string, CliFlagSpec>([
   ["install", INSTALL_FLAG_SPEC],
   ["setup", INSTALL_FLAG_SPEC],
+  ["version", VERSION_FLAG_SPEC],
 ]);
 
 const isFlagLike = (argument: string): boolean => argument.startsWith("-") && argument !== "-";

--- a/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
+++ b/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
@@ -23,6 +23,7 @@ const ROOT_FLAG_SPEC: CliFlagSpec = {
     "--no-lint",
     "--no-respect-inline-disables",
     "--no-score",
+    "--no-telemetry",
     "--no-warnings",
     "--pr-comment",
     "--respect-inline-disables",

--- a/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
+++ b/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
@@ -20,6 +20,11 @@ export const validateModeFlags = (flags: InspectFlags): void => {
   if (flags.score && flags.json) {
     throw new Error("Cannot combine --score and --json; pick one output mode.");
   }
+  if (flags.score && flags.telemetry === false) {
+    throw new Error(
+      "Cannot combine --score with --no-telemetry; --score prints the score that --no-telemetry disables.",
+    );
+  }
   if (flags.prComment && (flags.json || flags.score)) {
     throw new Error("--pr-comment cannot be combined with --json or --score.");
   }

--- a/packages/react-doctor/src/instrument.ts
+++ b/packages/react-doctor/src/instrument.ts
@@ -5,9 +5,10 @@ import { VERSION } from "./cli/utils/version.js";
 let isInitialized = false;
 
 const shouldEnableSentry = (): boolean => {
-  // `--no-score` opts out of crash reporting. Read from raw argv because
-  // Sentry initializes before Commander parses.
-  if (process.argv.includes("--no-score")) return false;
+  // `--no-score` (and its `--no-telemetry` alias) opts out of crash
+  // reporting. Read from raw argv because Sentry initializes before
+  // Commander parses.
+  if (process.argv.includes("--no-score") || process.argv.includes("--no-telemetry")) return false;
   // Never phone home from this repo's own test runs (the e2e suite
   // spawns the built CLI as a subprocess, which inherits VITEST).
   if (process.env.VITEST || process.env.NODE_ENV === "test") return false;

--- a/packages/react-doctor/tests/apply-color-preference.test.ts
+++ b/packages/react-doctor/tests/apply-color-preference.test.ts
@@ -22,33 +22,42 @@ afterEach(() => {
 });
 
 describe("applyColorPreference", () => {
-  it("disables color when --no-color is present", () => {
+  it("disables color and sets NO_COLOR when --no-color is present", () => {
     setColorEnabled(true);
-    applyColorPreference(["node", "react-doctor", ".", "--no-color"]);
+    const env: NodeJS.ProcessEnv = {};
+    applyColorPreference(["node", "react-doctor", ".", "--no-color"], env);
     expect(hasAnsi(highlighter.info("x"))).toBe(false);
+    expect(env.NO_COLOR).toBe("1");
+    expect(env.FORCE_COLOR).toBeUndefined();
   });
 
-  it("forces color on when --color is present", () => {
+  it("forces color and sets FORCE_COLOR when --color is present", () => {
     setColorEnabled(false);
-    applyColorPreference(["node", "react-doctor", ".", "--color"]);
+    const env: NodeJS.ProcessEnv = { NO_COLOR: "1" };
+    applyColorPreference(["node", "react-doctor", ".", "--color"], env);
     expect(hasAnsi(highlighter.info("x"))).toBe(true);
+    expect(env.FORCE_COLOR).toBe("1");
+    expect(env.NO_COLOR).toBeUndefined();
   });
 
-  it("leaves the current color state untouched when neither flag is passed", () => {
+  it("leaves color and env untouched when neither flag nor env var is set", () => {
     setColorEnabled(false);
-    applyColorPreference(["node", "react-doctor", "."]);
+    const env: NodeJS.ProcessEnv = {};
+    applyColorPreference(["node", "react-doctor", "."], env);
     expect(hasAnsi(highlighter.info("x"))).toBe(false);
+    expect(env.NO_COLOR).toBeUndefined();
+    expect(env.FORCE_COLOR).toBeUndefined();
   });
 
   it("lets the last flag win when both are passed", () => {
     setColorEnabled(true);
-    applyColorPreference(["node", "react-doctor", "--color", "--no-color"]);
+    applyColorPreference(["node", "react-doctor", "--color", "--no-color"], {});
     expect(hasAnsi(highlighter.info("x"))).toBe(false);
   });
 
   it("ignores color flags that appear after the -- end-of-options marker", () => {
     setColorEnabled(true);
-    applyColorPreference(["node", "react-doctor", "--", "--no-color"]);
+    applyColorPreference(["node", "react-doctor", "--", "--no-color"], {});
     expect(hasAnsi(highlighter.info("x"))).toBe(true);
   });
 

--- a/packages/react-doctor/tests/apply-color-preference.test.ts
+++ b/packages/react-doctor/tests/apply-color-preference.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
+import { highlighter, setColorEnabled } from "@react-doctor/core";
+import { applyColorPreference } from "../src/cli/utils/apply-color-preference.js";
+
+const hasAnsi = (text: string): boolean => text.includes("\u001B[");
+
+// `setColorEnabled` mutates a process-wide singleton, so each case runs
+// from an explicit state and the original (ambient) state is restored
+// afterwards, keeping this file from leaking forced color into others.
+let originalColorEnabled = false;
+
+beforeAll(() => {
+  originalColorEnabled = hasAnsi(highlighter.info("x"));
+});
+
+afterAll(() => {
+  setColorEnabled(originalColorEnabled);
+});
+
+afterEach(() => {
+  setColorEnabled(originalColorEnabled);
+});
+
+describe("applyColorPreference", () => {
+  it("disables color when --no-color is present", () => {
+    setColorEnabled(true);
+    applyColorPreference(["node", "react-doctor", ".", "--no-color"]);
+    expect(hasAnsi(highlighter.info("x"))).toBe(false);
+  });
+
+  it("forces color on when --color is present", () => {
+    setColorEnabled(false);
+    applyColorPreference(["node", "react-doctor", ".", "--color"]);
+    expect(hasAnsi(highlighter.info("x"))).toBe(true);
+  });
+
+  it("leaves the current color state untouched when neither flag is passed", () => {
+    setColorEnabled(false);
+    applyColorPreference(["node", "react-doctor", "."]);
+    expect(hasAnsi(highlighter.info("x"))).toBe(false);
+  });
+
+  it("lets the last flag win when both are passed", () => {
+    setColorEnabled(true);
+    applyColorPreference(["node", "react-doctor", "--color", "--no-color"]);
+    expect(hasAnsi(highlighter.info("x"))).toBe(false);
+  });
+
+  it("ignores color flags that appear after the -- end-of-options marker", () => {
+    setColorEnabled(true);
+    applyColorPreference(["node", "react-doctor", "--", "--no-color"]);
+    expect(hasAnsi(highlighter.info("x"))).toBe(true);
+  });
+
+  it("honors REACT_DOCTOR_NO_COLOR when no flag is passed", () => {
+    setColorEnabled(true);
+    applyColorPreference(["node", "react-doctor", "."], { REACT_DOCTOR_NO_COLOR: "1" });
+    expect(hasAnsi(highlighter.info("x"))).toBe(false);
+  });
+
+  it("honors REACT_DOCTOR_FORCE_COLOR when no flag is passed", () => {
+    setColorEnabled(false);
+    applyColorPreference(["node", "react-doctor", "."], { REACT_DOCTOR_FORCE_COLOR: "1" });
+    expect(hasAnsi(highlighter.info("x"))).toBe(true);
+  });
+
+  it("lets an explicit flag win over the env var", () => {
+    setColorEnabled(false);
+    applyColorPreference(["node", "react-doctor", "--color"], { REACT_DOCTOR_NO_COLOR: "1" });
+    expect(hasAnsi(highlighter.info("x"))).toBe(true);
+  });
+
+  it("treats an empty env value as unset", () => {
+    setColorEnabled(true);
+    applyColorPreference(["node", "react-doctor", "."], { REACT_DOCTOR_NO_COLOR: "" });
+    expect(hasAnsi(highlighter.info("x"))).toBe(true);
+  });
+});

--- a/packages/react-doctor/tests/normalize-help-command.test.ts
+++ b/packages/react-doctor/tests/normalize-help-command.test.ts
@@ -21,6 +21,11 @@ describe("normalizeHelpInvocation", () => {
     expect(normalize(["help", "bogus"])).toEqual(["--help"]);
   });
 
+  it("finds the subcommand target past intervening flags", () => {
+    expect(normalize(["help", "--no-color", "install"])).toEqual(["install", "--help"]);
+    expect(normalize(["help", "--no-color"])).toEqual(["--help"]);
+  });
+
   it("leaves a non-leading `help` token untouched (e.g. a flag value)", () => {
     expect(normalize(["--project", "help"])).toEqual(["--project", "help"]);
     expect(normalize(["."])).toEqual(["."]);

--- a/packages/react-doctor/tests/normalize-help-command.test.ts
+++ b/packages/react-doctor/tests/normalize-help-command.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vite-plus/test";
+import { normalizeHelpInvocation } from "../src/cli/utils/normalize-help-command.js";
+
+const KNOWN_COMMANDS = ["install", "setup", "version"];
+
+const normalize = (userArguments: ReadonlyArray<string>): string[] =>
+  normalizeHelpInvocation(["node", "react-doctor", ...userArguments], KNOWN_COMMANDS).slice(2);
+
+describe("normalizeHelpInvocation", () => {
+  it("rewrites a bare `help` into the root `--help`", () => {
+    expect(normalize(["help"])).toEqual(["--help"]);
+  });
+
+  it("rewrites `help <command>` into `<command> --help`", () => {
+    expect(normalize(["help", "install"])).toEqual(["install", "--help"]);
+    expect(normalize(["help", "setup"])).toEqual(["setup", "--help"]);
+    expect(normalize(["help", "version"])).toEqual(["version", "--help"]);
+  });
+
+  it("falls back to root help when the target is not a known command", () => {
+    expect(normalize(["help", "bogus"])).toEqual(["--help"]);
+  });
+
+  it("leaves a non-leading `help` token untouched (e.g. a flag value)", () => {
+    expect(normalize(["--project", "help"])).toEqual(["--project", "help"]);
+    expect(normalize(["."])).toEqual(["."]);
+  });
+
+  it("does not treat `help` as a command target argument", () => {
+    // `help install` is help-for-install, never a directory scan.
+    expect(normalize(["help", "install"])).not.toContain(".");
+  });
+});

--- a/packages/react-doctor/tests/resolve-cli-inspect-options.test.ts
+++ b/packages/react-doctor/tests/resolve-cli-inspect-options.test.ts
@@ -1,20 +1,91 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import { resolveCliInspectOptions } from "../src/cli/utils/resolve-cli-inspect-options.js";
 
-describe("resolveCliInspectOptions — noScore", () => {
-  it("opts out of scoring when --no-score is passed (flags.score === false)", () => {
-    expect(resolveCliInspectOptions({ score: false }, null).noScore).toBe(true);
+const CI_ENVIRONMENT_VARIABLES = ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"] as const;
+
+describe("resolveCliInspectOptions: CI behavior (issue #302)", () => {
+  let savedEnvironment: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnvironment = {};
+    for (const envVariable of CI_ENVIRONMENT_VARIABLES) {
+      savedEnvironment[envVariable] = process.env[envVariable];
+      delete process.env[envVariable];
+    }
   });
 
-  it("opts out of scoring via the --no-telemetry alias (flags.telemetry === false)", () => {
+  afterEach(() => {
+    for (const envVariable of CI_ENVIRONMENT_VARIABLES) {
+      const previousValue = savedEnvironment[envVariable];
+      if (previousValue === undefined) {
+        delete process.env[envVariable];
+      } else {
+        process.env[envVariable] = previousValue;
+      }
+    }
+  });
+
+  it("does not auto-disable scoring in CI; the score path still runs", () => {
+    process.env.GITHUB_ACTIONS = "true";
+
+    const resolved = resolveCliInspectOptions({}, null);
+
+    expect(resolved.noScore).toBe(false);
+    expect(resolved.isCi).toBe(true);
+  });
+
+  it("respects an explicit user opt-out (CLI flag or config) in CI", () => {
+    process.env.GITHUB_ACTIONS = "true";
+
+    expect(resolveCliInspectOptions({ score: false }, null).noScore).toBe(true);
+    expect(resolveCliInspectOptions({}, { noScore: true }).noScore).toBe(true);
+  });
+
+  it("leaves isCi false outside CI", () => {
+    expect(resolveCliInspectOptions({}, null).isCi).toBe(false);
+  });
+
+  it("detects GITHUB_ACTIONS, GITLAB_CI, and CIRCLECI", () => {
+    for (const envVariable of ["GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"] as const) {
+      process.env[envVariable] = "true";
+      expect(resolveCliInspectOptions({}, null).isCi).toBe(true);
+      delete process.env[envVariable];
+    }
+  });
+});
+
+describe("resolveCliInspectOptions: warnings vs --fail-on", () => {
+  it("leaves warnings unset by default (hidden via the inspect() default)", () => {
+    expect(resolveCliInspectOptions({}, null).warnings).toBeUndefined();
+  });
+
+  it("forces warnings on for --fail-on warning (flag or config) so the gate can fire", () => {
+    expect(resolveCliInspectOptions({ failOn: "warning" }, null).warnings).toBe(true);
+    expect(resolveCliInspectOptions({}, { failOn: "warning" }).warnings).toBe(true);
+  });
+
+  it("does not set warnings when failing on errors", () => {
+    expect(resolveCliInspectOptions({ failOn: "error" }, null).warnings).toBeUndefined();
+  });
+
+  it("respects an explicit --no-warnings even with --fail-on warning", () => {
+    expect(resolveCliInspectOptions({ failOn: "warning", warnings: false }, null).warnings).toBe(
+      false,
+    );
+  });
+
+  it("respects an explicit --warnings", () => {
+    expect(resolveCliInspectOptions({ warnings: true }, null).warnings).toBe(true);
+  });
+});
+
+describe("resolveCliInspectOptions: --no-telemetry alias", () => {
+  it("opts out of scoring via --no-telemetry (flags.telemetry === false), like --no-score", () => {
     expect(resolveCliInspectOptions({ telemetry: false }, null).noScore).toBe(true);
+    expect(resolveCliInspectOptions({ score: false }, null).noScore).toBe(true);
   });
 
   it("keeps scoring on by default", () => {
     expect(resolveCliInspectOptions({}, null).noScore).toBe(false);
-  });
-
-  it("inherits noScore from user config when no flag is passed", () => {
-    expect(resolveCliInspectOptions({}, { noScore: true }).noScore).toBe(true);
   });
 });

--- a/packages/react-doctor/tests/resolve-cli-inspect-options.test.ts
+++ b/packages/react-doctor/tests/resolve-cli-inspect-options.test.ts
@@ -1,80 +1,20 @@
-import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from "vite-plus/test";
 import { resolveCliInspectOptions } from "../src/cli/utils/resolve-cli-inspect-options.js";
 
-const CI_ENVIRONMENT_VARIABLES = ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"] as const;
-
-describe("resolveCliInspectOptions: CI behavior (issue #302)", () => {
-  let savedEnvironment: Record<string, string | undefined>;
-
-  beforeEach(() => {
-    savedEnvironment = {};
-    for (const envVariable of CI_ENVIRONMENT_VARIABLES) {
-      savedEnvironment[envVariable] = process.env[envVariable];
-      delete process.env[envVariable];
-    }
-  });
-
-  afterEach(() => {
-    for (const envVariable of CI_ENVIRONMENT_VARIABLES) {
-      const previousValue = savedEnvironment[envVariable];
-      if (previousValue === undefined) {
-        delete process.env[envVariable];
-      } else {
-        process.env[envVariable] = previousValue;
-      }
-    }
-  });
-
-  it("does not auto-disable scoring in CI; the score path still runs", () => {
-    process.env.GITHUB_ACTIONS = "true";
-
-    const resolved = resolveCliInspectOptions({}, null);
-
-    expect(resolved.noScore).toBe(false);
-    expect(resolved.isCi).toBe(true);
-  });
-
-  it("respects an explicit user opt-out (CLI flag or config) in CI", () => {
-    process.env.GITHUB_ACTIONS = "true";
-
+describe("resolveCliInspectOptions — noScore", () => {
+  it("opts out of scoring when --no-score is passed (flags.score === false)", () => {
     expect(resolveCliInspectOptions({ score: false }, null).noScore).toBe(true);
+  });
+
+  it("opts out of scoring via the --no-telemetry alias (flags.telemetry === false)", () => {
+    expect(resolveCliInspectOptions({ telemetry: false }, null).noScore).toBe(true);
+  });
+
+  it("keeps scoring on by default", () => {
+    expect(resolveCliInspectOptions({}, null).noScore).toBe(false);
+  });
+
+  it("inherits noScore from user config when no flag is passed", () => {
     expect(resolveCliInspectOptions({}, { noScore: true }).noScore).toBe(true);
-  });
-
-  it("leaves isCi false outside CI", () => {
-    expect(resolveCliInspectOptions({}, null).isCi).toBe(false);
-  });
-
-  it("detects GITHUB_ACTIONS, GITLAB_CI, and CIRCLECI", () => {
-    for (const envVariable of ["GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"] as const) {
-      process.env[envVariable] = "true";
-      expect(resolveCliInspectOptions({}, null).isCi).toBe(true);
-      delete process.env[envVariable];
-    }
-  });
-});
-
-describe("resolveCliInspectOptions: warnings vs --fail-on", () => {
-  it("leaves warnings unset by default (hidden via the inspect() default)", () => {
-    expect(resolveCliInspectOptions({}, null).warnings).toBeUndefined();
-  });
-
-  it("forces warnings on for --fail-on warning (flag or config) so the gate can fire", () => {
-    expect(resolveCliInspectOptions({ failOn: "warning" }, null).warnings).toBe(true);
-    expect(resolveCliInspectOptions({}, { failOn: "warning" }).warnings).toBe(true);
-  });
-
-  it("does not set warnings when failing on errors", () => {
-    expect(resolveCliInspectOptions({ failOn: "error" }, null).warnings).toBeUndefined();
-  });
-
-  it("respects an explicit --no-warnings even with --fail-on warning", () => {
-    expect(resolveCliInspectOptions({ failOn: "warning", warnings: false }, null).warnings).toBe(
-      false,
-    );
-  });
-
-  it("respects an explicit --warnings", () => {
-    expect(resolveCliInspectOptions({ warnings: true }, null).warnings).toBe(true);
   });
 });

--- a/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
+++ b/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
@@ -53,4 +53,15 @@ describe("stripUnknownCliFlags", () => {
   it("keeps an optional-value flag followed by another flag", () => {
     expect(stripUserArguments(["--diff", "--json"])).toEqual(["--diff", "--json"]);
   });
+
+  it("keeps the --color / --no-color flags so the color resolver can see them", () => {
+    expect(stripUserArguments([".", "--color"])).toEqual([".", "--color"]);
+    expect(stripUserArguments([".", "--no-color"])).toEqual([".", "--no-color"]);
+    expect(stripUserArguments(["install", "--no-color", "--cwd", "."])).toEqual([
+      "install",
+      "--no-color",
+      "--cwd",
+      ".",
+    ]);
+  });
 });

--- a/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
+++ b/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
@@ -64,4 +64,10 @@ describe("stripUnknownCliFlags", () => {
       ".",
     ]);
   });
+
+  it("keeps color flags on the version subcommand and drops unknown ones", () => {
+    expect(stripUserArguments(["version", "--no-color"])).toEqual(["version", "--no-color"]);
+    expect(stripUserArguments(["version", "--color"])).toEqual(["version", "--color"]);
+    expect(stripUserArguments(["version", "--offline"])).toEqual(["version"]);
+  });
 });

--- a/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
+++ b/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
@@ -65,6 +65,10 @@ describe("stripUnknownCliFlags", () => {
     ]);
   });
 
+  it("keeps the --no-telemetry alias for --no-score", () => {
+    expect(stripUserArguments([".", "--no-telemetry"])).toEqual([".", "--no-telemetry"]);
+  });
+
   it("keeps color flags on the version subcommand and drops unknown ones", () => {
     expect(stripUserArguments(["version", "--no-color"])).toEqual(["version", "--no-color"]);
     expect(stripUserArguments(["version", "--color"])).toEqual(["version", "--color"]);

--- a/packages/react-doctor/tests/validate-mode-flags.test.ts
+++ b/packages/react-doctor/tests/validate-mode-flags.test.ts
@@ -17,4 +17,14 @@ describe("validateModeFlags", () => {
       "--pr-comment cannot be combined with --json or --score.",
     );
   });
+
+  it("rejects --score combined with --no-telemetry (contradictory intent)", () => {
+    expect(() => validateModeFlags({ score: true, telemetry: false })).toThrow(
+      "Cannot combine --score with --no-telemetry",
+    );
+  });
+
+  it("allows --no-telemetry without --score", () => {
+    expect(() => validateModeFlags({ telemetry: false })).not.toThrow();
+  });
 });

--- a/packages/react-doctor/tests/version-command.test.ts
+++ b/packages/react-doctor/tests/version-command.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildVersionString } from "../src/cli/commands/version.js";
+import { VERSION } from "../src/cli/utils/version.js";
+
+describe("buildVersionString", () => {
+  it("includes the CLI version, platform/arch, and Node version for debugging", () => {
+    const versionString = buildVersionString();
+    expect(versionString).toContain(`react-doctor/${VERSION}`);
+    expect(versionString).toContain(`${process.platform}-${process.arch}`);
+    expect(versionString).toContain(`node-${process.version}`);
+  });
+
+  it("is a single line", () => {
+    expect(buildVersionString()).not.toContain("\n");
+  });
+});


### PR DESCRIPTION
## Why

Bring the `react-doctor` CLI in line with the [clig.dev](https://clig.dev/) and [12-factor CLI Apps](https://jdxcode.medium.com/12-factor-cli-apps-dd3c227a0e46) guidelines. Three concrete gaps:

1. **`help` was broken** — `react-doctor help` tried to scan a directory named `help` and errored.
2. **No color control** — picocolors auto-detected `NO_COLOR`/TTY, but there was no `--color`/`--no-color` override or app-specific env toggle.
3. **Thin version surface + example-less help** — only terse `-v`/`--version`; no `version` subcommand, no `-V`, and `--help` had zero examples (clig.dev's top Help guideline is "lead with examples").

Before:

```console
$ react-doctor help
Something went wrong…
No React project found in /…/help. Expected a package.json…

$ react-doctor --no-color    # silently stripped, no effect
$ react-doctor version       # tried to scan ./version
```

After:

```console
$ react-doctor help                 # root help
$ react-doctor help install         # install help
$ react-doctor --no-color           # disables color across all output
$ react-doctor version
react-doctor/0.2.14 darwin-arm64 node-v24.14.0
$ react-doctor -V
0.2.14
```

## What changed

- **Color control** — `--color` / `--no-color` flags plus app-specific `REACT_DOCTOR_NO_COLOR` / `REACT_DOCTOR_FORCE_COLOR` env vars, resolved before Commander parses so the choice reaches every surface (scan report, branded header, score, prompts, errors). Flags win over env vars, which win over picocolors' built-in `NO_COLOR`/`FORCE_COLOR`/`TERM`/TTY detection. Backed by a new `@react-doctor/core` `setColorEnabled()` toggle.
- **Examples-led help** — root and `install` `--help` now open with aligned `Examples:` blocks and a "Feedback & bug reports" link (rendered lazily so they honor the color preference).
- **`version` subcommand + `-V`** — `react-doctor version` prints version + Node + platform for debugging; `-v` / `-V` / `--version` stay terse for scripts.
- **`help` / `help <command>`** — normalized in the bootstrap to the existing `--help` paths instead of being swallowed by the default scan action.
- Allowed the new flags through the pre-parse flag stripper and consolidated the shared `NODE_ARGUMENT_COUNT` argv constant into `constants.ts`.

## Eval results

Not applicable — this is a CLI/UX change, not a lint rule, so the RDE rule-eval harness was not run.

## Test plan

- [x] react-doctor suite green — `pnpm --filter react-doctor exec vp test run tests/` (1453 passed)
- [x] New unit tests pass (22): `apply-color-preference`, `normalize-help-command`, `version-command`, extended `strip-unknown-cli-flags`
- [x] `pnpm --filter react-doctor typecheck`
- [x] `pnpm exec vp lint` (changed files) + `pnpm exec vp fmt --check`
- [x] `pnpm smoke:json-report`
- [x] Manual smoke: `help`, `help install`, `version`, `-v`/`-V`/`--version`, `--color`/`--no-color` (ANSI on/off verified when piped), `REACT_DOCTOR_FORCE_COLOR=1`

> Pre-existing failures on the merged base — `core/check-expo-project` (environment-specific: a global `~/.config/git/ignore` that lists `.env.local`) and `oxlint-plugin-react-doctor/no-multi-comp` — are in files untouched by this PR and unrelated to it.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI bootstrap, help text, and output coloring; telemetry opt-out extends existing --no-score behavior without altering scan logic.
> 
> **Overview**
> Aligns the **react-doctor** CLI with clig.dev / 12-factor UX: explicit **color control**, fixed **help** routing, richer **version** output, and clearer opt-out wording for score/telemetry.
> 
> **Color** — Adds `--color` / `--no-color` on the default scan, `install`, and `version` flows, plus `REACT_DOCTOR_FORCE_COLOR` / `REACT_DOCTOR_NO_COLOR`. Preference is resolved from **stripped argv before Commander runs** (so help epilogs respect it), updates the shared `highlighter` via new `setColorEnabled()` in `@react-doctor/core`, and mirrors the choice onto `FORCE_COLOR` / `NO_COLOR` for spinners and prompts. Last flag wins; tokens after `--` are ignored.
> 
> **Help** — Rewrites leading `help` / `help <command>` to `--help` / `<command> --help` so users no longer scan a directory named `help`. Root and `install` help now **lead with example commands** (lazy epilog renderers) and add a feedback/issues link.
> 
> **Version** — New `react-doctor version` prints `react-doctor/<ver> <platform>-<arch> node-<node>`; standalone **`-V`** prints the bare version before parse (alongside existing `-v` / `--version`).
> 
> **Telemetry alias** — `--no-telemetry` aliases `--no-score` (score API, share URL, Sentry); inspect resolution and early Sentry init honor it; `--score` + `--no-telemetry` is rejected. Flag stripper knows the new flags and `version` subcommand spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a931264f27b66ebc0a6a884c697456aa22640840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->