### PR TITLE
feat(cli): redesign inspect report with first-run onboarding reveal

### DIFF
--- a/.changeset/onboarding-section-pacing.md
+++ b/.changeset/onboarding-section-pacing.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": patch
+---
+
+Redesigned the interactive scan report and added a first-run onboarding reveal.
+
+The default single-project report now reads top-to-bottom the way a human scans it: the category tally, then the score box (with the total issue count inline on the score line, e.g. `7 / 100 Critical   295 issues`), the projection, the top fixes one by one, the warning roll-up, a single merged `+N more errors and +N more warnings` overflow line, and finally Share / Docs / Tip. The per-section `+N more rules` lines, the `N warnings` sub-header, and the `Top N errors you should fix` header were removed for a cleaner read. CI, coding-agent, git-hook, and verbose runs keep the classic information-dense layout (diagnostics first, then agent guidance and score).
+
+On a user's first interactive run it plays as an onboarding sequence: a happy React Doctor "welcome" scene opens, the scan runs, the category tallies count up from zero in parallel, and then each section — and each of the top errors — reveals on an ~850ms beat (quickening to ~680ms once the score lands) instead of a wall of text. It runs only once (a marker persisted in the global config records that it was shown), and is skipped entirely in CI, under coding agents, and on any non-TTY / score-only / JSON run.

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -36,8 +36,11 @@ import {
   writeJsonErrorReport,
   writeJsonReport,
 } from "../utils/json-mode.js";
+import { canAnimateOnboarding, isOnboardingForced } from "../utils/onboarding-pacing.js";
+import { hasCompletedOnboarding } from "../utils/onboarding-state.js";
 import { printAnnotations } from "../utils/print-annotations.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
+import { playWelcomeScene } from "../utils/render-welcome.js";
 import { reportErrorToSentry } from "../utils/report-error.js";
 import { readChangedFilesFrom } from "../utils/read-changed-files-from.js";
 import { printMultiProjectSummary } from "../utils/render-multi-project-summary.js";
@@ -201,7 +204,15 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
     }
 
     if (!isQuiet) {
-      Effect.runSync(printBrandedHeader);
+      // First-run (or forced) onboarding opens with the animated welcome scene
+      // in place of the static branded header; everything else keeps the header.
+      const showWelcome =
+        (isOnboardingForced() || !hasCompletedOnboarding()) && canAnimateOnboarding(process.stdout);
+      if (showWelcome) {
+        await Effect.runPromise(playWelcomeScene());
+      } else {
+        Effect.runSync(printBrandedHeader);
+      }
     }
 
     const scanOptions = resolveCliInspectOptions(flags, userConfig);
@@ -389,9 +400,14 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
     // After the results print, offer to hand the issues to a coding agent
     // — an interactive select (no flag). Skipped for quiet, skip-prompts,
-    // non-TTY, and agent/CI runs (those get the install hint below).
+    // non-TTY, and agent/CI runs (those get the install hint below). Verbose
+    // is a static review and prints its own "ask an agent" tip instead.
     const canPromptInteractively =
