### PR TITLE
fix(rules): stop no-wide-letter-spacing flagging uppercase wrapper-prop labels

### DIFF
--- a/.changeset/wide-letter-spacing-uppercase-prop.md
+++ b/.changeset/wide-letter-spacing-uppercase-prop.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+`no-wide-letter-spacing` no longer false-positives on uppercase labels styled through a wrapper component prop.
+
+The rule exempts wide tracking on uppercase text, but it could only see `textTransform: 'uppercase'` written inline in the same style object. Design-system text components routinely apply the transform from a prop instead (`<SSText uppercase style={{ letterSpacing: 2 }}>`), which the rule can't see inside the component (#671). It now also treats a sibling `uppercase` boolean prop or a `textTransform="uppercase"` prop on the same element as the uppercase signal, so those short labels stay quiet.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-wide-letter-spacing.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-wide-letter-spacing.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noWideLetterSpacing } from "./no-wide-letter-spacing.js";
+
+describe("no-wide-letter-spacing", () => {
+  it("flags wide letter spacing on body text", () => {
+    const code = `
+      const Body = () => (
+        <p style={{ letterSpacing: 2 }}>Some long paragraph of body copy.</p>
+      );
+    `;
+    const result = runRule(noWideLetterSpacing, code);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("letter spacing");
+  });
+
+  it("does NOT flag when inline textTransform uppercase is present", () => {
+    const code = `
+      const Label = () => (
+        <span style={{ letterSpacing: 2, textTransform: "uppercase" }}>NEW</span>
+      );
+    `;
+    const result = runRule(noWideLetterSpacing, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag when a sibling boolean `uppercase` prop is present", () => {
+    // The uppercase transform lives inside the wrapper component, applied
+    // by its `uppercase` prop, so the rule can't see it in the style object
+    // (satsigner#671). The sibling prop is the visible signal.
+    const code = `
+      const Label = () => (
+        <SSText uppercase style={{ letterSpacing: 2 }}>LABEL</SSText>
+      );
+    `;
+    const result = runRule(noWideLetterSpacing, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag when a sibling `uppercase={true}` prop is present", () => {
+    const code = `
+      const Label = () => (
+        <SSText uppercase={true} style={{ letterSpacing: 2 }}>LABEL</SSText>
+      );
+    `;
+    const result = runRule(noWideLetterSpacing, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('does NOT flag when a sibling `textTransform="uppercase"` prop is present', () => {
+    const code = `
+      const Label = () => (
+        <Text textTransform="uppercase" style={{ letterSpacing: 2 }}>LABEL</Text>
+      );
+    `;
+    const result = runRule(noWideLetterSpacing, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags when a sibling `uppercase={false}` prop is present", () => {
+    const code = `
+      const Body = () => (
+        <SSText uppercase={false} style={{ letterSpacing: 2 }}>body copy</SSText>
+      );
+    `;
+    const result = runRule(noWideLetterSpacing, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does NOT flag letter spacing within the readable threshold", () => {
+    const code = `
+      const Body = () => (
+        <p style={{ letterSpacing: 0.5 }}>Some long paragraph of body copy.</p>
+      );
+    `;
+    const result = runRule(noWideLetterSpacing, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-wide-letter-spacing.ts
@@ -7,7 +7,63 @@ import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// Reads a JSX attribute value as a string literal, unwrapping a
+// `{'...'}` expression container. Returns null for dynamic/non-string
+// values. Covers `textTransform="uppercase"` and `textTransform={'uppercase'}`.
+const getJsxAttributeStringValue = (attributeValue: EsTreeNode | null): string | null => {
+  if (!attributeValue) return null;
+  if (isNodeOfType(attributeValue, "Literal") && typeof attributeValue.value === "string") {
+    return attributeValue.value;
+  }
+  if (isNodeOfType(attributeValue, "JSXExpressionContainer")) {
+    const expression = attributeValue.expression;
+    if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
+      return expression.value;
+    }
+  }
+  return null;
+};
+
+// A bare boolean prop (`uppercase`) has a null value; `uppercase={true}`
+// wraps a `true` literal. Both signal the prop is enabled.
+const isTruthyBooleanJsxAttribute = (attributeValue: EsTreeNode | null): boolean => {
+  if (attributeValue === null) return true;
+  if (isNodeOfType(attributeValue, "JSXExpressionContainer")) {
+    const expression = attributeValue.expression;
+    return isNodeOfType(expression, "Literal") && expression.value === true;
+  }
+  return false;
+};
+
+// The rule's whole false-positive exemption is "wide tracking is fine on
+// uppercase labels". When the uppercase transform comes from inline
+// `textTransform`, the loop below sees it. But design-system text
+// components routinely expose the transform as a sibling prop —
+// `<SSText uppercase style={{ letterSpacing: 2 }}>` (satsigner#671) — or
+// a `textTransform="uppercase"` prop. The rule can't see inside the
+// component, so it inspects the element's own attributes: if the same
+// element already declares the uppercase intent, treat the wide tracking
+// as the recommended use and stay quiet.
+const hasUppercaseSiblingProp = (styleAttribute: EsTreeNodeOfType<"JSXAttribute">): boolean => {
+  const openingElement = styleAttribute.parent;
+  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
+  for (const attribute of openingElement.attributes ?? []) {
+    if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+    if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
+    const attributeName = attribute.name.name;
+    if (attributeName === "uppercase" && isTruthyBooleanJsxAttribute(attribute.value)) return true;
+    if (
+      attributeName === "textTransform" &&
+      getJsxAttributeStringValue(attribute.value) === "uppercase"
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
 
 export const noWideLetterSpacing = defineRule<Rule>({
   id: "no-wide-letter-spacing",
@@ -20,6 +76,8 @@ export const noWideLetterSpacing = defineRule<Rule>({
     JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
+
+      if (hasUppercaseSiblingProp(node)) return;
 
       let isUppercase = false;
       let letterSpacingProperty: EsTreeNode | null = null;


### PR DESCRIPTION
## Summary

Fixes #671.

`no-wide-letter-spacing` exempts wide tracking on uppercase text, but it could only see `textTransform: 'uppercase'` written inline in the same style object. Design-system text components routinely apply the transform from a prop instead — e.g. `<SSText uppercase style={{ letterSpacing: 2 }}>` — which the rule can't see inside the component, so every such short label was flagged as body text.

The rule now also treats an uppercase signal declared on the same JSX element as the exemption:

- a sibling boolean `uppercase` prop (`uppercase` / `uppercase={true}`)
- a `textTransform="uppercase"` / `textTransform={'uppercase'}` prop

Body text (`uppercase={false}` or no signal) still reports.

## Test plan

- [ ] Wide letter spacing on body text still flagged
- [ ] Inline `textTransform: 'uppercase'` still exempt
- [ ] Sibling `uppercase` / `uppercase={true}` / `textTransform="uppercase"` prop exempts
- [ ] `uppercase={false}` still flagged

New test file `no-wide-letter-spacing.test.ts` covers all of the above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only heuristic with new unit tests; no runtime app behavior, though misnamed `uppercase` props could suppress a valid warning.
> 
> **Overview**
> **`no-wide-letter-spacing`** now treats sibling JSX props as proof of uppercase intent, not only inline `textTransform: 'uppercase'` in the `style` object. Before this change, labels like `<SSText uppercase style={{ letterSpacing: 2 }}>` were flagged because the transform lives inside the design-system component (#671).
> 
> The rule bails out early when the same element has a truthy `uppercase` prop (`uppercase` or `uppercase={true}`) or `textTransform="uppercase"` / `textTransform={'uppercase'}`. **`uppercase={false}`** and plain body copy with wide tracking still warn. A dedicated test file covers flag, exempt, and threshold cases; the release is a **patch** for `react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6094c250c71efa29873b8d00db7ebb489ac038f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->