### PR TITLE
feat(ci): surface React Doctor results on `main` + offer v1→v2 action upgrade

### DIFF
--- a/.changeset/proactive-action-v2-upgrade.md
+++ b/.changeset/proactive-action-v2-upgrade.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+CI setup now offers a one-time, per-repo prompt to upgrade an existing React Doctor GitHub Actions workflow from `@v1` to `@v2` — accepting opens a PR with the bump, declining is remembered so it never asks again. The generated / "Add to CI" workflow now pins `millionco/react-doctor@v2` and grants `statuses: write`, so the action can publish the score as a commit status (and surface results on pushes to the default branch).

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  statuses: write
 
 jobs:
   react-doctor:

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   review-comments:
     description: "Post inline review comments on the changed lines that triggered diagnostics (pull requests only)."
     default: "true"
+  commit-status:
+    description: "Publish a commit status with the score and error / warning counts, linking to the run. Surfaces the result on pushes to the default branch (where the PR comment is skipped). Requires `statuses: write` (skipped with a warning otherwise)."
+    default: "true"
   node-version:
     description: "Node.js version to use"
     default: "24"
@@ -183,6 +186,14 @@ runs:
       run: |
         node "$GITHUB_ACTION_PATH/scripts/render-github-action-comment.mjs" "$REPORT_FILE" "$COMMENT_FILE"
         echo "comment-file=$COMMENT_FILE" >> "$GITHUB_OUTPUT"
+
+        # Mirror the rendered report into the run's job summary so every event —
+        # including pushes to the default branch, where the sticky PR comment is
+        # skipped — has a visible result on the run page. The commit status's
+        # "Details" link lands here.
+        if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -f "$COMMENT_FILE" ]; then
+          cat "$COMMENT_FILE" >> "$GITHUB_STEP_SUMMARY"
+        fi
 
     - name: Update sticky PR comment
       if: ${{ always() && github.event_name == 'pull_request' && inputs.comment == 'true' }}
@@ -384,12 +395,70 @@ runs:
             }
           }
 
+    - name: Publish commit status
+      if: ${{ always() && inputs.commit-status == 'true' }}
+      uses: actions/github-script@v8
+      env:
+        REACT_DOCTOR_SCORE: ${{ steps.render.outputs.score }}
+        REACT_DOCTOR_ERROR_COUNT: ${{ steps.render.outputs.error-count }}
+        REACT_DOCTOR_WARNING_COUNT: ${{ steps.render.outputs.warning-count }}
+        REACT_DOCTOR_SCAN_EXIT: ${{ steps.scan.outputs.exit-code }}
+        # On a PR the merge ref's parent is the reviewed commit; `github.sha`
+        # covers push runs.
+        REACT_DOCTOR_STATUS_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        REACT_DOCTOR_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      with:
+        script: |
+          const sha = process.env.REACT_DOCTOR_STATUS_SHA;
+          if (!sha) return;
+
+          const score = process.env.REACT_DOCTOR_SCORE;
+          const errorCount = Number(process.env.REACT_DOCTOR_ERROR_COUNT || "0");
+          const warningCount = Number(process.env.REACT_DOCTOR_WARNING_COUNT || "0");
+          const scanExit = process.env.REACT_DOCTOR_SCAN_EXIT;
+          const isPullRequest = context.eventName === "pull_request";
+
+          const pluralize = (count, noun) => `${count} ${noun}${count === 1 ? "" : "s"}`;
+          const counts = `${pluralize(errorCount, "error")} · ${pluralize(warningCount, "warning")}`;
+          const scanFailed = scanExit !== undefined && scanExit !== "" && scanExit !== "0";
+          // `score` is empty when the scan couldn't produce one (crash / aborted).
+          const description = score ? `Score: ${score}/100 · ${counts}` : scanFailed ? "Scan could not complete" : counts;
+
+          // Advisory on pushes (a default-branch health-trend signal that must
+          // never turn the branch red); on a PR the status mirrors the gate so it
+          // agrees with the job's own pass/fail.
+          const state = isPullRequest && scanFailed ? "failure" : "success";
+
+          try {
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha,
+              state,
+              context: "React Doctor",
+              description: description.slice(0, 140),
+              target_url: process.env.REACT_DOCTOR_RUN_URL,
+            });
+          } catch (error) {
+            core.warning(
+              `React Doctor could not publish the commit status (${error.message}). ` +
+                "Grant the workflow `statuses: write` to enable it.",
+            );
+          }
+
     - name: Fail if React Doctor found blocking issues
       if: always()
       shell: bash
       env:
         SCAN_STATUS: ${{ steps.scan.outputs.exit-code }}
+        EVENT_NAME: ${{ github.event_name }}
       run: |
-        # The CLI's exit code already reflects the `blocking` threshold
-        # (`blocking: none` exits 0 even with findings); just propagate it.
+        # Non-PR events (e.g. a push to the default branch) run a full-project
+        # health snapshot, not a PR gate: the result is surfaced through the job
+        # summary + commit status, but the run never fails on findings so `main`
+        # doesn't go red on pre-existing issues. PRs still propagate the CLI exit
+        # code, which already reflects the `blocking` threshold (`blocking: none`
+        # exits 0 even with findings).
+        if [ "$EVENT_NAME" != "pull_request" ]; then
+          exit 0
+        fi
         exit "${SCAN_STATUS:-1}"

--- a/action.yml
+++ b/action.yml
@@ -420,7 +420,10 @@ runs:
 
           const pluralize = (count, noun) => `${count} ${noun}${count === 1 ? "" : "s"}`;
           const counts = `${pluralize(errorCount, "error")} · ${pluralize(warningCount, "warning")}`;
