### PR TITLE
ci: pin internal actions to commit SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,14 +56,14 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ inputs.node-version }}
         package-manager-cache: false
 
     - id: pr-files
       if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_CHANGED_FILES: ${{ runner.temp }}/react-doctor-changed-files.txt
       with:
@@ -197,7 +197,7 @@ runs:
 
     - name: Update sticky PR comment
       if: ${{ always() && github.event_name == 'pull_request' && inputs.comment == 'true' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_COMMENT_FILE: ${{ steps.render.outputs.comment-file }}
       with:
@@ -236,7 +236,7 @@ runs:
 
     - name: Post inline review comments
       if: ${{ always() && github.event_name == 'pull_request' && inputs.review-comments == 'true' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_REPORT_FILE: ${{ steps.scan.outputs.report-file }}
         INPUT_DIRECTORY: ${{ inputs.directory }}
@@ -397,7 +397,7 @@ runs:
 
     - name: Publish commit status
       if: ${{ always() && inputs.commit-status == 'true' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_SCORE: ${{ steps.render.outputs.score }}
         REACT_DOCTOR_ERROR_COUNT: ${{ steps.render.outputs.error-count }}


### PR DESCRIPTION
Pin actions/setup-node and actions/github-script (referenced inside the composite action) to full-length commit SHAs, keeping the version tag as a trailing comment so they stay readable and Dependabot-updatable.

Why: many orgs enforce GitHub's "require actions pinned to a full-length commit SHA" ruleset (sha_pinning_required). That rule applies transitively to actions referenced *inside* a composite action. Because action.yml references setup-node@v5 and github-script@v8 by floating tag, the whole action is rejected by such policies before it ever runs -- so consumers on SHA-pinning orgs cannot use millionco/react-doctor@v2 at all. Pinning the internal refs makes the action consumable under those policies with no change in behaviour.

Generated-By: PostHog Code
Task-Id: ac09988a-6c71-4856-87d6-32b9e44b7684

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Supply-chain hardening only; no runtime logic or inputs change beyond resolving the same action versions by immutable SHA.
> 
> **Overview**
> Pins **transitive** third-party steps inside the composite `action.yml` so orgs with **SHA pinning required** can use the action without policy rejection.
> 
> **`actions/setup-node`** is now `actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5` (was `@v5`). **`actions/github-script`** is now `actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8` in all four composite steps that call it (PR changed-files, sticky comment, inline review comments, commit status). Step inputs and scripts are unchanged; only the `uses` refs are hardened. Version comments after the SHAs keep the pins readable and Dependabot-friendly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330072077156ffbbdf4bceff2b39362a824f3ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->