### PR TITLE
feat(telemetry): emit a per-scan wide event for CI + usage analysis

### DIFF
--- a/.changeset/ci-telemetry-wide-event.md
+++ b/.changeset/ci-telemetry-wide-event.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+react-doctor now records a single anonymized per-scan "wide event" on its Sentry run span — the full run/CI/project/outcome context (scan mode, score, diagnostics by severity and category, top rule, lint/dead-code state, and, in CI, the GitHub event, an official-action marker, the forwarded action inputs, and the pull-request gate) — so usage and CI behavior can be analyzed by querying spans instead of pre-aggregated counters.
+
+It also mints a random per-run `runId` attached to the Sentry run context (never as a tag or metric dimension) to correlate the spans of a single run. Telemetry stays anonymized — no repo, owner, username, branch, or path is sent to Sentry — and `--no-score` / `--no-telemetry` still opts out entirely. The official GitHub Action forwards its inputs (fail-on, non-blocking, comment, annotations, version) so action configuration is visible in telemetry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,48 @@ for this codebase) for canonical examples.
   `scrubSentryEvent`), returning `null` to drop on failure. Add new counters
   through `record-metric.ts` + the `METRIC` map, and confirm any new attribute
   carries no username, path, or secret.
+- **Sentry canonical run wide event (CLI only).** The richest telemetry is one
+  high-dimensionality "wide event" per scan, not a pile of narrow counters: the
+  per-run root span (`withSentryRunSpan`) is enriched with the full outcome by
+  `cli/utils/build-run-event.ts` (`recordRunEvent`, plus the pure, testable
+  `buildRunEventAttributes`). `inspect.ts` calls it on the success path (after
+  `recordScanMetrics`) and, via a `try/catch` around the span body, on the
+  failure path — so the event lands with an `outcome` (`clean`/`ok`/`blocked`/
+  `error`), `exitCode`, and `errorTag` taxonomy even when the scan throws. The
+  run + project base context is already on the span (run tags from
+  `withSentryRunSpan`, project shape from `recordSentryProjectContext`), so the
+  event adds only what those don't: scan config (`mode`, `parallel`,
+  `workerCount`, `rulesConfigured`/`rulesDisabled`, `ignoredTagCount`,
+  `hasCustomConfig`, …), outcome (`totalDiagnostics`, `errorCount`/
+  `warningCount`, `affectedFiles`, `distinctRulesFired`, `topRule`, per-category
+  `diag.category.*`, `score`/`scoreLabel`/`scoreAvailable`, `scanClean`,
+  `skippedCheckCount`, lint/dead-code failure), and the CI/PR specifics
+  (`actorAssociation`, `runnerOs`, the forwarded action knobs `failOn`/
+  `nonBlocking`/`comment`/`annotations`/`versionPin`, and the `wouldBlock` gate).
+  Typing matters for querying: numeric outcomes are numbers (so Sentry can do
+  `p75(score)`), dimensions are strings/bools (so they filter/group); `null` is
+  dropped via `toSpanAttributes` so absent signals never become `"null"`. Query
+  it in Sentry's **Trace Explorer** and build **Dashboard widgets on the Spans
+  dataset** (filter/group by any attribute) instead of pre-aggregating counters.
+  Put new run-level dimensions on `build-run-context.ts` → `build-sentry-scope.ts`
+  (now also the `eventName` + `viaAction` tags) so they ride every event and
+  metric; put per-scan outcome dimensions on the wide event, **not** new
+  counters (we deliberately did not add `ci.*` counters — those dims are wide-
+  event attributes; the `scan.*`/`rule.fired` counters stay as the cheap,
+  trace-sampling-independent floor alongside `cli.invoked`/`cli.error`). Score
+  reachability is derivable (`!scoreAvailable && !didLintFail && !noScore`) and
+  score latency is the `Score.compute` child span's duration, so neither needs a
+  dedicated field. CI detection + the official-action marker and forwarded
+  inputs live in `cli/utils/is-ci-environment.ts`; `action.yml` sets the
+  `REACT_DOCTOR_GITHUB_ACTION` marker + `REACT_DOCTOR_ACTION_*` env on its scan
+  step. All attributes pass through `scrubSentryEvent`; keep them free of
+  username, path, secret, and repo/owner identity.
+- **runId.** `cli/utils/run-id.ts` mints one random `runId` per CLI run
+  (process). It rides the Sentry `run` context (and thus the wide event) but is
+  **never** a tag or metric attribute — a per-run unique value there would
+  explode tag/counter cardinality. A workspace invocation scanning several
+  projects shares one `runId`; the per-project span attributes disambiguate. Do
+  not add a plaintext or hashed repo id to Sentry.
 
 ### Console / logging
 

--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,16 @@ runs:
         CHANGED_FILES_FROM: ${{ steps.pr-files.outputs.path }}
         RUNNER_TEMP: ${{ runner.temp }}
         GITHUB_RUN_ID: ${{ github.run_id }}
+        # Telemetry: mark runs as launched by the official action and forward the
+        # inputs the CLI can't otherwise see (comment / non-blocking are handled
+        # in later steps, not as flags). These ride along on the scan's Sentry
+        # wide event. Anonymous: no repo, owner, actor, or ref.
+        REACT_DOCTOR_GITHUB_ACTION: ${{ github.action_ref || '1' }}
+        REACT_DOCTOR_ACTION_FAIL_ON: ${{ inputs.fail-on }}
+        REACT_DOCTOR_ACTION_NON_BLOCKING: ${{ inputs.non-blocking }}
+        REACT_DOCTOR_ACTION_COMMENT: ${{ inputs.comment }}
+        REACT_DOCTOR_ACTION_ANNOTATIONS: ${{ inputs.annotations }}
+        REACT_DOCTOR_ACTION_VERSION: ${{ inputs.version }}
       run: |
         REPORT_FILE="${RUNNER_TEMP:-/tmp}/react-doctor-report-${GITHUB_RUN_ID:-$$}.json"
         echo "report-file=$REPORT_FILE" >> "$GITHUB_OUTPUT"