-          const scanFailed = scanExit !== undefined && scanExit !== "" && scanExit !== "0";
+          // An empty / missing exit code means the scan step never finished; treat
+          // it as a failure so this status can't show green while the PR gate (which
+          // uses `${SCAN_STATUS:-1}`) fails the run.
+          const scanFailed = scanExit !== "0";
           // `score` is empty when the scan couldn't produce one (crash / aborted).
           const description = score ? `Score: ${score}/100 · ${counts}` : scanFailed ? "Scan could not complete" : counts;
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -66,6 +66,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  statuses: write # lets the action publish the score as a commit status
 
 concurrency:
   group: react-doctor-${{ github.event.pull_request.number || github.ref }}
@@ -78,15 +79,15 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # so React Doctor can diff against the merge-base for new-vs-existing
-      - uses: millionco/react-doctor@v1
+      - uses: millionco/react-doctor@v2
 ```
 
 `fetch-depth: 0` is recommended so the baseline comparison can read the base commit; without enough history the Action falls back to reporting every finding in the changed files.
 
-`@v1` always resolves to the latest `v1.x` release of the Action. For hardened CI — recommended whenever the workflow is granted `pull-requests: write` — pin to a full commit SHA instead and let Dependabot or Renovate keep it current:
+`@v2` always resolves to the latest `v2.x` release of the Action. For hardened CI — recommended whenever the workflow is granted `pull-requests: write` — pin to a full commit SHA instead and let Dependabot or Renovate keep it current:
 
 ```yaml
