### PR TITLE
feat(cli): terminal-width-aware rendering and CI-first onboarding

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -82,6 +82,11 @@ export const SHARE_BASE_URL = "https://react.doctor/share";
 // agent-handoff prompt points the agent here too.
 export const CI_URL = "https://react.doctor/ci";
 
+// Canonical GitHub Actions setup guide. The interactive "Add React Doctor to
+// GitHub Actions?" prompt's "Read docs" choice opens this directly.
+export const GITHUB_ACTIONS_SETUP_URL =
+  "https://www.react.doctor/docs/ci-and-prs/github-actions-setup";
+
 // Root of the documentation site. Guides for CI/CD setup, config files (to
 // suppress rules), and diff/PR scanning live under it; the CLI links here
 // from its closing "learn more" note.

--- a/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
@@ -46,7 +46,7 @@ export const askAddToGitHubActions = async (
         hint: " ",
         choices: [
           {
-            title: "Yes (recommended)",
+            title: "Yes",
             description: "Adds the workflow file and a doctor package script",
             value: CI_YES_CHOICE,
           },
@@ -56,7 +56,7 @@ export const askAddToGitHubActions = async (
             value: CI_LEARN_MORE_CHOICE,
           },
           {
-            title: "No, thanks",
+            title: "No",
             description: "Skip for now — you can add it later",
             value: CI_NO_CHOICE,
           },

--- a/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
@@ -52,7 +52,7 @@ export const askAddToGitHubActions = async (
           },
           {
             title: "Learn more",
-            description: "Read docs",
+            description: "Opens the docs page in your browser",
             value: CI_LEARN_MORE_CHOICE,
           },
           {

--- a/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
@@ -57,7 +57,7 @@ export const askAddToGitHubActions = async (
           },
           {
             title: "No",
-            description: "Skip for now — you can add it later",
+            description: "Skip for now",
             value: CI_NO_CHOICE,
           },
         ],

--- a/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
@@ -1,4 +1,4 @@
-import { CI_URL, highlighter } from "@react-doctor/core";
+import { GITHUB_ACTIONS_SETUP_URL, highlighter } from "@react-doctor/core";
 import { cliLogger as logger } from "./cli-logger.js";
 import { CI_TRUST_COMPANIES } from "./constants.js";
 import { openUrl } from "./open-url.js";
@@ -52,7 +52,7 @@ export const askAddToGitHubActions = async (
           },
           {
             title: "Learn more",
-            description: highlighter.info(CI_URL),
+            description: "Read docs",
             value: CI_LEARN_MORE_CHOICE,
           },
           {
@@ -71,11 +71,11 @@ export const askAddToGitHubActions = async (
     if (ciChoice === CI_NO_CHOICE) return "no";
 
     // CI_LEARN_MORE_CHOICE: open the docs and loop back to the question.
-    const opened = openUrl(CI_URL);
+    const opened = openUrl(GITHUB_ACTIONS_SETUP_URL);
     logger.log(
       opened
-        ? `Opened ${highlighter.info(CI_URL)} in your browser.`
-        : `Visit ${highlighter.info(CI_URL)} to learn more.`,
+        ? `Opened ${highlighter.info(GITHUB_ACTIONS_SETUP_URL)} in your browser.`
+        : `Visit ${highlighter.info(GITHUB_ACTIONS_SETUP_URL)} to learn more.`,
     );
     logger.break();
   }

--- a/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
@@ -1,0 +1,82 @@
+import { CI_URL, highlighter } from "@react-doctor/core";
+import { cliLogger as logger } from "./cli-logger.js";
+import { CI_TRUST_COMPANIES } from "./constants.js";
+import { openUrl } from "./open-url.js";
+import { prompts } from "./prompts.js";
+
+const CI_YES_CHOICE = "ci-yes";
+const CI_LEARN_MORE_CHOICE = "ci-learn-more";
+const CI_NO_CHOICE = "ci-no";
+
+// `\x1b[22m` (SGR "bold off") cancels the bold the `prompts` `select` renderer
+// wraps every message in (`select.js`: `color.bold(this.msg)`), so the question
+// stays bold while the indented pitch lines render in normal weight (and dim,
+// for the social-proof tagline) — matching the intended two-line emphasis.
+const SGR_BOLD_OFF = "\x1b[22m";
+
+// The pitch (incremental backlog + social proof) lives as part of the `message`
+// text, indented under the question itself so the value is visually attached to
+// the action it justifies. `hint: " "` (single space — `""` re-triggers the
+// library's verbose fallback) keeps the trailing ` ›` quietly on the last pitch
+// line instead of a "Use arrow-keys…" row that reads as broken UI.
+const ciQuestionMessage = [
+  "Add React Doctor to GitHub Actions?",
+  `${SGR_BOLD_OFF}  ${highlighter.dim("Scan every pull request to prevent new React issues while you fix the backlog.")}`,
+  `${SGR_BOLD_OFF}  ${highlighter.dim(`Used by teams at ${CI_TRUST_COMPANIES}.`)}`,
+].join("\n");
+
+export type CiPromptOutcome = "yes" | "no" | "cancel";
+
+// The single canonical "Add React Doctor to GitHub Actions?" pitch, shared by
+// the `install` onboarding and the post-scan agent handoff so both surfaces ask
+// it identically. "Learn more" opens the docs in the user's default browser via
+// `openUrl` and re-prompts, so the user can decide after reading without
+// restarting the CLI. Cancel (Esc / Ctrl-C) maps to "cancel" so a stray
+// keypress never accidentally installs workflow files. The `prompt` arg is
+// injectable for tests; production callers use the default real prompt.
+export const askAddToGitHubActions = async (
+  prompt: typeof prompts = prompts,
+): Promise<CiPromptOutcome> => {
+  while (true) {
+    const { ciChoice } = await prompt<"ciChoice">(
+      {
+        type: "select",
+        name: "ciChoice",
+        message: ciQuestionMessage,
+        hint: " ",
+        choices: [
+          {
+            title: "Yes (recommended)",
+            description: "Adds the workflow file and a doctor package script",
+            value: CI_YES_CHOICE,
+          },
+          {
+            title: "Learn more",
+            description: highlighter.info(CI_URL),
+            value: CI_LEARN_MORE_CHOICE,
+          },
+          {
+            title: "No, thanks",
+            description: "Skip for now — you can add it later",
+            value: CI_NO_CHOICE,
+          },
+        ],
+        initial: 0,
+      },
+      { onCancel: () => true },
+    );
+
+    if (ciChoice === undefined) return "cancel";
+    if (ciChoice === CI_YES_CHOICE) return "yes";
+    if (ciChoice === CI_NO_CHOICE) return "no";
+
+    // CI_LEARN_MORE_CHOICE: open the docs and loop back to the question.
+    const opened = openUrl(CI_URL);
+    logger.log(
+      opened
+        ? `Opened ${highlighter.info(CI_URL)} in your browser.`
+        : `Visit ${highlighter.info(CI_URL)} to learn more.`,
+    );
+    logger.break();
+  }
+};

--- a/packages/react-doctor/src/cli/utils/ask-upgrade-action-version.ts
+++ b/packages/react-doctor/src/cli/utils/ask-upgrade-action-version.ts
@@ -1,0 +1,43 @@
+import { prompts } from "./prompts.js";
+
+const UPGRADE_YES_CHOICE = "upgrade-yes";
+const UPGRADE_NO_CHOICE = "upgrade-no";
+
+export type ActionUpgradePromptOutcome = "yes" | "no" | "cancel";
+
+// The single canonical "upgrade this repo's workflow to the action's new major
+// (`@v2`)?" prompt, shared by the `install` onboarding and the post-scan agent
+// handoff so both surfaces ask it identically. Two choices only — a "no"
+// doubles as "don't ask again" (persisted by the caller). Cancel (Esc /
+// Ctrl-C) maps to "cancel" so a stray keypress neither bumps the workflow nor
+// permanently suppresses the offer. The `prompt` arg is injectable for tests;
+// production callers use the default real prompt.
+export const askUpgradeActionVersion = async (
+  prompt: typeof prompts = prompts,
+): Promise<ActionUpgradePromptOutcome> => {
+  const { upgradeChoice } = await prompt<"upgradeChoice">(
+    {
+      type: "select",
+      name: "upgradeChoice",
+      message: "A new major of the React Doctor Action (v2) is out. Upgrade this repo's workflow?",
+      hint: " ",
+      choices: [
+        {
+          title: "Yes (recommended)",
+          description: "Bump the workflow to millionco/react-doctor@v2",
+          value: UPGRADE_YES_CHOICE,
+        },
+        {
+          title: "No, thanks",
+          description: "Keep @v1 — won't ask again for this repo",
+          value: UPGRADE_NO_CHOICE,
+        },
+      ],
+      initial: 0,
+    },
+    { onCancel: () => true },
+  );
+
+  if (upgradeChoice === undefined) return "cancel";
+  return upgradeChoice === UPGRADE_YES_CHOICE ? "yes" : "no";
+};

--- a/packages/react-doctor/src/cli/utils/build-section-divider.ts
+++ b/packages/react-doctor/src/cli/utils/build-section-divider.ts
@@ -1,4 +1,7 @@
-import { highlighter, OUTPUT_MEASURE_WIDTH_CHARS } from "@react-doctor/core";
+import { highlighter } from "@react-doctor/core";
+import { resolveMeasureWidth } from "./resolve-measure-width.js";
+
+const DIVIDER_INDENT = "  ";
 
 export const buildSectionDivider = (): string =>
-  highlighter.dim(`  ${"─".repeat(OUTPUT_MEASURE_WIDTH_CHARS)}`);
+  highlighter.dim(`${DIVIDER_INDENT}${"─".repeat(resolveMeasureWidth(DIVIDER_INDENT.length))}`);

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -54,6 +54,25 @@ export const SCORE_PROJECTION_FRAME_DELAY_MS = 35;
 // improve line, blank, face-bottom, branding, bar.
 export const SCORE_PROJECTION_BAR_ROWS_ABOVE_CURSOR = 5;
 
+// Floor for the terminal-aware typographic measure (`resolveMeasureWidth`).
+// A terminal narrower than this is pathological; clamp here so prose can't
+// collapse into a one-or-two-character sliver.
+export const MIN_MEASURE_WIDTH_CHARS = 24;
+
+// Floor for the score bar when it's shrunk to fit a narrow terminal (the score
+// header clamps it to the columns left of the doctor face). Below this the bar
+// stops conveying the score proportionally, so we let it sit at this width.
+export const SCORE_BAR_MIN_WIDTH_CHARS = 10;
+
+// Keep one column free at the right edge so a full-width line can't trip the
+// terminal's auto-margin into a soft wrap, which breaks the in-place `\r`
+// redraws (the score-bar animation and the welcome typewriter).
+export const RIGHT_EDGE_SAFETY_COLUMNS = 1;
+
+// Visible columns the box border + padding adds around a code frame
+// (`│ ` … ` │` in box-text.ts). Reserved when fitting a box to the terminal.
+export const BOX_BORDER_WIDTH_CHARS = 4;
+
 // Last-resort fallback when buildJsonReportError itself throws — keeps
 // stdout valid JSON so downstream parsers don't see a half-written report.
 export const INTERNAL_ERROR_JSON_FALLBACK =

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -1,14 +1,12 @@
 import * as fs from "node:fs";
 import { getSkillAgentConfig } from "agent-install";
 import type { Diagnostic } from "@react-doctor/core";
-import { CI_URL, highlighter } from "@react-doctor/core";
+import { highlighter } from "@react-doctor/core";
 import { buildHandoffPayload } from "./build-handoff-payload.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import { detectAvailableAgents } from "./detect-agents.js";
 import { findNearestPackageDirectory } from "./install-doctor-script.js";
-import { installReactDoctorScriptStep } from "./install-react-doctor.js";
 import {
-  installReactDoctorWorkflow,
   isReactDoctorWorkflowInstalled,
   readReactDoctorWorkflow,
   upgradeWorkflowActionToV2,
@@ -16,11 +14,12 @@ import {
   type InstalledReactDoctorWorkflow,
 } from "./install-github-workflow.js";
 import { hasHandledActionUpgrade, recordActionUpgradeDecision } from "./action-upgrade-prompt.js";
-import { reportWorkflowResult } from "./report-workflow-result.js";
+import { askAddToGitHubActions } from "./ask-add-to-github-actions.js";
+import { askUpgradeActionVersion } from "./ask-upgrade-action-version.js";
+import { setUpGitHubActions } from "./set-up-github-actions.js";
 import { installReactDoctorSkillForAgent } from "./install-skill-for-agent.js";
 import { isCommandAvailable } from "./is-command-available.js";
-import { CI_TRUST_COMPANIES, METRIC } from "./constants.js";
-import { openUrl } from "./open-url.js";
+import { METRIC } from "./constants.js";
 import { openWorkflowPullRequest, stageWorkflowFile } from "./open-workflow-pull-request.js";
 import { recordCount } from "./record-metric.js";
 import {
@@ -39,9 +38,6 @@ export interface HandoffToAgentInput {
   readonly interactive: boolean;
 }
 
-const CI_YES_CHOICE = "ci-yes";
-const CI_LEARN_MORE_CHOICE = "ci-learn-more";
-const CI_NO_CHOICE = "ci-no";
 const CLIPBOARD_CHOICE = "clipboard";
 const SKIP_CHOICE = "skip";
 
@@ -52,110 +48,11 @@ const printPayload = (payload: string): void => {
   logger.log(highlighter.dim("──────────────────────"));
 };
 
-// Sets React Doctor up to scan every pull request: writes the GitHub Actions
-// workflow + adds a `doctor` package script (which runs `npx react-doctor@latest`,
-// no local dep required). The local dev-dep install isn't called from this path:
-// nothing here needs it, and on pnpm with a beta channel it noisily trips the
-// supply-chain trust guard for zero user benefit. Users who actually want a
-// pinned local copy go through the `react-doctor install` command. Resolves the
-// nearest package root first (mirroring `install`) so a nested scan directory
-// doesn't drop the workflow in the wrong place. The script step throws on a
-// read-only / permission-denied FS, so it's guarded: a failed setup must
-// never crash a scan that already succeeded.
-//
-// When the workflow is freshly written AND the user has `gh` installed,
-// `openWorkflowPullRequest` commits the YAML on a dedicated branch and
-// opens a PR for review — that matches the "everything else lands as a
-// reviewable PR" mental model teams already have for CI changes, instead
-// of silently dropping a top-level workflow file into their working tree.
-// On any failure (gh missing, not authenticated, push refused, …) we fall
-// back to `git add`ing the file so it at least shows up in the user's
-// next `git status` / commit instead of becoming an orphan untracked path.
-const setUpGitHubActions = async (rootDirectory: string): Promise<void> => {
-  const projectRoot = findNearestPackageDirectory(rootDirectory) ?? rootDirectory;
-  try {
-    installReactDoctorScriptStep(projectRoot);
-  } catch {}
-
-  const workflowSpinner = spinner("Adding GitHub Actions workflow...").start();
-  const workflowResult = installReactDoctorWorkflow(projectRoot);
-  reportWorkflowResult(workflowSpinner, workflowResult, projectRoot);
-
-  logger.break();
-  if (workflowResult.status === "failed") {
-    logger.log(
-      `  Couldn't set up GitHub Actions automatically. Follow the guide at ${highlighter.info(CI_URL)}`,
-    );
-    return;
-  }
-  if (workflowResult.status === "created") {
-    const pullRequestSpinner = spinner("Opening a pull request for review...").start();
-    const pullRequestResult = await openWorkflowPullRequest({
-      workflowPath: workflowResult.workflowPath,
-    });
-    if (pullRequestResult.status === "pr-opened") {
-      pullRequestSpinner.succeed(
-        `Opened pull request for review: ${highlighter.info(pullRequestResult.url)}`,
-      );
-    } else if (pullRequestResult.status === "branch-pushed") {
-      pullRequestSpinner.warn(
-        `Pushed branch ${highlighter.bold(pullRequestResult.branch)} but couldn't open a PR. Open one with: gh pr create --head ${pullRequestResult.branch}`,
-      );
-    } else {
-      pullRequestSpinner.stop();
-      const didStage = await stageWorkflowFile({ workflowPath: workflowResult.workflowPath });
-      if (didStage) {
-        logger.log(`  Staged the workflow file. Commit it to start scanning every pull request.`);
-      } else {
-        logger.log("  React Doctor will now scan every new pull request automatically.");
-      }
-    }
-  }
-  logger.log(`  Learn more: ${highlighter.info(CI_URL)}`);
-};
-
-const UPGRADE_YES_CHOICE = "upgrade-yes";
-const UPGRADE_NO_CHOICE = "upgrade-no";
-
 const UPGRADE_COMMIT_MESSAGE = "ci: upgrade React Doctor GitHub Action to v2";
 const UPGRADE_PR_TITLE = "Upgrade React Doctor Action to v2";
 const UPGRADE_PR_BODY = `Bumps the React Doctor GitHub Actions workflow to the action's latest major, \`millionco/react-doctor@v2\`.
 
 Docs: https://www.react.doctor/ci`;
-
-type UpgradePromptChoice = "yes" | "no" | "cancel";
-
-// One-time-per-repo offer to bump an existing workflow from the action's
-// previous floating major (`@v1`) to `@v2`. Two choices only — a "no" doubles
-// as "don't ask again" (persisted by the caller). Cancel (Esc / Ctrl-C) is
-// left un-answered so a stray keypress doesn't permanently suppress the offer.
-const askUpgradeActionVersion = async (): Promise<UpgradePromptChoice> => {
-  const { upgradeChoice } = await prompts<"upgradeChoice">(
-    {
-      type: "select",
-      name: "upgradeChoice",
-      message: "A new major of the React Doctor Action (v2) is out. Upgrade this repo's workflow?",
-      hint: " ",
-      choices: [
-        {
-          title: "Yes (recommended)",
-          description: "Open a PR bumping the workflow to millionco/react-doctor@v2",
-          value: UPGRADE_YES_CHOICE,
-        },
-        {
-          title: "No, thanks",
-          description: "Keep @v1 — won't ask again for this repo",
-          value: UPGRADE_NO_CHOICE,
-        },
-      ],
-      initial: 0,
-    },
-    { onCancel: () => true },
-  );
-
-  if (upgradeChoice === undefined) return "cancel";
-  return upgradeChoice === UPGRADE_YES_CHOICE ? "yes" : "no";
-};
 
 // Writes the `@v2` bump into the existing (tracked) workflow file and opens a
 // PR for it — mirroring the fresh-install flow's commit-on-a-branch model so
@@ -192,7 +89,9 @@ const upgradeGitHubActionsWorkflow = async (
     );
   } else if (pullRequestResult.status === "branch-pushed") {
     upgradeSpinner.warn(
-      `Pushed branch ${highlighter.bold(pullRequestResult.branch)} but couldn't open a PR. Open one with: gh pr create --head ${pullRequestResult.branch}`,
+      `Pushed branch ${highlighter.bold(
+        pullRequestResult.branch,
+      )} but couldn't open a PR. Open one with: gh pr create --head ${pullRequestResult.branch}`,
     );
   } else {
     upgradeSpinner.stop();
@@ -207,7 +106,9 @@ const upgradeGitHubActionsWorkflow = async (
       logger.log("  Couldn't finish the upgrade. Re-run React Doctor to try again.");
       return false;
     }
-    const didStage = await stageWorkflowFile({ workflowPath: workflow.workflowPath });
+    const didStage = await stageWorkflowFile({
+      workflowPath: workflow.workflowPath,
+    });
     logger.log(
       didStage
         ? "  Updated the workflow to @v2 and staged it. Commit it to finish the upgrade."
@@ -243,88 +144,6 @@ const maybeOfferActionUpgrade = async (projectRoot: string): Promise<void> => {
 
   const didApplyUpgrade = await upgradeGitHubActionsWorkflow(workflow);
   if (didApplyUpgrade) recordActionUpgradeDecision(projectRoot, "accepted");
-};
-
-// First handoff question, asked only when the GitHub Actions workflow isn't
-// already on disk. Pulled out of the main handoff prompt so the agent
-// selection below stays a clean "what runs next?" question instead of a
-// multi-axis decision.
-//
-// The pitch (incremental backlog + social proof) lives as part of the
-// `message` text, indented under the question itself so the value is
-// visually attached to the action it justifies — printing those lines via
-// `logger.log` before the prompt left them floating with a blank line
-// between the value prop and the question, and users skip past floating
-// preamble. `\x1b[22m` (SGR "bold off") cancels the bold the `prompts`
-// `select` renderer wraps every message in (`select.js` line 131:
-// `color.bold(this.msg)`), so the question stays bold while the indented
-// pitch lines render in normal weight (and dim, for the social-proof
-// tagline) — matching the original two-line layout's emphasis.
-//
-// `hint: " "` (single space — `""` would re-trigger the library's
-// `opts.hint || "- Use arrow-keys..."` fallback) suppresses the verbose
-// default hint so the trailing ` ›` rides quietly on the last pitch line
-// instead of becoming a "› - Use arrow-keys. Return to submit." row that
-// reads as broken UI between the pitch and the choices.
-//
-// "Learn more" opens the docs in the user's default browser via `openUrl` and
-// re-prompts, so the user can decide after reading without restarting the
-// CLI. Non-interactive runs never reach this function (the caller short-circuits
-// on `!input.interactive`); cancel (Esc / Ctrl-C) maps to "no" so a stray
-// keypress doesn't accidentally install workflow files.
-type CiHandoffOutcome = "yes" | "no" | "cancel";
-
-const SGR_BOLD_OFF = "\x1b[22m";
-
-const ciQuestionMessage = [
-  "Add React Doctor to GitHub Actions?",
-  `${SGR_BOLD_OFF}  ${highlighter.dim("Scan every pull request to prevent new React issues while you fix the backlog.")}`,
-  `${SGR_BOLD_OFF}  ${highlighter.dim(`Used by teams at ${CI_TRUST_COMPANIES}.`)}`,
-].join("\n");
-
-const askAddToGitHubActions = async (): Promise<CiHandoffOutcome> => {
-  while (true) {
-    const { ciChoice } = await prompts<"ciChoice">(
-      {
-        type: "select",
-        name: "ciChoice",
-        message: ciQuestionMessage,
-        hint: " ",
-        choices: [
-          {
-            title: "Yes (recommended)",
-            description: "Adds the workflow file and a doctor package script",
-            value: CI_YES_CHOICE,
-          },
-          {
-            title: "Learn more",
-            description: highlighter.info(CI_URL),
-            value: CI_LEARN_MORE_CHOICE,
-          },
-          {
-            title: "No, thanks",
-            description: "Continue to the agent handoff",
-            value: CI_NO_CHOICE,
-          },
-        ],
-        initial: 0,
-      },
-      { onCancel: () => true },
-    );
-
-    if (ciChoice === undefined) return "cancel";
-    if (ciChoice === CI_YES_CHOICE) return "yes";
-    if (ciChoice === CI_NO_CHOICE) return "no";
-
-    // CI_LEARN_MORE_CHOICE: open the docs and loop back to the question.
-    const opened = openUrl(CI_URL);
-    logger.log(
-      opened
-        ? `Opened ${highlighter.info(CI_URL)} in your browser.`
-        : `Visit ${highlighter.info(CI_URL)} to learn more.`,
-    );
-    logger.break();
-  }
 };
 
 // CLI agents we can launch: detected as installed by `agent-install`
@@ -366,7 +185,7 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
     });
     if (ciOutcome === "cancel") return;
     if (ciOutcome === "yes") {
-      await setUpGitHubActions(input.rootDirectory);
+      await setUpGitHubActions({ rootDirectory: input.rootDirectory });
       logger.break();
     }
   } else {

--- a/packages/react-doctor/src/cli/utils/install-doctor-script.ts
+++ b/packages/react-doctor/src/cli/utils/install-doctor-script.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { getPackageJsonPath, isRecord, readPackageJson, writeJsonFile } from "./git-hook-shared.js";
+import { spinner } from "./spinner.js";
 import * as fs from "node:fs";
 
 const DOCTOR_SCRIPT_NAME = "doctor";
@@ -148,4 +149,39 @@ export const installDoctorScript = (
     scriptStatus,
     ...(scriptTarget.reason !== undefined ? { scriptReason: scriptTarget.reason } : {}),
   };
+};
+
+const formatDoctorScriptInstallMessage = (scriptResult: InstallDoctorScriptResult): string => {
+  const scriptName = scriptResult.scriptName ?? "doctor";
+  if (scriptResult.scriptStatus === "created") {
+    return `Added package script: ${scriptName}.`;
+  }
+  if (scriptResult.scriptStatus === "existing") {
+    return `Package script already exists: ${scriptName}.`;
+  }
+  if (scriptResult.scriptReason === "script-names-taken") {
+    return "Skipped package script: doctor and react-doctor are already taken.";
+  }
+  if (scriptResult.scriptReason === "doctor-script-taken") {
+    return "Skipped package script: doctor and react-doctor scripts already exist.";
+  }
+  if (scriptResult.scriptReason === "invalid-scripts") {
+    return "Skipped package script: scripts field is not an object.";
+  }
+  return "Skipped package script: package.json missing or invalid.";
+};
+
+// Adds the `doctor` (or `react-doctor`) script to package.json so users can
+// run `pnpm doctor` / `npm run doctor`. The script invokes `npx react-doctor@latest`,
+// so no local dev-dep is required for it to work — that's why the "Add to CI"
+// path calls this step directly instead of the full package-setup function.
+export const installReactDoctorScriptStep = (projectRoot: string): void => {
+  const scriptSpinner = spinner("Installing React Doctor package script...").start();
+  try {
+    const scriptResult = installDoctorScript({ projectRoot });
+    scriptSpinner.succeed(formatDoctorScriptInstallMessage(scriptResult));
+  } catch (error) {
+    scriptSpinner.fail("Failed to install React Doctor package script.");
+    throw error;
+  }
 };

--- a/packages/react-doctor/src/cli/utils/install-github-workflow.ts
+++ b/packages/react-doctor/src/cli/utils/install-github-workflow.ts
@@ -141,3 +141,38 @@ export const installReactDoctorWorkflow = (projectRoot: string): InstallGitHubWo
     return { status: "failed", workflowPath };
   }
 };
+
+export interface UpgradeGitHubWorkflowResult {
+  // "upgraded": the floating `@v1` ref was rewritten to `@v2` in place.
+  // "not-needed": no workflow on disk, or it doesn't pin the floating `@v1`.
+  // "failed": the rewrite couldn't be persisted (read-only / permission FS).
+  readonly status: "upgraded" | "not-needed" | "failed";
+  readonly workflowPath: string;
+}
+
+// Rewrites an existing `.github/workflows/react-doctor.yml` from the action's
+// previous floating major (`@v1`) to `@v2` in place, leaving everything else
+// untouched. Mirrors `installReactDoctorWorkflow`'s "write to the working tree,
+// user reviews + commits" contract for the `install` flow — the PR-opening
+// upgrade variant lives in the post-scan handoff. Returns "failed" (rather than
+// throwing) so callers can degrade gracefully.
+export const upgradeReactDoctorWorkflowInPlace = (
+  projectRoot: string,
+): UpgradeGitHubWorkflowResult => {
+  const workflow = readReactDoctorWorkflow(projectRoot);
+  if (!workflow)
+    return {
+      status: "not-needed",
+      workflowPath: getReactDoctorWorkflowPath(projectRoot),
+    };
+
+  const { content, changed } = upgradeWorkflowActionToV2(workflow.content);
+  if (!changed) return { status: "not-needed", workflowPath: workflow.workflowPath };
+
+  try {
+    fs.writeFileSync(workflow.workflowPath, content);
+    return { status: "upgraded", workflowPath: workflow.workflowPath };
+  } catch {
+    return { status: "failed", workflowPath: workflow.workflowPath };
+  }
+};

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -641,20 +641,6 @@ export const runInstallReactDoctor = async (
 
   if (selectedAgents.length === 0) return;
 
-  // The CI decision from Step 1 lands here, now that the install is confirmed.
-  let didInstallWorkflow = false;
-  if (!options.dryRun && (shouldInstallWorkflow || shouldUpgradeWorkflow)) {
-    if (shouldInstallWorkflow) {
-      didInstallWorkflow = installReactDoctorWorkflowStep(projectRoot);
-    } else if (upgradeReactDoctorWorkflowStep(projectRoot)) {
-      // Applied upgrade is terminal too — record it so the post-scan handoff
-      // never re-offers the bump on the next scan.
-      recordActionUpgradeDecision(projectRoot, "accepted");
-    }
-    // Blank line between the workflow install/upgrade and the skill group.
-    logger.break();
-  }
-
   let dependencyResult: InstallReactDoctorDependencyResult | undefined;
   if (!options.dryRun) {
     await installReactDoctorSkillStep(sourceDir, selectedAgents, projectRoot);
@@ -662,6 +648,22 @@ export const runInstallReactDoctor = async (
       projectRoot,
       options.installDependencyRunner,
     );
+  }
+
+  // The CI decision from Step 1 lands here, after the core skill + package setup
+  // has run — so a thrown skill/package install never strands an orphan workflow
+  // on disk (the workflow write is the last write in the core install group).
+  let didInstallWorkflow = false;
+  if (!options.dryRun && (shouldInstallWorkflow || shouldUpgradeWorkflow)) {
+    // Blank line between the skill group and the workflow install/upgrade.
+    logger.break();
+    if (shouldInstallWorkflow) {
+      didInstallWorkflow = installReactDoctorWorkflowStep(projectRoot);
+    } else if (upgradeReactDoctorWorkflowStep(projectRoot)) {
+      // Applied upgrade is terminal too — record it so the post-scan handoff
+      // never re-offers the bump on the next scan.
+      recordActionUpgradeDecision(projectRoot, "accepted");
+    }
   }
 
   // Step 3 — optional setup (pre-commit hook, agent hooks).

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -22,7 +22,7 @@ import {
 } from "./install-doctor-script.js";
 import { askAddToGitHubActions } from "./ask-add-to-github-actions.js";
 import { askUpgradeActionVersion } from "./ask-upgrade-action-version.js";
-import { recordActionUpgradeDecision } from "./action-upgrade-prompt.js";
+import { hasHandledActionUpgrade, recordActionUpgradeDecision } from "./action-upgrade-prompt.js";
 import { installReactDoctorAgentHooks } from "./install-agent-hooks.js";
 import {
   getReactDoctorWorkflowPath,
@@ -582,8 +582,15 @@ export const runInstallReactDoctor = async (
   // offer on existence so we never pitch installing over a file that's already
   // there (and can't be upgraded either, since we couldn't read its contents).
   const canInstallWorkflow = !fs.existsSync(workflowTargetPath);
+  // Mirror the post-scan handoff's `maybeOfferActionUpgrade`: the `@v1` → `@v2`
+  // bump is a one-time, per-repo offer. Once it's been answered (accepted OR
+  // declined), `hasHandledActionUpgrade` suppresses it here too — so `install`
+  // never re-prompts, and `--yes` never silently re-applies an already-declined
+  // bump.
   const canUpgradeWorkflow =
-    existingWorkflow !== null && workflowUsesV1Action(existingWorkflow.content);
+    existingWorkflow !== null &&
+    workflowUsesV1Action(existingWorkflow.content) &&
+    !hasHandledActionUpgrade(projectRoot);
 
   // Each install step runs right after the user commits to the install (past the
   // agent-selection guard below), so the writes land in one visible group and

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -22,6 +22,7 @@ import {
 } from "./install-doctor-script.js";
 import { askAddToGitHubActions } from "./ask-add-to-github-actions.js";
 import { askUpgradeActionVersion } from "./ask-upgrade-action-version.js";
+import { recordActionUpgradeDecision } from "./action-upgrade-prompt.js";
 import { installReactDoctorAgentHooks } from "./install-agent-hooks.js";
 import {
   getReactDoctorWorkflowPath,
@@ -518,16 +519,16 @@ const installReactDoctorWorkflowStep = (projectRoot: string): boolean => {
 // the fresh-install write — the PR-opening upgrade variant is the post-scan
 // handoff's job). Counts the same `install.workflow` activation as a fresh
 // write so CI adoption stays comparable across both entry points.
-const upgradeReactDoctorWorkflowStep = (projectRoot: string): void => {
+const upgradeReactDoctorWorkflowStep = (projectRoot: string): boolean => {
   const workflowSpinner = spinner("Upgrading GitHub Actions workflow to v2...").start();
   const upgradeResult = upgradeReactDoctorWorkflowInPlace(projectRoot);
   if (upgradeResult.status === "failed") {
     workflowSpinner.fail("Couldn't update the GitHub Actions workflow.");
-    return;
+    return false;
   }
   if (upgradeResult.status === "not-needed") {
     workflowSpinner.succeed("GitHub Actions workflow already up to date.");
-    return;
+    return false;
   }
   workflowSpinner.succeed(
     `Upgraded the GitHub Actions workflow to v2 at ${path.relative(
@@ -536,6 +537,7 @@ const upgradeReactDoctorWorkflowStep = (projectRoot: string): void => {
     )}.`,
   );
   recordCount(METRIC.installWorkflow, 1, { kind: "upgrade" });
+  return true;
 };
 
 export const runInstallReactDoctor = async (
@@ -576,7 +578,10 @@ export const runInstallReactDoctor = async (
 
   const workflowTargetPath = getReactDoctorWorkflowPath(projectRoot);
   const existingWorkflow = readReactDoctorWorkflow(projectRoot);
-  const canInstallWorkflow = existingWorkflow === null;
+  // A present-but-unreadable workflow also reads back as `null`; gate the "add"
+  // offer on existence so we never pitch installing over a file that's already
+  // there (and can't be upgraded either, since we couldn't read its contents).
+  const canInstallWorkflow = !fs.existsSync(workflowTargetPath);
   const canUpgradeWorkflow =
     existingWorkflow !== null && workflowUsesV1Action(existingWorkflow.content);
 
@@ -598,9 +603,20 @@ export const runInstallReactDoctor = async (
   const shouldInstallWorkflow =
     canInstallWorkflow &&
     (Boolean(options.yes) || (!skipPrompts && (await askAddToGitHubActions(prompt)) === "yes"));
+  const upgradePromptOutcome =
+    canUpgradeWorkflow && !options.yes && !skipPrompts
+      ? await askUpgradeActionVersion(prompt)
+      : null;
   const shouldUpgradeWorkflow =
-    canUpgradeWorkflow &&
-    (Boolean(options.yes) || (!skipPrompts && (await askUpgradeActionVersion(prompt)) === "yes"));
+    canUpgradeWorkflow && (Boolean(options.yes) || upgradePromptOutcome === "yes");
+
+  // The upgrade prompt's "No, thanks" promises "won't ask again for this repo",
+  // so persist a decline immediately — mirroring the post-scan handoff, and so
+  // the offer stays suppressed even if the rest of the install is cancelled
+  // below. Dry runs preview without writing anything.
+  if (upgradePromptOutcome === "no" && !options.dryRun) {
+    recordActionUpgradeDecision(projectRoot, "declined");
+  }
 
   // Step 2 — the agent skill + package setup (the core of `install`).
   const selectedAgents: SkillAgentType[] = skipPrompts
@@ -630,8 +646,10 @@ export const runInstallReactDoctor = async (
   if (!options.dryRun && (shouldInstallWorkflow || shouldUpgradeWorkflow)) {
     if (shouldInstallWorkflow) {
       didInstallWorkflow = installReactDoctorWorkflowStep(projectRoot);
-    } else {
-      upgradeReactDoctorWorkflowStep(projectRoot);
+    } else if (upgradeReactDoctorWorkflowStep(projectRoot)) {
+      // Applied upgrade is terminal too — record it so the post-scan handoff
+      // never re-offers the bump on the next scan.
+      recordActionUpgradeDecision(projectRoot, "accepted");
     }
     // Blank line between the workflow install/upgrade and the skill group.
     logger.break();

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -18,13 +18,17 @@ import {
   DOCTOR_PACKAGE_NAME,
   findNearestPackageDirectory,
   hasDoctorDependency,
-  installDoctorScript,
+  installReactDoctorScriptStep,
 } from "./install-doctor-script.js";
+import { askAddToGitHubActions } from "./ask-add-to-github-actions.js";
+import { askUpgradeActionVersion } from "./ask-upgrade-action-version.js";
 import { installReactDoctorAgentHooks } from "./install-agent-hooks.js";
 import {
   getReactDoctorWorkflowPath,
   installReactDoctorWorkflow,
-  isReactDoctorWorkflowInstalled,
+  readReactDoctorWorkflow,
+  upgradeReactDoctorWorkflowInPlace,
+  workflowUsesV1Action,
 } from "./install-github-workflow.js";
 import { reportWorkflowResult } from "./report-workflow-result.js";
 import { isRecord, readPackageJson } from "./git-hook-shared.js";
@@ -36,7 +40,6 @@ import { spinner } from "./spinner.js";
 
 const SETUP_OPTION_GIT_HOOK = "git-hook";
 const SETUP_OPTION_AGENT_HOOKS = "agent-hooks";
-const SETUP_OPTION_WORKFLOW = "workflow";
 const SETUP_OPTION_SKIP = "skip";
 
 const CONFIG_ONLY_GIT_HOOK_KINDS = new Set([
@@ -136,13 +139,25 @@ const buildInstallCommand = (projectRoot: string): InstallReactDoctorDependencyR
   const packageManager = detectPackageManager(projectRoot);
   const packageSpecifier = `${DOCTOR_PACKAGE_NAME}@latest`;
   if (packageManager === "npm") {
-    return { command: "npm", args: ["install", "--save-dev", packageSpecifier], cwd: projectRoot };
+    return {
+      command: "npm",
+      args: ["install", "--save-dev", packageSpecifier],
+      cwd: projectRoot,
+    };
   }
   if (packageManager === "yarn") {
-    return { command: "yarn", args: ["add", "--dev", packageSpecifier], cwd: projectRoot };
+    return {
+      command: "yarn",
+      args: ["add", "--dev", packageSpecifier],
+      cwd: projectRoot,
+    };
   }
   if (packageManager === "bun") {
-    return { command: "bun", args: ["add", "--dev", packageSpecifier], cwd: projectRoot };
+    return {
+      command: "bun",
+      args: ["add", "--dev", packageSpecifier],
+      cwd: projectRoot,
+    };
   }
   return {
     command: "pnpm",
@@ -173,7 +188,11 @@ const defaultInstallDependencyRunner = async (
 // earlier one. It reads as a compromise but is routinely tripped by
 // pre-release deps; detect it so we can reassure instead of alarm.
 const isSupplyChainTrustError = (error: unknown): boolean => {
-  const candidate = error as { stderr?: unknown; stdout?: unknown; message?: unknown } | null;
+  const candidate = error as {
+    stderr?: unknown;
+    stdout?: unknown;
+    message?: unknown;
+  } | null;
   const haystack = [candidate?.stderr, candidate?.stdout, candidate?.message]
     .map((part) => String(part ?? ""))
     .join("\n");
@@ -231,28 +250,6 @@ const formatGitHookInstallMessage = (
   return `React Doctor pre-commit hook ${hookResult.status} at ${hookResult.hookPath}.`;
 };
 
-const formatDoctorScriptInstallMessage = (
-  scriptResult: ReturnType<typeof installDoctorScript>,
-): string => {
-  const messages: string[] = [];
-  const scriptName = scriptResult.scriptName ?? "doctor";
-  if (scriptResult.scriptStatus === "created") {
-    messages.push(`Added package script: ${scriptName}.`);
-  } else if (scriptResult.scriptStatus === "existing") {
-    messages.push(`Package script already exists: ${scriptName}.`);
-  } else if (scriptResult.scriptReason === "script-names-taken") {
-    messages.push("Skipped package script: doctor and react-doctor are already taken.");
-  } else if (scriptResult.scriptReason === "doctor-script-taken") {
-    messages.push("Skipped package script: doctor and react-doctor scripts already exist.");
-  } else if (scriptResult.scriptReason === "invalid-scripts") {
-    messages.push(`Skipped package script: scripts field is not an object.`);
-  } else {
-    messages.push("Skipped package script: package.json missing or invalid.");
-  }
-
-  return messages.join(" ");
-};
-
 const formatDependencyInstallMessage = (result: InstallReactDoctorDependencyResult): string => {
   if (result.dependencyStatus === "created") {
     return "Installed dev dependency: react-doctor.";
@@ -284,21 +281,6 @@ const buildDependencyFollowUp = (
   const installCommand =
     result.installCommand ?? `npm install --save-dev ${DOCTOR_PACKAGE_NAME}@latest`;
   return `  React Doctor still works via \`npx react-doctor\`. To install locally: ${installCommand}`;
-};
-
-// Adds the `doctor` (or `react-doctor`) script to package.json so users can
-// run `pnpm doctor` / `npm run doctor`. The script invokes `npx react-doctor@latest`,
-// so no local dev-dep is required for it to work — that's why the "Add to CI"
-// path calls this step directly instead of the full package-setup function.
-export const installReactDoctorScriptStep = (projectRoot: string): void => {
-  const scriptSpinner = spinner("Installing React Doctor package script...").start();
-  try {
-    const scriptResult = installDoctorScript({ projectRoot });
-    scriptSpinner.succeed(formatDoctorScriptInstallMessage(scriptResult));
-  } catch (error) {
-    scriptSpinner.fail("Failed to install React Doctor package script.");
-    throw error;
-  }
 };
 
 export const installReactDoctorPackageSetup = async (
@@ -381,7 +363,10 @@ const findBundledSiblingSkills = (primarySkillDir: string): BundledSiblingSkill[
   return fs
     .readdirSync(skillsParent, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
-    .map((entry) => ({ name: entry.name, source: path.join(skillsParent, entry.name) }))
+    .map((entry) => ({
+      name: entry.name,
+      source: path.join(skillsParent, entry.name),
+    }))
     .filter(
       (sibling) =>
         path.resolve(sibling.source) !== resolvedPrimary &&
@@ -416,6 +401,142 @@ const installBundledSiblingSkills = async (
 
 const canInstallNativeAgentHooks = (agents: readonly SkillAgentType[]): boolean =>
   agents.some((agent) => agent === "claude-code" || agent === "cursor");
+
+// Installs the primary skill (throws on failure — the install can't continue
+// without it) and then the bundled sibling skills (best-effort).
+const installReactDoctorSkillStep = async (
+  sourceDir: string,
+  selectedAgents: SkillAgentType[],
+  projectRoot: string,
+): Promise<void> => {
+  const installSpinner = spinner(`Installing ${SKILL_NAME} skill...`).start();
+  try {
+    const installResult = await installSkillsFromSource({
+      source: sourceDir,
+      agents: selectedAgents,
+      cwd: projectRoot,
+      mode: "copy",
+    });
+
+    if (installResult.skills.length === 0) {
+      throw new Error(
+        `Could not parse ${SKILL_MANIFEST_FILE} for ${SKILL_NAME} (missing or invalid frontmatter).`,
+      );
+    }
+    if (installResult.failed.length > 0) {
+      throw new Error(
+        installResult.failed
+          .map((failure) => `${getSkillAgentConfig(failure.agent).displayName}: ${failure.error}`)
+          .join("\n"),
+      );
+    }
+
+    installSpinner.succeed(
+      `${SKILL_NAME} skill installed for ${selectedAgents
+        .map((agent) => getSkillAgentConfig(agent).displayName)
+        .join(", ")}.`,
+    );
+  } catch (error) {
+    installSpinner.fail(`Failed to install ${SKILL_NAME} skill.`);
+    throw error;
+  }
+
+  try {
+    const installedSiblingSkills = await installBundledSiblingSkills(
+      sourceDir,
+      selectedAgents,
+      projectRoot,
+    );
+    if (installedSiblingSkills.length > 0) {
+      logger.dim(`  Also installed the ${installedSiblingSkills.join(", ")} skill.`);
+    }
+  } catch {
+    logger.dim("  Skipped bundled sibling skills (install error).");
+  }
+};
+
+const installReactDoctorGitHookStep = (gitHookTarget: GitHookTarget): void => {
+  const hookSpinner = spinner("Installing React Doctor pre-commit hook...").start();
+  try {
+    const hookResult = installReactDoctorGitHook({
+      hookPath: gitHookTarget.hookPath,
+      projectRoot: gitHookTarget.runnerRoot,
+      kind: gitHookTarget.kind,
+      hooksPathConfig: gitHookTarget.hooksPathConfig,
+    });
+    hookSpinner.succeed(formatGitHookInstallMessage(hookResult));
+    recordCount(METRIC.installGitHook, 1, { kind: hookResult.kind });
+  } catch (error) {
+    hookSpinner.fail("Failed to install React Doctor pre-commit hook.");
+    throw error;
+  }
+};
+
+const installReactDoctorAgentHooksStep = (
+  projectRoot: string,
+  selectedAgents: SkillAgentType[],
+): void => {
+  const hookSpinner = spinner("Installing React Doctor agent hooks...").start();
+  try {
+    const hookResult = installReactDoctorAgentHooks({
+      projectRoot,
+      agents: selectedAgents,
+    });
+    if (hookResult.installedAgents.length === 0) {
+      hookSpinner.succeed("No supported native agent hook targets selected.");
+    } else {
+      hookSpinner.succeed(
+        `React Doctor agent hooks installed for ${hookResult.installedAgents
+          .map((agent) => getSkillAgentConfig(agent).displayName)
+          .join(", ")}.`,
+      );
+      recordCount(METRIC.installAgentHooks, 1, {
+        agentsCount: hookResult.installedAgents.length,
+      });
+    }
+  } catch (error) {
+    hookSpinner.fail("Failed to install React Doctor agent hooks.");
+    throw error;
+  }
+};
+
+// Writes the workflow into the working tree alongside the other files `install`
+// lands (skill, package script, git hook) so the user reviews and commits it
+// themselves. The PR-opening flow belongs to the post-scan handoff, not
+// `install` — committing to a throwaway branch can lose the file if the push is
+// rejected, leaving "yes" with nothing on disk.
+const installReactDoctorWorkflowStep = (projectRoot: string): boolean => {
+  const workflowSpinner = spinner("Adding GitHub Actions workflow...").start();
+  return reportWorkflowResult(
+    workflowSpinner,
+    installReactDoctorWorkflow(projectRoot),
+    projectRoot,
+  );
+};
+
+// Bumps an existing workflow's floating `@v1` ref to `@v2` in place (mirroring
+// the fresh-install write — the PR-opening upgrade variant is the post-scan
+// handoff's job). Counts the same `install.workflow` activation as a fresh
+// write so CI adoption stays comparable across both entry points.
+const upgradeReactDoctorWorkflowStep = (projectRoot: string): void => {
+  const workflowSpinner = spinner("Upgrading GitHub Actions workflow to v2...").start();
+  const upgradeResult = upgradeReactDoctorWorkflowInPlace(projectRoot);
+  if (upgradeResult.status === "failed") {
+    workflowSpinner.fail("Couldn't update the GitHub Actions workflow.");
+    return;
+  }
+  if (upgradeResult.status === "not-needed") {
+    workflowSpinner.succeed("GitHub Actions workflow already up to date.");
+    return;
+  }
+  workflowSpinner.succeed(
+    `Upgraded the GitHub Actions workflow to v2 at ${path.relative(
+      projectRoot,
+      upgradeResult.workflowPath,
+    )}.`,
+  );
+  recordCount(METRIC.installWorkflow, 1, { kind: "upgrade" });
+};
 
 export const runInstallReactDoctor = async (
   options: InstallReactDoctorOptions = {},
@@ -453,6 +574,35 @@ export const runInstallReactDoctor = async (
     options.onPromptCancel === undefined ? {} : { onCancel: options.onPromptCancel };
   const prompt = options.prompt ?? prompts;
 
+  const workflowTargetPath = getReactDoctorWorkflowPath(projectRoot);
+  const existingWorkflow = readReactDoctorWorkflow(projectRoot);
+  const canInstallWorkflow = existingWorkflow === null;
+  const canUpgradeWorkflow =
+    existingWorkflow !== null && workflowUsesV1Action(existingWorkflow.content);
+
+  // Each install step runs right after the user commits to the install (past the
+  // agent-selection guard below), so the writes land in one visible group and
+  // cancelling agent selection never strands files on disk. `--yes`/non-interactive
+  // runs have no prompts; `--dryRun` runs the prompts but defers every write to
+  // the plan print below.
+
+  // Step 1 — CI pitch leads the onboarding: scanning every pull request is the
+  // highest-leverage setup step, so it's asked first using the same shared pitch
+  // as the post-scan handoff. The decision is captured here, but the workflow
+  // file isn't written until the install is confirmed (after the agent guard),
+  // so a cancel can't leave an orphan workflow without the rest of the setup.
+  // A fresh workflow is offered when none exists; an existing one still pinned
+  // to the action's previous floating major (`@v1`) is offered the in-place
+  // `@v2` bump instead. The two are mutually exclusive — only one can apply.
+  // `--yes` opts in and a bare non-interactive run opts out.
+  const shouldInstallWorkflow =
+    canInstallWorkflow &&
+    (Boolean(options.yes) || (!skipPrompts && (await askAddToGitHubActions(prompt)) === "yes"));
+  const shouldUpgradeWorkflow =
+    canUpgradeWorkflow &&
+    (Boolean(options.yes) || (!skipPrompts && (await askUpgradeActionVersion(prompt)) === "yes"));
+
+  // Step 2 — the agent skill + package setup (the core of `install`).
   const selectedAgents: SkillAgentType[] = skipPrompts
     ? detectedAgents
     : ((
@@ -475,8 +625,28 @@ export const runInstallReactDoctor = async (
 
   if (selectedAgents.length === 0) return;
 
-  const workflowTargetPath = getReactDoctorWorkflowPath(projectRoot);
-  const canInstallWorkflow = !isReactDoctorWorkflowInstalled(projectRoot);
+  // The CI decision from Step 1 lands here, now that the install is confirmed.
+  let didInstallWorkflow = false;
+  if (!options.dryRun && (shouldInstallWorkflow || shouldUpgradeWorkflow)) {
+    if (shouldInstallWorkflow) {
+      didInstallWorkflow = installReactDoctorWorkflowStep(projectRoot);
+    } else {
+      upgradeReactDoctorWorkflowStep(projectRoot);
+    }
+    // Blank line between the workflow install/upgrade and the skill group.
+    logger.break();
+  }
+
+  let dependencyResult: InstallReactDoctorDependencyResult | undefined;
+  if (!options.dryRun) {
+    await installReactDoctorSkillStep(sourceDir, selectedAgents, projectRoot);
+    dependencyResult = await installReactDoctorPackageSetup(
+      projectRoot,
+      options.installDependencyRunner,
+    );
+  }
+
+  // Step 3 — optional setup (pre-commit hook, agent hooks).
   const setupActionChoices = [
     ...(gitHookPath === null || gitHookPath === undefined
       ? []
@@ -498,16 +668,6 @@ export const runInstallReactDoctor = async (
           },
         ]
       : []),
-    ...(canInstallWorkflow
-      ? [
-          {
-            title: "GitHub Actions workflow",
-            description: "Scan pull requests in CI",
-            value: SETUP_OPTION_WORKFLOW,
-            selected: true,
-          },
-        ]
-      : []),
   ];
   const setupChoices =
     setupActionChoices.length === 0
@@ -521,6 +681,10 @@ export const runInstallReactDoctor = async (
           },
           ...setupActionChoices,
         ];
+
+  // Blank line between the skill group and the optional-setup group.
+  if (setupChoices.length > 0 && !options.dryRun) logger.break();
+
   const selectedSetupOptions: string[] =
     skipPrompts || setupChoices.length === 0
       ? []
@@ -550,10 +714,15 @@ export const runInstallReactDoctor = async (
   const shouldInstallAgentHooks =
     Boolean(options.agentHooks) ||
     (!didSkipOptionalSetup && selectedSetupActions.includes(SETUP_OPTION_AGENT_HOOKS));
-  const shouldInstallWorkflow =
-    canInstallWorkflow &&
-    (Boolean(options.yes) ||
-      (!didSkipOptionalSetup && selectedSetupActions.includes(SETUP_OPTION_WORKFLOW)));
+
+  if (!options.dryRun) {
+    if (shouldInstallGitHook && gitHookTarget !== null && gitHookTarget !== undefined) {
+      installReactDoctorGitHookStep(gitHookTarget);
+    }
+    if (shouldInstallAgentHooks) {
+      installReactDoctorAgentHooksStep(projectRoot, selectedAgents);
+    }
+  }
 
   if (options.dryRun) {
     logger.log(`Dry run — would install ${SKILL_NAME} skill for:`);
@@ -575,107 +744,15 @@ export const runInstallReactDoctor = async (
     if (shouldInstallWorkflow) {
       logger.dim(`  GitHub Actions workflow: ${path.relative(projectRoot, workflowTargetPath)}`);
     }
+    if (shouldUpgradeWorkflow) {
+      logger.dim(
+        `  Upgrade GitHub Actions workflow to v2: ${path.relative(
+          projectRoot,
+          workflowTargetPath,
+        )}`,
+      );
+    }
     return;
-  }
-
-  const installSpinner = spinner(`Installing ${SKILL_NAME} skill...`).start();
-  try {
-    const installResult = await installSkillsFromSource({
-      source: sourceDir,
-      agents: selectedAgents,
-      cwd: projectRoot,
-      mode: "copy",
-    });
-
-    if (installResult.skills.length === 0) {
-      throw new Error(
-        `Could not parse ${SKILL_MANIFEST_FILE} for ${SKILL_NAME} (missing or invalid frontmatter).`,
-      );
-    }
-    if (installResult.failed.length > 0) {
-      throw new Error(
-        installResult.failed
-          .map((failure) => `${getSkillAgentConfig(failure.agent).displayName}: ${failure.error}`)
-          .join("\n"),
-      );
-    }
-
-    installSpinner.succeed(
-      `${SKILL_NAME} skill installed for ${selectedAgents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ")}.`,
-    );
-  } catch (error) {
-    installSpinner.fail(`Failed to install ${SKILL_NAME} skill.`);
-    throw error;
-  }
-
-  // Best-effort: the bundled `doctor-explain` skill installs alongside the
-  // primary one. A failure here shouldn't abort the rest of the setup.
-  try {
-    const installedSiblingSkills = await installBundledSiblingSkills(
-      sourceDir,
-      selectedAgents,
-      projectRoot,
-    );
-    if (installedSiblingSkills.length > 0) {
-      logger.dim(`  Also installed the ${installedSiblingSkills.join(", ")} skill.`);
-    }
-  } catch {
-    logger.dim("  Skipped bundled sibling skills (install error).");
-  }
-
-  const dependencyResult = await installReactDoctorPackageSetup(
-    projectRoot,
-    options.installDependencyRunner,
-  );
-
-  if (shouldInstallGitHook && gitHookTarget !== null && gitHookTarget !== undefined) {
-    const hookSpinner = spinner("Installing React Doctor pre-commit hook...").start();
-    try {
-      const hookResult = installReactDoctorGitHook({
-        hookPath: gitHookTarget.hookPath,
-        projectRoot: gitHookTarget.runnerRoot,
-        kind: gitHookTarget.kind,
-        hooksPathConfig: gitHookTarget.hooksPathConfig,
-      });
-      hookSpinner.succeed(formatGitHookInstallMessage(hookResult));
-      recordCount(METRIC.installGitHook, 1, { kind: hookResult.kind });
-    } catch (error) {
-      hookSpinner.fail("Failed to install React Doctor pre-commit hook.");
-      throw error;
-    }
-  }
-
-  if (shouldInstallAgentHooks) {
-    const hookSpinner = spinner("Installing React Doctor agent hooks...").start();
-    try {
-      const hookResult = installReactDoctorAgentHooks({
-        projectRoot,
-        agents: selectedAgents,
-      });
-      if (hookResult.installedAgents.length === 0) {
-        hookSpinner.succeed("No supported native agent hook targets selected.");
-      } else {
-        hookSpinner.succeed(
-          `React Doctor agent hooks installed for ${hookResult.installedAgents.map((agent) => getSkillAgentConfig(agent).displayName).join(", ")}.`,
-        );
-        recordCount(METRIC.installAgentHooks, 1, {
-          agentsCount: hookResult.installedAgents.length,
-        });
-      }
-    } catch (error) {
-      hookSpinner.fail("Failed to install React Doctor agent hooks.");
-      throw error;
-    }
-  }
-
-  let didInstallWorkflow = false;
-  if (shouldInstallWorkflow) {
-    const workflowSpinner = spinner("Adding GitHub Actions workflow...").start();
-    didInstallWorkflow = reportWorkflowResult(
-      workflowSpinner,
-      installReactDoctorWorkflow(projectRoot),
-      projectRoot,
-    );
   }
 
   // Activation summary for a real (non-dry-run) install: how many agents, which
@@ -686,7 +763,7 @@ export const runInstallReactDoctor = async (
     gitHook: shouldInstallGitHook,
     agentHooks: shouldInstallAgentHooks,
     workflow: didInstallWorkflow,
-    dependencyStatus: dependencyResult.dependencyStatus,
+    dependencyStatus: dependencyResult?.dependencyStatus ?? "skipped",
     packageManager: detectPackageManager(projectRoot),
   });
   for (const agent of selectedAgents) {

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -9,7 +9,6 @@ import {
   groupBy,
   highlighter,
   MILLISECONDS_PER_SECOND,
-  OUTPUT_MEASURE_WIDTH_CHARS,
   TOP_ERRORS_DISPLAY_COUNT,
 } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
@@ -17,6 +16,7 @@ import { boxText } from "./box-text.js";
 import { buildCodeFrame } from "./build-code-frame.js";
 import { buildSectionDivider } from "./build-section-divider.js";
 import {
+  BOX_BORDER_WIDTH_CHARS,
   CATEGORY_COUNTUP_FRAME_DELAY_MS,
   CATEGORY_COUNTUP_MAX_STEPS,
   CATEGORY_COUNTUP_SETTLE_HOLD_MS,
@@ -27,6 +27,7 @@ import {
   formatLearnMoreLine,
 } from "./diagnostic-grouping.js";
 import { indentMultilineText } from "./indent-multiline-text.js";
+import { resolveMeasureWidth } from "./resolve-measure-width.js";
 import { wrapTextToWidth } from "./wrap-indented-text.js";
 import { writeStdout } from "./write-stdout.js";
 
@@ -292,9 +293,10 @@ const buildDiagnosticClusterLines = (
       })
     : null;
   if (codeFrame) {
-    lines.push(
-      indentMultilineText(boxText(codeFrame, OUTPUT_MEASURE_WIDTH_CHARS), TOP_ERROR_DETAIL_INDENT),
+    const boxInnerWidth = resolveMeasureWidth(
+      TOP_ERROR_DETAIL_INDENT.length + BOX_BORDER_WIDTH_CHARS,
     );
+    lines.push(indentMultilineText(boxText(codeFrame, boxInnerWidth), TOP_ERROR_DETAIL_INDENT));
   }
   const seenHints = new Set<string>();
   for (const diagnostic of cluster.diagnostics) {
@@ -347,7 +349,7 @@ const buildRuleDetailBlock = (
   if (!renderEverySite) {
     for (const explanationLine of wrapTextToWidth(
       representative.message,
-      OUTPUT_MEASURE_WIDTH_CHARS,
+      resolveMeasureWidth(TOP_ERROR_DETAIL_INDENT.length),
       { breakLongWords: false },
     )) {
       // The description stays the terminal's default color (not dimmed) —
@@ -361,9 +363,11 @@ const buildRuleDetailBlock = (
   // too long to sit at the code-frame caret). Dim `→` lead-in marks it as
   // the suggested action.
   if (representative.help) {
-    for (const fixLine of wrapTextToWidth(`→ ${representative.help}`, OUTPUT_MEASURE_WIDTH_CHARS, {
-      breakLongWords: false,
-    })) {
+    for (const fixLine of wrapTextToWidth(
+      `→ ${representative.help}`,
+      resolveMeasureWidth(TOP_ERROR_DETAIL_INDENT.length),
+      { breakLongWords: false },
+    )) {
       lines.push(highlighter.dim(`${TOP_ERROR_DETAIL_INDENT}${fixLine}`));
     }
   }

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -12,6 +12,8 @@ import { colorizeByScore } from "./colorize-by-score.js";
 import {
   PERFECT_SCORE_RAINBOW_FRAME_COUNT,
   PERFECT_SCORE_RAINBOW_FRAME_DELAY_MS,
+  RIGHT_EDGE_SAFETY_COLUMNS,
+  SCORE_BAR_MIN_WIDTH_CHARS,
   SCORE_HEADER_ANIMATION_FRAME_COUNT,
   SCORE_HEADER_ANIMATION_FRAME_DELAY_MS,
   SCORE_PROJECTION_FRAME_COUNT,
@@ -19,6 +21,7 @@ import {
 } from "./constants.js";
 import { easeOutCubic } from "./ease-out-cubic.js";
 import { canAnimateOnboarding } from "./onboarding-pacing.js";
+import { resolveClampedWidth } from "./resolve-measure-width.js";
 import { isSpinnerSilent } from "./spinner.js";
 import { writeStdout } from "./write-stdout.js";
 
@@ -26,6 +29,31 @@ const RAINBOW_HUE_SHIFT_PER_FRAME = 9;
 const RAINBOW_GRADIENT_WIDTH = 80;
 const RAINBOW_OKLCH_LIGHTNESS = 0.638;
 const RAINBOW_OKLCH_CHROMA = 0.129;
+
+const FACE_INDENT = "  ";
+
+// Top border of the doctor face box (`buildRawFaceLines`). Deriving the column
+// offset from the same string the face actually renders keeps them in sync — a
+// wider face automatically widens the inset instead of bleeding past the edge.
+const FACE_BOX_TOP_BORDER = "┌─────┐";
+
+// Visible columns the score bar (and the rest of the right column) is inset by:
+// the leading indent, the doctor face box, and the matching gap before the
+// content (`  ┌─────┐  `). The bar can't be wider than the terminal minus this.
+const SCORE_RIGHT_COLUMN_OFFSET =
+  FACE_INDENT.length + FACE_BOX_TOP_BORDER.length + FACE_INDENT.length;
+
+// The bar width clamped to what fits beside the face on this terminal. Falls
+// back to the full width when the column count is unknown (non-TTY / piped),
+// and floors at `SCORE_BAR_MIN_WIDTH_CHARS` so it stays proportional. All the
+// bar builders read this, so the fill proportion and empty remainder always
+// agree within a single render (the column count is stable per render).
+const getScoreBarWidth = (): number =>
+  resolveClampedWidth({
+    reservedColumns: SCORE_RIGHT_COLUMN_OFFSET + RIGHT_EDGE_SAFETY_COLUMNS,
+    fullWidth: SCORE_BAR_WIDTH_CHARS,
+    minWidth: SCORE_BAR_MIN_WIDTH_CHARS,
+  });
 
 interface ScoreBarSegments {
   filledSegment: string;
@@ -57,7 +85,7 @@ interface InitialScoreHeaderLineInput {
 }
 
 const buildScoreBarSegments = (filledCount: number): ScoreBarSegments => {
-  const emptyCount = SCORE_BAR_WIDTH_CHARS - filledCount;
+  const emptyCount = Math.max(0, getScoreBarWidth() - filledCount);
 
   return {
     filledSegment: "█".repeat(filledCount),
@@ -66,7 +94,7 @@ const buildScoreBarSegments = (filledCount: number): ScoreBarSegments => {
 };
 
 const getFilledCount = (score: number): number =>
-  Math.round((score / PERFECT_SCORE) * SCORE_BAR_WIDTH_CHARS);
+  Math.round((score / PERFECT_SCORE) * getScoreBarWidth());
 
 const joinScoreHeaderFrame = (lines: [string, string, string, string]): string =>
   `${lines[0]}\n\r${lines[1]}\n\r${lines[2]}\n\r${lines[3]}\n`;
@@ -145,10 +173,11 @@ const buildScoreBar = (displayScore: number, colorScore = displayScore): string 
 // by fixing the top errors, then the dim remainder. Same total width as
 // the plain bar, so layout is unchanged.
 const buildProjectedScoreBar = (currentScore: number, potentialScore: number): string => {
+  const barWidth = getScoreBarWidth();
   const currentFill = getFilledCount(currentScore);
-  const potentialFill = Math.min(getFilledCount(potentialScore), SCORE_BAR_WIDTH_CHARS);
+  const potentialFill = Math.min(getFilledCount(potentialScore), barWidth);
   const gainCount = Math.max(0, potentialFill - currentFill);
-  const emptyCount = Math.max(0, SCORE_BAR_WIDTH_CHARS - currentFill - gainCount);
+  const emptyCount = Math.max(0, barWidth - currentFill - gainCount);
   return (
     colorizeByScore("█".repeat(currentFill), currentScore) +
     highlighter.dim(colorizeByScore("▓".repeat(gainCount), currentScore)) +
@@ -167,7 +196,7 @@ const RAW_BRANDING_LINE = "React Doctor (https://react.doctor)";
 
 const buildRawFaceLines = (score: number): string[] => {
   const [eyes, mouth] = getDoctorFace(score);
-  return ["┌─────┐", `│ ${eyes} │`, `│ ${mouth} │`, "└─────┘"];
+  return [FACE_BOX_TOP_BORDER, `│ ${eyes} │`, `│ ${mouth} │`, "└─────┘"];
 };
 
 const buildFaceRenderedLines = (score: number): string[] => {

--- a/packages/react-doctor/src/cli/utils/render-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-summary.ts
@@ -17,7 +17,21 @@ import {
   printNoScoreHeader,
   printScoreHeader,
 } from "./render-score-header.js";
+import { resolveMeasureWidth } from "./resolve-measure-width.js";
+import { wrapTextToWidth } from "./wrap-indented-text.js";
 import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
+
+const FOOTER_DESCRIPTION_INDENT = "  ";
+
+// Prints a dimmed link description, wrapped to the measure but never past the
+// terminal's right edge. Dim is applied per line so the SGR survives the wrap.
+const printFooterDescription = (description: string): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const wrapWidth = resolveMeasureWidth(FOOTER_DESCRIPTION_INDENT.length);
+    for (const line of wrapTextToWidth(description, wrapWidth)) {
+      yield* Console.log(highlighter.dim(`${FOOTER_DESCRIPTION_INDENT}${line}`));
+    }
+  });
 
 const buildShareUrl = (
   diagnostics: Diagnostic[],
@@ -53,20 +67,18 @@ export const printFooter = (input: PrintFooterInput): Effect.Effect<void> =>
     if (!input.isOffline) {
       const shareUrl = buildShareUrl(input.diagnostics, input.scoreResult, input.projectName);
       yield* Console.log(`  ${highlighter.bold("Share:")} ${highlighter.info(shareUrl)}`);
-      yield* Console.log(highlighter.dim("  Tell others how you did on socials"));
+      yield* printFooterDescription("Tell others how you did on socials");
       yield* Console.log("");
     }
     yield* Console.log(`  ${highlighter.bold("Docs:")} ${highlighter.info(DOCS_URL)}`);
-    yield* Console.log(
-      highlighter.dim(
-        "  Learn more about fixing issues, setting up CI/CD, and configuring rules with a config file",
-      ),
+    yield* printFooterDescription(
+      "Learn more about fixing issues, setting up CI/CD, and configuring rules with a config file",
     );
     yield* Console.log("");
     yield* Console.log(
       `  ${highlighter.bold("GitHub:")} ${highlighter.info(CANONICAL_GITHUB_URL)}`,
     );
-    yield* Console.log(highlighter.dim("  Report issues and star the repository!"));
+    yield* printFooterDescription("Report issues and star the repository!");
   });
 
 export interface PrintSummaryInput {

--- a/packages/react-doctor/src/cli/utils/render-welcome.ts
+++ b/packages/react-doctor/src/cli/utils/render-welcome.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 import { highlighter } from "@react-doctor/core";
 import {
+  RIGHT_EDGE_SAFETY_COLUMNS,
   WELCOME_EXPLANATION_HOLD_MS,
   WELCOME_INTER_LINE_DELAY_MS,
   WELCOME_TYPEWRITER_CHAR_DELAY_MS,
@@ -9,11 +10,28 @@ import { writeStdout } from "./write-stdout.js";
 
 const HAPPY_FACE_LINES = ["┌─────┐", "│ ◠ ◠ │", "│  ▽  │", "└─────┘"] as const;
 
+// Two-space gutter the face box and the typed text are inset by.
+const FACE_INDENT = "  ";
+
+// Visible columns to the left of the typed greeting/tagline: the left indent,
+// the face box, and the matching gap before the text (`  ┌─────┐  `).
+const FACE_PREFIX_WIDTH =
+  FACE_INDENT.length + (HAPPY_FACE_LINES[0]?.length ?? 0) + FACE_INDENT.length;
+
 // Scales every welcome-scene delay down by this factor on returning runs
 // (`hasCompletedOnboarding()` === true), so a user who's already seen the
 // intro gets a snappier replay rather than the full first-run cadence.
 // Tuned to feel quicker without making the tagline unreadable in one beat.
 export const RETURNING_USER_SPEED_MULTIPLIER = 2;
+
+// Truncates `text` (with a trailing ellipsis) so it never exceeds `maxColumns`
+// visible columns. `Infinity` (terminal width unknown) leaves it untouched.
+const clampToColumns = (text: string, maxColumns: number): string => {
+  if (maxColumns <= 0) return "";
+  if (text.length <= maxColumns) return text;
+  if (maxColumns === 1) return "…";
+  return `${text.slice(0, maxColumns - 1).trimEnd()}…`;
+};
 
 export interface WelcomeSceneOptions {
   // Divides every typewriter and hold delay. Defaults to 1 (full first-run
@@ -47,16 +65,30 @@ export const playWelcomeScene = (options: WelcomeSceneOptions = {}): Effect.Effe
     const explanationHoldMs = WELCOME_EXPLANATION_HOLD_MS / speedMultiplier;
 
     const face = HAPPY_FACE_LINES.map((line) => highlighter.success(line));
-    const mouthPrefix = `  ${face[2] ?? ""}  `;
+    const mouthPrefix = `${FACE_INDENT}${face[2] ?? ""}${FACE_INDENT}`;
+
+    // Clamp both lines to what fits beside the face on this terminal so the
+    // typewriter never soft-wraps (which would cascade the line down the
+    // screen). `Infinity` when the column count is unknown leaves them intact.
+    const terminalColumns = process.stdout.columns;
+    const availableTextColumns =
+      terminalColumns && terminalColumns > 0
+        ? Math.max(0, terminalColumns - FACE_PREFIX_WIDTH - RIGHT_EDGE_SAFETY_COLUMNS)
+        : Number.POSITIVE_INFINITY;
+    const greeting = clampToColumns("Welcome to React Doctor", availableTextColumns);
+    const tagline = clampToColumns(
+      "I diagnose your React code for bugs, security & performance.",
+      availableTextColumns,
+    );
 
     // Blank line + face box; cursor ends just below the box.
-    yield* writeStdout(`\n${face.map((line) => `  ${line}`).join("\n")}\n`);
+    yield* writeStdout(`\n${face.map((line) => `${FACE_INDENT}${line}`).join("\n")}\n`);
 
     // Up to the eyes row; type the greeting.
     yield* writeStdout("\x1b[3A");
     yield* typeLine(
-      `  ${face[1] ?? ""}  `,
-      "Welcome to React Doctor",
+      `${FACE_INDENT}${face[1] ?? ""}${FACE_INDENT}`,
+      greeting,
       (fragment) => highlighter.bold(fragment),
       charDelayMs,
     );
@@ -64,12 +96,7 @@ export const playWelcomeScene = (options: WelcomeSceneOptions = {}): Effect.Effe
     // Down to the mouth row; type the tagline.
     yield* Effect.sleep(interLineDelayMs);
     yield* writeStdout("\x1b[1B");
-    yield* typeLine(
-      mouthPrefix,
-      "I diagnose your React code for bugs, security & performance.",
-      (fragment) => highlighter.dim(fragment),
-      charDelayMs,
-    );
+    yield* typeLine(mouthPrefix, tagline, (fragment) => highlighter.dim(fragment), charDelayMs);
 
     // Hold so the tagline stays on screen long enough to read, then erase
     // the block: up to the leading blank, clear to end of screen.

--- a/packages/react-doctor/src/cli/utils/resolve-measure-width.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-measure-width.ts
@@ -1,0 +1,33 @@
+import { OUTPUT_MEASURE_WIDTH_CHARS } from "@react-doctor/core";
+import { MIN_MEASURE_WIDTH_CHARS } from "./constants.js";
+
+interface ResolveClampedWidthInput {
+  // Columns left of the clamped content (leading indent + any box chrome).
+  readonly reservedColumns: number;
+  // Width used when the terminal column count is unknown (piped / non-TTY).
+  readonly fullWidth: number;
+  // Lower bound so a pathologically narrow terminal can't collapse content.
+  readonly minWidth: number;
+}
+
+// Clamps a target width to the live terminal: the terminal width minus
+// `reservedColumns`, capped at `fullWidth` and floored at `minWidth`. Returns
+// `fullWidth` untouched when the column count is unknown. The single source for
+// every terminal-aware width in the CLI renderers.
+export const resolveClampedWidth = (input: ResolveClampedWidthInput): number => {
+  const terminalColumns = process.stdout.columns;
+  if (!terminalColumns || terminalColumns <= 0) return input.fullWidth;
+  const availableColumns = terminalColumns - input.reservedColumns;
+  return Math.max(input.minWidth, Math.min(input.fullWidth, availableColumns));
+};
+
+// The typographic measure clamped to the live terminal width. Prose and boxes
+// wrap to `OUTPUT_MEASURE_WIDTH_CHARS` for comfortable reading, but a narrower
+// terminal wins so nothing bleeds past the right edge. `reservedColumns` is the
+// leading indent (plus any box chrome) that sits left of the wrapped content.
+export const resolveMeasureWidth = (reservedColumns = 0): number =>
+  resolveClampedWidth({
+    reservedColumns,
+    fullWidth: OUTPUT_MEASURE_WIDTH_CHARS,
+    minWidth: MIN_MEASURE_WIDTH_CHARS,
+  });

--- a/packages/react-doctor/src/cli/utils/set-up-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/set-up-github-actions.ts
@@ -1,0 +1,82 @@
+import { CI_URL, highlighter } from "@react-doctor/core";
+import { cliLogger as logger } from "./cli-logger.js";
+import {
+  findNearestPackageDirectory,
+  installReactDoctorScriptStep,
+} from "./install-doctor-script.js";
+import { installReactDoctorWorkflow } from "./install-github-workflow.js";
+import { openWorkflowPullRequest, stageWorkflowFile } from "./open-workflow-pull-request.js";
+import { reportWorkflowResult } from "./report-workflow-result.js";
+import { spinner } from "./spinner.js";
+
+export interface SetUpGitHubActionsOptions {
+  readonly rootDirectory: string;
+}
+
+// Sets React Doctor up to scan every pull request: writes the GitHub Actions
+// workflow + adds a `doctor` package script (which runs
+// `npx react-doctor@latest`, no local dep required). The local dev-dep install
+// isn't called from this path: nothing here needs it, and on pnpm with a beta
+// channel it noisily trips the supply-chain trust guard for zero user benefit.
+// Users who want a pinned local copy go through the `react-doctor install`
+// command. Resolves the nearest package root first so a nested scan directory
+// doesn't drop the workflow in the wrong place. The script step throws on a
+// read-only / permission-denied FS, so it's guarded: a failed setup must never
+// crash a scan that already succeeded.
+//
+// When the workflow is freshly written AND the user has `gh` installed,
+// `openWorkflowPullRequest` commits the YAML on a dedicated branch and opens a
+// PR for review — that matches the "everything else lands as a reviewable PR"
+// mental model teams already have for CI changes, instead of silently dropping
+// a top-level workflow file into their working tree. On any failure (gh
+// missing, not authenticated, push refused, …) we fall back to `git add`ing the
+// file so it at least shows up in the user's next `git status` / commit instead
+// of becoming an orphan untracked path.
+//
+// Returns whether a workflow was freshly written, so callers can record
+// accurate activation telemetry.
+export const setUpGitHubActions = async (options: SetUpGitHubActionsOptions): Promise<boolean> => {
+  const projectRoot = findNearestPackageDirectory(options.rootDirectory) ?? options.rootDirectory;
+  try {
+    installReactDoctorScriptStep(projectRoot);
+  } catch {}
+
+  const workflowSpinner = spinner("Adding GitHub Actions workflow...").start();
+  const workflowResult = installReactDoctorWorkflow(projectRoot);
+  const didCreateWorkflow = reportWorkflowResult(workflowSpinner, workflowResult, projectRoot);
+
+  logger.break();
+  if (workflowResult.status === "failed") {
+    logger.log(
+      `  Couldn't set up GitHub Actions automatically. Follow the guide at ${highlighter.info(CI_URL)}`,
+    );
+    return false;
+  }
+
+  if (workflowResult.status === "created") {
+    const pullRequestSpinner = spinner("Opening a pull request for review...").start();
+    const pullRequestResult = await openWorkflowPullRequest({
+      workflowPath: workflowResult.workflowPath,
+    });
+    if (pullRequestResult.status === "pr-opened") {
+      pullRequestSpinner.succeed(
+        `Opened pull request for review: ${highlighter.info(pullRequestResult.url)}`,
+      );
+    } else if (pullRequestResult.status === "branch-pushed") {
+      pullRequestSpinner.warn(
+        `Pushed branch ${highlighter.bold(pullRequestResult.branch)} but couldn't open a PR. Open one with: gh pr create --head ${pullRequestResult.branch}`,
+      );
+    } else {
+      pullRequestSpinner.stop();
+      const didStage = await stageWorkflowFile({ workflowPath: workflowResult.workflowPath });
+      logger.log(
+        didStage
+          ? `  Staged the workflow file. Commit it to start scanning every pull request.`
+          : "  React Doctor will now scan every new pull request automatically.",
+      );
+    }
+  }
+
+  logger.log(`  Learn more: ${highlighter.info(CI_URL)}`);
+  return didCreateWorkflow;
+};

--- a/packages/react-doctor/tests/e2e/__snapshots__/terminal-visuals.test.ts.snap
+++ b/packages/react-doctor/tests/e2e/__snapshots__/terminal-visuals.test.ts.snap
@@ -62,7 +62,8 @@ exports[`in-process render across terminal widths and render modes > matches the
   ────────────────────────────────────────────────────────────
 
   Docs: https://react.doctor/docs
-  Learn more about fixing issues, setting up CI/CD, and configuring rules with a config file
+  Learn more about fixing issues, setting up CI/CD, and
+  configuring rules with a config file
 
   GitHub: https://github.com/millionco/react-doctor
   Report issues and star the repository!"
@@ -70,12 +71,12 @@ exports[`in-process render across terminal widths and render modes > matches the
 
 exports[`in-process render across terminal widths and render modes > matches the terminal-width × mode overflow matrix 1`] = `
 "mode                            60c    80c   100c   120c   160c
-default-errors-great           wrap   wrap     ok     ok     ok
-default-errors-perfect         wrap   wrap     ok     ok     ok
-default-errors-ok              wrap   wrap     ok     ok     ok
-default-errors-needs-work      wrap   wrap     ok     ok     ok
-default-errors-no-score        wrap   wrap     ok     ok     ok
-default-warnings-only          wrap   wrap     ok     ok     ok
-default-clean-perfect          wrap   wrap     ok     ok     ok
+default-errors-great           wrap     ok     ok     ok     ok
+default-errors-perfect         wrap     ok     ok     ok     ok
+default-errors-ok              wrap     ok     ok     ok     ok
+default-errors-needs-work      wrap     ok     ok     ok     ok
+default-errors-no-score        wrap     ok     ok     ok     ok
+default-warnings-only          wrap     ok     ok     ok     ok
+default-clean-perfect          wrap     ok     ok     ok     ok
 verbose-errors-great           wrap   wrap     ok     ok     ok"
 `;

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -44,6 +44,27 @@ const writePackageJson = (projectRoot: string, value: Record<string, unknown>): 
   fs.writeFileSync(path.join(projectRoot, "package.json"), `${JSON.stringify(value, null, 2)}\n`);
 };
 
+const writeExistingWorkflow = (projectRoot: string, actionRef: string): string => {
+  const workflowPath = path.join(projectRoot, ".github", "workflows", "react-doctor.yml");
+  fs.mkdirSync(path.dirname(workflowPath), { recursive: true });
+  fs.writeFileSync(
+    workflowPath,
+    [
+      "name: React Doctor",
+      "on:",
+      "  pull_request:",
+      "jobs:",
+      "  react-doctor:",
+      "    runs-on: ubuntu-latest",
+      "    steps:",
+      "      - uses: actions/checkout@v5",
+      `      - uses: ${actionRef}`,
+      "",
+    ].join("\n"),
+  );
+  return workflowPath;
+};
+
 const readFixturePackageJson = (projectRoot: string): Record<string, unknown> =>
   JSON.parse(fs.readFileSync(path.join(projectRoot, "package.json"), "utf8"));
 
@@ -103,7 +124,17 @@ const runInteractiveInstallReactDoctorForTest = async (
     const answers: Answers<PromptName> = Object.create(null);
     const questionName = promptQuestion?.name;
     if (typeof questionName !== "string") return answers;
-    answers[questionName] = questionName === "agents" ? ["cursor"] : options.setupOptions;
+    if (questionName === "agents") {
+      answers[questionName] = ["cursor"];
+    } else if (questionName === "ciChoice") {
+      answers[questionName] = options.setupOptions.includes("workflow") ? "ci-yes" : "ci-no";
+    } else if (questionName === "upgradeChoice") {
+      answers[questionName] = options.setupOptions.includes("workflow-upgrade")
+        ? "upgrade-yes"
+        : "upgrade-no";
+    } else {
+      answers[questionName] = options.setupOptions;
+    }
     return answers;
   };
 
@@ -626,21 +657,24 @@ describe("runInstallReactDoctor", () => {
       promptQuestions,
     });
 
-    expect(promptQuestions).toHaveLength(2);
-    expect(promptQuestions[1]).toEqual(
+    expect(promptQuestions).toHaveLength(3);
+    // CI is asked first, as its own dedicated question (the shared pitch).
+    expect(promptQuestions[0]).toEqual(
+      expect.objectContaining({ type: "select", name: "ciChoice" }),
+    );
+    expect(promptQuestions[2]).toEqual(
       expect.objectContaining({
         type: "multiselect",
         name: "setupOptions",
         message: "Select additional React Doctor setup:",
       }),
     );
-    expect(promptQuestions[1]).toEqual(
+    expect(promptQuestions[2]).toEqual(
       expect.objectContaining({
         choices: expect.arrayContaining([
           expect.objectContaining({ value: "skip" }),
           expect.objectContaining({ value: "git-hook" }),
           expect.objectContaining({ value: "agent-hooks" }),
-          expect.objectContaining({ value: "workflow" }),
         ]),
       }),
     );
@@ -717,7 +751,10 @@ describe("runInstallReactDoctor", () => {
   it("--yes installs Git and agent hooks in CI using real git detection", async () => {
     writeValidSkill(fixture.sourceDir);
     process.env.CI = "1";
-    execFileSync("git", ["init"], { cwd: fixture.projectRoot, stdio: "ignore" });
+    execFileSync("git", ["init"], {
+      cwd: fixture.projectRoot,
+      stdio: "ignore",
+    });
 
     await runInstallReactDoctorForTest({
       yes: true,
@@ -741,10 +778,107 @@ describe("runInstallReactDoctor", () => {
     ).toContain("PostToolBatch");
   });
 
+  it("--yes upgrades an existing @v1 workflow to @v2 in place", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const workflowPath = writeExistingWorkflow(fixture.projectRoot, "millionco/react-doctor@v1");
+
+    await runInstallReactDoctorForTest({
+      yes: true,
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      detectedAgents: ["cursor"],
+      gitHookPath: null,
+    });
+
+    const workflowContent = fs.readFileSync(workflowPath, "utf8");
+    expect(workflowContent).toContain("millionco/react-doctor@v2");
+    expect(workflowContent).not.toContain("millionco/react-doctor@v1");
+  });
+
+  it("--yes leaves an exactly-pinned workflow untouched", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const workflowPath = writeExistingWorkflow(
+      fixture.projectRoot,
+      "millionco/react-doctor@v1.2.3",
+    );
+    const originalContent = fs.readFileSync(workflowPath, "utf8");
+
+    await runInstallReactDoctorForTest({
+      yes: true,
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      detectedAgents: ["cursor"],
+      gitHookPath: null,
+    });
+
+    expect(fs.readFileSync(workflowPath, "utf8")).toBe(originalContent);
+  });
+
+  it("--yes leaves an already-@v2 workflow untouched", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const workflowPath = writeExistingWorkflow(fixture.projectRoot, "millionco/react-doctor@v2");
+    const originalContent = fs.readFileSync(workflowPath, "utf8");
+
+    await runInstallReactDoctorForTest({
+      yes: true,
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      detectedAgents: ["cursor"],
+      gitHookPath: null,
+    });
+
+    expect(fs.readFileSync(workflowPath, "utf8")).toBe(originalContent);
+  });
+
+  it("interactively upgrades an existing @v1 workflow when the offer is accepted", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = writeExistingWorkflow(fixture.projectRoot, "millionco/react-doctor@v1");
+    const promptQuestions: unknown[] = [];
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      setupOptions: ["workflow-upgrade"],
+      promptQuestions,
+    });
+
+    // The upgrade prompt replaces the "add" prompt when a workflow exists.
+    expect(promptQuestions[0]).toEqual(
+      expect.objectContaining({ type: "select", name: "upgradeChoice" }),
+    );
+    expect(fs.readFileSync(workflowPath, "utf8")).toContain("millionco/react-doctor@v2");
+  });
+
+  it("interactively keeps an existing @v1 workflow when the offer is declined", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = writeExistingWorkflow(fixture.projectRoot, "millionco/react-doctor@v1");
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      setupOptions: [],
+    });
+
+    expect(fs.readFileSync(workflowPath, "utf8")).toContain("millionco/react-doctor@v1");
+    expect(fs.readFileSync(workflowPath, "utf8")).not.toContain("millionco/react-doctor@v2");
+  });
+
   it("CI skips prompts without --yes but does not install the optional Git hook", async () => {
     writeValidSkill(fixture.sourceDir);
     process.env.CI = "1";
-    execFileSync("git", ["init"], { cwd: fixture.projectRoot, stdio: "ignore" });
+    execFileSync("git", ["init"], {
+      cwd: fixture.projectRoot,
+      stdio: "ignore",
+    });
 
     await runInstallReactDoctorForTest({
       agentHooks: true,

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -11,6 +11,7 @@ import {
 import { NON_INTERACTIVE_ENVIRONMENT_VARIABLES } from "../src/cli/utils/is-non-interactive-environment.js";
 import { runInstallReactDoctor } from "../src/cli/utils/install-react-doctor.js";
 import type { InstallReactDoctorDependencyRunnerInput } from "../src/cli/utils/install-react-doctor.js";
+import { recordActionUpgradeDecision } from "../src/cli/utils/action-upgrade-prompt.js";
 import { setSpinnerSilent } from "../src/cli/utils/spinner.js";
 import { silenceConsoleForTest } from "./helpers/silence-console.js";
 
@@ -866,6 +867,47 @@ describe("runInstallReactDoctor", () => {
       projectRoot: fixture.projectRoot,
       gitHookPath: hookPath,
       setupOptions: [],
+    });
+
+    expect(fs.readFileSync(workflowPath, "utf8")).toContain("millionco/react-doctor@v1");
+    expect(fs.readFileSync(workflowPath, "utf8")).not.toContain("millionco/react-doctor@v2");
+  });
+
+  it("interactively skips the @v1 upgrade offer once the decision is already persisted", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = writeExistingWorkflow(fixture.projectRoot, "millionco/react-doctor@v1");
+    recordActionUpgradeDecision(fixture.projectRoot, "declined");
+    const promptQuestions: unknown[] = [];
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      // Would normally accept the bump — but the persisted decline suppresses
+      // the offer entirely, so the prompt is never shown.
+      setupOptions: ["workflow-upgrade"],
+      promptQuestions,
+    });
+
+    expect(promptQuestions).not.toContainEqual(expect.objectContaining({ name: "upgradeChoice" }));
+    expect(fs.readFileSync(workflowPath, "utf8")).toContain("millionco/react-doctor@v1");
+    expect(fs.readFileSync(workflowPath, "utf8")).not.toContain("millionco/react-doctor@v2");
+  });
+
+  it("--yes does not re-apply an already-declined @v1 upgrade", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const workflowPath = writeExistingWorkflow(fixture.projectRoot, "millionco/react-doctor@v1");
+    recordActionUpgradeDecision(fixture.projectRoot, "declined");
+
+    await runInstallReactDoctorForTest({
+      yes: true,
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      detectedAgents: ["cursor"],
+      gitHookPath: null,
     });
 
     expect(fs.readFileSync(workflowPath, "utf8")).toContain("millionco/react-doctor@v1");

--- a/packages/react-doctor/tests/render-onboarding-animation.test.ts
+++ b/packages/react-doctor/tests/render-onboarding-animation.test.ts
@@ -73,6 +73,34 @@ describe("playWelcomeScene", () => {
     expect(output).toContain("\u001B[3A");
     expect(output).toContain("\u001B[0J");
   });
+
+  it("clamps the tagline to the terminal width so it never soft-wraps", async () => {
+    const NARROW_COLUMNS = 40;
+    const previousColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+    Object.defineProperty(process.stdout, "columns", {
+      value: NARROW_COLUMNS,
+      configurable: true,
+    });
+    try {
+      const writes = await captureStdout(() => Effect.runPromise(playWelcomeScene()));
+      // The full tagline is truncated with an ellipsis…
+      const output = stripAnsi(writes.join(""));
+      expect(output).toContain("…");
+      expect(output).not.toContain("performance.");
+      // …and no single typewriter frame's visible line is wide enough to wrap.
+      for (const write of writes) {
+        for (const segment of stripAnsi(write).split(/[\r\n]/)) {
+          expect(segment.length).toBeLessThanOrEqual(NARROW_COLUMNS);
+        }
+      }
+    } finally {
+      if (previousColumns) {
+        Object.defineProperty(process.stdout, "columns", previousColumns);
+      } else {
+        delete (process.stdout as unknown as { columns?: number }).columns;
+      }
+    }
+  });
 });
 
 describe("printDiagnostics onboarding count-up", () => {
@@ -128,6 +156,42 @@ describe("printSummary onboarding projection", () => {
     // The eased projection redraws the bar in place and reveals the ghost gain.
     expect(output).toContain("\u001B[5A");
     expect(output).toContain("▓");
+  });
+});
+
+describe("score bar width", () => {
+  it("clamps the score bar so the header fits a narrow terminal", async () => {
+    const NARROW_COLUMNS = 60;
+    const previousColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+    Object.defineProperty(process.stdout, "columns", {
+      value: NARROW_COLUMNS,
+      configurable: true,
+    });
+    try {
+      const writes = await captureStdout(() =>
+        Effect.runPromise(
+          printSummary({
+            diagnostics: [makeDiagnostic("Bugs", "error")],
+            elapsedMilliseconds: 0,
+            scoreResult: { score: 75, label: "OK" } as ScoreResult,
+            totalSourceFileCount: 1,
+            noScoreMessage: "",
+          }),
+        ),
+      );
+      const barLine = stripAnsi(writes.join(""))
+        .split("\n")
+        .find((line) => line.includes("█") && line.includes("░"));
+      // The bar still renders (filled + empty), but the whole line now fits.
+      expect(barLine).toBeDefined();
+      expect((barLine ?? "").length).toBeLessThanOrEqual(NARROW_COLUMNS);
+    } finally {
+      if (previousColumns) {
+        Object.defineProperty(process.stdout, "columns", previousColumns);
+      } else {
+        delete (process.stdout as unknown as { columns?: number }).columns;
+      }
+    }
   });
 });
 

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,7 @@
       "outputs": ["dist/**"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Summary

- **Terminal-width-aware rendering.** Adds `resolve-measure-width.ts` (`resolveClampedWidth` / `resolveMeasureWidth`) as the single source for every terminal-aware width in the CLI renderers. Prose footer descriptions, code-frame boxes (`render-diagnostics`), the score bar (`render-score-header`), the section divider, and the welcome typewriter (`render-welcome`) now clamp to the live terminal — flooring at sensible minimums and reserving one column at the right edge — so output never soft-wraps or bleeds past the edge on narrow terminals (which also corrupted the in-place `\r` animations). New magic numbers live in `constants.ts` (`MIN_MEASURE_WIDTH_CHARS`, `SCORE_BAR_MIN_WIDTH_CHARS`, `RIGHT_EDGE_SAFETY_COLUMNS`, `BOX_BORDER_WIDTH_CHARS`).
- **CI-first onboarding restructure.** Extracts the shared "Add React Doctor to GitHub Actions?" pitch (`ask-add-to-github-actions.ts`), the "Upgrade action to v2?" prompt (`ask-upgrade-action-version.ts`), and `set-up-github-actions.ts` into their own one-per-file utils, reused identically by both `install` onboarding and the post-scan agent handoff (de-duplicating ~200 lines previously inlined in `handoff-to-agent.ts`). The CI pitch now leads the install flow as its own dedicated question, and an existing workflow still pinned to the action's floating `@v1` is offered an in-place `@v2` bump (`upgradeReactDoctorWorkflowInPlace`) instead of the add prompt.
- Moves `installReactDoctorScriptStep` + its message formatter into `install-doctor-script.ts` and breaks `runInstallReactDoctor` into focused per-step helpers (skill, git hook, agent hooks, workflow) so each install write lands in one visible group after the install is confirmed.

## Test plan

- [x] `vp test run install-react-doctor render-onboarding-animation terminal-visuals` — 60 passing (covers narrow-terminal tagline/score-bar clamping, the overflow matrix snapshot, and the new `@v1`→`@v2` upgrade + decline paths).
- [x] Lint clean on changed files.
- [ ] CI: full `pnpm test` / `pnpm lint` / `pnpm typecheck` across all packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing install/handoff flows and writes workflow files on disk, but behavior is heavily tested and mostly consolidates existing paths rather than new security surface.
> 
> **Overview**
> **Terminal-aware CLI layout** adds `resolve-measure-width.ts` so dividers, diagnostic prose, code-frame boxes, footer blurbs, the welcome typewriter, and the score bar clamp to `process.stdout.columns` (with min widths and a one-column right-edge buffer). Narrow terminals should stop soft-wrapping and breaking in-place `\r` animations.
> 
> **CI onboarding is unified and reordered.** Shared prompts (`ask-add-to-github-actions`, `ask-upgrade-action-version`) and `set-up-github-actions` replace duplicated logic in post-scan handoff; **Learn more** now opens `GITHUB_ACTIONS_SETUP_URL` instead of the generic CI page. `install` asks the GitHub Actions pitch **first** (workflow writes only after agent selection), drops workflow from the optional multiselect, and can **in-place bump** floating `@v1` → `@v2` via `upgradeReactDoctorWorkflowInPlace` with the same per-repo decline persistence as handoff. `installReactDoctorScriptStep` moves to `install-doctor-script.ts`; install is split into step helpers.
> 
> **Minor:** `turbo.json` `dev` depends on `^build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d642a5adb069dd760b69e9fc32b7e2b166a02a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->