### PR TITLE
chore: bump deslop-js

### DIFF
--- a/.changeset/bump-deslop-js.md
+++ b/.changeset/bump-deslop-js.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Update the dead-code analysis engine (`deslop-js`) to `0.0.16`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@effect/platform-node-shared": "4.0.0-beta.70",
     "confbox": "^0.2.4",
-    "deslop-js": "^0.0.15",
+    "deslop-js": "^0.0.16",
     "effect": "4.0.0-beta.70",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -61,7 +61,7 @@
     "agent-install": "0.0.5",
     "conf": "^15.1.0",
     "confbox": "^0.2.4",
-    "deslop-js": "^0.0.15",
+    "deslop-js": "^0.0.16",
     "effect": "4.0.0-beta.70",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^0.2.4
         version: 0.2.4
       deslop-js:
-        specifier: ^0.0.15
-        version: 0.0.15(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.0.16
+        version: 0.0.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
@@ -152,8 +152,8 @@ importers:
         specifier: ^0.2.4
         version: 0.2.4
       deslop-js:
-        specifier: ^0.0.15
-        version: 0.0.15(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.0.16
+        version: 0.0.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
@@ -2303,8 +2303,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deslop-js@0.0.15:
-    resolution: {integrity: sha512-TWEjcGTxsGgSaxY0JB68sDucuCUrGADQ5SbW0cFfZZQjqzZ9pkN36xq3adujim0AkkvGHDUa6Wy6rlLY43G0nA==}
+  deslop-js@0.0.16:
+    resolution: {integrity: sha512-S8jh7CKRLCOVefBwcdBYZnYxZyuP6W6f5dgyEyNGB4EnAVAH6TTbnBzXS/1ZbxFJRUjRWd9FlQAW6vMc8SywQg==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -5045,7 +5045,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deslop-js@0.0.15(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  deslop-js@0.0.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `deslop-js` from `^0.0.15` to `^0.0.16` in `@react-doctor/core` and `react-doctor`.
- Refresh `pnpm-lock.yaml` to resolve `deslop-js@0.0.16`.
- Add a patch changeset for the published CLI package.

## Verification
- `nr format:check`
- `nr typecheck`
- `nr lint`
- `nr test`
- `nr smoke:json-report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b76a0a5-efed-4bb3-9877-f6ad72cc7670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b76a0a5-efed-4bb3-9877-f6ad72cc7670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

