### PR TITLE
feat(oxlint): add prefer-explicit-variants rule

### DIFF
--- a/.changeset/add-prefer-explicit-variants.md
+++ b/.changeset/add-prefer-explicit-variants.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat: add `prefer-explicit-variants` rule. Flags a component that picks which component to render from 2+ boolean props (each used as the test of a two-sided JSX ternary), nudging toward explicit variant components instead of variants jammed into one component. App-only, `warn` severity; cross-cutting state/responsive/auth booleans (`isLoading`, `isMobile`, …) and single switches are intentionally ignored.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -249,6 +249,7 @@ export const DIAGNOSTIC_CATEGORY_BUCKETS = [
 export const APP_ONLY_RULE_KEYS: ReadonlySet<string> = new Set([
   "react-hooks-js/static-components",
   "react-doctor/no-render-prop-children",
+  "react-doctor/prefer-explicit-variants",
 ]);
 
 // The `compiler-cleanup` severity bucket: redundant-memoization rules that

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
@@ -7,6 +7,11 @@ export const SEQUENTIAL_AWAIT_THRESHOLD = 3;
 export const PROPERTY_ACCESS_REPEAT_THRESHOLD = 3;
 export const BOOLEAN_PROP_THRESHOLD = 4;
 export const RENDER_PROP_PROLIFERATION_THRESHOLD = 3;
+// Distinct boolean props a single component must use as the test of a
+// two-sided JSX ternary before `prefer-explicit-variants` fires. Two is
+// the "several variants jammed into one component" signal — a lone
+// `isMobile ? <Mobile /> : <Desktop />` switch is legitimate and stays quiet.
+export const BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD = 2;
 export const GET_HANDLER_BINDING_RESOLUTION_DEPTH = 3;
 // Chains rooted in a literal array `[a, b, c].map(...).filter(...)` at
 // or below this length are skipped by the iteration-combination rules

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -235,6 +235,7 @@ import { preactPreferOndblclick } from "./rules/preact/preact-prefer-ondblclick.
 import { preactPreferOninput } from "./rules/preact/preact-prefer-oninput.js";
 import { preferDynamicImport } from "./rules/bundle-size/prefer-dynamic-import.js";
 import { preferEs6Class } from "./rules/react-builtins/prefer-es6-class.js";
+import { preferExplicitVariants } from "./rules/architecture/prefer-explicit-variants.js";
 import { preferFunctionComponent } from "./rules/react-builtins/prefer-function-component.js";
 import { preferHtmlDialog } from "./rules/a11y/prefer-html-dialog.js";
 import { preferModuleScopePureFunction } from "./rules/architecture/prefer-module-scope-pure-function.js";
@@ -2839,6 +2840,17 @@ export const reactDoctorRules = [
     originallyExternal: true,
     rule: {
       ...preferEs6Class,
+      framework: "global",
+      category: "Maintainability",
+    },
+  },
+  {
+    key: "react-doctor/prefer-explicit-variants",
+    id: "prefer-explicit-variants",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...preferExplicitVariants,
       framework: "global",
       category: "Maintainability",
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { preferExplicitVariants } from "./prefer-explicit-variants.js";
+
+const expectDiagnosticCount = (
+  code: string,
+  expectedDiagnosticCount: number,
+  filename = "fixture.tsx",
+): void => {
+  const result = runRule(preferExplicitVariants, code, { filename });
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedDiagnosticCount);
+};
+
+describe("architecture/prefer-explicit-variants — fail cases", () => {
+  it("flags two boolean props each swapping whole components", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isEditing }) {
+  return (
+    <div>
+      {isThread ? <ThreadHeader /> : <ChannelHeader />}
+      {isEditing ? <EditActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("flags the arrow-component form", () => {
+    expectDiagnosticCount(
+      `const Composer = ({ isThread, isEditing }) => (
+  <div>
+    {isThread ? <ThreadHeader /> : <ChannelHeader />}
+    {isEditing ? <EditActions /> : <DefaultActions />}
+  </div>
+);`,
+      1,
+    );
+  });
+
+  it("flags a negated boolean-prop test", () => {
+    expectDiagnosticCount(
+      `function Composer({ isEditing, isForwarding }) {
+  return (
+    <div>
+      {!isEditing ? <ReadOnlyBody /> : <EditableBody />}
+      {isForwarding ? <ForwardActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("follows a renamed destructured boolean prop", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread: showThread, isEditing }) {
+  return (
+    <div>
+      {showThread ? <ThreadHeader /> : <ChannelHeader />}
+      {isEditing ? <EditActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("follows a defaulted boolean prop", () => {
+    expectDiagnosticCount(
+      `function Banner({ isPrimary = false, isCompact = false }) {
+  return (
+    <section>
+      {isPrimary ? <PrimaryTitle /> : <SecondaryTitle />}
+      {isCompact ? <CompactBody /> : <FullBody />}
+    </section>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("treats JSX fragments as branch output", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isEditing }) {
+  return (
+    <div>
+      {isThread ? <><ThreadHeader /></> : <><ChannelHeader /></>}
+      {isEditing ? <EditActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+
+  it("flags parenthesized multi-line ternary arms (the Prettier shape)", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isEditing }) {
+  return (
+    <div>
+      {isThread ? (
+        <ThreadHeader />
+      ) : (
+        <ChannelHeader />
+      )}
+      {isEditing ? (
+        <EditActions />
+      ) : (
+        <DefaultActions />
+      )}
+    </div>
+  );
+}`,
+      1,
+    );
+  });
+});
+
+describe("architecture/prefer-explicit-variants — pass cases (no diagnostics)", () => {
+  it("ignores a single boolean-prop component switch", () => {
+    expectDiagnosticCount(
+      `function Nav({ isMobile, label }) {
+  return <div>{isMobile ? <MobileNav /> : <DesktopNav />}{label}</div>;
+}`,
+      0,
+    );
+  });
+
+  it("ignores visibility toggles where an arm is null", () => {
+    expectDiagnosticCount(
+      `function Panel({ isLoading, isOpen }) {
+  return (
+    <div>
+      {isLoading ? <Spinner /> : null}
+      {isOpen ? <Body /> : null}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores repeated ternaries on the same single boolean prop", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, title }) {
+  return (
+    <div>
+      {isThread ? <ThreadHeader /> : <ChannelHeader />}
+      <h1>{title}</h1>
+      {isThread ? <ThreadFooter /> : <ChannelFooter />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores ternaries on non-boolean-prefixed props", () => {
+    expectDiagnosticCount(
+      `function View({ status, mode }) {
+  return (
+    <div>
+      {status ? <Active /> : <Inactive />}
+      {mode ? <Grid /> : <List />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores boolean locals that are not props", () => {
+    expectDiagnosticCount(
+      `import { useState } from "react";
+
+function Composer() {
+  const [isThread, setIsThread] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  return (
+    <div>
+      {isThread ? <ThreadHeader /> : <ChannelHeader />}
+      {isEditing ? <EditActions /> : <DefaultActions />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores ternaries whose arms are not JSX", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isEditing }) {
+  const heading = isThread ? "Thread" : "Channel";
+  const action = isEditing ? "Save" : "Send";
+  return <div>{heading}{action}</div>;
+}`,
+      0,
+    );
+  });
+
+  it("does not descend into nested function branches", () => {
+    expectDiagnosticCount(
+      `function List({ isThread, isEditing, items }) {
+  return (
+    <Items
+      data={items}
+      renderItem={() => (isThread ? <ThreadRow /> : <ChannelRow />)}
+      renderFooter={() => (isEditing ? <EditFooter /> : <DefaultFooter />)}
+    />
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores non-component functions", () => {
+    expectDiagnosticCount(
+      `function resolve({ isThread, isEditing }) {
+  return isThread ? <ThreadHeader /> : isEditing ? <EditActions /> : <DefaultActions />;
+}`,
+      0,
+    );
+  });
+
+  it("ignores cross-cutting state booleans rendered two ways", () => {
+    expectDiagnosticCount(
+      `function Card({ isLoading, isError }) {
+  return (
+    <div>
+      {isLoading ? <Spinner /> : <Content />}
+      {isError ? <ErrorState /> : <OkState />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+
+  it("ignores a mode prop paired with a state prop below the threshold", () => {
+    expectDiagnosticCount(
+      `function Composer({ isThread, isLoading }) {
+  return (
+    <div>
+      {isThread ? <ThreadHeader /> : <ChannelHeader />}
+      {isLoading ? <Spinner /> : <Body />}
+    </div>
+  );
+}`,
+      0,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.ts
@@ -1,0 +1,186 @@
+import { BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD } from "../../constants/thresholds.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { isBooleanPrefixedPropName } from "../../utils/is-boolean-prefixed-prop-name.js";
+import { isComponentAssignment } from "../../utils/is-component-assignment.js";
+import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
+import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { Rule } from "../../utils/rule.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Strips parens / TS wrappers first: Prettier wraps multi-line JSX ternary
+// arms in parentheses (`cond ? (<A />) : (<B />)`), which the parser surfaces
+// as a `ParenthesizedExpression` wrapping the JSXElement.
+const isJsxElementOrFragment = (node: EsTreeNode | null | undefined): boolean => {
+  if (!node) return false;
+  const inner = stripParenExpression(node);
+  return isNodeOfType(inner, "JSXElement") || isNodeOfType(inner, "JSXFragment");
+};
+
+// Resolve a ternary `test` to the local binding name when it is a bare
+// boolean prop (`isEditing ? …`) or its negation (`!isEditing ? …`), and
+// only when that binding is one of the component's boolean-prefixed props.
+// Anything else (member access, `===` comparisons, logical chains) is not a
+// "boolean prop variant switch" and is intentionally ignored.
+const resolveBooleanPropTestName = (
+  testNode: EsTreeNode,
+  booleanPropBindings: ReadonlySet<string>,
+): string | null => {
+  let identifierNode = stripParenExpression(testNode);
+  if (isNodeOfType(identifierNode, "UnaryExpression") && identifierNode.operator === "!") {
+    identifierNode = stripParenExpression(identifierNode.argument);
+  }
+  if (!isNodeOfType(identifierNode, "Identifier")) return null;
+  return booleanPropBindings.has(identifierNode.name) ? identifierNode.name : null;
+};
+
+// Cross-cutting state / responsive / auth booleans whose two-way render
+// (`isLoading ? <Spinner /> : <Content />`) is ordinary conditional UI, not
+// the "variants jammed into one component" smell. Excluded so the rule fires
+// on domain "mode" props (isThread, isEditing, isPrimary) and stays quiet on
+// these. Curated, not exhaustive — precision over recall for an opinionated rule.
+const CROSS_CUTTING_STATE_BOOLEAN_NAMES = new Set<string>([
+  "isLoading",
+  "isPending",
+  "isFetching",
+  "isRefetching",
+  "isSubmitting",
+  "isError",
+  "isSuccess",
+  "isEmpty",
+  "isReady",
+  "isDirty",
+  "isValid",
+  "isInvalid",
+  "isOpen",
+  "isClosed",
+  "isVisible",
+  "isHidden",
+  "isActive",
+  "isInactive",
+  "isExpanded",
+  "isCollapsed",
+  "isSelected",
+  "isChecked",
+  "isDisabled",
+  "isEnabled",
+  "isFocused",
+  "isHovered",
+  "isDragging",
+  "isFullscreen",
+  "isMobile",
+  "isDesktop",
+  "isTablet",
+  "isOnline",
+  "isOffline",
+  "isLoggedIn",
+  "isAuthenticated",
+  "isAuthorized",
+  "isDark",
+  "isLight",
+]);
+
+// The local binding name of a destructured boolean-prefixed prop, following
+// renames (`{ isThread: renamed }`) and defaults (`{ isPrimary = false }`)
+// so the ternary-test lookup matches what the body actually references.
+const collectBooleanPropBindings = (param: EsTreeNode | undefined): Set<string> => {
+  const bindings = new Set<string>();
+  if (!param || !isNodeOfType(param, "ObjectPattern")) return bindings;
+  for (const property of param.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) continue;
+    if (property.computed) continue;
+    if (!isNodeOfType(property.key, "Identifier")) continue;
+    if (!isBooleanPrefixedPropName(property.key.name)) continue;
+    if (CROSS_CUTTING_STATE_BOOLEAN_NAMES.has(property.key.name)) continue;
+    const propertyValue = property.value;
+    if (isNodeOfType(propertyValue, "Identifier")) {
+      bindings.add(propertyValue.name);
+    } else if (
+      isNodeOfType(propertyValue, "AssignmentPattern") &&
+      isNodeOfType(propertyValue.left, "Identifier")
+    ) {
+      bindings.add(propertyValue.left.name);
+    }
+  }
+  return bindings;
+};
+
+const collectVariantBranchProps = (
+  body: EsTreeNode | undefined,
+  booleanPropBindings: ReadonlySet<string>,
+): Set<string> => {
+  const variantBranchProps = new Set<string>();
+  if (!body) return variantBranchProps;
+  walkAst(body, (current: EsTreeNode) => {
+    // A ternary inside a nested function (render prop, event handler, inner
+    // component) does not select THIS component's rendered output — prune it.
+    if (isNodeOfType(current, "FunctionDeclaration") || isInlineFunctionExpression(current)) {
+      return false;
+    }
+    if (!isNodeOfType(current, "ConditionalExpression")) return;
+    const propName = resolveBooleanPropTestName(current.test, booleanPropBindings);
+    if (!propName) return;
+    // Both arms must be JSX: a two-sided component swap, not a visibility
+    // toggle (`isOpen ? <Panel /> : null`) or a value pick.
+    if (!isJsxElementOrFragment(current.consequent) || !isJsxElementOrFragment(current.alternate)) {
+      return;
+    }
+    variantBranchProps.add(propName);
+  });
+  return variantBranchProps;
+};
+
+// HACK: a component that selects which component to render from multiple
+// boolean props (`isThread ? <A /> : <B />` plus `isEditing ? <C /> : <D />`)
+// is several variants jammed into one — the "explicit variants" smell from
+// the composition-patterns guidance. We require TWO distinct boolean props
+// each driving a two-sided JSX ternary, because a single such switch
+// (`isMobile ? <Mobile /> : <Desktop />`) is a legitimate, common pattern.
+// Name-based prop detection mirrors `no-many-boolean-props` (TS types aren't
+// visible at this AST layer). v1 only models two-sided ternaries on
+// destructured props; if/else early-return variants and multi-way chains
+// ending in `null` are out of scope.
+export const preferExplicitVariants = defineRule<Rule>({
+  id: "prefer-explicit-variants",
+  title: "Prefer explicit variant components",
+  severity: "warn",
+  tags: ["test-noise", "react-jsx-only"],
+  recommendation:
+    "Replace boolean props that switch whole subtrees with explicit variant components, like `<ThreadComposer />` and `<EditMessageComposer />`, so each variant renders one clear path.",
+  create: (context: RuleContext) => {
+    const checkComponent = (
+      param: EsTreeNode | undefined,
+      body: EsTreeNode | undefined,
+      componentName: string,
+      reportNode: EsTreeNode,
+    ): void => {
+      const booleanPropBindings = collectBooleanPropBindings(param);
+      if (booleanPropBindings.size < BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD) return;
+      const variantBranchProps = collectVariantBranchProps(body, booleanPropBindings);
+      if (variantBranchProps.size < BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD) return;
+      const propList = [...variantBranchProps].slice(0, 3).join(", ");
+      const overflow = variantBranchProps.size > 3 ? "…" : "";
+      context.report({
+        node: reportNode,
+        message: `Component "${componentName}" picks which component to render from ${variantBranchProps.size} boolean props (${propList}${overflow}), which multiplies untestable variants. Split it into explicit variant components so each renders one clear path.`,
+      });
+    };
+
+    return {
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+        if (!isComponentDeclaration(node) || !node.id) return;
+        checkComponent(node.params?.[0], node.body, node.id.name, node.id);
+      },
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+        if (!isComponentAssignment(node)) return;
+        if (!isNodeOfType(node.id, "Identifier")) return;
+        if (!isInlineFunctionExpression(node.init)) return;
+        checkComponent(node.init.params?.[0], node.init.body, node.id.name, node.id);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.ts
@@ -4,6 +4,7 @@ import { isBooleanPrefixedPropName } from "../../utils/is-boolean-prefixed-prop-
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
+import { isJsxElementOrFragment } from "../../utils/is-jsx-element-or-fragment.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -11,15 +12,6 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-
-// Strips parens / TS wrappers first: Prettier wraps multi-line JSX ternary
-// arms in parentheses (`cond ? (<A />) : (<B />)`), which the parser surfaces
-// as a `ParenthesizedExpression` wrapping the JSXElement.
-const isJsxElementOrFragment = (node: EsTreeNode | null | undefined): boolean => {
-  if (!node) return false;
-  const inner = stripParenExpression(node);
-  return isNodeOfType(inner, "JSXElement") || isNodeOfType(inner, "JSXFragment");
-};
 
 // Resolve a ternary `test` to the local binding name when it is a bare
 // boolean prop (`isEditing ? …`) or its negation (`!isEditing ? …`), and
@@ -125,10 +117,12 @@ const collectVariantBranchProps = (
     const propName = resolveBooleanPropTestName(current.test, booleanPropBindings);
     if (!propName) return;
     // Both arms must be JSX: a two-sided component swap, not a visibility
-    // toggle (`isOpen ? <Panel /> : null`) or a value pick.
-    if (!isJsxElementOrFragment(current.consequent) || !isJsxElementOrFragment(current.alternate)) {
-      return;
-    }
+    // toggle (`isOpen ? <Panel /> : null`) or a value pick. Strip parens
+    // first — Prettier wraps multi-line ternary arms in parentheses, which
+    // the parser surfaces as a `ParenthesizedExpression` around the JSX.
+    const consequent = stripParenExpression(current.consequent);
+    const alternate = stripParenExpression(current.alternate);
+    if (!isJsxElementOrFragment(consequent) || !isJsxElementOrFragment(alternate)) return;
     variantBranchProps.add(propName);
   });
   return variantBranchProps;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-jsx-element-or-fragment.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-jsx-element-or-fragment.ts
@@ -1,0 +1,16 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+/**
+ * Type-guard for the two single-node JSX output forms: `JSXElement`
+ * (`<Foo />`) and `JSXFragment` (`<>…</>`). Canonical home for the
+ * `isNodeOfType(x, "JSXElement") || isNodeOfType(x, "JSXFragment")` check
+ * that many rules otherwise inline. Does NOT unwrap parens / TS wrappers —
+ * callers that need the semantic expression should `stripParenExpression`
+ * first.
+ */
+export const isJsxElementOrFragment = (
+  node: EsTreeNode | null | undefined,
+): node is EsTreeNodeOfType<"JSXElement"> | EsTreeNodeOfType<"JSXFragment"> =>
+  Boolean(node && (isNodeOfType(node, "JSXElement") || isNodeOfType(node, "JSXFragment")));


### PR DESCRIPTION
## Summary
Adds `prefer-explicit-variants` (architecture, `warn`, app-only) — the one net-new lintable pattern from the vercel-labs composition-patterns skill (the rest are already shipped or aren't statically lintable).

**Catches** a component that picks *which component to render* from 2+ boolean-prefixed props, each the test of a two-sided JSX ternary:

```tsx
// flagged
function Composer({ isThread, isEditing }) {
  return (
    <div>
      {isThread ? <ThreadHeader /> : <ChannelHeader />}
      {isEditing ? <EditActions /> : <DefaultActions />}
    </div>
  );
}
```

**Stays quiet** on: single boolean switch (`isMobile ? <A/> : <B/>`), visibility toggles (`? <X/> : null`), cross-cutting state/responsive/auth booleans (`isLoading`, `isError`, `isMobile`, …), non-prefixed props, local `useState` booleans, and nested-function branches.

Precision: requires 2 distinct props; both arms must be JSX with parens/TS-wrappers stripped (so Prettier's multi-line `cond ? (<A/>) : (<B/>)` is caught — thanks to the thermo review); curated state-boolean denylist for false-positive control.

> Stacked on #704 (reuses `isBooleanPrefixedPropName`). Review/merge #704 first.

## Test plan
- [x] 17 adversarial rule tests (incl. parenthesized arms, state-boolean exclusion, nested-fn pruning, renamed/defaulted destructuring)
- [x] integration `run-oxlint/architecture.test.ts` + rule meta-tests (registry/metadata/tags/docs-url)
- [x] `typecheck` / `lint` / `format:check`

## Follow-ups (rule-validate stage)
- [ ] ESLint mirror in `eslint-plugin-react-doctor`
- [ ] RDE noise eval against OSS (opinionated `test-noise` tier; threshold may tune)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional maintainability lint at warn severity with deliberate false-positive guards; no runtime or security impact.
> 
> **Overview**
> Adds **`react-doctor/prefer-explicit-variants`**, an architecture **warn** that nudges apps away from one component whose render path is driven by **two or more** boolean-prefixed props, each used as the test of a **two-sided JSX ternary** (both arms must be element/fragment; parens stripped for Prettier-shaped arms).
> 
> The rule is registered in the oxlint plugin, tagged **`test-noise`** / **`react-jsx-only`**, and listed in **`APP_ONLY_RULE_KEYS`** so it runs on app/unknown packages but stays off confidently classified libraries. **`BOOLEAN_PROP_VARIANT_BRANCH_THRESHOLD`** (2) gates firing; a curated denylist skips cross-cutting booleans (`isLoading`, `isMobile`, etc.), and nested inline functions are not walked.
> 
> Supporting change: shared **`isJsxElementOrFragment`** helper plus a focused unit test suite and a minor changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 003de9cc81bc16f5cd1993480cfa6508d6389b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->