### PR TITLE
Fix Reanimated layout animation false positive

### DIFF
--- a/.changeset/retire-reanimated-layout-rule.md
+++ b/.changeset/retire-reanimated-layout-rule.md
@@ -3,6 +3,6 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-React Doctor no longer reports `rn-animate-layout-property` for React Native Reanimated `useAnimatedStyle` layout styles.
+React Doctor narrows `rn-animate-layout-property` for React Native Reanimated `useAnimatedStyle` layout styles.
 
-The rule is now a retired compatibility stub: existing configs can still resolve the rule id, but it is default-off and emits no diagnostics. Reanimated supports animating layout-affecting styles on its animated style pipeline; while transform/opacity can still be preferable for purely visual movement, blanket-reporting every `width`, `height`, `padding`, or margin update as a bug produced false positives for valid UI-thread animations such as keyboard-driven layouts.
+The rule now reports only when a layout-affecting style is locally driven by Reanimated animation helpers such as `withTiming` or `withSpring`. It no longer blanket-reports `interpolate(...)`, shared-value reads, or other valid UI-thread layout updates such as keyboard-driven layouts.

--- a/.changeset/retire-reanimated-layout-rule.md
+++ b/.changeset/retire-reanimated-layout-rule.md
@@ -5,4 +5,4 @@
 
 React Doctor no longer reports `rn-animate-layout-property` for React Native Reanimated `useAnimatedStyle` layout styles.
 
-Reanimated supports animating layout-affecting styles on its animated style pipeline; while transform/opacity can still be preferable for purely visual movement, blanket-reporting every `width`, `height`, `padding`, or margin update as a bug produced false positives for valid UI-thread animations such as keyboard-driven layouts.
+The rule is now a retired compatibility stub: existing configs can still resolve the rule id, but it is default-off and emits no diagnostics. Reanimated supports animating layout-affecting styles on its animated style pipeline; while transform/opacity can still be preferable for purely visual movement, blanket-reporting every `width`, `height`, `padding`, or margin update as a bug produced false positives for valid UI-thread animations such as keyboard-driven layouts.

--- a/.changeset/retire-reanimated-layout-rule.md
+++ b/.changeset/retire-reanimated-layout-rule.md
@@ -1,0 +1,8 @@
+---
+"react-doctor": patch
+"oxlint-plugin-react-doctor": patch
+---
+
+React Doctor no longer reports `rn-animate-layout-property` for React Native Reanimated `useAnimatedStyle` layout styles.
+
+Reanimated supports animating layout-affecting styles on its animated style pipeline; while transform/opacity can still be preferable for purely visual movement, blanket-reporting every `width`, `height`, `padding`, or margin update as a bug produced false positives for valid UI-thread animations such as keyboard-driven layouts.

--- a/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
+++ b/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
@@ -83,6 +83,11 @@ const RULE_IDS_TO_SKIP_REGISTRATION = new Set([
   // reference. Implementation + regression suite + fixture lines kept
   // in place; remove this entry to re-enable.
   "react-compiler-destructure-method",
+  // Reanimated supports animating layout-affecting styles through
+  // `useAnimatedStyle`; they can be slower than transform/opacity, but
+  // blanket-reporting them as Bugs produced false positives for valid
+  // UI-thread animations such as keyboard-driven layout changes.
+  "rn-animate-layout-property",
 ]);
 
 // Fine-grained category → the clear, user-facing bucket the scan output

--- a/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
+++ b/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
@@ -83,11 +83,6 @@ const RULE_IDS_TO_SKIP_REGISTRATION = new Set([
   // reference. Implementation + regression suite + fixture lines kept
   // in place; remove this entry to re-enable.
   "react-compiler-destructure-method",
-  // Reanimated supports animating layout-affecting styles through
-  // `useAnimatedStyle`; they can be slower than transform/opacity, but
-  // blanket-reporting them as Bugs produced false positives for valid
-  // UI-thread animations such as keyboard-driven layout changes.
-  "rn-animate-layout-property",
 ]);
 
 // Fine-grained category → the clear, user-facing bucket the scan output

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vite-plus/test";
 import { ALL_REACT_DOCTOR_RULE_KEYS, REACT_NATIVE_RULES } from "../rules.js";
 import { ruleRegistry } from "./rule-registry.js";
 
