### PR TITLE
Add Inertia dead-code entry roots

### DIFF
--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -31,6 +31,7 @@ interface CheckDeadCodeOptions {
 interface DeadCodeWorkerInput {
   readonly rootDirectory: string;
   readonly tsConfigPath?: string;
+  readonly entryPatterns: ReadonlyArray<string>;
   readonly ignorePatterns: ReadonlyArray<string>;
   readonly deslopJsModuleSpecifier: string;
 }
@@ -42,6 +43,11 @@ interface DeadCodeWorkerHandle {
 
 interface DeadCodeWorkerFactory {
   (input: DeadCodeWorkerInput): DeadCodeWorkerHandle;
+}
+
+interface DeadCodeFrameworkEntryPatternGroup {
+  readonly dependencyNames: ReadonlyArray<string>;
+  readonly entryPatterns: ReadonlyArray<string>;
 }
 
 interface DeadCodeWorkerUnusedFile {
@@ -89,6 +95,46 @@ interface DeadCodeWorkerFailureMessage {
 }
 
 const TSCONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"];
+const DEFAULT_DEAD_CODE_ENTRY_PATTERNS = [
+  "src/index.{ts,tsx,js,jsx}",
+  "src/main.{ts,tsx,js,jsx}",
+  "index.{ts,tsx,js,jsx}",
+  "main.{ts,tsx,js,jsx}",
+];
+const DEAD_CODE_FRAMEWORK_ENTRY_PATTERN_GROUPS: ReadonlyArray<DeadCodeFrameworkEntryPatternGroup> =
+  [
+    {
+      dependencyNames: [
+        "@inertiajs/react",
+        "@inertiajs/inertia-react",
+        "@inertiajs/vue3",
+        "@inertiajs/inertia-vue3",
+        "@inertiajs/svelte",
+        "@inertiajs/inertia-svelte",
+        "@inertiajs/inertia",
+      ],
+      entryPatterns: [
+        "resources/js/app.{ts,tsx,js,jsx}",
+        "resources/js/App.{ts,tsx,js,jsx}",
+        "resources/js/Pages/**/*.{ts,tsx,js,jsx}",
+        "resources/js/pages/**/*.{ts,tsx,js,jsx}",
+        "src/app.{ts,tsx,js,jsx}",
+        "src/App.{ts,tsx,js,jsx}",
+        "src/Pages/**/*.{ts,tsx,js,jsx}",
+        "src/pages/**/*.{ts,tsx,js,jsx}",
+      ],
+    },
+    {
+      dependencyNames: ["@redwoodjs/router", "@redwoodjs/web"],
+      entryPatterns: [
+        "web/src/App.{ts,tsx,js,jsx}",
+        "web/src/Routes.{ts,tsx,js,jsx}",
+        "web/src/index.{ts,tsx,js,jsx}",
+        "web/src/layouts/**/*.{ts,tsx,js,jsx}",
+        "web/src/pages/**/*.{ts,tsx,js,jsx}",
+      ],
+    },
+  ];
 
 // Runs in a child PROCESS (node -e), not a worker_thread — see
 // `createDeadCodeWorker`. Reads the worker input as JSON on stdin and
@@ -135,6 +181,9 @@ process.stdin.on("end", () => {
       const config = {
         rootDir: workerInput.rootDirectory,
         ...(workerInput.tsConfigPath ? { tsConfigPath: workerInput.tsConfigPath } : {}),
+        ...(workerInput.entryPatterns.length > 0
+          ? { entryPatterns: workerInput.entryPatterns }
+          : {}),
         ...(workerInput.ignorePatterns.length > 0
           ? { ignorePatterns: workerInput.ignorePatterns }
           : {}),
@@ -172,6 +221,46 @@ const collectDeadCodeIgnorePatterns = (
     for (const pattern of source) seen.add(pattern);
   }
   return [...seen].filter((pattern) => pattern.length > 0);
+};
+
+const readPackageDependencyNames = (rootDirectory: string): Set<string> => {
+  const packageJsonPath = path.join(rootDirectory, "package.json");
+  const dependencyNames = new Set<string>();
+  if (!fs.existsSync(packageJsonPath)) return dependencyNames;
+
+  const parsedPackageJson: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  if (!isRecord(parsedPackageJson)) return dependencyNames;
+
+  for (const fieldName of [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ]) {
+    const dependencies = parsedPackageJson[fieldName];
+    if (!isRecord(dependencies)) continue;
+    for (const [dependencyName, version] of Object.entries(dependencies)) {
+      if (typeof version === "string") dependencyNames.add(dependencyName);
+    }
+  }
+
+  return dependencyNames;
+};
+
+const buildDeadCodeEntryPatterns = (rootDirectory: string): string[] => {
+  const dependencyNames = readPackageDependencyNames(rootDirectory);
+  const entryPatterns = new Set<string>();
+
+  for (const group of DEAD_CODE_FRAMEWORK_ENTRY_PATTERN_GROUPS) {
+    const isEnabled = group.dependencyNames.some((dependencyName) =>
+      dependencyNames.has(dependencyName),
+    );
+    if (!isEnabled) continue;
+    for (const pattern of DEFAULT_DEAD_CODE_ENTRY_PATTERNS) entryPatterns.add(pattern);
+    for (const pattern of group.entryPatterns) entryPatterns.add(pattern);
+  }
+
+  return [...entryPatterns];
 };
 
 // HACK: route through `toRelativePath` (which normalizes backslashes to
@@ -451,6 +540,7 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
   const workerHandle = (options.createWorker ?? createDeadCodeWorker)({
     rootDirectory,
     tsConfigPath: resolveTsConfigPath(rootDirectory),
+    entryPatterns: buildDeadCodeEntryPatterns(rootDirectory),
     ignorePatterns,
     deslopJsModuleSpecifier: options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js"),
   });

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -118,6 +118,15 @@ const DEAD_CODE_FRAMEWORK_ENTRY_PATTERN_GROUPS: ReadonlyArray<DeadCodeFrameworkE
         "resources/js/App.{ts,tsx,js,jsx}",
         "resources/js/Pages/**/*.{ts,tsx,js,jsx}",
         "resources/js/pages/**/*.{ts,tsx,js,jsx}",
+        "app/frontend/Pages/**/*.{ts,tsx,js,jsx}",
+        "app/frontend/pages/**/*.{ts,tsx,js,jsx}",
+        "app/frontend/entrypoints/**/*.{ts,tsx,js,jsx}",
+        "app/javascript/Pages/**/*.{ts,tsx,js,jsx}",
+        "app/javascript/pages/**/*.{ts,tsx,js,jsx}",
+        "frontend/src/Pages/**/*.{ts,tsx,js,jsx}",
+        "frontend/src/pages/**/*.{ts,tsx,js,jsx}",
+        "inertia/Pages/**/*.{ts,tsx,js,jsx}",
+        "inertia/pages/**/*.{ts,tsx,js,jsx}",
         "src/app.{ts,tsx,js,jsx}",
         "src/App.{ts,tsx,js,jsx}",
         "src/Pages/**/*.{ts,tsx,js,jsx}",
@@ -132,6 +141,43 @@ const DEAD_CODE_FRAMEWORK_ENTRY_PATTERN_GROUPS: ReadonlyArray<DeadCodeFrameworkE
         "web/src/index.{ts,tsx,js,jsx}",
         "web/src/layouts/**/*.{ts,tsx,js,jsx}",
         "web/src/pages/**/*.{ts,tsx,js,jsx}",
+      ],
+    },
+    {
+      dependencyNames: ["waku"],
+      entryPatterns: [
+        "src/pages/**/*.{ts,tsx,js,jsx}",
+        "src/waku.client.{ts,tsx,js,jsx}",
+        "src/waku.server.{ts,tsx,js,jsx}",
+      ],
+    },
+    {
+      dependencyNames: ["vike", "vite-plugin-ssr"],
+      entryPatterns: [
+        "pages/**/*.{ts,tsx,js,jsx,md,mdx}",
+        "renderer/**/*.{ts,tsx,js,jsx}",
+        "src/pages/**/*.{ts,tsx,js,jsx,md,mdx}",
+        "src/renderer/**/*.{ts,tsx,js,jsx}",
+      ],
+    },
+    {
+      dependencyNames: ["rakkasjs"],
+      entryPatterns: [
+        "src/client.{ts,tsx,js,jsx}",
+        "src/server.{ts,tsx,js,jsx}",
+        "src/routes/**/*.{ts,tsx,js,jsx}",
+      ],
+    },
+    {
+      dependencyNames: [
+        "@module-federation/enhanced",
+        "@module-federation/node",
+        "@module-federation/vite",
+        "@originjs/vite-plugin-federation",
+      ],
+      entryPatterns: [
+        "federation.config.{ts,js,mjs,cjs,mts,cts}",
+        "module-federation.config.{ts,js,mjs,cjs,mts,cts}",
       ],
     },
   ];

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -8,6 +8,8 @@ import {
   DEAD_CODE_WORKER_TIMEOUT_MS,
   MILLISECONDS_PER_SECOND,
 } from "./constants.js";
+import { buildDeadCodeEntryPatterns } from "./dead-code-entry-patterns.js";
+import { readPackageJson } from "./project-info/index.js";
 import { readIgnoreFile } from "./read-ignore-file.js";
 import { toCanonicalPath } from "./utils/to-canonical-path.js";
 import { toRelativePath } from "./utils/to-relative-path.js";
@@ -43,11 +45,6 @@ interface DeadCodeWorkerHandle {
 
 interface DeadCodeWorkerFactory {
   (input: DeadCodeWorkerInput): DeadCodeWorkerHandle;
-}
-
-interface DeadCodeFrameworkEntryPatternGroup {
-  readonly dependencyNames: ReadonlyArray<string>;
-  readonly entryPatterns: ReadonlyArray<string>;
 }
 
 interface DeadCodeWorkerUnusedFile {
@@ -95,92 +92,6 @@ interface DeadCodeWorkerFailureMessage {
 }
 
 const TSCONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"];
-const DEFAULT_DEAD_CODE_ENTRY_PATTERNS = [
-  "src/index.{ts,tsx,js,jsx}",
-  "src/main.{ts,tsx,js,jsx}",
-  "index.{ts,tsx,js,jsx}",
-  "main.{ts,tsx,js,jsx}",
-];
-const DEAD_CODE_FRAMEWORK_ENTRY_PATTERN_GROUPS: ReadonlyArray<DeadCodeFrameworkEntryPatternGroup> =
-  [
-    {
-      dependencyNames: [
-        "@inertiajs/react",
-        "@inertiajs/inertia-react",
-        "@inertiajs/vue3",
-        "@inertiajs/inertia-vue3",
-        "@inertiajs/svelte",
-        "@inertiajs/inertia-svelte",
-        "@inertiajs/inertia",
-      ],
-      entryPatterns: [
-        "resources/js/app.{ts,tsx,js,jsx}",
-        "resources/js/App.{ts,tsx,js,jsx}",
-        "resources/js/Pages/**/*.{ts,tsx,js,jsx}",
-        "resources/js/pages/**/*.{ts,tsx,js,jsx}",
-        "app/frontend/Pages/**/*.{ts,tsx,js,jsx}",
-        "app/frontend/pages/**/*.{ts,tsx,js,jsx}",
-        "app/frontend/entrypoints/**/*.{ts,tsx,js,jsx}",
-        "app/javascript/Pages/**/*.{ts,tsx,js,jsx}",
-        "app/javascript/pages/**/*.{ts,tsx,js,jsx}",
-        "frontend/src/Pages/**/*.{ts,tsx,js,jsx}",
-        "frontend/src/pages/**/*.{ts,tsx,js,jsx}",
-        "inertia/Pages/**/*.{ts,tsx,js,jsx}",
-        "inertia/pages/**/*.{ts,tsx,js,jsx}",
-        "src/app.{ts,tsx,js,jsx}",
-        "src/App.{ts,tsx,js,jsx}",
-        "src/Pages/**/*.{ts,tsx,js,jsx}",
-        "src/pages/**/*.{ts,tsx,js,jsx}",
-      ],
-    },
-    {
-      dependencyNames: ["@redwoodjs/router", "@redwoodjs/web"],
-      entryPatterns: [
-        "web/src/App.{ts,tsx,js,jsx}",
-        "web/src/Routes.{ts,tsx,js,jsx}",
-        "web/src/index.{ts,tsx,js,jsx}",
-        "web/src/layouts/**/*.{ts,tsx,js,jsx}",
-        "web/src/pages/**/*.{ts,tsx,js,jsx}",
-      ],
-    },
-    {
-      dependencyNames: ["waku"],
-      entryPatterns: [
-        "src/pages/**/*.{ts,tsx,js,jsx}",
-        "src/waku.client.{ts,tsx,js,jsx}",
-        "src/waku.server.{ts,tsx,js,jsx}",
-      ],
-    },
-    {
-      dependencyNames: ["vike", "vite-plugin-ssr"],
-      entryPatterns: [
-        "pages/**/*.{ts,tsx,js,jsx,md,mdx}",
-        "renderer/**/*.{ts,tsx,js,jsx}",
-        "src/pages/**/*.{ts,tsx,js,jsx,md,mdx}",
-        "src/renderer/**/*.{ts,tsx,js,jsx}",
-      ],
-    },
-    {
-      dependencyNames: ["rakkasjs"],
-      entryPatterns: [
-        "src/client.{ts,tsx,js,jsx}",
-        "src/server.{ts,tsx,js,jsx}",
-        "src/routes/**/*.{ts,tsx,js,jsx}",
-      ],
-    },
-    {
-      dependencyNames: [
-        "@module-federation/enhanced",
-        "@module-federation/node",
-        "@module-federation/vite",
-        "@originjs/vite-plugin-federation",
-      ],
-      entryPatterns: [
-        "federation.config.{ts,js,mjs,cjs,mts,cts}",
-        "module-federation.config.{ts,js,mjs,cjs,mts,cts}",
-      ],
-    },
-  ];
 
 // Runs in a child PROCESS (node -e), not a worker_thread — see
 // `createDeadCodeWorker`. Reads the worker input as JSON on stdin and
@@ -267,46 +178,6 @@ const collectDeadCodeIgnorePatterns = (
     for (const pattern of source) seen.add(pattern);
   }
   return [...seen].filter((pattern) => pattern.length > 0);
-};
-
-const readPackageDependencyNames = (rootDirectory: string): Set<string> => {
-  const packageJsonPath = path.join(rootDirectory, "package.json");
-  const dependencyNames = new Set<string>();
-  if (!fs.existsSync(packageJsonPath)) return dependencyNames;
-
-  const parsedPackageJson: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-  if (!isRecord(parsedPackageJson)) return dependencyNames;
-
-  for (const fieldName of [
-    "dependencies",
-    "devDependencies",
-    "peerDependencies",
-    "optionalDependencies",
-  ]) {
-    const dependencies = parsedPackageJson[fieldName];
-    if (!isRecord(dependencies)) continue;
-    for (const [dependencyName, version] of Object.entries(dependencies)) {
-      if (typeof version === "string") dependencyNames.add(dependencyName);
-    }
-  }
-
-  return dependencyNames;
-};
-
-const buildDeadCodeEntryPatterns = (rootDirectory: string): string[] => {
-  const dependencyNames = readPackageDependencyNames(rootDirectory);
-  const entryPatterns = new Set<string>();
-
-  for (const group of DEAD_CODE_FRAMEWORK_ENTRY_PATTERN_GROUPS) {
-    const isEnabled = group.dependencyNames.some((dependencyName) =>
-      dependencyNames.has(dependencyName),
-    );
-    if (!isEnabled) continue;
-    for (const pattern of DEFAULT_DEAD_CODE_ENTRY_PATTERNS) entryPatterns.add(pattern);
-    for (const pattern of group.entryPatterns) entryPatterns.add(pattern);
-  }
-
-  return [...entryPatterns];
 };
 
 // HACK: route through `toRelativePath` (which normalizes backslashes to
@@ -580,13 +451,15 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
   // Canonicalize up front so the deslop graph and its resolver share one
   // path space (see `toCanonicalPath` for why a symlinked root breaks it).
   const rootDirectory = toCanonicalPath(options.rootDirectory);
-  if (!fs.existsSync(path.join(rootDirectory, "package.json"))) return [];
+  const packageJsonPath = path.join(rootDirectory, "package.json");
+  if (!fs.existsSync(packageJsonPath)) return [];
 
+  const packageJson = readPackageJson(packageJsonPath);
   const ignorePatterns = collectDeadCodeIgnorePatterns(rootDirectory, userConfig);
   const workerHandle = (options.createWorker ?? createDeadCodeWorker)({
     rootDirectory,
     tsConfigPath: resolveTsConfigPath(rootDirectory),
-    entryPatterns: buildDeadCodeEntryPatterns(rootDirectory),
+    entryPatterns: buildDeadCodeEntryPatterns(packageJson),
     ignorePatterns,
     deslopJsModuleSpecifier: options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js"),
   });

--- a/packages/core/src/dead-code-entry-patterns.ts
+++ b/packages/core/src/dead-code-entry-patterns.ts
@@ -1,0 +1,127 @@
+import type { PackageJson } from "./types/index.js";
+
+interface DeadCodeFrameworkEntryPatternGroup {
+  readonly dependencyNames: ReadonlyArray<string>;
+  readonly entryPatterns: ReadonlyArray<string>;
+}
+
+const DEFAULT_DEAD_CODE_ENTRY_PATTERNS = [
+  "src/index.{ts,tsx,js,jsx}",
+  "src/main.{ts,tsx,js,jsx}",
+  "index.{ts,tsx,js,jsx}",
+  "main.{ts,tsx,js,jsx}",
+];
+const JS_TS_EXTENSIONS = "{ts,tsx,js,jsx}";
+const INERTIA_EXTENSIONS = "{ts,tsx,js,jsx,vue,svelte}";
+const VIKE_ROUTE_EXTENSIONS = "{ts,tsx,js,jsx,md,mdx}";
+
+const DEAD_CODE_FRAMEWORK_ENTRY_PATTERN_GROUPS: ReadonlyArray<DeadCodeFrameworkEntryPatternGroup> =
+  [
+    {
+      dependencyNames: [
+        "@inertiajs/react",
+        "@inertiajs/inertia-react",
+        "@inertiajs/vue3",
+        "@inertiajs/inertia-vue3",
+        "@inertiajs/svelte",
+        "@inertiajs/inertia-svelte",
+        "@inertiajs/inertia",
+      ],
+      entryPatterns: [
+        `resources/js/app.${INERTIA_EXTENSIONS}`,
+        `resources/js/App.${INERTIA_EXTENSIONS}`,
+        `resources/js/Pages/**/*.${INERTIA_EXTENSIONS}`,
+        `resources/js/pages/**/*.${INERTIA_EXTENSIONS}`,
+        `app/frontend/Pages/**/*.${INERTIA_EXTENSIONS}`,
+        `app/frontend/pages/**/*.${INERTIA_EXTENSIONS}`,
+        `app/frontend/entrypoints/**/*.${INERTIA_EXTENSIONS}`,
+        `app/javascript/Pages/**/*.${INERTIA_EXTENSIONS}`,
+        `app/javascript/pages/**/*.${INERTIA_EXTENSIONS}`,
+        `frontend/src/Pages/**/*.${INERTIA_EXTENSIONS}`,
+        `frontend/src/pages/**/*.${INERTIA_EXTENSIONS}`,
+        `inertia/Pages/**/*.${INERTIA_EXTENSIONS}`,
+        `inertia/pages/**/*.${INERTIA_EXTENSIONS}`,
+        `src/app.${INERTIA_EXTENSIONS}`,
+        `src/App.${INERTIA_EXTENSIONS}`,
+        `src/Pages/**/*.${INERTIA_EXTENSIONS}`,
+        `src/pages/**/*.${INERTIA_EXTENSIONS}`,
+      ],
+    },
+    {
+      dependencyNames: ["@redwoodjs/router", "@redwoodjs/web"],
+      entryPatterns: [
+        `web/src/App.${JS_TS_EXTENSIONS}`,
+        `web/src/Routes.${JS_TS_EXTENSIONS}`,
+        `web/src/index.${JS_TS_EXTENSIONS}`,
+        `web/src/layouts/**/*.${JS_TS_EXTENSIONS}`,
+        `web/src/pages/**/*.${JS_TS_EXTENSIONS}`,
+      ],
+    },
+    {
+      dependencyNames: ["waku"],
+      entryPatterns: [
+        `src/pages/**/*.${JS_TS_EXTENSIONS}`,
+        `src/waku.client.${JS_TS_EXTENSIONS}`,
+        `src/waku.server.${JS_TS_EXTENSIONS}`,
+      ],
+    },
+    {
+      dependencyNames: ["vike", "vite-plugin-ssr"],
+      entryPatterns: [
+        `pages/**/*.${VIKE_ROUTE_EXTENSIONS}`,
+        `renderer/**/*.${JS_TS_EXTENSIONS}`,
+        `src/pages/**/*.${VIKE_ROUTE_EXTENSIONS}`,
+        `src/renderer/**/*.${JS_TS_EXTENSIONS}`,
+      ],
+    },
+    {
+      dependencyNames: ["rakkasjs"],
+      entryPatterns: [
+        `src/client.${JS_TS_EXTENSIONS}`,
+        `src/server.${JS_TS_EXTENSIONS}`,
+        `src/routes/**/*.${JS_TS_EXTENSIONS}`,
+      ],
+    },
+    {
+      dependencyNames: [
+        "@module-federation/enhanced",
+        "@module-federation/node",
+        "@module-federation/vite",
+        "@originjs/vite-plugin-federation",
+      ],
+      entryPatterns: [
+        "federation.config.{ts,js,mjs,cjs,mts,cts}",
+        "module-federation.config.{ts,js,mjs,cjs,mts,cts}",
+      ],
+    },
+  ];
+
+const collectDependencyNames = (packageJson: PackageJson): Set<string> => {
+  const dependencyNames = new Set<string>();
+  for (const dependencies of [
+    packageJson.dependencies,
+    packageJson.devDependencies,
+    packageJson.peerDependencies,
+    packageJson.optionalDependencies,
+  ]) {
+    if (dependencies === undefined) continue;
+    for (const dependencyName of Object.keys(dependencies)) dependencyNames.add(dependencyName);
+  }
+  return dependencyNames;
+};
+
+export const buildDeadCodeEntryPatterns = (packageJson: PackageJson): string[] => {
+  const dependencyNames = collectDependencyNames(packageJson);
+  const entryPatterns = new Set<string>();
+
+  for (const group of DEAD_CODE_FRAMEWORK_ENTRY_PATTERN_GROUPS) {
+    const isEnabled = group.dependencyNames.some((dependencyName) =>
+      dependencyNames.has(dependencyName),
+    );
+    if (!isEnabled) continue;
+    for (const pattern of DEFAULT_DEAD_CODE_ENTRY_PATTERNS) entryPatterns.add(pattern);
+    for (const pattern of group.entryPatterns) entryPatterns.add(pattern);
+  }
+
+  return [...entryPatterns];
+};

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -6,11 +6,20 @@ import { checkDeadCode } from "../src/check-dead-code.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-check-dead-code-"));
 
+interface SetupProjectOptions {
+  readonly dependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
+}
+
 afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
 });
 
