### PR TITLE
fix(rules): disable prefer-module-scope-static-value under React Compiler

### DIFF
--- a/.changeset/static-value-react-compiler.md
+++ b/.changeset/static-value-react-compiler.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+`prefer-module-scope-static-value` ("Static value rebuilt every render") is now disabled when React Compiler is enabled.
+
+React Compiler already hoists and caches per-render array/object allocations, so both halves of the recommendation — avoid the re-allocation and preserve referential equality for memoized children — are handled automatically, making the warning pure noise on a compiler-enabled codebase (#669). The rule now carries `disabledBy: ["react-compiler"]`, matching the `jsx-no-new-*-as-prop` rules that gate on the same capability.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
@@ -194,6 +194,13 @@ export const preferModuleScopeStaticValue = defineRule<Rule>({
   tags: ["test-noise"],
   severity: "warn",
   category: "Architecture",
+  // React Compiler hoists/caches these per-render allocations itself, so
+  // both halves of the recommendation (avoid the re-allocation, preserve
+  // referential equality for memoized children) are already handled — the
+  // warning is pure noise on a compiler-enabled codebase. Mirrors the
+  // `jsx-no-new-*-as-prop` rules, which gate on the same capability for
+  // the same referential-equality reason.
+  disabledBy: ["react-compiler"],
   recommendation:
     "Move the value above the component, at the top of the file. It doesn't use local state, so rebuilding it each update is wasted and makes it look new every time.",
   create: (context: RuleContext) => ({


### PR DESCRIPTION
## Summary

Fixes #669.

`prefer-module-scope-static-value` ("Static value rebuilt every render") fired on array/object literals declared inside a component even on React Compiler-enabled projects. React Compiler already hoists and caches those per-render allocations, so both halves of the recommendation — avoid the re-allocation and preserve referential equality for memoized children — are handled automatically. The warning is pure noise there (hundreds of low-priority hits on a compiler codebase).

The rule now carries `disabledBy: ["react-compiler"]`, matching the existing `jsx-no-new-*-as-prop` rules that gate on the same capability for the same referential-equality reason.

## Test plan

- [ ] `prefer-module-scope-static-value` still fires on non-compiler projects
- [ ] Rule is dropped when the `react-compiler` capability is present (existing `scan-resilience` gate covers `disabledBy: ["react-compiler"]`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single rule metadata change plus changelog; existing scan gating for `disabledBy` applies with no new runtime logic.
> 
> **Overview**
> **`prefer-module-scope-static-value`** no longer runs when the **`react-compiler`** capability is detected, fixing noisy warnings on compiler-enabled projects (#669).
> 
> The rule definition now includes **`disabledBy: ["react-compiler"]`**, aligned with other rules (e.g. **`jsx-no-new-*-as-prop`**) that skip the same class of referential-equality advice because React Compiler already hoists and caches per-render array/object literals. Behavior is unchanged for projects without the compiler. A patch **changeset** documents the release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8074c51ba12421f7834bd788ee9f74e29489fbca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->