### PR TITLE
feat(cli): reveal category breakdown one issue at a time

### DIFF
--- a/.changeset/category-reveal-one-at-a-time.md
+++ b/.changeset/category-reveal-one-at-a-time.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+The interactive category breakdown now reveals issues one at a time — a category's errors before its warnings, top to bottom — instead of every count easing up in parallel, holds for a beat once it settles, and finally plays on monorepo (multi-project) scans too.
+
+Previously the count-up only animated on single-project scans; the multi-project aggregate report rendered the breakdown (and the score projection) statically. Both now share the same interactive reveal, gated on the same real-TTY predicate, so a monorepo's report animates like a single project's. Small and medium breakdowns step one issue per frame; very large ones grow the per-step increment so the reveal still resolves quickly.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -80,7 +80,7 @@ export const SHARE_BASE_URL = "https://react.doctor/share";
 // Root of the documentation site. Guides for CI/CD setup, config files (to
 // suppress rules), and diff/PR scanning live under it; the CLI links here
 // from its closing "learn more" note.
-export const DOCS_URL = "https://www.react.doctor/docs";
+export const DOCS_URL = "https://react.doctor/docs";
 
 // Base URL for the per-rule documentation pages. The canonical,
 // human-readable fix recipe for one rule lives at `<base>/<plugin>/<rule>`

--- a/packages/core/src/utils/build-rule-docs-url.ts
+++ b/packages/core/src/utils/build-rule-docs-url.ts
@@ -3,7 +3,7 @@ import { DOCS_RULES_BASE_URL } from "../constants.js";
 /**
  * Canonical URL for a rule's documentation page — its reviewer-tested fix
  * recipe rendered for humans — served at
- * `https://www.react.doctor/docs/rules/<plugin>/<rule>`. The CLI links here
+ * `https://react.doctor/docs/rules/<plugin>/<rule>`. The CLI links here
  * from its fix-recipe directive so each fix follows the canonical recipe
  * instead of being improvised per diagnostic.
  */

--- a/packages/core/tests/build-rule-docs-url.test.ts
+++ b/packages/core/tests/build-rule-docs-url.test.ts
@@ -10,7 +10,7 @@ describe("buildRuleDocsUrl", () => {
 
   it("preserves non-react-doctor plugin namespaces", () => {
     expect(buildRuleDocsUrl("jsx-a11y", "anchor-is-valid")).toBe(
-      "https://www.react.doctor/docs/rules/jsx-a11y/anchor-is-valid",
+      "https://react.doctor/docs/rules/jsx-a11y/anchor-is-valid",
     );
   });
 });

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -28,8 +28,15 @@ export const WELCOME_TYPEWRITER_CHAR_DELAY_MS = 32;
 export const WELCOME_INTER_LINE_DELAY_MS = 500;
 export const WELCOME_EXPLANATION_HOLD_MS = 2000;
 export const WELCOME_HOLD_MS = 1000;
-export const CATEGORY_COUNTUP_FRAME_COUNT = 16;
-export const CATEGORY_COUNTUP_FRAME_DELAY_MS = 45;
+// The category breakdown reveals one issue at a time (errors then warnings,
+// category by category). Small/medium breakdowns step by a single unit per
+// frame; `MAX_STEPS` caps the frame budget so a huge repo's reveal stays short
+// (the per-step increment grows instead).
+export const CATEGORY_COUNTUP_MAX_STEPS = 24;
+export const CATEGORY_COUNTUP_FRAME_DELAY_MS = 70;
+// Beat to hold on the settled category tally before the detail blocks reveal,
+// so the at-a-glance breakdown reads before the report scrolls on.
+export const CATEGORY_COUNTUP_SETTLE_HOLD_MS = 1000;
 export const SCORE_PROJECTION_FRAME_COUNT = 16;
 export const SCORE_PROJECTION_FRAME_DELAY_MS = 35;
 // Terminal rows from the cursor (sitting just after the "you could improve"

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -15,14 +15,17 @@ import type { Diagnostic } from "@react-doctor/core";
 import { boxText } from "./box-text.js";
 import { buildCodeFrame } from "./build-code-frame.js";
 import { buildSectionDivider } from "./build-section-divider.js";
-import { CATEGORY_COUNTUP_FRAME_COUNT, CATEGORY_COUNTUP_FRAME_DELAY_MS } from "./constants.js";
+import {
+  CATEGORY_COUNTUP_FRAME_DELAY_MS,
+  CATEGORY_COUNTUP_MAX_STEPS,
+  CATEGORY_COUNTUP_SETTLE_HOLD_MS,
+} from "./constants.js";
 import {
   buildSortedRuleGroups,
   compareByRulePriority,
   formatFixRecipeLine,
   formatLearnMoreLine,
 } from "./diagnostic-grouping.js";
