### PR TITLE
chore(skills): add /ship release pipeline skill

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ship
+description: Take the current branch from done-coding to merge-ready in one pass — review the diff against AGENTS.md, deslop, commit and push, open a PR using rule-validate's PR copy, then babysit until mergeable. Use when the user types `/ship` or asks to ship, finalize, or land the current branch.
+disable-model-invocation: true
+---
+
+# Ship
+
+Sequential release pipeline for the current branch. Run only when explicitly invoked — it commits, pushes, and opens a PR.
+
+Each stage delegates to an existing skill. Run them in order and do not advance while a stage still has unresolved findings.
+
+Copy this checklist and track progress:
+
+```
+Ship progress:
+- [ ] 1. Review the diff against AGENTS.md
+- [ ] 2. Deslop the touched code
+- [ ] 3. Commit and push
+- [ ] 4. Open the PR
+- [ ] 5. Babysit to merge-ready
+```
+
+## 1. Review against AGENTS.md
+
+Read `AGENTS.md` first (its rules change), then run `/review` on this branch's diff, judging it against those rules. Fix real violations before continuing. Pause for the user only if a fix would change behavior or broaden scope.
+
+## 2. Deslop
+
+Run `/deslop` ([`../deslop/SKILL.md`](../deslop/SKILL.md)) to simplify the recently modified code while preserving functionality, including its `truffler` duplicate-consolidation pass. Apply the refinements before committing.
+
+## 3. Commit and push
+
+- Stage only the intended changes; never commit secrets.
+- Add a changeset first when a published package's behavior changed (follow the **Changeset** section of `/rule-validate`); skip only for private/docs/test/tooling-only changes and note why.
+- Run the repo checks that fit the change before committing: `nr test`, `nr lint`, `nr typecheck`, `nr format:check`.
+- Write a concise commit message in the repo's style, focused on the why.
+- Push the branch, setting upstream with `-u` on the first push.
+- Git safety: no force-push to `main`, no skipped hooks, no `git config` changes.
+
+## 4. Open the PR
+
+Create the PR with `gh pr create`, writing the body with the **PR Description** structure from `/rule-validate` ([`../rule-validate/SKILL.md`](../rule-validate/SKILL.md)): Why (with before/after), What changed, Eval results (omit the table if RDE was not run), Test plan. Pass the body via a heredoc. Return the PR URL.
+
+## 5. Babysit
+
+Run `/babysit` to drive the PR to merge-ready: resolve merge conflicts preserving intent, triage unresolved comments (including Bugbot), and fix in-scope CI in a loop until the PR is mergeable, green, and its comments are triaged. Report back instead of merging.
+
+## Stop conditions
+
+Pause and ask the user when:
+
+- Review or babysit surfaces a change that would broaden scope or alter intended behavior.
+- A merge conflict has genuinely conflicting intent on the two branches.
+- CI fails for reasons outside this branch's scope even after merging the latest base.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ review-*.md
 !/.agents/skills/find-similar-functions/**
 !/.agents/skills/deslop/
 !/.agents/skills/deslop/**
+!/.agents/skills/ship/
+!/.agents/skills/ship/**
 
 # Local-only: rule-catalog generators and per-rule prompts. The generated
 # `rules.json` and the prompts themselves live in the (private) evals repo;


### PR DESCRIPTION
## Why

Finishing a branch means running the same chain by hand every time: review against `AGENTS.md`, deslop, commit/push, open a PR, then nurse it to green. `/ship` makes that one explicit command so nothing in the tail end gets skipped.

## What changed

- Adds the `ship` agent skill (`.agents/skills/ship/SKILL.md`), a sequential pipeline that delegates to existing skills:
  1. Read `AGENTS.md`, then `/review` the branch diff against it.
  2. `/deslop` the touched code.
  3. Commit and push (changeset when a published package changed; git-safety guardrails).
  4. Open the PR using `/rule-validate`'s PR-description structure.
  5. `/babysit` to merge-ready.
- `disable-model-invocation: true` so it only runs when invoked explicitly (it commits, pushes, and opens PRs).
- Allowlists the skill in `.gitignore` alongside the other repository-owned agent skills.

## Test plan

- [ ] `/ship` is discoverable and its sibling links to `deslop` and `rule-validate` resolve.
- [ ] Docs/tooling-only change: no changeset (no published package behavior changed).
- [ ] `format:check` not run locally (worktree has no `node_modules`); CI formatter covers the new markdown.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill metadata only; no runtime, auth, or package behavior changes.
> 
> **Overview**
> Adds a new **`/ship`** agent skill that documents a **five-step, sequential release pipeline** for the current branch: review the diff against **`AGENTS.md`** via **`/review`**, **`/deslop`**, commit/push (with changeset, checks, and git-safety rules), open a PR with **`gh pr create`** using **`/rule-validate`**’s PR body template, then **`/babysit`** until merge-ready—with explicit **stop conditions** when scope, conflicts, or out-of-scope CI block progress.
> 
> The skill is **invocation-gated** (`disable-model-invocation: true`) because it drives commits, pushes, and PR creation. **`.gitignore`** is updated to **track** `.agents/skills/ship/` like the other repository-owned skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7388a3f0e1c41b8951f61515a585dd99db831d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->