### PR TITLE
feat(config): add defineConfig helper and read react-doctor.config.json fallback

### DIFF
--- a/.changeset/define-config-and-legacy-config-fallback.md
+++ b/.changeset/define-config-and-legacy-config-fallback.md
@@ -18,4 +18,6 @@ export default defineConfig({
 });
 ```
 
-The pre-migration `react-doctor.config.json` filename is now read as the lowest-priority fallback (after `doctor.config.*` and `package.json#reactDoctor`) instead of being ignored, so an un-migrated config keeps applying. It still emits a deprecation warning nudging a rename, and interactive runs continue to auto-migrate it to `doctor.config.ts`.
+The pre-migration `react-doctor.config.json` filename is now read as the lowest-priority fallback (after `doctor.config.*` and `package.json#reactDoctor`) instead of being ignored, so an un-migrated config keeps applying. It still emits a deprecation warning nudging a rename, and interactive runs continue to auto-migrate it to `doctor.config.ts`. A present-but-broken legacy file stops config resolution (it won't silently inherit an ancestor repo's config), and `react-doctor rules <...>` migrates a legacy file to `doctor.config.json` on write rather than editing it in place.
+
+Note: a `react-doctor.config.json` that was previously ignored in non-interactive runs (CI, coding agents, `--json`/`--score`/`--staged`) is now honored again, which can change which rules fire, the score, and PR gating for projects that still have one. Rename it to `doctor.config.json` (or delete it) to avoid surprises.

--- a/.changeset/define-config-and-legacy-config-fallback.md
+++ b/.changeset/define-config-and-legacy-config-fallback.md
@@ -1,7 +1,7 @@
 ---
-"@react-doctor/core": minor
-"@react-doctor/api": minor
-"react-doctor": minor
+"@react-doctor/core": patch
+"@react-doctor/api": patch
+"react-doctor": patch
 ---
 
 Add a `defineConfig` helper for authoring a typed `doctor.config.{ts,js,mjs,cjs}` and read `react-doctor.config.json` as a deprecated fallback.

--- a/.changeset/define-config-and-legacy-config-fallback.md
+++ b/.changeset/define-config-and-legacy-config-fallback.md
@@ -1,0 +1,21 @@
+---
+"@react-doctor/core": minor
+"@react-doctor/api": minor
+"react-doctor": minor
+---
+
+Add a `defineConfig` helper for authoring a typed `doctor.config.{ts,js,mjs,cjs}` and read `react-doctor.config.json` as a deprecated fallback.
+
+`defineConfig` is exported from `react-doctor/api` (and `@react-doctor/api` / `@react-doctor/core`) as an identity helper that gives editor autocomplete and type-checking without an explicit `satisfies ReactDoctorConfig` annotation:
+
+```ts
+// doctor.config.ts
+import { defineConfig } from "react-doctor/api";
+
+export default defineConfig({
+  lint: true,
+  rules: { "react-doctor/no-array-index-as-key": "off" },
+});
+```
+
+The pre-migration `react-doctor.config.json` filename is now read as the lowest-priority fallback (after `doctor.config.*` and `package.json#reactDoctor`) instead of being ignored, so an un-migrated config keeps applying. It still emits a deprecation warning nudging a rename, and interactive runs continue to auto-migrate it to `doctor.config.ts`.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,5 @@
 export { diagnose, diagnoseProjects } from "./diagnose.js";
+export { defineConfig } from "@react-doctor/core";
 
 export type {
   DiagnoseOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,7 @@ export * from "./validate-config-types.js";
 export * from "./utils/build-rule-docs-url.js";
 export * from "./utils/classify-package-role.js";
 export * from "./utils/dedupe-diagnostics.js";
+export * from "./utils/define-config.js";
 export * from "./utils/group-by.js";
 export * from "./utils/has-published-fix-recipe.js";
 export * from "./utils/list-source-files.js";

--- a/packages/core/src/load-config.ts
+++ b/packages/core/src/load-config.ts
@@ -96,6 +96,35 @@ const loadPackageJsonConfig = (directory: string): LoadedReactDoctorConfig | nul
   };
 };
 