-import { easeOutCubic } from "./ease-out-cubic.js";
 import { indentMultilineText } from "./indent-multiline-text.js";
 import { wrapTextToWidth } from "./wrap-indented-text.js";
 import { writeStdout } from "./write-stdout.js";
@@ -142,25 +145,51 @@ const buildCategoryTally = (categoryGroup: CategoryDiagnosticGroup): CategoryTal
 const buildCategoryTallyLines = (tallies: ReadonlyArray<CategoryTally>): string[] =>
   tallies.map((tally) => formatCategoryTallyLine(tally, tally.errorCount, tally.warningCount));
 
-// Animated count-up of the category tally for a first interactive run; counts
-// only grow, so frames never shrink and no per-line clear is needed. Lands on
-// the exact same lines `buildCategoryTallyLines` prints statically.
+// Renders the breakdown with only the first `revealedUnitCount` issues shown,
+// filled one category at a time (a category's errors before its warnings)
+// so the reveal reads as issues landing one by one, top to bottom.
+const buildPartiallyRevealedTallyLines = (
+  tallies: ReadonlyArray<CategoryTally>,
+  revealedUnitCount: number,
+): string[] => {
+  let remainingToReveal = revealedUnitCount;
+  return tallies.map((tally) => {
+    const errorShown = Math.min(tally.errorCount, remainingToReveal);
+    remainingToReveal -= errorShown;
+    const warningShown = Math.min(tally.warningCount, remainingToReveal);
+    remainingToReveal -= warningShown;
+    return formatCategoryTallyLine(tally, errorShown, warningShown);
+  });
+};
+
+// Animated reveal of the category tally for an interactive run: issues land one
+// at a time (errors then warnings, category by category) rather than every
+// count easing up at once. Counts only grow, so frames never shrink and no
+// per-line clear is needed; the last frame matches `buildCategoryTallyLines`.
 const printCategoryCountUp = (tallies: ReadonlyArray<CategoryTally>): Effect.Effect<void> =>
   Effect.gen(function* () {
-    for (let frame = 0; frame <= CATEGORY_COUNTUP_FRAME_COUNT; frame += 1) {
-      const fraction = easeOutCubic(frame / CATEGORY_COUNTUP_FRAME_COUNT);
-      const lines = tallies.map((tally) =>
-        formatCategoryTallyLine(
-          tally,
-          Math.round(tally.errorCount * fraction),
-          Math.round(tally.warningCount * fraction),
-        ),
-      );
-      const cursorUp = frame === 0 ? "" : `\x1b[${tallies.length}A`;
+    const totalUnitCount = tallies.reduce(
+      (sum, tally) => sum + tally.errorCount + tally.warningCount,
+      0,
+    );
+    // Step one issue per frame when there are few; otherwise grow the step so a
+    // large breakdown still resolves within the frame budget.
+    const unitsPerStep = Math.max(1, Math.ceil(totalUnitCount / CATEGORY_COUNTUP_MAX_STEPS));
+    for (
+      let revealedUnitCount = 0;
+      revealedUnitCount < totalUnitCount;
+      revealedUnitCount += unitsPerStep
+    ) {
+      const lines = buildPartiallyRevealedTallyLines(tallies, revealedUnitCount);
+      const cursorUp = revealedUnitCount === 0 ? "" : `\x1b[${tallies.length}A`;
       yield* writeStdout(`${cursorUp}\r${lines.join("\n\r")}\n`);
-      if (frame < CATEGORY_COUNTUP_FRAME_COUNT)
-        yield* Effect.sleep(CATEGORY_COUNTUP_FRAME_DELAY_MS);
+      yield* Effect.sleep(CATEGORY_COUNTUP_FRAME_DELAY_MS);
     }
+    // Land on the full tallies (the loop stops one step short when the total
+    // isn't a clean multiple of the step).
+    const cursorUp = totalUnitCount === 0 ? "" : `\x1b[${tallies.length}A`;
+    yield* writeStdout(`${cursorUp}\r${buildCategoryTallyLines(tallies).join("\n\r")}\n`);
+    yield* Effect.sleep(CATEGORY_COUNTUP_SETTLE_HOLD_MS);
   });
 
 const TOP_ERROR_DETAIL_INDENT = "    ";

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -11,6 +11,7 @@ import { colorizeByScore } from "./colorize-by-score.js";
 import { computeProjectedScore } from "./compute-score-projection.js";
 import { buildRulePriorityMap } from "./diagnostic-grouping.js";
 import { isCodingAgentEnvironment } from "./is-ci-environment.js";
+import { canAnimateOnboarding } from "./onboarding-pacing.js";
 import { formatElapsedTime, printDiagnostics } from "./render-diagnostics.js";
 import { printFooter, printSummary } from "./render-summary.js";
 
@@ -86,6 +87,11 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
   Effect.gen(function* () {
     const { completedScans, userConfig, verbose, isOffline, projectName } = input;
 
+    // Report animations (category count-up + score-projection ghost gain) play
+    // on every interactive aggregate render, mirroring the single-project path
+    // in `inspect.ts`. The first-run section pacing stays single-project-only.
+    const animateRender = !verbose && canAnimateOnboarding(process.stdout);
+
     const allDiagnostics: Diagnostic[] = completedScans.flatMap((scan) => scan.result.diagnostics);
     const surfaceDiagnostics = filterDiagnosticsForSurface(allDiagnostics, "cli", userConfig);
 
@@ -141,6 +147,7 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
         resolveDiagnosticSourceRoot,
         buildRulePriorityMap(completedScans.map((scan) => scan.result.score)),
         isCodingAgentEnvironment(),
+        { animateCountUp: animateRender },
       );
     }
 
@@ -176,6 +183,7 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
       totalSourceFileCount,
       noScoreMessage: "Score unavailable.",
       verbose,
+      animateProjection: animateRender,
     });
 
     const entries: ProjectScanEntry[] = completedScans.map((scan) => {

--- a/packages/react-doctor/tests/e2e/__snapshots__/terminal-visuals.test.ts.snap
+++ b/packages/react-doctor/tests/e2e/__snapshots__/terminal-visuals.test.ts.snap
@@ -60,7 +60,7 @@ exports[`in-process render across terminal widths and render modes > matches the
 
   ────────────────────────────────────────────────────────────
 
-  Docs: https://www.react.doctor/docs
+  Docs: https://react.doctor/docs
   Learn more about fixing issues, setting up CI/CD, and configuring rules with a config file
 
   GitHub: https://github.com/millionco/react-doctor


### PR DESCRIPTION
## Summary

- The interactive category breakdown now reveals issues **one at a time** — a category's errors before its warnings, filled top-to-bottom — instead of easing every count up in parallel. Small/medium breakdowns step one issue per frame; very large ones grow the per-step increment so the reveal stays short.
- Added a ~1s settle hold after the breakdown lands, before the detail blocks reveal.
- **Monorepo fix:** the multi-project (aggregate) summary path was calling `printDiagnostics`/`printSummary` without the animation flags, so monorepo scans rendered the breakdown and score projection statically. It now shares the same animations, gated on the same real-TTY predicate (`canAnimateOnboarding`). Since `react-doctor` is itself a monorepo, this was why the category stats weren't animating locally.
- Pointed `DOCS_URL` at the canonical `react.doctor/docs` (dropped the `www.`), with the matching terminal snapshot update.

## Implementation notes

- `printCategoryCountUp` now distributes a growing "revealed unit" budget sequentially across categories via `buildPartiallyRevealedTallyLines`, replacing the eased parallel count-up (the now-unused `easeOutCubic` import was removed from this file).
- New constants: `CATEGORY_COUNTUP_MAX_STEPS` (frame budget cap), `CATEGORY_COUNTUP_SETTLE_HOLD_MS` (post-reveal hold); `CATEGORY_COUNTUP_FRAME_DELAY_MS` retuned for the per-issue cadence.
- Animations remain off for non-TTY / piped / CI / git-hook / verbose / score-only / JSON runs.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `react-doctor` package: `render-onboarding-animation` + `terminal-visuals` suites pass (26 tests)
- [ ] Manually confirm in a real terminal: single-project and monorepo scans both reveal the breakdown one issue at a time, then hold ~1s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and documentation URL constants only; no scan, scoring, or auth logic changes.
> 
> **Overview**
> The interactive **category breakdown** no longer eases every error/warning count in parallel; it **reveals issues one at a time** (errors before warnings within each category, top to bottom), with a **~1s hold** after the tally settles before detail blocks appear. Large scans cap frames via **`CATEGORY_COUNTUP_MAX_STEPS`** by increasing the per-step increment instead of one issue per frame.
> 
> **Monorepo aggregate reports** now pass the same real-TTY animation flags as single-project scans (`animateCountUp` / `animateProjection` via `canAnimateOnboarding`), so multi-project summaries were previously static for the breakdown and score projection.
> 
> **Docs links** in core and terminal output move from `https://www.react.doctor/docs` to **`https://react.doctor/docs`** (tests and e2e snapshot updated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f545ebf734cbce50bfcf58d32d014ac256e61a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->