-const setupProject = (caseId: string, files: Record<string, string>): string => {
+const setupProject = (
+  caseId: string,
+  files: Record<string, string>,
+  options: SetupProjectOptions = {},
+): string => {
   const projectDirectory = path.join(tempRoot, caseId);
   fs.mkdirSync(projectDirectory, { recursive: true });
   fs.writeFileSync(
@@ -18,7 +27,8 @@ const setupProject = (caseId: string, files: Record<string, string>): string => 
     JSON.stringify({
       name: caseId,
       type: "module",
-      dependencies: { react: "^19.0.0" },
+      dependencies: { react: "^19.0.0", ...options.dependencies },
+      ...(options.devDependencies ? { devDependencies: options.devDependencies } : {}),
     }),
   );
   fs.writeFileSync(
@@ -80,6 +90,13 @@ const flaggedUnusedFiles = async (rootDirectory: string): Promise<string[]> =>
     .filter((diagnostic) => diagnostic.rule === "unused-file")
     .map((diagnostic) => diagnostic.filePath)
     .sort();
+
+const emptyWorkerResult = {
+  unusedFiles: [],
+  unusedExports: [],
+  unusedDependencies: [],
+  circularDependencies: [],
+};
 
 describe("checkDeadCode", () => {
   it("returns no diagnostics when the directory has no package.json", async () => {
@@ -182,6 +199,69 @@ describe("checkDeadCode", () => {
     expect(
       diagnostics.find((diagnostic) => diagnostic.rule === "circular-dependency")?.message,
     ).toContain("src/a.ts → src/b.ts");
+  });
+
+  it("passes Inertia page roots to the dead-code worker when Inertia is installed", async () => {
+    const directory = setupProject(
+      "inertia-worker-entry-patterns",
+      {
+        "src/index.ts": "export const used = 1;\n",
+      },
+      { dependencies: { "@inertiajs/react": "^2.0.0" } },
+    );
+    let capturedEntryPatterns: ReadonlyArray<string> = [];
+
+    await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: (input) => {
+        capturedEntryPatterns = input.entryPatterns;
+        return { result: Promise.resolve(emptyWorkerResult) };
+      },
+    });
+
+    expect(capturedEntryPatterns).toContain("src/index.{ts,tsx,js,jsx}");
+    expect(capturedEntryPatterns).toContain("resources/js/Pages/**/*.{ts,tsx,js,jsx}");
+    expect(capturedEntryPatterns).toContain("resources/js/pages/**/*.{ts,tsx,js,jsx}");
+    expect(capturedEntryPatterns).toContain("src/Pages/**/*.{ts,tsx,js,jsx}");
+  });
+
+  it("does not flag Inertia pages as orphan files", async () => {
+    const directory = setupProject(
+      "inertia-pages",
+      {
+        "resources/js/app.tsx":
+          "import { createInertiaApp } from '@inertiajs/react';\n" +
+          "createInertiaApp({ resolve: (name) => name, setup: () => undefined });\n",
+        "resources/js/Pages/Home.tsx": "export default () => <main>Home</main>;\n",
+        "resources/js/pages/Settings.tsx": "export default () => <main>Settings</main>;\n",
+        "resources/js/components/Unused.tsx": "export const Unused = () => <div />;\n",
+      },
+      { dependencies: { "@inertiajs/react": "^2.0.0" } },
+    );
+
+    const flagged = await flaggedUnusedFiles(directory);
+    expect(flagged).not.toContain("resources/js/Pages/Home.tsx");
+    expect(flagged).not.toContain("resources/js/pages/Settings.tsx");
+    expect(flagged).toContain("resources/js/components/Unused.tsx");
+  });
+
+  it("does not flag RedwoodJS pages or layouts as orphan files", async () => {
+    const directory = setupProject(
+      "redwood-pages",
+      {
+        "web/src/Routes.tsx": "export const Routes = () => null;\n",
+        "web/src/pages/HomePage/HomePage.tsx": "export default () => <main>Home</main>;\n",
+        "web/src/layouts/MainLayout/MainLayout.tsx":
+          "export default ({ children }: { children: React.ReactNode }) => <>{children}</>;\n",
+        "web/src/components/Unused.tsx": "export const Unused = () => <div />;\n",
+      },
+      { dependencies: { "@redwoodjs/web": "^8.0.0" } },
+    );
+
+    const flagged = await flaggedUnusedFiles(directory);
+    expect(flagged).not.toContain("web/src/pages/HomePage/HomePage.tsx");
+    expect(flagged).not.toContain("web/src/layouts/MainLayout/MainLayout.tsx");
+    expect(flagged).toContain("web/src/components/Unused.tsx");
   });
 
   it("rejects malformed worker results instead of silently dropping diagnostics", async () => {

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -98,6 +98,20 @@ const emptyWorkerResult = {
   circularDependencies: [],
 };
 
+const captureDeadCodeEntryPatterns = async (
+  rootDirectory: string,
+): Promise<ReadonlyArray<string>> => {
+  let capturedEntryPatterns: ReadonlyArray<string> = [];
+  await checkDeadCode({
+    rootDirectory,
+    createWorker: (input) => {
+      capturedEntryPatterns = input.entryPatterns;
+      return { result: Promise.resolve(emptyWorkerResult) };
+    },
+  });
+  return capturedEntryPatterns;
+};
+
 describe("checkDeadCode", () => {
   it("returns no diagnostics when the directory has no package.json", async () => {
     const directory = path.join(tempRoot, "no-package-json");
@@ -209,19 +223,12 @@ describe("checkDeadCode", () => {
       },
       { dependencies: { "@inertiajs/react": "^2.0.0" } },
     );
-    let capturedEntryPatterns: ReadonlyArray<string> = [];
-
-    await checkDeadCode({
-      rootDirectory: directory,
-      createWorker: (input) => {
-        capturedEntryPatterns = input.entryPatterns;
-        return { result: Promise.resolve(emptyWorkerResult) };
-      },
-    });
+    const capturedEntryPatterns = await captureDeadCodeEntryPatterns(directory);
 
     expect(capturedEntryPatterns).toContain("src/index.{ts,tsx,js,jsx}");
     expect(capturedEntryPatterns).toContain("resources/js/Pages/**/*.{ts,tsx,js,jsx}");
     expect(capturedEntryPatterns).toContain("resources/js/pages/**/*.{ts,tsx,js,jsx}");
+    expect(capturedEntryPatterns).toContain("app/frontend/pages/**/*.{ts,tsx,js,jsx}");
     expect(capturedEntryPatterns).toContain("src/Pages/**/*.{ts,tsx,js,jsx}");
   });
 
@@ -234,6 +241,7 @@ describe("checkDeadCode", () => {
           "createInertiaApp({ resolve: (name) => name, setup: () => undefined });\n",
         "resources/js/Pages/Home.tsx": "export default () => <main>Home</main>;\n",
         "resources/js/pages/Settings.tsx": "export default () => <main>Settings</main>;\n",
+        "app/frontend/pages/Posts/Index.tsx": "export default () => <main>Posts</main>;\n",
         "resources/js/components/Unused.tsx": "export const Unused = () => <div />;\n",
       },
       { dependencies: { "@inertiajs/react": "^2.0.0" } },
@@ -242,6 +250,7 @@ describe("checkDeadCode", () => {
     const flagged = await flaggedUnusedFiles(directory);
     expect(flagged).not.toContain("resources/js/Pages/Home.tsx");
     expect(flagged).not.toContain("resources/js/pages/Settings.tsx");
+    expect(flagged).not.toContain("app/frontend/pages/Posts/Index.tsx");
     expect(flagged).toContain("resources/js/components/Unused.tsx");
   });
 
@@ -262,6 +271,86 @@ describe("checkDeadCode", () => {
     expect(flagged).not.toContain("web/src/pages/HomePage/HomePage.tsx");
     expect(flagged).not.toContain("web/src/layouts/MainLayout/MainLayout.tsx");
     expect(flagged).toContain("web/src/components/Unused.tsx");
+  });
+
+  it("does not flag Waku pages as orphan files", async () => {
+    const directory = setupProject(
+      "waku-pages",
+      {
+        "src/waku.server.ts": "export default {};\n",
+        "src/pages/index.tsx": "export default () => <main>Home</main>;\n",
+        "src/pages/about.tsx": "export default () => <main>About</main>;\n",
+        "src/components/Unused.tsx": "export const Unused = () => <div />;\n",
+      },
+      { dependencies: { waku: "^0.22.0" } },
+    );
+
+    const flagged = await flaggedUnusedFiles(directory);
+    expect(flagged).not.toContain("src/pages/index.tsx");
+    expect(flagged).not.toContain("src/pages/about.tsx");
+    expect(flagged).not.toContain("src/waku.server.ts");
+    expect(flagged).toContain("src/components/Unused.tsx");
+  });
+
+  it("does not flag Vike pages or renderer hooks as orphan files", async () => {
+    const directory = setupProject(
+      "vike-pages",
+      {
+        "pages/index/+Page.tsx": "export default () => <main>Home</main>;\n",
+        "pages/about/+Page.tsx": "export default () => <main>About</main>;\n",
+        "renderer/+onRenderHtml.tsx": "export const onRenderHtml = () => '<main></main>';\n",
+        "src/components/Unused.tsx": "export const Unused = () => <div />;\n",
+      },
+      { dependencies: { vike: "^0.4.0" } },
+    );
+
+    const flagged = await flaggedUnusedFiles(directory);
+    expect(flagged).not.toContain("pages/index/+Page.tsx");
+    expect(flagged).not.toContain("pages/about/+Page.tsx");
+    expect(flagged).not.toContain("renderer/+onRenderHtml.tsx");
+    expect(flagged).toContain("src/components/Unused.tsx");
+  });
+
+  it("does not flag Rakkas routes as orphan files", async () => {
+    const directory = setupProject(
+      "rakkas-routes",
+      {
+        "src/client.tsx": "export default {};\n",
+        "src/routes/index.page.tsx": "export default () => <main>Home</main>;\n",
+        "src/routes/about.page.tsx": "export default () => <main>About</main>;\n",
+        "src/components/Unused.tsx": "export const Unused = () => <div />;\n",
+      },
+      { dependencies: { rakkasjs: "^0.7.0" } },
+    );
+
+    const flagged = await flaggedUnusedFiles(directory);
+    expect(flagged).not.toContain("src/routes/index.page.tsx");
+    expect(flagged).not.toContain("src/routes/about.page.tsx");
+    expect(flagged).not.toContain("src/client.tsx");
+    expect(flagged).toContain("src/components/Unused.tsx");
+  });
+
+  it("passes module federation config roots to the dead-code worker", async () => {
+    const directory = setupProject(
+      "federation-worker-entry-patterns",
+      {
+        "module-federation.config.ts": "export default {};\n",
+      },
+      { devDependencies: { "@module-federation/enhanced": "^0.21.0" } },
+    );
+
+    const capturedEntryPatterns = await captureDeadCodeEntryPatterns(directory);
+    expect(capturedEntryPatterns).toContain("module-federation.config.{ts,js,mjs,cjs,mts,cts}");
+    expect(capturedEntryPatterns).toContain("federation.config.{ts,js,mjs,cjs,mts,cts}");
+  });
+
+  it("keeps generic page directories orphan-checkable without a matching framework", async () => {
+    const directory = setupProject("ungated-pages", {
+      "src/index.ts": "export const used = 1;\n",
+      "src/pages/Standalone.tsx": "export default () => <main>Standalone</main>;\n",
+    });
+
+    expect(await flaggedUnusedFiles(directory)).toContain("src/pages/Standalone.tsx");
   });
 
   it("rejects malformed worker results instead of silently dropping diagnostics", async () => {

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -226,10 +226,10 @@ describe("checkDeadCode", () => {
     const capturedEntryPatterns = await captureDeadCodeEntryPatterns(directory);
 
     expect(capturedEntryPatterns).toContain("src/index.{ts,tsx,js,jsx}");
-    expect(capturedEntryPatterns).toContain("resources/js/Pages/**/*.{ts,tsx,js,jsx}");
-    expect(capturedEntryPatterns).toContain("resources/js/pages/**/*.{ts,tsx,js,jsx}");
-    expect(capturedEntryPatterns).toContain("app/frontend/pages/**/*.{ts,tsx,js,jsx}");
-    expect(capturedEntryPatterns).toContain("src/Pages/**/*.{ts,tsx,js,jsx}");
+    expect(capturedEntryPatterns).toContain("resources/js/Pages/**/*.{ts,tsx,js,jsx,vue,svelte}");
+    expect(capturedEntryPatterns).toContain("resources/js/pages/**/*.{ts,tsx,js,jsx,vue,svelte}");
+    expect(capturedEntryPatterns).toContain("app/frontend/pages/**/*.{ts,tsx,js,jsx,vue,svelte}");
+    expect(capturedEntryPatterns).toContain("src/Pages/**/*.{ts,tsx,js,jsx,vue,svelte}");
   });
 
   it("does not flag Inertia pages as orphan files", async () => {
@@ -251,6 +251,25 @@ describe("checkDeadCode", () => {
     expect(flagged).not.toContain("resources/js/Pages/Home.tsx");
     expect(flagged).not.toContain("resources/js/pages/Settings.tsx");
     expect(flagged).not.toContain("app/frontend/pages/Posts/Index.tsx");
+    expect(flagged).toContain("resources/js/components/Unused.tsx");
+  });
+
+  it("does not flag Vue or Svelte Inertia pages as orphan files", async () => {
+    const directory = setupProject(
+      "inertia-adapters",
+      {
+        "resources/js/app.ts": "import { createInertiaApp } from '@inertiajs/vue3';\n",
+        "resources/js/Pages/Dashboard.vue":
+          "<template><main>Dashboard</main></template>\n<script setup></script>\n",
+        "resources/js/pages/Profile.svelte": "<main>Profile</main>\n",
+        "resources/js/components/Unused.tsx": "export const Unused = () => <div />;\n",
+      },
+      { dependencies: { "@inertiajs/vue3": "^2.0.0", "@inertiajs/svelte": "^2.0.0" } },
+    );
+
+    const flagged = await flaggedUnusedFiles(directory);
+    expect(flagged).not.toContain("resources/js/Pages/Dashboard.vue");
+    expect(flagged).not.toContain("resources/js/pages/Profile.svelte");
     expect(flagged).toContain("resources/js/components/Unused.tsx");
   });
 
@@ -342,6 +361,16 @@ describe("checkDeadCode", () => {
     const capturedEntryPatterns = await captureDeadCodeEntryPatterns(directory);
     expect(capturedEntryPatterns).toContain("module-federation.config.{ts,js,mjs,cjs,mts,cts}");
     expect(capturedEntryPatterns).toContain("federation.config.{ts,js,mjs,cjs,mts,cts}");
+  });
+
+  it("keeps dead-code analysis running when package.json is malformed", async () => {
+    const directory = setupProject("malformed-package-json", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    fs.writeFileSync(path.join(directory, "package.json"), "{");
+
+    const capturedEntryPatterns = await captureDeadCodeEntryPatterns(directory);
+    expect(capturedEntryPatterns).toEqual([]);
   });
 
   it("keeps generic page directories orphan-checkable without a matching framework", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add dependency-gated dead-code entry roots for Inertia page/app files, including Laravel, Rails-style, Django/split-frontend, Adonis-style, Vue, and Svelte paths
- add page/route roots for other runtime/file-route React ecosystems that `deslop-js` does not already cover: RedwoodJS, Waku, Vike/vite-plugin-ssr, and Rakkas
- add narrow module-federation config roots for federation plugin packages
- move framework entry-pattern selection into a focused dead-code entry-pattern module and reuse canonical package.json parsing
- cover the worker config, real orphan-file behavior, malformed package.json handling, and an ungated `src/pages` negative control with focused core tests

## Testing
- `pnpm dlx --package @antfu/ni nr test tests/check-dead-code.test.ts` (from `packages/core`)
- `pnpm dlx --package @antfu/ni nr typecheck`
- `pnpm dlx --package @antfu/ni nr lint` (passes with existing fixture warnings)
- `pnpm dlx --package @antfu/ni nr format:check`
- `pnpm dlx --package @antfu/ni nr test`
- `pnpm dlx --package @antfu/ni nr smoke:json-report`
- GitHub CI: all checks passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6faeb649-e96b-4911-a8ea-baf489d2f208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6faeb649-e96b-4911-a8ea-baf489d2f208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

