### PR TITLE
feat(action): add `scope` input to opt into full-project scans on PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,10 +147,8 @@ runs:
         # running a diff scan despite the user asking for a full one.
         SCOPE="$(printf '%s' "$INPUT_SCOPE" | tr '[:upper:]' '[:lower:]')"
         if [ "$SCOPE" = "full" ]; then
-          # `--diff false` forces a full-project scan: it disables baseline/diff
-          # mode and overrides any `diff` value in the project's config. The
-          # pr-files step is skipped under this scope, so no --changed-files-from
-          # competes with it.
+          # `--diff false` scans the whole project. It turns off diff mode and
+          # ignores any `diff` value set in the project's config.
           FLAGS+=("--diff" "false")
         elif [ -n "$CHANGED_FILES_FROM" ]; then
           FLAGS+=("--changed-files-from" "$CHANGED_FILES_FROM")

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   project:
     description: 'Workspace project(s) to scan (comma-separated). Use "*" to scan every discovered project.'
     default: "*"
+  scope:
+    description: "On pull requests, what to scan: 'changed' (only files changed in the PR, the default baseline/diff behavior) or 'full' (the entire project, reporting every finding). Non-PR events always scan the full project."
+    default: "changed"
   blocking:
     description: "Severity that fails the workflow: error (default), warning, or none (advisory — report findings but always exit 0)."
     default: "error"
@@ -56,7 +59,7 @@ runs:
         package-manager-cache: false
 
     - id: pr-files
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' }}
       uses: actions/github-script@v8
       env:
         REACT_DOCTOR_CHANGED_FILES: ${{ runner.temp }}/react-doctor-changed-files.txt
@@ -89,7 +92,7 @@ runs:
           core.setOutput("path", outputPath);
 
     - id: base
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' }}
       shell: bash
       env:
         INPUT_DIRECTORY: ${{ inputs.directory }}
@@ -111,6 +114,7 @@ runs:
         NO_COLOR: "1"
         INPUT_DIRECTORY: ${{ inputs.directory }}
         INPUT_PROJECT: ${{ inputs.project }}
+        INPUT_SCOPE: ${{ inputs.scope }}
         INPUT_BLOCKING: ${{ inputs.blocking }}
         INPUT_VERSION: ${{ inputs.version }}
         CHANGED_FILES_FROM: ${{ steps.pr-files.outputs.path }}
@@ -135,7 +139,22 @@ runs:
         FLAGS=("--json" "--json-compact")
         if [ -n "$INPUT_BLOCKING" ]; then FLAGS+=("--blocking" "$INPUT_BLOCKING"); fi
         if [ -n "$INPUT_PROJECT" ]; then FLAGS+=("--project" "$INPUT_PROJECT"); fi
-        if [ -n "$CHANGED_FILES_FROM" ]; then FLAGS+=("--changed-files-from" "$CHANGED_FILES_FROM"); fi
+
+        # Lowercase the scope so this bash test matches the case-insensitive
+        # comparison the pr-files/base steps' `inputs.scope != 'full'`
+        # expressions use. Without this, `scope: Full` would skip those steps
+        # (GHA matches) yet fall through to changed-files here (bash wouldn't),
+        # running a diff scan despite the user asking for a full one.
+        SCOPE="$(printf '%s' "$INPUT_SCOPE" | tr '[:upper:]' '[:lower:]')"
+        if [ "$SCOPE" = "full" ]; then
+          # `--diff false` forces a full-project scan: it disables baseline/diff
+          # mode and overrides any `diff` value in the project's config. The
+          # pr-files step is skipped under this scope, so no --changed-files-from
+          # competes with it.
+          FLAGS+=("--diff" "false")
+        elif [ -n "$CHANGED_FILES_FROM" ]; then
+          FLAGS+=("--changed-files-from" "$CHANGED_FILES_FROM")
+        fi
 
         if [[ "$INPUT_VERSION" = ./* || "$INPUT_VERSION" = ../* || "$INPUT_VERSION" = /* ]]; then
           PACKAGE_SPEC="$INPUT_VERSION"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

A user set up the React Doctor GitHub Action on a PR, "purposefully made obvious mistakes," but the sticky comment reported **Score 100 / 100, 0 issues** with a scope of *"N files changed on `adding-react-doctor` vs. `main`"*. The "full scan" they tried to enable changed nothing.

On `pull_request` events the Action scopes the scan to the PR's changed files (now baseline/diff mode after #663), and there is **no input to scan the whole project**. For a PR that *introduces* React Doctor, the changed files are just the workflow YAML + config — none of which contain React issues — so the scan legitimately finds **0 issues / score 100**, while obvious mistakes in pre-existing, untouched files are never scanned.

### Reproduction

A throwaway React project with obvious issues (array-index key, inline object/function props, etc.):

- `--changed-files-from` listing only config/workflow → `mode: diff, issues: 0, score: 100` ← **exactly the screenshot**
- Full scan → `mode: full, issues: 6` ✅

## Fix

Add a `scope` input to the Action:

- `scope: changed` (default) — preserves today's behavior (scan only PR-changed files / baseline).
- `scope: full` — scan the whole project on every run.

When `scope: full`:
1. The `pr-files` and `base` steps are skipped (no `--changed-files-from`, no baseline machinery).
2. The scan passes **`--diff false`**, the documented full-scan escape hatch, which disables baseline/diff and overrides any `diff` value set in the project's config.

```yaml
- uses: millionco/react-doctor@v1
  with:
    scope: full
```

Verified on the post-#663 CLI: `scope: full` (and `Full`/`FULL`) → `mode: full, 6 issues`; `scope: changed` with config-only changes → `mode: diff, 0 issues`; `scope: changed` with buggy source → `mode: diff, 5 issues`.

### Notes

- **Rebased onto post-#663 `main`.** #663 (the `blocking` gate / baseline / inline-review overhaul) merged while this PR was open; this is re-implemented on top of its new `action.yml` (uses `--diff false`, the replacement for the removed `--full`).
- **Case-insensitive scope** (Bugbot finding): GitHub Actions expressions compare strings case-insensitively, so the `pr-files`/`base` steps' `inputs.scope != 'full'` already treats `Full`/`FULL` as full. The bash test lowercases `INPUT_SCOPE` to agree, otherwise `scope: Full` would skip those steps yet still run a diff scan.

## Action release note

This touches the composite Action (`action.yml`), so per `AGENTS.md` it needs a tag bump on the merge commit — a new input is a `feat(action)` → **minor** bump, then move the floating `v1` to the same commit.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://million-js.slack.com/archives/C09BLPH3B1R/p1780434971006229?thread_ts=1780434971.006229&cid=C09BLPH3B1R)

<div><a href="https://cursor.com/agents/bc-a2343b08-234e-5d9f-9dc3-b2d72412ca37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2343b08-234e-5d9f-9dc3-b2d72412ca37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