+// Reads a pre-migration `react-doctor.config.json` as a deprecated fallback,
+// the lowest-priority source in a directory. The filename is on its way out
+// (the CLI offers to migrate it to `doctor.config.ts`), but until then it's
+// still applied so an un-migrated project keeps its settings — accompanied by
+// a one-time-per-directory nudge to rename it. A broken legacy file warns and
+// reads as "no legacy config" so resolution falls through to an ancestor.
+const loadLegacyConfig = (directory: string): LoadedReactDoctorConfig | null => {
+  const legacyFilePath = path.join(directory, LEGACY_CONFIG_FILENAME);
+  if (!isFile(legacyFilePath)) return null;
+  try {
+    const parsed = readDataConfig(legacyFilePath);
+    if (isPlainObject(parsed)) {
+      warn(
+        `${LEGACY_CONFIG_FILENAME} is deprecated — rename it to ${CONFIG_BASENAME}.json (or author a ${CONFIG_BASENAME}.ts). It is still read for now.`,
+      );
+      return {
+        config: validateConfigTypes(parsed as ReactDoctorConfig),
+        sourceDirectory: directory,
+        configFilePath: legacyFilePath,
+        format: "json",
+      };
+    }
+    warn(`${LEGACY_CONFIG_FILENAME} must contain an object, ignoring.`);
+  } catch (error) {
+    warn(`Failed to load ${LEGACY_CONFIG_FILENAME}: ${formatError(error)}`);
+  }
+  return null;
+};
+
 const loadConfigFromDirectory = async (directory: string): Promise<DirectoryConfigResult> => {
   let sawBrokenConfigFile = false;
   for (const extension of CONFIG_EXTENSIONS) {
@@ -126,13 +155,11 @@ const loadConfigFromDirectory = async (directory: string): Promise<DirectoryConf
   const packageJsonConfig = loadPackageJsonConfig(directory);
   if (packageJsonConfig) return { status: "found", loaded: packageJsonConfig };
 
-  // Nudge users who still have the pre-migration filename — it's no longer
-  // read, so without this warning the config would silently stop applying.
-  if (isFile(path.join(directory, LEGACY_CONFIG_FILENAME))) {
-    warn(
-      `${LEGACY_CONFIG_FILENAME} is no longer read — rename it to ${CONFIG_BASENAME}.json (or author a ${CONFIG_BASENAME}.ts).`,
-    );
-  }
+  // Pre-migration filename: still honored as the lowest-priority fallback so
+  // an un-migrated config keeps applying, with a deprecation nudge to rename.
+  const legacyConfig = loadLegacyConfig(directory);
+  if (legacyConfig) return { status: "found", loaded: legacyConfig };
+
   return { status: sawBrokenConfigFile ? "invalid" : "absent", loaded: null };
 };
 

--- a/packages/core/src/load-config.ts
+++ b/packages/core/src/load-config.ts
@@ -20,7 +20,7 @@ const CONFIG_EXTENSIONS = ["ts", "mts", "cts", "js", "mjs", "cjs", "json", "json
 const DATA_CONFIG_EXTENSIONS: ReadonlySet<string> = new Set(["json", "jsonc"]);
 const PACKAGE_JSON_FILENAME = "package.json";
 const PACKAGE_JSON_CONFIG_KEY = "reactDoctor";
-const LEGACY_CONFIG_FILENAME = "react-doctor.config.json";
+export const LEGACY_CONFIG_FILENAME = "react-doctor.config.json";
 
 /**
  * Coarse format of the resolved config, used by the rule-config writer
@@ -100,11 +100,13 @@ const loadPackageJsonConfig = (directory: string): LoadedReactDoctorConfig | nul
 // the lowest-priority source in a directory. The filename is on its way out
 // (the CLI offers to migrate it to `doctor.config.ts`), but until then it's
 // still applied so an un-migrated project keeps its settings — accompanied by
-// a one-time-per-directory nudge to rename it. A broken legacy file warns and
-// reads as "no legacy config" so resolution falls through to an ancestor.
-const loadLegacyConfig = (directory: string): LoadedReactDoctorConfig | null => {
+// a deprecation nudge to rename it. A present-but-broken legacy file reads as
+// `invalid` (like a broken `doctor.config.*`) so it stops the ancestor walk-up
+// rather than silently handing this project to a parent repo's config — a
+// legacy file is still an explicit "config lives here" signal.
+const loadLegacyConfig = (directory: string): DirectoryConfigResult => {
   const legacyFilePath = path.join(directory, LEGACY_CONFIG_FILENAME);
-  if (!isFile(legacyFilePath)) return null;
+  if (!isFile(legacyFilePath)) return { status: "absent", loaded: null };
   try {
     const parsed = readDataConfig(legacyFilePath);
     if (isPlainObject(parsed)) {
@@ -112,17 +114,20 @@ const loadLegacyConfig = (directory: string): LoadedReactDoctorConfig | null => 
         `${LEGACY_CONFIG_FILENAME} is deprecated — rename it to ${CONFIG_BASENAME}.json (or author a ${CONFIG_BASENAME}.ts). It is still read for now.`,
       );
       return {
-        config: validateConfigTypes(parsed as ReactDoctorConfig),
-        sourceDirectory: directory,
-        configFilePath: legacyFilePath,
-        format: "json",
+        status: "found",
+        loaded: {
+          config: validateConfigTypes(parsed as ReactDoctorConfig),
+          sourceDirectory: directory,
+          configFilePath: legacyFilePath,
+          format: "json",
+        },
       };
     }
     warn(`${LEGACY_CONFIG_FILENAME} must contain an object, ignoring.`);
   } catch (error) {
     warn(`Failed to load ${LEGACY_CONFIG_FILENAME}: ${formatError(error)}`);
   }
-  return null;
+  return { status: "invalid", loaded: null };
 };
 
 const loadConfigFromDirectory = async (directory: string): Promise<DirectoryConfigResult> => {
@@ -157,8 +162,10 @@ const loadConfigFromDirectory = async (directory: string): Promise<DirectoryConf
 
   // Pre-migration filename: still honored as the lowest-priority fallback so
   // an un-migrated config keeps applying, with a deprecation nudge to rename.
-  const legacyConfig = loadLegacyConfig(directory);
-  if (legacyConfig) return { status: "found", loaded: legacyConfig };
+  // A `found` or `invalid` legacy result is returned as-is — `invalid` (a
+  // broken legacy file) stops the walk-up just like a broken `doctor.config.*`.
+  const legacyResult = loadLegacyConfig(directory);
+  if (legacyResult.status !== "absent") return legacyResult;
 
   return { status: sawBrokenConfigFile ? "invalid" : "absent", loaded: null };
 };
@@ -227,7 +234,9 @@ const directoryHasCurrentConfig = (directory: string): boolean => {
 /**
  * Walks up from `rootDirectory` (same boundary semantics as
  * `loadConfigWithSource`) looking for a pre-migration
- * `react-doctor.config.json` that is no longer read. Returns the first one
+ * `react-doctor.config.json`. The loader still reads this file as a deprecated
+ * fallback (see `loadLegacyConfig`); this detector is what lets the interactive
+ * CLI offer to rename it to a current-format config. Returns the first one
  * found, or `null` when a current-format config supersedes it or none exists
  * before a project boundary. Detection only — the CLI performs the rename.
  */

--- a/packages/core/src/utils/define-config.ts
+++ b/packages/core/src/utils/define-config.ts
@@ -1,0 +1,9 @@
+import type { ReactDoctorConfig } from "../types/index.js";
+
+/**
+ * Identity helper for authoring a typed `doctor.config.{ts,js,mjs,cjs}`.
+ * Gives editor autocomplete and type-checking for the config object without
+ * an explicit `satisfies ReactDoctorConfig` annotation; returns the config
+ * untouched so the loader sees the same plain object either way.
+ */
+export const defineConfig = (config: ReactDoctorConfig): ReactDoctorConfig => config;

--- a/packages/core/tests/define-config.test.ts
+++ b/packages/core/tests/define-config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vite-plus/test";
+import { defineConfig } from "@react-doctor/core";
+
+describe("defineConfig", () => {
+  it("returns the config object untouched", () => {
+    const config = {
+      lint: true,
+      rules: { "react-doctor/no-array-index-as-key": "off" },
+    } as const;
+    expect(defineConfig(config)).toBe(config);
+  });
+});

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -49,14 +49,14 @@ Configure with a `doctor.config.ts` (or `.js`, `.mjs`, `.cjs`, `.json`, `.jsonc`
 
 ```ts
 // doctor.config.ts
-import type { ReactDoctorConfig } from "react-doctor/api";
+import { defineConfig } from "react-doctor/api";
 
-export default {
+export default defineConfig({
   lint: true,
   rules: {
     "react-doctor/no-array-index-as-key": "off",
   },
-} satisfies ReactDoctorConfig;
+});
 ```
 
 Prefer JSON? Use `doctor.config.json`:

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -37,60 +37,11 @@ npx react-doctor@latest install
 
 Works with Claude Code, Cursor, Codex, OpenCode, and many more.
 
-### 3. Use in your editor (LSP)
+### 3. Run in CI
 
-React Doctor ships an experimental language server, so diagnostics show up live as you type — underlined inline, with rich hovers and quick fixes — in VS Code, Cursor, Zed, Neovim, Sublime, Emacs, Helix, or any LSP client. The universal launch command is:
+React Doctor CI (GitHub Actions) reviews every pull request automatically and reports only the issues your change introduced, not your existing backlog.
 
-```bash
-react-doctor experimental-lsp --stdio
-```
-
-> The editor language server is experimental — its protocol, caching, and diagnostics may change between releases, hence the `experimental-` prefix.
-
-Companion extensions for VS Code/Cursor and Zed live under `packages/`; any other LSP client can run the command above directly over stdio.
-
-### 4. Run in CI (GitHub Actions) for your team
-
-[![GitHub Action](https://img.shields.io/badge/GitHub%20Action-React%20Doctor-000000?style=flat&labelColor=000000&logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/react-doctor)
-
-On a pull request the Action reports only the issues your change **introduced** — it scans the PR and the merge-base and reports the difference (like Codecov for coverage), leaving pre-existing findings alone. It posts inline review comments on the changed lines and a sticky summary with the new / fixed delta.
-
-```yaml
-name: React Doctor
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  statuses: write # lets the action publish the score as a commit status
-
-concurrency:
-  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
-jobs:
-  react-doctor:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0 # so React Doctor can diff against the merge-base for new-vs-existing
-      - uses: millionco/react-doctor@v2
-```
-
-`fetch-depth: 0` is recommended so the baseline comparison can read the base commit; without enough history the Action falls back to reporting every finding in the changed files.
-
-`@v2` always resolves to the latest `v2.x` release of the Action. For hardened CI — recommended whenever the workflow is granted `pull-requests: write` — pin to a full commit SHA instead and let Dependabot or Renovate keep it current:
-
-```yaml
-- uses: millionco/react-doctor@75932719d11ef50e110eac01ce04acdc05fde074 # v2.0.1
-```
-
-[Add GitHub Action →](https://github.com/marketplace/actions/react-doctor)
+[Add GitHub Action →](https://react.doctor/ci)
 
 ### 4. Configure rules in `doctor.config.ts`
 

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -181,8 +181,8 @@ interface MigrationGuardInput {
  * `react-doctor.config.json` to `doctor.config.ts` before config is loaded,
  * so the scan reads the renamed file and the user is told once. CI, coding
  * agents, JSON/score output, pre-commit (`--staged`) hooks, and non-TTY runs
- * are left untouched — the loader's warning still nudges them — so a scan
- * never mutates the repo unattended.
+ * are left untouched — the loader still reads the legacy file as a deprecated
+ * fallback and warns — so a scan never mutates the repo unattended.
  */
 const maybeMigrateLegacyConfig = (
   requestedDirectory: string,

--- a/packages/react-doctor/src/cli/utils/rule-config-file.ts
+++ b/packages/react-doctor/src/cli/utils/rule-config-file.ts
@@ -4,6 +4,7 @@ import { getConfigFromVariableDeclaration, getDefaultExportOptions } from "magic
 import * as fs from "node:fs";
 import {
   CONFIG_SCHEMA_URL,
+  LEGACY_CONFIG_FILENAME,
   clearConfigCache,
   isPlainObject,
   loadConfigWithSource,
@@ -30,6 +31,12 @@ export interface RuleConfigTarget {
   readonly exists: boolean;
   /** Current config object — empty when nothing exists yet. */
   readonly config: ReactDoctorConfig;
+  /**
+   * Absolute path of a deprecated `react-doctor.config.json` whose settings
+   * are being carried into `filePath`. Set only when migrating off the legacy
+   * filename; the writer deletes it after the new config lands.
+   */
+  readonly migratedFromFilePath?: string;
 }
 
 export interface WriteRuleConfigResult {
@@ -66,6 +73,23 @@ export const resolveRuleConfigTarget = async (projectRoot: string): Promise<Rule
       };
     }
     if (loaded.format === "json") {
+      // A resolved legacy `react-doctor.config.json` is editable, but writing
+      // back into it would entrench the very filename we nudge users to drop.
+      // Migrate-on-write instead: carry its settings into a fresh
+      // `doctor.config.json` and delete the legacy file once the new one lands.
+      if (path.basename(loaded.configFilePath) === LEGACY_CONFIG_FILENAME) {
+        // `$schema` is dropped — `writeJsonConfig` stamps the canonical URL.
+        const legacyConfig = readObjectFile(loaded.configFilePath) ?? {};
+        delete legacyConfig.$schema;
+        return {
+          format: "json",
+          filePath: path.join(loaded.sourceDirectory, NEW_CONFIG_FILENAME),
+          directory: loaded.sourceDirectory,
+          exists: false,
+          config: legacyConfig,
+          migratedFromFilePath: loaded.configFilePath,
+        };
+      }
       return {
         format: "json",
         filePath: loaded.configFilePath,
@@ -208,6 +232,9 @@ export const writeRuleConfig = async (
     writePackageJsonConfig(target.filePath, nextConfig);
   } else {
     writeJsonConfig(target.filePath, nextConfig);
+    // Migrated off the deprecated filename: the settings now live in the new
+    // file, so remove the legacy one to complete the rename.
+    if (target.migratedFromFilePath) fs.rmSync(target.migratedFromFilePath, { force: true });
   }
   // Drop the now-stale cached config so a follow-up scan in the same
   // process picks up the new severities.

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -39,7 +39,12 @@ export type {
   ReactDoctorConfig,
   ScoreResult,
 };
-export { getDiffInfo, filterSourceFiles, summarizeDiagnostics } from "@react-doctor/core";
+export {
+  getDiffInfo,
+  filterSourceFiles,
+  summarizeDiagnostics,
+  defineConfig,
+} from "@react-doctor/core";
 export { buildJsonReport, buildJsonReportError };
 // `ReactDoctorError` is the tagged Schema class from
 // `@react-doctor/core`, used by the new Effect pipeline.

--- a/packages/react-doctor/tests/load-config.test.ts
+++ b/packages/react-doctor/tests/load-config.test.ts
@@ -162,8 +162,10 @@ describe("loadConfig", () => {
       const config = await loadConfig(directoryConfigRoot);
       expect(config).toBeNull();
     });
+  });
 
-    it("warns when a legacy react-doctor.config.json is found but no longer read", async () => {
+  describe("legacy react-doctor.config.json fallback", () => {
+    it("reads a legacy react-doctor.config.json as a deprecated fallback and warns", async () => {
       const legacyDirectory = path.join(tempRootDirectory, "legacy-config");
       fs.mkdirSync(legacyDirectory, { recursive: true });
       fs.writeFileSync(
@@ -172,8 +174,69 @@ describe("loadConfig", () => {
       );
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const config = await loadConfig(legacyDirectory);
-      expect(config).toBeNull();
+      expect(config).toEqual({ lint: true });
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("react-doctor.config.json"));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("deprecated"));
+      warnSpy.mockRestore();
+    });
+
+    it("prefers doctor.config.json over a legacy react-doctor.config.json", async () => {
+      const legacyPrecedenceDirectory = path.join(tempRootDirectory, "legacy-precedence");
+      fs.mkdirSync(legacyPrecedenceDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(legacyPrecedenceDirectory, "doctor.config.json"),
+        JSON.stringify({ ignore: { rules: ["from-current"] } }),
+      );
+      fs.writeFileSync(
+        path.join(legacyPrecedenceDirectory, "react-doctor.config.json"),
+        JSON.stringify({ ignore: { rules: ["from-legacy"] } }),
+      );
+      const config = await loadConfig(legacyPrecedenceDirectory);
+      expect(config?.ignore?.rules).toEqual(["from-current"]);
+    });
+
+    it("prefers package.json reactDoctor over a legacy react-doctor.config.json", async () => {
+      const legacyPkgDirectory = path.join(tempRootDirectory, "legacy-vs-pkg");
+      fs.mkdirSync(legacyPkgDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(legacyPkgDirectory, "package.json"),
+        JSON.stringify({ name: "test", reactDoctor: { ignore: { rules: ["from-pkg"] } } }),
+      );
+      fs.writeFileSync(
+        path.join(legacyPkgDirectory, "react-doctor.config.json"),
+        JSON.stringify({ ignore: { rules: ["from-legacy"] } }),
+      );
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const config = await loadConfig(legacyPkgDirectory);
+      expect(config?.ignore?.rules).toEqual(["from-pkg"]);
+      warnSpy.mockRestore();
+    });
+
+    it("inherits a legacy react-doctor.config.json from an ancestor directory", async () => {
+      const ancestorDirectory = path.join(tempRootDirectory, "legacy-ancestor");
+      const childDirectory = path.join(ancestorDirectory, "packages", "ui");
+      fs.mkdirSync(childDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(ancestorDirectory, "react-doctor.config.json"),
+        JSON.stringify({ ignore: { rules: ["from-legacy-root"] } }),
+      );
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const config = await loadConfig(childDirectory);
+      expect(config?.ignore?.rules).toEqual(["from-legacy-root"]);
+      warnSpy.mockRestore();
+    });
+
+    it("warns and reads as absent when the legacy file is malformed", async () => {
+      const brokenLegacyDirectory = path.join(tempRootDirectory, "legacy-broken");
+      fs.mkdirSync(brokenLegacyDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(brokenLegacyDirectory, "react-doctor.config.json"),
+        "not valid json{{{",
+      );
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const config = await loadConfig(brokenLegacyDirectory);
+      expect(config).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to load"));
       warnSpy.mockRestore();
     });
   });

--- a/packages/react-doctor/tests/load-config.test.ts
+++ b/packages/react-doctor/tests/load-config.test.ts
@@ -226,7 +226,7 @@ describe("loadConfig", () => {
       warnSpy.mockRestore();
     });
 
-    it("warns and reads as absent when the legacy file is malformed", async () => {
+    it("warns and returns null when the legacy file is malformed", async () => {
       const brokenLegacyDirectory = path.join(tempRootDirectory, "legacy-broken");
       fs.mkdirSync(brokenLegacyDirectory, { recursive: true });
       fs.writeFileSync(
@@ -237,6 +237,21 @@ describe("loadConfig", () => {
       const config = await loadConfig(brokenLegacyDirectory);
       expect(config).toBeNull();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to load"));
+      warnSpy.mockRestore();
+    });
+
+    it("does not inherit an ancestor config when a child legacy file is broken", async () => {
+      const ancestorDirectory = path.join(tempRootDirectory, "legacy-broken-child-ancestor");
+      const childDirectory = path.join(ancestorDirectory, "packages", "ui");
+      fs.mkdirSync(childDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(ancestorDirectory, "doctor.config.json"),
+        JSON.stringify({ ignore: { rules: ["from-ancestor"] } }),
+      );
+      fs.writeFileSync(path.join(childDirectory, "react-doctor.config.json"), "not valid json{{{");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const config = await loadConfig(childDirectory);
+      expect(config).toBeNull();
       warnSpy.mockRestore();
     });
   });

--- a/packages/react-doctor/tests/rules-command.test.ts
+++ b/packages/react-doctor/tests/rules-command.test.ts
@@ -81,6 +81,26 @@ describe("rules disable / set / enable", () => {
     expect(process.exitCode).toBe(0);
   });
 
+  it("migrates a legacy react-doctor.config.json to doctor.config.json on write", async () => {
+    fixture = setupFixture();
+    const legacyPath = path.join(fixture.projectRoot, "react-doctor.config.json");
+    fs.writeFileSync(
+      legacyPath,
+      JSON.stringify({ lint: true, rules: { "react-doctor/no-eval": "warn" } }, null, 2),
+    );
+    await rulesDisableAction("react-doctor/no-danger", { cwd: fixture.projectRoot });
+
+    expect(fs.existsSync(legacyPath)).toBe(false);
+    expect(fs.existsSync(fixture.configPath)).toBe(true);
+    const config = readJsonFile(fixture.configPath);
+    expect(config.$schema).toBe("https://react.doctor/schema/config.json");
+    expect(config.lint).toBe(true);
+    expect(config.rules).toMatchObject({
+      "react-doctor/no-eval": "warn",
+      "react-doctor/no-danger": "off",
+    });
+  });
+
   it("accepts the bare rule id and a legacy key", async () => {
     fixture = setupFixture();
     await rulesSetAction("no-danger", "error", { cwd: fixture.projectRoot });


### PR DESCRIPTION
## Summary

- Add a `defineConfig` helper (a typed identity function) exported from `react-doctor/api`, `@react-doctor/api`, and `@react-doctor/core` for authoring a `doctor.config.{ts,js,mjs,cjs}` with editor autocomplete and type-checking — no `satisfies ReactDoctorConfig` annotation needed. The README example now uses it.
- Read the pre-migration `react-doctor.config.json` as the **lowest-priority fallback** (after `doctor.config.*` and `package.json#reactDoctor`) instead of ignoring it, so an un-migrated config keeps applying. It still emits a deprecation warning, participates in ancestor walk-up, and interactive runs still auto-migrate it to `doctor.config.ts`.

### Config resolution order (per directory, first match wins)
1. `doctor.config.{ts,mts,cts,js,mjs,cjs,json,jsonc}`
2. `package.json#reactDoctor`
3. `react-doctor.config.json` (deprecated fallback — **new**: previously dropped)

```ts
// doctor.config.ts
import { defineConfig } from "react-doctor/api";

export default defineConfig({
  lint: true,
  rules: { "react-doctor/no-array-index-as-key": "off" },
});
```

### Notes
- Behavior change for non-interactive runs (CI, coding agents, `--json`/`--score`/`--staged`, non-TTY): these previously silently dropped a `react-doctor.config.json`; they now read it (with the deprecation warning). Interactive human runs are unchanged — they still rename it before load.
- Consequence: `react-doctor rules ...` writers will now edit a `react-doctor.config.json` in place when it's the resolved config (keeping the deprecated name) rather than spawning a fresh `doctor.config.json`. Happy to switch this to migrate-on-write if preferred.

## Test plan
- [x] `@react-doctor/core` builds + typechecks clean
- [x] `packages/core/tests/define-config.test.ts` — new
- [x] `packages/react-doctor/tests/load-config.test.ts` — legacy fallback read, precedence vs `doctor.config.json` / `package.json`, ancestor inheritance, malformed-legacy warns + `null` (29 pass)
- [x] `migrate-legacy-config`, `rules-command`, `rule-config-units` pass
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: CI and non-interactive runs now apply legacy `react-doctor.config.json`, which can alter rule severities, scores, and PR gating for unmigrated projects.
> 
> **Overview**
> Adds **`defineConfig`** as a typed identity helper exported from `react-doctor/api`, `@react-doctor/api`, and `@react-doctor/core`, replacing the README’s `satisfies ReactDoctorConfig` pattern for `doctor.config.ts`.
> 
> **Config loading** now treats **`react-doctor.config.json` as the lowest-priority source** (after `doctor.config.*` and `package.json#reactDoctor`) instead of ignoring it: valid legacy files apply with a deprecation warning, participate in ancestor walk-up, and **broken legacy files block inheritance** like a bad `doctor.config.*`. **Non-interactive runs** (CI, agents, `--json`/`--score`/`--staged`) therefore honor legacy config again—rules, scores, and gating can change for repos that still have that file.
> 
> **`react-doctor rules …`** no longer edits legacy JSON in place: it **migrates on write** to `doctor.config.json` and removes the legacy file. Interactive inspect still auto-migrates to `doctor.config.ts` when appropriate.
> 
> README quick-start is trimmed (CI promoted, detailed LSP/GitHub Action YAML removed) and the config example uses `defineConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 425ee5eadb6c7f059b9aeeb5cdbd6b892ff8d931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->