### PR TITLE
fix: make oxlint an optional peer dependency to avoid pnpm vitest duplication

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,10 +28,17 @@
     "effect": "4.0.0-beta.70",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",
-    "oxlint": "^1.66.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "picomatch": "^4.0.4",
     "typescript": "^6.0.3"
+  },
+  "peerDependencies": {
+    "oxlint": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "oxlint": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@effect/vitest": "4.0.0-beta.70",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,3 +89,4 @@ export * from "./utils/warn-config-issue.js";
 export * from "./runners/oxlint/capabilities.js";
 export * from "./runners/oxlint/config.js";
 export * from "./runners/oxlint/plugin-resolution.js";
+export { OxlintNotInstalledError } from "./runners/oxlint/resolve-paths.js";

--- a/packages/core/src/runners/oxlint/resolve-paths.ts
+++ b/packages/core/src/runners/oxlint/resolve-paths.ts
@@ -4,8 +4,27 @@ import * as path from "node:path";
 
 const esmRequire = createRequire(import.meta.url);
 
+export class OxlintNotInstalledError extends Error {
+  constructor() {
+    super(
+      `oxlint is not installed. Install it as a dependency:\n\n` +
+        `  npm install -D oxlint\n` +
+        `  # or: pnpm add -D oxlint\n` +
+        `  # or: yarn add -D oxlint\n\n` +
+        `In pnpm monorepos using vite-plus/vitest, install oxlint at the workspace root ` +
+        `to avoid duplicate module instances. See: https://github.com/millionco/react-doctor/issues`,
+    );
+    this.name = "OxlintNotInstalledError";
+  }
+}
+
 export const resolveOxlintBinary = (): string => {
-  const oxlintMainPath = esmRequire.resolve("oxlint");
+  let oxlintMainPath: string;
+  try {
+    oxlintMainPath = esmRequire.resolve("oxlint");
+  } catch {
+    throw new OxlintNotInstalledError();
+  }
   const oxlintPackageDirectory = path.resolve(path.dirname(oxlintMainPath), "..");
   return path.join(oxlintPackageDirectory, "bin", "oxlint");
 };

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -116,6 +116,54 @@ Prefer JSON? Use `doctor.config.json`:
 }
 ```
 
+## Troubleshooting
+
+### pnpm monorepos with vite-plus/vitest
+
+Installing `react-doctor` as a workspace devDependency in pnpm monorepos using vite-plus (or custom vitest aliases) can cause Vitest to fail with:
+
+```
+Error: Vitest failed to find the current suite.
+```
+
+This happens because `react-doctor` depends on `oxlint`, which can introduce a second physical install of vitest with a different peer-dependency fingerprint. pnpm creates multiple module instances when peer contexts differ, causing Vitest's hook registry to split.
+
+**Workarounds:**
+
+1. **Use `npx`/`pnpm dlx` instead of installing** (recommended):
+
+   ```bash
+   pnpm dlx react-doctor@latest
+   ```
+
+   This avoids polluting the dependency graph entirely.
+
+2. **Install `oxlint` at the workspace root separately**:
+
+   ```bash
+   pnpm add -Dw oxlint
+   ```
+
+   Then add `react-doctor` to a specific package instead of the workspace root.
+
+3. **Use pnpm overrides** to force a single vitest instance:
+
+   ```yaml
+   # pnpm-workspace.yaml or package.json
+   pnpm:
+     overrides:
+       vitest: "catalog:viteplus"
+     peerDependencyRules:
+       allowedVersions:
+         vitest: "*"
+   ```
+
+For programmatic use without the dependency graph, you can import types only:
+
+```ts
+import type { ReactDoctorConfig } from "react-doctor/api";
+```
+
 ## Telemetry
 
 The CLI reports crashes, basic run traces, and anonymous usage counters to [Sentry](https://sentry.io/) to help us fix bugs and prioritize work.

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -66,13 +66,20 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",
     "magicast": "^0.5.3",
-    "oxlint": "^1.66.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "prompts": "^2.4.2",
     "typescript": ">=5.0.4 <7",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-uri": "^3.1.0"
+  },
+  "peerDependencies": {
+    "oxlint": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "oxlint": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@react-doctor/api": "workspace:*",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses the issue where installing `react-doctor` as a workspace devDependency in pnpm monorepos using vite-plus/vitest causes duplicate Vitest module instances.

## Root Cause

When `react-doctor` is installed, its dependency on `oxlint` introduces a different peer-dependency fingerprint. pnpm creates multiple physical installations of the same Vitest fork when peer contexts differ, causing Vitest's hook registry to split between instances. This results in:

```
Error: Vitest failed to find the current suite.
```

## Changes

1. **Move `oxlint` to optional peer dependency** (`peerDependencies` with `peerDependenciesMeta.optional: true`) in both `@react-doctor/core` and `react-doctor`
   - This allows pnpm to use a single shared oxlint instance when users install it separately
   - Users who don't have oxlint installed will get a helpful error message

2. **Add `OxlintNotInstalledError`** with clear installation instructions:
   ```
   oxlint is not installed. Install it as a dependency:

     npm install -D oxlint
     # or: pnpm add -D oxlint
     # or: yarn add -D oxlint

   In pnpm monorepos using vite-plus/vitest, install oxlint at the workspace root 
   to avoid duplicate module instances.
   ```

3. **Add troubleshooting documentation** in README with workarounds:
   - Use `pnpm dlx react-doctor@latest` (recommended for monorepos)
   - Install `oxlint` at workspace root separately
   - Use pnpm overrides to force single vitest instance

## Testing

- All existing tests pass
- TypeScript typecheck passes
- Verified error message renders correctly when oxlint is not installed

## Migration for Users

Users who install `react-doctor` will now need to also install `oxlint`:

```bash
npm install -D react-doctor oxlint
# or: pnpm add -D react-doctor oxlint
```

For users running via `npx`/`pnpm dlx`, no changes are needed as the temporary installation handles dependencies.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9bdd09b-baae-4c7d-824c-0deeafe837f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9bdd09b-baae-4c7d-824c-0deeafe837f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

