### PR TITLE
chore: bump deslop-js to 0.0.17

### DIFF
--- a/.changeset/bump-deslop-js-0.0.17.md
+++ b/.changeset/bump-deslop-js-0.0.17.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Bump bundled `deslop-js` to `^0.0.17`, which stops `deslop/unused-dev-dependency` from false-positiving on dependencies referenced in a `package.json` script as a flag argument rather than the leading command — e.g. `jest --testResultsProcessor jest-sonar-reporter` or `--reporters=jest-junit` (#653).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@effect/platform-node-shared": "4.0.0-beta.70",
     "confbox": "^0.2.4",
-    "deslop-js": "^0.0.16",
+    "deslop-js": "^0.0.17",
     "effect": "4.0.0-beta.70",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -61,7 +61,7 @@
     "agent-install": "0.0.5",
     "conf": "^15.1.0",
     "confbox": "^0.2.4",
-    "deslop-js": "^0.0.16",
+    "deslop-js": "^0.0.17",
     "effect": "4.0.0-beta.70",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^0.2.4
         version: 0.2.4
       deslop-js:
-        specifier: ^0.0.16
-        version: 0.0.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.0.17
+        version: 0.0.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
@@ -152,8 +152,8 @@ importers:
         specifier: ^0.2.4
         version: 0.2.4
       deslop-js:
-        specifier: ^0.0.16
-        version: 0.0.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.0.17
+        version: 0.0.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       effect:
         specifier: 4.0.0-beta.70
         version: 4.0.0-beta.70
@@ -2303,8 +2303,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deslop-js@0.0.16:
-    resolution: {integrity: sha512-S8jh7CKRLCOVefBwcdBYZnYxZyuP6W6f5dgyEyNGB4EnAVAH6TTbnBzXS/1ZbxFJRUjRWd9FlQAW6vMc8SywQg==}
+  deslop-js@0.0.17:
+    resolution: {integrity: sha512-iO7S+ZhOPCv5UW6DPo4Rom9jx+86VDoNCuYfosepzz27dmkOuHR9obj0LpgS8QCpY/mjxrRYvQQcEhygjwwQEA==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -5045,7 +5045,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deslop-js@0.0.16(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  deslop-js@0.0.17(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3


### PR DESCRIPTION
## Summary

Bumps the bundled `deslop-js` dependency from `^0.0.16` to `^0.0.17` in `@react-doctor/core` and `react-doctor`.

`deslop-js@0.0.17` ships millionco/deslop-js#23: `detectStalePackages` now recognizes a dependency referenced in a `package.json` script as a **flag argument** (`jest --testResultsProcessor jest-sonar-reporter`, `--reporters=jest-junit`, scoped packages, and `pkg/subpath`), not just as the leading command/binary token.

Resolves #653.

## Test plan

- [x] `pnpm install --lockfile-only` resolves `deslop-js@0.0.17`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no local logic changes; lowers false-positive noise on unused dev dependency diagnostics.
> 
> **Overview**
> Bumps bundled **`deslop-js`** from `^0.0.16` to **`^0.0.17`** in `@react-doctor/core` and `react-doctor`, with lockfile and a patch changeset for `react-doctor`.
> 
> The upgrade pulls in upstream fixes so **`deslop/unused-dev-dependency`** no longer flags packages that only appear in **`package.json` scripts** as flag values (e.g. `jest --testResultsProcessor jest-sonar-reporter`, `--reporters=jest-junit`), not just as the command binary. Addresses #653.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 791add159689d6b86318a995506dcc4cf7b779e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->