### PR TITLE
feat(rules): demote 19 low-signal rules to opt-in

### DIFF
--- a/.changeset/opt-out-low-value-default-rules.md
+++ b/.changeset/opt-out-low-value-default-rules.md
@@ -1,0 +1,12 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+Demote 19 low-signal rules to opt-in (`defaultEnabled: false`) so the recommended preset focuses on correctness, performance, accessibility, and security instead of subjective style.
+
+- Subjective design / house-style preferences (now opt-in): `no-gradient-text`, `no-dark-mode-glow`, `no-pure-black-background`, `no-side-tab-border`, `no-wide-letter-spacing`, `no-justified-text`, `no-z-index-9999`, `design-no-em-dash-in-jsx-text`, `design-no-three-period-ellipsis`, `design-no-vague-button-label`, `design-no-redundant-padding-axes`, `design-no-redundant-size-axes`, `design-no-space-on-flex-children`.
+- Naming-convention preferences (now opt-in): `no-generic-handler-names`, `jsx-pascal-case`.
+- Legacy class-component / PropTypes rules that don't fire in a modern function-component + TypeScript codebase (now opt-in): `prefer-es6-class`, `no-default-props`, `no-prop-types`.
+- Deduplicated the array-index-key pair: `no-array-index-key` is now opt-in because it double-reported with the canonical `no-array-index-as-key` (Bugs category, friendlier message). Opt back into `no-array-index-key` only if you need its extra `React.cloneElement` coverage.
+
+Every rule still ships in the plugin and can be re-enabled via `severityControls` / config, so teams that adopted any of these as a deliberate house style keep them with a one-line opt-in.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.ts
@@ -19,6 +19,9 @@ export const noDefaultProps = defineRule<Rule>({
   requires: ["react:19"],
   tags: ["test-noise"],
   severity: "warn",
+  // Default off: legacy `defaultProps` pattern superseded by ES default
+  // parameters in function components. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     'React 19 drops `Component.defaultProps` for function components. Set the defaults in the destructured props instead: `function Foo({ size = "md", variant = "primary" })` instead of `Foo.defaultProps = { size: "md", variant: "primary" }`.',
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-generic-handler-names.ts
@@ -9,6 +9,9 @@ export const noGenericHandlerNames = defineRule<Rule>({
   id: "no-generic-handler-names",
   title: "Vague event handler name",
   severity: "warn",
+  // Default off: naming-convention preference, not a correctness issue.
+  // Opt in via config to enforce the handler naming style.
+  defaultEnabled: false,
   tags: ["test-noise"],
   recommendation:
     "Rename it to say what it does. For example `handleSubmit` could be `saveUserProfile`, and `handleClick` could be `toggleSidebar`.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-prop-types.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-prop-types.ts
@@ -74,6 +74,9 @@ export const noPropTypes = defineRule<Rule>({
   requires: ["react:19"],
   tags: ["test-noise"],
   severity: "warn",
+  // Default off: `propTypes` are dead in a TypeScript codebase, where types
+  // are the source of truth. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     "React 19 ignores `Component.propTypes`, so invalid props pass silently. Describe props with TypeScript types and add real runtime checks (or schema parsing) only where data can actually be wrong. Only runs on React 19+ projects.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -74,6 +74,9 @@ export const noDarkModeGlow = defineRule<Rule>({
   title: "Colored glow on dark background",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     "Use a subtle `box-shadow` in neutral colors for depth, or a faint `border`. Colored glows on dark backgrounds look overdone.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gradient-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gradient-text.ts
@@ -12,6 +12,9 @@ export const noGradientText = defineRule<Rule>({
   title: "Gradient text is hard to read",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     "Use a solid text color so it stays readable. For emphasis, change the weight, size, or color instead of using a gradient.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-justified-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-justified-text.ts
@@ -11,6 +11,9 @@ export const noJustifiedText = defineRule<Rule>({
   title: "Justified text without hyphens",
   tags: ["test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   category: "Accessibility",
   recommendation:
     "Use `text-align: left` for body text. If you must justify, add `hyphens: auto` and `overflow-wrap: break-word`.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-pure-black-background.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-pure-black-background.ts
@@ -13,6 +13,9 @@ export const noPureBlackBackground = defineRule<Rule>({
   title: "Pure black background",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     "Nudge the background slightly toward your brand color, like `#0a0a0f` or Tailwind's `bg-gray-950`. Pure black looks harsh on modern screens.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.ts
@@ -58,6 +58,9 @@ export const noSideTabBorder = defineRule<Rule>({
   title: "Thick one-sided border",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     "Use a softer accent like an inset box-shadow, a background, or a thin border-bottom instead of a thick one-sided border.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
@@ -13,6 +13,9 @@ export const noWideLetterSpacing = defineRule<Rule>({
   id: "no-wide-letter-spacing",
   title: "Wide letter spacing on body text",
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   tags: ["test-noise"],
   recommendation:
     "Save wide letter-spacing (over 0.05em) for short uppercase labels, nav items, and buttons, not body text.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-z-index9999.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-z-index9999.ts
@@ -15,6 +15,9 @@ export const noZIndex9999 = defineRule<Rule>({
   title: "Excessively high z-index",
   tags: ["test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     "Pick a small z-index scale, like dropdown 10, modal 20, toast 30. To layer something on top, use `isolation: isolate` instead of bigger numbers.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-pascal-case.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-pascal-case.ts
@@ -152,6 +152,9 @@ export const jsxPascalCase = defineRule<Rule>({
   id: "jsx-pascal-case",
   title: "Component name not PascalCase",
   severity: "warn",
+  // Default off: component naming-convention preference, not a correctness
+  // issue (TypeScript already enforces component-ness). Opt in to enforce it.
+  defaultEnabled: false,
   tags: ["test-noise"],
   recommendation: "Rename custom JSX components to PascalCase.",
   category: "Architecture",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-array-index-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-array-index-key.ts
@@ -361,6 +361,11 @@ export const noArrayIndexKey = defineRule<Rule>({
   id: "no-array-index-key",
   title: "Array index used as a key",
   severity: "warn",
+  // Default off: duplicate of `no-array-index-as-key`, which is the
+  // canonical rule (Bugs category, friendlier message). Both fire on the
+  // same `key={index}` JSX, so keeping both double-reports. This oxc port
+  // adds `React.cloneElement` coverage — opt in if you need that edge.
+  defaultEnabled: false,
   recommendation: "Use a stable `key` from your data instead of the array index.",
   category: "Performance",
   create: (context) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/prefer-es6-class.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/prefer-es6-class.ts
@@ -27,6 +27,9 @@ export const preferEs6Class = defineRule<Rule>({
   id: "prefer-es6-class",
   title: "createClass instead of ES6 class",
   severity: "warn",
+  // Default off: only fires on `createReactClass` / ES5 class components,
+  // which don't occur in a modern function-component codebase. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     "Pick one component style for the whole codebase: `class extends React.Component` (default) or `createReactClass` (legacy).",
   category: "Architecture",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-em-dash-in-jsx-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-em-dash-in-jsx-text.ts
@@ -11,6 +11,9 @@ export const noEmDashInJsxText = defineRule<Rule>({
   title: "Em dash in JSX text",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   category: "Architecture",
   recommendation:
     "Replace em dashes in UI text with commas, colons, semicolons, or parentheses so the copy reads less like AI output.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
@@ -16,6 +16,9 @@ export const noRedundantPaddingAxes = defineRule<Rule>({
   title: "Redundant padding axes",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   category: "Architecture",
   recommendation:
     "Collapse `px-N py-N` to `p-N` when both sides match. Keep them split only when one side changes at a breakpoint (`py-2 md:py-3`).",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
@@ -14,6 +14,9 @@ export const noRedundantSizeAxes = defineRule<Rule>({
   requires: ["tailwind:3.4"],
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   category: "Architecture",
   recommendation: "Collapse `w-N h-N` to `size-N` (Tailwind v3.4+) when both sides match.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
@@ -14,6 +14,9 @@ export const noSpaceOnFlexChildren = defineRule<Rule>({
   title: "space-* utility on flex children",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   category: "Architecture",
   recommendation:
     "Use `gap-*` on the flex or grid parent. `space-x-*` and `space-y-*` leave gaps when a child is hidden, miss spacing on wrapped lines, and don't flip in right-to-left layouts.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-three-period-ellipsis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-three-period-ellipsis.ts
@@ -10,6 +10,9 @@ export const noThreePeriodEllipsis = defineRule<Rule>({
   title: "Three dots instead of ellipsis",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   category: "Architecture",
   recommendation:
     'Use the real ellipsis "…" (or `&hellip;`) instead of three dots. Good for labels like "Rename…" and "Loading…".',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-vague-button-label.ts
@@ -61,6 +61,9 @@ export const noVagueButtonLabel = defineRule<Rule>({
   title: "Vague button label",
   tags: ["design", "test-noise"],
   severity: "warn",
+  // Default off: subjective design / house-style preference, not a
+  // correctness, performance, or accessibility issue. Opt in to enforce it.
+  defaultEnabled: false,
   recommendation:
     'Name the action: "Save changes" instead of "Continue", "Send invite" instead of "Submit". The label is the button\'s accessible name.',
   create: (context: RuleContext) => ({

--- a/packages/react-doctor/tests/inspect-surface-filter.test.ts
+++ b/packages/react-doctor/tests/inspect-surface-filter.test.ts
@@ -27,6 +27,18 @@ const FIXTURES_DIRECTORY = path.resolve(
   "fixtures",
 );
 
+// The `design`-tagged rules ship `defaultEnabled: false`, so the surface
+// filter has nothing to act on unless we opt them back in. Enable a few
+// inline-style design rules that fire on `basic-react/src/design-issues.tsx`
+// (no Tailwind capability required) so these surface-filter assertions
+// exercise real design-tagged diagnostics.
+const DESIGN_RULE_OVERRIDES = {
+  "react-doctor/no-gradient-text": "warn",
+  "react-doctor/no-pure-black-background": "warn",
+  "react-doctor/no-dark-mode-glow": "warn",
+  "react-doctor/no-side-tab-border": "warn",
+} satisfies Record<string, "error" | "warn" | "off">;
+
 interface CapturedFetchCall {
   url: string;
   body: string;
@@ -75,6 +87,7 @@ describe("inspect — score surface filter", () => {
         deadCode: false,
         noScore: false,
         warnings: true,
+        configOverride: { rules: DESIGN_RULE_OVERRIDES },
       });
 
       const scoreCall = captured.find(({ url }) => url.includes("score"));
@@ -122,6 +135,7 @@ describe("inspect — score surface filter", () => {
           deadCode: false,
           noScore: true,
           warnings: true,
+          configOverride: { rules: DESIGN_RULE_OVERRIDES },
         });
         const baselineDesignCount = baselineResult.diagnostics.filter(
           (diagnostic) =>
@@ -137,7 +151,10 @@ describe("inspect — score surface filter", () => {
           noScore: true,
           warnings: true,
           outputSurface: "cli",
-          configOverride: { surfaces: { cli: { excludeTags: ["design"] } } },
+          configOverride: {
+            rules: DESIGN_RULE_OVERRIDES,
+            surfaces: { cli: { excludeTags: ["design"] } },
+          },
         });
 
         const printedText = printedLines.join("\n");

--- a/packages/react-doctor/tests/regressions/_helpers.ts
+++ b/packages/react-doctor/tests/regressions/_helpers.ts
@@ -176,6 +176,10 @@ export const collectRuleHits = async (
   const diagnostics = await runOxlint({
     rootDirectory: projectDir,
     project,
+    // Force-enable the rule under test so default-disabled rules
+    // (`defaultEnabled: false`) still produce hits here. Severity is
+    // irrelevant — callers assert on file path and message, not severity.
+    userConfig: { rules: { [`react-doctor/${ruleId}`]: "warn" } },
   });
   return diagnostics
     .filter((diagnostic) => diagnostic.rule === ruleId)


### PR DESCRIPTION
## Summary

Move 19 low-signal rules out of the default recommended preset via `defaultEnabled: false`, so a default scan focuses on **correctness, performance, accessibility, and security** instead of subjective style. Every demoted rule still ships in the plugin and can be re-enabled with a one-line `severityControls` / config entry.

### Demoted to opt-in

- **Subjective design / house-style (13):** `no-gradient-text`, `no-dark-mode-glow`, `no-pure-black-background`, `no-side-tab-border`, `no-wide-letter-spacing`, `no-justified-text`, `no-z-index-9999`, `design-no-em-dash-in-jsx-text`, `design-no-three-period-ellipsis`, `design-no-vague-button-label`, `design-no-redundant-padding-axes`, `design-no-redundant-size-axes`, `design-no-space-on-flex-children`
- **Naming-convention preferences (2):** `no-generic-handler-names`, `jsx-pascal-case`
- **Legacy class / PropTypes (3):** `prefer-es6-class`, `no-default-props`, `no-prop-types` — don't fire in a modern function-component + TypeScript codebase
- **Dedupe (1):** `no-array-index-key` — double-reported with the canonical `no-array-index-as-key` (Bugs category, friendlier message). The port's only unique coverage is `React.cloneElement`; opt back in if you need it.

### Notes

- Each demoted rule carries a short comment explaining why it's off by default.
- `collectRuleHits` (regression helper) now force-enables the rule under test, so default-disabled rules still produce hits in their own tests. Severity is irrelevant there — callers assert on file path + message.
- Changeset: `minor` bump (changes the default-enabled rule set), which fans out to the three `fixed` published packages.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (only pre-existing fixture warnings)
- [x] Registry regen (`pnpm gen`) — no diff (the flag flows through the rule spread)
- [x] `react-19-migration-rules`, `react-ui-rules`, `rules-command`, `terminal-visuals` — pass
- [x] Core metadata tests (`build-rule-docs-url`, `has-published-fix-recipe`, `dead-code-may-surface`) — pass
- [ ] CI green

> Note: one pre-existing `no-array-index-key` rule-tester case (`key={1 + index}`) fails on clean `main` as well — unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrading changes which diagnostics appear without config (preset behavior), though every rule remains one-line re-enableable and no runtime app logic changes.
> 
> **Overview**
> **Nineteen react-doctor rules are opt-in by default** (`defaultEnabled: false`), so the built-in recommended preset runs fewer warnings out of the box and emphasizes correctness, performance, accessibility, and security over style and legacy patterns.
> 
> The demoted set covers **subjective design / copy / Tailwind house style** (e.g. gradient text, pure black backgrounds, em dashes, redundant `px`/`py`), **naming tastes** (`jsx-pascal-case`, `no-generic-handler-names`), **legacy React 19 migration nags** (`defaultProps`, `propTypes`, `prefer-es6-class`), and **`no-array-index-key`** to avoid double-reporting with `no-array-index-as-key` (still available for `React.cloneElement` if opted in). Each rule file documents why it is off by default; a **minor** changeset records the preset change for `oxlint-plugin-react-doctor`.
> 
> **Tests:** `collectRuleHits` always enables the rule under test via `userConfig`, and inspect surface-filter tests opt a few design rules back in so `design`-tag filtering still has real diagnostics to assert on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ffbc9fbea93aeb6a6211c44023ca7e4de890de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->