-const RETIRED_REANIMATED_LAYOUT_RULE_ID = "rn-animate-layout-property";
-const RETIRED_REANIMATED_LAYOUT_RULE_KEY = "react-doctor/rn-animate-layout-property";
+const REANIMATED_LAYOUT_RULE_ID = "rn-animate-layout-property";
+const REANIMATED_LAYOUT_RULE_KEY = "react-doctor/rn-animate-layout-property";
 
 describe("rule registry", () => {
-  it("keeps the retired Reanimated layout-property rule resolvable but default-off", () => {
-    expect(ruleRegistry[RETIRED_REANIMATED_LAYOUT_RULE_ID]?.lifecycle).toBe("retired");
-    expect(ruleRegistry[RETIRED_REANIMATED_LAYOUT_RULE_ID]?.defaultEnabled).toBe(false);
-    expect(ALL_REACT_DOCTOR_RULE_KEYS.has(RETIRED_REANIMATED_LAYOUT_RULE_KEY)).toBe(true);
-    expect(REACT_NATIVE_RULES[RETIRED_REANIMATED_LAYOUT_RULE_KEY]).toBeUndefined();
+  it("keeps the narrowed Reanimated layout-property rule enabled for React Native", () => {
+    expect(ruleRegistry[REANIMATED_LAYOUT_RULE_ID]?.lifecycle).toBeUndefined();
+    expect(ruleRegistry[REANIMATED_LAYOUT_RULE_ID]?.defaultEnabled).toBeUndefined();
+    expect(ALL_REACT_DOCTOR_RULE_KEYS.has(REANIMATED_LAYOUT_RULE_KEY)).toBe(true);
+    expect(REACT_NATIVE_RULES[REANIMATED_LAYOUT_RULE_KEY]).toBe("warn");
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vite-plus/test";
 import { ALL_REACT_DOCTOR_RULE_KEYS, REACT_NATIVE_RULES } from "../rules.js";
 import { ruleRegistry } from "./rule-registry.js";
 
+const RETIRED_REANIMATED_LAYOUT_RULE_ID = "rn-animate-layout-property";
 const RETIRED_REANIMATED_LAYOUT_RULE_KEY = "react-doctor/rn-animate-layout-property";
 
 describe("rule registry", () => {
-  it("does not register the retired Reanimated layout-property rule", () => {
-    expect(ruleRegistry[RETIRED_REANIMATED_LAYOUT_RULE_KEY]).toBeUndefined();
-    expect(ALL_REACT_DOCTOR_RULE_KEYS.has(RETIRED_REANIMATED_LAYOUT_RULE_KEY)).toBe(false);
+  it("keeps the retired Reanimated layout-property rule resolvable but default-off", () => {
+    expect(ruleRegistry[RETIRED_REANIMATED_LAYOUT_RULE_ID]?.lifecycle).toBe("retired");
+    expect(ruleRegistry[RETIRED_REANIMATED_LAYOUT_RULE_ID]?.defaultEnabled).toBe(false);
+    expect(ALL_REACT_DOCTOR_RULE_KEYS.has(RETIRED_REANIMATED_LAYOUT_RULE_KEY)).toBe(true);
     expect(REACT_NATIVE_RULES[RETIRED_REANIMATED_LAYOUT_RULE_KEY]).toBeUndefined();
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vite-plus/test";
+import { ALL_REACT_DOCTOR_RULE_KEYS, REACT_NATIVE_RULES } from "../rules.js";
+import { ruleRegistry } from "./rule-registry.js";
+
+const RETIRED_REANIMATED_LAYOUT_RULE_KEY = "react-doctor/rn-animate-layout-property";
+
+describe("rule registry", () => {
+  it("does not register the retired Reanimated layout-property rule", () => {
+    expect(ruleRegistry[RETIRED_REANIMATED_LAYOUT_RULE_KEY]).toBeUndefined();
+    expect(ALL_REACT_DOCTOR_RULE_KEYS.has(RETIRED_REANIMATED_LAYOUT_RULE_KEY)).toBe(false);
+    expect(REACT_NATIVE_RULES[RETIRED_REANIMATED_LAYOUT_RULE_KEY]).toBeUndefined();
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -3185,7 +3185,7 @@ export const reactDoctorRules = [
     rule: {
       ...rnAnimateLayoutProperty,
       framework: "react-native",
-      category: "Bugs",
+      category: "Performance",
       tags: [...new Set(["react-native", ...(rnAnimateLayoutProperty.tags ?? [])])],
     },
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -3185,7 +3185,7 @@ export const reactDoctorRules = [
     rule: {
       ...rnAnimateLayoutProperty,
       framework: "react-native",
-      category: "Performance",
+      category: "Bugs",
       tags: [...new Set(["react-native", ...(rnAnimateLayoutProperty.tags ?? [])])],
     },
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -266,7 +266,6 @@ import { rerenderMemoBeforeEarlyReturn } from "./rules/performance/rerender-memo
 import { rerenderMemoWithDefaultValue } from "./rules/performance/rerender-memo-with-default-value.js";
 import { rerenderStateOnlyInHandlers } from "./rules/state-and-effects/rerender-state-only-in-handlers.js";
 import { rerenderTransitionsScroll } from "./rules/performance/rerender-transitions-scroll.js";
-import { rnAnimateLayoutProperty } from "./rules/react-native/rn-animate-layout-property.js";
 import { rnAnimationReactionAsDerived } from "./rules/react-native/rn-animation-reaction-as-derived.js";
 import { rnBottomSheetPreferNative } from "./rules/react-native/rn-bottom-sheet-prefer-native.js";
 import { rnDetoxMissingAwait } from "./rules/react-native/rn-detox-missing-await.js";
@@ -3175,18 +3174,6 @@ export const reactDoctorRules = [
       ...rerenderTransitionsScroll,
       framework: "global",
       category: "Performance",
-    },
-  },
-  {
-    key: "react-doctor/rn-animate-layout-property",
-    id: "rn-animate-layout-property",
-    source: "react-doctor",
-    originallyExternal: false,
-    rule: {
-      ...rnAnimateLayoutProperty,
-      framework: "react-native",
-      category: "Bugs",
-      tags: [...new Set(["react-native", ...(rnAnimateLayoutProperty.tags ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -266,6 +266,7 @@ import { rerenderMemoBeforeEarlyReturn } from "./rules/performance/rerender-memo
 import { rerenderMemoWithDefaultValue } from "./rules/performance/rerender-memo-with-default-value.js";
 import { rerenderStateOnlyInHandlers } from "./rules/state-and-effects/rerender-state-only-in-handlers.js";
 import { rerenderTransitionsScroll } from "./rules/performance/rerender-transitions-scroll.js";
+import { rnAnimateLayoutProperty } from "./rules/react-native/rn-animate-layout-property.js";
 import { rnAnimationReactionAsDerived } from "./rules/react-native/rn-animation-reaction-as-derived.js";
 import { rnBottomSheetPreferNative } from "./rules/react-native/rn-bottom-sheet-prefer-native.js";
 import { rnDetoxMissingAwait } from "./rules/react-native/rn-detox-missing-await.js";
@@ -3174,6 +3175,18 @@ export const reactDoctorRules = [
       ...rerenderTransitionsScroll,
       framework: "global",
       category: "Performance",
+    },
+  },
+  {
+    key: "react-doctor/rn-animate-layout-property",
+    id: "rn-animate-layout-property",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...rnAnimateLayoutProperty,
+      framework: "react-native",
+      category: "Performance",
+      tags: [...new Set(["react-native", ...(rnAnimateLayoutProperty.tags ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.test.ts
@@ -3,7 +3,62 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { rnAnimateLayoutProperty } from "./rn-animate-layout-property.js";
 
 describe("rn-animate-layout-property", () => {
-  it("does not flag legacy Reanimated layout-style false positives", () => {
+  it("flags layout properties driven directly by Reanimated animation helpers", () => {
+    const code = `
+      import Animated, { useAnimatedStyle, withTiming } from "react-native-reanimated";
+
+      const Panel = ({ isOpen }) => {
+        const animatedLayoutStyle = useAnimatedStyle(() => ({
+          height: withTiming(isOpen ? 240 : 0),
+        }));
+
+        return <Animated.View style={animatedLayoutStyle} />;
+      };
+    `;
+
+    const result = runRule(rnAnimateLayoutProperty, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain('"height"');
+  });
+
+  it("flags aliased Reanimated animation helpers", () => {
+    const code = `
+      import Animated, { useAnimatedStyle, withSpring as spring } from "react-native-reanimated";
+
+      const Panel = ({ targetWidth }) => {
+        const animatedLayoutStyle = useAnimatedStyle(() => ({
+          width: spring(targetWidth),
+        }));
+
+        return <Animated.View style={animatedLayoutStyle} />;
+      };
+    `;
+
+    const result = runRule(rnAnimateLayoutProperty, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags namespace Reanimated animation helpers", () => {
+    const code = `
+      import * as Reanimated from "react-native-reanimated";
+
+      const Panel = ({ targetWidth }) => {
+        const animatedLayoutStyle = Reanimated.useAnimatedStyle(() => ({
+          "width": Reanimated.withTiming(targetWidth),
+        }));
+
+        return <Reanimated.View style={animatedLayoutStyle} />;
+      };
+    `;
+
+    const result = runRule(rnAnimateLayoutProperty, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag Reanimated interpolate-driven layout styles", () => {
     const code = `
       import Animated, { interpolate, useAnimatedStyle, useSharedValue } from "react-native-reanimated";
 
@@ -23,5 +78,83 @@ describe("rn-animate-layout-property", () => {
     const result = runRule(rnAnimateLayoutProperty, code);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag shared-value layout styles without an animation helper", () => {
+    const code = `
+      import Animated, { useAnimatedStyle, useSharedValue } from "react-native-reanimated";
+
+      const Panel = () => {
+        const height = useSharedValue(100);
+        const animatedLayoutStyle = useAnimatedStyle(() => ({
+          height: height.value,
+        }));
+
+        return <Animated.View style={animatedLayoutStyle} />;
+      };
+    `;
+
+    const result = runRule(rnAnimateLayoutProperty, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag non-layout styles driven by animation helpers", () => {
+    const code = `
+      import Animated, { useAnimatedStyle, withTiming } from "react-native-reanimated";
+
+      const Panel = ({ isOpen }) => {
+        const animatedStyle = useAnimatedStyle(() => ({
+          opacity: withTiming(isOpen ? 1 : 0),
+          transform: [{ scale: withTiming(isOpen ? 1 : 0.95) }],
+        }));
+
+        return <Animated.View style={animatedStyle} />;
+      };
+    `;
+
+    const result = runRule(rnAnimateLayoutProperty, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag local functions with Reanimated-like names", () => {
+    const code = `
+      const useAnimatedStyle = (callback) => callback();
+      const withTiming = (value) => value;
+
+      const Panel = ({ targetHeight }) => {
+        const animatedLayoutStyle = useAnimatedStyle(() => ({
+          height: withTiming(targetHeight),
+        }));
+
+        return <View style={animatedLayoutStyle} />;
+      };
+    `;
+
+    const result = runRule(rnAnimateLayoutProperty, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag shadowed animation helper names", () => {
+    const code = `
+      import Animated, { useAnimatedStyle, withTiming as reanimatedTiming } from "react-native-reanimated";
+
+      const Panel = ({ targetHeight }) => {
+        const withTiming = (value) => value;
+        const animatedLayoutStyle = useAnimatedStyle(() => ({
+          height: withTiming(targetHeight),
+          marginTop: reanimatedTiming(8),
+        }));
+
+        return <Animated.View style={animatedLayoutStyle} />;
+      };
+    `;
+
+    const result = runRule(rnAnimateLayoutProperty, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain('"marginTop"');
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rnAnimateLayoutProperty } from "./rn-animate-layout-property.js";
+
+describe("rn-animate-layout-property", () => {
+  it("does not flag Reanimated keyboard-driven layout styles", () => {
+    const code = `
+      import { useKeyboardHandler } from "react-native-keyboard-controller";
+      import Animated, { interpolate, useAnimatedStyle, useSharedValue } from "react-native-reanimated";
+
+      const LoginScreen = () => {
+        const progress = useSharedValue(0);
+
+        useKeyboardHandler(
+          {
+            onMove: (event) => {
+              "worklet";
+              progress.set(event.progress);
+            },
+          },
+          [],
+        );
+
+        const headerOuterStyle = useAnimatedStyle(() => ({
+          paddingBottom: interpolate(progress.value, [0, 1], [42, 16]),
+        }));
+
+        const iconContainerStyle = useAnimatedStyle(() => ({
+          width: interpolate(progress.value, [0, 1], [70, 44]),
+          height: interpolate(progress.value, [0, 1], [70, 44]),
+          borderRadius: interpolate(progress.value, [0, 1], [24, 12]),
+          marginBottom: interpolate(progress.value, [0, 1], [14, 0]),
+          marginRight: interpolate(progress.value, [0, 1], [0, 12]),
+        }));
+
+        return <Animated.View style={[headerOuterStyle, iconContainerStyle]} />;
+      };
+    `;
+
+    const result = runRule(rnAnimateLayoutProperty, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.test.ts
@@ -3,37 +3,20 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { rnAnimateLayoutProperty } from "./rn-animate-layout-property.js";
 
 describe("rn-animate-layout-property", () => {
-  it("does not flag Reanimated keyboard-driven layout styles", () => {
+  it("does not flag legacy Reanimated layout-style false positives", () => {
     const code = `
-      import { useKeyboardHandler } from "react-native-keyboard-controller";
       import Animated, { interpolate, useAnimatedStyle, useSharedValue } from "react-native-reanimated";
 
       const LoginScreen = () => {
         const progress = useSharedValue(0);
 
-        useKeyboardHandler(
-          {
-            onMove: (event) => {
-              "worklet";
-              progress.set(event.progress);
-            },
-          },
-          [],
-        );
-
-        const headerOuterStyle = useAnimatedStyle(() => ({
+        const animatedLayoutStyle = useAnimatedStyle(() => ({
           paddingBottom: interpolate(progress.value, [0, 1], [42, 16]),
-        }));
-
-        const iconContainerStyle = useAnimatedStyle(() => ({
           width: interpolate(progress.value, [0, 1], [70, 44]),
           height: interpolate(progress.value, [0, 1], [70, 44]),
-          borderRadius: interpolate(progress.value, [0, 1], [24, 12]),
-          marginBottom: interpolate(progress.value, [0, 1], [14, 0]),
-          marginRight: interpolate(progress.value, [0, 1], [0, 12]),
         }));
 
-        return <Animated.View style={[headerOuterStyle, iconContainerStyle]} />;
+        return <Animated.View style={animatedLayoutStyle} />;
       };
     `;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
@@ -1,11 +1,206 @@
-import { defineRetiredRule } from "../../utils/define-retired-rule.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
 
-export const rnAnimateLayoutProperty = defineRetiredRule({
+const REANIMATED_MODULE = "react-native-reanimated";
+
+const REANIMATED_LAYOUT_STYLE_PROPERTIES = new Set([
+  "width",
+  "height",
+  "top",
+  "left",
+  "right",
+  "bottom",
+  "minWidth",
+  "minHeight",
+  "maxWidth",
+  "maxHeight",
+  "margin",
+  "marginTop",
+  "marginBottom",
+  "marginLeft",
+  "marginRight",
+  "marginHorizontal",
+  "marginVertical",
+  "padding",
+  "paddingTop",
+  "paddingBottom",
+  "paddingLeft",
+  "paddingRight",
+  "paddingHorizontal",
+  "paddingVertical",
+  "flex",
+  "flexBasis",
+  "flexGrow",
+  "flexShrink",
+  "borderWidth",
+  "borderTopWidth",
+  "borderBottomWidth",
+  "borderLeftWidth",
+  "borderRightWidth",
+  "fontSize",
+  "lineHeight",
+  "letterSpacing",
+]);
+
+const REANIMATED_ANIMATION_HELPERS = new Set([
+  "withTiming",
+  "withSpring",
+  "withDecay",
+  "withDelay",
+  "withRepeat",
+  "withSequence",
+  "withClamp",
+]);
+
+const findImportDeclaration = (
+  symbol: SymbolDescriptor,
+): EsTreeNodeOfType<"ImportDeclaration"> | null => {
+  let currentNode: EsTreeNode | null | undefined = symbol.declarationNode.parent;
+  while (currentNode && !isNodeOfType(currentNode, "ImportDeclaration")) {
+    currentNode = currentNode.parent ?? null;
+  }
+  return currentNode && isNodeOfType(currentNode, "ImportDeclaration") ? currentNode : null;
+};
+
+const isReanimatedImport = (symbol: SymbolDescriptor): boolean => {
+  const importDeclaration = findImportDeclaration(symbol);
+  if (!importDeclaration) return false;
+  return importDeclaration.source.value === REANIMATED_MODULE;
+};
+
+const getReanimatedNamedImport = (node: EsTreeNode, context: RuleContext): string | null => {
+  if (!isNodeOfType(node, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(node);
+  if (!symbol || symbol.kind !== "import") return null;
+  if (!isReanimatedImport(symbol)) return null;
+  const declarationNode = symbol.declarationNode;
+  if (!isNodeOfType(declarationNode, "ImportSpecifier")) return null;
+  const importedName = declarationNode.imported;
+  if (isNodeOfType(importedName, "Identifier")) return importedName.name;
+  if (isNodeOfType(importedName, "Literal") && typeof importedName.value === "string") {
+    return importedName.value;
+  }
+  return null;
+};
+
+const isReanimatedNamespace = (node: EsTreeNode, context: RuleContext): boolean => {
+  if (!isNodeOfType(node, "Identifier")) return false;
+  const symbol = context.scopes.symbolFor(node);
+  if (!symbol || symbol.kind !== "import") return false;
+  if (!isReanimatedImport(symbol)) return false;
+  return isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier");
+};
+
+const isUseAnimatedStyleCallee = (callee: EsTreeNode, context: RuleContext): boolean => {
+  if (isNodeOfType(callee, "Identifier")) {
+    return getReanimatedNamedImport(callee, context) === "useAnimatedStyle";
+  }
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  if (callee.property.name !== "useAnimatedStyle") return false;
+  return isReanimatedNamespace(callee.object, context);
+};
+
+const isReanimatedAnimationHelperCallee = (callee: EsTreeNode, context: RuleContext): boolean => {
+  if (isNodeOfType(callee, "Identifier")) {
+    const importedName = getReanimatedNamedImport(callee, context);
+    return importedName !== null && REANIMATED_ANIMATION_HELPERS.has(importedName);
+  }
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  if (!REANIMATED_ANIMATION_HELPERS.has(callee.property.name)) return false;
+  return isReanimatedNamespace(callee.object, context);
+};
+
+const isFunctionLike = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "ArrowFunctionExpression") ||
+  isNodeOfType(node, "FunctionExpression") ||
+  isNodeOfType(node, "FunctionDeclaration");
+
+const containsReanimatedAnimationHelperCall = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const rootExpression = stripParenExpression(expression);
+  let didFindAnimationHelper = false;
+  walkAst(rootExpression, (node) => {
+    if (didFindAnimationHelper) return false;
+    if (node !== rootExpression && isFunctionLike(node)) return false;
+    if (
+      isNodeOfType(node, "CallExpression") &&
+      isReanimatedAnimationHelperCallee(node.callee, context)
+    ) {
+      didFindAnimationHelper = true;
+      return false;
+    }
+  });
+  return didFindAnimationHelper;
+};
+
+const findReturnedObject = (callback: EsTreeNode): EsTreeNodeOfType<"ObjectExpression"> | null => {
+  if (
+    !isNodeOfType(callback, "ArrowFunctionExpression") &&
+    !isNodeOfType(callback, "FunctionExpression")
+  ) {
+    return null;
+  }
+  const body = stripParenExpression(callback.body);
+  if (isNodeOfType(body, "ObjectExpression")) return body;
+  if (!isNodeOfType(body, "BlockStatement")) return null;
+  for (const statement of body.body ?? []) {
+    if (!isNodeOfType(statement, "ReturnStatement")) continue;
+    if (!statement.argument) continue;
+    const returnArgument = stripParenExpression(statement.argument);
+    if (isNodeOfType(returnArgument, "ObjectExpression")) return returnArgument;
+  }
+  return null;
+};
+
+const getStaticPropertyName = (property: EsTreeNodeOfType<"Property">): string | null => {
+  if (!property.computed && isNodeOfType(property.key, "Identifier")) return property.key.name;
+  if (isNodeOfType(property.key, "Literal") && typeof property.key.value === "string") {
+    return property.key.value;
+  }
+  return null;
+};
+
+export const rnAnimateLayoutProperty = defineRule<Rule>({
   id: "rn-animate-layout-property",
   title: "Animating a layout property",
   tags: ["test-noise"],
   requires: ["react-native"],
   severity: "warn",
+  category: "Performance",
   recommendation:
-    "This retired rule no longer reports Reanimated layout styles. Reanimated supports animating layout-affecting styles; prefer transform or opacity for purely visual motion when that preserves the intended layout.",
+    "Prefer transform or opacity when a Reanimated animation helper drives purely visual motion; use layout-affecting styles only when the layout itself must change.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isUseAnimatedStyleCallee(node.callee, context)) return;
+      const callback = node.arguments?.[0];
+      if (!callback) return;
+      const returnedObject = findReturnedObject(callback);
+      if (!returnedObject) return;
+
+      for (const property of returnedObject.properties ?? []) {
+        if (!isNodeOfType(property, "Property")) continue;
+        const propertyName = getStaticPropertyName(property);
+        if (propertyName === null) continue;
+        if (!REANIMATED_LAYOUT_STYLE_PROPERTIES.has(propertyName)) continue;
+        const propertyValue = property.value;
+        if (!containsReanimatedAnimationHelperCall(propertyValue, context)) continue;
+
+        context.report({
+          node: property,
+          message: `Reanimated can animate "${propertyName}", but this layout-affecting style recalculates layout while the animation runs; prefer transform or opacity when the motion is only visual.`,
+        });
+      }
+    },
+  }),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
@@ -1,100 +1,13 @@
-import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { defineRetiredRule } from "../../utils/define-retired-rule.js";
 import type { Rule } from "../../utils/rule.js";
-import type { RuleContext } from "../../utils/rule-context.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const REANIMATED_LAYOUT_KEYS = new Set([
-  "width",
-  "height",
-  "top",
-  "left",
-  "right",
-  "bottom",
-  "minWidth",
-  "minHeight",
-  "maxWidth",
-  "maxHeight",
-  "margin",
-  "marginTop",
-  "marginBottom",
-  "marginLeft",
-  "marginRight",
-  "marginHorizontal",
-  "marginVertical",
-  "padding",
-  "paddingTop",
-  "paddingBottom",
-  "paddingLeft",
-  "paddingRight",
-  "paddingHorizontal",
-  "paddingVertical",
-  "flex",
-  "flexBasis",
-  "flexGrow",
-  "flexShrink",
-  "borderWidth",
-  "borderTopWidth",
-  "borderBottomWidth",
-  "borderLeftWidth",
-  "borderRightWidth",
-  "fontSize",
-  "lineHeight",
-  "letterSpacing",
-]);
-
-const findReturnedObject = (callback: EsTreeNode): EsTreeNodeOfType<"ObjectExpression"> | null => {
-  if (
-    !isNodeOfType(callback, "ArrowFunctionExpression") &&
-    !isNodeOfType(callback, "FunctionExpression")
-  ) {
-    return null;
-  }
-  const body = callback.body;
-  if (isNodeOfType(body, "ObjectExpression")) return body;
-  if (!isNodeOfType(body, "BlockStatement")) return null;
-  for (const stmt of body.body ?? []) {
-    if (isNodeOfType(stmt, "ReturnStatement") && isNodeOfType(stmt.argument, "ObjectExpression")) {
-      return stmt.argument;
-    }
-  }
-  return null;
-};
-
-// HACK: in Reanimated, `useAnimatedStyle(() => ({ height: …, width: … }))`
-// runs the animation on the JS layout thread (or worse, triggers actual
-// layout passes per frame). transform / opacity stay on the GPU
-// compositor. For anything driven by `withTiming` / `withSpring` /
-// shared values, animate `transform: [{ translateX/Y }, { scale }]` or
-// `opacity` instead.
-export const rnAnimateLayoutProperty = defineRule<Rule>({
+export const rnAnimateLayoutProperty = defineRetiredRule({
   id: "rn-animate-layout-property",
   title: "Animating a layout property",
   tags: ["test-noise"],
   requires: ["react-native"],
-  severity: "error",
+  severity: "warn",
+  category: "Performance",
   recommendation:
-    "Animating size or position props runs on the JS thread and can stutter. Animate `transform: [{ translateX/Y }, { scale }]` or `opacity` instead, which run on the GPU.",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "useAnimatedStyle")
-        return;
-      const callback = node.arguments?.[0];
-      if (!callback) return;
-      const returnedObject = findReturnedObject(callback);
-      if (!returnedObject) return;
-
-      for (const property of returnedObject.properties ?? []) {
-        if (!isNodeOfType(property, "Property")) continue;
-        if (!isNodeOfType(property.key, "Identifier")) continue;
-        if (!REANIMATED_LAYOUT_KEYS.has(property.key.name)) continue;
-
-        context.report({
-          node: property,
-          message: `Your users see stutter when useAnimatedStyle animates "${property.key.name}" on the layout thread.`,
-        });
-      }
-    },
-  }),
-});
+    "This retired rule no longer reports Reanimated layout styles. Reanimated supports animating layout-affecting styles; prefer transform or opacity for purely visual motion when that preserves the intended layout.",
+} satisfies Omit<Rule, "create" | "defaultEnabled" | "lifecycle">);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animate-layout-property.ts
@@ -1,5 +1,4 @@
 import { defineRetiredRule } from "../../utils/define-retired-rule.js";
-import type { Rule } from "../../utils/rule.js";
 
 export const rnAnimateLayoutProperty = defineRetiredRule({
   id: "rn-animate-layout-property",
@@ -7,7 +6,6 @@ export const rnAnimateLayoutProperty = defineRetiredRule({
   tags: ["test-noise"],
   requires: ["react-native"],
   severity: "warn",
-  category: "Performance",
   recommendation:
     "This retired rule no longer reports Reanimated layout styles. Reanimated supports animating layout-affecting styles; prefer transform or opacity for purely visual motion when that preserves the intended layout.",
-} satisfies Omit<Rule, "create" | "defaultEnabled" | "lifecycle">);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- narrow `rn-animate-layout-property` instead of retiring it outright
- report only when a layout-affecting style returned from Reanimated `useAnimatedStyle` is locally driven by Reanimated animation helpers such as `withTiming`, `withSpring`, `withRepeat`, or `withSequence`
- keep valid UI-thread layout updates quiet, including `interpolate(...)`, shared-value reads, static values, non-layout transform/opacity animations, local helper name collisions, and shadowed Reanimated-like names
- make the rule a Performance warning and keep it enabled for React Native projects
- add focused regressions for positive, alias, namespace, and false-positive cases

## Testing
- `pnpm --filter oxlint-plugin-react-doctor exec vp test run src/plugin/rules/react-native/rn-animate-layout-property.test.ts src/plugin/rule-registry.test.ts`
- `pnpm --filter oxlint-plugin-react-doctor run gen:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm build`
- `pnpm smoke:json-report`

## Notes
- The required `truffler` dedupe search could not run in this image because the installed `truffler` binary executes `bun`, and `bun` is not available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa47b13c-3dbc-4ed1-a0e9-012f02cdf86b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa47b13c-3dbc-4ed1-a0e9-012f02cdf86b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

