### PR TITLE
fix(cli): exit cleanly on terminal hangup (read EIO) during interactive prompts

### DIFF
--- a/.changeset/stdin-hangup-guard.md
+++ b/.changeset/stdin-hangup-guard.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+A terminal hangup during an interactive prompt no longer crashes the CLI. When the terminal/PTY backing a prompt goes away mid-read (closing the tab, a dropped SSH/tmux session, sleep/wake), Node raises `read EIO` on the raw-mode stdin handle; the CLI now exits cleanly (code 129) instead of surfacing it as a fatal uncaught exception and reporting it to crash telemetry. Genuine stdin errors still funnel to the error reporter unchanged.

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -16,6 +16,7 @@ import {
 import { versionAction } from "./commands/version.js";
 import { applyColorPreference } from "./utils/apply-color-preference.js";
 import { exitGracefully } from "./utils/exit-gracefully.js";
+import { guardStdin } from "./utils/guard-stdin.js";
 import { handleError } from "./utils/handle-error.js";
 import { isJsonModeActive, writeJsonErrorReport } from "./utils/json-mode.js";
 import { normalizeHelpInvocation } from "./utils/normalize-help-command.js";
@@ -29,6 +30,10 @@ initializeSentry();
 process.on("SIGINT", exitGracefully);
 process.on("SIGTERM", exitGracefully);
 unrefStdin();
+// Catch `read EIO` (and kin) from a terminal that vanishes while an
+// interactive prompt is reading stdin, so a hangup exits cleanly instead of
+// crashing as an uncaught exception. Armed before any command runs.
+guardStdin();
 
 const formatExampleLines = (
   examples: ReadonlyArray<readonly [command: string, description: string]>,

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -30,9 +30,10 @@ initializeSentry();
 process.on("SIGINT", exitGracefully);
 process.on("SIGTERM", exitGracefully);
 unrefStdin();
-// Catch `read EIO` (and kin) from a terminal that vanishes while an
-// interactive prompt is reading stdin, so a hangup exits cleanly instead of
-// crashing as an uncaught exception. Armed before any command runs.
+// HACK: a terminal that vanishes while an interactive prompt is reading
+// stdin makes Node raise `read EIO` on the raw-mode handle; with no listener
+// it escalates to a fatal uncaught exception. Guard it so a hangup exits
+// cleanly (mirrors the stdout EPIPE guard below). Armed before any command.
 guardStdin();
 
 const formatExampleLines = (

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -2,6 +2,12 @@
 // (128 + signal number). Used by exit-gracefully.ts on SIGINT/SIGTERM.
 export const SIGINT_EXIT_CODE = 130;
 
+// Exit code for a terminal hangup, per POSIX (128 + SIGHUP = 129). Used by
+// guard-stdin.ts when the TTY backing an interactive prompt goes away
+// mid-read (`read EIO`), so the CLI exits like an interrupted run instead of
+// crashing on the uncaught stdin stream error.
+export const TERMINAL_HANGUP_EXIT_CODE = 129;
+
 // Length of the `[node, script]` prefix that precedes user arguments in
 // `process.argv`. Shared by the argv processors (flag stripping, help
 // normalization, the `-V` alias).

--- a/packages/react-doctor/src/cli/utils/guard-stdin.ts
+++ b/packages/react-doctor/src/cli/utils/guard-stdin.ts
@@ -1,0 +1,33 @@
+import { TERMINAL_HANGUP_EXIT_CODE } from "./constants.js";
+
+// `errno` codes that mean the terminal/PTY backing the CLI went away while
+// Node was reading stdin: closing the terminal tab/window, the parent shell
+// exiting, an SSH/tmux/screen session detaching or dropping, the machine
+// sleeping/waking, or the emulator being killed. On a real TTY the next
+// `read()` returns one of these.
+const TERMINAL_HANGUP_CODES = new Set(["EIO", "ENXIO"]);
+
+/**
+ * Handles a `process.stdin` `'error'` event. A terminal hangup mid-read
+ * (`read EIO`) is environmental, not a bug, so exit like an interrupted run
+ * instead of crashing. Re-throws anything else so genuine stdin failures keep
+ * funneling to the crash reporter exactly as they did before this guard.
+ */
+export const handleStdinError = (error: NodeJS.ErrnoException): void => {
+  if (error.code !== undefined && TERMINAL_HANGUP_CODES.has(error.code)) {
+    process.exit(TERMINAL_HANGUP_EXIT_CODE);
+  }
+  throw error;
+};
+
+/**
+ * Arms a `process.stdin` error guard at startup. The only thing that reads
+ * stdin is the interactive `prompts` UI, which opens the TTY in raw mode and
+ * never attaches an `'error'` listener of its own. Without a listener Node
+ * turns a `read EIO` from a vanished terminal into a fatal uncaught exception
+ * (reported to Sentry as a crash); with one, {@link handleStdinError} exits
+ * cleanly on a hangup. Mirrors the stdout EPIPE guard in `cli/index.ts`.
+ */
+export const guardStdin = (): void => {
+  process.stdin.on("error", handleStdinError);
+};

--- a/packages/react-doctor/tests/guard-stdin.test.ts
+++ b/packages/react-doctor/tests/guard-stdin.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { TERMINAL_HANGUP_EXIT_CODE } from "../src/cli/utils/constants.js";
+import { guardStdin, handleStdinError } from "../src/cli/utils/guard-stdin.js";
+
+const makeStdinError = (code: string | undefined): NodeJS.ErrnoException => {
+  const error: NodeJS.ErrnoException = new Error(`read ${code}`);
+  error.code = code;
+  error.syscall = "read";
+  return error;
+};
+
+describe("handleStdinError", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // A vanished terminal surfaces as `read EIO` on the raw-mode stdin handle.
+  // Exit like an interrupted run instead of crashing as an uncaught exception.
+  it.each(["EIO", "ENXIO"])("exits with the hangup code on %s", (code) => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(((exitCode?: number) => {
+      throw new Error(`__exit__:${exitCode}`);
+    }) as never);
+
+    expect(() => handleStdinError(makeStdinError(code))).toThrow(
+      `__exit__:${TERMINAL_HANGUP_EXIT_CODE}`,
+    );
+    expect(exit).toHaveBeenCalledWith(TERMINAL_HANGUP_EXIT_CODE);
+  });
+
+  // Anything that isn't a terminal hangup must keep funneling to the crash
+  // reporter exactly as it did before the guard existed: re-thrown, not exited.
+  it.each(["EPIPE", "EACCES", undefined])("re-throws and never exits on %s", (code) => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(((exitCode?: number) => {
+      throw new Error(`__exit__:${exitCode}`);
+    }) as never);
+    const error = makeStdinError(code);
+
+    expect(() => handleStdinError(error)).toThrow(error);
+    expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+describe("guardStdin", () => {
+  afterEach(() => {
+    process.stdin.removeListener("error", handleStdinError);
+  });
+
+  it("registers the stdin error handler", () => {
+    expect(process.stdin.listeners("error")).not.toContain(handleStdinError);
+    guardStdin();
+    expect(process.stdin.listeners("error")).toContain(handleStdinError);
+  });
+});

--- a/packages/react-doctor/tests/guard-stdin.test.ts
+++ b/packages/react-doctor/tests/guard-stdin.test.ts
@@ -5,9 +5,16 @@ import { guardStdin, handleStdinError } from "../src/cli/utils/guard-stdin.js";
 const makeStdinError = (code: string | undefined): NodeJS.ErrnoException => {
   const error: NodeJS.ErrnoException = new Error(`read ${code}`);
   error.code = code;
-  error.syscall = "read";
   return error;
 };
+
+// Make `process.exit` throw a sentinel instead of exiting the test runner, so
+// a call is observable and `handleStdinError`'s post-exit `throw` stays
+// unreached (mirroring how a real exit halts execution there).
+const stubProcessExitToThrow = () =>
+  vi.spyOn(process, "exit").mockImplementation(((exitCode?: number) => {
+    throw new Error(`__exit__:${exitCode}`);
+  }) as never);
 
 describe("handleStdinError", () => {
   afterEach(() => {
@@ -17,9 +24,7 @@ describe("handleStdinError", () => {
   // A vanished terminal surfaces as `read EIO` on the raw-mode stdin handle.
   // Exit like an interrupted run instead of crashing as an uncaught exception.
   it.each(["EIO", "ENXIO"])("exits with the hangup code on %s", (code) => {
-    const exit = vi.spyOn(process, "exit").mockImplementation(((exitCode?: number) => {
-      throw new Error(`__exit__:${exitCode}`);
-    }) as never);
+    const exit = stubProcessExitToThrow();
 
     expect(() => handleStdinError(makeStdinError(code))).toThrow(
       `__exit__:${TERMINAL_HANGUP_EXIT_CODE}`,
@@ -30,9 +35,7 @@ describe("handleStdinError", () => {
   // Anything that isn't a terminal hangup must keep funneling to the crash
   // reporter exactly as it did before the guard existed: re-thrown, not exited.
   it.each(["EPIPE", "EACCES", undefined])("re-throws and never exits on %s", (code) => {
-    const exit = vi.spyOn(process, "exit").mockImplementation(((exitCode?: number) => {
-      throw new Error(`__exit__:${exitCode}`);
-    }) as never);
+    const exit = stubProcessExitToThrow();
     const error = makeStdinError(code);
 
     expect(() => handleStdinError(error)).toThrow(error);


### PR DESCRIPTION
## Why

Catches the `Error: read EIO` crash reported in Sentry ([REACT-DOCTOR-S](https://millionco.sentry.io/issues/7521581896/)).

The only thing that reads stdin is the interactive `prompts` UI (e.g. the multiselect "Select projects" prompt in a monorepo), which opens the TTY in raw mode and never attaches an `'error'` listener. When the terminal/PTY backing that prompt goes away mid-read — closing the tab, the parent shell exiting, a dropped SSH/tmux/screen session, or the machine sleeping/waking — the next `read()` returns `EIO`. With no listener on `process.stdin`, Node escalates that stream error into a fatal uncaught exception, which the Sentry `onuncaughtexception` integration reports as a crash (`level: fatal`, `handled: no`). The stack is pure Node internals (`TTY.onStreamRead`), confirming an environmental terminal teardown rather than a logic bug.

Before (no stdin error listener — an environmental hangup crashes and is reported to Sentry):

```ts
process.on("SIGINT", exitGracefully);
process.on("SIGTERM", exitGracefully);
unrefStdin();
// stdout EPIPE is guarded, but stdin has no 'error' handler →
// `read EIO` becomes a fatal uncaught exception.
```

After (stdin is guarded; a hangup exits cleanly, genuine errors still report):

```ts
unrefStdin();
guardStdin(); // process.stdin.on("error", …): exit 129 on EIO/ENXIO, re-throw otherwise
```

## What changed

- Added `guardStdin()` (`src/cli/utils/guard-stdin.ts`), armed at startup in `cli/index.ts` next to `unrefStdin()` and the existing stdout EPIPE guard it mirrors.
- On a terminal-hangup `errno` (`EIO`/`ENXIO`) the CLI exits cleanly with code `129` (POSIX `128 + SIGHUP`), so the run ends like an interruption instead of a crash.
- Re-throws any other stdin error, so genuine stdin failures keep funneling to the crash reporter exactly as before.
- Added `TERMINAL_HANGUP_EXIT_CODE = 129` to `constants.ts`, alongside the existing `SIGINT_EXIT_CODE`.
- Adds tests for: exits with 129 on `EIO`/`ENXIO`, re-throws (never exits) on `EPIPE`/`EACCES`/no-code, and that `guardStdin()` registers the handler.

## Eval results

RDE not run — this is a CLI stdin/teardown fix, not a lint rule, so the rule-eval harness doesn't apply.

## Test plan

- `pnpm test` (react-doctor) — 170 passed, incl. new `tests/guard-stdin.test.ts`
- `pnpm typecheck` — clean
- `pnpm format:check` — clean; `pnpm lint` — clean (only pre-existing fixture warnings)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, startup-only stdin listener with narrow errno handling; non-hangup errors unchanged; covered by unit tests.
> 
> **Overview**
> Adds a **startup stdin error guard** (parallel to the existing stdout `EPIPE` handler) so losing the TTY while an interactive `prompts` read is in progress no longer becomes a fatal uncaught `read EIO` / Sentry crash.
> 
> `guardStdin()` wires `process.stdin` `'error'` to **`handleStdinError`**: **`EIO` / `ENXIO`** → **`process.exit(129)`** via new **`TERMINAL_HANGUP_EXIT_CODE`**; any other code is **re-thrown** so real stdin failures still hit the crash reporter. **`guardStdin()`** is invoked from **`cli/index.ts`** right after **`unrefStdin()`**, before commands run. Tests cover hangup vs non-hangup errno and listener registration; changeset documents the patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 134f3052970cdb0073d22439f67192924065a28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->