--- a/packages/core/src/calculate-score.ts
+++ b/packages/core/src/calculate-score.ts
@@ -50,6 +50,7 @@ export interface ScoreRequestMetadata {
   sourceFileCount?: number;
   defaultBranch?: string;
   doctorVersion?: string;
+  runId?: string;
   githubEventName?: string;
   githubActorAssociation?: string;
   githubViewerPermission?: string;
@@ -75,6 +76,7 @@ export const calculateScore = async (
         : {}),
       ...(options.metadata?.defaultBranch ? { defaultBranch: options.metadata.defaultBranch } : {}),
       ...(options.metadata?.doctorVersion ? { doctorVersion: options.metadata.doctorVersion } : {}),
+      ...(options.metadata?.runId ? { runId: options.metadata.runId } : {}),
       ...(options.metadata?.githubEventName
         ? { githubEventName: options.metadata.githubEventName }
         : {}),

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -64,6 +64,8 @@ export interface InspectInput {
   readonly isCi: boolean;
   /** react-doctor release version sent with score requests. */
   readonly doctorVersion?: string;
+  /** Random per-run id. */
+  readonly runId?: string;
   /** Enables best-effort authenticated local GitHub permission lookup for score metadata. */
   readonly resolveLocalGithubViewerPermission?: boolean;
   /**
@@ -462,6 +464,7 @@ export const runInspect = <HooksR = never>(
       sourceFileCount: project.sourceFileCount,
       ...(defaultBranch !== null ? { defaultBranch } : {}),
       ...(input.doctorVersion !== undefined ? { doctorVersion: input.doctorVersion } : {}),
+      ...(input.runId !== undefined ? { runId: input.runId } : {}),
       ...githubActionsScoreMetadata,
       ...(githubViewerPermission !== null ? { githubViewerPermission } : {}),
     };

--- a/packages/react-doctor/src/cli/utils/build-run-context.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-context.ts
@@ -1,17 +1,23 @@
 import {
+  detectCiEventName,
   detectCiProvider,
   detectCodingAgent,
   isCiEnvironment,
   isCodingAgentEnvironment,
+  isOfficialGithubAction,
 } from "./is-ci-environment.js";
 import { isGitHookEnvironment } from "./is-git-hook-environment.js";
 import { isNonInteractiveEnvironment } from "./is-non-interactive-environment.js";
 import { isJsonModeActive } from "./json-mode.js";
+import { getRunId } from "./run-id.js";
 import { scrubSensitivePaths } from "./scrub-sensitive-text.js";
 import { VERSION } from "./version.js";
 
 export interface RunContext {
   version: string;
+  // Random per-run (per-process) id, carried on events/spans (via
+  // `contexts.run`) only — never a tag.
+  runId: string;
   origin: string;
   command: string;
   argv: string;
@@ -22,6 +28,10 @@ export interface RunContext {
   arch: string;
   ci: boolean;
   ciProvider: string | null;
+  // GitHub Actions triggering event (e.g. `pull_request`), null off GitHub.
+  eventName: string | null;
+  // Launched by the official react-doctor GitHub Action.
+  viaAction: boolean;
   codingAgent: string | null;
   interactive: boolean;
   jsonMode: boolean;
@@ -75,6 +85,7 @@ export const buildRunContext = (): RunContext => {
   const userArguments = process.argv.slice(2);
   return {
     version: VERSION,
+    runId: getRunId(),
     origin: detectOrigin(),
     command: detectCommand(userArguments),
     // Scrub home-directory paths so the OS username never rides along in the
@@ -88,6 +99,8 @@ export const buildRunContext = (): RunContext => {
     arch: process.arch,
     ci: isCiEnvironment(),
     ciProvider: detectCiProvider(),
+    eventName: detectCiEventName(),
+    viaAction: isOfficialGithubAction(),
     codingAgent: detectCodingAgent(),
     interactive: !isNonInteractiveEnvironment(),
     jsonMode: isJsonModeActive(),

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -1,0 +1,232 @@
+import {
+  filterDiagnosticsForSurface,
+  isReactDoctorError,
+  resolveGithubActionsScoreMetadata,
+  summarizeDiagnostics,
+} from "@react-doctor/core";
+import type { FailOnLevel, InspectResult, ReactDoctorConfig } from "@react-doctor/core";
+import { ACTION_INPUT_ENVIRONMENT_VARIABLES, detectRunnerOs } from "./is-ci-environment.js";
+import { summarizeRuleFirings } from "./record-scan-metrics.js";
+import { shouldFailForDiagnostics } from "./should-fail-for-diagnostics.js";
+import { toSpanAttributes } from "./to-span-attributes.js";
+import type { SentryRootSpan } from "./with-sentry-run-span.js";
+
+// A tag-like map: `null` denotes an absent signal and is dropped by
+// `toSpanAttributes` so it never becomes a misleading `"null"` attribute.
+interface RunEventAttributes {
+  [attributeName: string]: string | number | boolean | null;
+}
+
+const FAIL_ON_LEVELS = new Set<FailOnLevel>(["error", "warning", "none"]);
+
+/**
+ * Outcome of one scan, attached to its root span (the canonical "wide event").
+ * `result` is absent on the failure path (the scan threw before finalizing);
+ * `error` is present there so the event still records what happened.
+ */
+export interface RunEventInput {
+  readonly result?: InspectResult;
+  /** `"diff"` / `"full"` / `"staged"`. */
+  readonly mode: string;
+  readonly parallel: boolean;
+  readonly workerCount: number | undefined;
+  readonly lint: boolean;
+  readonly deadCode: boolean;
+  readonly scoreOnly: boolean;
+  readonly noScore: boolean;
+  readonly respectInlineDisables: boolean;
+  readonly showWarnings: boolean;
+  readonly ignoredTagCount: number;
+  readonly hasCustomConfig: boolean;
+  readonly userConfig: ReactDoctorConfig | null;
+  // Lint / dead-code outcome — only known on the success path. The failure path
+  // (the scan threw) omits these rather than asserting a benign default.
+  readonly didLintFail?: boolean;
+  readonly lintFailureReasonKind?: string | null;
+  readonly lintPartialFailureCount?: number;
+  readonly didDeadCodeFail?: boolean;
+  /** Present only when the scan threw. */
+  readonly error?: unknown;
+}
+
+const readEnvBoolean = (name: string): boolean | null => {
+  const value = process.env[name];
+  if (value === undefined) return null;
+  return value.toLowerCase() === "true" || value === "1";
+};
+
+// How the official action's `version` input was pinned, derived from the
+// forwarded value: `latest`, a local path spec, or an explicit version.
+const resolveVersionPin = (versionInput: string | undefined): string | null => {
+  if (versionInput === undefined || versionInput.trim() === "") return null;
+  if (versionInput === "latest") return "latest";
+  if (/^(\.\.?\/|\/)/.test(versionInput)) return "local";
+  return "pinned";
+};
+
+// The fail-on threshold for the `wouldBlock` signal. The action forwards its
+// own `fail-on` input (so we see the gate even though it's handled outside the
+// CLI); otherwise fall back to the config value, then advisory `none`. A bare
+// `--fail-on` CLI flag (no action, no config) isn't visible here — an accepted
+// gap, since CI gating runs through the action or config.
+const resolveTelemetryFailOn = (userConfig: ReactDoctorConfig | null): FailOnLevel => {
+  const fromAction = process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.failOn];
+  if (fromAction !== undefined && FAIL_ON_LEVELS.has(fromAction as FailOnLevel)) {
+    return fromAction as FailOnLevel;
+  }
+  return userConfig?.failOn ?? "none";
+};
+
+// Lowercase, key-safe form of a rule category for the `diag.category.*`
+// attribute namespace (categories carry spaces / capitals, e.g. "Performance").
+const toCategoryKey = (category: string): string =>
+  category.toLowerCase().replace(/[^a-z0-9]+/g, "_");
+
+const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
+  // Failure path: the scan threw before producing a result.
+  if (input.result === undefined) {
+    const error = input.error;
+    const known = isReactDoctorError(error);
+    return {
+      outcome: "error",
+      exitCode: 1,
+      knownError: known,
+      errorTag: known ? error.reason._tag : error instanceof Error ? error.name : null,
+    };
+  }
+
+  const result = input.result;
+  const summary = summarizeDiagnostics(result.diagnostics);
+  const failOnLevel = resolveTelemetryFailOn(input.userConfig);
+  // Mirror the CLI's real fail-on gate (cli/commands/inspect.ts → finalizeScans):
+  // it tests the threshold against diagnostics filtered for the `ciFailure`
+  // surface (weak-signal `design`-tagged rules are dropped by default), so the
+  // wide event's wouldBlock/outcome/exitCode can't disagree with the actual
+  // process exit. The descriptive totals below still reflect the full findings.
+  const gateDiagnostics = filterDiagnosticsForSurface(
+    result.diagnostics,
+    "ciFailure",
+    input.userConfig,
+  );
+  // `scoreOnly` runs never raise a non-zero exit (finalizeScans guards the gate
+  // on `!isScoreOnly`), so the threshold can't actually block them — keep
+  // wouldBlock/outcome/exitCode consistent with the real process exit.
+  const wouldBlock = !input.scoreOnly && shouldFailForDiagnostics(gateDiagnostics, failOnLevel);
+  const hasSkippedChecks = result.skippedChecks.length > 0;
+  const isClean = result.diagnostics.length === 0 && !hasSkippedChecks;
+  const outcome = wouldBlock ? "blocked" : isClean ? "clean" : "ok";
+
+  const firings = summarizeRuleFirings(result.diagnostics);
+  const countByRule = new Map<string, number>();
+  const countByCategory = new Map<string, number>();
+  for (const firing of firings) {
+    countByRule.set(firing.rule, (countByRule.get(firing.rule) ?? 0) + firing.count);
+    countByCategory.set(
+      firing.category,
+      (countByCategory.get(firing.category) ?? 0) + firing.count,
+    );
+  }
+  let topRule: string | null = null;
+  let topRuleCount = 0;
+  for (const [rule, count] of countByRule) {
+    if (count > topRuleCount) {
+      topRule = rule;
+      topRuleCount = count;
+    }
+  }
+
+  const attributes: RunEventAttributes = {
+    outcome,
+    exitCode: wouldBlock ? 1 : 0,
+    wouldBlock,
+    failOn: failOnLevel,
+    scanClean: isClean,
+    totalDiagnostics: summary.totalDiagnosticCount,
+    errorCount: summary.errorCount,
+    warningCount: summary.warningCount,
+    affectedFiles: summary.affectedFileCount,
+    distinctRulesFired: countByRule.size,
+    topRule,
+    scannedFileCount: result.scannedFileCount ?? null,
+    elapsedMs: result.elapsedMilliseconds,
+    scanPhaseMs: result.scanElapsedMilliseconds ?? null,
+    score: result.score ? result.score.score : null,
+    scoreLabel: result.score ? result.score.label : null,
+    scoreAvailable: result.score !== null,
+    skippedCheckCount: result.skippedChecks.length,
+    didLintFail: input.didLintFail ?? null,
+    lintFailureReasonKind: input.lintFailureReasonKind ?? null,
+    lintPartialFailureCount: input.lintPartialFailureCount ?? null,
+    didDeadCodeFail: input.didDeadCodeFail ?? null,
+  };
+  for (const [category, count] of countByCategory) {
+    attributes[`diag.category.${toCategoryKey(category)}`] = count;
+  }
+  return attributes;
+};
+
+const buildCiAttributes = (): RunEventAttributes => {
+  const { githubActorAssociation } = resolveGithubActionsScoreMetadata();
+  return {
+    actorAssociation: githubActorAssociation ?? null,
+    runnerOs: detectRunnerOs(),
+    // Action knobs: present only when the official action forwarded them, so
+    // they're `null` (dropped) for any non-action run. The action's `fail-on`
+    // is already captured as `failOn` (resolveTelemetryFailOn prefers it).
+    nonBlocking: readEnvBoolean(ACTION_INPUT_ENVIRONMENT_VARIABLES.nonBlocking),
+    comment: readEnvBoolean(ACTION_INPUT_ENVIRONMENT_VARIABLES.comment),
+    annotations: readEnvBoolean(ACTION_INPUT_ENVIRONMENT_VARIABLES.annotations),
+    versionPin: resolveVersionPin(process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.version]),
+  };
+};
+
+const buildConfigAttributes = (input: RunEventInput): RunEventAttributes => {
+  const ruleOverrides = input.userConfig?.rules ?? {};
+  const ruleKeys = Object.keys(ruleOverrides);
+  return {
+    mode: input.mode,
+    parallel: input.parallel,
+    workerCount: input.workerCount ?? null,
+    lint: input.lint,
+    deadCode: input.deadCode,
+    scoreOnly: input.scoreOnly,
+    noScore: input.noScore,
+    respectInlineDisables: input.respectInlineDisables,
+    showWarnings: input.showWarnings,
+    ignoredTagCount: input.ignoredTagCount,
+    hasCustomConfig: input.hasCustomConfig,
+    rulesConfigured: ruleKeys.length,
+    rulesDisabled: ruleKeys.filter((key) => ruleOverrides[key] === "off").length,
+  };
+};
+
+/**
+ * Projects a scan into the flat attribute set for its root span — the canonical
+ * per-scan "wide event". Pure and exported so the projection (outcome
+ * precedence, rule/category rollups, CI knobs, config shape) is unit-testable
+ * without a live Sentry client. `null` values are dropped so absent signals
+ * never become misleading `"null"` attributes. The run + project base context
+ * (version, command, ci/provider, framework, …) is already on the span from
+ * `withSentryRunSpan` / `recordSentryProjectContext`, so this adds only what
+ * those don't carry.
+ */
+export const buildRunEventAttributes = (
+  input: RunEventInput,
+): Record<string, string | number | boolean> =>
+  toSpanAttributes({
+    ...buildConfigAttributes(input),
+    ...buildCiAttributes(),
+    ...buildOutcomeAttributes(input),
+  });
+
+/**
+ * Stamps the wide-event attributes onto the run's root span. A guarded no-op
+ * when tracing is off (no `rootSpan`) and swallow-on-throw, so telemetry can
+ * never break the run.
+ */
+export const recordRunEvent = (rootSpan: SentryRootSpan, input: RunEventInput): void => {
+  if (!rootSpan) return;
+  try {
+    rootSpan.setAttributes(buildRunEventAttributes(input));
+  } catch {}
+};