-      !isQuiet && !skipPrompts && process.stdout.isTTY === true && !isCiOrCodingAgentEnvironment();
+      !isQuiet &&
+      !skipPrompts &&
+      !flags.verbose &&
+      process.stdout.isTTY === true &&
+      !isCiOrCodingAgentEnvironment();
     if (canPromptInteractively && surfaceDiagnostics.length > 0) {
       await handoffToAgent({
         diagnostics: surfaceDiagnostics,

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -22,6 +22,18 @@ export const SCORE_HEADER_ANIMATION_FRAME_DELAY_MS = 50;
 export const PERFECT_SCORE_RAINBOW_FRAME_COUNT = 16;
 export const PERFECT_SCORE_RAINBOW_FRAME_DELAY_MS = 50;
 
+// First-run onboarding animation cadences: welcome typewriter + holds, the
+// category count-up, the warning roll-up typewriter, and the score projection.
+export const WELCOME_TYPEWRITER_CHAR_DELAY_MS = 32;
+export const WELCOME_INTER_LINE_DELAY_MS = 500;
+export const WELCOME_EXPLANATION_HOLD_MS = 2000;
+export const WELCOME_HOLD_MS = 1000;
+export const CATEGORY_COUNTUP_FRAME_COUNT = 16;
+export const CATEGORY_COUNTUP_FRAME_DELAY_MS = 45;
+export const WARNING_TYPEWRITER_FRAME_DELAY_MS = 14;
+export const SCORE_PROJECTION_FRAME_COUNT = 16;
+export const SCORE_PROJECTION_FRAME_DELAY_MS = 35;
+
 // Last-resort fallback when buildJsonReportError itself throws — keeps
 // stdout valid JSON so downstream parsers don't see a half-written report.
 export const INTERNAL_ERROR_JSON_FALLBACK =

--- a/packages/react-doctor/src/cli/utils/ease-out-cubic.ts
+++ b/packages/react-doctor/src/cli/utils/ease-out-cubic.ts
@@ -1,0 +1,2 @@
+// Ease-out cubic: maps 0..1 progress to an eased 0..1 value (fast start, gentle settle).
+export const easeOutCubic = (progress: number): number => 1 - (1 - progress) ** 3;

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -25,7 +25,6 @@ export interface HandoffToAgentInput {
 }
 
 const CLIPBOARD_CHOICE = "clipboard";
-const PRINT_CHOICE = "print";
 const SKIP_CHOICE = "skip";
 
 const printPayload = (payload: string): void => {
@@ -58,7 +57,7 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
     {
       type: "select",
       name: "handoffTarget",
-      message: "Hand these issues to an agent?",
+      message: "Would you like to spawn an agent to fix these issues?",
       choices: [
         ...launchableAgents.map((agentId) => ({
           title: getSkillAgentConfig(agentId).displayName,
@@ -70,7 +69,6 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
           description: "Paste into any agent or chat",
           value: CLIPBOARD_CHOICE,
         },
-        { title: "Print prompt", description: "Show the prompt below", value: PRINT_CHOICE },
         { title: "Skip", description: "Don't hand off", value: SKIP_CHOICE },
       ],
       initial: 0,
@@ -79,11 +77,10 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
   );
 
   // Count the fix-loop outcome (the core activation moment): did the user launch
-  // an agent (any agent id), copy/print the prompt, or skip/cancel?
+  // an agent (any agent id), copy the prompt, or skip/cancel?
   let handoffOutcome = "launch";
   if (handoffTarget === undefined) handoffOutcome = "cancel";
   else if (handoffTarget === SKIP_CHOICE) handoffOutcome = "skip";
-  else if (handoffTarget === PRINT_CHOICE) handoffOutcome = "print";
   else if (handoffTarget === CLIPBOARD_CHOICE) handoffOutcome = "clipboard";
   recordCount(METRIC.agentHandoff, 1, {
     outcome: handoffOutcome,
@@ -99,10 +96,6 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
     projectName: input.projectName,
   });
 
-  if (handoffTarget === PRINT_CHOICE) {
-    printPayload(payload);
-    return;
-  }
   if (handoffTarget === CLIPBOARD_CHOICE) {
     const didCopy = await copyToClipboard(payload);
     if (didCopy) logger.log("Copied the prompt to your clipboard.");

--- a/packages/react-doctor/src/cli/utils/has-react-doctor-workflow.ts
+++ b/packages/react-doctor/src/cli/utils/has-react-doctor-workflow.ts
@@ -1,0 +1,42 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+// Matches a workflow referencing React Doctor (the action, an `npx react-doctor`
+// step, or a "React Doctor" job name).
+const REACT_DOCTOR_REFERENCE = /react[- ]doctor/i;
+
+const directoryHasReactDoctorWorkflow = (directory: string): boolean => {
+  const workflowsDirectory = path.join(directory, ".github", "workflows");
+  if (!existsSync(workflowsDirectory)) return false;
+  let entries: string[];
+  try {
+    entries = readdirSync(workflowsDirectory);
+  } catch {
+    return false;
+  }
+  return entries.some((entry) => {
+    if (!entry.endsWith(".yml") && !entry.endsWith(".yaml")) return false;
+    try {
+      return REACT_DOCTOR_REFERENCE.test(
+        readFileSync(path.join(workflowsDirectory, entry), "utf8"),
+      );
+    } catch {
+      return false;
+    }
+  });
+};
+
+// True when a workflow referencing react-doctor exists in the scan dir or any
+// ancestor up to the repo root. Walks up so a monorepo package finds the
+// workflow above it. Suppresses the "set up CI/CD" tip.
+export const hasReactDoctorWorkflow = (scanDirectory: string): boolean => {
+  let currentDirectory = path.resolve(scanDirectory);
+  while (true) {
+    if (directoryHasReactDoctorWorkflow(currentDirectory)) return true;
+    // Stop at the repo root (already checked above).
+    if (existsSync(path.join(currentDirectory, ".git"))) return false;
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) return false;
+    currentDirectory = parentDirectory;
+  }
+};

--- a/packages/react-doctor/src/cli/utils/onboarding-pacing.ts
+++ b/packages/react-doctor/src/cli/utils/onboarding-pacing.ts
@@ -43,6 +43,29 @@ export const onboardingSectionPause = (
   delayMs: number = ONBOARDING_SECTION_DELAY_MS,
 ): Effect.Effect<void> => (shouldPace ? Effect.sleep(delayMs) : Effect.void);
 
+export interface OnboardingRecordInput {
+  // Section pacing was enabled for this run (TTY, first-run, not CI/agent).
+  readonly paceOnboardingSections: boolean;
+  // The run forces onboarding for a demo (replayable; never consumes the marker).
+  readonly forceOnboarding: boolean;
+  // The run is `--verbose` (a static review, no onboarding reveal).
+  readonly verbose: boolean;
+  // The run is non-interactive (CI, git hook, agent) and uses the classic layout.
+  readonly isNonInteractiveEnvironment: boolean;
+}
+
+// Whether a completed render should burn the first-run onboarding marker: only
+// when the interactive onboarding reveal actually ran. Verbose and the classic
+// non-interactive layout (e.g. a git hook with a TTY, where GIT_DIR marks the
+// run non-interactive while pacing still sees a TTY) pace section beats but
+// never show the welcome scene / animated report, so they leave the first run
+// intact. A forced demo replays every time and never consumes the marker.
+export const shouldRecordOnboarding = (input: OnboardingRecordInput): boolean =>
+  input.paceOnboardingSections &&
+  !input.forceOnboarding &&
+  !input.verbose &&
+  !input.isNonInteractiveEnvironment;
+
 // Whether onboarding animations can drive the stream — they need a real TTY.
 // A forced demo animates even under an agent/CI shell (which `isSpinnerInteractive` rejects).
 export const canAnimateOnboarding = (stream: NodeJS.WriteStream = process.stdout): boolean => {

--- a/packages/react-doctor/src/cli/utils/onboarding-pacing.ts
+++ b/packages/react-doctor/src/cli/utils/onboarding-pacing.ts
@@ -1,0 +1,53 @@
+import * as Effect from "effect/Effect";
+import { isCiOrCodingAgentEnvironment } from "./is-ci-environment.js";
+import { isSpinnerInteractive } from "./is-spinner-interactive.js";
+
+// Each scan-report section waits this long before printing, so a first human
+// run reads as a guided reveal rather than one painted frame.
+export const ONBOARDING_SECTION_DELAY_MS = 850;
+
+// After the score lands, the report quickens by 1.25x.
+export const ONBOARDING_SECTION_DELAY_FAST_MS = Math.round(ONBOARDING_SECTION_DELAY_MS / 1.25);
+
+// Internal escape hatch: force the first-run onboarding on any run, bypassing
+// the onboarded marker, the TTY check, and CI/agent detection. For demos.
+export const FORCE_ONBOARDING_ENV_VAR = "REACT_DOCTOR_FORCE_ONBOARDING";
+
+const FALSY_FLAG_VALUES = new Set(["", "0", "false"]);
+
+export const isOnboardingForced = (environment: NodeJS.ProcessEnv = process.env): boolean => {
+  const value = environment[FORCE_ONBOARDING_ENV_VAR];
+  return value !== undefined && !FALSY_FLAG_VALUES.has(value.toLowerCase());
+};
+
+export interface OnboardingPacingInput {
+  // Defaults to the live stdout TTY probe; injectable for tests.
+  readonly isInteractive?: boolean;
+  // Defaults to the live CI/coding-agent env probe; injectable for tests.
+  readonly isCiOrCodingAgent?: boolean;
+}
+
+// Pace only on an interactive TTY that isn't CI or a coding agent, so automated
+// callers stay instant and their captured output is unchanged.
+export const shouldPaceOnboardingSections = (input: OnboardingPacingInput = {}): boolean => {
+  if (isOnboardingForced()) return true;
+  const isInteractive = input.isInteractive ?? process.stdout.isTTY === true;
+  const isCiOrCodingAgent = input.isCiOrCodingAgent ?? isCiOrCodingAgentEnvironment();
+  return isInteractive && !isCiOrCodingAgent;
+};
+
+// The beat to `yield*` before a section: a sleep when pacing, else a no-op.
+// `delayMs` picks the pre-score (default) or faster post-score cadence.
+export const onboardingSectionPause = (
+  shouldPace: boolean,
+  delayMs: number = ONBOARDING_SECTION_DELAY_MS,
+): Effect.Effect<void> => (shouldPace ? Effect.sleep(delayMs) : Effect.void);
+
+// Whether onboarding animations can drive the stream — they need a real TTY.
+// A forced demo animates even under an agent/CI shell (which `isSpinnerInteractive` rejects).
+export const canAnimateOnboarding = (stream: NodeJS.WriteStream = process.stdout): boolean => {
+  if (isOnboardingForced()) {
+    return stream.isTTY === true && (stream.columns ?? 0) > 0 && process.env.TERM !== "dumb";
+  }
+  return isSpinnerInteractive(stream);
+};

--- a/packages/react-doctor/src/cli/utils/onboarding-state.ts
+++ b/packages/react-doctor/src/cli/utils/onboarding-state.ts
@@ -1,0 +1,45 @@
+import Conf from "conf";
+
+// Shared global config file with the setup-prompt state; Conf preserves unknown
+// keys, so both concerns coexist in one file.
+const GLOBAL_CONFIG_PROJECT_NAME = "react-doctor";
+
+const ONBOARDED_AT_KEY = "onboardedAt";
+
+export interface OnboardingStoreOptions {
+  // Overrides the config dir; tests point this at a temp dir.
+  readonly cwd?: string;
+}
+
+interface OnboardingGlobalConfig {
+  // ISO timestamp of the first onboarding reveal; its presence means onboarded.
+  readonly [ONBOARDED_AT_KEY]?: string;
+}
+
+const getOnboardingStore = (options: OnboardingStoreOptions = {}): Conf<OnboardingGlobalConfig> =>
+  new Conf<OnboardingGlobalConfig>({
+    projectName: GLOBAL_CONFIG_PROJECT_NAME,
+    cwd: options.cwd,
+  });
+
+export const getOnboardingConfigPath = (options: OnboardingStoreOptions = {}): string =>
+  getOnboardingStore(options).path;
+
+export const hasCompletedOnboarding = (options: OnboardingStoreOptions = {}): boolean => {
+  try {
+    return typeof getOnboardingStore(options).get(ONBOARDED_AT_KEY) === "string";
+  } catch {
+    // Fail safe to "already onboarded" if the store is unreadable.
+    return true;
+  }
+};
+
+export const markOnboardingComplete = (options: OnboardingStoreOptions = {}): void => {
+  try {
+    const store = getOnboardingStore(options);
+    if (typeof store.get(ONBOARDED_AT_KEY) === "string") return;
+    store.set(ONBOARDED_AT_KEY, new Date().toISOString());
+  } catch {
+    // Best-effort: persisting the marker must never break a scan.
+  }
+};

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -22,8 +22,10 @@ import {
   formatFixRecipeLine,
   formatLearnMoreLine,
 } from "./diagnostic-grouping.js";
+import { easeOutCubic } from "./ease-out-cubic.js";
 import { indentMultilineText } from "./indent-multiline-text.js";
 import { wrapTextToWidth } from "./wrap-indented-text.js";
+import { writeStdout } from "./write-stdout.js";
 
 const POINTER = isUnicodeSupported() ? "›" : ">";
 
@@ -46,7 +48,7 @@ interface CategoryDiagnosticGroup {
 
 // Resolves the absolute project root a given diagnostic's relative
 // `filePath` should be read from when building its inline code frame.
-interface SourceRootResolver {
+export interface SourceRootResolver {
   (diagnostic: Diagnostic): string;
 }
 
@@ -121,7 +123,9 @@ const buildCompactCategoryLine = (categoryGroup: CategoryDiagnosticGroup): strin
   return `  ${highlighter.bold(categoryGroup.category)} ${highlighter.dim(POINTER)} ${parts.join(highlighter.dim(", "))}`;
 };
 
-const TOP_ERROR_DETAIL_INDENT = "    ";
+// Detail (message, fix, location, frame) lines up at col 2 under the headline;
+// the ✖ marker hangs in the gutter at col 0.
+const TOP_ERROR_DETAIL_INDENT = "  ";
 
 const pickRepresentativeDiagnostic = (ruleDiagnostics: Diagnostic[]): Diagnostic =>
   ruleDiagnostics.find((diagnostic) => diagnostic.line > 0) ?? ruleDiagnostics[0];
@@ -252,9 +256,10 @@ const buildRuleDetailBlock = (
     `${representative.category}: ${representative.title ?? ruleKey}`,
     severity,
   );
-  const icon = colorizeBySeverity(severity === "error" ? "✗" : "⚠", severity);
+  const icon = colorizeBySeverity(severity === "error" ? "✖" : "⚠", severity);
 
-  const lines: string[] = [`  ${icon} ${headline}${trailingBadge}`];
+  // ✖ hangs in the gutter (col 0); the headline starts at the report edge (col 2).
+  const lines: string[] = [`${icon} ${headline}${trailingBadge}`];
 
   // Verbose lists every rule & site, so the per-rule impact prose would
   // just repeat down the whole report — skip it there and let the boxed
@@ -295,9 +300,9 @@ const buildRuleDetailBlock = (
   return lines;
 };
 
-// Indent under a warning's header line — six spaces so the body sits
-// just past the `  ⚠ ` marker.
-const WARNING_DETAIL_INDENT = "      ";
+// Warning body (message, fix, sites) lines up at col 2 under the rule name;
+// the ⚠ marker hangs in the gutter at col 0, matching the error blocks.
+const WARNING_DETAIL_INDENT = "  ";
 
 // Column the warning rule names pad to so each `×N` site badge lines up
 // regardless of name length. Grows past the default when a rule key is
@@ -323,7 +328,8 @@ const buildWarningHeaderLine = (
 ): string => {
   const hasBadge = formatSiteCountBadge(siteCount).length > 0;
   const ruleName = hasBadge ? padRuleNameToColumn(ruleKey, ruleNameColumnWidth) : ruleKey;
-  return `  ${highlighter.warn("⚠")} ${ruleName}${formatTrailingSiteBadge(siteCount)}`;
+  // ⚠ hangs in the gutter (col 0); the rule name starts at the report edge (col 2).
+  return `${highlighter.warn("⚠")} ${ruleName}${formatTrailingSiteBadge(siteCount)}`;
 };
 
 // Compact warning block: the `plugin/rule` key + `×N` badge, the impact,
@@ -423,14 +429,21 @@ export const getTopErrorRuleKeys = (
 ): ReadonlySet<string> =>
   new Set(selectTopErrorRuleGroups(diagnostics, limit, rulePriority).map(([ruleKey]) => ruleKey));
 
-const buildTopErrorsLines = (
+// The top-errors section, with each rule block's start offset (within `lines`)
+// so the renderer can play the onboarding beat before each error reveals.
+interface TopErrorsSection {
+  readonly lines: ReadonlyArray<string>;
+  readonly blockOffsets: ReadonlyArray<number>;
+}
+
+const buildTopErrorsSection = (
   diagnostics: Diagnostic[],
   resolveSourceRoot: SourceRootResolver,
   rulePriority?: ReadonlyMap<string, number>,
-): ReadonlyArray<string> => {
+): TopErrorsSection => {
   const errorRuleGroups = selectErrorRuleGroups(diagnostics, rulePriority);
   const topRuleGroups = errorRuleGroups.slice(0, TOP_ERRORS_DISPLAY_COUNT);
-  if (topRuleGroups.length === 0) return [];
+  if (topRuleGroups.length === 0) return { lines: [], blockOffsets: [] };
   const hiddenRuleCount = errorRuleGroups.length - topRuleGroups.length;
 
   const lines: string[] = [
@@ -439,14 +452,16 @@ const buildTopErrorsLines = (
     `  ${highlighter.bold(`Top ${topRuleGroups.length} ${topRuleGroups.length === 1 ? "error" : "errors"} you should fix`)}`,
     "",
   ];
+  const blockOffsets: number[] = [];
   for (const [ruleKey, ruleDiagnostics] of topRuleGroups) {
+    blockOffsets.push(lines.length);
     lines.push(...buildRuleDetailBlock(ruleKey, ruleDiagnostics, resolveSourceRoot, false));
     lines.push("");
   }
   if (hiddenRuleCount > 0) {
     lines.push(buildMoreRulesLine(hiddenRuleCount, "errors", highlighter.error));
   }
-  return lines;
+  return { lines, blockOffsets };
 };
 
 // In non-verbose mode errors get the detailed top-N block; warnings are
@@ -486,36 +501,218 @@ const buildWarningsListLines = (
 // The compact "Security › 6 errors" category tally, shown ABOVE the
 // detailed blocks so the reader gets the at-a-glance breakdown first,
 // then drills into specifics.
-const buildCategoryBreakdownLines = (
+export const buildCategoryBreakdownLines = (
   diagnostics: Diagnostic[],
   rulePriority?: ReadonlyMap<string, number>,
 ): string[] =>
   buildCategoryDiagnosticGroups(diagnostics, rulePriority).map(buildCompactCategoryLine);
 
-const joinSections = (...sections: ReadonlyArray<string>[]): string[] => {
+interface CategoryTally {
+  readonly category: string;
+  readonly errorCount: number;
+  readonly warningCount: number;
+}
+
+const buildCategoryTallies = (
+  diagnostics: Diagnostic[],
+  rulePriority?: ReadonlyMap<string, number>,
+): CategoryTally[] =>
+  buildCategoryDiagnosticGroups(diagnostics, rulePriority).map((group) => ({
+    category: group.category,
+    errorCount: group.diagnostics.filter((diagnostic) => diagnostic.severity === "error").length,
+    warningCount: group.diagnostics.filter((diagnostic) => diagnostic.severity === "warning")
+      .length,
+  }));
+
+// One category line at arbitrary displayed counts (count-up renders partial
+// values). At full counts it matches `buildCompactCategoryLine`'s static output.
+const formatCategoryTallyLine = (
+  tally: CategoryTally,
+  errorShown: number,
+  warningShown: number,
+): string => {
+  const parts: string[] = [];
+  if (tally.errorCount > 0) {
+    parts.push(highlighter.error(`${errorShown} ${errorShown === 1 ? "error" : "errors"}`));
+  }
+  if (tally.warningCount > 0) {
+    parts.push(
+      highlighter.warn(
+        highlighter.dim(`${warningShown} ${warningShown === 1 ? "warning" : "warnings"}`),
+      ),
+    );
+  }
+  return `  ${highlighter.bold(tally.category)} ${highlighter.dim(POINTER)} ${parts.join(highlighter.dim(", "))}`;
+};
+
+const CATEGORY_COUNTUP_FRAME_COUNT = 16;
+const CATEGORY_COUNTUP_FRAME_DELAY_MS = 45;
+
+// The category tally. When `animate`, the counts count up from zero in parallel
+// (first-run onboarding on a TTY); else the final lines print at once. Counts
+// only grow, so frames never shrink — no per-line clear needed.
+export const printCategoryBreakdown = (
+  diagnostics: Diagnostic[],
+  rulePriority: ReadonlyMap<string, number> | undefined,
+  animate: boolean,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const tallies = buildCategoryTallies(diagnostics, rulePriority);
+    if (tallies.length === 0) return;
+
+    if (!animate) {
+      for (const tally of tallies) {
+        yield* Console.log(formatCategoryTallyLine(tally, tally.errorCount, tally.warningCount));
+      }
+      return;
+    }
+
+    for (let frame = 0; frame <= CATEGORY_COUNTUP_FRAME_COUNT; frame += 1) {
+      const fraction = easeOutCubic(frame / CATEGORY_COUNTUP_FRAME_COUNT);
+      const lines = tallies.map((tally) =>
+        formatCategoryTallyLine(
+          tally,
+          Math.round(tally.errorCount * fraction),
+          Math.round(tally.warningCount * fraction),
+        ),
+      );
+      const cursorUp = frame === 0 ? "" : `\x1b[${tallies.length}A`;
+      yield* writeStdout(`${cursorUp}\r${lines.join("\n\r")}\n`);
+      if (frame < CATEGORY_COUNTUP_FRAME_COUNT)
+        yield* Effect.sleep(CATEGORY_COUNTUP_FRAME_DELAY_MS);
+    }
+  });
+
+// Joins sections with a single blank line between non-empty ones (and a
+// trailing blank). Also returns each section's start index in the result
+// (null for an empty section) so the renderer can pace a specific section.
+const joinSections = (
+  ...sections: ReadonlyArray<string>[]
+): { lines: string[]; sectionStarts: ReadonlyArray<number | null> } => {
   const lines: string[] = [];
+  const sectionStarts: (number | null)[] = [];
   for (const section of sections) {
-    if (section.length === 0) continue;
+    if (section.length === 0) {
+      sectionStarts.push(null);
+      continue;
+    }
     if (lines.length > 0) lines.push("");
+    sectionStarts.push(lines.length);
     lines.push(...section);
   }
   if (lines.length > 0 && lines[lines.length - 1] !== "") lines.push("");
-  return lines;
+  return { lines, sectionStarts };
 };
 
-// The total-issue tally (e.g. "600 issues"), shown right under the
-// category breakdown as part of the overview. The "list every issue"
-// hint lives at the very bottom of the run instead (see `printVerboseTip`).
-const buildCountsSummaryLines = (diagnostics: Diagnostic[]): ReadonlyArray<string> => {
+// The colored "N issues" label (no indent), or null when there are none.
+export const buildIssueCountLabel = (diagnostics: Diagnostic[]): string | null => {
   const totalIssueCount = diagnostics.length;
-  if (totalIssueCount === 0) return [];
+  if (totalIssueCount === 0) return null;
   const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
   const warningCount = totalIssueCount - errorCount;
   const issueCountColor =
     errorCount > 0 ? highlighter.error : warningCount > 0 ? highlighter.warn : highlighter.dim;
-  return [
-    `  ${issueCountColor(`${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`)}`,
-  ];
+  return issueCountColor(`${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`);
+};
+
+export const buildCountsSummaryLines = (diagnostics: Diagnostic[]): ReadonlyArray<string> => {
+  const label = buildIssueCountLabel(diagnostics);
+  return label === null ? [] : [`  ${label}`];
+};
+
+// The top error rule blocks (detail + code frame), one array per block, no
+// shared header — the report announces them via the "fixing the top N" line.
+export const buildTopErrorBlocks = (
+  diagnostics: Diagnostic[],
+  sourceRoot: string | SourceRootResolver,
+  rulePriority?: ReadonlyMap<string, number>,
+): string[][] => {
+  const resolveSourceRoot: SourceRootResolver =
+    typeof sourceRoot === "function" ? sourceRoot : () => sourceRoot;
+  return selectErrorRuleGroups(diagnostics, rulePriority)
+    .slice(0, TOP_ERRORS_DISPLAY_COUNT)
+    .map(([ruleKey, ruleDiagnostics]) => [
+      ...buildRuleDetailBlock(ruleKey, ruleDiagnostics, resolveSourceRoot, false),
+    ]);
+};
+
+const WARNING_TYPEWRITER_FRAME_DELAY_MS = 14;
+
+// The compact `⚠ rule ×N` warning list (capped); no header, no overflow (folded
+// into the merged line above). ⚠ sits at col 2 so the error blocks keep the
+// col-0 gutter to themselves. When `animate`, each rule name types in (all rows
+// in parallel, snapping to the padded ×N form when done); else prints at once.
+export const printWarningRollup = (
+  diagnostics: Diagnostic[],
+  rulePriority: ReadonlyMap<string, number> | undefined,
+  animate: boolean,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const warningDiagnostics = diagnostics.filter(
+      (diagnostic) => diagnostic.severity === "warning",
+    );
+    if (warningDiagnostics.length === 0) return;
+    const shownRuleGroups = buildSortedRuleGroups(warningDiagnostics, rulePriority).slice(
+      0,
+      MAX_WARNING_RULES_SHOWN_NON_VERBOSE,
+    );
+    const ruleNameColumnWidth = computeRuleNameColumnWidth(
+      shownRuleGroups.map(([ruleKey]) => ruleKey),
+    );
+    const finalLines = shownRuleGroups.map(
+      ([ruleKey, ruleDiagnostics]) =>
+        `  ${buildWarningHeaderLine(ruleKey, ruleDiagnostics.length, ruleNameColumnWidth)}`,
+    );
+
+    if (!animate) {
+      for (const line of finalLines) yield* Console.log(line);
+      return;
+    }
+
+    // All names finish on the same frame: paced by the longest, each shorter
+    // name reveals proportionally slower so the list lands together.
+    const longestRuleKeyLength = Math.max(...shownRuleGroups.map(([ruleKey]) => ruleKey.length));
+    for (let frame = 0; frame <= longestRuleKeyLength; frame += 1) {
+      const progress = frame / longestRuleKeyLength;
+      const lines = shownRuleGroups.map(([ruleKey], index) => {
+        const shown = Math.round(ruleKey.length * progress);
+        return shown >= ruleKey.length
+          ? (finalLines[index] ?? "")
+          : `  ${highlighter.warn("⚠")} ${ruleKey.slice(0, shown)}`;
+      });
+      const cursorUp = frame === 0 ? "" : `\x1b[${lines.length}A`;
+      yield* writeStdout(`${cursorUp}\r${lines.join("\n\r")}\n`);
+      if (frame < longestRuleKeyLength) {
+        yield* Effect.sleep(WARNING_TYPEWRITER_FRAME_DELAY_MS);
+      }
+    }
+  });
+
+// "+8 more errors and +107 more warnings." — one overflow line replacing the
+// per-section "+N more rules". Counts are rule groups beyond what's displayed.
+export const buildMergedOverflowLine = (
+  diagnostics: Diagnostic[],
+  rulePriority?: ReadonlyMap<string, number>,
+): string | null => {
+  const errorRuleGroupCount = selectErrorRuleGroups(diagnostics, rulePriority).length;
+  const warningRuleGroupCount = buildSortedRuleGroups(
+    diagnostics.filter((diagnostic) => diagnostic.severity === "warning"),
+    rulePriority,
+  ).length;
+  const moreErrors = Math.max(0, errorRuleGroupCount - TOP_ERRORS_DISPLAY_COUNT);
+  const moreWarnings = Math.max(0, warningRuleGroupCount - MAX_WARNING_RULES_SHOWN_NON_VERBOSE);
+  if (moreErrors === 0 && moreWarnings === 0) return null;
+
+  const parts: string[] = [];
+  if (moreErrors > 0) {
+    parts.push(highlighter.error(`+${moreErrors} more ${moreErrors === 1 ? "error" : "errors"}`));
+  }
+  if (moreWarnings > 0) {
+    parts.push(
+      highlighter.warn(`+${moreWarnings} more ${moreWarnings === 1 ? "warning" : "warnings"}`),
+    );
+  }
+  return `  ${highlighter.dim("We also found")} ${parts.join(highlighter.dim(" and "))}${highlighter.dim(".")}`;
 };
 
 /**
@@ -542,6 +739,9 @@ export const printDiagnostics = (
   // emit the cache-busting fetch directive instead of the human "Learn more"
   // link. Defaults to false (human) so tests render deterministically.
   isAgentEnvironment = false,
+  // The onboarding beat before each top-error block reveals. Defaults to a
+  // no-op, so non-onboarding runs print the whole block at once.
+  sectionPause: Effect.Effect<void> = Effect.void,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     const resolveSourceRoot: SourceRootResolver =
@@ -551,8 +751,13 @@ export const printDiagnostics = (
     // In verbose the detail is EVERY rule and EVERY site (not just the
     // top N representative) — same readable block layout, just exhaustive.
     let detailLines: ReadonlyArray<string>;
+    // Offsets within `detailLines` where each top-error block begins, to pace
+    // the reveal between errors. Empty in verbose (lists every rule, not top-N).
+    let topErrorBlockOffsets: ReadonlyArray<number> = [];
     if (!isVerbose) {
-      detailLines = buildTopErrorsLines(diagnostics, resolveSourceRoot, rulePriority);
+      const topErrors = buildTopErrorsSection(diagnostics, resolveSourceRoot, rulePriority);
+      detailLines = topErrors.lines;
+      topErrorBlockOffsets = topErrors.blockOffsets;
     } else {
       const sortedRuleGroups = buildSortedRuleGroups(diagnostics, rulePriority);
       // Warnings share one padded name column so their `×N` badges align;
@@ -575,7 +780,7 @@ export const printDiagnostics = (
       });
     }
 
-    const lines = joinSections(
+    const { lines, sectionStarts } = joinSections(
       buildCategoryBreakdownLines(diagnostics, rulePriority),
       buildCountsSummaryLines(diagnostics),
       detailLines,
@@ -583,8 +788,20 @@ export const printDiagnostics = (
       // warning roll-up is non-verbose only.
       isVerbose ? [] : buildWarningsListLines(diagnostics, rulePriority),
     );
+
+    // `detailLines` is the 3rd section; map its block offsets to absolute line
+    // indices so the beat plays just before each block.
+    const detailStart = sectionStarts[2];
+    const pauseBeforeLineIndices =
+      detailStart == null
+        ? new Set<number>()
+        : new Set(topErrorBlockOffsets.map((offset) => detailStart + offset));
+
+    let lineIndex = 0;
     for (const line of lines) {
+      if (pauseBeforeLineIndices.has(lineIndex)) yield* sectionPause;
       yield* Console.log(line);
+      lineIndex++;
     }
   });
 

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -17,6 +17,11 @@ import type { Diagnostic } from "@react-doctor/core";
 import { boxText } from "./box-text.js";
 import { buildCodeFrame } from "./build-code-frame.js";
 import {
+  CATEGORY_COUNTUP_FRAME_COUNT,
+  CATEGORY_COUNTUP_FRAME_DELAY_MS,
+  WARNING_TYPEWRITER_FRAME_DELAY_MS,
+} from "./constants.js";
+import {
   buildSortedRuleGroups,
   compareByRulePriority,
   formatFixRecipeLine,
@@ -545,9 +550,6 @@ const formatCategoryTallyLine = (
   return `  ${highlighter.bold(tally.category)} ${highlighter.dim(POINTER)} ${parts.join(highlighter.dim(", "))}`;
 };
 
-const CATEGORY_COUNTUP_FRAME_COUNT = 16;
-const CATEGORY_COUNTUP_FRAME_DELAY_MS = 45;
-
 // The category tally. When `animate`, the counts count up from zero in parallel
 // (first-run onboarding on a TTY); else the final lines print at once. Counts
 // only grow, so frames never shrink — no per-line clear needed.
@@ -604,15 +606,24 @@ const joinSections = (
   return { lines, sectionStarts };
 };
 
-// The colored "N issues" label (no indent), or null when there are none.
-export const buildIssueCountLabel = (diagnostics: Diagnostic[]): string | null => {
+// The plain "N issues" text (no color, no indent), or null when there are none.
+export const buildIssueCountText = (diagnostics: Diagnostic[]): string | null => {
   const totalIssueCount = diagnostics.length;
   if (totalIssueCount === 0) return null;
+  return `${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`;
+};
+
+// The "N issues" label colored by severity (red with errors, yellow with only
+// warnings, else dim), for the standalone count line. The inline score-line
+// suffix instead colors it by score, to match the bar — see `buildScoreLine`.
+export const buildIssueCountLabel = (diagnostics: Diagnostic[]): string | null => {
+  const text = buildIssueCountText(diagnostics);
+  if (text === null) return null;
   const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
-  const warningCount = totalIssueCount - errorCount;
+  const warningCount = diagnostics.length - errorCount;
   const issueCountColor =
     errorCount > 0 ? highlighter.error : warningCount > 0 ? highlighter.warn : highlighter.dim;
-  return issueCountColor(`${totalIssueCount} ${totalIssueCount === 1 ? "issue" : "issues"}`);
+  return issueCountColor(text);
 };
 
 export const buildCountsSummaryLines = (diagnostics: Diagnostic[]): ReadonlyArray<string> => {
@@ -635,8 +646,6 @@ export const buildTopErrorBlocks = (
       ...buildRuleDetailBlock(ruleKey, ruleDiagnostics, resolveSourceRoot, false),
     ]);
 };
-
-const WARNING_TYPEWRITER_FRAME_DELAY_MS = 14;
 
 // The compact `⚠ rule ×N` warning list (capped); no header, no overflow (folded
 // into the merged line above). ⚠ sits at col 2 so the error blocks keep the

--- a/packages/react-doctor/src/cli/utils/render-report.ts
+++ b/packages/react-doctor/src/cli/utils/render-report.ts
@@ -1,0 +1,174 @@
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import { highlighter } from "@react-doctor/core";
+import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+import {
+  buildCountsSummaryLines,
+  buildIssueCountLabel,
+  buildMergedOverflowLine,
+  buildTopErrorBlocks,
+  printCategoryBreakdown,
+  printWarningRollup,
+  type SourceRootResolver,
+} from "./render-diagnostics.js";
+import { printAgentGuidance } from "./render-agent-guidance.js";
+import {
+  animateScoreProjection,
+  printBrandingOnlyHeader,
+  printNoScoreHeader,
+  printScoreHeader,
+} from "./render-score-header.js";
+import {
+  buildImproveLine,
+  buildShareLine,
+  printDocsNote,
+  printVerboseTip,
+} from "./render-summary.js";
+
+export interface InspectReportInput {
+  readonly diagnostics: Diagnostic[];
+  readonly score: ScoreResult | null;
+  // Score reachable by fixing the top errors; drives the projected score bar
+  // and the "you could improve" line. Omitted when there's nothing to project.
+  readonly potentialScore?: number | null;
+  readonly projectName: string;
+  readonly sourceRoot: string | SourceRootResolver;
+  readonly rulePriority?: ReadonlyMap<string, number>;
+  readonly outputSurface: string;
+  readonly demotedDiagnosticCount: number;
+  readonly noScoreMessage: string;
+  readonly isOffline: boolean;
+  readonly hasSkippedChecks: boolean;
+  readonly skippedChecks: ReadonlyArray<string>;
+  readonly verbose: boolean;
+  readonly isNonInteractiveEnvironment: boolean;
+  // The onboarding beat played before each section up to and including the
+  // score. Defaults to a no-op so normal runs render with zero delay.
+  readonly sectionPause?: Effect.Effect<void>;
+  // The (shorter) beat for everything after the score — the report quickens
+  // once the headline lands. Defaults to `sectionPause`.
+  readonly sectionPauseFast?: Effect.Effect<void>;
+  // Count the category tallies up from zero (first-run onboarding on a TTY).
+  readonly animateCountUp?: boolean;
+  // Whether to show the "set up CI/CD" docs tip (false when CI/CD already set up).
+  readonly showCiCdTip?: boolean;
+}
+
+// The non-verbose single-project report, in reading order: category tally,
+// score, projection, top fixes, warning roll-up, merged overflow, footer.
+// First-run onboarding only layers the count-up and `sectionPause` beats on top.
+export const printInspectReport = (input: InspectReportInput): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const pause = input.sectionPause ?? Effect.void;
+    // The report quickens once the score lands; defaults to the same beat.
+    const fastPause = input.sectionPauseFast ?? pause;
+    const { diagnostics, rulePriority } = input;
+    const animate = input.animateCountUp ?? false;
+    const issueLabel = buildIssueCountLabel(diagnostics);
+
+    yield* pause;
+    yield* printCategoryBreakdown(diagnostics, rulePriority, animate);
+
+    yield* Console.log("");
+    yield* pause;
+    if (input.hasSkippedChecks) {
+      yield* printBrandingOnlyHeader;
+      yield* Console.log(highlighter.gray("  Score not shown — some checks could not complete."));
+      for (const line of buildCountsSummaryLines(diagnostics)) yield* Console.log(line);
+    } else if (input.score) {
+      // Issue count rides inline on the score line. When animating, the bar
+      // draws plain here and the ghost gain is revealed later (see below).
+      yield* printScoreHeader(
+        input.score,
+        animate ? undefined : (input.potentialScore ?? undefined),
+        issueLabel ?? "",
+      );
+    } else {
+      yield* printNoScoreHeader(input.noScoreMessage);
+      for (const line of buildCountsSummaryLines(diagnostics)) yield* Console.log(line);
+    }
+
+    // The score box prints a trailing blank, so the first section after it
+    // skips its own leading blank to keep a single gap. (The no-score / skipped
+    // branches above already consumed that blank with the count line.)
+    let scoreBlankPending = input.score != null && !input.hasSkippedChecks;
+    const leadingGap = Effect.gen(function* () {
+      if (scoreBlankPending) {
+        scoreBlankPending = false;
+      } else {
+        yield* Console.log("");
+      }
+    });
+
+    // Share sits directly under the score box.
+    if (!input.isOffline) {
+      yield* leadingGap;
+      yield* fastPause;
+      yield* Console.log(buildShareLine(diagnostics, input.score, input.projectName));
+    }
+
+    const improveLine = buildImproveLine(input.score, input.potentialScore);
+    if (improveLine) {
+      yield* leadingGap;
+      yield* fastPause;
+      yield* Console.log(improveLine);
+      // Then grow the bar's projected gain in, eased, in sync with that line.
+      // Rows from the cursor up to the bar: the box's trailing blank, branding,
+      // └, this line + its leading blank, and (when shown) the Share line above.
+      const barRowsAboveCursor = input.isOffline ? 5 : 7;
+      if (animate && input.score && !input.hasSkippedChecks && input.potentialScore != null) {
+        yield* animateScoreProjection(input.score, input.potentialScore, barRowsAboveCursor);
+      }
+    }
+
+    for (const block of buildTopErrorBlocks(diagnostics, input.sourceRoot, rulePriority)) {
+      yield* leadingGap;
+      yield* fastPause;
+      for (const line of block) yield* Console.log(line);
+    }
+
+    if (input.isNonInteractiveEnvironment && input.outputSurface !== "prComment") {
+      yield* leadingGap;
+      yield* printAgentGuidance();
+    }
+
+    const overflowLine = buildMergedOverflowLine(diagnostics, rulePriority);
+    if (overflowLine) {
+      yield* leadingGap;
+      yield* fastPause;
+      yield* Console.log(overflowLine);
+    }
+
+    if (diagnostics.some((diagnostic) => diagnostic.severity === "warning")) {
+      yield* leadingGap;
+      yield* fastPause;
+      yield* printWarningRollup(diagnostics, rulePriority, animate);
+    }
+
+    if (input.demotedDiagnosticCount > 0) {
+      yield* leadingGap;
+      yield* fastPause;
+      yield* Console.log(
+        highlighter.gray(
+          `  ${input.demotedDiagnosticCount} demoted from the ${input.outputSurface} surface (e.g. design cleanup) — run \`npx react-doctor@latest .\` locally for the full list.`,
+        ),
+      );
+    }
+
+    if (input.hasSkippedChecks) {
+      yield* leadingGap;
+      yield* fastPause;
+      const skippedLabel = input.skippedChecks.join(" and ");
+      yield* Console.warn(
+        highlighter.warn(`  Note: ${skippedLabel} checks failed — score may be incomplete.`),
+      );
+    }
+
+    // `printDocsNote` opens with its own blank line, so it spaces itself.
+    yield* fastPause;
+    yield* printDocsNote(input.showCiCdTip ?? true);
+
+    yield* Console.log("");
+    yield* fastPause;
+    yield* printVerboseTip(diagnostics, input.verbose);
+  });

--- a/packages/react-doctor/src/cli/utils/render-report.ts
+++ b/packages/react-doctor/src/cli/utils/render-report.ts
@@ -4,7 +4,7 @@ import { highlighter } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import {
   buildCountsSummaryLines,
-  buildIssueCountLabel,
+  buildIssueCountText,
   buildMergedOverflowLine,
   buildTopErrorBlocks,
   printCategoryBreakdown,
@@ -64,7 +64,7 @@ export const printInspectReport = (input: InspectReportInput): Effect.Effect<voi
     const fastPause = input.sectionPauseFast ?? pause;
     const { diagnostics, rulePriority } = input;
     const animate = input.animateCountUp ?? false;
-    const issueLabel = buildIssueCountLabel(diagnostics);
+    const issueLabel = buildIssueCountText(diagnostics);
 
     yield* pause;
     yield* printCategoryBreakdown(diagnostics, rulePriority, animate);

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -15,8 +15,10 @@ import {
   SCORE_HEADER_ANIMATION_FRAME_COUNT,
   SCORE_HEADER_ANIMATION_FRAME_DELAY_MS,
 } from "./constants.js";
+import { easeOutCubic } from "./ease-out-cubic.js";
 import { isSpinnerInteractive } from "./is-spinner-interactive.js";
 import { isSpinnerSilent } from "./spinner.js";
+import { writeStdout } from "./write-stdout.js";
 
 const RAINBOW_HUE_SHIFT_PER_FRAME = 9;
 const RAINBOW_GRADIENT_WIDTH = 80;
@@ -51,11 +53,6 @@ interface InitialScoreHeaderLineInput {
   rawRightColumnContent: string;
   score: number;
 }
-
-const easeOutCubic = (progress: number): number => 1 - (1 - progress) ** 3;
-
-const sleep = (milliseconds: number): Effect.Effect<void> =>
-  Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
 
 const buildScoreBarSegments = (filledCount: number): ScoreBarSegments => {
   const emptyCount = SCORE_BAR_WIDTH_CHARS - filledCount;
@@ -176,15 +173,16 @@ const buildFaceRenderedLines = (score: number): string[] => {
   return buildRawFaceLines(score).map(colorize);
 };
 
-const writeScoreHeaderLine = (line: string): Effect.Effect<void> =>
-  Effect.sync(() => {
-    process.stdout.write(line);
-  });
-
-const buildScoreLine = (displayScore: number, finalScore: number, label: string): string => {
+const buildScoreLine = (
+  displayScore: number,
+  finalScore: number,
+  label: string,
+  scoreLineSuffix = "",
+): string => {
   const scoreNumber = colorizeByScore(`${displayScore}`, finalScore);
   const scoreLabel = colorizeByScore(label, finalScore);
-  return `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}`;
+  const suffix = scoreLineSuffix.length > 0 ? `   ${scoreLineSuffix}` : "";
+  return `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}${suffix}`;
 };
 
 const buildRawScoreLine = (displayScore: number, label: string): string =>
@@ -247,6 +245,7 @@ const printAnimatedScore = (
   score: number,
   label: string,
   potentialScore?: number,
+  scoreLineSuffix = "",
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     const isPerfectScore = score === PERFECT_SCORE;
@@ -256,7 +255,7 @@ const printAnimatedScore = (
       const animatedScore = Math.round(score * progress);
       if (isPerfectScore) {
         const cursorUp = frame === 0 ? "" : "\x1b[4A";
-        yield* writeScoreHeaderLine(
+        yield* writeStdout(
           `${cursorUp}\r${buildRainbowScoreHeaderFrame({
             score,
             displayScore: animatedScore,
@@ -265,12 +264,12 @@ const printAnimatedScore = (
           })}`,
         );
         if (frame < SCORE_HEADER_ANIMATION_FRAME_COUNT) {
-          yield* sleep(SCORE_HEADER_ANIMATION_FRAME_DELAY_MS);
+          yield* Effect.sleep(SCORE_HEADER_ANIMATION_FRAME_DELAY_MS);
         }
         continue;
       }
 
-      const animatedScoreLine = buildScoreLine(animatedScore, score, label);
+      const animatedScoreLine = buildScoreLine(animatedScore, score, label, scoreLineSuffix);
       // Reveal the projection ghost only once the count-up settles on the
       // real score — mid-animation it would fight the filling bar.
       const isFinalFrame = frame === SCORE_HEADER_ANIMATION_FRAME_COUNT;
@@ -281,18 +280,18 @@ const printAnimatedScore = (
       // HACK: \x1b[2A moves cursor up 2 lines to overwrite both the
       // score number line and the bar line in place each frame.
       const cursorUp = frame === 0 ? "" : "\x1b[2A";
-      yield* writeScoreHeaderLine(
+      yield* writeStdout(
         `${cursorUp}\r${buildScoreHeaderLine(scoreFaceLine, animatedScoreLine)}\n\r${buildScoreHeaderLine(barFaceLine, animatedBarLine)}\n`,
       );
       if (frame < SCORE_HEADER_ANIMATION_FRAME_COUNT) {
-        yield* sleep(SCORE_HEADER_ANIMATION_FRAME_DELAY_MS);
+        yield* Effect.sleep(SCORE_HEADER_ANIMATION_FRAME_DELAY_MS);
       }
     }
 
     if (!isPerfectScore) return;
 
     for (let frame = 0; frame < PERFECT_SCORE_RAINBOW_FRAME_COUNT; frame += 1) {
-      yield* writeScoreHeaderLine(
+      yield* writeStdout(
         `\x1b[4A\r${buildRainbowScoreHeaderFrame({
           score,
           displayScore: score,
@@ -300,10 +299,10 @@ const printAnimatedScore = (
           frame,
         })}`,
       );
-      yield* sleep(PERFECT_SCORE_RAINBOW_FRAME_DELAY_MS);
+      yield* Effect.sleep(PERFECT_SCORE_RAINBOW_FRAME_DELAY_MS);
     }
 
-    yield* writeScoreHeaderLine(
+    yield* writeStdout(
       `\x1b[4A\r${buildFinalPerfectScoreHeaderFrame(score, label, PERFECT_SCORE_RAINBOW_FRAME_COUNT)}\x1b[2A`,
     );
   });
@@ -313,6 +312,9 @@ export const printScoreHeader = (
   // The score reachable by fixing the top errors, drawn as a ghost gain
   // segment on the bar. Omitted when there's nothing to project.
   potentialScore?: number,
+  // Appended after the label, e.g. the issue count so it reads
+  // "7 / 100 Critical   295 issues". Empty to omit.
+  scoreLineSuffix = "",
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     const isPerfectScore = scoreResult.score === PERFECT_SCORE;
@@ -321,7 +323,12 @@ export const printScoreHeader = (
     const shouldAnimate = !isSpinnerSilent() && isSpinnerInteractive(process.stdout);
 
     const displayScore = shouldAnimate ? 0 : scoreResult.score;
-    const scoreLine = buildScoreLine(displayScore, scoreResult.score, scoreResult.label);
+    const scoreLine = buildScoreLine(
+      displayScore,
+      scoreResult.score,
+      scoreResult.label,
+      scoreLineSuffix,
+    );
     const scoreBarLine = shouldAnimate
       ? buildScoreBar(0, scoreResult.score)
       : potentialScore !== undefined
@@ -356,15 +363,46 @@ export const printScoreHeader = (
       // HACK: move cursor up to the score number line (5 lines up:
       // 4 face lines + 1 trailing blank) and animate score + bar
       // together, then move cursor back down past branding + blank.
-      yield* writeScoreHeaderLine("\x1b[5A");
+      yield* writeStdout("\x1b[5A");
       yield* printAnimatedScore(
         renderedFaceLines[0],
         renderedFaceLines[1],
         scoreResult.score,
         scoreResult.label,
         potentialScore,
+        scoreLineSuffix,
       );
-      yield* writeScoreHeaderLine("\x1b[3B");
+      yield* writeStdout("\x1b[3B");
+    }
+  });
+
+const SCORE_PROJECTION_FRAME_COUNT = 16;
+const SCORE_PROJECTION_FRAME_DELAY_MS = 35;
+
+// Grows the score bar's projected "ghost gain" (▓) in, eased, synced with the
+// "you could improve" line. `linesBelowBar` is the cursor's distance beneath the
+// bar, so each frame redraws the bar in place and returns. No-op for a perfect
+// score or no gain.
+export const animateScoreProjection = (
+  scoreResult: ScoreResult,
+  potentialScore: number,
+  linesBelowBar: number,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    if (scoreResult.score === PERFECT_SCORE || potentialScore <= scoreResult.score) return;
+    const barFaceLine = buildFaceRenderedLines(scoreResult.score)[1] ?? "";
+    for (let frame = 1; frame <= SCORE_PROJECTION_FRAME_COUNT; frame += 1) {
+      const progress = easeOutCubic(frame / SCORE_PROJECTION_FRAME_COUNT);
+      const displayedPotential =
+        scoreResult.score + (potentialScore - scoreResult.score) * progress;
+      const barLine = buildScoreHeaderLine(
+        barFaceLine,
+        buildProjectedScoreBar(scoreResult.score, displayedPotential),
+      );
+      yield* writeStdout(`\x1b[${linesBelowBar}A\r${barLine}\x1b[${linesBelowBar}B\r`);
+      if (frame < SCORE_PROJECTION_FRAME_COUNT) {
+        yield* Effect.sleep(SCORE_PROJECTION_FRAME_DELAY_MS);
+      }
     }
   });
 

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -14,6 +14,8 @@ import {
   PERFECT_SCORE_RAINBOW_FRAME_DELAY_MS,
   SCORE_HEADER_ANIMATION_FRAME_COUNT,
   SCORE_HEADER_ANIMATION_FRAME_DELAY_MS,
+  SCORE_PROJECTION_FRAME_COUNT,
+  SCORE_PROJECTION_FRAME_DELAY_MS,
 } from "./constants.js";
 import { easeOutCubic } from "./ease-out-cubic.js";
 import { isSpinnerInteractive } from "./is-spinner-interactive.js";
@@ -181,7 +183,9 @@ const buildScoreLine = (
 ): string => {
   const scoreNumber = colorizeByScore(`${displayScore}`, finalScore);
   const scoreLabel = colorizeByScore(label, finalScore);
-  const suffix = scoreLineSuffix.length > 0 ? `   ${scoreLineSuffix}` : "";
+  // The issue-count suffix matches the score color so it reads as one status.
+  const suffix =
+    scoreLineSuffix.length > 0 ? `   ${colorizeByScore(scoreLineSuffix, finalScore)}` : "";
   return `${scoreNumber} ${highlighter.dim(`/ ${PERFECT_SCORE}`)} ${scoreLabel}${suffix}`;
 };
 
@@ -375,9 +379,6 @@ export const printScoreHeader = (
       yield* writeStdout("\x1b[3B");
     }
   });
-
-const SCORE_PROJECTION_FRAME_COUNT = 16;
-const SCORE_PROJECTION_FRAME_DELAY_MS = 35;
 
 // Grows the score bar's projected "ghost gain" (▓) in, eased, synced with the
 // "you could improve" line. `linesBelowBar` is the cursor's distance beneath the

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -12,6 +12,28 @@ import { collectAffectedFiles } from "./render-diagnostics.js";
 import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
 import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 
+// The "You could improve +X% by fixing the top N issues" line, or null when
+// there's no score or nothing to project.
+export const buildImproveLine = (
+  scoreResult: ScoreResult | null,
+  potentialScore: number | null | undefined,
+): string | null => {
+  if (!scoreResult || potentialScore == null) return null;
+  const improvement = potentialScore - scoreResult.score;
+  return (
+    highlighter.gray("  You could improve ") +
+    colorizeByScore(`+${improvement}%`, potentialScore) +
+    highlighter.gray(` by fixing these top ${TOP_ERRORS_DISPLAY_COUNT} issues`)
+  );
+};
+
+export const buildShareLine = (
+  diagnostics: Diagnostic[],
+  scoreResult: ScoreResult | null,
+  projectName: string,
+): string =>
+  `  ${highlighter.bold("Share:")} ${highlighter.info(buildShareUrl(diagnostics, scoreResult, projectName))}`;
+
 const buildShareUrl = (
   diagnostics: Diagnostic[],
   scoreResult: ScoreResult | null,
@@ -54,13 +76,19 @@ export const printVerboseTip = (
 // A closing pointer to the docs for the workflows the scan output doesn't
 // teach inline: wiring up CI/CD, writing a config file to suppress rules,
 // and scanning only a diff or PR. Printed once at the very end of a run.
-export const printDocsNote = (): Effect.Effect<void> =>
+export const printDocsNote = (showCiCdTip = true): Effect.Effect<void> =>
   Effect.gen(function* () {
     yield* Console.log("");
     yield* Console.log(`  ${highlighter.bold("Docs:")} ${highlighter.info(DOCS_URL)}`);
-    yield* Console.log(
-      highlighter.dim("  Set up CI/CD, suppress rules with a config file, and scan diffs or PRs."),
-    );
+    // Skip the "set up CI/CD" nudge for projects that already run CI.
+    if (showCiCdTip) {
+      yield* Console.log("");
+      yield* Console.log(
+        highlighter.dim(
+          "  Tip: Set up CI/CD, suppress rules with a config file, and scan diffs or PRs.",
+        ),
+      );
+    }
   });
 
 export interface PrintSummaryInput {
@@ -81,14 +109,8 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
   Effect.gen(function* () {
     if (input.scoreResult) {
       yield* printScoreHeader(input.scoreResult, input.potentialScore ?? undefined);
-      if (input.potentialScore != null) {
-        const improvement = input.potentialScore - input.scoreResult.score;
-        yield* Console.log(
-          highlighter.gray("  You could improve ") +
-            colorizeByScore(`+${improvement}%`, input.potentialScore) +
-            highlighter.gray(` by fixing the top ${TOP_ERRORS_DISPLAY_COUNT} issues`),
-        );
-      }
+      const improveLine = buildImproveLine(input.scoreResult, input.potentialScore);
+      if (improveLine) yield* Console.log(improveLine);
     } else {
       yield* printNoScoreHeader(input.noScoreMessage);
     }
@@ -108,8 +130,7 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
 
     if (!input.isOffline) {
       yield* Console.log("");
-      const shareUrl = buildShareUrl(input.diagnostics, input.scoreResult, input.projectName);
-      yield* Console.log(`  ${highlighter.bold("Share:")} ${highlighter.info(shareUrl)}`);
+      yield* Console.log(buildShareLine(input.diagnostics, input.scoreResult, input.projectName));
       yield* Console.log("");
     }
   });

--- a/packages/react-doctor/src/cli/utils/render-welcome.ts
+++ b/packages/react-doctor/src/cli/utils/render-welcome.ts
@@ -1,11 +1,12 @@
 import * as Effect from "effect/Effect";
 import { highlighter } from "@react-doctor/core";
+import {
+  WELCOME_EXPLANATION_HOLD_MS,
+  WELCOME_HOLD_MS,
+  WELCOME_INTER_LINE_DELAY_MS,
+  WELCOME_TYPEWRITER_CHAR_DELAY_MS,
+} from "./constants.js";
 import { writeStdout } from "./write-stdout.js";
-
-const TYPEWRITER_CHAR_DELAY_MS = 32;
-const INTER_LINE_DELAY_MS = 500;
-const EXPLANATION_HOLD_MS = 2000;
-const WELCOME_HOLD_MS = 1000;
 
 const HAPPY_FACE_LINES = ["┌─────┐", "│ ◠ ◠ │", "│  ▽  │", "└─────┘"] as const;
 
@@ -20,7 +21,7 @@ const typeLine = (
     const characters = [...text];
     for (let length = 1; length <= characters.length; length += 1) {
       yield* writeStdout(`\r${linePrefix}${style(characters.slice(0, length).join(""))}\x1b[K`);
-      yield* Effect.sleep(TYPEWRITER_CHAR_DELAY_MS);
+      yield* Effect.sleep(WELCOME_TYPEWRITER_CHAR_DELAY_MS);
     }
   });
 
@@ -41,7 +42,7 @@ export const playWelcomeScene = (): Effect.Effect<void> =>
     );
 
     // Down to the mouth row; type the tagline.
-    yield* Effect.sleep(INTER_LINE_DELAY_MS);
+    yield* Effect.sleep(WELCOME_INTER_LINE_DELAY_MS);
     yield* writeStdout("\x1b[1B");
     yield* typeLine(
       mouthPrefix,
@@ -50,7 +51,7 @@ export const playWelcomeScene = (): Effect.Effect<void> =>
     );
 
     // Hold, then overwrite the mouth line in place with the closing line.
-    yield* Effect.sleep(EXPLANATION_HOLD_MS);
+    yield* Effect.sleep(WELCOME_EXPLANATION_HOLD_MS);
     yield* typeLine(mouthPrefix, "Let's scan your codebase...", (fragment) =>
       highlighter.dim(fragment),
     );

--- a/packages/react-doctor/src/cli/utils/render-welcome.ts
+++ b/packages/react-doctor/src/cli/utils/render-welcome.ts
@@ -1,0 +1,61 @@
+import * as Effect from "effect/Effect";
+import { highlighter } from "@react-doctor/core";
+import { writeStdout } from "./write-stdout.js";
+
+const TYPEWRITER_CHAR_DELAY_MS = 32;
+const INTER_LINE_DELAY_MS = 500;
+const EXPLANATION_HOLD_MS = 2000;
+const WELCOME_HOLD_MS = 1000;
+
+const HAPPY_FACE_LINES = ["┌─────┐", "│ ◠ ◠ │", "│  ▽  │", "└─────┘"] as const;
+
+// Types `text` in one char at a time, each step rewriting from column 0 and
+// clearing to end of line so it also overwrites any longer text already there.
+const typeLine = (
+  linePrefix: string,
+  text: string,
+  style: (fragment: string) => string,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const characters = [...text];
+    for (let length = 1; length <= characters.length; length += 1) {
+      yield* writeStdout(`\r${linePrefix}${style(characters.slice(0, length).join(""))}\x1b[K`);
+      yield* Effect.sleep(TYPEWRITER_CHAR_DELAY_MS);
+    }
+  });
+
+// First-run greeting: the doctor face draws in, the welcome + tagline type beside
+// it, then the block is wiped for the scan. Caller guarantees a TTY.
+export const playWelcomeScene = (): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const face = HAPPY_FACE_LINES.map((line) => highlighter.success(line));
+    const mouthPrefix = `  ${face[2] ?? ""}  `;
+
+    // Blank line + face box; cursor ends just below the box.
+    yield* writeStdout(`\n${face.map((line) => `  ${line}`).join("\n")}\n`);
+
+    // Up to the eyes row; type the greeting.
+    yield* writeStdout("\x1b[3A");
+    yield* typeLine(`  ${face[1] ?? ""}  `, "Welcome to React Doctor", (fragment) =>
+      highlighter.bold(fragment),
+    );
+
+    // Down to the mouth row; type the tagline.
+    yield* Effect.sleep(INTER_LINE_DELAY_MS);
+    yield* writeStdout("\x1b[1B");
+    yield* typeLine(
+      mouthPrefix,
+      "I diagnose your React code for bugs, security & performance.",
+      (fragment) => highlighter.dim(fragment),
+    );
+
+    // Hold, then overwrite the mouth line in place with the closing line.
+    yield* Effect.sleep(EXPLANATION_HOLD_MS);
+    yield* typeLine(mouthPrefix, "Let's scan your codebase...", (fragment) =>
+      highlighter.dim(fragment),
+    );
+
+    // Hold, then erase the block: up to the leading blank, clear to end of screen.
+    yield* Effect.sleep(WELCOME_HOLD_MS);
+    yield* writeStdout("\x1b[3A\r\x1b[0J");
+  });

--- a/packages/react-doctor/src/cli/utils/run-explain.ts
+++ b/packages/react-doctor/src/cli/utils/run-explain.ts
@@ -66,7 +66,7 @@ export const runExplain = async (
 
   for (const diagnostic of matchingDiagnostics) {
     const ruleIdentifier = `${diagnostic.plugin}/${diagnostic.rule}`;
-    const severitySymbol = diagnostic.severity === "error" ? "✗" : "⚠";
+    const severitySymbol = diagnostic.severity === "error" ? "✖" : "⚠";
     const colorizedRule = colorizeRuleByDiagnostic(ruleIdentifier, diagnostic.severity);
     const severityLabel = colorizeRuleByDiagnostic(diagnostic.severity, diagnostic.severity);
     logger.log(

--- a/packages/react-doctor/src/cli/utils/write-stdout.ts
+++ b/packages/react-doctor/src/cli/utils/write-stdout.ts
@@ -1,0 +1,8 @@
+import * as Effect from "effect/Effect";
+
+// Raw stdout write with no trailing newline — for in-place terminal animations
+// (cursor moves, line rewrites) that `Console.log` can't express.
+export const writeStdout = (text: string): Effect.Effect<void> =>
+  Effect.sync(() => {
+    process.stdout.write(text);
+  });

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -49,6 +49,7 @@ import {
   ONBOARDING_SECTION_DELAY_FAST_MS,
   onboardingSectionPause,
   shouldPaceOnboardingSections,
+  shouldRecordOnboarding,
 } from "./cli/utils/onboarding-pacing.js";
 import { hasCompletedOnboarding, markOnboardingComplete } from "./cli/utils/onboarding-state.js";
 import { printProjectDetection } from "./cli/utils/render-project-detection.js";
@@ -376,9 +377,17 @@ const runInspectWithRuntime = async (
       options.silent ? Effect.provideService(Console.Console, silentConsole) : (program) => program,
     ),
   );
-  // Record the marker after a paced render so later runs print instantly. A
-  // forced run is a demo, so it stays replayable and never burns the marker.
-  if (paceOnboardingSections && !forceOnboarding) {
+  // Burn the first-run marker only when the onboarding reveal was actually shown
+  // (the interactive layout branch below) — not for verbose, the classic
+  // non-interactive layout, or a forced demo. See `shouldRecordOnboarding`.
+  if (
+    shouldRecordOnboarding({
+      paceOnboardingSections,
+      forceOnboarding,
+      verbose: options.verbose,
+      isNonInteractiveEnvironment: options.isNonInteractiveEnvironment,
+    })
+  ) {
     markOnboardingComplete();
   }
   recordScanMetrics({

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -61,6 +61,7 @@ import { printDocsNote, printSummary, printVerboseTip } from "./cli/utils/render
 import { resolveOxlintNode } from "./cli/utils/resolve-oxlint-node.js";
 import { isSpinnerSilent, setSpinnerSilent } from "./cli/utils/spinner.js";
 import { VERSION } from "./cli/utils/version.js";
+import { writeDiagnosticsDirectory } from "./cli/utils/write-diagnostics-directory.js";
 
 const silentConsole = makeNoopConsole();
 
@@ -541,6 +542,16 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
         buildRulePriorityMap([score]),
         isCodingAgentEnvironment(),
       );
+      // Verbose is the deep-dive mode: point to the full diagnostics dump on disk.
+      const diagnosticsDirectory = yield* Effect.try({
+        try: () => writeDiagnosticsDirectory([...surfaceDiagnostics]),
+        catch: (cause) => cause,
+      }).pipe(Effect.orElseSucceed(() => null as string | null));
+      if (diagnosticsDirectory !== null) {
+        yield* Console.log(
+          highlighter.gray(`  Full diagnostics written to ${diagnosticsDirectory}`),
+        );
+      }
       yield* Console.log("");
       if (hasSkippedChecks) {
         yield* printBrandingOnlyHeader;

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -38,9 +38,19 @@ import {
   isCodingAgentEnvironment,
 } from "./cli/utils/is-ci-environment.js";
 import { computeProjectedScore } from "./cli/utils/compute-score-projection.js";
+import { hasReactDoctorWorkflow } from "./cli/utils/has-react-doctor-workflow.js";
 import { buildRulePriorityMap } from "./cli/utils/diagnostic-grouping.js";
 import { printDiagnostics } from "./cli/utils/render-diagnostics.js";
+import { printInspectReport } from "./cli/utils/render-report.js";
 import { isNonInteractiveEnvironment } from "./cli/utils/is-non-interactive-environment.js";
+import {
+  canAnimateOnboarding,
+  isOnboardingForced,
+  ONBOARDING_SECTION_DELAY_FAST_MS,
+  onboardingSectionPause,
+  shouldPaceOnboardingSections,
+} from "./cli/utils/onboarding-pacing.js";
+import { hasCompletedOnboarding, markOnboardingComplete } from "./cli/utils/onboarding-state.js";
 import { printProjectDetection } from "./cli/utils/render-project-detection.js";
 import {
   printBrandingOnlyHeader,
@@ -330,8 +340,21 @@ const runInspectWithRuntime = async (
   const score = didLintFail ? null : output.score;
 
   const elapsedMilliseconds = performance.now() - startTime;
+  // Stagger sections only on a user's first interactive run: nothing to pace for
+  // silent/score-only/suppressed renders; CI, agents, and non-TTY are gated out;
+  // and the persisted marker (read last) limits it to the very first attempt.
+  // `REACT_DOCTOR_FORCE_ONBOARDING` replays the first-run experience on demand.
+  const forceOnboarding = isOnboardingForced();
+  const paceOnboardingSections =
+    !options.silent &&
+    !options.scoreOnly &&
+    !options.suppressRendering &&
+    shouldPaceOnboardingSections({ isCiOrCodingAgent: options.isCiOrCodingAgentEnvironment }) &&
+    (forceOnboarding || !hasCompletedOnboarding());
   const finalizeInput: FinalizeInput = {
     options,
+    paceOnboardingSections,
+    forceOnboarding,
     elapsedMilliseconds,
     diagnostics: inspectDiagnostics,
     score,
@@ -352,6 +375,11 @@ const runInspectWithRuntime = async (
       options.silent ? Effect.provideService(Console.Console, silentConsole) : (program) => program,
     ),
   );
+  // Record the marker after a paced render so later runs print instantly. A
+  // forced run is a demo, so it stays replayable and never burns the marker.
+  if (paceOnboardingSections && !forceOnboarding) {
+    markOnboardingComplete();
+  }
   recordScanMetrics({
     result,
     mode: isDiffMode ? "diff" : "full",
@@ -372,6 +400,8 @@ const runInspectWithRuntime = async (
 
 interface FinalizeInput {
   options: ResolvedInspectOptions;
+  paceOnboardingSections: boolean;
+  forceOnboarding: boolean;
   elapsedMilliseconds: number;
   diagnostics: ReadonlyArray<Diagnostic>;
   score: ScoreResult | null;
@@ -392,6 +422,8 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
   Effect.gen(function* () {
     const {
       options,
+      paceOnboardingSections,
+      forceOnboarding,
       elapsedMilliseconds,
       diagnostics,
       score,
@@ -444,6 +476,9 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       return buildResult();
     }
 
+    // Onboarding beat before each section below (no-op off onboarding).
+    const pause = onboardingSectionPause(paceOnboardingSections);
+
     const surfaceDiagnostics = filterDiagnosticsForSurface(
       [...diagnostics],
       options.outputSurface,
@@ -454,6 +489,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
     const lintSourceFileCount = isDiffMode ? options.includePaths.length : project.sourceFileCount;
 
     if (surfaceDiagnostics.length === 0) {
+      yield* pause;
       if (hasSkippedChecks) {
         const skippedLabel = skippedChecks.join(" and ");
         yield* Console.warn(
@@ -471,6 +507,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
         yield* Console.log(highlighter.success("No issues found!"));
       }
       yield* Console.log("");
+      yield* pause;
       if (hasSkippedChecks) {
         yield* printBrandingOnlyHeader;
         yield* Console.log(highlighter.gray("  Score not shown — some checks could not complete."));
@@ -482,58 +519,117 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       return buildResult();
     }
 
-    yield* Console.log("");
-    yield* printDiagnostics(
-      [...surfaceDiagnostics],
-      options.verbose,
-      directory,
-      buildRulePriorityMap([score]),
-      isCodingAgentEnvironment(),
-    );
-    if (options.isNonInteractiveEnvironment && options.outputSurface !== "prComment") {
-      yield* printAgentGuidance();
-    }
+    // Re-score with the top errors removed to show the payoff as the bar's ghost
+    // gain. Verbose has no projection, so it skips this extra score-API call.
+    const potentialScore =
+      score && !options.verbose
+        ? yield* Effect.promise(() =>
+            computeProjectedScore([...surfaceDiagnostics], [...surfaceDiagnostics], score),
+          )
+        : null;
+    const shouldShowShareLink = !options.noScore && options.share && !options.isCi;
+    const showCiCdTip = !hasReactDoctorWorkflow(directory);
 
-    if (demotedDiagnosticCount > 0) {
-      yield* Console.log(
-        highlighter.gray(
-          `  ${demotedDiagnosticCount} demoted from the ${options.outputSurface} surface (e.g. design cleanup) — run \`npx react-doctor@latest .\` locally for the full list.`,
-        ),
+    if (options.verbose) {
+      // Verbose is a focused review: full errors + warnings list, score bar, and
+      // a one-line agent tip — no projection, share, docs, CI/CD tip, or top-3.
+      yield* Console.log("");
+      yield* printDiagnostics(
+        [...surfaceDiagnostics],
+        true,
+        directory,
+        buildRulePriorityMap([score]),
+        isCodingAgentEnvironment(),
       );
       yield* Console.log("");
+      if (hasSkippedChecks) {
+        yield* printBrandingOnlyHeader;
+        yield* Console.log(highlighter.gray("  Score not shown — some checks could not complete."));
+      } else if (score) {
+        yield* printScoreHeader(score);
+      } else {
+        yield* printNoScoreHeader(noScoreMessage);
+      }
+      yield* Console.log(
+        highlighter.dim("  Tip: Ask an agent like Claude Code or Codex to fix these issues."),
+      );
+      return buildResult();
     }
 
-    // Re-score with the displayed top errors removed so the score bar can
-    // show the payoff as a ghost gain segment.
-    const potentialScore = score
-      ? yield* Effect.promise(() =>
-          computeProjectedScore([...surfaceDiagnostics], [...surfaceDiagnostics], score),
-        )
-      : null;
+    if (options.isNonInteractiveEnvironment && !forceOnboarding) {
+      // Non-interactive runs (CI, git hooks, agents) keep the classic layout
+      // (diagnostics + agent guidance first), unless onboarding is forced.
+      yield* pause;
+      yield* Console.log("");
+      yield* printDiagnostics(
+        [...surfaceDiagnostics],
+        false,
+        directory,
+        buildRulePriorityMap([score]),
+        isCodingAgentEnvironment(),
+        pause,
+      );
+      if (options.outputSurface !== "prComment") {
+        yield* printAgentGuidance();
+      }
+      if (demotedDiagnosticCount > 0) {
+        yield* pause;
+        yield* Console.log(
+          highlighter.gray(
+            `  ${demotedDiagnosticCount} demoted from the ${options.outputSurface} surface (e.g. design cleanup) — run \`npx react-doctor@latest .\` locally for the full list.`,
+          ),
+        );
+        yield* Console.log("");
+      }
+      yield* pause;
+      yield* printSummary({
+        diagnostics: [...surfaceDiagnostics],
+        elapsedMilliseconds,
+        scoreResult: score,
+        potentialScore,
+        projectName: project.projectName,
+        totalSourceFileCount: lintSourceFileCount,
+        noScoreMessage,
+        isOffline: !shouldShowShareLink,
+        verbose: false,
+      });
+      if (hasSkippedChecks) {
+        yield* pause;
+        const skippedLabel = skippedChecks.join(" and ");
+        yield* Console.log("");
+        yield* Console.warn(
+          highlighter.warn(`  Note: ${skippedLabel} checks failed — score may be incomplete.`),
+        );
+      }
+      yield* pause;
+      yield* printVerboseTip([...surfaceDiagnostics], false);
+      yield* printDocsNote(showCiCdTip);
+      return buildResult();
+    }
 
-    const shouldShowShareLink = !options.noScore && options.share && !options.isCi;
-    yield* printSummary({
+    yield* printInspectReport({
       diagnostics: [...surfaceDiagnostics],
-      elapsedMilliseconds,
-      scoreResult: score,
+      score,
       potentialScore,
       projectName: project.projectName,
-      totalSourceFileCount: lintSourceFileCount,
+      sourceRoot: directory,
+      rulePriority: buildRulePriorityMap([score]),
+      outputSurface: options.outputSurface,
+      demotedDiagnosticCount,
       noScoreMessage,
       isOffline: !shouldShowShareLink,
-      verbose: options.verbose,
+      hasSkippedChecks,
+      skippedChecks,
+      verbose: false,
+      isNonInteractiveEnvironment: options.isNonInteractiveEnvironment,
+      sectionPause: pause,
+      sectionPauseFast: onboardingSectionPause(
+        paceOnboardingSections,
+        ONBOARDING_SECTION_DELAY_FAST_MS,
+      ),
+      animateCountUp: paceOnboardingSections && canAnimateOnboarding(process.stdout),
+      showCiCdTip,
     });
-
-    if (hasSkippedChecks) {
-      const skippedLabel = skippedChecks.join(" and ");
-      yield* Console.log("");
-      yield* Console.warn(
-        highlighter.warn(`  Note: ${skippedLabel} checks failed — score may be incomplete.`),
-      );
-    }
-
-    yield* printVerboseTip([...surfaceDiagnostics], options.verbose);
-    yield* printDocsNote();
 
     return buildResult();
   });

--- a/packages/react-doctor/tests/e2e/__snapshots__/terminal-visuals.test.ts.snap
+++ b/packages/react-doctor/tests/e2e/__snapshots__/terminal-visuals.test.ts.snap
@@ -5,60 +5,55 @@ exports[`in-process render across terminal widths and render modes > matches the
   Maintainability > 1 error
   Performance > 1 warning
 
-  5 issues
-
-  ────────────────────────────────────────────────────────────
-  Top 3 errors you should fix
-
-  ✗ Bugs: react-doctor/no-adjust-state-on-prop-change ×2
-    State adjusted in a useEffect when a prop changes — forces
-    an extra render with a stale UI between the two commits.
-    Adjust the state during render with a \`prev\`-prop
-    comparison instead, or refactor to remove the duplicated
-    state.
-
-    src/text-swap.tsx:5
-    ┌──────────────────────────────────────────────────────────────┐
-    │   4 |   useEffect(() => {                                    │
-    │ > 5 |     setCount(0);                                       │
-    │     |     ^                                                  │
-    │   6 |   }, [value]);                                         │
-    └──────────────────────────────────────────────────────────────┘
-
-  ✗ Maintainability: react-doctor/no-nested-component-definition
-    Component defined inside another component remounts on
-    every render, throwing away its state and DOM.
-
-    src/text-swap.tsx:2
-    ┌──────────────────────────────────────────────────────────────┐
-    │   1 | import { useState, useEffect } from 'react';           │
-    │ > 2 | export const TextSwap = ({ value }) => {               │
-    │     |     ^                                                  │
-    │   3 |   const [count, setCount] = useState(0);               │
-    └──────────────────────────────────────────────────────────────┘
-
-  ✗ Bugs: react-doctor/no-array-index-key
-    Using the array index as a key breaks reconciliation when
-    the list reorders.
-
-    src/text-swap.tsx:7
-    ┌──────────────────────────────────────────────────────────────┐
-    │   6 |   }, [value]);                                         │
-    │ > 7 |   return count;                                        │
-    │     |     ^                                                  │
-    │   8 | };                                                     │
-    └──────────────────────────────────────────────────────────────┘
-
-
-  ────────────────────────────────────────────────────────────
-  1 warning
-
-  ⚠ react-doctor/rendering-hoist-jsx
-
-  ┌─────┐  99 / 100 Great
+  ┌─────┐  99 / 100 Great   5 issues
   │ ◠ ◠ │  ██████████████████████████████████████████████████
   │  ▽  │  React Doctor (https://react.doctor)
   └─────┘
+
+✖ Bugs: react-doctor/no-adjust-state-on-prop-change ×2
+  State adjusted in a useEffect when a prop changes — forces
+  an extra render with a stale UI between the two commits.
+  Adjust the state during render with a \`prev\`-prop
+  comparison instead, or refactor to remove the duplicated
+  state.
+
+  src/text-swap.tsx:5
+  ┌──────────────────────────────────────────────────────────────┐
+  │   4 |   useEffect(() => {                                    │
+  │ > 5 |     setCount(0);                                       │
+  │     |     ^                                                  │
+  │   6 |   }, [value]);                                         │
+  └──────────────────────────────────────────────────────────────┘
+
+✖ Maintainability: react-doctor/no-nested-component-definition
+  Component defined inside another component remounts on
+  every render, throwing away its state and DOM.
+
+  src/text-swap.tsx:2
+  ┌──────────────────────────────────────────────────────────────┐
+  │   1 | import { useState, useEffect } from 'react';           │
+  │ > 2 | export const TextSwap = ({ value }) => {               │
+  │     |     ^                                                  │
+  │   3 |   const [count, setCount] = useState(0);               │
+  └──────────────────────────────────────────────────────────────┘
+
+✖ Bugs: react-doctor/no-array-index-key
+  Using the array index as a key breaks reconciliation when
+  the list reorders.
+
+  src/text-swap.tsx:7
+  ┌──────────────────────────────────────────────────────────────┐
+  │   6 |   }, [value]);                                         │
+  │ > 7 |   return count;                                        │
+  │     |     ^                                                  │
+  │   8 | };                                                     │
+  └──────────────────────────────────────────────────────────────┘
+
+  ⚠ react-doctor/rendering-hoist-jsx
+
+  Docs: https://www.react.doctor/docs
+
+  Tip: Set up CI/CD, suppress rules with a config file, and scan diffs or PRs.
 
   Tip: Run npx react-doctor@latest --verbose to see each warning explained with its fix"
 `;

--- a/packages/react-doctor/tests/e2e/terminal-visuals.test.ts
+++ b/packages/react-doctor/tests/e2e/terminal-visuals.test.ts
@@ -26,6 +26,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { OUTPUT_DETAIL_WRAP_WIDTH_CHARS } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { printDiagnostics } from "../../src/cli/utils/render-diagnostics.js";
+import { printInspectReport } from "../../src/cli/utils/render-report.js";
 import { printSummary, printVerboseTip } from "../../src/cli/utils/render-summary.js";
 import { setupReactProject } from "../regressions/_helpers.js";
 import { renderInTerminal } from "../helpers/render-in-terminal.js";
@@ -181,6 +182,29 @@ describe("in-process render across terminal widths and render modes", () => {
       verbose: boolean;
     }): Promise<string> =>
       captureConsoleBytes(async () => {
+        // The default (non-verbose) run with issues uses the reordered
+        // single-project report; verbose and clean runs keep the classic
+        // diagnostics + summary sequence, mirroring the CLI's own branches.
+        if (!options.verbose && options.diagnostics.length > 0) {
+          await Effect.runPromise(
+            printInspectReport({
+              diagnostics: options.diagnostics,
+              score: options.scoreResult,
+              potentialScore: null,
+              projectName: SHARE_ONLY_PROJECT_NAME,
+              sourceRoot: projectDirectory,
+              outputSurface: "cli",
+              demotedDiagnosticCount: 0,
+              noScoreMessage: "Score unavailable.",
+              isOffline: true,
+              hasSkippedChecks: false,
+              skippedChecks: [],
+              verbose: false,
+              isNonInteractiveEnvironment: false,
+            }),
+          );
+          return;
+        }
         await Effect.runPromise(
           printDiagnostics(options.diagnostics, options.verbose, projectDirectory),
         );
@@ -279,7 +303,8 @@ describe("in-process render across terminal widths and render modes", () => {
     // emulator consumes those escapes and exposes the plain text the user
     // actually sees.
     const rendered = await renderInTerminal(defaultScenarioBytes, { cols: 120 });
-    expect(rendered.text).toContain("errors you should fix");
+    // The headline count anchors the report; the top-error blocks follow it.
+    expect(rendered.text).toContain("5 issues");
     // The code frame caret line is the load-bearing visual element.
     expect(rendered.text).toContain("setCount(0)");
   });
@@ -450,7 +475,7 @@ describe.skipIf(!hasBuiltCli)("built CLI subprocess visual smoke", () => {
 
     expect(typeof exitCode === "number").toBe(true);
     expect(stdout).toContain("React Doctor");
-    expect(stdout).toContain("error you should fix");
+    expect(stdout).toContain("Bugs");
     // The top-error headline shows the rule's human title (not the id).
     expect(stdout).toContain("State synced to a prop inside an effect");
     // The inline code frame is rendered from the actual fixture file.
@@ -470,7 +495,7 @@ describe.skipIf(!hasBuiltCli)("built CLI subprocess visual smoke", () => {
     const visualRegion = stdout.split("Agent guidance")[0];
     const rendered = await renderInTerminal(toTerminalStream(visualRegion), { cols: 120 });
 
-    expect(rendered.text).toContain("error you should fix");
+    expect(rendered.text).toContain("Bugs");
     expect(rendered.overflowed).toBe(false);
   }, 60_000);
 });

--- a/packages/react-doctor/tests/has-react-doctor-workflow.test.ts
+++ b/packages/react-doctor/tests/has-react-doctor-workflow.test.ts
@@ -1,0 +1,60 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { hasReactDoctorWorkflow } from "../src/cli/utils/has-react-doctor-workflow.js";
+
+describe("hasReactDoctorWorkflow", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "rd-workflow-"));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const writeWorkflow = (directory: string, name: string, contents: string): void => {
+    const workflows = path.join(directory, ".github", "workflows");
+    mkdirSync(workflows, { recursive: true });
+    writeFileSync(path.join(workflows, name), contents);
+  };
+
+  it("is false with no workflows", () => {
+    writeFileSync(path.join(root, ".git"), "");
+    expect(hasReactDoctorWorkflow(root)).toBe(false);
+  });
+
+  it("is false for a CI workflow that does not run react-doctor", () => {
+    writeFileSync(path.join(root, ".git"), "");
+    writeWorkflow(root, "ci.yml", "name: CI\njobs:\n  test:\n    steps:\n      - run: npm test\n");
+    expect(hasReactDoctorWorkflow(root)).toBe(false);
+  });
+
+  it("detects a workflow using the react-doctor action", () => {
+    writeWorkflow(
+      root,
+      "react-doctor.yml",
+      "jobs:\n  scan:\n    steps:\n      - uses: millionco/react-doctor@main\n",
+    );
+    expect(hasReactDoctorWorkflow(root)).toBe(true);
+  });
+
+  it("detects an `npx react-doctor` step in any workflow file", () => {
+    writeWorkflow(
+      root,
+      "quality.yml",
+      "jobs:\n  q:\n    steps:\n      - run: npx react-doctor .\n",
+    );
+    expect(hasReactDoctorWorkflow(root)).toBe(true);
+  });
+
+  it("finds the workflow at the repo root above a nested package (uses the scan dir)", () => {
+    writeWorkflow(root, "react-doctor.yml", "- uses: millionco/react-doctor@main\n");
+    writeFileSync(path.join(root, ".git"), "");
+    const packageDirectory = path.join(root, "packages", "app");
+    mkdirSync(packageDirectory, { recursive: true });
+    expect(hasReactDoctorWorkflow(packageDirectory)).toBe(true);
+  });
+});

--- a/packages/react-doctor/tests/onboarding-pacing.test.ts
+++ b/packages/react-doctor/tests/onboarding-pacing.test.ts
@@ -12,6 +12,7 @@ import {
   ONBOARDING_SECTION_DELAY_MS,
   onboardingSectionPause,
   shouldPaceOnboardingSections,
+  shouldRecordOnboarding,
 } from "../src/cli/utils/onboarding-pacing.js";
 
 describe("shouldPaceOnboardingSections", () => {
@@ -110,6 +111,37 @@ describe("isOnboardingForced", () => {
     expect(isOnboardingForced({ [FORCE_ONBOARDING_ENV_VAR]: "0" })).toBe(false);
     expect(isOnboardingForced({ [FORCE_ONBOARDING_ENV_VAR]: "false" })).toBe(false);
     expect(isOnboardingForced({ [FORCE_ONBOARDING_ENV_VAR]: "" })).toBe(false);
+  });
+});
+
+describe("shouldRecordOnboarding", () => {
+  const baseInput = {
+    paceOnboardingSections: true,
+    forceOnboarding: false,
+    verbose: false,
+    isNonInteractiveEnvironment: false,
+  };
+
+  it("records after an interactive onboarding reveal", () => {
+    expect(shouldRecordOnboarding(baseInput)).toBe(true);
+  });
+
+  it("does not record when pacing was off (no reveal)", () => {
+    expect(shouldRecordOnboarding({ ...baseInput, paceOnboardingSections: false })).toBe(false);
+  });
+
+  it("does not record a forced demo, so it stays replayable", () => {
+    expect(shouldRecordOnboarding({ ...baseInput, forceOnboarding: true })).toBe(false);
+  });
+
+  it("does not record a verbose run (static review, no reveal)", () => {
+    expect(shouldRecordOnboarding({ ...baseInput, verbose: true })).toBe(false);
+  });
+
+  it("does not record a non-interactive run that paced but used the classic layout", () => {
+    // Regression: a git hook with a TTY (GIT_DIR set) leaves pacing's TTY probe
+    // true while routing to the classic layout, so it must not burn the marker.
+    expect(shouldRecordOnboarding({ ...baseInput, isNonInteractiveEnvironment: true })).toBe(false);
   });
 });
 

--- a/packages/react-doctor/tests/onboarding-pacing.test.ts
+++ b/packages/react-doctor/tests/onboarding-pacing.test.ts
@@ -1,0 +1,134 @@
+import { performance } from "node:perf_hooks";
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  CI_ENVIRONMENT_VARIABLES,
+  CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+  CODING_AGENT_ENVIRONMENT_VARIABLES,
+} from "../src/cli/utils/is-ci-environment.js";
+import {
+  FORCE_ONBOARDING_ENV_VAR,
+  isOnboardingForced,
+  ONBOARDING_SECTION_DELAY_MS,
+  onboardingSectionPause,
+  shouldPaceOnboardingSections,
+} from "../src/cli/utils/onboarding-pacing.js";
+
+describe("shouldPaceOnboardingSections", () => {
+  let savedForce: string | undefined;
+
+  beforeEach(() => {
+    savedForce = process.env[FORCE_ONBOARDING_ENV_VAR];
+    delete process.env[FORCE_ONBOARDING_ENV_VAR];
+  });
+
+  afterEach(() => {
+    if (savedForce === undefined) {
+      delete process.env[FORCE_ONBOARDING_ENV_VAR];
+    } else {
+      process.env[FORCE_ONBOARDING_ENV_VAR] = savedForce;
+    }
+  });
+
+  it("paces an interactive human run", () => {
+    expect(shouldPaceOnboardingSections({ isInteractive: true, isCiOrCodingAgent: false })).toBe(
+      true,
+    );
+  });
+
+  it("does not pace a non-interactive (piped) run", () => {
+    expect(shouldPaceOnboardingSections({ isInteractive: false, isCiOrCodingAgent: false })).toBe(
+      false,
+    );
+  });
+
+  it("does not pace CI or coding-agent runs even on a TTY", () => {
+    expect(shouldPaceOnboardingSections({ isInteractive: true, isCiOrCodingAgent: true })).toBe(
+      false,
+    );
+  });
+
+  it("paces regardless of environment when forced", () => {
+    process.env[FORCE_ONBOARDING_ENV_VAR] = "1";
+    expect(shouldPaceOnboardingSections({ isInteractive: false, isCiOrCodingAgent: true })).toBe(
+      true,
+    );
+  });
+
+  describe("env-driven defaults", () => {
+    const ENVIRONMENT_VARIABLES = [
+      "CI",
+      ...CI_ENVIRONMENT_VARIABLES,
+      ...CODING_AGENT_ENVIRONMENT_VARIABLES,
+      ...CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+    ] as const;
+    let savedEnv: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      savedEnv = {};
+      for (const envVariable of ENVIRONMENT_VARIABLES) {
+        savedEnv[envVariable] = process.env[envVariable];
+        delete process.env[envVariable];
+      }
+    });
+
+    afterEach(() => {
+      for (const envVariable of ENVIRONMENT_VARIABLES) {
+        const previousValue = savedEnv[envVariable];
+        if (previousValue === undefined) {
+          delete process.env[envVariable];
+        } else {
+          process.env[envVariable] = previousValue;
+        }
+      }
+    });
+
+    it("falls back to the live CI/agent probe", () => {
+      expect(shouldPaceOnboardingSections({ isInteractive: true })).toBe(true);
+      process.env.CI = "true";
+      expect(shouldPaceOnboardingSections({ isInteractive: true })).toBe(false);
+    });
+
+    it("falls back to the coding-agent probe", () => {
+      process.env.CURSOR_AGENT = "1";
+      expect(shouldPaceOnboardingSections({ isInteractive: true })).toBe(false);
+    });
+  });
+});
+
+describe("isOnboardingForced", () => {
+  it("is false when the flag is unset", () => {
+    expect(isOnboardingForced({})).toBe(false);
+  });
+
+  it("is true for truthy values", () => {
+    expect(isOnboardingForced({ [FORCE_ONBOARDING_ENV_VAR]: "1" })).toBe(true);
+    expect(isOnboardingForced({ [FORCE_ONBOARDING_ENV_VAR]: "true" })).toBe(true);
+  });
+
+  it("is false for explicit falsy values", () => {
+    expect(isOnboardingForced({ [FORCE_ONBOARDING_ENV_VAR]: "0" })).toBe(false);
+    expect(isOnboardingForced({ [FORCE_ONBOARDING_ENV_VAR]: "false" })).toBe(false);
+    expect(isOnboardingForced({ [FORCE_ONBOARDING_ENV_VAR]: "" })).toBe(false);
+  });
+});
+
+describe("onboardingSectionPause", () => {
+  it("is a no-op when pacing is off", async () => {
+    expect(onboardingSectionPause(false)).toBe(Effect.void);
+
+    const start = performance.now();
+    await Effect.runPromise(onboardingSectionPause(false));
+    expect(performance.now() - start).toBeLessThan(50);
+  });
+
+  it("waits the configured delay when pacing is on", async () => {
+    expect(ONBOARDING_SECTION_DELAY_MS).toBe(850);
+
+    const start = performance.now();
+    await Effect.runPromise(onboardingSectionPause(true));
+    // Generous lower bound: a real sleep never returns early, but timer
+    // granularity / CI jitter can shave a few milliseconds off the wall clock.
+    expect(performance.now() - start).toBeGreaterThanOrEqual(700);
+  });
+});

--- a/packages/react-doctor/tests/onboarding-state.test.ts
+++ b/packages/react-doctor/tests/onboarding-state.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  getOnboardingConfigPath,
+  hasCompletedOnboarding,
+  markOnboardingComplete,
+} from "../src/cli/utils/onboarding-state.js";
+import {
+  disableSetupPrompt,
+  getSetupPromptConfigPath,
+  hasDisabledSetupPrompt,
+} from "../src/cli/utils/prompt-install-setup.js";
+
+describe("onboarding state", () => {
+  let configRoot: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const root = mkdtempSync(path.join(tmpdir(), "react-doctor-onboarding-"));
+    configRoot = root;
+    cleanup = () => rmSync(root, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reports not-onboarded before the first run", () => {
+    expect(hasCompletedOnboarding({ cwd: configRoot })).toBe(false);
+  });
+
+  it("marks onboarding complete so later runs skip the reveal", () => {
+    markOnboardingComplete({ cwd: configRoot });
+    expect(hasCompletedOnboarding({ cwd: configRoot })).toBe(true);
+  });
+
+  it("keeps the first-run timestamp stable across repeated marks", () => {
+    markOnboardingComplete({ cwd: configRoot });
+    const firstStamp = JSON.parse(
+      readFileSync(getOnboardingConfigPath({ cwd: configRoot }), "utf8"),
+    ).onboardedAt;
+
+    markOnboardingComplete({ cwd: configRoot });
+    const secondStamp = JSON.parse(
+      readFileSync(getOnboardingConfigPath({ cwd: configRoot }), "utf8"),
+    ).onboardedAt;
+
+    expect(typeof firstStamp).toBe("string");
+    expect(secondStamp).toBe(firstStamp);
+  });
+
+  it("shares one config file with setup-prompt state without clobbering it", () => {
+    const projectRoot = path.join(configRoot, "project");
+    disableSetupPrompt(projectRoot, { cwd: configRoot });
+    markOnboardingComplete({ cwd: configRoot });
+
+    expect(getOnboardingConfigPath({ cwd: configRoot })).toBe(
+      getSetupPromptConfigPath({ cwd: configRoot }),
+    );
+    expect(hasDisabledSetupPrompt(projectRoot, { cwd: configRoot })).toBe(true);
+    expect(hasCompletedOnboarding({ cwd: configRoot })).toBe(true);
+  });
+});

--- a/packages/react-doctor/tests/render-onboarding-animation.test.ts
+++ b/packages/react-doctor/tests/render-onboarding-animation.test.ts
@@ -1,0 +1,211 @@
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+import { animateScoreProjection } from "../src/cli/utils/render-score-header.js";
+import {
+  buildMergedOverflowLine,
+  printCategoryBreakdown,
+  printWarningRollup,
+} from "../src/cli/utils/render-diagnostics.js";
+import { playWelcomeScene } from "../src/cli/utils/render-welcome.js";
+import {
+  canAnimateOnboarding,
+  FORCE_ONBOARDING_ENV_VAR,
+} from "../src/cli/utils/onboarding-pacing.js";
+
+const ANSI = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
+const stripAnsi = (text: string): string => text.replace(ANSI, "");
+
+// Captures both sinks the renderers use: the static path prints via
+// `Console.log` (→ console.log) while the animated path writes raw cursor
+// controls straight to `process.stdout.write`.
+const captureStdout = async (run: () => Promise<void>): Promise<string[]> => {
+  const writes: string[] = [];
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    writes.push(`${args.join(" ")}\n`);
+  });
+  const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  try {
+    await run();
+  } finally {
+    logSpy.mockRestore();
+    writeSpy.mockRestore();
+  }
+  return writes;
+};
+
+const makeDiagnostic = (
+  category: string,
+  severity: "error" | "warning",
+  rule = `${category.toLowerCase()}-${severity}`,
+): Diagnostic =>
+  ({
+    filePath: "src/App.tsx",
+    plugin: "react-doctor",
+    rule,
+    severity,
+    message: "",
+    help: "",
+    line: 1,
+    column: 1,
+    category,
+  }) as Diagnostic;
+
+describe("playWelcomeScene", () => {
+  it("types the greeting in beside the happy face, then erases it", async () => {
+    const writes = await captureStdout(() => Effect.runPromise(playWelcomeScene()));
+    const output = writes.join("");
+    expect(stripAnsi(output)).toContain("Welcome to React Doctor");
+    // The middle sentence explains what React Doctor does, then is replaced in
+    // place by the closing line.
+    expect(stripAnsi(output)).toContain("I diagnose your React code");
+    expect(stripAnsi(output)).toContain("Let's scan your codebase");
+    expect(output).toContain("◠ ◠");
+    // Typewriter: many incremental frames, and an early partial reveal.
+    expect(writes.length).toBeGreaterThan(20);
+    expect(stripAnsi(writes[5] ?? "")).not.toContain("Welcome to React Doctor");
+    // After the hold, the cursor moves up over the block (incl. the blank line)
+    // and clears to the end of the screen.
+    expect(output).toContain("\u001B[3A");
+    expect(output).toContain("\u001B[0J");
+  });
+});
+
+describe("printCategoryBreakdown", () => {
+  const diagnostics = [
+    makeDiagnostic("Bugs", "error"),
+    makeDiagnostic("Bugs", "error"),
+    makeDiagnostic("Performance", "warning"),
+  ];
+
+  it("prints final tallies at once when not animating", async () => {
+    const writes = await captureStdout(() =>
+      Effect.runPromise(printCategoryBreakdown(diagnostics, undefined, false)),
+    );
+    const output = stripAnsi(writes.join(""));
+    expect(output).toContain("2 errors");
+    expect(output).toContain("1 warning");
+    // No cursor-control frames in the static path.
+    expect(writes.join("")).not.toContain("\u001B[2A");
+  });
+
+  it("counts up to the final tallies when animating", async () => {
+    const writes = await captureStdout(() =>
+      Effect.runPromise(printCategoryBreakdown(diagnostics, undefined, true)),
+    );
+    // Redraw frames move the cursor up over the two category lines.
+    expect(writes.join("")).toContain("\u001B[2A");
+    // The settled (last) frame shows the real counts.
+    const lastFrame = stripAnsi(writes[writes.length - 1] ?? "");
+    expect(lastFrame).toContain("Bugs");
+    expect(lastFrame).toContain("2 errors");
+    expect(lastFrame).toContain("Performance");
+    expect(lastFrame).toContain("1 warning");
+  });
+});
+
+describe("printWarningRollup", () => {
+  const diagnostics = [
+    makeDiagnostic("Bugs", "warning", "react-doctor/aaa"),
+    makeDiagnostic("Bugs", "warning", "react-doctor/bbbbbbbbb"),
+  ];
+
+  it("prints the rule list at once when not animating", async () => {
+    const writes = await captureStdout(() =>
+      Effect.runPromise(printWarningRollup(diagnostics, undefined, false)),
+    );
+    const output = stripAnsi(writes.join(""));
+    expect(output).toContain("react-doctor/aaa");
+    expect(output).toContain("react-doctor/bbbbbbbbb");
+    expect(writes.join("")).not.toContain("\u001B[2A");
+  });
+
+  it("types the rule names in parallel when animating", async () => {
+    const writes = await captureStdout(() =>
+      Effect.runPromise(printWarningRollup(diagnostics, undefined, true)),
+    );
+    // Redraw frames move the cursor up over both warning lines.
+    expect(writes.join("")).toContain("\u001B[2A");
+    // The settled (last) frame shows both full rule names.
+    const lastFrame = stripAnsi(writes[writes.length - 1] ?? "");
+    expect(lastFrame).toContain("react-doctor/aaa");
+    expect(lastFrame).toContain("react-doctor/bbbbbbbbb");
+  });
+});
+
+describe("buildMergedOverflowLine", () => {
+  it("leads with 'We also found' and counts the overflow rule groups", () => {
+    const diagnostics = [
+      ...Array.from({ length: 5 }, (_, index) => makeDiagnostic("Bugs", "error", `err-${index}`)),
+      ...Array.from({ length: 12 }, (_, index) =>
+        makeDiagnostic("Bugs", "warning", `warn-${index}`),
+      ),
+    ];
+    const line = stripAnsi(buildMergedOverflowLine(diagnostics) ?? "");
+    expect(line).toContain("We also found");
+    expect(line).toContain("+2 more errors");
+    expect(line).toContain("+2 more warnings");
+  });
+
+  it("is null when nothing overflows the shown rules", () => {
+    expect(buildMergedOverflowLine([makeDiagnostic("Bugs", "error")])).toBeNull();
+  });
+});
+
+describe("animateScoreProjection", () => {
+  it("grows the ghost gain segment in over multiple frames, redrawing in place", async () => {
+    const scoreResult = { score: 20, label: "Critical" } as ScoreResult;
+    const writes = await captureStdout(() =>
+      Effect.runPromise(animateScoreProjection(scoreResult, 60, 5)),
+    );
+    const output = writes.join("");
+    // Animated: many redraw frames, each jumping up to the bar and back.
+    expect(writes.length).toBeGreaterThan(5);
+    expect(output).toContain("\u001B[5A");
+    expect(output).toContain("\u001B[5B");
+    // The settled frame shows the projected gain (▓) in the bar.
+    expect(stripAnsi(writes[writes.length - 1] ?? "")).toContain("▓");
+  });
+
+  it("is a no-op for a perfect score", async () => {
+    const scoreResult = { score: 100, label: "Great" } as ScoreResult;
+    const writes = await captureStdout(() =>
+      Effect.runPromise(animateScoreProjection(scoreResult, 100, 5)),
+    );
+    expect(writes.join("")).toBe("");
+  });
+});
+
+describe("canAnimateOnboarding", () => {
+  let savedForce: string | undefined;
+  let savedTerm: string | undefined;
+
+  beforeEach(() => {
+    savedForce = process.env[FORCE_ONBOARDING_ENV_VAR];
+    savedTerm = process.env.TERM;
+    delete process.env[FORCE_ONBOARDING_ENV_VAR];
+    process.env.TERM = "xterm-256color";
+  });
+
+  afterEach(() => {
+    if (savedForce === undefined) delete process.env[FORCE_ONBOARDING_ENV_VAR];
+    else process.env[FORCE_ONBOARDING_ENV_VAR] = savedForce;
+    if (savedTerm === undefined) delete process.env.TERM;
+    else process.env.TERM = savedTerm;
+  });
+
+  it("animates a forced run on a real TTY (regardless of agent/CI detection)", () => {
+    process.env[FORCE_ONBOARDING_ENV_VAR] = "1";
+    const stream = { isTTY: true, columns: 80 } as unknown as NodeJS.WriteStream;
+    expect(canAnimateOnboarding(stream)).toBe(true);
+  });
+
+  it("does not animate a forced run when the stream is not a TTY", () => {
+    process.env[FORCE_ONBOARDING_ENV_VAR] = "1";
+    const stream = { isTTY: false, columns: 0 } as unknown as NodeJS.WriteStream;
+    expect(canAnimateOnboarding(stream)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

The first run of `react-doctor` painted the whole report in a single frame, and the layout buried the headline (score + issue count) beneath dense diagnostics. This makes the default single-project report read top-to-bottom the way a human scans it, and turns a user's *first* run into a short guided reveal — while changing nothing for CI, coding agents, or piped/JSON output.

**Before** (first interactive run): a wall of text, score near the bottom.
**After:** welcome scene → category tallies count up → score box with the issue count inline → projection → top fixes one by one → warning roll-up → footer.

## What changed

- **Report layout (all single-project runs):** category tally → score box with the issue count inline (`7 / 100 Critical   295 issues`) → projection → top fixes one by one → warning roll-up → a single merged `We also found +N more errors and +N more warnings` line → Share / Docs / Tip. Removed the per-section `+N more rules` lines, the `N warnings` sub-header, and the `Top N errors you should fix` header.
- **First-run onboarding (interactive TTY only):** an animated welcome scene, parallel count-up of the category tallies, an eased score-projection "ghost gain", and staggered section reveals (~850ms, quickening to ~680ms once the score lands). Runs once via a per-machine marker; `REACT_DOCTOR_FORCE_ONBOARDING=1` replays it for demos.
- **Gating:** skipped entirely in CI, under coding agents, and on non-TTY / score-only / JSON runs, which keep the classic information-dense layout (diagnostics first, then agent guidance and score).
- **Verbose mode:** now shows only the errors+warnings list, the score bar, and a one-line "ask an agent" tip — no projection, share, docs, CI/CD tip, top-3 block, or interactive handoff.
- **CI/CD tip:** hidden when a `react-doctor` GitHub Actions workflow already exists (walks up to the repo root).
- **Marker:** `✗` → `✖` for error blocks (CLI report + `--explain`).
- **Internals:** shared `writeStdout` / `easeOutCubic` utilities and `Effect.sleep` in place of hand-rolled `setTimeout` (DRY consolidation across the renderers).

## Validation

This is a CLI/report change, not a lint rule, so the RDE rule-eval harness does not apply (it measures rule precision against repo corpora — there's no rule here). Verified instead via the CLI's own unit + e2e terminal-snapshot tests and adversarial CLI runs across every render mode (interactive, no-score, score, json, verbose, forced, classic/agent, multi-project, no-issues) plus CI/CD-tip gating against out-of-repo fixtures.

| Check | Result |
| --- | --- |
| `vp test run` (full suite) | ✅ 1597 passed, 15 skipped |
| `tsc --noEmit` | ✅ pass |
| `vp lint` | ✅ pass |
| `vp fmt --check` | ✅ pass (only pre-existing `CHANGELOG.md` flagged) |
| `pnpm smoke:json-report` | ✅ Smoke OK |

Changeset: `.changeset/onboarding-section-pacing.md` (`react-doctor` patch).

## Test plan

- [x] `pnpm --filter react-doctor exec vp test run`
- [x] `pnpm --filter react-doctor run typecheck`
- [x] `pnpm --filter react-doctor exec vp lint`
- [x] `pnpm --filter react-doctor exec vp fmt --check`
- [x] `pnpm smoke:json-report`
- [x] Adversarial CLI smokes across modes + CI/CD-tip gating (no-CI / react-doctor-CI / generic-CI fixtures)
- [ ] Manual eyeball of the animated first-run reveal in a real TTY (animations are unit-tested; piped runs render static)

## Residual / non-goals

- Multi-project runs still always show the "set up CI/CD" tip (gating is single-project only).
- Animation timing constants are co-located with their renderers (matches existing `RAINBOW_*` / `SCORE_PROJECTION_*` precedent rather than `constants.ts`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large CLI rendering and branching changes affect what users and scripts see on stdout, though automation paths are explicitly gated; onboarding persistence and TTY cursor animations add edge-case risk.
> 
> **Overview**
> The default **single-project** interactive report is reordered so the score and inline issue count (`7 / 100 Critical   295 issues`) land early, followed by share/projection, top error blocks (no `Top N errors` header), a compact warning roll-up, and one merged **We also found +N more errors and +N more warnings** line instead of separate overflow headers.
> 
> **First-run onboarding** on a TTY adds a typewriter welcome scene, parallel category count-up, staggered section reveals (~850ms, faster after the score), and an eased score-bar projection; completion is stored in global config (`onboardedAt`), with `REACT_DOCTOR_FORCE_ONBOARDING` for demos. CI, coding agents, JSON/score-only, piped output, `--verbose`, and the classic non-interactive path (diagnostics first) are unchanged in behavior intent.
> 
> **Other:** `--verbose` trims footer/handoff; CI/CD setup tip is skipped when a repo workflow references react-doctor (walk up to `.git`); agent handoff drops the print-prompt option; error glyph `✖`; shared `writeStdout` / `easeOutCubic` for terminal animations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437e53b71e2d96cd130fdd4e2ed82e823823f56f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->