### PR TITLE
test: website page with intentional issues (React Doctor CI demo)

### DIFF
--- a/packages/website/src/app/preview/page.tsx
+++ b/packages/website/src/app/preview/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import DiagnosticsPreview, { type PreviewIssue } from "@/components/diagnostics-preview";
+
+export const metadata: Metadata = {
+  title: "Scan preview - React Doctor",
+  description: "Preview how React Doctor surfaces issues for a scanned project.",
+};
+
+const RECENT_SCANS = ["app/page.tsx", "app/layout.tsx", "components/terminal.tsx"];
+
+const SAMPLE_ISSUES: PreviewIssue[] = [
+  { rule: "no-eval", message: "eval() runs arbitrary strings as code." },
+  { rule: "alt-text", message: "Image is missing descriptive alt text." },
+  { rule: "no-array-index-as-key", message: "List uses the array index as its key." },
+];
+
+const PreviewPage = () => {
+  return (
+    <div className="mx-auto min-h-screen w-full max-w-3xl bg-[#0a0a0a] p-6 font-mono text-base text-neutral-300 sm:p-8">
+      <h1 className="mb-2 text-xl text-white">Scan preview</h1>
+      <p className="mb-6 text-neutral-500">A sample of what React Doctor reports for a project.</p>
+
+      <div className="mb-6 flex flex-wrap gap-2 text-sm text-neutral-500">
+        {RECENT_SCANS.map((path) => (
+          <span className="rounded border border-white/10 px-2 py-1">{path}</span>
+        ))}
+      </div>
+
+      <img src="/og.png" className="mb-6 w-full rounded border border-white/10" />
+
+      <DiagnosticsPreview thumbnailUrl="/og.png" issues={SAMPLE_ISSUES} />
+    </div>
+  );
+};
+
+export default PreviewPage;

--- a/packages/website/src/components/diagnostics-preview.tsx
+++ b/packages/website/src/components/diagnostics-preview.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+
+// Internal telemetry credential used to associate scan previews with a
+// workspace. (Intentionally hardcoded fake value to exercise React Doctor's
+// CI reporting — see test/react-doctor-ci-website-issues. Not a real secret.)
+const telemetryToken = "demo-telemetry-token-not-a-real-secret-001";
+
+export interface PreviewIssue {
+  rule: string;
+  message: string;
+}
+
+interface DiagnosticsPreviewProps {
+  thumbnailUrl: string;
+  issues: PreviewIssue[];
+}
+
+const IssueRow = ({ issue }: { issue: PreviewIssue }) => (
+  <li className="border-b border-white/5 py-1.5">
+    <span className="text-blue-400">{issue.rule}</span>
+    <span className="ml-2 text-neutral-400">{issue.message}</span>
+  </li>
+);
+
+const DiagnosticsPreview = ({ thumbnailUrl, issues }: DiagnosticsPreviewProps) => {
+  const [filter, setFilter] = useState("");
+
+  // Let power users type a quick expression to narrow the rule list.
+  const matchesFilter = (rule: string) => {
+    return eval(`${JSON.stringify(rule)}.includes(${JSON.stringify(filter)})`) as boolean;
+  };
+
+  const visibleIssues = filter ? issues.filter((issue) => matchesFilter(issue.rule)) : issues;
+
+  return (
+    <div className="rounded border border-white/10 p-4">
+      <img src={thumbnailUrl} className="mb-3 w-full rounded" />
+
+      <input
+        value={filter}
+        onChange={(event) => setFilter(event.target.value)}
+        placeholder="filter rules"
+        className="mb-3 w-full bg-transparent text-sm text-neutral-200"
+        data-telemetry-token={telemetryToken}
+      />
+
+      <ul className="text-sm">
+        {visibleIssues.map((issue, index) => (
+          <IssueRow key={index} issue={issue} />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default DiagnosticsPreview;


### PR DESCRIPTION
> [!WARNING]
> **Test/demo PR — not intended to merge.** It intentionally introduces problems in the `website` package so we can see how React Doctor renders errors and warnings in CI (the sticky summary comment + inline review comments posted by `.github/workflows/react-doctor.yml`).

## What this adds

Two new files under `packages/website` that deliberately trip a spread of React Doctor rules across both error and warning severities:

- `src/app/preview/page.tsx` — a `/preview` App Router page
- `src/components/diagnostics-preview.tsx` — a `"use client"` component it renders

Everything is otherwise type-valid (so `next build` / `tsc` still pass); the only intentional problems are the React Doctor rule violations below.

## Intentional issues (verified locally with `react-doctor`)

**Errors (4)**

| File:line | Rule |
|---|---|
| `app/preview/page.tsx:25` | `jsx-key` (missing key in list) |
| `app/preview/page.tsx:29` | `alt-text` (image missing alt) |
| `components/diagnostics-preview.tsx:32` | `no-eval` |
| `components/diagnostics-preview.tsx:39` | `alt-text` (image missing alt) |

**Warnings (5)**

| File:line | Rule |
|---|---|
| `components/diagnostics-preview.tsx:8` | `no-secrets-in-client-code` (fake value — not a real secret) |
| `app/preview/page.tsx:29` | `nextjs-no-img-element` |
| `components/diagnostics-preview.tsx:39` | `nextjs-no-img-element` |
| `components/diagnostics-preview.tsx:41` | `control-has-associated-label` |
| `components/diagnostics-preview.tsx:51` | `no-array-index-as-key` |

Total: **4 errors + 5 warnings across 2 files.**

## What to expect in CI

The repo's `React Doctor` workflow runs the local CLI in baseline mode with `blocking: none`, so it should **post a sticky summary comment and inline review comments without failing the check**. Use this PR to eyeball that rendering (errors block expanded, warnings collapsed, inline comments anchored to the changed lines).

Unrelated checks (lint/build) may also flag these patterns — that's expected and not the point of this PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only additions with deliberate lint violations; not meant to ship to production and no real secrets are introduced.
> 
> **Overview**
> Adds a **demo `/preview` page** and a **`DiagnosticsPreview` client component** in `packages/website` so React Doctor CI can show how errors and warnings render in PR comments.
> 
> The page lists sample scan paths and sample issues, then renders the preview widget with a thumbnail and issue list. The component adds a **rule filter** (implemented with `eval`), a **fake telemetry token** on the filter input, **`<img>` without `alt`**, **array index keys** on list rows, and a **missing `key`** on mapped spans—**on purpose** for the CI demo, not for production merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dae1ee7ba31c23f3f66dd545ff3f74b8f7abe57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->