### PR TITLE
fix(cli): treat expected user/CLI errors as clean errors, not Sentry crashes

### DIFF
--- a/.changeset/no-react-dependency-not-a-crash.md
+++ b/.changeset/no-react-dependency-not-a-crash.md
@@ -1,0 +1,15 @@
+---
+"react-doctor": patch
+---
+
+Expected, user-actionable failures are no longer reported to Sentry or rendered as crashes.
+
+When react-doctor exits because of the user's project or invocation — not a bug — it now prints a clean, single-line message and exits non-zero, instead of the generic "Something went wrong, open a prefilled issue" block. These cases are also no longer sent to Sentry or counted in the alertable error-rate metric. This was flooding crash reporting with non-bugs from CI, coding agents, and sandboxes.
+
+Covered cases:
+
+- **No React / no project / missing path** — every project-discovery failure (`NoReactDependencyError`, `ProjectNotFoundError`, `PackageJsonNotFoundError`, `NotADirectoryError`, `AmbiguousProjectError`) is now treated as a clean user error (REACT-DOCTOR-1, -4, -6, -7). When the scan target simply doesn't exist on disk, the message now says the path doesn't exist instead of the misleading "Expected a package.json…" guidance.
+- **CLI invocation mistakes** — a malformed `<file>:<line>` argument, mutually exclusive flags (e.g. `--yes` + `--full`), and an unknown `--project` name now render as clean errors (REACT-DOCTOR-B, -D, -G, -H).
+- **Read-only config directory** — react-doctor no longer crashes when it can't create/read its global setup-prompt store on a locked-down or read-only filesystem; it degrades gracefully (REACT-DOCTOR-E).
+
+The fix is enforced centrally in `reportErrorToSentry`, so the CLI entry point, `inspect`, and `install` all benefit.

--- a/packages/core/src/project-info/errors.ts
+++ b/packages/core/src/project-info/errors.ts
@@ -20,16 +20,36 @@
  * `ReactDoctorError` from `../errors.js` instead.
  */
 
