### PR TITLE
fix(core): skip un-enumerable directories during subproject discovery

### DIFF
--- a/.changeset/readdir-einval-not-a-crash.md
+++ b/.changeset/readdir-einval-not-a-crash.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+react-doctor no longer crashes when a directory can't be enumerated during project discovery.
+
+The recursive subproject crawl reads directories best-effort and already skipped ones it couldn't open for permission or missing-path reasons (`EACCES`/`EPERM`/`ENOENT`/`ENOTDIR`). It now also skips directories the underlying filesystem rejects outright — `EINVAL` on `scandir` (REACT-DOCTOR-N, seen on special/virtual mounts), plus symlink loops (`ELOOP`) and over-long paths (`ENAMETOOLONG`) — instead of throwing and reporting the environment issue to Sentry. The crawl continues past the unreadable directory.

--- a/packages/core/src/project-info/utils/read-directory-entries.ts
+++ b/packages/core/src/project-info/utils/read-directory-entries.ts
@@ -1,6 +1,18 @@
 import fs from "node:fs";
 
-const IGNORABLE_READDIR_ERROR_CODES = new Set(["EACCES", "EPERM", "ENOENT", "ENOTDIR"]);
+// Discovery crawls an unknown tree best-effort: a directory we can't enumerate
+// is skipped, never a crash. These are the "can't read this path" codes —
+// missing/not-a-dir/permission-blocked, plus symlink loops, over-long paths, and
+// filesystems that reject the scandir outright (`EINVAL`, REACT-DOCTOR-N).
+const IGNORABLE_READDIR_ERROR_CODES = new Set([
+  "EACCES",
+  "EPERM",
+  "ENOENT",
+  "ENOTDIR",
+  "EINVAL",
+  "ELOOP",
+  "ENAMETOOLONG",
+]);
 
 const isIgnorableReaddirError = (error: unknown): boolean => {
   if (typeof error !== "object" || error === null) return false;

--- a/packages/core/tests/read-directory-entries.test.ts
+++ b/packages/core/tests/read-directory-entries.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { readDirectoryEntries } from "@react-doctor/core";
+
+let temporaryRoot: string;
+
+beforeEach(() => {
+  temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-read-dir-entries-"));
+});
+
+afterEach(() => {
+  fs.rmSync(temporaryRoot, { recursive: true, force: true });
+});
+
+describe("readDirectoryEntries", () => {
+  it("lists entries of a readable directory", () => {
+    fs.writeFileSync(path.join(temporaryRoot, "package.json"), "{}");
+    fs.mkdirSync(path.join(temporaryRoot, "src"));
+
+    const names = readDirectoryEntries(temporaryRoot)
+      .map((entry) => entry.name)
+      .toSorted();
+
+    expect(names).toEqual(["package.json", "src"]);
+  });
+
+  // A best-effort discovery crawl must skip directories it cannot enumerate
+  // rather than crash the scan (and report the environment to Sentry). Each
+  // case triggers a real `readdirSync` failure from the ignorable family;
+  // `EINVAL` (REACT-DOCTOR-N) shares the same Set-membership code path but is
+  // not portably reproducible from userland, so the family is covered here.
+  it("returns no entries when the path does not exist (ENOENT)", () => {
+    expect(readDirectoryEntries(path.join(temporaryRoot, "missing"))).toEqual([]);
+  });
+
+  it("returns no entries when a path component is a file (ENOTDIR)", () => {
+    const filePath = path.join(temporaryRoot, "a-file");
+    fs.writeFileSync(filePath, "not a directory");
+
+    expect(readDirectoryEntries(path.join(filePath, "child"))).toEqual([]);
+  });
+
+  it("returns no entries when the name is too long (ENAMETOOLONG)", () => {
+    expect(readDirectoryEntries(path.join(temporaryRoot, "n".repeat(300)))).toEqual([]);
+  });
+
+  it("returns no entries when the path loops through symlinks (ELOOP)", () => {
+    const firstLink = path.join(temporaryRoot, "first-link");
+    const secondLink = path.join(temporaryRoot, "second-link");
+    fs.symlinkSync(secondLink, firstLink);
+    fs.symlinkSync(firstLink, secondLink);
+
+    expect(readDirectoryEntries(path.join(firstLink, "child"))).toEqual([]);
+  });
+});

--- a/packages/core/tests/read-directory-entries.test.ts
+++ b/packages/core/tests/read-directory-entries.test.ts
@@ -27,10 +27,7 @@ describe("readDirectoryEntries", () => {
   });
 
   // A best-effort discovery crawl must skip directories it cannot enumerate
-  // rather than crash the scan (and report the environment to Sentry). Each
-  // case triggers a real `readdirSync` failure from the ignorable family;
-  // `EINVAL` (REACT-DOCTOR-N) shares the same Set-membership code path but is
-  // not portably reproducible from userland, so the family is covered here.
+  // rather than crash the scan (and report the environment to Sentry).
   it("returns no entries when the path does not exist (ENOENT)", () => {
     expect(readDirectoryEntries(path.join(temporaryRoot, "missing"))).toEqual([]);
   });
@@ -41,17 +38,26 @@ describe("readDirectoryEntries", () => {
 
     expect(readDirectoryEntries(path.join(filePath, "child"))).toEqual([]);
   });
-
-  it("returns no entries when the name is too long (ENAMETOOLONG)", () => {
-    expect(readDirectoryEntries(path.join(temporaryRoot, "n".repeat(300)))).toEqual([]);
-  });
-
-  it("returns no entries when the path loops through symlinks (ELOOP)", () => {
-    const firstLink = path.join(temporaryRoot, "first-link");
-    const secondLink = path.join(temporaryRoot, "second-link");
-    fs.symlinkSync(secondLink, firstLink);
-    fs.symlinkSync(firstLink, secondLink);
-
-    expect(readDirectoryEntries(path.join(firstLink, "child"))).toEqual([]);
-  });
 });
