### PR TITLE
fix(oxlint-plugin-react-doctor): declare oxc-parser as a runtime dependency

### DIFF
--- a/.changeset/fix-oxc-parser-runtime-dependency.md
+++ b/.changeset/fix-oxc-parser-runtime-dependency.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `react-doctor@latest` (and the ESLint/oxlint plugins) crashing before the scan starts with `ERR_MODULE_NOT_FOUND: Cannot find package 'oxc-parser'` under strict package managers like pnpm. The published `oxlint-plugin-react-doctor/dist/index.js` performs a runtime `import { parseSync } from "oxc-parser"` (cross-file parsing for rules like `no-mutating-reducer-state`) and the build intentionally keeps `oxc-parser` external, but the package only declared it under `devDependencies`, so consumers never had it installed. `oxc-parser` is now a real `dependency`. See #629.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,16 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '22.18.0' }}
         run: pnpm smoke:json-report
 
+      # Regression guard for #629: a published package's built output must not
+      # import a package that isn't in its `dependencies` (such phantom imports
+      # only resolve when a sibling dependency happens to supply them, and crash
+      # consumers on strict installs). Builds every package, then audits dist.
+      - name: Check published packages declare their runtime dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '22.18.0' }}
+        run: |
+          pnpm build
+          pnpm check:published-deps
+
       # Allocates a real pseudo-terminal (`pty.openpty()`) so the CLI sees an
       # interactive TTY and renders the multiselect prompt, then asserts the
       # process stays alive waiting for input instead of exiting by itself

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "check": "vp check",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "pnpm build && node scripts/sentry-sourcemaps.mjs && changeset publish",
+    "release": "pnpm build && pnpm check:published-deps && node scripts/sentry-sourcemaps.mjs && changeset publish",
+    "check:published-deps": "node --experimental-strip-types --no-warnings scripts/check-published-deps.ts",
     "smoke:json-report": "node --experimental-strip-types --no-warnings scripts/smoke-json-report.ts",
     "smoke:tty-prompt": "python3 scripts/smoke-tty-prompt.py",
     "build:schema": "node --experimental-strip-types --no-warnings scripts/generate-config-schema.ts"

