### PR TITLE
docs(readme): update readme

### DIFF
--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -27,8 +27,6 @@ npx react-doctor@latest
 
 https://github.com/user-attachments/assets/07cc88d9-9589-44c3-aa73-5d603cb1c570
 
-<small>Taking too long? Add `--experimental-parallel` to fan the scan out across your CPU cores.</small>
-
 ### 2. Install for agents
 
 Once you have an audit, you can install the skill for your coding agent to learn from the issues and fix them in the future.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -27,13 +27,7 @@ npx react-doctor@latest
 
 https://github.com/user-attachments/assets/07cc88d9-9589-44c3-aa73-5d603cb1c570
 
-On a large repo, add `--experimental-parallel` to fan the scan out across your CPU cores:
-
-```bash
-npx react-doctor@latest --experimental-parallel
-```
-
-React Doctor's rules run as oxlint JS plugins, which are single-threaded per process, so the scan scales nearly linearly with the number of worker processes — typically 3–4x faster on large codebases. Pass `--experimental-parallel <n>` to cap the worker count, or set `REACT_DOCTOR_PARALLEL=<n>` (handy in CI). Diagnostics are identical to a serial run.
+<small>Taking too long? Add `--experimental-parallel` to fan the scan out across your CPU cores.</small>
 
 ### 2. Install for agents
 
@@ -75,15 +69,11 @@ jobs:
       - uses: millionco/react-doctor@main
 ```
 
-React Doctor scans the files changed in the pull request, emits inline annotations, blocks on error-level findings, and updates one sticky PR comment with the score and issue summary. The built-in GitHub token is used automatically; no secret or PAT is required. On forked PRs where GitHub withholds write permissions, the scan and annotations still run, but the sticky comment may be skipped.
-
-**Permissions:** set `permissions: { contents: read, pull-requests: write }` so React Doctor can read the pull request's changed files for a changed-files-only scan and post the sticky summary comment. If `pull-requests: read` is unavailable (for example on fork PRs or with a restricted default token), the action degrades gracefully to a full-project scan instead of failing.
-
 [Add GitHub Action →](https://github.com/marketplace/actions/react-doctor)
 
 ### 4. Configure rules in `doctor.config.ts`
 
-Configure with a `doctor.config.ts` (or `.js`, `.mjs`, `.cjs`, `.json`, `.jsonc`) in your project root — or a `"reactDoctor"` key in `package.json`.
+Configure with a `doctor.config.ts` (or `.js`, `.mjs`, `.cjs`, `.json`, `.jsonc`) in your project root.
 
 ```ts
 // doctor.config.ts
@@ -97,24 +87,13 @@ export default {
 } satisfies ReactDoctorConfig;
 ```
 
-Prefer JSON? Use `doctor.config.json` and point `$schema` at `https://react.doctor/schema/config.json` for autocomplete, hover docs, and typo warnings in any editor that understands JSON Schema (comments and trailing commas are allowed):
+Prefer JSON? Use `doctor.config.json`:
 
 ```jsonc
 {
   "$schema": "https://react.doctor/schema/config.json",
   "lint": true,
 }
-```
-
-Don't hand-edit if you'd rather not — the `rules` subcommands list, explain, and configure rules for you (they edit your `doctor.config.*` in place — including TS/JS, preserving formatting — or `package.json#reactDoctor`):
-
-```bash
-npx react-doctor@latest rules list                 # every rule + its effective severity
-npx react-doctor@latest rules explain <rule>        # why a rule matters and how to tune it
-npx react-doctor@latest rules disable <rule>        # turn a rule off
-npx react-doctor@latest rules set <rule> warn       # off | warn | error
-npx react-doctor@latest rules category "React Native" off
-npx react-doctor@latest rules ignore-tag design     # skip a whole rule family
 ```
 
 ## Telemetry
@@ -125,10 +104,8 @@ Telemetry is **anonymized** before it leaves your machine: no IP address is coll
 
 Opt out at any time:
 
-- `npx react-doctor@latest --no-score` disables Sentry entirely (crash reporting and tracing) for that run, alongside the hosted score API.
+- `npx react-doctor@latest --no-telemetry` disables Sentry entirely (crash reporting and tracing) for that run, alongside the hosted score API.
 - `SENTRY_TRACES_SAMPLE_RATE=0` keeps crash reporting but turns off performance tracing.
-
-Telemetry is also skipped automatically under test runs, and the programmatic `react-doctor/api` library never initializes Sentry. Advanced overrides: `SENTRY_DSN` (point at your own Sentry project), `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, and `SENTRY_DEBUG=1`.
 
 ## Contributing
 


### PR DESCRIPTION
Sloppy sloppy readme
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API behavior changes in this diff.
> 
> **Overview**
> This PR **trims** `packages/react-doctor/README.md` by removing several how-to sections and tightening a few that remain.
> 
> Removed coverage includes **`--experimental-parallel`**, detailed **GitHub Action** behavior (changed-files scan, sticky comments, fork degradation, permissions), **`package.json#reactDoctor`** and the **`rules` CLI** subcommands, extra **JSON Schema** editor guidance, and **advanced Sentry** env overrides.
> 
> What stays is shorter: config is described as living in **`doctor.config.*` only** (no `package.json` key), JSON config is a minimal example, and telemetry opt-out now points at **`--no-telemetry`** instead of **`--no-score`** (aligned with the CLI alias).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a29c59d9560a2147dd7731cd5c97574c6ba822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->