+
+// POSIX-only: Windows runners can't create symlinks without elevation and map
+// these filesystem limits to different error codes. `EINVAL` (REACT-DOCTOR-N)
+// shares the same Set-membership code path as `ELOOP`/`ENAMETOOLONG` but isn't
+// portably reproducible from userland, so the family is exercised here.
+describe.skipIf(process.platform === "win32")(
+  "readDirectoryEntries (POSIX filesystem limits)",
+  () => {
+    it("returns no entries when the name is too long (ENAMETOOLONG)", () => {
+      expect(readDirectoryEntries(path.join(temporaryRoot, "n".repeat(300)))).toEqual([]);
+    });
+
+    it("returns no entries when the path loops through symlinks (ELOOP)", () => {
+      const firstLink = path.join(temporaryRoot, "first-link");
+      const secondLink = path.join(temporaryRoot, "second-link");
+      fs.symlinkSync(secondLink, firstLink);
+      fs.symlinkSync(firstLink, secondLink);
+
+      expect(readDirectoryEntries(path.join(firstLink, "child"))).toEqual([]);
+    });
+  },
+);


### PR DESCRIPTION
## Why

Fixes **REACT-DOCTOR-N** (`EINVAL: invalid argument, scandir`), an unresolved Sentry crash.

During a scan with no `package.json`/workspace manifest at the root, react-doctor falls back to a best-effort recursive crawl (`resolveScanTarget` → `discoverReactSubprojects` → `discoverReactSubprojectsByFilesystem` → `readDirectoryEntries`). That wrapper already swallows the common "can't open this directory" errors and skips the entry, but a `readdirSync` that fails with `EINVAL` (the filesystem rejecting the `scandir` outright — seen on special/virtual mounts) was re-thrown, crashing the whole scan and reporting an environment issue to Sentry.

Before:

```text
$ npx react-doctor   # scanning a tree containing a directory the FS can't scandir
Error: EINVAL: invalid argument, scandir  → crash + Sentry report
```

After:

```text
$ npx react-doctor   # the un-enumerable directory is skipped; the scan continues
```

## What changed

- Added `EINVAL`, `ELOOP` (symlink loops), and `ENAMETOOLONG` (over-long paths) to `IGNORABLE_READDIR_ERROR_CODES` in `read-directory-entries.ts` — the same "can't read this path" family already covered by `EACCES`/`EPERM`/`ENOENT`/`ENOTDIR`.
- Added a regression test (`packages/core/tests/read-directory-entries.test.ts`) that triggers real `readdirSync` failures (`ENOENT`, `ENOTDIR`, `ENAMETOOLONG`, `ELOOP`) and asserts `readDirectoryEntries` returns `[]` rather than throwing. `EINVAL` shares the same Set-membership code path but isn't portably reproducible from userland, so the family is exercised via its reproducible members.
- Added a `react-doctor` patch changeset.

## Test plan

- `pnpm exec vp test run packages/core/tests/read-directory-entries.test.ts` — 5 passed.
- `pnpm exec turbo run typecheck --filter=@react-doctor/core` — passed.
- `pnpm exec vp lint` / `pnpm exec vp fmt --check` — clean (only pre-existing warnings in test fixtures).
- Full `@react-doctor/core` suite: 558 passed; 1 unrelated pre-existing failure (`check-expo-project.test.ts > flags a committed .env.local that is not gitignored`) reproduces on clean `main` and is environment/git-state dependent, not caused by this change.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to best-effort directory enumeration error handling with regression tests; no auth, data, or scan-result logic changes.
> 
> **Overview**
> **Project discovery** no longer aborts when `readdirSync` hits paths the OS or filesystem refuses to enumerate.
> 
> `readDirectoryEntries` already swallowed common “can’t open this directory” errors and returned `[]`. It now treats **`EINVAL`**, **`ELOOP`**, and **`ENAMETOOLONG`** the same way (alongside existing permission/missing-path codes), so recursive subproject discovery skips those directories instead of throwing and sending **REACT-DOCTOR-N** to Sentry.
> 
> New tests cover the happy path plus ignorable failures (`ENOENT`, `ENOTDIR`, and POSIX-only `ENAMETOOLONG` / `ELOOP`). A patch changeset documents the user-facing fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca89f3208788d29a1d78cfa34da24d4ae745d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->