--- a/packages/react-doctor/src/cli/utils/build-sentry-scope.ts
+++ b/packages/react-doctor/src/cli/utils/build-sentry-scope.ts
@@ -31,12 +31,17 @@ export const buildSentryScope = (runContext: RunContext = buildRunContext()): Se
     command: runContext.command,
     ci: runContext.ci,
     ciProvider: runContext.ciProvider,
+    eventName: runContext.eventName,
+    viaAction: runContext.viaAction,
     codingAgent: runContext.codingAgent,
     interactive: runContext.interactive,
     jsonMode: runContext.jsonMode,
     invokedVia: runContext.invokedVia,
     nodeMajor: runContext.nodeMajor,
   };
+  // `runId` is intentionally NOT a tag: it's a per-run unique value and would
+  // explode tag cardinality. It still rides `contexts.run` below (the full
+  // run-context spread).
   const contexts: Record<string, Record<string, unknown>> = { run: { ...runContext } };
 
   const projectInfo = getSentryProjectInfo();

--- a/packages/react-doctor/src/cli/utils/is-ci-environment.ts
+++ b/packages/react-doctor/src/cli/utils/is-ci-environment.ts
@@ -22,6 +22,24 @@ const CI_PROVIDER_BY_ENVIRONMENT_VARIABLE: ReadonlyArray<readonly [string, strin
   ["DRONE", "drone"],
 ];
 