+/**
+ * Distinguishes the two situations that both surface as "no project here", so
+ * the rendered message matches reality:
+ *
+ * - `no-project` (default): the path exists but has no React project — no
+ *   `package.json` at the root and no discoverable nested React subproject.
+ * - `missing-path`: the resolved scan target does not exist on disk at all
+ *   (a typo, a stale temp path, a monorepo subdir that isn't present). The
+ *   generic "expected a package.json" guidance is misleading here, so point
+ *   at the missing path instead.
+ */
+export interface ProjectNotFoundOptions extends ErrorOptions {
+  readonly kind?: "no-project" | "missing-path";
+}
+
 export class ProjectNotFoundError extends Error {
   override readonly name = "ProjectNotFoundError";
   readonly directory: string;
+  readonly kind: "no-project" | "missing-path";
 
-  constructor(directory: string, options?: ErrorOptions) {
+  constructor(directory: string, options?: ProjectNotFoundOptions) {
+    const kind = options?.kind ?? "no-project";
     super(
-      `No React project found in ${directory}. Expected a package.json at the directory root or a nested package.json with a React dependency.`,
+      kind === "missing-path"
+        ? `Scan target "${directory}" does not exist. Check the path and try again.`
+        : `No React project found in ${directory}. Expected a package.json at the directory root or a nested package.json with a React dependency.`,
       options,
     );
     this.directory = directory;
+    this.kind = kind;
   }
 }
 

--- a/packages/core/src/resolve-scan-target.ts
+++ b/packages/core/src/resolve-scan-target.ts
@@ -69,7 +69,7 @@ export const resolveScanTarget = async (
   if (!isDirectory(resolvedDirectory)) {
     throw existsSync(resolvedDirectory)
       ? new NotADirectoryError(resolvedDirectory)
-      : new ProjectNotFoundError(resolvedDirectory);
+      : new ProjectNotFoundError(resolvedDirectory, { kind: "missing-path" });
   }
 
   return {

--- a/packages/core/tests/resolve-scan-target.test.ts
+++ b/packages/core/tests/resolve-scan-target.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
-import { AmbiguousProjectError, resolveScanTarget } from "../src/index.js";
+import { AmbiguousProjectError, ProjectNotFoundError, resolveScanTarget } from "../src/index.js";
 
 const tempDirectories: string[] = [];
 
@@ -45,5 +45,24 @@ describe("resolveScanTarget", () => {
 
     const scanTarget = await resolveScanTarget(wrapperDirectory, { allowAmbiguous: true });
     expect(scanTarget.resolvedDirectory).toBe(wrapperDirectory);
+  });
+
+  it("reports a missing scan target as a non-existent path, not a missing package.json", async () => {
+    // REACT-DOCTOR-4: a scan target that doesn't exist on disk (a typo or a
+    // stale path) is user input, and the "expected a package.json" guidance is
+    // misleading — the path simply isn't there.
+    const missingDirectory = path.join(createTempDirectory(), "does-not-exist");
+
+    const rejection = await resolveScanTarget(missingDirectory).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    if (!(rejection instanceof ProjectNotFoundError)) {
+      throw new Error(`Expected ProjectNotFoundError, got ${String(rejection)}`);
+    }
+    expect(rejection.kind).toBe("missing-path");
+    expect(rejection.message).toContain("does not exist");
+    expect(rejection.message).not.toContain("package.json");
   });
 });

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -9,7 +9,6 @@ import {
   findLegacyConfig,
   getDiffInfo,
   highlighter,
-  isReactDoctorError,
   resolveScanTarget,
   toRelativePath,
 } from "@react-doctor/core";
@@ -27,6 +26,7 @@ import { recordCount } from "../utils/record-metric.js";
 import { getStagedSourceFiles, materializeStagedFiles } from "../utils/get-staged-files.js";
 import type { InspectFlags } from "../utils/inspect-flags.js";
 import { handleError, handleUserError } from "../utils/handle-error.js";
+import { isExpectedUserError } from "../utils/is-expected-user-error.js";
 import { handoffToAgent } from "../utils/handoff-to-agent.js";
 import { migrateLegacyConfig } from "../utils/migrate-legacy-config.js";
 import {
@@ -426,14 +426,11 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       }
     }
   } catch (error) {
-    // A bad `--diff` value (or an unfetched base branch) is the user's
+    // Expected, user-actionable failures — a directory without React, a missing
+    // package.json, or a bad `--diff` base branch — are the user's project or
     // input, not a react-doctor bug: skip Sentry and the "open a prefilled
-    // issue" block so it doesn't become triage noise. Dispatch on the tagged
-    // reason inline (AGENTS.md: don't add new error-shape helpers).
-    const isUserError =
-      isReactDoctorError(error) &&
-      (error.reason._tag === "GitBaseBranchInvalid" ||
-        error.reason._tag === "GitBaseBranchMissing");
+    // issue" block so they don't become triage noise.
+    const isUserError = isExpectedUserError(error);
     const sentryEventId = isUserError ? undefined : await reportErrorToSentry(error);
     if (isJsonMode) {
       writeJsonErrorReport(error);

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -16,7 +16,8 @@ import {
 import { versionAction } from "./commands/version.js";
 import { applyColorPreference } from "./utils/apply-color-preference.js";
 import { exitGracefully } from "./utils/exit-gracefully.js";
-import { handleError } from "./utils/handle-error.js";
+import { handleError, handleUserError } from "./utils/handle-error.js";
+import { isExpectedUserError } from "./utils/is-expected-user-error.js";
 import { isJsonModeActive, writeJsonErrorReport } from "./utils/json-mode.js";
 import { normalizeHelpInvocation } from "./utils/normalize-help-command.js";
 import { reportErrorToSentry } from "./utils/report-error.js";
@@ -271,10 +272,18 @@ program
   // success path; error funnels flush via `reportErrorToSentry`.
   .then(() => flushSentry())
   .catch(async (error: unknown) => {
-    const sentryEventId = await reportErrorToSentry(error);
+    // Mirror the per-command policy at the top-level funnel: expected,
+    // user-actionable failures skip Sentry and render as a plain message
+    // (no "open a prefilled issue" block), so they don't become triage noise.
+    const isUserError = isExpectedUserError(error);
+    const sentryEventId = isUserError ? undefined : await reportErrorToSentry(error);
     if (isJsonModeActive()) {
       writeJsonErrorReport(error);
       process.exit(1);
+    }
+    if (isUserError) {
+      handleUserError(error);
+      return;
     }
     handleError(error, { sentryEventId });
   });

--- a/packages/react-doctor/src/cli/utils/cli-input-error.ts
+++ b/packages/react-doctor/src/cli/utils/cli-input-error.ts
@@ -1,0 +1,13 @@
+/**
+ * A mistake in *how the CLI was invoked* — a malformed `<file>:<line>`
+ * argument, mutually exclusive flags, or an unknown `--project` name. This is
+ * user input, not a react-doctor bug, so `isExpectedUserError` routes it
+ * through `handleUserError`: a clean, single-line message with no Sentry
+ * report and no "Something went wrong, open a prefilled issue" block.
+ *
+ * The `message` is rendered verbatim, so it must read as a complete,
+ * human-readable sentence that tells the user how to fix their invocation.
+ */
+export class CliInputError extends Error {
+  override readonly name = "CliInputError";
+}

--- a/packages/react-doctor/src/cli/utils/is-expected-user-error.ts
+++ b/packages/react-doctor/src/cli/utils/is-expected-user-error.ts
@@ -1,0 +1,33 @@
+import { isProjectDiscoveryError, isReactDoctorError } from "@react-doctor/core";
+import { CliInputError } from "./cli-input-error.js";
+
+/**
+ * Whether `error` is an expected, user-actionable failure — the user's project
+ * or input, not a react-doctor bug. Such failures must be kept out of crash
+ * reporting (Sentry + the alertable error-rate metric) and rendered via
+ * `handleUserError` (a plain message — no "Something went wrong", prefilled
+ * issue, Discord link, or Sentry reference), since there is no bug to report.
+ *
+ * Three distinct shapes reach the CLI's catch blocks:
+ *
+ * - **Project-discovery failures** (`NoReactDependencyError`,
+ *   `ProjectNotFoundError`, `PackageJsonNotFoundError`, `NotADirectoryError`,
+ *   `AmbiguousProjectError`) arrive as their plain legacy classes (so
+ *   `isReactDoctorError` is `false` for them) — narrow with
+ *   `isProjectDiscoveryError`. Running react-doctor against a directory that
+ *   has no React, or a path that doesn't exist, is the canonical example.
+ * - **CLI invocation mistakes** (`CliInputError`): a malformed
+ *   `<file>:<line>` argument, mutually exclusive flags, or an unknown
+ *   `--project` name.
+ * - **Bad `--diff` input** (`GitBaseBranchInvalid` / `GitBaseBranchMissing`)
+ *   stays the tagged `ReactDoctorError`, so dispatch on the reason `_tag`.
+ *
+ * This composes the existing core narrowers rather than introducing a new
+ * error-shape helper (AGENTS.md): it encodes CLI-layer reporting policy, not
+ * knowledge of the `ReactDoctorError` shape.
+ */
+export const isExpectedUserError = (error: unknown): boolean =>
+  error instanceof CliInputError ||
+  isProjectDiscoveryError(error) ||
+  (isReactDoctorError(error) &&
+    (error.reason._tag === "GitBaseBranchInvalid" || error.reason._tag === "GitBaseBranchMissing"));

--- a/packages/react-doctor/src/cli/utils/parse-file-line-argument.ts
+++ b/packages/react-doctor/src/cli/utils/parse-file-line-argument.ts
@@ -1,3 +1,5 @@
+import { CliInputError } from "./cli-input-error.js";
+
 interface ParsedFileLineArgument {
   filePath: string;
   line: number;
@@ -6,16 +8,18 @@ interface ParsedFileLineArgument {
 export const parseFileLineArgument = (rawArgument: string): ParsedFileLineArgument => {
   const lastColonIndex = rawArgument.lastIndexOf(":");
   if (lastColonIndex < 0) {
-    throw new Error(`Expected "<file>:<line>" (e.g. "src/foo.tsx:42"), got "${rawArgument}".`);
+    throw new CliInputError(
+      `Expected "<file>:<line>" (e.g. "src/foo.tsx:42"), got "${rawArgument}".`,
+    );
   }
   const filePath = rawArgument.slice(0, lastColonIndex);
   const lineText = rawArgument.slice(lastColonIndex + 1);
   if (filePath.length === 0) {
-    throw new Error(`Missing file path in "${rawArgument}".`);
+    throw new CliInputError(`Missing file path in "${rawArgument}".`);
   }
   const line = Number.parseInt(lineText, 10);
   if (!Number.isFinite(line) || line <= 0 || String(line) !== lineText.trim()) {
-    throw new Error(`Expected a positive line number in "${rawArgument}".`);
+    throw new CliInputError(`Expected a positive line number in "${rawArgument}".`);
   }
   return { filePath, line };
 };

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -46,27 +46,41 @@ export const hasDisabledSetupPrompt = (
   projectRoot: string,
   storeOptions: SetupPromptStoreOptions = {},
 ): boolean => {
-  const store = getSetupPromptStore(storeOptions);
-  const projects = store.get("projects", {});
-  return projects[getSetupPromptProjectKey(projectRoot)]?.setupPrompt === false;
+  try {
+    const store = getSetupPromptStore(storeOptions);
+    const projects = store.get("projects", {});
+    return projects[getSetupPromptProjectKey(projectRoot)]?.setupPrompt === false;
+  } catch {
+    // A read-only or otherwise inaccessible global-config directory (EPERM /
+    // EROFS in locked-down CI and sandboxes) is an environment limitation, not
+    // a react-doctor bug. Degrade to "not disabled" rather than crashing the
+    // scan and reporting it to Sentry — at worst the install hint shows again.
+    return false;
+  }
 };
 
 export const disableSetupPrompt = (
   projectRoot: string,
   storeOptions: SetupPromptStoreOptions = {},
 ): boolean => {
-  const store = getSetupPromptStore(storeOptions);
-  const projects = store.get("projects", {});
-  const projectKey = getSetupPromptProjectKey(projectRoot);
-  store.set("projects", {
-    ...projects,
-    [projectKey]: {
-      ...(projects[projectKey] ?? {}),
-      rootDirectory: path.resolve(projectRoot),
-      setupPrompt: false,
-    },
-  });
-  return true;
+  try {
+    const store = getSetupPromptStore(storeOptions);
+    const projects = store.get("projects", {});
+    const projectKey = getSetupPromptProjectKey(projectRoot);
+    store.set("projects", {
+      ...projects,
+      [projectKey]: {
+        ...(projects[projectKey] ?? {}),
+        rootDirectory: path.resolve(projectRoot),
+        setupPrompt: false,
+      },
+    });
+    return true;
+  } catch {
+    // Couldn't persist the opt-out (read-only config dir). Signal failure to
+    // the caller instead of crashing — the choice just won't be remembered.
+    return false;
+  }
 };
 
 export const resolveInstallSetupProjectRoot = (

--- a/packages/react-doctor/src/cli/utils/report-error.ts
+++ b/packages/react-doctor/src/cli/utils/report-error.ts
@@ -3,6 +3,7 @@ import { isReactDoctorError } from "@react-doctor/core";
 import { getActiveRunTrace } from "./active-run-trace.js";
 import { buildSentryScope } from "./build-sentry-scope.js";
 import { METRIC, SENTRY_FLUSH_TIMEOUT_MS } from "./constants.js";
+import { isExpectedUserError } from "./is-expected-user-error.js";
 import { recordCount } from "./record-metric.js";
 
 /**
@@ -22,6 +23,11 @@ import { recordCount } from "./record-metric.js";
  */
 export const reportErrorToSentry = async (error: unknown): Promise<string | undefined> => {
   if (!Sentry.isInitialized()) return undefined;
+  // Expected user errors (see `isExpectedUserError`) are the user's
+  // project/input, not a bug. Drop them before the metric + capture so they
+  // never become a Sentry crash or inflate the alertable error rate — the one
+  // choke point that covers every entry point regardless of caller-side gating.
+  if (isExpectedUserError(error)) return undefined;
   try {
     const { tags, contexts } = buildSentryScope();
 

--- a/packages/react-doctor/src/cli/utils/select-projects.ts
+++ b/packages/react-doctor/src/cli/utils/select-projects.ts
@@ -8,6 +8,7 @@ import {
   listWorkspacePackages,
 } from "@react-doctor/core";
 import { cliLogger as logger } from "./cli-logger.js";
+import { CliInputError } from "./cli-input-error.js";
 import { prompts } from "./prompts.js";
 
 export const selectProjects = async (
@@ -57,7 +58,7 @@ const resolveProjectFlag = (
       const availableNames = workspacePackages
         .map((workspacePackage) => workspacePackage.name)
         .join(", ");
-      throw new Error(`Project "${requestedName}" not found. Available: ${availableNames}`);
+      throw new CliInputError(`Project "${requestedName}" not found. Available: ${availableNames}`);
     }
 
     resolvedDirectories.push(matched.directory);

--- a/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
+++ b/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
@@ -1,3 +1,4 @@
+import { CliInputError } from "./cli-input-error.js";
 import type { InspectFlags } from "./inspect-flags.js";
 import { coerceDiffValue } from "./coerce-diff-value.js";
 
@@ -12,34 +13,34 @@ export const validateModeFlags = (flags: InspectFlags): void => {
   ].filter((modeName): modeName is string => modeName !== null);
 
   if (exclusiveModes.length > 1) {
-    throw new Error(`Cannot combine ${exclusiveModes.join(" and ")}; pick one mode.`);
+    throw new CliInputError(`Cannot combine ${exclusiveModes.join(" and ")}; pick one mode.`);
   }
   if (flags.yes && flags.full) {
-    throw new Error("Cannot combine --yes and --full; pick one.");
+    throw new CliInputError("Cannot combine --yes and --full; pick one.");
   }
   if (flags.score && flags.json) {
-    throw new Error("Cannot combine --score and --json; pick one output mode.");
+    throw new CliInputError("Cannot combine --score and --json; pick one output mode.");
   }
   if (flags.score && flags.telemetry === false) {
-    throw new Error(
+    throw new CliInputError(
       "Cannot combine --score with --no-telemetry; --score prints the score that --no-telemetry disables.",
     );
   }
   if (flags.prComment && (flags.json || flags.score)) {
-    throw new Error("--pr-comment cannot be combined with --json or --score.");
+    throw new CliInputError("--pr-comment cannot be combined with --json or --score.");
   }
   if (flags.annotations && flags.score) {
-    throw new Error("--annotations cannot be combined with --score.");
+    throw new CliInputError("--annotations cannot be combined with --score.");
   }
   if (flags.explain !== undefined && flags.why !== undefined) {
-    throw new Error("Use --explain or --why, not both — they're aliases of the same flag.");
+    throw new CliInputError("Use --explain or --why, not both — they're aliases of the same flag.");
   }
   const explainArgument = flags.explain ?? flags.why;
   if (
     explainArgument !== undefined &&
     (flags.json || flags.score || flags.annotations || flags.staged)
   ) {
-    throw new Error(
+    throw new CliInputError(
       "--explain cannot be combined with --json, --score, --annotations, or --staged.",
     );
   }

--- a/packages/react-doctor/tests/is-expected-user-error.test.ts
+++ b/packages/react-doctor/tests/is-expected-user-error.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  AmbiguousProjectError,
+  GitBaseBranchInvalid,
+  GitBaseBranchMissing,
+  NoReactDependencyError,
+  NotADirectoryError,
+  OxlintSpawnFailed,
+  PackageJsonNotFoundError,
+  ProjectNotFoundError,
+  ReactDoctorError,
+} from "@react-doctor/core";
+import { CliInputError } from "../src/cli/utils/cli-input-error.js";
+import { isExpectedUserError } from "../src/cli/utils/is-expected-user-error.js";
+
+describe("isExpectedUserError", () => {
+  it("classifies every project-discovery failure as an expected user error (kept out of Sentry)", () => {
+    // Regression: running react-doctor against a directory with no React
+    // (REACT-DOCTOR-1) or a path that doesn't exist (REACT-DOCTOR-4) is
+    // expected, user-actionable behavior — not a crash to report.
+    expect(isExpectedUserError(new NoReactDependencyError("/var/tmp"))).toBe(true);
+    expect(isExpectedUserError(new ProjectNotFoundError("/tmp/audit-v7"))).toBe(true);
+    expect(
+      isExpectedUserError(new ProjectNotFoundError("/tmp/audit-v7", { kind: "missing-path" })),
+    ).toBe(true);
+    expect(isExpectedUserError(new PackageJsonNotFoundError("/var/tmp"))).toBe(true);
+    expect(isExpectedUserError(new NotADirectoryError("/var/tmp/file.txt"))).toBe(true);
+    expect(isExpectedUserError(new AmbiguousProjectError("/work", ["a", "b"]))).toBe(true);
+  });
+
+  it("classifies CLI invocation mistakes as expected user errors", () => {
+    // REACT-DOCTOR-B/D/G/H: mutually exclusive flags, a malformed
+    // "<file>:<line>" argument, or an unknown --project name are user
+    // invocation mistakes, not crashes.
+    expect(
+      isExpectedUserError(new CliInputError("Cannot combine --yes and --full; pick one.")),
+    ).toBe(true);
+    expect(
+      isExpectedUserError(new CliInputError('Expected "<file>:<line>", got "package.json".')),
+    ).toBe(true);
+  });
+
+  it("classifies bad --diff base-branch input as an expected user error", () => {
+    expect(
+      isExpectedUserError(
+        new ReactDoctorError({ reason: new GitBaseBranchInvalid({ detail: "bad ref" }) }),
+      ),
+    ).toBe(true);
+    expect(
+      isExpectedUserError(
+        new ReactDoctorError({ reason: new GitBaseBranchMissing({ branch: "main" }) }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not mask genuine bugs (those stay reportable)", () => {
+    expect(isExpectedUserError(new Error("boom"))).toBe(false);
+    expect(isExpectedUserError(undefined)).toBe(false);
+    expect(
+      isExpectedUserError(
+        new ReactDoctorError({ reason: new OxlintSpawnFailed({ cause: new Error("nope") }) }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/prompt-install-setup.test.ts
+++ b/packages/react-doctor/tests/prompt-install-setup.test.ts
@@ -323,6 +323,26 @@ describe("shouldShowAgentInstallHint", () => {
   });
 });
 
+describe("setup-prompt store resilience", () => {
+  it("degrades instead of crashing when the config directory cannot be created", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "react-doctor-prompt-install-setup-eperm-"));
+    const blockerFile = path.join(root, "blocker");
+    writeFileSync(blockerFile, "not a directory");
+    // A config `cwd` whose parent is a file makes conf's mkdir fail with
+    // ENOTDIR — the same class of failure as EPERM/EROFS on a read-only or
+    // locked-down filesystem (REACT-DOCTOR-E). It must degrade, not crash.
+    const unwritableCwd = path.join(blockerFile, "config");
+
+    try {
+      expect(() => hasDisabledSetupPrompt("/some/project", { cwd: unwritableCwd })).not.toThrow();
+      expect(hasDisabledSetupPrompt("/some/project", { cwd: unwritableCwd })).toBe(false);
+      expect(disableSetupPrompt("/some/project", { cwd: unwritableCwd })).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("printAgentInstallHint", () => {
   it("prints the install command and description", () => {
     const writtenLines: string[] = [];


### PR DESCRIPTION
## Why

react-doctor was capturing **expected, user-actionable failures** to Sentry and rendering them with the scary "Something went wrong, open a prefilled issue" block. These aren't bugs, so they flooded crash reporting with hundreds of events from CI, coding agents, and sandboxes (REACT-DOCTOR-1, -4, -6, -7, -B, -D, -E, -G, -H) and told users to file bug reports for their own input mistakes.

Before (running in a directory without React — `handled: yes` event sent to Sentry):

```text
Something went wrong. Please check the error below for more details.
If the problem persists, please open this prefilled issue: https://github.com/millionco/react-doctor/issues/new?...
You can also ask for help in Discord: https://discord.gg/...
Reference (mention this when reporting): 1db34283468a41c98e67c7239f7948a4

NoReactDependencyError: No React dependency found in /var/tmp/package.json. Add "react" to dependencies (or peerDependencies) and re-run.
```

After (clean, single-line message, exits non-zero, nothing sent to Sentry):

```text
No React dependency found in /var/tmp/package.json. Add "react" to dependencies (or peerDependencies) and re-run.
```

## What changed

- Added `isExpectedUserError` (a CLI-layer policy predicate composing the existing core narrowers) and routed it through a single choke point in `reportErrorToSentry`, so expected failures skip both Sentry capture **and** the alertable `cliError` metric. Applied consistently at the CLI entry point, `inspect`, and `install`; expected errors now render via `handleUserError`.
- **Project-discovery failures** — `NoReactDependencyError`, `ProjectNotFoundError`, `PackageJsonNotFoundError`, `NotADirectoryError`, `AmbiguousProjectError` are now treated as clean user errors via `isProjectDiscoveryError` (REACT-DOCTOR-1/-4/-6/-7). A scan target that doesn't exist now reports that the **path doesn't exist** (new `ProjectNotFoundError` `kind: "missing-path"`) instead of the misleading "Expected a package.json…" guidance.
- **CLI invocation mistakes** — a malformed `<file>:<line>` argument, mutually exclusive flags (e.g. `--yes` + `--full`), and an unknown `--project` name now throw a typed `CliInputError` instead of a plain `Error` (REACT-DOCTOR-B/-D/-G/-H).
- **Read-only config directory** — `react-doctor` no longer crashes when it can't create/read its global setup-prompt store (EPERM/EROFS on locked-down filesystems); it degrades gracefully (REACT-DOCTOR-E).
- Added regression tests + a changeset (`patch` to `react-doctor`).

Out of scope (flagged for a follow-up): REACT-DOCTOR-F (`git rev-parse` spawn `NotFound` when git isn't installed) — degrading the core git service when git is unavailable is a separate behavior decision. REACT-DOCTOR-A/-9 (bad `--diff` base branch) are already handled in current code; their events are from `0.2.15`, before that gate shipped.

## Eval results

RDE not run — this is a CLI error-handling change, not a lint rule, so the rule-eval harness doesn't apply. Validated with focused unit + behavior tests instead (below).

## Test plan

- `pnpm --filter react-doctor exec vp test run tests/is-expected-user-error.test.ts tests/parse-file-line-argument.test.ts tests/validate-mode-flags.test.ts tests/prompt-install-setup.test.ts tests/report-error.test.ts tests/handle-error.test.ts tests/inspect.test.ts` → 46 passed
- `pnpm --filter @react-doctor/core exec vp test run tests/resolve-scan-target.test.ts tests/errors.test.ts` → 18 passed (broader core suite green too)
- `tsc --noEmit` for `react-doctor` and `@react-doctor/core` → clean
- `vp lint` + `vp fmt --check` on all changed files → clean

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-only error classification and messaging; no scan/lint logic changes, with broad unit test coverage.
> 
> **Overview**
> Expected, user-actionable failures now exit with a **plain error message** instead of the generic crash UI, and are **excluded from Sentry** and the **`cliError` metric**.
> 
> A new **`isExpectedUserError`** policy (project-discovery errors via `isProjectDiscoveryError`, **`CliInputError`** for bad flags/`--project`/`<file>:<line>`, and invalid/missing `--diff` branches) is applied at **`reportErrorToSentry`** and in the **CLI root** and **`inspect`** catch paths so those cases use **`handleUserError`** instead of **`handleError`**.
> 
> **`ProjectNotFoundError`** gains **`kind: "missing-path"`** when the scan target is absent on disk, with **`resolveScanTarget`** throwing that variant instead of the misleading package.json wording.
> 
> **Setup-prompt** global config reads/writes are wrapped in **try/catch** so read-only or unwritable config dirs degrade (hint may repeat; opt-out may not persist) instead of crashing.
> 
> Regression tests cover classification, missing paths, and config-store resilience; **`react-doctor`** gets a **patch** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f37afd8bdab4e09c26c5adf564e3c0963db1882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->