### PR TITLE
Fix React Compiler context provider value false positive #664

### DIFF
--- a/.changeset/react-compiler-context-provider-value.md
+++ b/.changeset/react-compiler-context-provider-value.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+React Compiler projects no longer report `jsx-no-constructed-context-values` for fresh context provider values that the compiler memoizes automatically.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-constructed-context-values.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-constructed-context-values.ts
@@ -137,6 +137,7 @@ export const jsxNoConstructedContextValues = defineRule<Rule>({
   title: "Unstable context provider value",
   tags: ["react-jsx-only"],
   severity: "warn",
+  disabledBy: ["react-compiler"],
   recommendation: "Wrap the context value in `useMemo`, or move it outside the component.",
   category: "Performance",
   create: (context) => {

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -542,10 +542,9 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
     }
   });
 
-  // The four `jsx-no-new-*-as-prop` perf rules guard against a footgun
-  // (new array/object/function/JSX as a prop breaks downstream
-  // `React.memo`) that React Compiler auto-fixes at compile time. When
-  // RC is in scope they're unactionable noise, so they ship with
+  // These perf rules guard against fresh allocations that React Compiler
+  // auto-fixes at compile time. When RC is in scope they're unactionable
+  // noise, so they ship with
   // `disabledBy: ["react-compiler"]` and the gate must drop them.
   it("disables react-compiler-redundant perf rules when React Compiler is detected", () => {
     const reactCompilerGatedRules = [
@@ -553,6 +552,7 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
       "react-doctor/jsx-no-new-array-as-prop",
       "react-doctor/jsx-no-new-function-as-prop",
       "react-doctor/jsx-no-jsx-as-prop",
+      "react-doctor/jsx-no-constructed-context-values",
     ];
 
     const withoutCompiler = createOxlintConfig({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Disable `jsx-no-constructed-context-values` when React Compiler is detected, matching the existing compiler-redundant allocation rule gates.
- Extend the scan-resilience regression to assert the context provider rule is dropped for compiler-enabled projects.
- Add a patch changeset for the published behavior fix.

Fixes #664.

## Verification
- `npx -y -p @antfu/ni nr test tests/regressions/scan-resilience.test.ts` (from `packages/react-doctor`)
- `npx -y -p @antfu/ni nr test`
- `npx -y -p @antfu/ni nr lint`
- `npx -y -p @antfu/ni nr typecheck`
- `npx -y -p @antfu/ni nr format:check`
- `npx -y -p @antfu/ni nr smoke:json-report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-632998d9-5c85-4961-98f2-966a5290247f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-632998d9-5c85-4961-98f2-966a5290247f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