+// Marker the official react-doctor GitHub Action sets on its scan step so CLI
+// telemetry can tell "ran via our action" apart from a hand-rolled `npx
+// react-doctor` step inside some GitHub workflow. Presence is all that matters;
+// the value is the action ref.
+export const GITHUB_ACTION_MARKER_ENVIRONMENT_VARIABLE = "REACT_DOCTOR_GITHUB_ACTION";
+
+// Action inputs the CLI can't otherwise see (they're handled in `action.yml`
+// steps, not passed as flags). The official action forwards them as these env
+// vars so the wide event can record how the action was configured. Exported so
+// tests can save/restore the full surface.
+export const ACTION_INPUT_ENVIRONMENT_VARIABLES = {
+  failOn: "REACT_DOCTOR_ACTION_FAIL_ON",
+  nonBlocking: "REACT_DOCTOR_ACTION_NON_BLOCKING",
+  comment: "REACT_DOCTOR_ACTION_COMMENT",
+  annotations: "REACT_DOCTOR_ACTION_ANNOTATIONS",
+  version: "REACT_DOCTOR_ACTION_VERSION",
+} as const;
+
 // Coding-agent runtime marker env var -> stable brand label. Config-only or
 // auth vars (e.g. OPENAI_API_KEY, OPENCODE_CONFIG) are intentionally excluded so
 // a stored key doesn't read as "running inside an agent". This is the single
@@ -77,6 +95,27 @@ export const detectCiProvider = (): string | null => {
   }
   return isCiFlagSet(process.env.CI) ? "unknown" : null;
 };
