### PR TITLE
fix(cli): degrade git current-branch read when git is unavailable

### DIFF
--- a/.changeset/git-missing-binary-not-a-crash.md
+++ b/.changeset/git-missing-binary-not-a-crash.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+react-doctor no longer crashes when `git` isn't installed.
+
+During a normal scan, diff auto-detection reads the current branch first. When the `git` binary couldn't be spawned (e.g. a bare container with no git on `PATH`), that best-effort read threw instead of degrading, crashing the scan and reporting an environment issue to Sentry (REACT-DOCTOR-F). It now degrades to "unknown branch" — matching how a non-zero `git` exit was already handled — so the scan continues without git context.

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -342,6 +342,12 @@ export class Git extends Context.Service<
             const branch = trimOrNull(result.stdout);
             return branch === "HEAD" ? null : branch;
           }),
+          // Best-effort branch read: a non-zero exit already maps to null, but a
+          // spawn failure (git not installed — e.g. a bare container) surfaces as
+          // a tagged failure. `diffSelection` calls this first during diff
+          // auto-detection, so let it degrade to "unknown branch" instead of
+          // crashing the whole scan and reporting an env issue to Sentry.
+          Effect.orElseSucceed(() => null),
         );
 
       const defaultBranch = (directory: string): Effect.Effect<string | null, ReactDoctorError> =>

--- a/packages/core/tests/services/git-missing-binary.test.ts
+++ b/packages/core/tests/services/git-missing-binary.test.ts
@@ -1,0 +1,34 @@
+import os from "node:os";
+import * as Effect from "effect/Effect";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { Git } from "@react-doctor/core";
+
+const originalPath = process.env.PATH;
+
+const restorePath = (): void => {
+  if (originalPath === undefined) {
+    delete process.env.PATH;
+    return;
+  }
+  process.env.PATH = originalPath;
+};
+
+describe("Git.layerNode when the git binary is unavailable", () => {
+  afterEach(restorePath);
+
+  it("degrades currentBranch to null instead of crashing the scan (REACT-DOCTOR-F)", async () => {
+    // Point PATH at a directory with no `git`, so spawning the binary fails
+    // with ENOENT (PlatformError NotFound) — the same shape as running in a
+    // bare container without git. The best-effort read must not throw.
+    process.env.PATH = os.tmpdir() + "/react-doctor-no-git-on-path";
+
+    const branch = await Effect.runPromise(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.currentBranch(os.tmpdir());
+      }).pipe(Effect.provide(Git.layerNode)),
+    );
+
+    expect(branch).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

react-doctor crashed when run in an environment without `git` installed (e.g. a bare container, `cwd=/app`), reporting the environment issue to Sentry as a bug (REACT-DOCTOR-F).

During a normal scan, diff auto-detection reads the current branch first (`diffSelection` → `currentBranch`). `currentBranch` mapped a **non-zero git exit** to `null`, but a **spawn failure** (git binary missing → `PlatformError: NotFound`) skipped that map and surfaced as a tagged `GitInvocationFailed`, which crashed the whole scan. Its sibling reads (`headSha`, `githubRepo`, `defaultBranch`) are already wrapped with `Effect.orElseSucceed(() => null)` at their call sites in `run-inspect.ts` — `currentBranch`, called from inside `diffSelection`, was the unguarded one.

Stack from the Sentry event:

```text
ReactDoctorError: git rev-parse --abbrev-ref HEAD (cwd=/app) failed: PlatformError: NotFound: ChildProcess.spawn (git rev-parse --abbrev-ref HEAD)
  at Module.systemError (effect.dist:PlatformError)
```

## What changed

- `currentBranch` now degrades a git spawn failure to `null` (`Effect.orElseSucceed(() => null)`), matching how a non-zero git exit was already handled and honoring its documented "null when rev-parse fails" contract. The scan continues without git context instead of crashing.
- Added a regression test (`git-missing-binary.test.ts`) that points `PATH` at a directory with no `git`, forcing the spawn to fail with `ENOENT`, and asserts `currentBranch` resolves to `null` instead of throwing. Verified it **fails without the fix** (throws the spawn `PlatformError`) and passes with it.
- Changeset (`patch` → `react-doctor`).

Scope: this targets the auto-detection crash (REACT-DOCTOR-F). An explicit `--diff <base>` in a no-git environment is a separate, unreported path (it still surfaces a clean `GitBaseBranchMissing` user error rather than a crash via `branchExists`), so it's intentionally left unchanged here.

## Eval results

RDE not run — this is a core git-service error-handling change, not a lint rule, so the rule-eval harness doesn't apply. Validated with unit tests instead (below).

## Test plan

- `pnpm --filter @react-doctor/core exec vp test run tests/services/git-missing-binary.test.ts tests/services/git.test.ts` → 21 passed (incl. the new regression test; confirmed it fails without the fix)
- `pnpm --filter @react-doctor/core exec vp test run tests/run-inspect.test.ts` → 13 passed
- `tsc --noEmit` for `@react-doctor/core` → clean
- `vp lint` + `vp fmt --check` on changed files → clean

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow best-effort error handling on `currentBranch` only; explicit `--diff` behavior is unchanged.
> 
> **Overview**
> **react-doctor** no longer aborts a scan when the **`git`** binary cannot be spawned (e.g. missing from **`PATH`** in a container).
> 
> **`currentBranch`** already treated a non-zero **`git rev-parse`** exit as **`null`**; spawn failures (**`PlatformError` / NotFound**) still surfaced as **`GitInvocationFailed`**, which broke diff auto-detection because **`diffSelection`** calls **`currentBranch`** first. The read now uses **`Effect.orElseSucceed(() => null)`** so missing **`git`** matches the documented “unknown branch” behavior and the scan can continue without git context.
> 
> A regression test forces **`ENOENT`** by pointing **`PATH`** at a directory with no **`git`**, and a **patch** changeset documents the fix (REACT-DOCTOR-F).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24bc48606c26ff446ed3b204b814727a2ad26f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->