### PR TITLE
fix: reduce placeholder secret false positives

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
@@ -74,6 +74,22 @@ export const PUBLIC_CLIENT_KEY_PATTERNS = [
   /^pk\.eyJ/, // Mapbox public token
 ];
 
+export const SECRET_UNAMBIGUOUS_PLACEHOLDER_VALUE_PATTERNS = [
+  /^[\s._\-*\u2022xX]{8,}$/,
+  /(?:\.{3,}|\u2026|[*\u2022]{3,})/,
+  /(?:^|[_\-\s])(?:your|redacted|masked|placeholder|replace[_\-\s]?me|changeme)(?:$|[_\-\s])/i,
+  /<[^>]*(?:auth|credential|key|password|secret|token|your|redacted|placeholder|masked)[^>]*>/i,
+  /\[[^\]]*(?:auth|credential|key|password|secret|token|your|redacted|placeholder|masked)[^\]]*\]/i,
+  /\{[^}]*(?:auth|credential|key|password|secret|token|your|redacted|placeholder|masked)[^}]*\}/i,
+];
+
+export const SECRET_CONTEXTUAL_PLACEHOLDER_VALUE_PATTERNS = [
+  /(?:^|[_\-\s])(?:example|sample|dummy)(?:$|[_\-\s])/i,
+];
+
+export const SECRET_PLACEHOLDER_CONTEXT_PATTERN =
+  /(?:placeholder|example|sample|dummy|masked|redacted|mask)/i;
+
 export const SECRET_VARIABLE_PATTERN = /(?:api_?key|secret|token|password|credential|auth)/i;
 
 export const SECRET_TOOLING_FILE_PATTERN = /(?:^|\/)[^/]+\.config\.[cm]?[jt]s$/;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -9,6 +9,7 @@ import {
 import { defineRule } from "../../utils/define-rule.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
 import { classifySecretFileExposure } from "../../utils/classify-secret-file-exposure.js";
+import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or-hook-name.js";
 import { getIdentifierTrailingWord } from "../../utils/get-identifier-trailing-word.js";
 import { getReactDoctorStringSetting } from "../../utils/get-react-doctor-setting.js";
 import type { Rule } from "../../utils/rule.js";
@@ -17,37 +18,7 @@ import { hasDirective } from "../../utils/has-directive.js";
 import { isInsideServerOnlyScope } from "../../utils/is-inside-server-only-scope.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isPlaceholderSecretValue } from "../../utils/is-placeholder-secret-value.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-
-const hasPlaceholderSecretContext = (node: EsTreeNode, variableName: string): boolean => {
-  if (SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(variableName)) return true;
-
-  let ancestor = node.parent ?? null;
-  while (ancestor) {
-    if (isNodeOfType(ancestor, "FunctionDeclaration") && ancestor.id) {
-      if (SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(ancestor.id.name)) return true;
-    }
-
-    if (isNodeOfType(ancestor, "ClassDeclaration") && ancestor.id) {
-      if (SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(ancestor.id.name)) return true;
-    }
-
-    if (
-      (isNodeOfType(ancestor, "FunctionExpression") ||
-        isNodeOfType(ancestor, "ArrowFunctionExpression")) &&
-      isNodeOfType(ancestor.parent, "VariableDeclarator") &&
-      isNodeOfType(ancestor.parent.id, "Identifier") &&
-      SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(ancestor.parent.id.name)
-    ) {
-      return true;
-    }
-
-    ancestor = ancestor.parent ?? null;
-  }
-
-  return false;
-};
 
 export const noSecretsInClientCode = defineRule<Rule>({
   id: "no-secrets-in-client-code",
@@ -78,17 +49,32 @@ export const noSecretsInClientCode = defineRule<Rule>({
 
         const variableName = node.id.name;
         const literalValue = node.init.value;
-        const isPlaceholderValue = isPlaceholderSecretValue(
-          literalValue,
-          hasPlaceholderSecretContext(node, variableName),
-        );
+        const componentOrHookName = enclosingComponentOrHookName(node);
+        const hasPlaceholderContext =
+          SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(variableName) ||
+          (componentOrHookName !== null &&
+            SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(componentOrHookName));
+        const isUnambiguousPlaceholderValue = isPlaceholderSecretValue(literalValue, {
+          allowContextualExamples: false,
+        });
+        const isPlaceholderValueForVariableHeuristic = isPlaceholderSecretValue(literalValue, {
+          allowContextualExamples: hasPlaceholderContext,
+        });
 
         // Public, client-safe keys ship in the browser by design; skip
         // them before either detector can flag them.
-        if (
-          isPlaceholderValue ||
-          PUBLIC_CLIENT_KEY_PATTERNS.some((pattern) => pattern.test(literalValue))
-        ) {
+        if (PUBLIC_CLIENT_KEY_PATTERNS.some((pattern) => pattern.test(literalValue))) {
+          return;
+        }
+
+        if (SECRET_PATTERNS.some((pattern) => pattern.test(literalValue))) {
+          if (!isUnambiguousPlaceholderValue) {
+            context.report({
+              node,
+              message:
+                "This hardcoded secret is a security vulnerability: it ships to the browser where anyone can read it.",
+            });
+          }
           return;
         }
 
@@ -102,6 +88,7 @@ export const noSecretsInClientCode = defineRule<Rule>({
           !isServerOnlyScope &&
           SECRET_VARIABLE_PATTERN.test(variableName) &&
           !isUiConstant &&
+          !isPlaceholderValueForVariableHeuristic &&
           literalValue.length > SECRET_MIN_LENGTH_CHARS
         ) {
           context.report({
@@ -109,14 +96,6 @@ export const noSecretsInClientCode = defineRule<Rule>({
             message: `Hardcoding "${variableName}" in client code is a security vulnerability: the secret ships to the browser where anyone can read it.`,
           });
           return;
-        }
-
-        if (SECRET_PATTERNS.some((pattern) => pattern.test(literalValue))) {
-          context.report({
-            node,
-            message:
-              "This hardcoded secret is a security vulnerability: it ships to the browser where anyone can read it.",
-          });
         }
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -2,6 +2,7 @@ import {
   PUBLIC_CLIENT_KEY_PATTERNS,
   SECRET_FALSE_POSITIVE_SUFFIXES,
   SECRET_MIN_LENGTH_CHARS,
+  SECRET_PLACEHOLDER_CONTEXT_PATTERN,
   SECRET_PATTERNS,
   SECRET_VARIABLE_PATTERN,
 } from "../../constants/security.js";
@@ -15,7 +16,38 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { isInsideServerOnlyScope } from "../../utils/is-inside-server-only-scope.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isPlaceholderSecretValue } from "../../utils/is-placeholder-secret-value.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+const hasPlaceholderSecretContext = (node: EsTreeNode, variableName: string): boolean => {
+  if (SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(variableName)) return true;
+
+  let ancestor = node.parent ?? null;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "FunctionDeclaration") && ancestor.id) {
+      if (SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(ancestor.id.name)) return true;
+    }
+
+    if (isNodeOfType(ancestor, "ClassDeclaration") && ancestor.id) {
+      if (SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(ancestor.id.name)) return true;
+    }
+
+    if (
+      (isNodeOfType(ancestor, "FunctionExpression") ||
+        isNodeOfType(ancestor, "ArrowFunctionExpression")) &&
+      isNodeOfType(ancestor.parent, "VariableDeclarator") &&
+      isNodeOfType(ancestor.parent.id, "Identifier") &&
+      SECRET_PLACEHOLDER_CONTEXT_PATTERN.test(ancestor.parent.id.name)
+    ) {
+      return true;
+    }
+
+    ancestor = ancestor.parent ?? null;
+  }
+
+  return false;
+};
 
 export const noSecretsInClientCode = defineRule<Rule>({
   id: "no-secrets-in-client-code",
@@ -46,10 +78,17 @@ export const noSecretsInClientCode = defineRule<Rule>({
 
         const variableName = node.id.name;
         const literalValue = node.init.value;
+        const isPlaceholderValue = isPlaceholderSecretValue(
+          literalValue,
+          hasPlaceholderSecretContext(node, variableName),
+        );
 
         // Public, client-safe keys ship in the browser by design; skip
         // them before either detector can flag them.
-        if (PUBLIC_CLIENT_KEY_PATTERNS.some((pattern) => pattern.test(literalValue))) {
+        if (
+          isPlaceholderValue ||
+          PUBLIC_CLIENT_KEY_PATTERNS.some((pattern) => pattern.test(literalValue))
+        ) {
           return;
         }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-placeholder-secret-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-placeholder-secret-value.ts
@@ -3,15 +3,19 @@ import {
   SECRET_UNAMBIGUOUS_PLACEHOLDER_VALUE_PATTERNS,
 } from "../constants/security.js";
 
+interface PlaceholderSecretValueOptions {
+  readonly allowContextualExamples: boolean;
+}
+
 export const isPlaceholderSecretValue = (
   literalValue: string,
-  hasPlaceholderContext: boolean,
+  options: PlaceholderSecretValueOptions,
 ): boolean => {
   const trimmedValue = literalValue.trim();
   if (trimmedValue.length === 0) return false;
   if (SECRET_UNAMBIGUOUS_PLACEHOLDER_VALUE_PATTERNS.some((pattern) => pattern.test(trimmedValue))) {
     return true;
   }
-  if (!hasPlaceholderContext) return false;
+  if (!options.allowContextualExamples) return false;
   return SECRET_CONTEXTUAL_PLACEHOLDER_VALUE_PATTERNS.some((pattern) => pattern.test(trimmedValue));
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-placeholder-secret-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-placeholder-secret-value.ts
@@ -1,0 +1,17 @@
+import {
+  SECRET_CONTEXTUAL_PLACEHOLDER_VALUE_PATTERNS,
+  SECRET_UNAMBIGUOUS_PLACEHOLDER_VALUE_PATTERNS,
+} from "../constants/security.js";
+
+export const isPlaceholderSecretValue = (
+  literalValue: string,
+  hasPlaceholderContext: boolean,
+): boolean => {
+  const trimmedValue = literalValue.trim();
+  if (trimmedValue.length === 0) return false;
+  if (SECRET_UNAMBIGUOUS_PLACEHOLDER_VALUE_PATTERNS.some((pattern) => pattern.test(trimmedValue))) {
+    return true;
+  }
+  if (!hasPlaceholderContext) return false;
+  return SECRET_CONTEXTUAL_PLACEHOLDER_VALUE_PATTERNS.some((pattern) => pattern.test(trimmedValue));
+};

--- a/packages/react-doctor/tests/regressions/no-secrets-in-client-code.test.ts
+++ b/packages/react-doctor/tests/regressions/no-secrets-in-client-code.test.ts
@@ -384,6 +384,78 @@ export const token = sessionStorage.getItem(DESKTOP_AUTH_PREFIX);
     await expect(getSecretIssues(projectDir)).resolves.toEqual([]);
   });
 
+  it("does not report masked placeholder strings through the weak variable-name heuristic", async () => {
+    const projectDir = setupReactProject(tempRoot, "client-masked-placeholder-secret", {
+      files: {
+        "src/token-display.tsx": `const apiKey = "************************";
+
+export const TokenDisplay = () => <div>{apiKey}</div>;
+`,
+      },
+    });
+
+    await expect(getSecretIssues(projectDir)).resolves.toEqual([]);
+  });
+
+  it("does not report docs components that render placeholder env variable values", async () => {
+    const projectDir = setupReactProject(tempRoot, "client-env-placeholder-display", {
+      files: {
+        "src/components/env-variables/value-placeholder.tsx": `const STRIPE_SECRET_VALUE_PLACEHOLDER = "sk_live_****************";
+const PUBLIC_API_KEY_EXAMPLE = "example_token_1234567890abcdef";
+
+export const ValuePlaceholder = () => (
+  <code>{STRIPE_SECRET_VALUE_PLACEHOLDER}{PUBLIC_API_KEY_EXAMPLE}</code>
+);
+`,
+      },
+    });
+
+    await expect(getSecretIssues(projectDir)).resolves.toEqual([]);
+  });
+
+  it("does not report bracketed example secret placeholders in display components", async () => {
+    const projectDir = setupReactProject(tempRoot, "client-bracketed-secret-placeholder", {
+      files: {
+        "src/components/env-variables/secret-example.tsx": `const STRIPE_SECRET_EXAMPLE = "sk_test_<your_secret_key>";
+
+export const SecretExample = () => <code>{STRIPE_SECRET_EXAMPLE}</code>;
+`,
+      },
+    });
+
+    await expect(getSecretIssues(projectDir)).resolves.toEqual([]);
+  });
+
+  it("still reports real secret literals in placeholder display components", async () => {
+    const projectDir = setupReactProject(tempRoot, "client-placeholder-real-secret", {
+      files: {
+        "src/components/env-variables/value-placeholder.tsx": `const STRIPE_SECRET_VALUE_PLACEHOLDER = "sk\\u005flive_REALsecret1234567890abcdef";
+
+export const ValuePlaceholder = () => <code>{STRIPE_SECRET_VALUE_PLACEHOLDER}</code>;
+`,
+      },
+    });
+
+    const secretIssues = await getSecretIssues(projectDir);
+    expect(secretIssues).toHaveLength(1);
+    expect(secretIssues[0].message).toContain("hardcoded secret is a security vulnerability");
+  });
+
+  it("still reports example-named api keys with non-placeholder values", async () => {
+    const projectDir = setupReactProject(tempRoot, "client-example-real-token", {
+      files: {
+        "src/token-display.tsx": `const EXAMPLE_API_KEY = "fixture_token_1234567890abcdef";
+
+export const TokenDisplay = () => <div>{EXAMPLE_API_KEY}</div>;
+`,
+      },
+    });
+
+    const secretIssues = await getSecretIssues(projectDir);
+    expect(secretIssues).toHaveLength(1);
+    expect(secretIssues[0].message).toContain("EXAMPLE_API_KEY");
+  });
+
   it("runs the weak variable-name heuristic in use-client App Router files", async () => {
     const projectDir = setupReactProject(tempRoot, "next-use-client-secret", {
       packageJsonExtras: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treat unambiguous masked/placeholder secret strings as non-reportable examples.
- Keep real known-secret literal detection explicit before the weak variable-name heuristic, only suppressing known-prefix examples when the literal is unambiguously masked/placeholder text.
- Require placeholder/example context for weaker sample/dummy values before suppressing the variable-name heuristic.
- Add regressions for env placeholder display components and real hardcoded secrets that must still report.

## Testing
- `PATH="/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm exec vp test run tests/regressions/no-secrets-in-client-code.test.ts` (from `packages/react-doctor`)
- `PATH="/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm --package=@antfu/ni dlx nr typecheck` (from `packages/oxlint-plugin-react-doctor`)
- `PATH="/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm --package=@antfu/ni dlx nr format:check`
- `PATH="/home/ubuntu/.nvm/versions/node/v22.22.2/bin:$PATH" pnpm --package=@antfu/ni dlx nr lint`

Note: `pnpm exec truffler ...` could not run because the installed `@rayhanadev/truffler` bin requires `bun`, which is not available in this environment; I used targeted repository search as the fallback duplicate check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20e3d9a0-c0fb-4b01-bc0c-9123e01b1046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20e3d9a0-c0fb-4b01-bc0c-9123e01b1046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