+
+// True when the run was launched by the official react-doctor GitHub Action
+// (which sets the marker env var on its scan step).
+export const isOfficialGithubAction = (): boolean =>
+  Boolean(process.env[GITHUB_ACTION_MARKER_ENVIRONMENT_VARIABLE]);
+
+// The triggering GitHub Actions event (`pull_request`, `push`, `schedule`,
+// `workflow_dispatch`, …) from the runner-provided `GITHUB_EVENT_NAME`. Null
+// off GitHub Actions. Low-cardinality, so safe as a run tag.
+export const detectCiEventName = (): string | null => process.env.GITHUB_EVENT_NAME?.trim() || null;
+
+// Whether the CI run was triggered by a pull request event.
+export const isPullRequestCiEvent = (): boolean => {
+  const eventName = detectCiEventName();
+  return eventName === "pull_request" || eventName === "pull_request_target";
+};
+
+// The runner OS GitHub Actions exposes as `RUNNER_OS` (`Linux`/`Windows`/
+// `macOS`). Null off GitHub Actions; the local `process.platform` covers the
+// non-action case.
+export const detectRunnerOs = (): string | null => process.env.RUNNER_OS?.trim() || null;
 
 const detectCodingAgentFromValue = (): string | null => {
   for (const environmentVariable of CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES) {

--- a/packages/react-doctor/src/cli/utils/run-id.ts
+++ b/packages/react-doctor/src/cli/utils/run-id.ts
@@ -1,0 +1,19 @@
+import { randomUUID } from "node:crypto";
+
+// One random id per CLI run (process), generated lazily and memoized on first
+// read. It rides the Sentry `run` context (and thus the per-scan root spans /
+// wide events).
+//
+// A workspace invocation that scans several projects shares one `runId` across
+// them by design: it's a single CLI run, and the per-project span attributes
+// disambiguate which project a given span belongs to.
+//
+// Deliberately never used as a Sentry tag or metric attribute: a per-run unique
+// value there would explode tag/counter cardinality. It belongs only on
+// events/spans via `contexts.run`.
+let cachedRunId: string | undefined;
+
+export const getRunId = (): string => {
+  cachedRunId ??= randomUUID();
+  return cachedRunId;
+};

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -22,6 +22,7 @@ import type { SentryRootSpan } from "./cli/utils/with-sentry-run-span.js";
 import { METRIC } from "./cli/utils/constants.js";
 import { recordCount } from "./cli/utils/record-metric.js";
 import { recordScanMetrics } from "./cli/utils/record-scan-metrics.js";
+import { recordRunEvent } from "./cli/utils/build-run-event.js";
 import type {
   Diagnostic,
   DiagnosticSurface,
@@ -56,6 +57,7 @@ import {
 } from "./cli/utils/render-score-header.js";
 import { printFooter, printSummary } from "./cli/utils/render-summary.js";
 import { resolveOxlintNode } from "./cli/utils/resolve-oxlint-node.js";
+import { getRunId } from "./cli/utils/run-id.js";
 import { isSpinnerSilent, setSpinnerSilent } from "./cli/utils/spinner.js";
 import { VERSION } from "./cli/utils/version.js";
 
@@ -122,6 +124,28 @@ const mergeInspectOptions = (
   concurrency: inputOptions.concurrency,
 });
 
+// The scan-config slice of the wide event, shared by the success and failure
+// emit paths (the failure path has no `result`, so it can only supply config).
+// The return type is inferred and checked at the call sites, which spread it
+// into the full `RunEventInput` — a missing field surfaces there.
+const buildRunEventConfig = (
+  options: ResolvedInspectOptions,
+  userConfig: ReactDoctorConfig | null,
+  hasCustomConfig: boolean,
+) => ({
+  parallel: options.concurrency !== undefined,
+  workerCount: options.concurrency,
+  lint: options.lint,
+  deadCode: options.deadCode,
+  scoreOnly: options.scoreOnly,
+  noScore: options.noScore,
+  respectInlineDisables: options.respectInlineDisables,
+  showWarnings: options.warnings,
+  ignoredTagCount: options.ignoredTags.size,
+  hasCustomConfig,
+  userConfig,
+});
+
 export const inspect = async (
   directory: string,
   inputOptions: InspectOptions = {},
@@ -173,17 +197,31 @@ export const inspect = async (
   if (options.silent) setSpinnerSilent(true);
 
   try {
-    const result = await withSentryRunSpan((rootSentrySpan) =>
-      runInspectWithRuntime(
-        scanDirectory,
-        options,
-        userConfig,
-        hasConfigOverride,
-        configSourceDirectory,
-        startTime,
-        rootSentrySpan,
-      ),
-    );
+    const result = await withSentryRunSpan(async (rootSentrySpan) => {
+      try {
+        return await runInspectWithRuntime(
+          scanDirectory,
+          options,
+          userConfig,
+          hasConfigOverride,
+          configSourceDirectory,
+          startTime,
+          rootSentrySpan,
+        );
+      } catch (error) {
+        // Emit the canonical wide event on the failure path too: the scan threw
+        // before finalizing, so there's no `result` — just the error taxonomy
+        // plus the config it ran with. The lint/dead-code outcome isn't known
+        // here, so it's omitted rather than asserted as a benign default.
+        // Rethrow so error handling is unchanged.
+        recordRunEvent(rootSentrySpan, {
+          ...buildRunEventConfig(options, userConfig, userConfig !== null),
+          mode: options.includePaths.length > 0 ? "diff" : "full",
+          error,
+        });
+        throw error;
+      }
+    });
     // Scan finished cleanly — clear run-scoped Sentry state so a later non-scan
     // error (inspectAction's finalize/handoff/install steps, or the next
     // project in a workspace loop) isn't mislabeled with this scan's project or
@@ -256,6 +294,7 @@ const runInspectWithRuntime = async (
       runDeadCode: options.deadCode,
       isCi: options.isCi,
       doctorVersion: VERSION,
+      runId: getRunId(),
       resolveLocalGithubViewerPermission: !options.noScore,
       suppressScanSummary: options.suppressRendering,
     },
@@ -400,6 +439,20 @@ const runInspectWithRuntime = async (
     lintFailureReasonKind: lintBindingMissing
       ? "native-binding-missing"
       : output.lintFailureReasonKind,
+    didDeadCodeFail: output.didDeadCodeFail,
+  });
+  // Canonical per-scan wide event: the full outcome stamped onto the run's root
+  // span (run + project base context is already on it) so any question is a
+  // single Trace Explorer query rather than a pre-aggregated counter.
+  recordRunEvent(rootSentrySpan, {
+    ...buildRunEventConfig(options, userConfig, userConfig !== null),
+    result,
+    mode: isDiffMode ? "diff" : "full",
+    didLintFail,
+    lintFailureReasonKind: lintBindingMissing
+      ? "native-binding-missing"
+      : output.lintFailureReasonKind,
+    lintPartialFailureCount: output.lintPartialFailures.length,
     didDeadCodeFail: output.didDeadCodeFail,
   });
   return result;

--- a/packages/react-doctor/tests/build-run-context.test.ts
+++ b/packages/react-doctor/tests/build-run-context.test.ts
@@ -2,13 +2,21 @@ import os from "node:os";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import { buildRunContext } from "../src/cli/utils/build-run-context.js";
 
+const CI_ENV_VARS = ["GITHUB_EVENT_NAME", "REACT_DOCTOR_GITHUB_ACTION"] as const;
+
 describe("buildRunContext", () => {
   let savedUserAgent: string | undefined;
   let savedArgv: string[];
+  let savedEnv: Record<string, string | undefined>;
 
   beforeEach(() => {
     savedUserAgent = process.env.npm_config_user_agent;
     savedArgv = process.argv;
+    savedEnv = {};
+    for (const name of CI_ENV_VARS) {
+      savedEnv[name] = process.env[name];
+      delete process.env[name];
+    }
   });
 
   afterEach(() => {
@@ -18,6 +26,11 @@ describe("buildRunContext", () => {
       process.env.npm_config_user_agent = savedUserAgent;
     }
     process.argv = savedArgv;
+    for (const name of CI_ENV_VARS) {
+      const previous = savedEnv[name];
+      if (previous === undefined) delete process.env[name];
+      else process.env[name] = previous;
+    }
   });
 
   it("derives invokedVia from the leading npm_config_user_agent token", () => {
@@ -49,5 +62,25 @@ describe("buildRunContext", () => {
     expect(argv).not.toContain(os.homedir());
     expect(argv).toContain("~/secret-project");
     expect(argv).toContain("--json");
+  });
+
+  it("memoizes a stable runId across calls", () => {
+    const { runId } = buildRunContext();
+    expect(runId).toMatch(/[0-9a-f-]{36}/i);
+    expect(buildRunContext().runId).toBe(runId);
+  });
+
+  it("reports the GitHub event name and official-action marker when present", () => {
+    process.env.GITHUB_EVENT_NAME = "pull_request";
+    process.env.REACT_DOCTOR_GITHUB_ACTION = "v1";
+    const context = buildRunContext();
+    expect(context.eventName).toBe("pull_request");
+    expect(context.viaAction).toBe(true);
+  });
+
+  it("leaves eventName null and viaAction false outside the GitHub Action", () => {
+    const context = buildRunContext();
+    expect(context.eventName).toBeNull();
+    expect(context.viaAction).toBe(false);
   });
 });

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import type { Diagnostic, InspectResult, ProjectInfo } from "@react-doctor/core";
+import { buildRunEventAttributes } from "../src/cli/utils/build-run-event.js";
+import type { RunEventInput } from "../src/cli/utils/build-run-event.js";
+import { ACTION_INPUT_ENVIRONMENT_VARIABLES } from "../src/cli/utils/is-ci-environment.js";
+
+// Cleared per test so the host CI environment can't leak into the CI/action
+// attribute assertions.
+const ENV_VARS = [
+  "GITHUB_ACTIONS",
+  "GITHUB_EVENT_NAME",
+  "GITHUB_EVENT_PATH",
+  "RUNNER_OS",
+  "REACT_DOCTOR_GITHUB_ACTION",
+  ...Object.values(ACTION_INPUT_ENVIRONMENT_VARIABLES),
+] as const;
+
+const projectInfo: ProjectInfo = {
+  rootDirectory: "/workspace/project",
+  projectName: "my-app",
+  reactVersion: "18.3.1",
+  reactMajorVersion: 18,
+  tailwindVersion: null,
+  zodVersion: null,
+  zodMajorVersion: null,
+  framework: "nextjs",
+  hasTypeScript: true,
+  hasReactCompiler: false,
+  hasTanStackQuery: false,
+  preactVersion: null,
+  preactMajorVersion: null,
+  hasReactNativeWorkspace: false,
+  expoVersion: null,
+  hasReanimated: false,
+  sourceFileCount: 100,
+};
+
+const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: "src/App.tsx",
+  plugin: "react-doctor",
+  rule: "no-array-index-as-key",
+  severity: "warning",
+  message: "Array index used as a key",
+  help: "Use a stable id",
+  line: 1,
+  column: 1,
+  category: "Correctness",
+  ...overrides,
+});
+
+const buildResult = (overrides: Partial<InspectResult> = {}): InspectResult => ({
+  diagnostics: [],
+  score: null,
+  skippedChecks: [],
+  project: projectInfo,
+  elapsedMilliseconds: 1200,
+  scannedFileCount: 10,
+  scanElapsedMilliseconds: 900,
+  ...overrides,
+});
+
+const baseInput = (overrides: Partial<RunEventInput> = {}): RunEventInput => ({
+  mode: "full",
+  parallel: true,
+  workerCount: 4,
+  lint: true,
+  deadCode: true,
+  scoreOnly: false,
+  noScore: false,
+  respectInlineDisables: true,
+  showWarnings: true,
+  ignoredTagCount: 0,
+  hasCustomConfig: false,
+  userConfig: null,
+  didLintFail: false,
+  lintFailureReasonKind: null,
+  lintPartialFailureCount: 0,
+  didDeadCodeFail: false,
+  ...overrides,
+});
+
+describe("buildRunEventAttributes", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const name of ENV_VARS) {
+      savedEnv[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of ENV_VARS) {
+      const previous = savedEnv[name];
+      if (previous === undefined) delete process.env[name];
+      else process.env[name] = previous;
+    }
+  });
+
+  it("marks a finding-free run clean and drops absent CI signals", () => {
+    const attributes = buildRunEventAttributes(baseInput({ result: buildResult() }));
+    expect(attributes.outcome).toBe("clean");
+    expect(attributes.scanClean).toBe(true);
+    expect(attributes.totalDiagnostics).toBe(0);
+    expect(attributes.exitCode).toBe(0);
+    expect(attributes.wouldBlock).toBe(false);
+    // No GitHub signals in the cleared env -> these are dropped, not "null".
+    expect(attributes.actorAssociation).toBeUndefined();
+    expect(attributes.runnerOs).toBeUndefined();
+    expect(attributes.versionPin).toBeUndefined();
+  });
+
+  it("rolls up diagnostics by severity, rule, and category", () => {
+    const result = buildResult({
+      diagnostics: [
+        buildDiagnostic({ severity: "error", rule: "no-foo", category: "Performance" }),
+        buildDiagnostic({ severity: "warning", rule: "no-foo", category: "Performance" }),
+        buildDiagnostic({
+          severity: "warning",
+          rule: "no-bar",
+          category: "Correctness",
+          filePath: "src/B.tsx",
+        }),
+      ],
+      score: { score: 73, label: "Fair" },
+    });
+    const attributes = buildRunEventAttributes(baseInput({ result }));
+    expect(attributes.outcome).toBe("ok");
+    expect(attributes.totalDiagnostics).toBe(3);
+    expect(attributes.errorCount).toBe(1);
+    expect(attributes.warningCount).toBe(2);
+    expect(attributes.affectedFiles).toBe(2);
+    expect(attributes.distinctRulesFired).toBe(2);
+    expect(attributes.topRule).toBe("react-doctor/no-foo");
+    expect(attributes["diag.category.performance"]).toBe(2);
+    expect(attributes["diag.category.correctness"]).toBe(1);
+    expect(attributes.score).toBe(73);
+    expect(attributes.scoreLabel).toBe("Fair");
+    expect(attributes.scoreAvailable).toBe(true);
+  });
+
+  it("flags a blocking run when the action fail-on gate would trip", () => {
+    process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.failOn] = "error";
+    const result = buildResult({ diagnostics: [buildDiagnostic({ severity: "error" })] });
+    const attributes = buildRunEventAttributes(baseInput({ result }));
+    expect(attributes.failOn).toBe("error");
+    expect(attributes.wouldBlock).toBe(true);
+    expect(attributes.outcome).toBe("blocked");
+    expect(attributes.exitCode).toBe(1);
+  });
+
+  it("derives wouldBlock from the CI-failure surface, not the full diagnostic list", () => {
+    process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.failOn] = "error";
+    const result = buildResult({
+      diagnostics: [buildDiagnostic({ severity: "error", rule: "no-foo" })],
+    });
+    // No surface exclusion: the error trips the gate.
+    expect(buildRunEventAttributes(baseInput({ result })).wouldBlock).toBe(true);
+    // Excluding the rule from the `ciFailure` surface (what the real CLI gate
+    // does for weak-signal `design`-tagged rules) -> the wide event must agree
+    // the run doesn't block, instead of disagreeing with the actual exit code.
+    const excluded = buildRunEventAttributes(
+      baseInput({
+        result,
+        userConfig: { surfaces: { ciFailure: { excludeRules: ["react-doctor/no-foo"] } } },
+      }),
+    );
+    expect(excluded.wouldBlock).toBe(false);
+    expect(excluded.outcome).toBe("ok");
+    expect(excluded.exitCode).toBe(0);
+  });
+
+  it("never reports a blocked run in score-only mode (matches the CLI exit guard)", () => {
+    process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.failOn] = "error";
+    const result = buildResult({ diagnostics: [buildDiagnostic({ severity: "error" })] });
+    // A normal run with these findings blocks...
+    expect(buildRunEventAttributes(baseInput({ result })).wouldBlock).toBe(true);
+    // ...but `scoreOnly` runs never raise a non-zero exit, so the wide event
+    // must not claim blocked/exitCode 1 when the process actually exits 0.
+    const scoreOnly = buildRunEventAttributes(baseInput({ result, scoreOnly: true }));
+    expect(scoreOnly.wouldBlock).toBe(false);
+    expect(scoreOnly.outcome).toBe("ok");
+    expect(scoreOnly.exitCode).toBe(0);
+  });
+
+  it("records the error taxonomy on the failure path", () => {
+    const attributes = buildRunEventAttributes(
+      baseInput({ result: undefined, error: new TypeError("boom") }),
+    );
+    expect(attributes.outcome).toBe("error");
+    expect(attributes.knownError).toBe(false);
+    expect(attributes.errorTag).toBe("TypeError");
+    expect(attributes.exitCode).toBe(1);
+    // No result -> no outcome rollups.
+    expect(attributes.totalDiagnostics).toBeUndefined();
+  });
+
+  it("captures forwarded action knobs and classifies the version pin", () => {
+    process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.nonBlocking] = "true";
+    process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.annotations] = "false";
+    process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.version] = "latest";
+    const attributes = buildRunEventAttributes(baseInput({ result: buildResult() }));
+    expect(attributes.nonBlocking).toBe(true);
+    expect(attributes.annotations).toBe(false);
+    expect(attributes.versionPin).toBe("latest");
+    // `comment` env not set -> dropped, never coerced to a value.
+    expect(attributes.comment).toBeUndefined();
+
+    process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.version] = "1.2.3";
+    expect(buildRunEventAttributes(baseInput({ result: buildResult() })).versionPin).toBe("pinned");
+    process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.version] = "./local/pkg";
+    expect(buildRunEventAttributes(baseInput({ result: buildResult() })).versionPin).toBe("local");
+  });
+
+  it("captures config shape and drops null/undefined-valued attributes", () => {
+    const attributes = buildRunEventAttributes(
+      baseInput({
+        result: buildResult({ scannedFileCount: undefined, scanElapsedMilliseconds: undefined }),
+        workerCount: undefined,
+        ignoredTagCount: 2,
+        hasCustomConfig: true,
+        userConfig: { rules: { "react-doctor/no-foo": "off", "react-doctor/no-bar": "error" } },
+      }),
+    );
+    expect(attributes.mode).toBe("full");
+    expect(attributes.rulesConfigured).toBe(2);
+    expect(attributes.rulesDisabled).toBe(1);
+    expect(attributes.ignoredTagCount).toBe(2);
+    expect(attributes.hasCustomConfig).toBe(true);
+    expect(attributes.workerCount).toBeUndefined();
+    expect(attributes.scannedFileCount).toBeUndefined();
+    expect(attributes.scanPhaseMs).toBeUndefined();
+  });
+});

