### PR TITLE
feat(cli): redesign scan summary, footer, and verbose warnings

### DIFF
--- a/.changeset/cli-output-footer-redesign.md
+++ b/.changeset/cli-output-footer-redesign.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Redesign the scan output's summary and footer. The default (non-verbose) run no longer lists every warning rule — warnings are rolled into a single overflow line alongside the hidden errors (e.g. `+4 more rules and +50 optional warnings — run npx react-doctor@latest --verbose for details`). `--verbose` now renders warnings in the same boxed, titled, code-framed format as errors (with a "Learn more" docs link), instead of a separate compact list. The closing footer is restructured into a `Share:` / `Docs:` / `GitHub:` block (each with a one-line description) separated by a divider, and the share link now appears for monorepo runs too (gated the same way as single-project: shown unless CI, `--no-score`, or `share: false`). The scan spinner's worker count now reads as a dimmed `[~N workers]`.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -215,20 +215,10 @@ export const MAX_CATEGORY_GROUPS_SHOWN_NON_VERBOSE = 5;
 
 export const MAX_RULE_GROUPS_PER_CATEGORY_NON_VERBOSE = 3;
 
-// Cap the non-verbose warnings roll-up so a long tail of low-severity
-// rules doesn't bury the scan summary; the overflow is surfaced as a
-// "+N more — run --verbose …" line below the list.
-export const MAX_WARNING_RULES_SHOWN_NON_VERBOSE = 10;
-
 // `minimumReleaseAge` in `pnpm-workspace.yaml` is denominated in
 // minutes. 7 days × 24 h × 60 min = 10080. Surfaced as the
 // recommended starting point for the supply-chain hardening check.
 export const RECOMMENDED_PNPM_MINIMUM_RELEASE_AGE_MINUTES = 10_080;
-
-// Minimum width of the rule-name column in the diagnostics list. Pads
-// shorter rule names so the right-aligned `N sites` count stays in a
-// consistent column even when one rule has a much longer identifier.
-export const RULE_NAME_COLUMN_WIDTH_CHARS = 36;
 
 // The closed set of user-facing diagnostic categories. Every rule
 // (collapsed at codegen via `CATEGORY_BUCKET` in

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -18,6 +18,7 @@ import { checkPnpmHardening } from "./check-pnpm-hardening.js";
 import { checkReactNativeProject } from "./check-react-native-project.js";
 import { checkReducedMotion } from "./check-reduced-motion.js";
 import { DEFAULT_SHOW_WARNINGS } from "./constants.js";