-- uses: millionco/react-doctor@b612664043a9be414166e3c6a69b355e39a8dcf4 # v1.1.1
+- uses: millionco/react-doctor@75932719d11ef50e110eac01ce04acdc05fde074 # v2.0.1
 ```
 
 [Add GitHub Action →](https://github.com/marketplace/actions/react-doctor)

--- a/packages/react-doctor/src/cli/utils/action-upgrade-prompt.ts
+++ b/packages/react-doctor/src/cli/utils/action-upgrade-prompt.ts
@@ -1,0 +1,80 @@
+import * as path from "node:path";
+import Conf from "conf";
+import { hashProjectRoot } from "./hash-project-root.js";
+
+// Shares the one global `react-doctor` config file with onboarding +
+// setup-prompt state; `Conf` preserves unknown keys, so this concern lives
+// under its own top-level `actionUpgrades` map without clobbering theirs.
+const GLOBAL_CONFIG_PROJECT_NAME = "react-doctor";
+
+export type ActionUpgradeOutcome = "accepted" | "declined";
+
+export interface ActionUpgradeStoreOptions {
+  // Overrides the config dir; tests point this at a temp dir.
+  readonly cwd?: string;
+}
+
+interface ActionUpgradeProjectConfig {
+  readonly rootDirectory: string;
+  readonly outcome: ActionUpgradeOutcome;
+  readonly at: string;
+}
+
+interface ActionUpgradeGlobalConfig {
+  readonly actionUpgrades?: Record<string, ActionUpgradeProjectConfig>;
+}
+
+const getActionUpgradeStore = (
+  options: ActionUpgradeStoreOptions = {},
+): Conf<ActionUpgradeGlobalConfig> =>
+  new Conf<ActionUpgradeGlobalConfig>({
+    projectName: GLOBAL_CONFIG_PROJECT_NAME,
+    cwd: options.cwd,
+  });
+
+export const getActionUpgradePromptConfigPath = (options: ActionUpgradeStoreOptions = {}): string =>
+  getActionUpgradeStore(options).path;
+
+// Whether the upgrade offer was already answered (accepted OR declined) for
+// this repo. Either answer suppresses future prompts so the offer is truly
+// one-time — an accepted-but-unmerged PR shouldn't re-prompt on the next scan.
+export const hasHandledActionUpgrade = (
+  projectRoot: string,
+  storeOptions: ActionUpgradeStoreOptions = {},
+): boolean => {
+  try {
+    const store = getActionUpgradeStore(storeOptions);
+    const upgrades = store.get("actionUpgrades", {});
+    return Boolean(upgrades[hashProjectRoot(projectRoot)]);
+  } catch {
+    // Unreadable global-config dir (EPERM / EROFS in locked-down CI and
+    // sandboxes). Fail safe to "already handled" so we never nag in an
+    // environment that can't remember the answer — the prompt is
+    // interactive-only and best skipped there anyway.
+    return true;
+  }
+};
+
+// Records the user's one-time answer for this repo. Returns whether it
+// persisted (a read-only config dir just means the choice isn't remembered).
+export const recordActionUpgradeDecision = (
+  projectRoot: string,
+  outcome: ActionUpgradeOutcome,
+  storeOptions: ActionUpgradeStoreOptions = {},
+): boolean => {
+  try {
+    const store = getActionUpgradeStore(storeOptions);
+    const upgrades = store.get("actionUpgrades", {});
+    store.set("actionUpgrades", {
+      ...upgrades,
+      [hashProjectRoot(projectRoot)]: {
+        rootDirectory: path.resolve(projectRoot),
+        outcome,
+        at: new Date().toISOString(),
+      },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -162,19 +162,21 @@ const askUpgradeActionVersion = async (): Promise<UpgradePromptChoice> => {
 // the change lands as a reviewable PR rather than a silent edit. On a PR-open
 // success the user's working tree is restored to `@v1` (the bump lives only on
 // the PR branch); when `gh` is unavailable we fall back to staging the edit so
-// it shows up in their next commit.
+// it shows up in their next commit. Returns whether the bump was applied: a
+// write failure returns `false` so the caller doesn't record the offer as
+// handled, leaving it to re-prompt on the next scan.
 const upgradeGitHubActionsWorkflow = async (
   workflow: InstalledReactDoctorWorkflow,
-): Promise<void> => {
+): Promise<boolean> => {
   const { content, changed } = upgradeWorkflowActionToV2(workflow.content);
-  if (!changed) return;
+  if (!changed) return false;
 
   const upgradeSpinner = spinner("Opening a pull request to upgrade React Doctor to v2...").start();
   try {
     fs.writeFileSync(workflow.workflowPath, content);
   } catch {
     upgradeSpinner.fail("Couldn't update the workflow file.");
-    return;
+    return false;
   }
 
   const pullRequestResult = await openWorkflowPullRequest({
@@ -201,13 +203,16 @@ const upgradeGitHubActionsWorkflow = async (
         : "  Updated the workflow to @v2. Commit the change to finish the upgrade.",
     );
   }
+
+  return true;
 };
 
 // Offered once per repo: when a React Doctor workflow is already on disk but
 // still pins the action's previous floating major (`@v1`), invite the user to
-// bump it to `@v2` via a PR. Both answers are persisted per-repo so the offer
-// never repeats; a cancel leaves it un-answered for next time. The caller has
-// already gated on an interactive run with findings.
+// bump it to `@v2` via a PR. A decline is persisted per-repo, and an accept
+// only once the bump is actually applied, so the offer never repeats; a cancel
+// (or a failed write) leaves it un-answered so the prompt can return next scan.
+// The caller has already gated on an interactive run with findings.
 const maybeOfferActionUpgrade = async (projectRoot: string): Promise<void> => {
   const workflow = readReactDoctorWorkflow(projectRoot);
   if (!workflow || !workflowUsesV1Action(workflow.content)) return;
@@ -225,8 +230,8 @@ const maybeOfferActionUpgrade = async (projectRoot: string): Promise<void> => {
     return;
   }
 
-  await upgradeGitHubActionsWorkflow(workflow);
-  recordActionUpgradeDecision(projectRoot, "accepted");
+  const didApplyUpgrade = await upgradeGitHubActionsWorkflow(workflow);
+  if (didApplyUpgrade) recordActionUpgradeDecision(projectRoot, "accepted");
 };
 
 // First handoff question, asked only when the GitHub Actions workflow isn't

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -196,6 +196,17 @@ const upgradeGitHubActionsWorkflow = async (
     );
   } else {
     upgradeSpinner.stop();
+    // A git failure mid-flight (e.g. a rejected push) leaves openWorkflowPull-
+    // Request having restored the original branch — reverting the tracked file
+    // back to `@v1`. Re-write the bump so the working tree definitely lands on
+    // `@v2` before staging, keeping the "updated to @v2" message honest (and the
+    // recorded `accepted` decision truthful).
+    try {
+      fs.writeFileSync(workflow.workflowPath, content);
+    } catch {
+      logger.log("  Couldn't finish the upgrade. Re-run React Doctor to try again.");
+      return false;
+    }
     const didStage = await stageWorkflowFile({ workflowPath: workflow.workflowPath });
     logger.log(
       didStage

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { getSkillAgentConfig } from "agent-install";
 import type { Diagnostic } from "@react-doctor/core";
 import { CI_URL, highlighter } from "@react-doctor/core";
@@ -9,7 +10,12 @@ import { installReactDoctorScriptStep } from "./install-react-doctor.js";
 import {
   installReactDoctorWorkflow,
   isReactDoctorWorkflowInstalled,
+  readReactDoctorWorkflow,
+  upgradeWorkflowActionToV2,
+  workflowUsesV1Action,
+  type InstalledReactDoctorWorkflow,
 } from "./install-github-workflow.js";
+import { hasHandledActionUpgrade, recordActionUpgradeDecision } from "./action-upgrade-prompt.js";
 import { reportWorkflowResult } from "./report-workflow-result.js";
 import { installReactDoctorSkillForAgent } from "./install-skill-for-agent.js";
 import { isCommandAvailable } from "./is-command-available.js";
@@ -106,6 +112,121 @@ const setUpGitHubActions = async (rootDirectory: string): Promise<void> => {
     }
   }
   logger.log(`  Learn more: ${highlighter.info(CI_URL)}`);
+};
+
+const UPGRADE_YES_CHOICE = "upgrade-yes";
+const UPGRADE_NO_CHOICE = "upgrade-no";
+
+const UPGRADE_COMMIT_MESSAGE = "ci: upgrade React Doctor GitHub Action to v2";
+const UPGRADE_PR_TITLE = "Upgrade React Doctor Action to v2";
+const UPGRADE_PR_BODY = `Bumps the React Doctor GitHub Actions workflow to the action's latest major, \`millionco/react-doctor@v2\`.
+
+Docs: https://www.react.doctor/ci`;
+
+type UpgradePromptChoice = "yes" | "no" | "cancel";
+
+// One-time-per-repo offer to bump an existing workflow from the action's
+// previous floating major (`@v1`) to `@v2`. Two choices only — a "no" doubles
+// as "don't ask again" (persisted by the caller). Cancel (Esc / Ctrl-C) is
+// left un-answered so a stray keypress doesn't permanently suppress the offer.
+const askUpgradeActionVersion = async (): Promise<UpgradePromptChoice> => {
+  const { upgradeChoice } = await prompts<"upgradeChoice">(
+    {
+      type: "select",
+      name: "upgradeChoice",
+      message: "A new major of the React Doctor Action (v2) is out. Upgrade this repo's workflow?",
+      hint: " ",
+      choices: [
+        {
+          title: "Yes (recommended)",
+          description: "Open a PR bumping the workflow to millionco/react-doctor@v2",
+          value: UPGRADE_YES_CHOICE,
+        },
+        {
+          title: "No, thanks",
+          description: "Keep @v1 — won't ask again for this repo",
+          value: UPGRADE_NO_CHOICE,
+        },
+      ],
+      initial: 0,
+    },
+    { onCancel: () => true },
+  );
+
+  if (upgradeChoice === undefined) return "cancel";
+  return upgradeChoice === UPGRADE_YES_CHOICE ? "yes" : "no";
+};
+
+// Writes the `@v2` bump into the existing (tracked) workflow file and opens a
+// PR for it — mirroring the fresh-install flow's commit-on-a-branch model so
+// the change lands as a reviewable PR rather than a silent edit. On a PR-open
+// success the user's working tree is restored to `@v1` (the bump lives only on
+// the PR branch); when `gh` is unavailable we fall back to staging the edit so
+// it shows up in their next commit.
+const upgradeGitHubActionsWorkflow = async (
+  workflow: InstalledReactDoctorWorkflow,
+): Promise<void> => {
+  const { content, changed } = upgradeWorkflowActionToV2(workflow.content);
+  if (!changed) return;
+
+  const upgradeSpinner = spinner("Opening a pull request to upgrade React Doctor to v2...").start();
+  try {
+    fs.writeFileSync(workflow.workflowPath, content);
+  } catch {
+    upgradeSpinner.fail("Couldn't update the workflow file.");
+    return;
+  }
+
+  const pullRequestResult = await openWorkflowPullRequest({
+    workflowPath: workflow.workflowPath,
+    commitMessage: UPGRADE_COMMIT_MESSAGE,
+    prTitle: UPGRADE_PR_TITLE,
+    prBody: UPGRADE_PR_BODY,
+  });
+
+  if (pullRequestResult.status === "pr-opened") {
+    upgradeSpinner.succeed(
+      `Opened pull request for review: ${highlighter.info(pullRequestResult.url)}`,
+    );
+  } else if (pullRequestResult.status === "branch-pushed") {
+    upgradeSpinner.warn(
+      `Pushed branch ${highlighter.bold(pullRequestResult.branch)} but couldn't open a PR. Open one with: gh pr create --head ${pullRequestResult.branch}`,
+    );
+  } else {
+    upgradeSpinner.stop();
+    const didStage = await stageWorkflowFile({ workflowPath: workflow.workflowPath });
+    logger.log(
+      didStage
+        ? "  Updated the workflow to @v2 and staged it. Commit it to finish the upgrade."
+        : "  Updated the workflow to @v2. Commit the change to finish the upgrade.",
+    );
+  }
+};
+
+// Offered once per repo: when a React Doctor workflow is already on disk but
+// still pins the action's previous floating major (`@v1`), invite the user to
+// bump it to `@v2` via a PR. Both answers are persisted per-repo so the offer
+// never repeats; a cancel leaves it un-answered for next time. The caller has
+// already gated on an interactive run with findings.
+const maybeOfferActionUpgrade = async (projectRoot: string): Promise<void> => {
+  const workflow = readReactDoctorWorkflow(projectRoot);
+  if (!workflow || !workflowUsesV1Action(workflow.content)) return;
+  if (hasHandledActionUpgrade(projectRoot)) return;
+
+  const outcome = await askUpgradeActionVersion();
+  if (outcome === "cancel") return;
+
+  recordCount(METRIC.agentHandoff, 1, {
+    outcome: outcome === "yes" ? "upgrade-accepted" : "upgrade-declined",
+  });
+
+  if (outcome === "no") {
+    recordActionUpgradeDecision(projectRoot, "declined");
+    return;
+  }
+
+  await upgradeGitHubActionsWorkflow(workflow);
+  recordActionUpgradeDecision(projectRoot, "accepted");
 };
 
 // First handoff question, asked only when the GitHub Actions workflow isn't