--- a/packages/react-doctor/tests/build-sentry-scope.test.ts
+++ b/packages/react-doctor/tests/build-sentry-scope.test.ts
@@ -6,6 +6,7 @@ import type { ProjectInfo } from "@react-doctor/core";
 
 const baseRunContext: RunContext = {
   version: "1.2.3",
+  runId: "run-abc123",
   origin: "ci",
   command: "inspect",
   argv: "--json",
@@ -16,6 +17,8 @@ const baseRunContext: RunContext = {
   arch: "arm64",
   ci: true,
   ciProvider: "github-actions",
+  eventName: "pull_request",
+  viaAction: true,
   codingAgent: null,
   interactive: false,
   jsonMode: true,
@@ -54,12 +57,22 @@ describe("buildSentryScope", () => {
       command: "inspect",
       ci: true,
       ciProvider: "github-actions",
+      eventName: "pull_request",
+      viaAction: true,
       codingAgent: null,
       interactive: false,
       jsonMode: true,
       invokedVia: "pnpm",
       nodeMajor: 22,
     });
+  });
+
+  it("carries runId in the run context but never as a tag", () => {
+    const { tags, contexts } = buildSentryScope(baseRunContext);
+    // The id rides events/spans without becoming a high-cardinality tag/metric
+    // dimension.
+    expect((contexts.run as RunContext).runId).toBe("run-abc123");
+    expect(tags.runId).toBeUndefined();
   });
 
   it("attaches the full run context as the `run` context block", () => {

--- a/packages/react-doctor/tests/is-ci-environment.test.ts
+++ b/packages/react-doctor/tests/is-ci-environment.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import {
+  ACTION_INPUT_ENVIRONMENT_VARIABLES,
   CI_ENVIRONMENT_VARIABLES,
   CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
   CODING_AGENT_ENVIRONMENT_VARIABLES,
+  GITHUB_ACTION_MARKER_ENVIRONMENT_VARIABLE,
+  detectCiEventName,
+  detectRunnerOs,
   isCiEnvironment,
   isCiOrCodingAgentEnvironment,
   isCodingAgentEnvironment,
+  isOfficialGithubAction,
+  isPullRequestCiEvent,
 } from "../src/cli/utils/is-ci-environment.js";
 
 const ENVIRONMENT_VARIABLES = [
@@ -13,6 +19,10 @@ const ENVIRONMENT_VARIABLES = [
   ...CI_ENVIRONMENT_VARIABLES,
   ...CODING_AGENT_ENVIRONMENT_VARIABLES,
   ...CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+  "GITHUB_EVENT_NAME",
+  "RUNNER_OS",
+  GITHUB_ACTION_MARKER_ENVIRONMENT_VARIABLE,
+  ...Object.values(ACTION_INPUT_ENVIRONMENT_VARIABLES),
   "OPENAI_API_KEY",
   "GEMINI_API_KEY",
   "OPENCODE_CONFIG",
@@ -175,5 +185,57 @@ describe("isCiEnvironment", () => {
     expect(isCiEnvironment()).toBe(false);
     expect(isCiOrCodingAgentEnvironment()).toBe(false);
     expect(isCodingAgentEnvironment()).toBe(false);
+  });
+});
+
+describe("GitHub Actions CI detectors", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const envVariable of ENVIRONMENT_VARIABLES) {
+      savedEnv[envVariable] = process.env[envVariable];
+      delete process.env[envVariable];
+    }
+  });
+
+  afterEach(() => {
+    for (const envVariable of ENVIRONMENT_VARIABLES) {
+      const previousValue = savedEnv[envVariable];
+      if (previousValue === undefined) {
+        delete process.env[envVariable];
+      } else {
+        process.env[envVariable] = previousValue;
+      }
+    }
+  });
+
+  it("detects the official react-doctor GitHub Action via its marker", () => {
+    expect(isOfficialGithubAction()).toBe(false);
+    process.env[GITHUB_ACTION_MARKER_ENVIRONMENT_VARIABLE] = "v1";
+    expect(isOfficialGithubAction()).toBe(true);
+  });
+
+  it("reads the GitHub event name and pull-request signal", () => {
+    expect(detectCiEventName()).toBeNull();
+    expect(isPullRequestCiEvent()).toBe(false);
+
+    process.env.GITHUB_EVENT_NAME = "pull_request";
+    expect(detectCiEventName()).toBe("pull_request");
+    expect(isPullRequestCiEvent()).toBe(true);
+
+    process.env.GITHUB_EVENT_NAME = "push";
+    expect(isPullRequestCiEvent()).toBe(false);
+  });
+
+  it("treats pull_request_target as a pull request event", () => {
+    process.env.GITHUB_EVENT_NAME = "pull_request_target";
+    expect(isPullRequestCiEvent()).toBe(true);
+  });
+
+  it("reads the runner OS when present", () => {
+    expect(detectRunnerOs()).toBeNull();
+    process.env.RUNNER_OS = "Linux";
+    expect(detectRunnerOs()).toBe("Linux");
   });
 });


