### PR TITLE
fix: widen oxlint version range to prevent duplicate vitest instances in pnpm monorepos

### DIFF
--- a/.changeset/fix-pnpm-vitest-duplicate.md
+++ b/.changeset/fix-pnpm-vitest-duplicate.md
@@ -1,0 +1,11 @@
+---
+"react-doctor": patch
+---
+
+fix: widen oxlint version range to `>=1.60.0` to prevent duplicate vitest instances in pnpm monorepos
+
+When `react-doctor` was installed alongside `vite-plus` (which pins `oxlint@=1.63.0`), pnpm created two instances of oxlint with different peer dependency fingerprints. This caused the vitest fork (`@voidzero-dev/vite-plus-test`) to also have two instances, breaking Vitest's internal hook registry and causing "Vitest failed to find the current suite" errors.
+
+By widening the version range from `^1.66.0` to `>=1.60.0`, pnpm can now dedupe the oxlint dependency when the consumer's workspace already provides a compatible version, preventing the cascade of duplicate instances.
+
+The CLI features react-doctor uses (`-c`, `--format json`, `--tsconfig`, `--ignore-path`) are stable across oxlint 1.60+.

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
       "unrs-resolver"
     ],
     "overrides": {
-      "oxlint": "^1.66.0",
+      "oxlint": ">=1.60.0",
       "oxlint-tsgolint": "^0.23.0"
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "effect": "4.0.0-beta.70",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",
-    "oxlint": "^1.66.0",
+    "oxlint": ">=1.60.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "picomatch": "^4.0.4",
     "typescript": "^6.0.3"

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",
     "magicast": "^0.5.3",
-    "oxlint": "^1.66.0",
+    "oxlint": ">=1.60.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "prompts": "^2.4.2",
     "typescript": ">=5.0.4 <7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  oxlint: ^1.66.0
+  oxlint: '>=1.60.0'
   oxlint-tsgolint: ^0.23.0
 
 importers:
@@ -80,7 +80,7 @@ importers:
         specifier: ^2.7.0
         version: 2.7.0
       oxlint:
-        specifier: ^1.66.0
+        specifier: '>=1.60.0'
         version: 1.66.0(oxlint-tsgolint@0.23.0)
       oxlint-plugin-react-doctor:
         specifier: workspace:*
@@ -186,7 +186,7 @@ importers:
         specifier: ^0.5.3
         version: 0.5.3
       oxlint:
-        specifier: ^1.66.0
+        specifier: '>=1.60.0'
         version: 1.66.0(oxlint-tsgolint@0.23.0)
       oxlint-plugin-react-doctor:
         specifier: workspace:*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #692 - Installing `react-doctor` in a pnpm monorepo with `vite-plus` causes duplicate Vitest instances and breaks test collection.

## Root Cause

When `react-doctor` (with `oxlint@^1.66.0`) was installed alongside `vite-plus` (which pins `oxlint@=1.63.0`), pnpm created two instances of oxlint with different peer dependency fingerprints:

```
oxlint@1.63.0 → vite-plus dependency graph
oxlint@1.68.0 → react-doctor dependency graph
```

This caused `@voidzero-dev/vite-plus-test` (the Vitest fork) to also have two instances with different peer contexts (`peer#3672` vs `peer#4bfa`). At test runtime, test files would import hooks from one Vitest instance while the runner used another, breaking Vitest's internal hook registry and causing "Vitest failed to find the current suite" errors.

## Solution

Widen the oxlint version range from `^1.66.0` to `>=1.60.0`. This allows pnpm to dedupe the oxlint dependency when the consumer's workspace already provides a compatible version (like vite-plus's `1.63.0`), preventing the cascade of duplicate instances.

The CLI features react-doctor uses (`-c`, `--format json`, `--tsconfig`, `--ignore-path`) are stable across oxlint 1.60+, so there's no compatibility concern.

## Verification

1. All existing tests pass
2. Typecheck passes
3. Lint passes
4. Format check passes

## Changes

- `packages/react-doctor/package.json`: `oxlint` `^1.66.0` → `>=1.60.0`
- `packages/core/package.json`: `oxlint` `^1.66.0` → `>=1.60.0`
- `package.json` (root overrides): `oxlint` `^1.66.0` → `>=1.60.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f476eb7b-e7f0-464f-a58a-0b516febbcd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f476eb7b-e7f0-464f-a58a-0b516febbcd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