@@ -232,6 +353,10 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
       await setUpGitHubActions(input.rootDirectory);
       logger.break();
     }
+  } else {
+    // Workflow already present: offer the one-time `@v1` → `@v2` upgrade
+    // instead. Mutually exclusive with the "add" prompt above.
+    await maybeOfferActionUpgrade(projectRootForCi);
   }
 
   const launchableAgents = await detectLaunchableAgents();

--- a/packages/react-doctor/src/cli/utils/hash-project-root.ts
+++ b/packages/react-doctor/src/cli/utils/hash-project-root.ts
@@ -1,0 +1,8 @@
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+
+// Stable per-repo key for the shared global config store: hashes the resolved
+// project root so absolute paths never land in the config file. Shared by the
+// per-repo prompt-state modules (setup prompt, action upgrade).
+export const hashProjectRoot = (projectRoot: string): string =>
+  createHash("sha256").update(path.resolve(projectRoot)).digest("hex");

--- a/packages/react-doctor/src/cli/utils/install-github-workflow.ts
+++ b/packages/react-doctor/src/cli/utils/install-github-workflow.ts
@@ -11,7 +11,7 @@ export interface InstallGitHubWorkflowResult {
 // scanning `main` on every push for a quality-trend graph, suppressing PR
 // comments) and explain why each permission is granted — without forcing
 // them off to the docs site to learn the basics. The action itself is pinned
-// to the floating major `@v1` (never `@main`, per the supply-chain guidance
+// to the floating major `@v2` (never `@main`, per the supply-chain guidance
 // in AGENTS.md): `@main` would run whatever HEAD points to with
 // `pull-requests: write` granted.
 const buildWorkflowContent =
@@ -47,6 +47,11 @@ permissions:
   # comments (PRs are issues under the hood). Not exercised on \`push\`
   # events, so safe to drop if you only run on \`main\`.
   issues: write
+  # Lets the action publish a commit status with the score + error/warning
+  # counts (links to the run). This is how a \`push\` to \`main\` surfaces its
+  # result, since the PR comment is skipped off pull requests. Drop it to
+  # disable the status (or set \`commit-status: false\` below).
+  statuses: write
 
 # Cancels any in-flight scan for the same PR (or branch, on push) the moment
 # a new commit arrives, so reviewers only ever see the latest run.
@@ -60,15 +65,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: millionco/react-doctor@v1
+      - uses: millionco/react-doctor@v2
         # Common configuration knobs — uncomment any to override the default.
         # Full reference: https://www.react.doctor/ci
         # with:
-        #   non-blocking: true       # Report findings but always exit 0 (won't fail the PR check)
-        #   fail-on: warning         # Gate level: "error" (default) | "warning" | "none"
+        #   blocking: warning        # Gate level: "error" (default) | "warning" | "none" (advisory)
+        #   scope: full              # On PRs, scan the whole project instead of just changed files
         #   comment: false           # Disable the sticky PR summary comment
-        #   annotations: false       # Disable inline GitHub Actions annotations on changed files
-        #   version: "0.2.18"        # Pin to a specific react-doctor version instead of "latest"
+        #   review-comments: false   # Disable inline review comments on changed lines
+        #   commit-status: false     # Disable the commit status (score + counts, links to the run)
+        #   version: "0.4.0"         # Pin to a specific react-doctor version instead of "latest"
         #   directory: apps/web      # Scan a sub-directory (default: ".")
         #   project: "web,admin"     # In a monorepo, scan specific workspace project(s)
 `;
@@ -78,6 +84,46 @@ export const getReactDoctorWorkflowPath = (projectRoot: string): string =>
 
 export const isReactDoctorWorkflowInstalled = (projectRoot: string): boolean =>
   fs.existsSync(getReactDoctorWorkflowPath(projectRoot));
+
+// Matches ONLY the floating-major action ref this template installs
+// (`millionco/react-doctor@v1`). The negative lookahead excludes exact tags
+// (`@v1.2.3`) and SHA pins (`@<sha> # v1.1.1`) — those are deliberate version
+// locks we must not silently move across a major boundary, so the upgrade
+// offer is scoped to the floating ref we ship by default.
+const V1_FLOATING_ACTION_REF = String.raw`millionco/react-doctor@v1(?![\w.])`;
+const V2_FLOATING_ACTION_REF = "millionco/react-doctor@v2";
+
+export interface InstalledReactDoctorWorkflow {
+  readonly workflowPath: string;
+  readonly content: string;
+}
+
+// Reads the canonical `.github/workflows/react-doctor.yml` if present. Returns
+// null when it's absent or unreadable (the upgrade offer simply doesn't fire).
+export const readReactDoctorWorkflow = (
+  projectRoot: string,
+): InstalledReactDoctorWorkflow | null => {
+  const workflowPath = getReactDoctorWorkflowPath(projectRoot);
+  try {
+    return { workflowPath, content: fs.readFileSync(workflowPath, "utf8") };
+  } catch {
+    return null;
+  }
+};
+
+// True when the workflow still pins the action's previous floating major.
+export const workflowUsesV1Action = (content: string): boolean =>
+  new RegExp(V1_FLOATING_ACTION_REF).test(content);
+
+// Rewrites the floating `@v1` ref(s) to `@v2`, leaving everything else
+// (formatting, comments, inputs, any exact/SHA pins) untouched. `changed` is
+// false when there was nothing to bump.
+export const upgradeWorkflowActionToV2 = (
+  content: string,
+): { readonly content: string; readonly changed: boolean } => {
+  const upgraded = content.replace(new RegExp(V1_FLOATING_ACTION_REF, "g"), V2_FLOATING_ACTION_REF);
+  return { content: upgraded, changed: upgraded !== content };
+};
 
 // Writes `.github/workflows/react-doctor.yml`, creating the workflows
 // directory if needed. Returns "exists" without overwriting a workflow that's

--- a/packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts
+++ b/packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts
@@ -5,14 +5,14 @@ import { isCommandAvailable } from "./is-command-available.js";
 
 const NEW_BRANCH_PREFIX = "react-doctor/add-github-actions";
 
-const COMMIT_MESSAGE = "ci: add React Doctor GitHub Actions workflow";
+const DEFAULT_COMMIT_MESSAGE = "ci: add React Doctor GitHub Actions workflow";
 
-const PR_TITLE = "Add React Doctor to GitHub Actions";
+const DEFAULT_PR_TITLE = "Add React Doctor to GitHub Actions";
 
 // Short body that lets the docs site carry the deeper explanation. The
 // installed workflow file already has inline comments for every option, so
 // the PR description doesn't need to re-explain them.
-const PR_BODY = `Adds a [React Doctor](https://www.react.doctor) scan to every pull request and every push to the default branch. The workflow file is documented inline.
+const DEFAULT_PR_BODY = `Adds a [React Doctor](https://www.react.doctor) scan to every pull request and every push to the default branch. The workflow file is documented inline.
 
 Docs: https://www.react.doctor/ci`;
 
@@ -110,8 +110,19 @@ const findUniqueBranchName = async (cwd: string): Promise<string> => {
 // runs sequentially via `await` because it depends on the previous one.
 export const openWorkflowPullRequest = async (params: {
   workflowPath: string;
+  // Override the commit message / PR title + body. Defaults describe a fresh
+  // install; the v1→v2 upgrade flow passes its own copy. The git/`gh` steps,
+  // failure modes, and branch cleanup are identical either way — both just
+  // commit the workflow file (newly written or modified in place) onto a
+  // dedicated branch and open a PR.
+  commitMessage?: string;
+  prTitle?: string;
+  prBody?: string;
 }): Promise<OpenWorkflowPullRequestResult> => {
   const workflowPath = path.resolve(params.workflowPath);
+  const commitMessage = params.commitMessage ?? DEFAULT_COMMIT_MESSAGE;
+  const prTitle = params.prTitle ?? DEFAULT_PR_TITLE;
+  const prBody = params.prBody ?? DEFAULT_PR_BODY;
 
   // Probe from the workflow file's directory so we resolve the repo root
   // even when the CLI was invoked from a sub-package in a monorepo.
@@ -168,7 +179,7 @@ export const openWorkflowPullRequest = async (params: {
     return { status: "not-attempted", reason: "git-add-failed" };
   }
 
-  if (!(await run("git", ["commit", "-m", COMMIT_MESSAGE], cwd)).success) {
+  if (!(await run("git", ["commit", "-m", commitMessage], cwd)).success) {
     await restoreToPreviousBranch(true);
     return { status: "not-attempted", reason: "git-commit-failed" };
   }
@@ -184,9 +195,9 @@ export const openWorkflowPullRequest = async (params: {
       "pr",
       "create",
       "--title",
-      PR_TITLE,
+      prTitle,
       "--body",
-      PR_BODY,
+      prBody,
       "--base",
       defaultBranch,
       "--head",

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -1,6 +1,6 @@
-import { createHash } from "node:crypto";
 import * as path from "node:path";
 import Conf from "conf";
+import { hashProjectRoot } from "./hash-project-root.js";
 import { findNearestPackageDirectory, hasDoctorScript } from "./install-doctor-script.js";
 import { isCodingAgentEnvironment } from "./is-ci-environment.js";
 
@@ -40,7 +40,7 @@ export const getSetupPromptConfigPath = (options: SetupPromptStoreOptions = {}):
   getSetupPromptStore(options).path;
 
 export const getSetupPromptProjectKey = (projectRoot: string): string =>
-  createHash("sha256").update(path.resolve(projectRoot)).digest("hex");
+  hashProjectRoot(projectRoot);
 
 export const hasDisabledSetupPrompt = (
   projectRoot: string,

--- a/packages/react-doctor/tests/action-upgrade.test.ts
+++ b/packages/react-doctor/tests/action-upgrade.test.ts
@@ -1,0 +1,133 @@
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  getReactDoctorWorkflowPath,
+  installReactDoctorWorkflow,
+  readReactDoctorWorkflow,
+  upgradeWorkflowActionToV2,
+  workflowUsesV1Action,
+} from "../src/cli/utils/install-github-workflow.js";
+import {
+  getActionUpgradePromptConfigPath,
+  hasHandledActionUpgrade,
+  recordActionUpgradeDecision,
+} from "../src/cli/utils/action-upgrade-prompt.js";
+
+const buildWorkflow = (actionRef: string): string =>
+  [
+    "name: React Doctor",
+    "on:",
+    "  pull_request:",
+    "jobs:",
+    "  react-doctor:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v5",
+    `      - uses: ${actionRef}`,
+    "",
+  ].join("\n");
+
+describe("workflow v1 detection + upgrade", () => {
+  it("detects only the floating @v1 ref", () => {
+    expect(workflowUsesV1Action(buildWorkflow("millionco/react-doctor@v1"))).toBe(true);
+    expect(workflowUsesV1Action(buildWorkflow("millionco/react-doctor@v2"))).toBe(false);
+    // Exact tags and SHA pins are deliberate version locks — left alone.
+    expect(workflowUsesV1Action(buildWorkflow("millionco/react-doctor@v1.2.3"))).toBe(false);
+    expect(
+      workflowUsesV1Action(
+        buildWorkflow("millionco/react-doctor@b612664043a9be414166e3c6a69b355e39a8dcf4 # v1.1.1"),
+      ),
+    ).toBe(false);
+  });
+
+  it("rewrites the floating @v1 ref to @v2 and reports the change", () => {
+    const upgraded = upgradeWorkflowActionToV2(buildWorkflow("millionco/react-doctor@v1"));
+    expect(upgraded.changed).toBe(true);
+    expect(upgraded.content).toContain("millionco/react-doctor@v2");
+    expect(upgraded.content).not.toContain("millionco/react-doctor@v1");
+  });
+
+  it("is a no-op for workflows already on @v2 or pinned exactly", () => {
+    expect(upgradeWorkflowActionToV2(buildWorkflow("millionco/react-doctor@v2")).changed).toBe(
+      false,
+    );
+    const exact = upgradeWorkflowActionToV2(buildWorkflow("millionco/react-doctor@v1.2.3"));
+    expect(exact.changed).toBe(false);
+    expect(exact.content).toContain("millionco/react-doctor@v1.2.3");
+  });
+
+  it("does not offer to upgrade a workflow this installer just wrote (already @v2)", () => {
+    const projectRoot = fs.mkdtempSync(path.join(tmpdir(), "react-doctor-upgrade-install-"));
+    try {
+      const result = installReactDoctorWorkflow(projectRoot);
+      expect(result.status).toBe("created");
+      const workflow = readReactDoctorWorkflow(projectRoot);
+      expect(workflow).not.toBeNull();
+      expect(workflow?.content).toContain("millionco/react-doctor@v2");
+      expect(workflowUsesV1Action(workflow?.content ?? "")).toBe(false);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("reads back an existing v1 workflow and returns null when absent", () => {
+    const projectRoot = fs.mkdtempSync(path.join(tmpdir(), "react-doctor-upgrade-read-"));
+    try {
+      expect(readReactDoctorWorkflow(projectRoot)).toBeNull();
+      const workflowPath = getReactDoctorWorkflowPath(projectRoot);
+      fs.mkdirSync(path.dirname(workflowPath), { recursive: true });
+      fs.writeFileSync(workflowPath, buildWorkflow("millionco/react-doctor@v1"));
+      const workflow = readReactDoctorWorkflow(projectRoot);
+      expect(workflow?.workflowPath).toBe(workflowPath);
+      expect(workflowUsesV1Action(workflow?.content ?? "")).toBe(true);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("action upgrade prompt state", () => {
+  let configRoot: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const root = fs.mkdtempSync(path.join(tmpdir(), "react-doctor-action-upgrade-"));
+    configRoot = root;
+    cleanup = () => fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reports not-handled before the offer is answered", () => {
+    expect(hasHandledActionUpgrade("/repo/a", { cwd: configRoot })).toBe(false);
+  });
+
+  it("persists a decline so the offer never repeats for that repo", () => {
+    expect(recordActionUpgradeDecision("/repo/a", "declined", { cwd: configRoot })).toBe(true);
+    expect(hasHandledActionUpgrade("/repo/a", { cwd: configRoot })).toBe(true);
+  });
+
+  it("treats an accept as handled too (no re-prompt while a PR is pending)", () => {
+    recordActionUpgradeDecision("/repo/a", "accepted", { cwd: configRoot });
+    expect(hasHandledActionUpgrade("/repo/a", { cwd: configRoot })).toBe(true);
+  });
+
+  it("scopes the decision per repo", () => {
+    recordActionUpgradeDecision("/repo/a", "declined", { cwd: configRoot });
+    expect(hasHandledActionUpgrade("/repo/a", { cwd: configRoot })).toBe(true);
+    expect(hasHandledActionUpgrade("/repo/b", { cwd: configRoot })).toBe(false);
+  });
+
+  it("stores state in the shared react-doctor config file", () => {
+    recordActionUpgradeDecision("/repo/a", "declined", { cwd: configRoot });
+    const configPath = getActionUpgradePromptConfigPath({ cwd: configRoot });
+    const stored = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const records = Object.values(stored.actionUpgrades);
+    expect(records).toHaveLength(1);
+    expect(records[0].outcome).toBe("declined");
+  });
+});

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -39,6 +39,7 @@ describe("GitHub Action contract", () => {
       "blocking",
       "comment",
       "review-comments",
+      "commit-status",
       "node-version",
       "version",
     ]) {
@@ -189,5 +190,45 @@ describe("GitHub Action contract", () => {
     // The gate lives in the CLI exit code now; the action just propagates it.
     expect(failStep).toContain('exit "${SCAN_STATUS:-1}"');
     expect(failStep).not.toContain("INPUT_NON_BLOCKING");
+  });
+
+  it("surfaces results on every event but only fails the run on pull requests", () => {
+    const actionYaml = readActionYaml();
+    const renderStep = normalizeWhitespace(extractStep(actionYaml, "- id: render"));
+    const failStep = normalizeWhitespace(
+      extractStep(actionYaml, "- name: Fail if React Doctor found blocking issues"),
+    );
+
+    // The rendered report is mirrored into the job summary so a push to the
+    // default branch (no PR comment) still shows its result on the run page.
+    expect(renderStep).toContain("GITHUB_STEP_SUMMARY");
+
+    // Non-PR events (push to `main`) report findings but never fail the run, so
+    // the default branch doesn't go red on pre-existing issues; PRs still
+    // propagate the CLI exit code.
+    expect(failStep).toContain("EVENT_NAME: ${{ github.event_name }}");
+    expect(failStep).toContain('if [ "$EVENT_NAME" != "pull_request" ]; then exit 0');
+    expect(failStep).toContain('exit "${SCAN_STATUS:-1}"');
+  });
+
+  it("publishes a commit status that carries the score and stays green on pushes", () => {
+    const actionYaml = readActionYaml();
+    const inputsBlock = extractBlock(actionYaml, "inputs:", "\noutputs:");
+    const statusStep = normalizeWhitespace(
+      extractStep(actionYaml, "- name: Publish commit status"),
+    );
+
+    expect(inputsBlock).toContain("  commit-status:");
+    expect(statusStep).toContain("inputs.commit-status == 'true'");
+    expect(statusStep).toContain("github.rest.repos.createCommitStatus");
+    expect(statusStep).toContain('context: "React Doctor"');
+    expect(statusStep).toContain("target_url:");
+    expect(statusStep).toContain("Score: ${score}/100");
+    // Advisory on push: only a PR whose scan failed posts a red (failure) status.
+    expect(statusStep).toContain(
+      'const state = isPullRequest && scanFailed ? "failure" : "success"',
+    );
+    // Missing `statuses: write` is a soft failure, not a crash.
+    expect(statusStep).toContain("core.warning");
   });
 });

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -650,8 +650,9 @@ describe("runInstallReactDoctor", () => {
     expect(workflowContent).toContain("name: React Doctor");
     expect(workflowContent).toContain("pull-requests: write");
     expect(workflowContent).toContain("issues: write");
+    expect(workflowContent).toContain("statuses: write");
     expect(workflowContent).toContain("actions/checkout@v5");
-    expect(workflowContent).toContain("millionco/react-doctor@v1");
+    expect(workflowContent).toContain("millionco/react-doctor@v2");
     expect(workflowContent).not.toContain("github-token");
     expect(workflowContent).not.toContain("diff: main");
   });
@@ -689,7 +690,7 @@ describe("runInstallReactDoctor", () => {
 
     expect(fs.existsSync(hookPath)).toBe(false);
     expect(fs.existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
-    expect(fs.readFileSync(workflowPath, "utf8")).toContain("millionco/react-doctor@v1");
+    expect(fs.readFileSync(workflowPath, "utf8")).toContain("millionco/react-doctor@v2");
   });
 
   it("--yes does not install native agent hooks unless --agent-hooks is set", async () => {


### PR DESCRIPTION
## Why

Merging a PR fires the React Doctor workflow on `main` via the `push` trigger, where it runs a **full-project** scan. Two problems:

1. With the default `blocking: error`, *any* pre-existing error fails the run — so `main` goes red on every commit even when the merged PR introduced nothing new.
2. The sticky comment + inline reviews are PR-only, so a `push` run surfaces **nothing**: just a green/red check and raw logs.

We want `main` to show a health-score trend (the score row from the screenshots), not act as a gate.

**Before** (push to `main`): full scan + `blocking: error` → run fails on pre-existing errors; no visible summary anywhere.

**After** (push to `main`): advisory (never fails on findings, so `main` stays green); a commit status `React Doctor — Score: 67/100 · 5 errors · 234 warnings` links to the run, and the full report is written to the job summary.

## What changed

**Action (`action.yml`)**
- New `commit-status` input (default `true`). A step publishes a commit status with the score + error/warning counts (`repos.createCommitStatus`) — advisory/green on push, mirrors the gate on PRs, soft-warns if `statuses: write` isn't granted.
- The render step mirrors the rendered report into `$GITHUB_STEP_SUMMARY` on every event (push runs finally have a visible result page).
- The gate step exits `0` on non-PR events so `main` never goes red on findings; PRs still propagate the CLI exit code (the `blocking` gate is unchanged for them).
- `.github/workflows/react-doctor.yml` now grants `statuses: write`.

**CLI (`packages/react-doctor`)**
- One-time, per-repo prompt in the post-scan handoff: when a workflow exists but still pins `@v1`, offer to open a PR bumping it to `@v2`. Accept → PR; decline → remembered per-repo (shared `conf` store) so it never asks again.
- The generated / "Add to CI" workflow template now pins `millionco/react-doctor@v2`, grants `statuses: write`, documents the `commit-status` knob, and fixes stale commented inputs (`non-blocking`/`fail-on`/`annotations` → the real `blocking`/`comment`/`review-comments`).
- Consolidated the duplicated per-repo config-key hashing into `hash-project-root.ts` (shared with the setup-prompt store).

## Follow-up (action release, not npm)
Per `AGENTS.md`, the composite action is versioned by git tag independently of the npm packages. This PR touches `action.yml` with a new input + behavior change → a **minor** action bump after merge: tag `v2.1.0` at the merge commit and move the floating `v2` to it.

## Test plan
- `vp test run` (react-doctor): **1666 passed**, 17 skipped. The single failure (`cli-and-output` "Agent guidance") is a local-only env leak — my dev shell sets `CURSOR_AGENT`, which the CLI's coding-agent detection reads; it passes with `CURSOR_AGENT` unset and in CI.
- `turbo run typecheck --filter=react-doctor` — pass.
- `vp lint` — pass (only pre-existing `tests/fixtures/**` warnings).
- `vp fmt --check` — pass.
- Added `tests/action-upgrade.test.ts` (10) + extended `github-action.test.ts` and `install-react-doctor.test.ts`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when GitHub Actions workflows fail (push vs PR) and adds GitHub API commit-status publishing; PR blocking behavior is preserved but consumers need `statuses: write` for the new status.
> 
> **Overview**
> **Default-branch pushes** are treated as advisory health snapshots: the action no longer fails the workflow on findings for non-`pull_request` events, while PRs still honor the `blocking` gate via the CLI exit code.
> 
> **Visibility on `main`**: a new **`commit-status`** input (default on) publishes a **React Doctor** commit status (score + error/warning counts, link to the run). The render step also copies the report into the **job summary** so push runs have a readable result without the sticky PR comment. Generated workflows and docs now pin **`millionco/react-doctor@v2`** and grant **`statuses: write`**.
> 
> **CLI migration**: after scan handoff, repos with an existing workflow still on floating **`@v1`** get a **one-time** prompt to open a PR bumping to **`@v2`**; accept/decline is remembered per repo in shared global config (`action-upgrade-prompt.ts`, workflow rewrite helpers). Fresh “Add to CI” templates match v2 + updated commented inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e0fe4b05b84a528ae75c467c9fbedf7e16ab15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->