### PR DESCRIPTION
## Why

react-doctor's telemetry was a growing pile of pre-aggregated Sentry counters. Counters can't be cross-joined and only answer questions defined in advance, so questions like *"score distribution for PR scans via the official action on Next.js repos where lint failed"* were unanswerable. Following the wide-events / canonical-log-line model, each scan should emit one context-rich event that's queryable across any dimension. There was also no CI-specific usage visibility (provider, PR vs push, official action vs hand-rolled, action config) and no way to tie a Sentry event back to a repo without storing identity in Sentry.

The unit of work is a scan, which already opens a Sentry root span — we make that span the canonical wide event.

## What changed

- **Canonical per-scan wide event** — `cli/utils/build-run-event.ts` (`recordRunEvent` + the pure, tested `buildRunEventAttributes`) stamps the full outcome onto the run's root span: scan config (mode, parallel/workers, rule-override counts, ignored tags, custom config), outcome (diagnostics by severity + `diag.category.*`, `distinctRulesFired`, `topRule`, score/label/availability, scanClean, skipped checks, lint/dead-code failure), CI/PR specifics (`actorAssociation`, `runnerOs`, forwarded action knobs, `wouldBlock` gate), and an `outcome`/`exitCode`/`errorTag` taxonomy. Emitted on success and, via a `try/catch` around the span body in `inspect.ts`, on the failure path. Numeric values stay numbers (so Sentry can `p75(score)`); dimensions stay strings/bools; `null` is dropped.
- **Run-tag lens** — `eventName` + `viaAction` added to the run context/tags so every existing event and counter is filterable by GitHub event and official-action.
- **scanId join** — `cli/utils/scan-id.ts` mints one random `scanId` per process; it rides the Sentry `run` context (never a tag/metric dimension) and is sent to the score API, so a crash/trace can be joined offline to the score backend's repo without putting repo/owner identity into Sentry.
- **CI detection + action** — `is-ci-environment.ts` gains the official-action marker, action-input env constants, `detectCiEventName`/`isPullRequestCiEvent`/`detectRunnerOs`; `action.yml` forwards the marker + `fail-on`/`non-blocking`/`comment`/`annotations`/`version` inputs.
- **Counters policy** — no new `ci.*` counters (those dimensions live on the wide event); `cli.invoked`/`cli.error` and the existing `scan.*` counters stay as the exact, sampling-independent floor.
- **Docs** — AGENTS.md documents the wide event, the numeric-vs-string typing rule, the scanId join, and how to query/build dashboards on the Spans dataset.

