### PR TITLE
Fix baseline scans for catalog workspaces

### DIFF
--- a/packages/react-doctor/src/cli/utils/build-runtime-layers.ts
+++ b/packages/react-doctor/src/cli/utils/build-runtime-layers.ts
@@ -13,7 +13,7 @@ import {
   Reporter,
   Score,
 } from "@react-doctor/core";
-import type { ProgressHandle, ReactDoctorConfig } from "@react-doctor/core";
+import type { ProgressHandle, ProjectInfo, ReactDoctorConfig } from "@react-doctor/core";
 import { spinner } from "./spinner.js";
 
 export interface BuildRuntimeLayersInput {
@@ -21,6 +21,12 @@ export interface BuildRuntimeLayersInput {
   readonly hasConfigOverride: boolean;
   readonly userConfig: ReactDoctorConfig | null;
   readonly configSourceDirectory: string | null;
+  /**
+   * Pre-resolved project metadata for scans that run against a synthetic tree.
+   * The baseline diff pass materializes only changed files plus root config, so
+   * it must inherit the head scan's project instead of rediscovering.
+   */
+  readonly projectInfoOverride?: ProjectInfo;
   /**
    * Whether lint is disabled (either by user flag or because the
    * oxlint native binding can't load on this Node version). Switches
@@ -97,6 +103,10 @@ export const buildRuntimeLayers = (input: BuildRuntimeLayersInput) => {
   const linterLayer = input.shouldSkipLint ? Linter.layerOf([]) : Linter.layerOxlint;
   const deadCodeLayer = input.shouldRunDeadCode ? DeadCode.layerNode : DeadCode.layerOf([]);
   const scoreLayer = input.shouldComputeScore ? Score.layerHttp : Score.layerOf(null);
+  const projectLayer =
+    input.projectInfoOverride === undefined
+      ? Project.layerNode
+      : Project.layerOf(input.projectInfoOverride);
   const progressLayer = input.shouldShowProgressSpinners
     ? Progress.layerOra(buildSpinnerProgressHandle)
     : Progress.layerNoop;
@@ -114,7 +124,7 @@ export const buildRuntimeLayers = (input: BuildRuntimeLayersInput) => {
     : Config.layerNode;
 
   const baseLayers = Layer.mergeAll(
-    Project.layerNode,
+    projectLayer,
     configLayer,
     Files.layerNode,
     Git.layerNode,

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -32,6 +32,7 @@ import type {
   DiagnosticSurface,
   InspectOptions,
   InspectResult,
+  ProjectInfo,
   ReactDoctorConfig,
   ScoreResult,
 } from "@react-doctor/core";
@@ -249,6 +250,16 @@ interface BaselineComparison {
   baselineDelta: NonNullable<InspectResult["baselineDelta"]>;
 }
 
+interface RunBaselineComparisonInput {
+  directory: string;
+  options: ResolvedInspectOptions;
+  userConfig: ReactDoctorConfig | null;
+  headProjectInfo: ProjectInfo;
+  headDiagnostics: ReadonlyArray<Diagnostic>;
+  resolvedNodeBinaryPath: string | null;
+  baselineRef: string;
+}
+
 /**
  * Runs a second, lint-only scan over the changed files as they existed at the
  * baseline ref (materialized into a temp tree with head's config) and diffs it
@@ -256,14 +267,9 @@ interface BaselineComparison {
  * introduced plus the fixed / base counts. No score, dead-code, progress, or
  * telemetry — it's a pure comparison pass. The temp tree is always cleaned up.
  */
-const runBaselineComparison = async (params: {
-  directory: string;
-  options: ResolvedInspectOptions;
-  userConfig: ReactDoctorConfig | null;
-  headDiagnostics: ReadonlyArray<Diagnostic>;
-  resolvedNodeBinaryPath: string | null;
-  baselineRef: string;
-}): Promise<BaselineComparison | null> => {
+const runBaselineComparison = async (
+  params: RunBaselineComparisonInput,
+): Promise<BaselineComparison | null> => {
   const tempDirectory = mkdtempSync(path.join(tmpdir(), BASELINE_FILES_TEMP_DIR_PREFIX));
   // If materialization throws before the snapshot (and its cleanup) exists,
   // remove the temp dir we just created so it can't leak.
@@ -282,6 +288,7 @@ const runBaselineComparison = async (params: {
       hasConfigOverride: true,
       userConfig: params.userConfig,
       configSourceDirectory: null,
+      projectInfoOverride: params.headProjectInfo,
       shouldSkipLint: !params.options.lint || !params.resolvedNodeBinaryPath,
       shouldRunDeadCode: false,
       shouldComputeScore: false,
@@ -489,6 +496,7 @@ const runInspectWithRuntime = async (
       directory,
       options,
       userConfig,
+      headProjectInfo: output.project,
       headDiagnostics: output.diagnostics,
       resolvedNodeBinaryPath,
       baselineRef: options.baseline.ref,

--- a/packages/react-doctor/tests/inspect.test.ts
+++ b/packages/react-doctor/tests/inspect.test.ts
@@ -4,7 +4,13 @@ import * as path from "node:path";
 import { afterAll, describe, expect, it, vi } from "vite-plus/test";
 import { inspect } from "../src/inspect.js";
 import { clearConfigCache } from "@react-doctor/core";
-import { setupReactProject } from "./regressions/_helpers.js";
+import {
+  commitAll,
+  initGitRepo,
+  setupReactProject,
+  writeFile,
+  writeJson,
+} from "./regressions/_helpers.js";
 
 const FIXTURES_DIRECTORY = path.resolve(
   import.meta.dirname,
@@ -168,6 +174,52 @@ describe("inspect", () => {
     } finally {
       consoleSpy.mockRestore();
       fs.rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses head project metadata for baseline scans of leaf-only pnpm catalog monorepos", async () => {
+    clearConfigCache();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const monorepoDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-catalog-"));
+    try {
+      writeFile(
+        path.join(monorepoDirectory, "pnpm-workspace.yaml"),
+        'packages:\n  - "apps/*"\n\ncatalog:\n  react: ^19.0.0\n',
+      );
+      writeJson(path.join(monorepoDirectory, "package.json"), {
+        name: "monorepo-root",
+        private: true,
+      });
+      writeJson(path.join(monorepoDirectory, "apps", "web", "package.json"), {
+        name: "web",
+        dependencies: { react: "catalog:" },
+      });
+      writeFile(
+        path.join(monorepoDirectory, "apps", "web", "src", "App.tsx"),
+        "export const App = () => <main>Base</main>;\n",
+      );
+      initGitRepo(monorepoDirectory);
+      const baseRef = commitAll(monorepoDirectory, "initial catalog workspace");
+
+      writeFile(
+        path.join(monorepoDirectory, "apps", "web", "src", "App.tsx"),
+        "export const App = () => <main>Head</main>;\n",
+      );
+
+      const result = await inspect(monorepoDirectory, {
+        lint: false,
+        deadCode: false,
+        noScore: true,
+        silent: true,
+        includePaths: ["apps/web/src/App.tsx"],
+        baseline: { ref: baseRef },
+      });
+
+      expect(result.project.reactVersion).toBe("^19.0.0");
+      expect(result.baselineDelta?.baseTotalCount).toBe(0);
+    } finally {
+      consoleSpy.mockRestore();
+      fs.rmSync(monorepoDirectory, { recursive: true, force: true });
     }
   });
 });

--- a/packages/react-doctor/tests/inspect.test.ts
+++ b/packages/react-doctor/tests/inspect.test.ts
@@ -207,7 +207,7 @@ describe("inspect", () => {
       );
 
       const result = await inspect(monorepoDirectory, {
-        lint: false,
+        lint: true,
         deadCode: false,
         noScore: true,
         silent: true,
@@ -216,6 +216,7 @@ describe("inspect", () => {
       });
 
       expect(result.project.reactVersion).toBe("^19.0.0");
+      expect(result.skippedChecks).not.toContain("lint");
       expect(result.baselineDelta?.baseTotalCount).toBe(0);
     } finally {
       consoleSpy.mockRestore();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reuse the head scan's discovered `ProjectInfo` when running the baseline comparison over the materialized temp tree.
- Keep normal scans on `Project.layerNode`; only synthetic baseline scans opt into `Project.layerOf(...)`.
- Add a regression for leaf-only pnpm catalog monorepos where React is declared only in a workspace package, with lint enabled to mirror the reported diff-scan path.

## Verification
- `pnpm exec vp test run packages/react-doctor/tests/inspect.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
- `pnpm build && pnpm smoke:json-report`

## Notes
- `bunx` / Bun was unavailable, so truffler could not run directly; targeted repository searches confirmed the existing `Project.layerOf` hook was reused instead of adding a duplicate project-discovery path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79b37bce-89f3-4591-8b30-e167031bc859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79b37bce-89f3-4591-8b30-e167031bc859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

