### PR TITLE
fix(cli): treat an unreadable --changed-files-from file as a clean error

### DIFF
--- a/.changeset/changed-files-from-unreadable-not-a-crash.md
+++ b/.changeset/changed-files-from-unreadable-not-a-crash.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+react-doctor no longer crashes when the `--changed-files-from` file can't be read.
+
+`--changed-files-from <file>` is user input, so an unreadable file — missing, a directory, permission-denied, or a stale pipe/process-substitution descriptor (`EBADF`, REACT-DOCTOR-V) — is an invocation mistake, not a bug. It now exits non-zero with a clean, single-line message telling you to pass a readable text file, instead of printing the generic "Something went wrong" block and reporting the read failure to Sentry.

--- a/packages/react-doctor/src/cli/utils/read-changed-files-from.ts
+++ b/packages/react-doctor/src/cli/utils/read-changed-files-from.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { CliInputError } from "./cli-input-error.js";
 import { toForwardSlashes } from "./path-format.js";
 
 const isSafeRelativePath = (filePath: string): boolean => {
@@ -12,7 +13,21 @@ const isSafeRelativePath = (filePath: string): boolean => {
 };
 
 export const readChangedFilesFrom = (filePath: string): string[] => {
-  const raw = fs.readFileSync(filePath, "utf8");
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    // The path comes from the user's `--changed-files-from <file>`, so an
+    // unreadable file (missing, a directory, permission-denied, or a stale
+    // pipe/process-substitution fd — EBADF, REACT-DOCTOR-V) is an invocation
+    // mistake, not a bug. Surface it as a clean CLI error instead of crashing
+    // and reporting the read failure to Sentry.
+    const errorCode = (error as NodeJS.ErrnoException)?.code;
+    throw new CliInputError(
+      `Could not read the --changed-files-from file "${filePath}"${errorCode ? ` (${errorCode})` : ""}. ` +
+        "Pass a path to a readable text file that lists changed files, one per line.",
+    );
+  }
   const uniqueFiles = new Set<string>();
   for (const line of raw.split(/\r?\n/)) {
     const candidate = toForwardSlashes(line.trim());

--- a/packages/react-doctor/tests/read-changed-files-from.test.ts
+++ b/packages/react-doctor/tests/read-changed-files-from.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
+import { CliInputError } from "../src/cli/utils/cli-input-error.js";
 import { readChangedFilesFrom } from "../src/cli/utils/read-changed-files-from.js";
 
 describe("readChangedFilesFrom", () => {
@@ -44,5 +45,24 @@ describe("readChangedFilesFrom", () => {
     fs.writeFileSync(changedFilesPath, "apps\\web\\src\\App.tsx\n");
 
     expect(readChangedFilesFrom(changedFilesPath)).toEqual(["apps/web/src/App.tsx"]);
+  });
+
+  // An unreadable --changed-files-from file is a user invocation mistake, not a
+  // bug: it must surface as a clean CliInputError (kept out of Sentry) rather
+  // than throwing the raw fs error (REACT-DOCTOR-V).
+  it("throws a clean CLI input error when the file does not exist", () => {
+    const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-changed-files-"));
+    tempDirectories.push(tempDirectory);
+    const missingPath = path.join(tempDirectory, "missing.txt");
+
+    expect(() => readChangedFilesFrom(missingPath)).toThrow(CliInputError);
+    expect(() => readChangedFilesFrom(missingPath)).toThrow("--changed-files-from");
+  });
+
+  it("throws a clean CLI input error when the path is a directory", () => {
+    const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-changed-files-"));
+    tempDirectories.push(tempDirectory);
+
+    expect(() => readChangedFilesFrom(tempDirectory)).toThrow(CliInputError);
   });
 });


### PR DESCRIPTION
## Why

Fixes **REACT-DOCTOR-V** (`EBADF: bad file descriptor, open`), an unresolved Sentry crash.

`inspect` reads the user-supplied `--changed-files-from <file>` via `readChangedFilesFrom`, which did a bare `fs.readFileSync`. When that path can't be read — it's missing, a directory, permission-denied, or a stale pipe / process-substitution descriptor that already closed (`EBADF`) — the raw `fs` error propagated out of `inspect`, printed the generic "Something went wrong, open a prefilled issue" block, and was reported to Sentry. But the file path is the user's invocation, not a react-doctor bug.

Before:

```text
$ react-doctor --changed-files-from <(git diff --name-only)   # fd closed by the time we read
Error: EBADF: bad file descriptor, open  → crash + Sentry report
```

After:

```text
$ react-doctor --changed-files-from missing.txt
Could not read the --changed-files-from file "missing.txt" (ENOENT). Pass a path to a readable text file that lists changed files, one per line.
# exits non-zero, no Sentry report
```

## What changed

- `readChangedFilesFrom` now wraps the `fs.readFileSync` and throws a `CliInputError` (with the errno code when present) when the file can't be read. `CliInputError` is already classified by `isExpectedUserError`, so it renders as a clean single-line message via `handleUserError` and is excluded from Sentry + the alertable error-rate metric — matching how other CLI invocation mistakes (bad `<file>:<line>`, mutually exclusive flags) are handled.
- Extended `read-changed-files-from.test.ts` with cases asserting a missing file and a directory each throw `CliInputError` mentioning `--changed-files-from`.
- Added a `react-doctor` patch changeset.

## Test plan

- `pnpm exec vp test run packages/react-doctor/tests/read-changed-files-from.test.ts` — 4 passed.
- `pnpm exec turbo run typecheck --filter=react-doctor` — passed.
- `pnpm exec vp lint` (exit 0) / `pnpm exec vp fmt --check` — clean.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI error-handling change with no auth, data, or scan-logic changes; success path for readable files is unchanged.
> 
> **Overview**
> **Unreadable `--changed-files-from` paths are now treated as user input errors** instead of uncaught `fs` failures that triggered the generic crash UI and Sentry (e.g. **REACT-DOCTOR-V** / `EBADF` from stale process substitution).
> 
> `readChangedFilesFrom` catches `readFileSync` failures and throws **`CliInputError`** with the path, optional errno, and guidance to pass a readable line-based file. That flows through the existing **`isExpectedUserError`** path for a single-line exit and no Sentry. Tests cover missing files and directory paths; a patch changeset documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe5614013703f7eb9c1e07d59fb8b18da567528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->