### PR TITLE
Fix generated image a11y false positives

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
@@ -3,6 +3,14 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { altText } from "./alt-text.js";
 
 describe("a11y/alt-text regressions", () => {
+  const imageAliasSettings = {
+    "react-doctor": {
+      altText: {
+        img: ["Image"],
+      },
+    },
+  };
+
   describe("Next.js metadata image route files", () => {
     const IMG_WITHOUT_ALT = `export default function OG() {
       return <div><img src="/bg.png" /></div>;
@@ -62,6 +70,116 @@ describe("a11y/alt-text regressions", () => {
       const result = runRule(altText, IMG_WITHOUT_ALT, {
         filename: "/proj/app/page.tsx",
       });
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("generated image renderer calls", () => {
+    it("skips helper JSX in files that render through next/og ImageResponse", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse } from "next/og";
+
+          const HeroImage = () => <div><img src="/bg.png" /></div>;
+
+          export const GET = () => new ImageResponse(<HeroImage />);
+        `,
+        {
+          filename: "/proj/app/api/og/route.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("skips helper JSX in files that render through a renamed ImageResponse import", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse as OgImageResponse } from "next/og";
+
+          const HeroImage = () => <div><img src="/bg.png" /></div>;
+
+          export const GET = () => new OgImageResponse(<HeroImage />);
+        `,
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("skips Image aliases in files that render through satori", () => {
+      const result = runRule(
+        altText,
+        `
+          import renderImage from "satori";
+
+          const Badge = () => <Image src="/badge.png" />;
+
+          export const render = () => renderImage(<Badge />);
+        `,
+        {
+          filename: "/proj/app/api/social-card.tsx",
+          settings: imageAliasSettings,
+        },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags img in ordinary page components", () => {
+      const result = runRule(
+        altText,
+        `export const Page = () => <div><img src="/bg.png" /></div>;`,
+        {
+          filename: "/proj/app/page.tsx",
+        },
+      );
+
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it("still flags ordinary /og pages without generated-image renderer calls", () => {
+      const result = runRule(
+        altText,
+        `export const Page = () => <div><img src="/bg.png" /></div>;`,
+        {
+          filename: "/proj/app/og/page.tsx",
+        },
+      );
+
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it("still flags Image aliases in ordinary page components", () => {
+      const result = runRule(
+        altText,
+        `
+          import Image from "next/image";
+
+          export const Page = () => <Image src="/hero.png" />;
+        `,
+        {
+          filename: "/proj/app/page.tsx",
+          settings: imageAliasSettings,
+        },
+      );
+
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it("does not trust locally named ImageResponse values", () => {
+      const result = runRule(
+        altText,
+        `
+          const ImageResponse = (children) => children;
+
+          export const Page = () => <div><img src="/bg.png" /></div>;
+
+          ImageResponse(<Page />);
+        `,
+      );
+
       expect(result.diagnostics.length).toBeGreaterThan(0);
     });
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
@@ -186,6 +186,62 @@ describe("a11y/alt-text regressions", () => {
       expect(result.diagnostics).toHaveLength(1);
     });
 
+    it("still flags shared helper components used by normal UI", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse } from "next/og";
+
+          const SharedImage = () => <div><img src="/shared.png" /></div>;
+
+          export const GET = () => new ImageResponse(<SharedImage />);
+
+          export const Page = () => <main><SharedImage /></main>;
+        `,
+        {
+          filename: "/proj/app/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("skips conditional helper JSX returned only through ImageResponse", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse } from "next/og";
+
+          const HeroImage = ({ enabled }) => enabled ? <img src="/enabled.png" /> : <img src="/disabled.png" />;
+
+          export const GET = () => new ImageResponse(<HeroImage enabled />);
+        `,
+        {
+          filename: "/proj/app/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("skips logical helper JSX returned only through ImageResponse", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse } from "next/og";
+
+          const HeroImage = ({ enabled }) => enabled && <img src="/enabled.png" />;
+
+          export const GET = () => new ImageResponse(<HeroImage enabled />);
+        `,
+        {
+          filename: "/proj/app/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("still flags Image aliases in ordinary page components", () => {
       const result = runRule(
         altText,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
@@ -108,6 +108,21 @@ describe("a11y/alt-text regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("skips helper JSX in files that render through @vercel/og ImageResponse", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse } from "@vercel/og";
+
+          const HeroImage = () => <div><img src="/bg.png" /></div>;
+
+          export const GET = () => new ImageResponse(<HeroImage />);
+        `,
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("skips Image aliases in files that render through satori", () => {
       const result = runRule(
         altText,
@@ -149,6 +164,26 @@ describe("a11y/alt-text regressions", () => {
       );
 
       expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it("still flags ordinary JSX in mixed files that also render generated images", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse } from "next/og";
+
+          const HeroImage = () => <div><img src="/og.png" /></div>;
+
+          export const GET = () => new ImageResponse(<HeroImage />);
+
+          export const Page = () => <main><img src="/page.png" /></main>;
+        `,
+        {
+          filename: "/proj/app/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toHaveLength(1);
     });
 
     it("still flags Image aliases in ordinary page components", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
@@ -242,6 +242,24 @@ describe("a11y/alt-text regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("skips JSX returned by helper calls passed to ImageResponse", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse } from "next/og";
+
+          const buildHeroImage = () => <div><img src="/hero.png" /></div>;
+
+          export const GET = () => new ImageResponse(buildHeroImage());
+        `,
+        {
+          filename: "/proj/app/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("still flags Image aliases in ordinary page components", () => {
       const result = runRule(
         altText,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.regressions.test.ts
@@ -260,6 +260,26 @@ describe("a11y/alt-text regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("still flags helper calls when the helper is also rendered as normal JSX", () => {
+      const result = runRule(
+        altText,
+        `
+          import { ImageResponse } from "next/og";
+
+          const SharedImage = () => <div><img src="/shared.png" /></div>;
+
+          export const GET = () => new ImageResponse(SharedImage());
+
+          export const Page = () => <main><SharedImage /></main>;
+        `,
+        {
+          filename: "/proj/app/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("still flags Image aliases in ordinary page components", () => {
       const result = runRule(
         altText,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.ts
@@ -4,9 +4,8 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
-import { isNextjsMetadataImageRouteFilename } from "../../utils/is-nextjs-metadata-image-route-filename.js";
+import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { normalizeFilename } from "../../utils/normalize-filename.js";
 import { objectHasAccessibleChild } from "../../utils/object-has-accessible-child.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
@@ -189,7 +188,7 @@ export const altText = defineRule<Rule>({
   recommendation: "Give every meaningful image an `alt`, `aria-label`, or `aria-labelledby`.",
   category: "Accessibility",
   create: (context): RuleVisitors => {
-    if (isNextjsMetadataImageRouteFilename(normalizeFilename(context.filename ?? ""))) return {};
+    if (isGeneratedImageRenderContext(context)) return {};
     const settings = resolveSettings(context.settings);
     // Settings.elements selects WHICH element classes to check.
     // Default: all four. Custom aliases are merged into each class.
@@ -204,6 +203,7 @@ export const altText = defineRule<Rule>({
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (isGeneratedImageRenderContext(context, node)) return;
         const tag = getElementType(node, context.settings);
 
         if (checkImg && (tag === "img" || imgAliases.has(tag))) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/img-redundant-alt.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/img-redundant-alt.regressions.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { imgRedundantAlt } from "./img-redundant-alt.js";
+
+describe("a11y/img-redundant-alt regressions", () => {
+  const imageAliasSettings = {
+    "react-doctor": {
+      imgRedundantAlt: {
+        components: ["Image"],
+      },
+    },
+  };
+
+  it("skips redundant alt wording in Next.js metadata image route files", () => {
+    const result = runRule(
+      imgRedundantAlt,
+      `export default function OG() {
+        return <div><img src="/bg.png" alt="Image of a product card" /></div>;
+      }`,
+      {
+        filename: "/proj/app/opengraph-image.tsx",
+      },
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("skips helper JSX in files that render through next/og ImageResponse", () => {
+    const result = runRule(
+      imgRedundantAlt,
+      `
+        import * as NextOg from "next/og";
+
+        const HeroImage = () => <img src="/bg.png" alt="Image of a product card" />;
+
+        export const GET = () => new NextOg.ImageResponse(<HeroImage />);
+      `,
+      {
+        filename: "/proj/app/api/social-card.tsx",
+      },
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("skips Image aliases in files that render through satori", () => {
+    const result = runRule(
+      imgRedundantAlt,
+      `
+        import satori from "satori";
+
+        const Badge = () => <Image src="/badge.png" alt="Photo of a badge" />;
+
+        export const render = () => satori(<Badge />);
+      `,
+      {
+        filename: "/proj/app/api/social-card.tsx",
+        settings: imageAliasSettings,
+      },
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags redundant img alt wording in ordinary page components", () => {
+    const result = runRule(
+      imgRedundantAlt,
+      `export const Page = () => <img src="/bg.png" alt="Image of a product card" />;`,
+      {
+        filename: "/proj/app/page.tsx",
+      },
+    );
+
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags redundant Image alt wording in ordinary page components", () => {
+    const result = runRule(
+      imgRedundantAlt,
+      `
+        import Image from "next/image";
+
+        export const Page = () => <Image src="/hero.png" alt="Photo of the hero" />;
+      `,
+      {
+        filename: "/proj/app/page.tsx",
+        settings: imageAliasSettings,
+      },
+    );
+
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/img-redundant-alt.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/img-redundant-alt.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
+import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
@@ -89,9 +90,11 @@ export const imgRedundantAlt = defineRule<Rule>({
   recommendation: "Do not put 'image' or 'photo' in alt text. Describe what is shown.",
   category: "Accessibility",
   create: (context) => {
+    if (isGeneratedImageRenderContext(context)) return {};
     const settings = resolveSettings(context.settings);
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (isGeneratedImageRenderContext(context, node)) return;
         const tag = getElementType(node, context.settings);
         if (!settings.components.includes(tag)) return;
         if (isHiddenFromScreenReader(node, context.settings)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/img-redundant-alt.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/img-redundant-alt.ts
@@ -7,6 +7,7 @@ import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-re
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { Rule } from "../../utils/rule.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 
 const MESSAGE =
   'Screen reader users hear "image" or "photo" twice because they already announce it, so describe what the image shows instead.';
@@ -89,7 +90,7 @@ export const imgRedundantAlt = defineRule<Rule>({
   severity: "warn",
   recommendation: "Do not put 'image' or 'photo' in alt text. Describe what is shown.",
   category: "Accessibility",
-  create: (context) => {
+  create: (context): RuleVisitors => {
     if (isGeneratedImageRenderContext(context)) return {};
     const settings = resolveSettings(context.settings);
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.regressions.test.ts
@@ -46,5 +46,23 @@ describe("nextjs/no-img-element regressions", () => {
       });
       expect(result.diagnostics.length).toBeGreaterThan(0);
     });
+
+    it("skips helper JSX in files that render through next/og ImageResponse", () => {
+      const result = runRule(
+        nextjsNoImgElement,
+        `
+          import { ImageResponse } from "next/og";
+
+          const HeroImage = () => <div><img src="/bg.png" /></div>;
+
+          export const GET = () => new ImageResponse(<HeroImage />);
+        `,
+        {
+          filename: "/proj/app/api/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -13,7 +14,7 @@ export const nextjsNoImgElement = defineRule<Rule>({
   severity: "warn",
   recommendation:
     "`import Image from 'next/image'` for automatic WebP/AVIF, lazy loading, and responsive srcset",
-  create: (context: RuleContext) => {
+  create: (context: RuleContext): RuleVisitors => {
     if (isGeneratedImageRenderContext(context)) return {};
 
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
@@ -1,7 +1,5 @@
-import { OG_ROUTE_PATTERN } from "../../constants/nextjs.js";
 import { defineRule } from "../../utils/define-rule.js";
-import { isNextjsMetadataImageRouteFilename } from "../../utils/is-nextjs-metadata-image-route-filename.js";
-import { normalizeFilename } from "../../utils/normalize-filename.js";
+import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -16,13 +14,11 @@ export const nextjsNoImgElement = defineRule<Rule>({
   recommendation:
     "`import Image from 'next/image'` for automatic WebP/AVIF, lazy loading, and responsive srcset",
   create: (context: RuleContext) => {
-    const filename = normalizeFilename(context.filename ?? "");
-    const isOgRoute = OG_ROUTE_PATTERN.test(filename);
-    const isMetadataImageRoute = isNextjsMetadataImageRouteFilename(filename);
+    if (isGeneratedImageRenderContext(context)) return {};
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (isOgRoute || isMetadataImageRoute) return;
+        if (isGeneratedImageRenderContext(context, node)) return;
         if (isNodeOfType(node.name, "JSXIdentifier") && node.name.name === "img") {
           context.report({
             node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.regressions.test.ts
@@ -7,10 +7,7 @@ describe("react-builtins/no-unknown-property — regressions", () => {
   // from DOM_PROPERTY_NAMES even though `onGotPointerCaptureCapture`
   // was present, producing false positives on the bubbling form.
   it("does not flag onGotPointerCapture", () => {
-    const result = runRule(
-      noUnknownProperty,
-      `<div onGotPointerCapture={x} />`,
-    );
+    const result = runRule(noUnknownProperty, `<div onGotPointerCapture={x} />`);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.regressions.test.ts
@@ -42,5 +42,23 @@ describe("react-builtins/no-unknown-property — regressions", () => {
       });
       expect(result.diagnostics.length).toBeGreaterThan(0);
     });
+
+    it("does not flag tw in files that render through ImageResponse", () => {
+      const result = runRule(
+        noUnknownProperty,
+        `
+          import { ImageResponse } from "next/og";
+
+          const HeroImage = () => <div tw="flex flex-col">Hello</div>;
+
+          export const GET = () => new ImageResponse(<HeroImage />);
+        `,
+        {
+          filename: "/proj/app/api/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toHaveLength(0);
+    });
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.regressions.test.ts
@@ -7,7 +7,10 @@ describe("react-builtins/no-unknown-property — regressions", () => {
   // from DOM_PROPERTY_NAMES even though `onGotPointerCaptureCapture`
   // was present, producing false positives on the bubbling form.
   it("does not flag onGotPointerCapture", () => {
-    const result = runRule(noUnknownProperty, `<div onGotPointerCapture={x} />`);
+    const result = runRule(
+      noUnknownProperty,
+      `<div onGotPointerCapture={x} />`,
+    );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
   });
@@ -59,6 +62,26 @@ describe("react-builtins/no-unknown-property — regressions", () => {
       );
 
       expect(result.diagnostics).toHaveLength(0);
+    });
+
+    it("still flags tw on ordinary JSX in mixed files that also render generated images", () => {
+      const result = runRule(
+        noUnknownProperty,
+        `
+          import { ImageResponse } from "next/og";
+
+          const HeroImage = () => <div tw="flex flex-col">Hello</div>;
+
+          export const GET = () => new ImageResponse(<HeroImage />);
+
+          export const Page = () => <main tw="flex">Hello</main>;
+        `,
+        {
+          filename: "/proj/app/social-card.tsx",
+        },
+      );
+
+      expect(result.diagnostics).toHaveLength(1);
     });
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.ts
@@ -9,8 +9,8 @@ import { DOM_PROPERTY_TO_ALLOWED_TAGS } from "../../constants/dom-property-tags.
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { isNextjsMetadataImageRouteFilename } from "../../utils/is-nextjs-metadata-image-route-filename.js";
 import { fileImportsNonReactJsxDialect } from "../../utils/non-react-jsx-dialect.js";
 import type { Rule } from "../../utils/rule.js";
 
@@ -87,7 +87,7 @@ export const noUnknownProperty = defineRule<Rule>({
   create: (context) => {
     const { ignore = [], requireDataLowercase = false } = resolveSettings(context.settings);
     const ignoreSet = new Set(ignore);
-    if (isNextjsMetadataImageRouteFilename(context.filename)) {
+    if (isGeneratedImageRenderContext(context)) {
       ignoreSet.add("tw");
     }
     let fileIsNonReactJsx = false;
@@ -138,6 +138,7 @@ export const noUnknownProperty = defineRule<Rule>({
           if (!isNodeOfType(attribute, "JSXAttribute")) continue;
           const actualName = getJsxAttributeName(attribute.name);
           if (!actualName) continue;
+          if (actualName === "tw" && isGeneratedImageRenderContext(context, node)) continue;
           if (ignoreSet.has(actualName)) continue;
 
           if (isValidDataAttribute(actualName)) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
@@ -101,6 +101,18 @@ export const isNamespaceImportFromModule = (
   return info.isNamespace && info.source === moduleSource;
 };
 
+export const isDefaultImportFromModule = (
+  contextNode: EsTreeNode,
+  localIdentifierName: string,
+  moduleSource: string,
+): boolean => {
+  const lookup = getImportLookup(contextNode);
+  if (!lookup) return false;
+  const info = lookup.get(localIdentifierName);
+  if (!info) return false;
+  return info.isDefault && info.source === moduleSource;
+};
+
 // Returns the originally-exported symbol name for a local binding that
 // came from a specific module, resolving renamed imports like
 // `import { useMemo as memoize } from "react"` so callers can match

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
@@ -1,0 +1,90 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import {
+  getImportedNameFromModule,
+  isDefaultImportFromModule,
+  isNamespaceImportFromModule,
+} from "./find-import-source-for-name.js";
+import { findProgramRoot } from "./find-program-root.js";
+import { isMemberProperty } from "./is-member-property.js";
+import { isNextjsMetadataImageRouteFilename } from "./is-nextjs-metadata-image-route-filename.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { normalizeFilename } from "./normalize-filename.js";
+import type { RuleContext } from "./rule-context.js";
+import { walkAst } from "./walk-ast.js";
+
+const IMAGE_RESPONSE_MODULES: ReadonlyArray<string> = ["next/og", "@vercel/og"];
+const SATORI_MODULE = "satori";
+
+const generatedImageProgramCache = new WeakMap<EsTreeNodeOfType<"Program">, boolean>();
+
+export const isGeneratedImageRenderFilename = (rawFilename: string | undefined): boolean => {
+  if (!rawFilename) return false;
+  const filename = normalizeFilename(rawFilename);
+  return isNextjsMetadataImageRouteFilename(filename);
+};
+
+const isImageResponseCallee = (contextNode: EsTreeNode, callee: EsTreeNode): boolean => {
+  if (isNodeOfType(callee, "Identifier")) {
+    return IMAGE_RESPONSE_MODULES.some(
+      (moduleSource) =>
+        getImportedNameFromModule(contextNode, callee.name, moduleSource) === "ImageResponse",
+    );
+  }
+
+  if (!isMemberProperty(callee, "ImageResponse")) return false;
+  if (!isNodeOfType(callee.object, "Identifier")) return false;
+
+  return IMAGE_RESPONSE_MODULES.some((moduleSource) =>
+    isNamespaceImportFromModule(contextNode, callee.object.name, moduleSource),
+  );
+};
+
+const isSatoriCallee = (contextNode: EsTreeNode, callee: EsTreeNode): boolean => {
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  if (getImportedNameFromModule(contextNode, callee.name, SATORI_MODULE) === "satori") return true;
+  return isDefaultImportFromModule(contextNode, callee.name, SATORI_MODULE);
+};
+
+const isGeneratedImageRendererCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression") && !isNodeOfType(node, "NewExpression")) {
+    return false;
+  }
+
+  if (!isNodeOfType(node.callee, "Identifier") && !isNodeOfType(node.callee, "MemberExpression")) {
+    return false;
+  }
+
+  return isImageResponseCallee(node, node.callee) || isSatoriCallee(node, node.callee);
+};
+
+const programContainsGeneratedImageRendererCall = (
+  programRoot: EsTreeNodeOfType<"Program">,
+): boolean => {
+  const cached = generatedImageProgramCache.get(programRoot);
+  if (cached !== undefined) return cached;
+
+  let containsGeneratedImageRendererCall = false;
+  walkAst(programRoot, (descendantNode) => {
+    if (containsGeneratedImageRendererCall) return false;
+    if (!isGeneratedImageRendererCall(descendantNode)) return;
+    containsGeneratedImageRendererCall = true;
+    return false;
+  });
+
+  generatedImageProgramCache.set(programRoot, containsGeneratedImageRendererCall);
+  return containsGeneratedImageRendererCall;
+};
+
+export const isGeneratedImageRenderContext = (
+  context: RuleContext,
+  node?: EsTreeNode,
+): boolean => {
+  if (isGeneratedImageRenderFilename(context.filename)) return true;
+  if (!node) return false;
+
+  const programRoot = findProgramRoot(node);
+  if (!programRoot) return false;
+
+  return programContainsGeneratedImageRendererCall(programRoot);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
@@ -86,6 +86,7 @@ const isFunctionLike = (
 
 const markFunctionReturnJsx = (
   functionNode: EsTreeNode,
+  programRoot: EsTreeNodeOfType<"Program">,
   generatedImageJsxNodes: WeakSet<EsTreeNode>,
   visitedComponentNames: Set<string>,
 ): void => {
@@ -94,7 +95,12 @@ const markFunctionReturnJsx = (
   if (isNodeOfType(functionNode, "ArrowFunctionExpression")) {
     const body = stripParenExpression(functionNode.body);
     if (!isNodeOfType(body, "BlockStatement")) {
-      markGeneratedImageExpression(body, generatedImageJsxNodes, visitedComponentNames);
+      markGeneratedImageExpression(
+        body,
+        programRoot,
+        generatedImageJsxNodes,
+        visitedComponentNames,
+      );
       return;
     }
   }
@@ -108,13 +114,32 @@ const markFunctionReturnJsx = (
     if (!descendantNode.argument) return;
     markGeneratedImageExpression(
       stripParenExpression(descendantNode.argument),
+      programRoot,
       generatedImageJsxNodes,
       visitedComponentNames,
     );
   });
 };
 
+const hasNormalJsxUsage = (
+  programRoot: EsTreeNodeOfType<"Program">,
+  componentName: string,
+  generatedImageJsxNodes: WeakSet<EsTreeNode>,
+): boolean => {
+  let hasNormalUsage = false;
+  walkAst(programRoot, (descendantNode) => {
+    if (hasNormalUsage) return false;
+    if (!isNodeOfType(descendantNode, "JSXOpeningElement")) return;
+    if (generatedImageJsxNodes.has(descendantNode)) return;
+    if (flattenJsxName(descendantNode.name) !== componentName) return;
+    hasNormalUsage = true;
+    return false;
+  });
+  return hasNormalUsage;
+};
+
 const markComponentRenderJsx = (
+  programRoot: EsTreeNodeOfType<"Program">,
   openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
   generatedImageJsxNodes: WeakSet<EsTreeNode>,
   visitedComponentNames: Set<string>,
@@ -122,6 +147,7 @@ const markComponentRenderJsx = (
   const tagName = flattenJsxName(openingElement.name);
   if (!tagName || tagName.includes(".") || !isComponentIdentifierName(tagName)) return;
   if (visitedComponentNames.has(tagName)) return;
+  if (hasNormalJsxUsage(programRoot, tagName, generatedImageJsxNodes)) return;
 
   const binding = findVariableInitializer(openingElement, tagName);
   if (!binding?.initializer) return;
@@ -129,6 +155,7 @@ const markComponentRenderJsx = (
   visitedComponentNames.add(tagName);
   markGeneratedImageExpression(
     stripParenExpression(binding.initializer),
+    programRoot,
     generatedImageJsxNodes,
     visitedComponentNames,
   );
@@ -136,18 +163,25 @@ const markComponentRenderJsx = (
 
 const markJsxSubtree = (
   node: EsTreeNode,
+  programRoot: EsTreeNodeOfType<"Program">,
   generatedImageJsxNodes: WeakSet<EsTreeNode>,
   visitedComponentNames: Set<string>,
 ): void => {
   walkAst(node, (descendantNode) => {
     if (!isNodeOfType(descendantNode, "JSXOpeningElement")) return;
     generatedImageJsxNodes.add(descendantNode);
-    markComponentRenderJsx(descendantNode, generatedImageJsxNodes, visitedComponentNames);
+    markComponentRenderJsx(
+      programRoot,
+      descendantNode,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
   });
 };
 
 const markGeneratedImageExpression = (
   expression: EsTreeNode,
+  programRoot: EsTreeNodeOfType<"Program">,
   generatedImageJsxNodes: WeakSet<EsTreeNode>,
   visitedComponentNames: Set<string>,
 ): void => {
@@ -157,12 +191,49 @@ const markGeneratedImageExpression = (
     isNodeOfType(unwrappedExpression, "JSXElement") ||
     isNodeOfType(unwrappedExpression, "JSXFragment")
   ) {
-    markJsxSubtree(unwrappedExpression, generatedImageJsxNodes, visitedComponentNames);
+    markJsxSubtree(unwrappedExpression, programRoot, generatedImageJsxNodes, visitedComponentNames);
     return;
   }
 
   if (isFunctionLike(unwrappedExpression)) {
-    markFunctionReturnJsx(unwrappedExpression, generatedImageJsxNodes, visitedComponentNames);
+    markFunctionReturnJsx(
+      unwrappedExpression,
+      programRoot,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+    return;
+  }
+
+  if (isNodeOfType(unwrappedExpression, "ConditionalExpression")) {
+    markGeneratedImageExpression(
+      unwrappedExpression.consequent,
+      programRoot,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+    markGeneratedImageExpression(
+      unwrappedExpression.alternate,
+      programRoot,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+    return;
+  }
+
+  if (isNodeOfType(unwrappedExpression, "LogicalExpression")) {
+    markGeneratedImageExpression(
+      unwrappedExpression.left,
+      programRoot,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+    markGeneratedImageExpression(
+      unwrappedExpression.right,
+      programRoot,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
     return;
   }
 
@@ -173,6 +244,7 @@ const markGeneratedImageExpression = (
     if (!binding?.initializer) return;
     markGeneratedImageExpression(
       stripParenExpression(binding.initializer),
+      programRoot,
       generatedImageJsxNodes,
       visitedComponentNames,
     );
@@ -189,7 +261,7 @@ const collectGeneratedImageJsxNodes = (
   walkAst(programRoot, (descendantNode) => {
     if (!isGeneratedImageRendererCall(descendantNode)) return;
     for (const argument of descendantNode.arguments) {
-      markGeneratedImageExpression(argument, generatedImageJsxNodes, new Set());
+      markGeneratedImageExpression(argument, programRoot, generatedImageJsxNodes, new Set());
     }
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
@@ -34,9 +34,10 @@ const isImageResponseCallee = (contextNode: EsTreeNode, callee: EsTreeNode): boo
 
   if (!isMemberProperty(callee, "ImageResponse")) return false;
   if (!isNodeOfType(callee.object, "Identifier")) return false;
+  const namespaceIdentifierName = callee.object.name;
 
   return IMAGE_RESPONSE_MODULES.some((moduleSource) =>
-    isNamespaceImportFromModule(contextNode, callee.object.name, moduleSource),
+    isNamespaceImportFromModule(contextNode, namespaceIdentifierName, moduleSource),
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
@@ -161,6 +161,32 @@ const markComponentRenderJsx = (
   );
 };
 
+const isInsideGeneratedImageRendererArgument = (node: EsTreeNode): boolean => {
+  let cursor = node.parent;
+  while (cursor) {
+    if (isGeneratedImageRendererCall(cursor)) return true;
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+const hasNormalFunctionCallUsage = (
+  programRoot: EsTreeNodeOfType<"Program">,
+  functionName: string,
+): boolean => {
+  let hasNormalUsage = false;
+  walkAst(programRoot, (descendantNode) => {
+    if (hasNormalUsage) return false;
+    if (!isNodeOfType(descendantNode, "CallExpression")) return;
+    if (!isNodeOfType(descendantNode.callee, "Identifier")) return;
+    if (descendantNode.callee.name !== functionName) return;
+    if (isInsideGeneratedImageRendererArgument(descendantNode)) return;
+    hasNormalUsage = true;
+    return false;
+  });
+  return hasNormalUsage;
+};
+
 const markJsxSubtree = (
   node: EsTreeNode,
   programRoot: EsTreeNodeOfType<"Program">,
@@ -230,6 +256,27 @@ const markGeneratedImageExpression = (
     );
     markGeneratedImageExpression(
       unwrappedExpression.right,
+      programRoot,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+    return;
+  }
+
+  if (isNodeOfType(unwrappedExpression, "CallExpression")) {
+    const callee = unwrappedExpression.callee;
+    if (isFunctionLike(callee)) {
+      markFunctionReturnJsx(callee, programRoot, generatedImageJsxNodes, visitedComponentNames);
+      return;
+    }
+    if (!isNodeOfType(callee, "Identifier")) return;
+    if (visitedComponentNames.has(callee.name)) return;
+    if (hasNormalFunctionCallUsage(programRoot, callee.name)) return;
+    const binding = findVariableInitializer(callee, callee.name);
+    if (!binding?.initializer || !isFunctionLike(stripParenExpression(binding.initializer))) return;
+    visitedComponentNames.add(callee.name);
+    markFunctionReturnJsx(
+      stripParenExpression(binding.initializer),
       programRoot,
       generatedImageJsxNodes,
       visitedComponentNames,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
@@ -6,29 +6,45 @@ import {
   isNamespaceImportFromModule,
 } from "./find-import-source-for-name.js";
 import { findProgramRoot } from "./find-program-root.js";
+import { findVariableInitializer } from "./find-variable-initializer.js";
+import { flattenJsxName } from "./flatten-jsx-name.js";
 import { isMemberProperty } from "./is-member-property.js";
 import { isNextjsMetadataImageRouteFilename } from "./is-nextjs-metadata-image-route-filename.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { normalizeFilename } from "./normalize-filename.js";
 import type { RuleContext } from "./rule-context.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
 import { walkAst } from "./walk-ast.js";
 
 const IMAGE_RESPONSE_MODULES: ReadonlyArray<string> = ["next/og", "@vercel/og"];
 const SATORI_MODULE = "satori";
 
-const generatedImageProgramCache = new WeakMap<EsTreeNodeOfType<"Program">, boolean>();
+const generatedImageJsxCache = new WeakMap<
+  EsTreeNodeOfType<"Program">,
+  WeakSet<EsTreeNode>
+>();
 
-export const isGeneratedImageRenderFilename = (rawFilename: string | undefined): boolean => {
+type GeneratedImageRendererCall =
+  | EsTreeNodeOfType<"CallExpression">
+  | EsTreeNodeOfType<"NewExpression">;
+
+export const isGeneratedImageRenderFilename = (
+  rawFilename: string | undefined,
+): boolean => {
   if (!rawFilename) return false;
   const filename = normalizeFilename(rawFilename);
   return isNextjsMetadataImageRouteFilename(filename);
 };
 
-const isImageResponseCallee = (contextNode: EsTreeNode, callee: EsTreeNode): boolean => {
+const isImageResponseCallee = (
+  contextNode: EsTreeNode,
+  callee: EsTreeNode,
+): boolean => {
   if (isNodeOfType(callee, "Identifier")) {
     return IMAGE_RESPONSE_MODULES.some(
       (moduleSource) =>
-        getImportedNameFromModule(contextNode, callee.name, moduleSource) === "ImageResponse",
+        getImportedNameFromModule(contextNode, callee.name, moduleSource) ===
+        "ImageResponse",
     );
   }
 
@@ -37,44 +53,201 @@ const isImageResponseCallee = (contextNode: EsTreeNode, callee: EsTreeNode): boo
   const namespaceIdentifierName = callee.object.name;
 
   return IMAGE_RESPONSE_MODULES.some((moduleSource) =>
-    isNamespaceImportFromModule(contextNode, namespaceIdentifierName, moduleSource),
+    isNamespaceImportFromModule(
+      contextNode,
+      namespaceIdentifierName,
+      moduleSource,
+    ),
   );
 };
 
-const isSatoriCallee = (contextNode: EsTreeNode, callee: EsTreeNode): boolean => {
+const isSatoriCallee = (
+  contextNode: EsTreeNode,
+  callee: EsTreeNode,
+): boolean => {
   if (!isNodeOfType(callee, "Identifier")) return false;
-  if (getImportedNameFromModule(contextNode, callee.name, SATORI_MODULE) === "satori") return true;
+  if (
+    getImportedNameFromModule(contextNode, callee.name, SATORI_MODULE) ===
+    "satori"
+  )
+    return true;
   return isDefaultImportFromModule(contextNode, callee.name, SATORI_MODULE);
 };
 
-const isGeneratedImageRendererCall = (node: EsTreeNode): boolean => {
-  if (!isNodeOfType(node, "CallExpression") && !isNodeOfType(node, "NewExpression")) {
+const isGeneratedImageRendererCall = (
+  node: EsTreeNode,
+): node is GeneratedImageRendererCall => {
+  if (
+    !isNodeOfType(node, "CallExpression") &&
+    !isNodeOfType(node, "NewExpression")
+  ) {
     return false;
   }
 
-  if (!isNodeOfType(node.callee, "Identifier") && !isNodeOfType(node.callee, "MemberExpression")) {
+  if (
+    !isNodeOfType(node.callee, "Identifier") &&
+    !isNodeOfType(node.callee, "MemberExpression")
+  ) {
     return false;
   }
 
-  return isImageResponseCallee(node, node.callee) || isSatoriCallee(node, node.callee);
+  return (
+    isImageResponseCallee(node, node.callee) ||
+    isSatoriCallee(node, node.callee)
+  );
 };
 
-const programContainsGeneratedImageRendererCall = (
-  programRoot: EsTreeNodeOfType<"Program">,
-): boolean => {
-  const cached = generatedImageProgramCache.get(programRoot);
-  if (cached !== undefined) return cached;
+const isComponentIdentifierName = (name: string): boolean => {
+  const firstCharacter = name[0];
+  return Boolean(
+    firstCharacter && firstCharacter === firstCharacter.toUpperCase(),
+  );
+};
 
-  let containsGeneratedImageRendererCall = false;
+const isFunctionLike = (
+  node: EsTreeNode | null | undefined,
+): node is
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"ArrowFunctionExpression"> =>
+  Boolean(
+    node &&
+      (isNodeOfType(node, "FunctionDeclaration") ||
+        isNodeOfType(node, "FunctionExpression") ||
+        isNodeOfType(node, "ArrowFunctionExpression")),
+  );
+
+const markFunctionReturnJsx = (
+  functionNode: EsTreeNode,
+  generatedImageJsxNodes: WeakSet<EsTreeNode>,
+  visitedComponentNames: Set<string>,
+): void => {
+  if (!isFunctionLike(functionNode)) return;
+
+  if (isNodeOfType(functionNode, "ArrowFunctionExpression")) {
+    const body = stripParenExpression(functionNode.body);
+    if (!isNodeOfType(body, "BlockStatement")) {
+      markGeneratedImageExpression(
+        body,
+        generatedImageJsxNodes,
+        visitedComponentNames,
+      );
+      return;
+    }
+  }
+
+  const body = functionNode.body;
+  if (!isNodeOfType(body, "BlockStatement")) return;
+
+  walkAst(body, (descendantNode) => {
+    if (descendantNode !== body && isFunctionLike(descendantNode)) return false;
+    if (!isNodeOfType(descendantNode, "ReturnStatement")) return;
+    if (!descendantNode.argument) return;
+    markGeneratedImageExpression(
+      stripParenExpression(descendantNode.argument),
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+  });
+};
+
+const markComponentRenderJsx = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  generatedImageJsxNodes: WeakSet<EsTreeNode>,
+  visitedComponentNames: Set<string>,
+): void => {
+  const tagName = flattenJsxName(openingElement.name);
+  if (!tagName || tagName.includes(".") || !isComponentIdentifierName(tagName))
+    return;
+  if (visitedComponentNames.has(tagName)) return;
+
+  const binding = findVariableInitializer(openingElement, tagName);
+  if (!binding?.initializer) return;
+
+  visitedComponentNames.add(tagName);
+  markGeneratedImageExpression(
+    stripParenExpression(binding.initializer),
+    generatedImageJsxNodes,
+    visitedComponentNames,
+  );
+};
+
+const markJsxSubtree = (
+  node: EsTreeNode,
+  generatedImageJsxNodes: WeakSet<EsTreeNode>,
+  visitedComponentNames: Set<string>,
+): void => {
+  walkAst(node, (descendantNode) => {
+    if (!isNodeOfType(descendantNode, "JSXOpeningElement")) return;
+    generatedImageJsxNodes.add(descendantNode);
+    markComponentRenderJsx(
+      descendantNode,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+  });
+};
+
+const markGeneratedImageExpression = (
+  expression: EsTreeNode,
+  generatedImageJsxNodes: WeakSet<EsTreeNode>,
+  visitedComponentNames: Set<string>,
+): void => {
+  const unwrappedExpression = stripParenExpression(expression);
+
+  if (
+    isNodeOfType(unwrappedExpression, "JSXElement") ||
+    isNodeOfType(unwrappedExpression, "JSXFragment")
+  ) {
+    markJsxSubtree(
+      unwrappedExpression,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+    return;
+  }
+
+  if (isFunctionLike(unwrappedExpression)) {
+    markFunctionReturnJsx(
+      unwrappedExpression,
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+    return;
+  }
+
+  if (isNodeOfType(unwrappedExpression, "Identifier")) {
+    if (visitedComponentNames.has(unwrappedExpression.name)) return;
+    visitedComponentNames.add(unwrappedExpression.name);
+    const binding = findVariableInitializer(
+      unwrappedExpression,
+      unwrappedExpression.name,
+    );
+    if (!binding?.initializer) return;
+    markGeneratedImageExpression(
+      stripParenExpression(binding.initializer),
+      generatedImageJsxNodes,
+      visitedComponentNames,
+    );
+  }
+};
+
+const collectGeneratedImageJsxNodes = (
+  programRoot: EsTreeNodeOfType<"Program">,
+): WeakSet<EsTreeNode> => {
+  const cached = generatedImageJsxCache.get(programRoot);
+  if (cached) return cached;
+
+  const generatedImageJsxNodes = new WeakSet<EsTreeNode>();
   walkAst(programRoot, (descendantNode) => {
-    if (containsGeneratedImageRendererCall) return false;
     if (!isGeneratedImageRendererCall(descendantNode)) return;
-    containsGeneratedImageRendererCall = true;
-    return false;
+    for (const argument of descendantNode.arguments) {
+      markGeneratedImageExpression(argument, generatedImageJsxNodes, new Set());
+    }
   });
 
-  generatedImageProgramCache.set(programRoot, containsGeneratedImageRendererCall);
-  return containsGeneratedImageRendererCall;
+  generatedImageJsxCache.set(programRoot, generatedImageJsxNodes);
+  return generatedImageJsxNodes;
 };
 
 export const isGeneratedImageRenderContext = (
@@ -87,5 +260,5 @@ export const isGeneratedImageRenderContext = (
   const programRoot = findProgramRoot(node);
   if (!programRoot) return false;
 
-  return programContainsGeneratedImageRendererCall(programRoot);
+  return collectGeneratedImageJsxNodes(programRoot).has(node);
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
@@ -271,6 +271,7 @@ const markGeneratedImageExpression = (
     }
     if (!isNodeOfType(callee, "Identifier")) return;
     if (visitedComponentNames.has(callee.name)) return;
+    if (hasNormalJsxUsage(programRoot, callee.name, generatedImageJsxNodes)) return;
     if (hasNormalFunctionCallUsage(programRoot, callee.name)) return;
     const binding = findVariableInitializer(callee, callee.name);
     if (!binding?.initializer || !isFunctionLike(stripParenExpression(binding.initializer))) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
@@ -19,32 +19,23 @@ import { walkAst } from "./walk-ast.js";
 const IMAGE_RESPONSE_MODULES: ReadonlyArray<string> = ["next/og", "@vercel/og"];
 const SATORI_MODULE = "satori";
 
-const generatedImageJsxCache = new WeakMap<
-  EsTreeNodeOfType<"Program">,
-  WeakSet<EsTreeNode>
->();
+const generatedImageJsxCache = new WeakMap<EsTreeNodeOfType<"Program">, WeakSet<EsTreeNode>>();
 
 type GeneratedImageRendererCall =
   | EsTreeNodeOfType<"CallExpression">
   | EsTreeNodeOfType<"NewExpression">;
 
-export const isGeneratedImageRenderFilename = (
-  rawFilename: string | undefined,
-): boolean => {
+export const isGeneratedImageRenderFilename = (rawFilename: string | undefined): boolean => {
   if (!rawFilename) return false;
   const filename = normalizeFilename(rawFilename);
   return isNextjsMetadataImageRouteFilename(filename);
 };
 
-const isImageResponseCallee = (
-  contextNode: EsTreeNode,
-  callee: EsTreeNode,
-): boolean => {
+const isImageResponseCallee = (contextNode: EsTreeNode, callee: EsTreeNode): boolean => {
   if (isNodeOfType(callee, "Identifier")) {
     return IMAGE_RESPONSE_MODULES.some(
       (moduleSource) =>
-        getImportedNameFromModule(contextNode, callee.name, moduleSource) ===
-        "ImageResponse",
+        getImportedNameFromModule(contextNode, callee.name, moduleSource) === "ImageResponse",
     );
   }
 
@@ -53,55 +44,31 @@ const isImageResponseCallee = (
   const namespaceIdentifierName = callee.object.name;
 
   return IMAGE_RESPONSE_MODULES.some((moduleSource) =>
-    isNamespaceImportFromModule(
-      contextNode,
-      namespaceIdentifierName,
-      moduleSource,
-    ),
+    isNamespaceImportFromModule(contextNode, namespaceIdentifierName, moduleSource),
   );
 };
 
-const isSatoriCallee = (
-  contextNode: EsTreeNode,
-  callee: EsTreeNode,
-): boolean => {
+const isSatoriCallee = (contextNode: EsTreeNode, callee: EsTreeNode): boolean => {
   if (!isNodeOfType(callee, "Identifier")) return false;
-  if (
-    getImportedNameFromModule(contextNode, callee.name, SATORI_MODULE) ===
-    "satori"
-  )
-    return true;
+  if (getImportedNameFromModule(contextNode, callee.name, SATORI_MODULE) === "satori") return true;
   return isDefaultImportFromModule(contextNode, callee.name, SATORI_MODULE);
 };
 
-const isGeneratedImageRendererCall = (
-  node: EsTreeNode,
-): node is GeneratedImageRendererCall => {
-  if (
-    !isNodeOfType(node, "CallExpression") &&
-    !isNodeOfType(node, "NewExpression")
-  ) {
+const isGeneratedImageRendererCall = (node: EsTreeNode): node is GeneratedImageRendererCall => {
+  if (!isNodeOfType(node, "CallExpression") && !isNodeOfType(node, "NewExpression")) {
     return false;
   }
 
-  if (
-    !isNodeOfType(node.callee, "Identifier") &&
-    !isNodeOfType(node.callee, "MemberExpression")
-  ) {
+  if (!isNodeOfType(node.callee, "Identifier") && !isNodeOfType(node.callee, "MemberExpression")) {
     return false;
   }
 
-  return (
-    isImageResponseCallee(node, node.callee) ||
-    isSatoriCallee(node, node.callee)
-  );
+  return isImageResponseCallee(node, node.callee) || isSatoriCallee(node, node.callee);
 };
 
 const isComponentIdentifierName = (name: string): boolean => {
   const firstCharacter = name[0];
-  return Boolean(
-    firstCharacter && firstCharacter === firstCharacter.toUpperCase(),
-  );
+  return Boolean(firstCharacter && firstCharacter === firstCharacter.toUpperCase());
 };
 
 const isFunctionLike = (
@@ -112,9 +79,9 @@ const isFunctionLike = (
   | EsTreeNodeOfType<"ArrowFunctionExpression"> =>
   Boolean(
     node &&
-      (isNodeOfType(node, "FunctionDeclaration") ||
-        isNodeOfType(node, "FunctionExpression") ||
-        isNodeOfType(node, "ArrowFunctionExpression")),
+    (isNodeOfType(node, "FunctionDeclaration") ||
+      isNodeOfType(node, "FunctionExpression") ||
+      isNodeOfType(node, "ArrowFunctionExpression")),
   );
 
 const markFunctionReturnJsx = (
@@ -127,11 +94,7 @@ const markFunctionReturnJsx = (
   if (isNodeOfType(functionNode, "ArrowFunctionExpression")) {
     const body = stripParenExpression(functionNode.body);
     if (!isNodeOfType(body, "BlockStatement")) {
-      markGeneratedImageExpression(
-        body,
-        generatedImageJsxNodes,
-        visitedComponentNames,
-      );
+      markGeneratedImageExpression(body, generatedImageJsxNodes, visitedComponentNames);
       return;
     }
   }
@@ -157,8 +120,7 @@ const markComponentRenderJsx = (
   visitedComponentNames: Set<string>,
 ): void => {
   const tagName = flattenJsxName(openingElement.name);
-  if (!tagName || tagName.includes(".") || !isComponentIdentifierName(tagName))
-    return;
+  if (!tagName || tagName.includes(".") || !isComponentIdentifierName(tagName)) return;
   if (visitedComponentNames.has(tagName)) return;
 
   const binding = findVariableInitializer(openingElement, tagName);
@@ -180,11 +142,7 @@ const markJsxSubtree = (
   walkAst(node, (descendantNode) => {
     if (!isNodeOfType(descendantNode, "JSXOpeningElement")) return;
     generatedImageJsxNodes.add(descendantNode);
-    markComponentRenderJsx(
-      descendantNode,
-      generatedImageJsxNodes,
-      visitedComponentNames,
-    );
+    markComponentRenderJsx(descendantNode, generatedImageJsxNodes, visitedComponentNames);
   });
 };
 
@@ -199,30 +157,19 @@ const markGeneratedImageExpression = (
     isNodeOfType(unwrappedExpression, "JSXElement") ||
     isNodeOfType(unwrappedExpression, "JSXFragment")
   ) {
-    markJsxSubtree(
-      unwrappedExpression,
-      generatedImageJsxNodes,
-      visitedComponentNames,
-    );
+    markJsxSubtree(unwrappedExpression, generatedImageJsxNodes, visitedComponentNames);
     return;
   }
 
   if (isFunctionLike(unwrappedExpression)) {
-    markFunctionReturnJsx(
-      unwrappedExpression,
-      generatedImageJsxNodes,
-      visitedComponentNames,
-    );
+    markFunctionReturnJsx(unwrappedExpression, generatedImageJsxNodes, visitedComponentNames);
     return;
   }
 
   if (isNodeOfType(unwrappedExpression, "Identifier")) {
     if (visitedComponentNames.has(unwrappedExpression.name)) return;
     visitedComponentNames.add(unwrappedExpression.name);
-    const binding = findVariableInitializer(
-      unwrappedExpression,
-      unwrappedExpression.name,
-    );
+    const binding = findVariableInitializer(unwrappedExpression, unwrappedExpression.name);
     if (!binding?.initializer) return;
     markGeneratedImageExpression(
       stripParenExpression(binding.initializer),
@@ -250,10 +197,7 @@ const collectGeneratedImageJsxNodes = (
   return generatedImageJsxNodes;
 };
 
-export const isGeneratedImageRenderContext = (
-  context: RuleContext,
-  node?: EsTreeNode,
-): boolean => {
+export const isGeneratedImageRenderContext = (context: RuleContext, node?: EsTreeNode): boolean => {
   if (isGeneratedImageRenderFilename(context.filename)) return true;
   if (!node) return false;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add shared generated-image render context detection for Next metadata image files, `ImageResponse`, and Satori calls
- suppress image-focused DOM a11y checks only for generated-image JSX render paths while preserving normal UI diagnostics in mixed/shared-component modules
- reuse the generated-image predicate for Next `<img>` and Satori `tw` special-cases
- handle generated-image helper returns through conditional/logical JSX expressions and same-file helper calls

## Verification
- `pnpm gen && pnpm exec vp test run src/plugin/rules/a11y/alt-text.regressions.test.ts src/plugin/rules/a11y/img-redundant-alt.regressions.test.ts src/plugin/rules/nextjs/nextjs-no-img-element.regressions.test.ts src/plugin/rules/react-builtins/no-unknown-property.regressions.test.ts`
- `pnpm typecheck` in `packages/oxlint-plugin-react-doctor`
- `pnpm format:check` under Node 22.18.0
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdd61604-f773-43f2-9c8f-5296e38d04c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdd61604-f773-43f2-9c8f-5296e38d04c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