Privacy: all attributes pass through `scrubSentryEvent`; no repo, owner, username, branch, or path is sent to Sentry. `--no-score` / `--no-telemetry` still opts out.

## Eval results

RDE not run — this is a telemetry/observability change, not a lint rule, so there is nothing to eval against OSS repos.

## Test plan

- `nr test` (react-doctor) — focused new/updated suites green: `build-run-event` (6), `is-ci-environment`, `build-run-context`, `build-sentry-scope` (43 total). New test asserts `scanId` rides `contexts.run` but never `tags`.
- `nr typecheck` — passes (react-doctor + core + api).
- `nr lint` + `nr format:check` — clean on the changed files.
- Full suite has two pre-existing, environment-only failures unrelated to this change: the "Agent guidance" CLI test (fails because `CURSOR_AGENT` is set in the dev shell; passes 12/12 with it unset) and the expo `.env.local` gitignore test (the dev machine's global `~/.config/git/ignore` lists `.env.local`, so `git check-ignore` reports it ignored).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only wiring with scrubbing, opt-out unchanged, and unit tests for attribute shape; no change to scan or fail-on behavior beyond recording it.
> 
> **Overview**
> Adds **one anonymized “wide event” per scan** by stamping rich attributes on the existing Sentry run root span (`build-run-event.ts` → `recordRunEvent` / `buildRunEventAttributes`), emitted from `inspect.ts` after metrics on success and from the span `try/catch` when the scan throws.
> 
> The event carries **scan config** (mode, workers, rule overrides, flags), **outcome** (diagnostic counts, per-category `diag.category.*`, score, lint/dead-code state, `outcome` / `exitCode` / `wouldBlock` aligned with the real `ciFailure` gate and `scoreOnly` behavior), and **CI/action context** (`actorAssociation`, `runnerOs`, forwarded action knobs). Run-level **`eventName`** and **`viaAction`** tags are added via `build-run-context` / `build-sentry-scope`.
> 
> A memoized per-process **`runId`** rides `contexts.run` and the Score API payload but is **never** a Sentry tag or metric dimension. The official GitHub Action sets `REACT_DOCTOR_GITHUB_ACTION` and `REACT_DOCTOR_ACTION_*` env vars; `is-ci-environment.ts` reads them. Existing counters are unchanged; AGENTS.md and a changeset document querying spans instead of new `ci.*` counters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1154947a9fb45f5e50aaaf362ac8118071ce0dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->