### PR TITLE
refactor(oxlint): extract shared isBooleanPrefixedPropName util

### DIFF
--- a/.changeset/add-prefer-explicit-variants.md
+++ b/.changeset/add-prefer-explicit-variants.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat: add `prefer-explicit-variants` rule. Flags a component that picks which component to render from 2+ boolean props (each used as the test of a two-sided JSX ternary), nudging toward explicit variant components instead of variants jammed into one component. App-only, `warn` severity; cross-cutting state/responsive/auth booleans (`isLoading`, `isMobile`, …) and single switches are intentionally ignored.

--- a/.changeset/extract-boolean-prefixed-prop-name.md
+++ b/.changeset/extract-boolean-prefixed-prop-name.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+refactor: extract the shared `isBooleanPrefixedPropName` predicate into a single-purpose util and reuse it in `no-many-boolean-props`. Behavior-preserving.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -249,6 +249,7 @@ export const DIAGNOSTIC_CATEGORY_BUCKETS = [
 export const APP_ONLY_RULE_KEYS: ReadonlySet<string> = new Set([
   "react-hooks-js/static-components",
   "react-doctor/no-render-prop-children",
+  "react-doctor/prefer-explicit-variants",
 ]);
 
 // The `compiler-cleanup` severity bucket: redundant-memoization rules that

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
@@ -7,6 +7,11 @@ export const SEQUENTIAL_AWAIT_THRESHOLD = 3;
 export const PROPERTY_ACCESS_REPEAT_THRESHOLD = 3;
 export const BOOLEAN_PROP_THRESHOLD = 4;
 export const RENDER_PROP_PROLIFERATION_THRESHOLD = 3;
+// Distinct boolean props a single component must use as the test of a
+// two-sided JSX ternary before `prefer-explicit-variants` fires. Two is
+// the "several variants jammed into one component" signal — a lone
+// `isMobile ? <Mobile /> : <Desktop />` switch is legitimate and stays quiet.
+export const BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD = 2;
 export const GET_HANDLER_BINDING_RESOLUTION_DEPTH = 3;
 // Chains rooted in a literal array `[a, b, c].map(...).filter(...)` at
 // or below this length are skipped by the iteration-combination rules

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -235,6 +235,7 @@ import { preactPreferOndblclick } from "./rules/preact/preact-prefer-ondblclick.
 import { preactPreferOninput } from "./rules/preact/preact-prefer-oninput.js";
 import { preferDynamicImport } from "./rules/bundle-size/prefer-dynamic-import.js";
 import { preferEs6Class } from "./rules/react-builtins/prefer-es6-class.js";
+import { preferExplicitVariants } from "./rules/architecture/prefer-explicit-variants.js";
 import { preferFunctionComponent } from "./rules/react-builtins/prefer-function-component.js";
 import { preferHtmlDialog } from "./rules/a11y/prefer-html-dialog.js";
 import { preferModuleScopePureFunction } from "./rules/architecture/prefer-module-scope-pure-function.js";
@@ -2839,6 +2840,17 @@ export const reactDoctorRules = [
     originallyExternal: true,
     rule: {
       ...preferEs6Class,
+      framework: "global",
+      category: "Maintainability",
+    },
+  },
+  {
+    key: "react-doctor/prefer-explicit-variants",
+    id: "prefer-explicit-variants",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...preferExplicitVariants,
       framework: "global",
       category: "Maintainability",
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -1,5 +1,6 @@
 import { BOOLEAN_PROP_THRESHOLD } from "../../constants/thresholds.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { isBooleanPrefixedPropName } from "../../utils/is-boolean-prefixed-prop-name.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
@@ -9,8 +10,6 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-
-const BOOLEAN_PROP_PREFIX_PATTERN = /^(?:is|has|should|can|show|hide|enable|disable|with)[A-Z]/;
 
 const collectBooleanLikePropsFromBody = (
   componentBody: EsTreeNode | undefined,
@@ -24,7 +23,7 @@ const collectBooleanLikePropsFromBody = (
     if (!isNodeOfType(child.object, "Identifier")) return;
     if (child.object.name !== propsParamName) return;
     if (!isNodeOfType(child.property, "Identifier")) return;
-    if (!BOOLEAN_PROP_PREFIX_PATTERN.test(child.property.name)) return;
+    if (!isBooleanPrefixedPropName(child.property.name)) return;
     found.add(child.property.name);
   });
   return found;
@@ -72,7 +71,7 @@ export const noManyBooleanProps = defineRule<Rule>({
           if (!isNodeOfType(property, "Property")) continue;
           const keyName = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
           if (!keyName) continue;
-          if (BOOLEAN_PROP_PREFIX_PATTERN.test(keyName)) {
+          if (isBooleanPrefixedPropName(keyName)) {
             booleanLikePropNames.push(keyName);
           }
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { preferExplicitVariants } from "./prefer-explicit-variants.js";
+
+const expectDiagnosticCount = (
+  code: string,
+  expectedDiagnosticCount: number,
+  filename = "fixture.tsx",
+): void => {
+  const result = runRule(preferExplicitVariants, code, { filename });
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedDiagnosticCount);
+};
+
+describe("architecture/prefer-explicit-variants — fail cases", () => {
+  it("flags two boolean props each swapping whole components", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isEditing }) {
+  return (
+    <div>
+      {isThread ? <ThreadHeader /> : <ChannelHeader />}
+      {isEditing ? <EditActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("flags the arrow-component form", () => {
+    expectDiagnosticCount(
+      `const Composer = ({ isThread, isEditing }) => (
+  <div>
+    {isThread ? <ThreadHeader /> : <ChannelHeader />}
+    {isEditing ? <EditActions /> : <DefaultActions />}
+  </div>
+);`,
+      1,
+    );
+  });
+
+  it("flags a negated boolean-prop test", () => {
+    expectDiagnosticCount(
+      `function Composer({ isEditing, isForwarding }) {
+  return (
+    <div>
+      {!isEditing ? <ReadOnlyBody /> : <EditableBody />}
+      {isForwarding ? <ForwardActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("follows a renamed destructured boolean prop", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread: showThread, isEditing }) {
+  return (
+    <div>
+      {showThread ? <ThreadHeader /> : <ChannelHeader />}
+      {isEditing ? <EditActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("follows a defaulted boolean prop", () => {
+    expectDiagnosticCount(
+      `function Banner({ isPrimary = false, isCompact = false }) {
+  return (
+    <section>
+      {isPrimary ? <PrimaryTitle /> : <SecondaryTitle />}
+      {isCompact ? <CompactBody /> : <FullBody />}
+    </section>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("treats JSX fragments as branch output", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isEditing }) {
+  return (
+    <div>
+      {isThread ? <><ThreadHeader /></> : <><ChannelHeader /></>}
+      {isEditing ? <EditActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("flags parenthesized multi-line ternary arms (the Prettier shape)", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isEditing }) {
+  return (
+    <div>
+      {isThread ? (
+        <ThreadHeader />
+      ) : (
+        <ChannelHeader />
+      )}
+      {isEditing ? (
+        <EditActions />
+      ) : (
+        <DefaultActions />
+      )}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+});
+
+describe("architecture/prefer-explicit-variants — pass cases (no diagnostics)", () => {
+  it("ignores a single boolean-prop component switch", () => {
+    expectDiagnosticCount(
+      `function Nav({ isMobile, label }) {
+  return <div>{isMobile ? <MobileNav /> : <DesktopNav />}{label}</div>;
+}`,
+      0,
+    );
+  });
+
+  it("ignores visibility toggles where an arm is null", () => {
+    expectDiagnosticCount(
+      `function Panel({ isLoading, isOpen }) {
+  return (
+    <div>
+      {isLoading ? <Spinner /> : null}
+      {isOpen ? <Body /> : null}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores repeated ternaries on the same single boolean prop", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, title }) {
+  return (
+    <div>
+      {isThread ? <ThreadHeader /> : <ChannelHeader />}
+      <h1>{title}</h1>
+      {isThread ? <ThreadFooter /> : <ChannelFooter />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores ternaries on non-boolean-prefixed props", () => {
+    expectDiagnosticCount(
+      `function View({ status, mode }) {
+  return (
+    <div>
+      {status ? <Active /> : <Inactive />}
+      {mode ? <Grid /> : <List />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores boolean locals that are not props", () => {
+    expectDiagnosticCount(
+      `import { useState } from "react";
+
+function Composer() {
+  const [isThread, setIsThread] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  return (
+    <div>
+      {isThread ? <ThreadHeader /> : <ChannelHeader />}
+      {isEditing ? <EditActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores ternaries whose arms are not JSX", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isEditing }) {
+  const heading = isThread ? "Thread" : "Channel";
+  const action = isEditing ? "Save" : "Send";
+  return <div>{heading}{action}</div>;
+}`,
+      0,
+    );
+  });
+
+  it("does not descend into nested function branches", () => {
+    expectDiagnosticCount(
+      `function List({ isThread, isEditing, items }) {
+  return (
+    <Items
+      data={items}
+      renderItem={() => (isThread ? <ThreadRow /> : <ChannelRow />)}
+      renderFooter={() => (isEditing ? <EditFooter /> : <DefaultFooter />)}
+    />
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores non-component functions", () => {
+    expectDiagnosticCount(
+      `function resolve({ isThread, isEditing }) {
+  return isThread ? <ThreadHeader /> : isEditing ? <EditActions /> : <DefaultActions />;
+}`,
+      0,
+    );
+  });
+
+  it("ignores cross-cutting state booleans rendered two ways", () => {
+    expectDiagnosticCount(
+      `function Card({ isLoading, isError }) {
+  return (
+    <div>
+      {isLoading ? <Spinner /> : <Content />}
+      {isError ? <ErrorState /> : <OkState />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores a mode prop paired with a state prop below the threshold", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isLoading }) {
+  return (
+    <div>
+      {isThread ? <ThreadHeader /> : <ChannelHeader />}
+      {isLoading ? <Spinner /> : <Body />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.ts
@@ -1,0 +1,180 @@
+import { BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD } from "../../constants/thresholds.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { isBooleanPrefixedPropName } from "../../utils/is-boolean-prefixed-prop-name.js";
+import { isComponentAssignment } from "../../utils/is-component-assignment.js";
+import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
+import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
+import { isJsxElementOrFragment } from "../../utils/is-jsx-element-or-fragment.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Resolve a ternary `test` to the local binding name when it is a bare
+// boolean prop (`isEditing ? …`) or its negation (`!isEditing ? …`), and
+// only when that binding is one of the component's boolean-prefixed props.
+// Anything else (member access, `===` comparisons, logical chains) is not a
+// "boolean prop variant switch" and is intentionally ignored.
+const resolveBooleanPropTestName = (
+  testNode: EsTreeNode,
+  booleanPropBindings: ReadonlySet<string>,
+): string | null => {
+  let identifierNode = stripParenExpression(testNode);
+  if (isNodeOfType(identifierNode, "UnaryExpression") && identifierNode.operator === "!") {
+    identifierNode = stripParenExpression(identifierNode.argument);
+  }
+  if (!isNodeOfType(identifierNode, "Identifier")) return null;
+  return booleanPropBindings.has(identifierNode.name) ? identifierNode.name : null;
+};
+
+// Cross-cutting state / responsive / auth booleans whose two-way render
+// (`isLoading ? <Spinner /> : <Content />`) is ordinary conditional UI, not
+// the "variants jammed into one component" smell. Excluded so the rule fires
+// on domain "mode" props (isThread, isEditing, isPrimary) and stays quiet on
+// these. Curated, not exhaustive — precision over recall for an opinionated rule.
+const CROSS_CUTTING_STATE_BOOLEAN_NAMES = new Set<string>([
+  "isLoading",
+  "isPending",
+  "isFetching",
+  "isRefetching",
+  "isSubmitting",
+  "isError",
+  "isSuccess",
+  "isEmpty",
+  "isReady",
+  "isDirty",
+  "isValid",
+  "isInvalid",
+  "isOpen",
+  "isClosed",
+  "isVisible",
+  "isHidden",
+  "isActive",
+  "isInactive",
+  "isExpanded",
+  "isCollapsed",
+  "isSelected",
+  "isChecked",
+  "isDisabled",
+  "isEnabled",
+  "isFocused",
+  "isHovered",
+  "isDragging",
+  "isFullscreen",
+  "isMobile",
+  "isDesktop",
+  "isTablet",
+  "isOnline",
+  "isOffline",
+  "isLoggedIn",
+  "isAuthenticated",
+  "isAuthorized",
+  "isDark",
+  "isLight",
+]);
+
+// The local binding name of a destructured boolean-prefixed prop, following
+// renames (`{ isThread: renamed }`) and defaults (`{ isPrimary = false }`)
+// so the ternary-test lookup matches what the body actually references.
+const collectBooleanPropBindings = (param: EsTreeNode | undefined): Set<string> => {
+  const bindings = new Set<string>();
+  if (!param || !isNodeOfType(param, "ObjectPattern")) return bindings;
+  for (const property of param.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) continue;
+    if (property.computed) continue;
+    if (!isNodeOfType(property.key, "Identifier")) continue;
+    if (!isBooleanPrefixedPropName(property.key.name)) continue;
+    if (CROSS_CUTTING_STATE_BOOLEAN_NAMES.has(property.key.name)) continue;
+    const propertyValue = property.value;
+    if (isNodeOfType(propertyValue, "Identifier")) {
+      bindings.add(propertyValue.name);
+    } else if (
+      isNodeOfType(propertyValue, "AssignmentPattern") &&
+      isNodeOfType(propertyValue.left, "Identifier")
+    ) {
+      bindings.add(propertyValue.left.name);
+    }
+  }
+  return bindings;
+};
+
+const collectVariantBranchProps = (
+  body: EsTreeNode | undefined,
+  booleanPropBindings: ReadonlySet<string>,
+): Set<string> => {
+  const variantBranchProps = new Set<string>();
+  if (!body) return variantBranchProps;
+  walkAst(body, (current: EsTreeNode) => {
+    // A ternary inside a nested function (render prop, event handler, inner
+    // component) does not select THIS component's rendered output — prune it.
+    if (isNodeOfType(current, "FunctionDeclaration") || isInlineFunctionExpression(current)) {
+      return false;
+    }
+    if (!isNodeOfType(current, "ConditionalExpression")) return;
+    const propName = resolveBooleanPropTestName(current.test, booleanPropBindings);
+    if (!propName) return;
+    // Both arms must be JSX: a two-sided component swap, not a visibility
+    // toggle (`isOpen ? <Panel /> : null`) or a value pick. Strip parens
+    // first — Prettier wraps multi-line ternary arms in parentheses, which
+    // the parser surfaces as a `ParenthesizedExpression` around the JSX.
+    const consequent = stripParenExpression(current.consequent);
+    const alternate = stripParenExpression(current.alternate);
+    if (!isJsxElementOrFragment(consequent) || !isJsxElementOrFragment(alternate)) return;
+    variantBranchProps.add(propName);
+  });
+  return variantBranchProps;
+};
+
+// HACK: a component that selects which component to render from multiple
+// boolean props (`isThread ? <A /> : <B />` plus `isEditing ? <C /> : <D />`)
+// is several variants jammed into one — the "explicit variants" smell from
+// the composition-patterns guidance. We require TWO distinct boolean props
+// each driving a two-sided JSX ternary, because a single such switch
+// (`isMobile ? <Mobile /> : <Desktop />`) is a legitimate, common pattern.
+// Name-based prop detection mirrors `no-many-boolean-props` (TS types aren't
+// visible at this AST layer). v1 only models two-sided ternaries on
+// destructured props; if/else early-return variants and multi-way chains
+// ending in `null` are out of scope.
+export const preferExplicitVariants = defineRule<Rule>({
+  id: "prefer-explicit-variants",
+  title: "Prefer explicit variant components",
+  severity: "warn",
+  tags: ["test-noise", "react-jsx-only"],
+  recommendation:
+    "Replace boolean props that switch whole subtrees with explicit variant components, like `<ThreadComposer />` and `<EditMessageComposer />`, so each variant renders one clear path.",
+  create: (context: RuleContext) => {
+    const checkComponent = (
+      param: EsTreeNode | undefined,
+      body: EsTreeNode | undefined,
+      componentName: string,
+      reportNode: EsTreeNode,
+    ): void => {
+      const booleanPropBindings = collectBooleanPropBindings(param);
+      if (booleanPropBindings.size < BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD) return;
+      const variantBranchProps = collectVariantBranchProps(body, booleanPropBindings);
+      if (variantBranchProps.size < BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD) return;
+      const propList = [...variantBranchProps].slice(0, 3).join(", ");
+      const overflow = variantBranchProps.size > 3 ? "…" : "";
+      context.report({
+        node: reportNode,
+        message: `Component "${componentName}" picks which component to render from ${variantBranchProps.size} boolean props (${propList}${overflow}), which multiplies untestable variants. Split it into explicit variant components so each renders one clear path.`,
+      });
+    };
+
+    return {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+        if (!isComponentDeclaration(node) || !node.id) return;
+        checkComponent(node.params?.[0], node.body, node.id.name, node.id);
+      },
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+        if (!isComponentAssignment(node)) return;
+        if (!isNodeOfType(node.id, "Identifier")) return;
+        if (!isInlineFunctionExpression(node.init)) return;
+        checkComponent(node.init.params?.[0], node.init.body, node.id.name, node.id);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-boolean-prefixed-prop-name.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-boolean-prefixed-prop-name.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isBooleanPrefixedPropName } from "./is-boolean-prefixed-prop-name.js";
+
+describe("isBooleanPrefixedPropName", () => {
+  it("matches on/off flag prefixes followed by an uppercase letter", () => {
+    for (const propName of [
+      "isOpen",
+      "hasIcon",
+      "shouldRender",
+      "canEdit",
+      "showHeader",
+      "hideFooter",
+      "enableSync",
+      "disableClose",
+      "withBorder",
+    ]) {
+      expect(isBooleanPrefixedPropName(propName)).toBe(true);
+    }
+  });
+
+  it("does not match names that merely start with the prefix letters", () => {
+    for (const propName of [
+      "istanbul",
+      "hashed",
+      "withdraw",
+      "shouldnt",
+      "isopen",
+      "is",
+      "Is",
+      "open",
+      "status",
+      "mode",
+      "disabled",
+    ]) {
+      expect(isBooleanPrefixedPropName(propName)).toBe(false);
+    }
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-boolean-prefixed-prop-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-boolean-prefixed-prop-name.ts
@@ -1,0 +1,7 @@
+// True for prop names that read as on/off flags (`isOpen`, `hasIcon`,
+// `canEdit`). Shared by the boolean-prop architecture rules
+// (`no-many-boolean-props`, `prefer-explicit-variants`).
+const BOOLEAN_PROP_PREFIX_PATTERN = /^(?:is|has|should|can|show|hide|enable|disable|with)[A-Z]/;
+
+export const isBooleanPrefixedPropName = (propName: string): boolean =>
+  BOOLEAN_PROP_PREFIX_PATTERN.test(propName);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-jsx-element-or-fragment.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-jsx-element-or-fragment.ts
@@ -1,0 +1,16 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+/**
+ * Type-guard for the two single-node JSX output forms: `JSXElement`
+ * (`<Foo />`) and `JSXFragment` (`<>…</>`). Canonical home for the
+ * `isNodeOfType(x, "JSXElement") || isNodeOfType(x, "JSXFragment")` check
+ * that many rules otherwise inline. Does NOT unwrap parens / TS wrappers —
+ * callers that need the semantic expression should `stripParenExpression`
+ * first.
+ */
+export const isJsxElementOrFragment = (
+  node: EsTreeNode | null | undefined,
+): node is EsTreeNodeOfType<"JSXElement"> | EsTreeNodeOfType<"JSXFragment"> =>
+  Boolean(node && (isNodeOfType(node, "JSXElement") || isNodeOfType(node, "JSXFragment")));


### PR DESCRIPTION
## Summary
- Extracts the boolean-prop-name regex (`^(?:is|has|should|can|show|hide|enable|disable|with)[A-Z]`) out of `no-many-boolean-props` into a single-purpose util `isBooleanPrefixedPropName` (one util per file).
- Reuses it in `no-many-boolean-props` — **behavior-preserving** (the regex is byte-identical, no `g`-flag state).
- Adds a focused unit test for the predicate.

Foundation for the stacked PR that adds `prefer-explicit-variants`, which reuses the same predicate instead of duplicating the pattern.

## Test plan
- [x] new unit test `is-boolean-prefixed-prop-name.test.ts`
- [x] integration `run-oxlint/architecture.test.ts` — `no-many-boolean-props` still fires (behavior unchanged)
- [x] `typecheck` / `lint` / `format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maintainability-only lint additions at warn severity with broad false-positive guards; `no-many-boolean-props` behavior is unchanged via the extracted predicate.
> 
> **Overview**
> Adds a new **`prefer-explicit-variants`** architecture rule (warn, app-only) that warns when a component uses **two or more** boolean-prefixed props, each as the test of a **two-sided JSX ternary** swapping whole subtrees—nudging split into explicit variant components. Heuristics deliberately skip single switches, null arms, non-JSX arms, nested render props, and a curated set of cross-cutting props (`isLoading`, `isMobile`, etc.).
> 
> **Refactor:** moves the boolean-prop name regex into shared **`isBooleanPrefixedPropName`** (with unit tests) and wires **`no-many-boolean-props`** through it unchanged. Adds **`isJsxElementOrFragment`**, **`BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD`**, registry wiring, and **`APP_ONLY_RULE_KEYS`** entry for the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d942131393bba49b71d29a32d70c688e31b0026a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->