--- a/packages/oxlint-plugin-react-doctor/package.json
+++ b/packages/oxlint-plugin-react-doctor/package.json
@@ -54,11 +54,11 @@
   "dependencies": {
     "@typescript-eslint/types": "^8.59.3",
     "eslint-scope": "^9.1.2",
-    "eslint-visitor-keys": "^5.0.1"
+    "eslint-visitor-keys": "^5.0.1",
+    "oxc-parser": "^0.132.0"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0",
-    "oxc-parser": "^0.132.0"
+    "@types/node": "^25.6.0"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,13 +123,13 @@ importers:
       eslint-visitor-keys:
         specifier: ^5.0.1
         version: 5.0.1
+      oxc-parser:
+        specifier: ^0.132.0
+        version: 0.132.0
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
-      oxc-parser:
-        specifier: ^0.132.0
-        version: 0.132.0
 
   packages/react-doctor:
     dependencies:

--- a/scripts/check-published-deps.ts
+++ b/scripts/check-published-deps.ts
@@ -1,0 +1,197 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = resolve(SCRIPT_DIRECTORY, "..");
+const PACKAGES_DIRECTORY = resolve(REPOSITORY_ROOT, "packages");
+const PUBLISHED_ARTIFACT_DIRECTORIES: readonly string[] = ["dist", "bin"];
+const JAVASCRIPT_EXTENSIONS: ReadonlySet<string> = new Set([".js", ".mjs", ".cjs"]);
+const NODE_BUILTIN_MODULES: ReadonlySet<string> = new Set([
+  ...builtinModules,
+  ...builtinModules.map((moduleName) => `node:${moduleName}`),
+]);
+
+interface PackageManifest {
+  readonly name: string;
+  readonly private?: boolean;
+  readonly dependencies?: Record<string, string>;
+  readonly peerDependencies?: Record<string, string>;
+  readonly optionalDependencies?: Record<string, string>;
+}
+
+interface PhantomDependency {
+  readonly importedPackage: string;
+  readonly importingFiles: readonly string[];
+}
+
+interface PackageAuditResult {
+  readonly manifest: PackageManifest;
+  readonly externalImports: readonly string[];
+  readonly phantomDependencies: readonly PhantomDependency[];
+  readonly artifactFileCount: number;
+}
+
+const readManifest = (packageDirectory: string): PackageManifest =>
+  JSON.parse(readFileSync(join(packageDirectory, "package.json"), "utf8"));
+
+const toPackageName = (moduleSpecifier: string): string => {
+  const segments = moduleSpecifier.split("/");
+  return moduleSpecifier.startsWith("@") ? segments.slice(0, 2).join("/") : segments[0];
+};
+
+const isBareSpecifier = (moduleSpecifier: string): boolean =>
+  Boolean(moduleSpecifier) && !moduleSpecifier.startsWith(".") && !moduleSpecifier.startsWith("/");
+
+const collectJavaScriptFiles = (directory: string): string[] => {
+  if (!existsSync(directory)) return [];
+  const javaScriptFiles: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      javaScriptFiles.push(...collectJavaScriptFiles(entryPath));
+    } else if (entry.isFile() && JAVASCRIPT_EXTENSIONS.has(extname(entry.name))) {
+      javaScriptFiles.push(entryPath);
+    }
+  }
+  return javaScriptFiles;
+};
+
+const collectModuleSpecifiers = (sourceText: string, fileName: string): Set<string> => {
+  const moduleSpecifiers = new Set<string>();
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS,
+  );
+  const visitNode = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      moduleSpecifiers.add(node.moduleSpecifier.text);
+    } else if (ts.isCallExpression(node)) {
+      const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+      const isRequireCall = ts.isIdentifier(node.expression) && node.expression.text === "require";
+      const [firstArgument] = node.arguments;
+      if (
+        (isDynamicImport || isRequireCall) &&
+        firstArgument &&
+        ts.isStringLiteral(firstArgument)
+      ) {
+        moduleSpecifiers.add(firstArgument.text);
+      }
+    }
+    ts.forEachChild(node, visitNode);
+  };
+  visitNode(sourceFile);
+  return moduleSpecifiers;
+};
+
+const auditPublishedPackage = (packageDirectory: string): PackageAuditResult => {
+  const manifest = readManifest(packageDirectory);
+  const declaredDependencies = new Set<string>([
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}),
+    ...Object.keys(manifest.optionalDependencies ?? {}),
+  ]);
+
+  const artifactFiles = PUBLISHED_ARTIFACT_DIRECTORIES.flatMap((artifactDirectory) =>
+    collectJavaScriptFiles(join(packageDirectory, artifactDirectory)),
+  );
+
+  const importingFilesByPackage = new Map<string, Set<string>>();
+  for (const artifactFile of artifactFiles) {
+    for (const moduleSpecifier of collectModuleSpecifiers(
+      readFileSync(artifactFile, "utf8"),
+      artifactFile,
+    )) {
+      if (!isBareSpecifier(moduleSpecifier) || NODE_BUILTIN_MODULES.has(moduleSpecifier)) continue;
+      const importedPackage = toPackageName(moduleSpecifier);
+      if (NODE_BUILTIN_MODULES.has(importedPackage) || importedPackage === manifest.name) continue;
+      const importingFiles = importingFilesByPackage.get(importedPackage) ?? new Set<string>();
+      importingFiles.add(relative(REPOSITORY_ROOT, artifactFile));
+      importingFilesByPackage.set(importedPackage, importingFiles);
+    }
+  }
+
+  const phantomDependencies = [...importingFilesByPackage]
+    .filter(([importedPackage]) => !declaredDependencies.has(importedPackage))
+    .map(([importedPackage, importingFiles]) => ({
+      importedPackage,
+      importingFiles: [...importingFiles].sort(),
+    }))
+    .sort((left, right) => left.importedPackage.localeCompare(right.importedPackage));
+
+  return {
+    manifest,
+    externalImports: [...importingFilesByPackage.keys()].sort(),
+    phantomDependencies,
+    artifactFileCount: artifactFiles.length,
+  };
+};
+
+const publishedPackageDirectories = readdirSync(PACKAGES_DIRECTORY, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => join(PACKAGES_DIRECTORY, entry.name))
+  .filter((packageDirectory) => existsSync(join(packageDirectory, "package.json")))
+  .filter((packageDirectory) => readManifest(packageDirectory).private !== true)
+  .sort();
+
+if (publishedPackageDirectories.length === 0) {
+  console.error("No published packages found under packages/.");
+  process.exit(1);
+}
+
+let hasMissingArtifacts = false;
+let hasPhantomDependencies = false;
+
+for (const packageDirectory of publishedPackageDirectories) {
+  const { manifest, externalImports, phantomDependencies, artifactFileCount } =
+    auditPublishedPackage(packageDirectory);
+
+  if (artifactFileCount === 0) {
+    hasMissingArtifacts = true;
+    console.error(`✗ ${manifest.name}: no built artifacts found.`);
+    continue;
+  }
+
+  if (phantomDependencies.length === 0) {
+    console.log(`✓ ${manifest.name}: ${externalImports.length} external import(s), all declared.`);
+    continue;
+  }
+
+  hasPhantomDependencies = true;
+  console.error(`✗ ${manifest.name}: built output imports packages absent from its dependencies:`);
+  for (const { importedPackage, importingFiles } of phantomDependencies) {
+    console.error(`    ${importedPackage}  (from ${importingFiles.join(", ")})`);
+  }
+}
+
+if (hasMissingArtifacts) {
+  console.error("\nBuild the packages before running this check: `pnpm build`.");
+  process.exit(1);
+}
+
+if (hasPhantomDependencies) {
+  console.error(
+    [
+      "",
+      "Phantom dependency detected. A published package's built output imports a package that is",
+      "not in its `dependencies` (or peer/optional), so it only resolves when a sibling dependency",
+      "happens to supply it. Consumers on strict installs (e.g. pnpm `hoist=false`) then crash with",
+      "ERR_MODULE_NOT_FOUND before the tool runs — see issue #629. Fix by adding the package to",
+      "`dependencies`, or inlining it through the build's `alwaysBundle` list.",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+console.log(
+  `\nAll ${publishedPackageDirectories.length} published packages declare their runtime dependencies.`,
+);


### PR DESCRIPTION
## Summary

Fixes #629 — `react-doctor@latest` (0.2.14) can crash **before scanning** with:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'oxc-parser' imported from
.../node_modules/oxlint-plugin-react-doctor/dist/index.js
```

`oxlint-plugin-react-doctor`'s published `dist/index.js` performs a **top-level static** `import { parseSync } from "oxc-parser"` (cross-file parsing for rules like `no-mutating-reducer-state`). `oxc-parser` is intentionally kept external at build time (`vite.config.ts` → `neverBundle: ["oxc-parser"]`, because its NAPI binding can't be bundled — same class as #404), so the published bundle needs it present at runtime. But it was only declared under `devDependencies`, which consumers never install.

This is a **phantom (undeclared) runtime dependency**. It's normally masked because `react-doctor → deslop-js → oxc-parser` supplies a copy that pnpm's default `hoist=true` exposes to the plugin. The bug surfaces when that accidental satisfaction goes away — strict installs (`hoist=false` / restrictive node-linker configs), other package managers/layouts, or any future `deslop-js` that drops/relocates `oxc-parser`.

## Fix

- Move `oxc-parser` from `devDependencies` → `dependencies` in `packages/oxlint-plugin-react-doctor/package.json` (kept `^0.132.0`, still external/not bundled).
- Update `pnpm-lock.yaml` (clean move, no version drift).
- Add a changeset. The three published packages (`react-doctor`, `eslint-plugin-react-doctor`, `oxlint-plugin-react-doctor`) are a `fixed` group, so this patch-bumps all three; the ESLint plugin also consumes the oxlint plugin and inherits the fix.

## Regression guard (new)

Added `scripts/check-published-deps.ts` + `pnpm check:published-deps` to prevent this whole class from recurring (it slipped in via #523 — a new runtime `import` without a manifest update). The guard:

- Parses every **published** package's built `dist`/`bin` output (TypeScript AST) and collects external `import` / `export … from` / dynamic `import()` / `require()` specifiers.
- Fails if any specifier resolves to a package **not** declared in that package's `dependencies` / `peerDependencies` / `optionalDependencies`.
- Is wired into the `release` script (before `changeset publish`) and into CI on PRs.

I verified it both ways: it passes on the fixed tree, and (temporarily reverting the fix) it fails with a pointed message naming `oxc-parser` and the importing file.

## Audit result (whole publish surface)

Beyond #629, I audited all three published packages' built output (published `0.2.14` **and** a fresh build of this branch). **`oxc-parser` was the only phantom dependency.** `react-doctor` and `eslint-plugin-react-doctor` are clean (e.g. `picomatch` is bundled inline into `react-doctor`, not external).

## Reproduction & verification (against published 0.2.14)

Default `pnpm add react-doctor@0.2.14` → plugin loads fine (phantom satisfied by `deslop-js` + hoisting). With `hoist=false` in `.npmrc`:

- **Before:** `react-doctor --verbose` exits 1 with the exact `Cannot find package 'oxc-parser'` error, before scanning.
- **After** (published tarball with only the dependency move applied, installed via override into the same strict tree): `oxc-parser` resolves from the plugin's own dep tree, the plugin imports OK, and the CLI proceeds to normal project discovery.

## Test plan

- [ ] CI green (lint / typecheck / tests / format / `smoke:json-report` / new `check:published-deps`)
- [ ] On release, `pnpm dlx react-doctor@<next>` under a strict `hoist=false` install starts scanning instead of crashing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and release-guard changes only; no application logic, auth, or data-handling behavior is modified.
> 
> **Overview**
> Fixes **#629** where `react-doctor` and related plugins could crash before a scan with `ERR_MODULE_NOT_FOUND` for **`oxc-parser`** on strict installs (e.g. pnpm with `hoist=false`). Published **`oxlint-plugin-react-doctor`** keeps **`oxc-parser`** external at build time but only listed it under **`devDependencies`**; it is now a real **`dependencies`** entry (lockfile updated, changeset added).
> 
> Adds **`scripts/check-published-deps.ts`** and **`pnpm check:published-deps`**, which parse each published package’s **`dist`/`bin`** output and fail if any runtime import is not declared in **`dependencies`**, **`peerDependencies`**, or **`optionalDependencies`**. The check runs in **CI** (after **`pnpm build`**) and in the **`release`** script before publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1251308ff810b8041ecd04f6ab4131719f29aa71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->