### PR TITLE
feat(cli): symbolicate Sentry crash traces via runtime sourcemaps

### DIFF
--- a/.changeset/cli-sourcemaps.md
+++ b/.changeset/cli-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Ship an external sourcemap for the CLI bundle (`dist/cli.js.map`) and enable Node's source-map support in the `react-doctor` bin. Uncaught errors captured by Sentry now resolve to original-TypeScript source positions instead of bundled `dist/cli.js` offsets, making crash stack traces triage-able. The map is external (not inlined) and read lazily by Node only when a stack trace is materialized — i.e. on a crash — so the no-crash path has no added startup cost. Symbolication happens at runtime on the user's machine; no sourcemap upload step is involved.

--- a/packages/react-doctor/bin/react-doctor.js
+++ b/packages/react-doctor/bin/react-doctor.js
@@ -10,4 +10,16 @@ if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   }
 }
 
+// Rewrite Error.stack with original-TypeScript positions from
+// dist/cli.js.map, so uncaught errors reported to Sentry point at source
+// files rather than the bundled dist/cli.js. This MUST run before the
+// dist/cli.js import below: Node caches each module's sourcemap at compile
+// time, so flipping this on from inside the already-loaded bundle would be
+// too late for the bundle's own frames. Node then reads the map lazily on
+// first stack access, so the happy path is free. Guarded like
+// enableCompileCache above so a runtime without the API can't crash the CLI.
+if (process.setSourceMapsEnabled) {
+  process.setSourceMapsEnabled(true);
+}
+
 await import("../dist/cli.js");

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -33,6 +33,7 @@
   "files": [
     "bin/**",
     "dist/**/*.js",
+    "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "dist/skills/**"
   ],

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -92,6 +92,16 @@ export default defineConfig({
       dts: true,
       target: "node20",
       platform: "node",
+      // Emit dist/cli.js.map (plus a sourceMappingURL comment) so crash
+      // reports reach Sentry with original-TypeScript frames instead of
+      // bundled dist/cli.js positions. The bin shim flips on Node's
+      // source-map support, which rewrites Error.stack using this map
+      // before @sentry/node reads it. Keep it external (not 'inline'):
+      // dist/cli.js stays lean and Node only reads the map lazily when a
+      // stack is materialized (i.e. on a crash), so startup pays nothing.
+      // Only this CLI entry emits a map — the API entry below doesn't, and
+      // never initializes Sentry.
+      sourcemap: true,
       env: {
         VERSION: process.env.VERSION ?? packageJson.version,
       },


### PR DESCRIPTION
cc @rayhanadev

## What

Crash reports added in #621 currently land in Sentry with frames pointing at the bundled `dist/cli.js` (offsets like `cli.js:1:48572`), which aren't triage-able. This wires up **on-device sourcemap symbolication** so traces resolve to original-TypeScript positions (`src/cli/...ts:line:col`).

## How

| File | Change |
|------|--------|
| `vite.config.ts` | `sourcemap: true` on the **CLI** pack entry only → emits `dist/cli.js.map` + a `sourceMappingURL` comment. The API entry stays map-free (it never initializes Sentry). |
| `package.json` | Added `dist/**/*.js.map` to `files` so the map ships in the npm tarball. |
| `bin/react-doctor.js` | `process.setSourceMapsEnabled(true)` before the `import`, so Node rewrites `Error.stack` to original positions before `@sentry/node` reads it. |
| `.changeset/cli-sourcemaps.md` | `patch` bump. |

### Why the bin shim, and why before the import

`setSourceMapsEnabled` is a process-global switch, and **Node caches a module's sourcemap at compile time** — so it must be flipped on *before* `dist/cli.js` is compiled by the `import()`. Putting it inside the bundled TS would be too late for the bundle's own frames. Verified empirically (enable-before → frame maps to source; enable-after → frame stays on the bundled file). The call is guarded like `enableCompileCache` so an exotic/old runtime can't crash the CLI for the sake of an observability nicety.

## Tradeoffs

- **External, not inline** — keeps `dist/cli.js` lean; Node reads the map *lazily*, only when a stack is materialized (i.e. on a crash), so the no-crash path has **zero** added startup cost.
- **No upload step** — symbolication is on-device; nothing is sent to Sentry's artifact store. (Debug-IDs + release upload remain a future option if we want server-side symbolication with context lines.)
- **No context lines** — frames show file/line/function but no code snippet, since the original `.ts` files aren't shipped. Frame paths will include the user's local install path, consistent with the existing `sendDefaultPii: true` posture.

## Testing

⚠️ Not built locally — this was authored in a worktree without installed deps. CI will build it; worth confirming `pnpm build` emits `dist/cli.js.map` + the `sourceMappingURL` comment, then triggering a deliberate throw to eyeball a symbolicated Sentry event before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)