+import { highlighter } from "./highlighter.js";
 import { computeJsxIncludePaths } from "./jsx-include-paths.js";
 import { deadCodeMaySurfaceWhenWarningsHidden } from "./utils/dead-code-may-surface.js";
 import {
@@ -335,7 +336,8 @@ export const runInspect = <HooksR = never>(
     // Reference to actually fan out the lint pass); defaults to parallel
     // (auto-detected cores).
     const scanConcurrency = yield* OxlintConcurrency;
-    const workerCountSuffix = scanConcurrency > 1 ? ` · ${scanConcurrency} workers` : "";
+    const workerCountSuffix =
+      scanConcurrency > 1 ? ` ${highlighter.dim(`[~${scanConcurrency} workers]`)}` : "";
 
     const scanProgress = yield* progressService.start("Scanning...");
     const scanStartTime = Date.now();

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -359,11 +359,15 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
     }
 
     if (!isQuiet && isMultiProject && completedScans.length > 0) {
+      const shouldShowShareLink =
+        !scanOptions.noScore && (userConfig?.share ?? true) && !scanOptions.isCi;
       await Effect.runPromise(
         printMultiProjectSummary({
           completedScans,
           userConfig,
           verbose: Boolean(flags.verbose),
+          isOffline: !shouldShowShareLink,
+          projectName: path.basename(resolvedDirectory),
         }),
       );
     }

--- a/packages/react-doctor/src/cli/utils/build-section-divider.ts
+++ b/packages/react-doctor/src/cli/utils/build-section-divider.ts
@@ -1,0 +1,6 @@
+import { highlighter, OUTPUT_MEASURE_WIDTH_CHARS } from "@react-doctor/core";
+
+// The dim horizontal rule that separates major sections of a run
+// (top-errors block, warning roll-up, the closing share/docs footer).
+export const buildSectionDivider = (): string =>
+  highlighter.dim(`  ${"─".repeat(OUTPUT_MEASURE_WIDTH_CHARS)}`);

--- a/packages/react-doctor/src/cli/utils/build-section-divider.ts
+++ b/packages/react-doctor/src/cli/utils/build-section-divider.ts
@@ -1,6 +1,4 @@
 import { highlighter, OUTPUT_MEASURE_WIDTH_CHARS } from "@react-doctor/core";
 
-// The dim horizontal rule that separates major sections of a run
-// (top-errors block, warning roll-up, the closing share/docs footer).
 export const buildSectionDivider = (): string =>
   highlighter.dim(`  ${"─".repeat(OUTPUT_MEASURE_WIDTH_CHARS)}`);

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -53,6 +53,8 @@ const detectLaunchableAgents = async (): Promise<CliAgentId[]> => {
 export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> => {
   if (!input.interactive || input.diagnostics.length === 0) return;
 
+  logger.break();
+
   const launchableAgents = await detectLaunchableAgents();
   const { handoffTarget } = await prompts<"handoffTarget">(
     {

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -7,15 +7,14 @@ import {
   CODE_FRAME_LINES_BELOW,
   groupBy,
   highlighter,
-  MAX_WARNING_RULES_SHOWN_NON_VERBOSE,
   MILLISECONDS_PER_SECOND,
   OUTPUT_MEASURE_WIDTH_CHARS,
-  RULE_NAME_COLUMN_WIDTH_CHARS,
   TOP_ERRORS_DISPLAY_COUNT,
 } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
 import { boxText } from "./box-text.js";
 import { buildCodeFrame } from "./build-code-frame.js";
+import { buildSectionDivider } from "./build-section-divider.js";
 import {
   buildSortedRuleGroups,
   compareByRulePriority,
@@ -125,11 +124,6 @@ const TOP_ERROR_DETAIL_INDENT = "    ";
 
 const pickRepresentativeDiagnostic = (ruleDiagnostics: Diagnostic[]): Diagnostic =>
   ruleDiagnostics.find((diagnostic) => diagnostic.line > 0) ?? ruleDiagnostics[0];
-
-// A rule group renders as an error block (boxed code frames) when its
-// representative is an error; otherwise it's a warning block (compact list).
-const isErrorRuleGroup = (ruleDiagnostics: Diagnostic[]): boolean =>
-  pickRepresentativeDiagnostic(ruleDiagnostics).severity === "error";
 
 // A run of same-file sites of one rule whose individual frames would
 // overlap, rendered as a single spanning frame instead of N near-identical
@@ -244,6 +238,7 @@ const buildRuleDetailBlock = (
   ruleDiagnostics: Diagnostic[],
   resolveSourceRoot: SourceRootResolver,
   renderEverySite: boolean,
+  isAgentEnvironment: boolean,
 ): ReadonlyArray<string> => {
   const representative = pickRepresentativeDiagnostic(ruleDiagnostics);
   const { severity } = representative;
@@ -255,6 +250,17 @@ const buildRuleDetailBlock = (
   const icon = colorizeBySeverity(severity === "error" ? "✗" : "⚠", severity);
 
   const lines: string[] = [`  ${icon} ${headline}${trailingBadge}`];
+
+  // Verbose lists every site, so humans get a prominent docs link right
+  // under the rule name; agents instead get the cache-busting fetch
+  // directive lower down (after the fix) so they pull and follow the
+  // canonical recipe before editing.
+  if (renderEverySite && !isAgentEnvironment) {
+    const learnMoreLine = formatLearnMoreLine(representative);
+    if (learnMoreLine) {
+      lines.push(`${TOP_ERROR_DETAIL_INDENT}${highlighter.info(learnMoreLine)}`);
+    }
+  }
 
   // Verbose lists every rule & site, so the per-rule impact prose would
   // just repeat down the whole report — skip it there and let the boxed
@@ -283,98 +289,21 @@ const buildRuleDetailBlock = (
     }
   }
 
-  // Code frames are reserved for errors: warnings list their sites but
-  // skip the boxed source so the report doesn't drown in frames now that
-  // warnings surface by default.
-  const renderCodeFrame = severity === "error";
+  if (renderEverySite && isAgentEnvironment) {
+    const fixRecipeLine = formatFixRecipeLine(representative);
+    if (fixRecipeLine) {
+      lines.push(highlighter.gray(`${TOP_ERROR_DETAIL_INDENT}${fixRecipeLine}`));
+    }
+  }
+
+  // Errors always get the boxed code frame; in verbose every rule does
+  // (warnings included) so the exhaustive view renders warnings in the same
+  // format as errors. The default summary keeps frames error-only so a long
+  // warning tail doesn't drown the report.
+  const renderCodeFrame = severity === "error" || renderEverySite;
   const sites = renderEverySite ? ruleDiagnostics : [representative];
   for (const cluster of clusterNearbyDiagnostics(sites)) {
     lines.push(...buildDiagnosticClusterLines(cluster, resolveSourceRoot, renderCodeFrame));
-  }
-
-  return lines;
-};
-
-// Indent under a warning's header line — six spaces so the body sits
-// just past the `  ⚠ ` marker.
-const WARNING_DETAIL_INDENT = "      ";
-
-// Column the warning rule names pad to so each `×N` site badge lines up
-// regardless of name length. Grows past the default when a rule key is
-// longer than the column.
-const computeRuleNameColumnWidth = (ruleKeys: ReadonlyArray<string>): number =>
-  ruleKeys.reduce(
-    (widest, ruleKey) => Math.max(widest, ruleKey.length),
-    RULE_NAME_COLUMN_WIDTH_CHARS,
-  );
-
-const padRuleNameToColumn = (ruleName: string, columnWidth: number): string =>
-  ruleName.length >= columnWidth ? ruleName : ruleName + " ".repeat(columnWidth - ruleName.length);
-
-// The `  ⚠ <rule> ×N` header shared by the verbose warning block and the
-// non-verbose roll-up. Only the icon carries the warning color — the rule
-// name stays neutral so a long list doesn't drown in yellow. The name pads
-// to the shared column only when a badge follows, so the `×N` badges align
-// without leaving trailing whitespace on single-site rules.
-const buildWarningHeaderLine = (
-  ruleKey: string,
-  siteCount: number,
-  ruleNameColumnWidth: number,
-): string => {
-  const hasBadge = formatSiteCountBadge(siteCount).length > 0;
-  const ruleName = hasBadge ? padRuleNameToColumn(ruleKey, ruleNameColumnWidth) : ruleKey;
-  return `  ${highlighter.warn("⚠")} ${ruleName}${formatTrailingSiteBadge(siteCount)}`;
-};
-
-// Compact warning block: the `plugin/rule` key + `×N` badge, the impact,
-// the fix, the canonical fix-recipe directive, then a flat, unspaced list
-// of every `file:line` site. Warnings skip the boxed code frames (reserved
-// for errors) so a long tail of low-severity findings stays scannable.
-const buildWarningRuleBlock = (
-  ruleKey: string,
-  ruleDiagnostics: Diagnostic[],
-  ruleNameColumnWidth: number,
-  isAgentEnvironment: boolean,
-): ReadonlyArray<string> => {
-  const representative = pickRepresentativeDiagnostic(ruleDiagnostics);
-  const lines: string[] = [
-    buildWarningHeaderLine(ruleKey, ruleDiagnostics.length, ruleNameColumnWidth),
-  ];
-
-  // Humans get a short, prominent docs link right under the rule name; an
-  // agent instead gets the cache-busting fetch directive lower down so it
-  // pulls and follows the canonical recipe before editing.
-  if (!isAgentEnvironment) {
-    const learnMoreLine = formatLearnMoreLine(representative);
-    if (learnMoreLine) {
-      lines.push(`${WARNING_DETAIL_INDENT}${highlighter.info(learnMoreLine)}`);
-    }
-  }
-
-  lines.push(highlighter.gray(indentMultilineText(representative.message, WARNING_DETAIL_INDENT)));
-  if (representative.help) {
-    lines.push(
-      highlighter.gray(indentMultilineText(`→ ${representative.help}`, WARNING_DETAIL_INDENT)),
-    );
-  }
-  if (isAgentEnvironment) {
-    const fixRecipeLine = formatFixRecipeLine(representative);
-    if (fixRecipeLine) {
-      lines.push(highlighter.gray(`${WARNING_DETAIL_INDENT}${fixRecipeLine}`));
-    }
-  }
-
-  for (const [filePath, sites] of buildVerboseSiteMap(ruleDiagnostics)) {
-    if (sites.length === 0) {
-      lines.push(highlighter.gray(`${WARNING_DETAIL_INDENT}${filePath}`));
-      continue;
-    }
-    for (const site of sites) {
-      lines.push(highlighter.gray(`${WARNING_DETAIL_INDENT}${filePath}:${site.line}`));
-      if (site.suppressionHint) {
-        lines.push(highlighter.gray(`${WARNING_DETAIL_INDENT}  ↳ ${site.suppressionHint}`));
-      }
-    }
   }
 
   return lines;
@@ -398,18 +327,46 @@ const selectTopErrorRuleGroups = (
   rulePriority?: ReadonlyMap<string, number>,
 ): [string, Diagnostic[]][] => selectErrorRuleGroups(diagnostics, rulePriority).slice(0, limit);
 
-// The "+N more rules — run --verbose to view the rest …" overflow line
-// shared by the capped error and warning lists. The count is rule groups
-// (not individual findings), spelled out as "rules" so it can't be misread
-// as "+N more errors" next to the occurrence tallies above. `accent` colors
-// it to the section's severity (error red / warning yellow).
-const buildMoreRulesLine = (
-  hiddenRuleCount: number,
-  severityNoun: "errors" | "warnings",
-  accent: (text: string) => string,
-): string => {
-  const ruleNoun = hiddenRuleCount === 1 ? "rule" : "rules";
-  return `  ${highlighter.bold(accent(`+${hiddenRuleCount} more ${ruleNoun}`))} ${highlighter.dim("— run")} ${highlighter.bold(highlighter.info("--verbose"))} ${highlighter.dim(`to view the rest of the ${severityNoun} and details about each`)}`;
+const countHiddenErrorRuleGroups = (
+  diagnostics: Diagnostic[],
+  rulePriority?: ReadonlyMap<string, number>,
+): number =>
+  Math.max(0, selectErrorRuleGroups(diagnostics, rulePriority).length - TOP_ERRORS_DISPLAY_COUNT);
+
+// Non-verbose hides EVERY warning rule (warnings aren't listed in the
+// default summary anymore), so the overflow line surfaces the full count as
+// "+N optional warnings" pointing at --verbose.
+const countHiddenWarningRuleGroups = (
+  diagnostics: Diagnostic[],
+  rulePriority?: ReadonlyMap<string, number>,
+): number => {
+  const warningDiagnostics = diagnostics.filter((diagnostic) => diagnostic.severity === "warning");
+  return buildSortedRuleGroups(warningDiagnostics, rulePriority).length;
+};
+
+// A single overflow line that merges the hidden error and warning rule
+// groups, e.g. "+4 more rules and +50 optional warnings — run --verbose …".
+// Counts are rule groups (not individual findings): hidden errors read as
+// "more rules" (error red) and hidden warnings as "optional warnings"
+// (warning yellow) so the two can't be misread as one tally. Returns
+// undefined when nothing is hidden so callers can skip the section.
+const buildOverflowSummaryLine = (
+  hiddenErrorRuleCount: number,
+  hiddenWarningRuleCount: number,
+): string | undefined => {
+  const parts: string[] = [];
+  if (hiddenErrorRuleCount > 0) {
+    const ruleNoun = hiddenErrorRuleCount === 1 ? "rule" : "rules";
+    parts.push(highlighter.bold(highlighter.error(`+${hiddenErrorRuleCount} more ${ruleNoun}`)));
+  }
+  if (hiddenWarningRuleCount > 0) {
+    const warningNoun = hiddenWarningRuleCount === 1 ? "warning" : "warnings";
+    parts.push(
+      highlighter.bold(highlighter.warn(`+${hiddenWarningRuleCount} optional ${warningNoun}`)),
+    );
+  }
+  if (parts.length === 0) return undefined;
+  return `  ${parts.join(highlighter.dim(" and "))} ${highlighter.dim("— run")} ${highlighter.bold(highlighter.info("npx react-doctor@latest --verbose"))} ${highlighter.dim("for details")}`;
 };
 
 // The exact rule keys surfaced in the top-errors block — the set the
@@ -431,54 +388,16 @@ const buildTopErrorsLines = (
   const errorRuleGroups = selectErrorRuleGroups(diagnostics, rulePriority);
   const topRuleGroups = errorRuleGroups.slice(0, TOP_ERRORS_DISPLAY_COUNT);
   if (topRuleGroups.length === 0) return [];
-  const hiddenRuleCount = errorRuleGroups.length - topRuleGroups.length;
 
   const lines: string[] = [
     // Dim rule separating the overview tally from the detailed fixes.
-    highlighter.dim(`  ${"─".repeat(OUTPUT_MEASURE_WIDTH_CHARS)}`),
+    buildSectionDivider(),
     `  ${highlighter.bold(`Top ${topRuleGroups.length} ${topRuleGroups.length === 1 ? "error" : "errors"} you should fix`)}`,
     "",
   ];
   for (const [ruleKey, ruleDiagnostics] of topRuleGroups) {
-    lines.push(...buildRuleDetailBlock(ruleKey, ruleDiagnostics, resolveSourceRoot, false));
+    lines.push(...buildRuleDetailBlock(ruleKey, ruleDiagnostics, resolveSourceRoot, false, false));
     lines.push("");
-  }
-  if (hiddenRuleCount > 0) {
-    lines.push(buildMoreRulesLine(hiddenRuleCount, "errors", highlighter.error));
-  }
-  return lines;
-};
-
-// In non-verbose mode errors get the detailed top-N block; warnings are
-// summarized here as a compact `rule ×count` list so users see what fired
-// and how often without the full per-site detail (which lives behind
-// --verbose). Sorted by score priority like every other rule list.
-const buildWarningsListLines = (
-  diagnostics: Diagnostic[],
-  rulePriority?: ReadonlyMap<string, number>,
-): ReadonlyArray<string> => {
-  const warningDiagnostics = diagnostics.filter((diagnostic) => diagnostic.severity === "warning");
-  if (warningDiagnostics.length === 0) return [];
-
-  const sortedRuleGroups = buildSortedRuleGroups(warningDiagnostics, rulePriority);
-  // A long tail of warning rules would bury the summary, so cap the list and
-  // surface the overflow as a single "+N more" line that points at --verbose.
-  const shownRuleGroups = sortedRuleGroups.slice(0, MAX_WARNING_RULES_SHOWN_NON_VERBOSE);
-  const hiddenRuleCount = sortedRuleGroups.length - shownRuleGroups.length;
-  const ruleNameColumnWidth = computeRuleNameColumnWidth(
-    shownRuleGroups.map(([ruleKey]) => ruleKey),
-  );
-
-  const lines: string[] = [
-    highlighter.dim(`  ${"─".repeat(OUTPUT_MEASURE_WIDTH_CHARS)}`),
-    `  ${highlighter.bold(`${warningDiagnostics.length} ${warningDiagnostics.length === 1 ? "warning" : "warnings"}`)}`,
-    "",
-  ];
-  for (const [ruleKey, ruleDiagnostics] of shownRuleGroups) {
-    lines.push(buildWarningHeaderLine(ruleKey, ruleDiagnostics.length, ruleNameColumnWidth));
-  }
-  if (hiddenRuleCount > 0) {
-    lines.push(buildMoreRulesLine(hiddenRuleCount, "warnings", highlighter.warn));
   }
   return lines;
 };
@@ -504,8 +423,8 @@ const joinSections = (...sections: ReadonlyArray<string>[]): string[] => {
 };
 
 // The total-issue tally (e.g. "600 issues"), shown right under the
-// category breakdown as part of the overview. The "list every issue"
-// hint lives at the very bottom of the run instead (see `printVerboseTip`).
+// category breakdown as part of the overview. The `--verbose` hint lives
+// in the combined overflow line at the end of the run instead.
 const buildCountsSummaryLines = (diagnostics: Diagnostic[]): ReadonlyArray<string> => {
   const totalIssueCount = diagnostics.length;
   if (totalIssueCount === 0) return [];
@@ -538,7 +457,7 @@ export const printDiagnostics = (
   // most-valuable-first; absent (offline / `--no-score`) ordering falls
   // back to severity + stakes.
   rulePriority?: ReadonlyMap<string, number>,
-  // True when a coding agent is driving the CLI. Verbose warning blocks then
+  // True when a coding agent is driving the CLI. Verbose rule blocks then
   // emit the cache-busting fetch directive instead of the human "Learn more"
   // link. Defaults to false (human) so tests render deterministically.
   isAgentEnvironment = false,
@@ -554,34 +473,38 @@ export const printDiagnostics = (
     if (!isVerbose) {
       detailLines = buildTopErrorsLines(diagnostics, resolveSourceRoot, rulePriority);
     } else {
+      // Verbose renders warnings in the same boxed-code-frame format as
+      // errors — one block builder for every rule group, ordered by priority.
       const sortedRuleGroups = buildSortedRuleGroups(diagnostics, rulePriority);
-      // Warnings share one padded name column so their `×N` badges align;
-      // errors render in the boxed-code-frame format instead.
-      const warningRuleNameColumnWidth = computeRuleNameColumnWidth(
-        sortedRuleGroups
-          .filter(([, ruleDiagnostics]) => !isErrorRuleGroup(ruleDiagnostics))
-          .map(([ruleKey]) => ruleKey),
-      );
       detailLines = sortedRuleGroups.flatMap(([ruleKey, ruleDiagnostics]) => {
-        const block = isErrorRuleGroup(ruleDiagnostics)
-          ? buildRuleDetailBlock(ruleKey, ruleDiagnostics, resolveSourceRoot, true)
-          : buildWarningRuleBlock(
-              ruleKey,
-              ruleDiagnostics,
-              warningRuleNameColumnWidth,
-              isAgentEnvironment,
-            );
+        const block = buildRuleDetailBlock(
+          ruleKey,
+          ruleDiagnostics,
+          resolveSourceRoot,
+          true,
+          isAgentEnvironment,
+        );
         return [...block, ""];
       });
     }
+
+    // Verbose renders every rule and site, so there's no hidden overflow to
+    // summarize; non-verbose merges the capped error + warning tails into one
+    // line at the very bottom.
+    const overflowLine = isVerbose
+      ? undefined
+      : buildOverflowSummaryLine(
+          countHiddenErrorRuleGroups(diagnostics, rulePriority),
+          countHiddenWarningRuleGroups(diagnostics, rulePriority),
+        );
 
     const lines = joinSections(
       buildCategoryBreakdownLines(diagnostics, rulePriority),
       buildCountsSummaryLines(diagnostics),
       detailLines,
-      // Verbose already renders every warning in full; the compact
-      // warning roll-up is non-verbose only.
-      isVerbose ? [] : buildWarningsListLines(diagnostics, rulePriority),
+      // Warnings aren't listed in the default summary — they're summarized in
+      // the overflow line and shown in full under --verbose.
+      overflowLine ? [overflowLine] : [],
     );
     for (const line of lines) {
       yield* Console.log(line);

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -327,37 +327,40 @@ const selectTopErrorRuleGroups = (
   rulePriority?: ReadonlyMap<string, number>,
 ): [string, Diagnostic[]][] => selectErrorRuleGroups(diagnostics, rulePriority).slice(0, limit);
 
-const countHiddenErrorRuleGroups = (
-  diagnostics: Diagnostic[],
-  rulePriority?: ReadonlyMap<string, number>,
-): number =>
-  Math.max(0, selectErrorRuleGroups(diagnostics, rulePriority).length - TOP_ERRORS_DISPLAY_COUNT);
-
-const countHiddenWarningRuleGroups = (
-  diagnostics: Diagnostic[],
-  rulePriority?: ReadonlyMap<string, number>,
-): number => {
-  const warningDiagnostics = diagnostics.filter((diagnostic) => diagnostic.severity === "warning");
-  return buildSortedRuleGroups(warningDiagnostics, rulePriority).length;
-};
-
+// The non-verbose run only shows one representative site per top error rule
+// group and no warnings at all, so anything past that — extra error rule
+// groups, the other sites of a shown rule, or any warning — only appears
+// under `--verbose`. The line surfaces that pointer whenever detail is
+// hidden, with `+N more rules` counting hidden error groups (the unit the
+// top-errors block uses) and `+N optional warnings` counting individual
+// warnings (matching the overview's per-category and total tallies).
 const buildOverflowSummaryLine = (
-  hiddenErrorRuleCount: number,
-  hiddenWarningRuleCount: number,
+  diagnostics: Diagnostic[],
+  rulePriority?: ReadonlyMap<string, number>,
 ): string | undefined => {
+  const errorRuleGroups = selectErrorRuleGroups(diagnostics, rulePriority);
+  const shownErrorRuleCount = Math.min(TOP_ERRORS_DISPLAY_COUNT, errorRuleGroups.length);
+  if (diagnostics.length <= shownErrorRuleCount) return undefined;
+
+  const hiddenErrorRuleCount = errorRuleGroups.length - shownErrorRuleCount;
+  const warningCount = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
+
   const parts: string[] = [];
   if (hiddenErrorRuleCount > 0) {
     const ruleNoun = hiddenErrorRuleCount === 1 ? "rule" : "rules";
     parts.push(highlighter.bold(highlighter.error(`+${hiddenErrorRuleCount} more ${ruleNoun}`)));
   }
-  if (hiddenWarningRuleCount > 0) {
-    const warningNoun = hiddenWarningRuleCount === 1 ? "warning" : "warnings";
-    parts.push(
-      highlighter.bold(highlighter.warn(`+${hiddenWarningRuleCount} optional ${warningNoun}`)),
-    );
+  if (warningCount > 0) {
+    const warningNoun = warningCount === 1 ? "warning" : "warnings";
+    parts.push(highlighter.bold(highlighter.warn(`+${warningCount} optional ${warningNoun}`)));
   }
-  if (parts.length === 0) return undefined;
-  return `  ${parts.join(highlighter.dim(" and "))} ${highlighter.dim("— run")} ${highlighter.bold(highlighter.info("npx react-doctor@latest --verbose"))} ${highlighter.dim("for details")}`;
+
+  const command = highlighter.bold(highlighter.info("npx react-doctor@latest --verbose"));
+  const lead =
+    parts.length > 0
+      ? `${parts.join(highlighter.dim(" and "))} ${highlighter.dim("— run")}`
+      : highlighter.dim("Run");
+  return `  ${lead} ${command} ${highlighter.dim("for details")}`;
 };
 
 // The exact rule keys surfaced in the top-errors block — the set the
@@ -479,10 +482,7 @@ export const printDiagnostics = (
 
     const overflowLine = isVerbose
       ? undefined
-      : buildOverflowSummaryLine(
-          countHiddenErrorRuleGroups(diagnostics, rulePriority),
-          countHiddenWarningRuleGroups(diagnostics, rulePriority),
-        );
+      : buildOverflowSummaryLine(diagnostics, rulePriority);
 
     const lines = joinSections(
       buildCategoryBreakdownLines(diagnostics, rulePriority),

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -333,9 +333,6 @@ const countHiddenErrorRuleGroups = (
 ): number =>
   Math.max(0, selectErrorRuleGroups(diagnostics, rulePriority).length - TOP_ERRORS_DISPLAY_COUNT);
 
-// Non-verbose hides EVERY warning rule (warnings aren't listed in the
-// default summary anymore), so the overflow line surfaces the full count as
-// "+N optional warnings" pointing at --verbose.
 const countHiddenWarningRuleGroups = (
   diagnostics: Diagnostic[],
   rulePriority?: ReadonlyMap<string, number>,
@@ -344,12 +341,6 @@ const countHiddenWarningRuleGroups = (
   return buildSortedRuleGroups(warningDiagnostics, rulePriority).length;
 };
 
-// A single overflow line that merges the hidden error and warning rule
-// groups, e.g. "+4 more rules and +50 optional warnings — run --verbose …".
-// Counts are rule groups (not individual findings): hidden errors read as
-// "more rules" (error red) and hidden warnings as "optional warnings"
-// (warning yellow) so the two can't be misread as one tally. Returns
-// undefined when nothing is hidden so callers can skip the section.
 const buildOverflowSummaryLine = (
   hiddenErrorRuleCount: number,
   hiddenWarningRuleCount: number,
@@ -473,8 +464,6 @@ export const printDiagnostics = (
     if (!isVerbose) {
       detailLines = buildTopErrorsLines(diagnostics, resolveSourceRoot, rulePriority);
     } else {
-      // Verbose renders warnings in the same boxed-code-frame format as
-      // errors — one block builder for every rule group, ordered by priority.
       const sortedRuleGroups = buildSortedRuleGroups(diagnostics, rulePriority);
       detailLines = sortedRuleGroups.flatMap(([ruleKey, ruleDiagnostics]) => {
         const block = buildRuleDetailBlock(
@@ -488,9 +477,6 @@ export const printDiagnostics = (
       });
     }
 
-    // Verbose renders every rule and site, so there's no hidden overflow to
-    // summarize; non-verbose merges the capped error + warning tails into one
-    // line at the very bottom.
     const overflowLine = isVerbose
       ? undefined
       : buildOverflowSummaryLine(
@@ -502,8 +488,6 @@ export const printDiagnostics = (
       buildCategoryBreakdownLines(diagnostics, rulePriority),
       buildCountsSummaryLines(diagnostics),
       detailLines,
-      // Warnings aren't listed in the default summary — they're summarized in
-      // the overflow line and shown in full under --verbose.
       overflowLine ? [overflowLine] : [],
     );
     for (const line of lines) {

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -12,7 +12,7 @@ import { computeProjectedScore } from "./compute-score-projection.js";
 import { buildRulePriorityMap } from "./diagnostic-grouping.js";
 import { isCodingAgentEnvironment } from "./is-ci-environment.js";
 import { formatElapsedTime, printDiagnostics } from "./render-diagnostics.js";
-import { printDocsNote, printSummary, printVerboseTip } from "./render-summary.js";
+import { printFooter, printSummary } from "./render-summary.js";
 
 interface ProjectScanEntry {
   readonly projectName: string;
@@ -78,11 +78,17 @@ export interface MultiProjectSummaryInput {
   readonly completedScans: ReadonlyArray<{ readonly result: InspectResult }>;
   readonly userConfig: ReactDoctorConfig | null;
   readonly verbose: boolean;
+  // Suppresses the share link (CI, --no-score, or share disabled), matching
+  // the single-project gate.
+  readonly isOffline: boolean;
+  // Label for the share URL's `p` param — the workspace root name, so the
+  // monorepo shares under one clean name instead of a joined package list.
+  readonly projectName: string;
 }
 
 export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effect.Effect<void> =>
   Effect.gen(function* () {
-    const { completedScans, userConfig, verbose } = input;
+    const { completedScans, userConfig, verbose, isOffline, projectName } = input;
 
     const allDiagnostics: Diagnostic[] = completedScans.flatMap((scan) => scan.result.diagnostics);
     const surfaceDiagnostics = filterDiagnosticsForSurface(allDiagnostics, "cli", userConfig);
@@ -197,7 +203,10 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
       yield* Console.log(buildSummaryLine(entry, longestProjectNameLength));
     }
 
-    yield* Console.log("");
-    yield* printVerboseTip(surfaceDiagnostics, verbose);
-    yield* printDocsNote();
+    yield* printFooter({
+      diagnostics: surfaceDiagnostics,
+      scoreResult: aggregateScore,
+      projectName,
+      isOffline,
+    });
   });

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -173,10 +173,8 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
       elapsedMilliseconds: totalElapsedMilliseconds,
       scoreResult: aggregateScore,
       potentialScore,
-      projectName: completedScans.map((scan) => scan.result.project.projectName).join(", "),
       totalSourceFileCount,
       noScoreMessage: "Score unavailable.",
-      isOffline: true,
       verbose,
     });
 

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -78,11 +78,7 @@ export interface MultiProjectSummaryInput {
   readonly completedScans: ReadonlyArray<{ readonly result: InspectResult }>;
   readonly userConfig: ReactDoctorConfig | null;
   readonly verbose: boolean;
-  // Suppresses the share link (CI, --no-score, or share disabled), matching
-  // the single-project gate.
   readonly isOffline: boolean;
-  // Label for the share URL's `p` param — the workspace root name, so the
-  // monorepo shares under one clean name instead of a joined package list.
   readonly projectName: string;
 }
 

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -37,15 +37,9 @@ export interface PrintFooterInput {
   readonly diagnostics: Diagnostic[];
   readonly scoreResult: ScoreResult | null;
   readonly projectName: string;
-  // When true (CI, --no-score, no --share) the share link is suppressed and
-  // the footer is docs-only.
   readonly isOffline: boolean;
 }
 
-// The closing footer: a divider, an optional share link, and the docs
-// pointer. Printed once at the very end of a run (below the per-project
-// summaries in a monorepo) so the links read as a closing call-to-action
-// rather than crowding the overview.
 export const printFooter = (input: PrintFooterInput): Effect.Effect<void> =>
   Effect.gen(function* () {
     yield* Console.log("");

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -71,10 +71,8 @@ export interface PrintSummaryInput {
   // Score reachable by fixing the top errors, rendered as the bar's ghost
   // gain segment. Omitted when there's nothing to project.
   readonly potentialScore?: number | null;
-  readonly projectName: string;
   readonly totalSourceFileCount: number;
   readonly noScoreMessage: string;
-  readonly isOffline: boolean;
   readonly verbose?: boolean;
 }
 

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -1,12 +1,14 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import {
+  CANONICAL_GITHUB_URL,
   DOCS_URL,
   highlighter,
   SHARE_BASE_URL,
   TOP_ERRORS_DISPLAY_COUNT,
 } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+import { buildSectionDivider } from "./build-section-divider.js";
 import { colorizeByScore } from "./colorize-by-score.js";
 import { collectAffectedFiles } from "./render-diagnostics.js";
 import { printNoScoreHeader, printScoreHeader } from "./render-score-header.js";
@@ -31,36 +33,41 @@ const buildShareUrl = (
   return `${SHARE_BASE_URL}?${params.toString()}`;
 };
 
-// The closing "--verbose explains everything" hint, printed as the very
-// last line of a run (below the per-project summaries in a monorepo) so it
-// reads as a closing tip rather than crowding the overview. No-op when
-// already verbose or when there's nothing to list. When warnings are
-// present the tip leads with them, since non-verbose only rolls warnings up
-// to a `rule ×count` list — `--verbose` is where each one is explained.
-export const printVerboseTip = (
-  diagnostics: Diagnostic[],
-  isVerbose: boolean,
-): Effect.Effect<void> =>
-  Effect.gen(function* () {
-    if (isVerbose || diagnostics.length === 0) return;
-    const command = highlighter.info("npx react-doctor@latest --verbose");
-    const hasWarnings = diagnostics.some((diagnostic) => diagnostic.severity === "warning");
-    const message = hasWarnings
-      ? `Run ${command} to see each warning explained with its fix`
-      : `Run ${command} to see each issue explained with its fix`;
-    yield* Console.log(highlighter.dim(`  Tip: ${message}`));
-  });
+export interface PrintFooterInput {
+  readonly diagnostics: Diagnostic[];
+  readonly scoreResult: ScoreResult | null;
+  readonly projectName: string;
+  // When true (CI, --no-score, no --share) the share link is suppressed and
+  // the footer is docs-only.
+  readonly isOffline: boolean;
+}
 
-// A closing pointer to the docs for the workflows the scan output doesn't
-// teach inline: wiring up CI/CD, writing a config file to suppress rules,
-// and scanning only a diff or PR. Printed once at the very end of a run.
-export const printDocsNote = (): Effect.Effect<void> =>
+// The closing footer: a divider, an optional share link, and the docs
+// pointer. Printed once at the very end of a run (below the per-project
+// summaries in a monorepo) so the links read as a closing call-to-action
+// rather than crowding the overview.
+export const printFooter = (input: PrintFooterInput): Effect.Effect<void> =>
   Effect.gen(function* () {
     yield* Console.log("");
+    yield* Console.log(buildSectionDivider());
+    yield* Console.log("");
+    if (!input.isOffline) {
+      const shareUrl = buildShareUrl(input.diagnostics, input.scoreResult, input.projectName);
+      yield* Console.log(`  ${highlighter.bold("Share:")} ${highlighter.info(shareUrl)}`);
+      yield* Console.log(highlighter.dim("  Tell others how you did on socials"));
+      yield* Console.log("");
+    }
     yield* Console.log(`  ${highlighter.bold("Docs:")} ${highlighter.info(DOCS_URL)}`);
     yield* Console.log(
-      highlighter.dim("  Set up CI/CD, suppress rules with a config file, and scan diffs or PRs."),
+      highlighter.dim(
+        "  Learn more about fixing issues, setting up CI/CD, and configuring rules with a config file",
+      ),
     );
+    yield* Console.log("");
+    yield* Console.log(
+      `  ${highlighter.bold("GitHub:")} ${highlighter.info(CANONICAL_GITHUB_URL)}`,
+    );
+    yield* Console.log(highlighter.dim("  Report issues and star the repository!"));
   });
 
 export interface PrintSummaryInput {
@@ -104,12 +111,5 @@ export const printSummary = (input: PrintSummaryInput): Effect.Effect<void> =>
     }).pipe(Effect.orElseSucceed(() => null as string | null));
     if (diagnosticsDirectory !== null && input.verbose) {
       yield* Console.log(highlighter.gray(`  Full diagnostics written to ${diagnosticsDirectory}`));
-    }
-
-    if (!input.isOffline) {
-      yield* Console.log("");
-      const shareUrl = buildShareUrl(input.diagnostics, input.scoreResult, input.projectName);
-      yield* Console.log(`  ${highlighter.bold("Share:")} ${highlighter.info(shareUrl)}`);
-      yield* Console.log("");
     }
   });

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -47,7 +47,7 @@ import {
   printNoScoreHeader,
   printScoreHeader,
 } from "./cli/utils/render-score-header.js";
-import { printDocsNote, printSummary, printVerboseTip } from "./cli/utils/render-summary.js";
+import { printFooter, printSummary } from "./cli/utils/render-summary.js";
 import { resolveOxlintNode } from "./cli/utils/resolve-oxlint-node.js";
 import { isSpinnerSilent, setSpinnerSilent } from "./cli/utils/spinner.js";
 import { VERSION } from "./cli/utils/version.js";
@@ -532,8 +532,12 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       );
     }
 
-    yield* printVerboseTip([...surfaceDiagnostics], options.verbose);
-    yield* printDocsNote();
+    yield* printFooter({
+      diagnostics: [...surfaceDiagnostics],
+      scoreResult: score,
+      projectName: project.projectName,
+      isOffline: !shouldShowShareLink,
+    });
 
     return buildResult();
   });

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -517,10 +517,8 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       elapsedMilliseconds,
       scoreResult: score,
       potentialScore,
-      projectName: project.projectName,
       totalSourceFileCount: lintSourceFileCount,
       noScoreMessage,
-      isOffline: !shouldShowShareLink,
       verbose: options.verbose,
     });
 

--- a/packages/react-doctor/tests/e2e/__snapshots__/terminal-visuals.test.ts.snap
+++ b/packages/react-doctor/tests/e2e/__snapshots__/terminal-visuals.test.ts.snap
@@ -50,17 +50,21 @@ exports[`in-process render across terminal widths and render modes > matches the
     └──────────────────────────────────────────────────────────────┘
 
 
-  ────────────────────────────────────────────────────────────
-  1 warning
-
-  ⚠ react-doctor/rendering-hoist-jsx
+  +1 optional warning — run npx react-doctor@latest --verbose for details
 
   ┌─────┐  99 / 100 Great
   │ ◠ ◠ │  ██████████████████████████████████████████████████
   │  ▽  │  React Doctor (https://react.doctor)
   └─────┘
 
-  Tip: Run npx react-doctor@latest --verbose to see each warning explained with its fix"
+
+  ────────────────────────────────────────────────────────────
+
+  Docs: https://www.react.doctor/docs
+  Learn more about fixing issues, setting up CI/CD, and configuring rules with a config file
+
+  GitHub: https://github.com/millionco/react-doctor
+  Report issues and star the repository!"
 `;
 
 exports[`in-process render across terminal widths and render modes > matches the terminal-width × mode overflow matrix 1`] = `
@@ -71,6 +75,6 @@ default-errors-ok              wrap   wrap     ok     ok     ok
 default-errors-needs-work      wrap   wrap     ok     ok     ok
 default-errors-no-score        wrap   wrap     ok     ok     ok
 default-warnings-only          wrap   wrap     ok     ok     ok
-default-clean-perfect          wrap     ok     ok     ok     ok
+default-clean-perfect          wrap   wrap     ok     ok     ok
 verbose-errors-great           wrap   wrap     ok     ok     ok"
 `;

--- a/packages/react-doctor/tests/e2e/terminal-visuals.test.ts
+++ b/packages/react-doctor/tests/e2e/terminal-visuals.test.ts
@@ -26,7 +26,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { OUTPUT_DETAIL_WRAP_WIDTH_CHARS } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
 import { printDiagnostics } from "../../src/cli/utils/render-diagnostics.js";
-import { printSummary, printVerboseTip } from "../../src/cli/utils/render-summary.js";
+import { printFooter, printSummary } from "../../src/cli/utils/render-summary.js";
 import { setupReactProject } from "../regressions/_helpers.js";
 import { renderInTerminal } from "../helpers/render-in-terminal.js";
 
@@ -196,7 +196,14 @@ describe("in-process render across terminal widths and render modes", () => {
             verbose: options.verbose,
           }),
         );
-        await Effect.runPromise(printVerboseTip(options.diagnostics, options.verbose));
+        await Effect.runPromise(
+          printFooter({
+            diagnostics: options.diagnostics,
+            scoreResult: options.scoreResult,
+            projectName: SHARE_ONLY_PROJECT_NAME,
+            isOffline: true,
+          }),
+        );
       });
 
     const scenarioSpecs: {

--- a/packages/react-doctor/tests/e2e/terminal-visuals.test.ts
+++ b/packages/react-doctor/tests/e2e/terminal-visuals.test.ts
@@ -189,10 +189,8 @@ describe("in-process render across terminal widths and render modes", () => {
             diagnostics: options.diagnostics,
             elapsedMilliseconds: 1234,
             scoreResult: options.scoreResult,
-            projectName: SHARE_ONLY_PROJECT_NAME,
             totalSourceFileCount: 1,
             noScoreMessage: "Score unavailable.",
-            isOffline: true,
             verbose: options.verbose,
           }),
         );
@@ -346,6 +344,73 @@ describe("in-process render across terminal widths and render modes", () => {
     // and not what this layout snapshot is asserting.
     const platformStableLayout = rendered.logicalLines.join("\n").replaceAll("›", ">");
     expect(platformStableLayout).toMatchSnapshot();
+  });
+});
+
+describe("non-verbose overflow summary line", () => {
+  const overflowProjectDirectory = path.join(tempRoot, "overflow");
+
+  const makeDiagnostic = (rule: string, severity: "error" | "warning", line: number): Diagnostic =>
+    ({
+      filePath: "src/x.tsx",
+      plugin: "react-doctor",
+      rule,
+      severity,
+      title: `${rule} title`,
+      message: "Impact.",
+      help: "Fix.",
+      line,
+      column: 1,
+      category: "Bugs",
+    }) as Diagnostic;
+
+  const renderOverflowText = async (diagnostics: Diagnostic[]): Promise<string> => {
+    const bytes = await captureConsoleBytes(() =>
+      Effect.runPromise(printDiagnostics(diagnostics, false, overflowProjectDirectory)),
+    );
+    return (await renderInTerminal(bytes, { cols: 120 })).text;
+  };
+
+  it("omits the --verbose pointer when every finding is already shown", async () => {
+    const text = await renderOverflowText([
+      makeDiagnostic("rule-a", "error", 1),
+      makeDiagnostic("rule-b", "error", 2),
+    ]);
+    expect(text).not.toContain("--verbose");
+    expect(text).not.toContain("for details");
+  });
+
+  it("points at --verbose when a shown error rule hides extra sites", async () => {
+    const text = await renderOverflowText([
+      makeDiagnostic("rule-a", "error", 1),
+      makeDiagnostic("rule-a", "error", 2),
+    ]);
+    expect(text).toContain("Run npx react-doctor@latest --verbose for details");
+    expect(text).not.toContain("optional");
+    expect(text).not.toContain("more rules");
+  });
+
+  it("counts optional warnings by individual diagnostics, not rule groups", async () => {
+    const text = await renderOverflowText([
+      makeDiagnostic("hoist", "warning", 1),
+      makeDiagnostic("hoist", "warning", 2),
+      makeDiagnostic("hoist", "warning", 3),
+    ]);
+    expect(text).toContain("+3 optional warnings");
+    expect(text).toContain("--verbose");
+  });
+
+  it("merges hidden error rules and optional warnings into one line", async () => {
+    const text = await renderOverflowText([
+      makeDiagnostic("err-1", "error", 1),
+      makeDiagnostic("err-2", "error", 2),
+      makeDiagnostic("err-3", "error", 3),
+      makeDiagnostic("err-4", "error", 4),
+      makeDiagnostic("warn-1", "warning", 5),
+      makeDiagnostic("warn-1", "warning", 6),
+    ]);
+    expect(text).toContain("+1 more rule");
+    expect(text).toContain("+2 optional warnings");
   });
 });
 

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -234,7 +234,8 @@ export const Cart = () => {
 
     expect(normalizedStdout).toContain("Bugs");
     expect(normalizedStdout).toMatch(/\d+ warnings?/);
-    expect(normalizedStdout).toContain("--verbose");
+    expect(normalizedStdout).toContain("Docs:");
+    expect(normalizedStdout).toContain("Learn more about fixing issues");
     expect(normalizedStdout).not.toContain("Agent guidance");
   });
 


### PR DESCRIPTION
## Summary

Reworks the CLI scan output (summary, footer, and verbose detail) for a cleaner, more scannable result.

- **Combined overflow line.** The non-verbose run no longer prints the per-rule warnings list. Hidden errors and warnings collapse into one line, e.g. `+4 more rules and +50 optional warnings — run npx react-doctor@latest --verbose for details`. (The old always-on "Tip: run --verbose" line is removed; the pointer now lives here.)
- **Verbose warnings == errors.** `--verbose` renders warnings in the same boxed, titled, code-framed block as errors (`⚠ Category: Title ×N`, a `Learn more:` docs link, the `→` fix, and a code frame at each site). Errors also now show the docs link / agent fix-recipe in verbose. One block builder for every rule group.
- **Restructured footer.** A divider followed by a `Share:` / `Docs:` / `GitHub:` block, each with a one-line description. The shared divider is extracted into `build-section-divider.ts`.
- **Share link for monorepos.** The aggregate footer now shows the share link on multi-project runs, gated identically to single-project (hidden in CI, with `--no-score`, or `share: false`), using the workspace root name for `p`.
- **Spinner suffix.** The worker count now reads as a dimmed `[~N workers]` (ASCII tilde) on both the live spinner and the final `Scanned …` line.
- **Handoff spacing.** A blank line before the "Hand these issues to an agent?" prompt.
- Removes the now-dead warning-list helpers and the `MAX_WARNING_RULES_SHOWN_NON_VERBOSE` / `RULE_NAME_COLUMN_WIDTH_CHARS` constants.

## Test plan

- [x] `pnpm typecheck` (8/8)
- [x] `pnpm lint` (clean)
- [x] `pnpm format:check`
- [x] `pnpm test` (all packages green; visuals + regression snapshots updated)
- [x] `pnpm smoke:json-report`
- [x] Manual: built CLI against a single-project and a 2-package monorepo — verified non-verbose overflow line, `--verbose` warning blocks with code frames, `--no-score` suppressing the share link, monorepo share link, and the dimmed `[~N workers]` suffix.

## Notes

- PR-comment output is built from the `--json` report (not this terminal renderer) and is unaffected; JSON mode silences the footer.
- Pre-existing, out of scope: the handoff prompt can hang on cancel (the prompt opts out of the default exit-on-cancel); flagged separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to terminal rendering and copy; scoring, lint, and JSON/PR comment paths are unchanged aside from footer placement and share URL gating for monorepos.
> 
> **Overview**
> The default scan output is **shorter and more scannable**: it no longer prints a per-rule warning list or separate “+N more rules” lines under top errors. Anything not fully shown—extra error rule groups, extra sites on a shown rule, or **all** warnings—is rolled into **one** overflow line (e.g. `+1 more rule and +2 optional warnings — run npx react-doctor@latest --verbose for details`). The old closing “Tip: run --verbose” line is removed in favor of that pointer.
> 
> **`--verbose`** now uses a **single** rule block builder for errors and warnings: category title, optional **Learn more**, fix text, and **boxed code frames** at every site (warnings match errors; default mode still frames errors only).
> 
> The **footer** is centralized in `printFooter`: divider, then **Share** / **Docs** / **GitHub** with one-line blurbs. Share moves out of `printSummary` into the footer; **monorepo** runs get the same share gating as single-project (`CI`, `--no-score`, `share: false`) with the workspace basename for `p`. Scan progress shows a dim **`[~N workers]`** suffix; agent handoff gets a blank line before the prompt.
> 
> Dead code paths (`buildWarningRuleBlock`, warning list caps, rule-name column padding) and related constants are removed; tests and snapshots follow the new layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39bb6fce679660622ae34b5ea4b65c95d86299b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->