### PR TITLE
ci: pin internal actions to commit SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,14 +56,14 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ inputs.node-version }}
         package-manager-cache: false
 
     - id: pr-files
       if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_CHANGED_FILES: ${{ runner.temp }}/react-doctor-changed-files.txt
       with:
@@ -197,7 +197,7 @@ runs:
 
     - name: Update sticky PR comment
       if: ${{ always() && github.event_name == 'pull_request' && inputs.comment == 'true' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_COMMENT_FILE: ${{ steps.render.outputs.comment-file }}
       with:
@@ -236,7 +236,7 @@ runs:
 
     - name: Post inline review comments
       if: ${{ always() && github.event_name == 'pull_request' && inputs.review-comments == 'true' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_REPORT_FILE: ${{ steps.scan.outputs.report-file }}
         INPUT_DIRECTORY: ${{ inputs.directory }}
@@ -397,7 +397,7 @@ runs:
 
     - name: Publish commit status
       if: ${{ always() && inputs.commit-status == 'true' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_SCORE: ${{ steps.render.outputs.score }}
         REACT_DOCTOR_ERROR_COUNT: ${{ steps.render.outputs.error-count }}

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -68,8 +68,14 @@ describe("GitHub Action contract", () => {
     const actionYaml = readActionYaml();
     const prFilesStep = normalizeWhitespace(extractStep(actionYaml, "- id: pr-files"));
 
-    expect(actionYaml).toContain("actions/setup-node@v5");
-    expect(actionYaml).toContain("actions/github-script@v8");
+    // setup-node/github-script may be referenced by a floating major tag
+    // (v5/v8) or pinned to a full-length commit SHA with a trailing version
+    // comment — the form required by orgs that enforce GitHub's "actions pinned
+    // to a full-length commit SHA" ruleset. Accept either so the composite
+    // action stays consumable under those policies (and Dependabot can still
+    // bump the pinned SHA), while keeping the major-version floor.
+    expect(actionYaml).toMatch(/actions\/setup-node@(?:v5\b|[0-9a-f]{40} # v5\b)/);
+    expect(actionYaml).toMatch(/actions\/github-script@(?:v8\b|[0-9a-f]{40} # v8\b)/);
     expect(actionYaml).not.toContain("actions/setup-node@v4");
     expect(actionYaml).not.toContain("actions/github-script@v7");
     expect(prFilesStep).toContain("github.rest.pulls.listFiles");


### PR DESCRIPTION
## Summary

Supersedes #751 (whose CI was red). Pins the composite action's transitive third-party steps to full-length commit SHAs so the action is consumable under orgs that enforce GitHub's `sha_pinning_required` ruleset — **plus** the `github-action` contract-test fix that #751 was missing.

- **Carries the original pinning commit from #751 unchanged** (authored by `@pauldambra`): `actions/setup-node` and the four `actions/github-script` steps are pinned to SHAs with a trailing `# v5` / `# v8` version comment.
- **Adds the missing test fix.** The contract test asserted the literal floating tags (`actions/setup-node@v5`, `actions/github-script@v8`), which no longer exist after pinning, so every `test (...)` matrix job failed on `tests/github-action.test.ts`. The assertions now accept **either** a floating major tag **or** a SHA-pin (via regex), keeping the major-version floor (`not v4` / `not v7`) and staying Dependabot-friendly.

## Why a new PR instead of pushing to #751

#751's branch lives on the `pauldambra/react-doctor` fork with "Allow edits by maintainers" disabled, so the contract-test fix couldn't be pushed onto that branch.

## Test plan

- [x] Contract-test assertions verified against the SHA-pinned `action.yml` and the floating form on `main`.
- [ ] CI `test (...)` matrix green on this branch.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Supply-chain pinning and test-only contract changes; no runtime scan or CLI behavior changes.
> 
> **Overview**
> Pins the composite action’s third-party steps from floating major tags (`@v5` / `@v8`) to **full commit SHAs** with trailing `# v5` / `# v8` comments on `actions/setup-node` and all four `actions/github-script` steps, so consumers can satisfy GitHub org rules that require `sha_pinning_required`.
> 
> Updates the **GitHub Action contract test** in `github-action.test.ts`: it no longer requires the literal `@v5` / `@v8` strings. Regex assertions accept **either** a major tag **or** a 40-char SHA pin (still rejecting `@v4` / `@v7`), so CI passes after pinning while remaining compatible with unpinned `main` and Dependabot SHA bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b102bebfd196bf655b55f83203658bc8cc4a533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->