### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,6 +387,53 @@ git push --force origin v1   # the force applies to the moving major tag only
   full commit-SHA pin with a trailing version comment for hardened CI
   (`uses: millionco/react-doctor@<sha> # v1.1.1`), or `@vN` for convenience.
 
+## Cursor Cloud specific instructions
+
+This is a **pnpm + Turborepo monorepo** with no databases or Docker services. The primary product is the `react-doctor` CLI; development is install → build → run CLI/tests on Node.
+
+### Node.js version (important)
+
+`package.json` requires `^20.19.0 || >=22.12.0`, but `vp lint` loads `vite.config.ts` via native TypeScript and needs **Node `^20.19.0` or `>=22.18.0`**. Cloud VMs may ship `/exec-daemon/node` at v22.14.0, which breaks `pnpm lint`. Use nvm Node **v22.22.2** (or any `>=22.18.0`):
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"
+node --version   # must be >=22.18.0 (or ^20.19.0)
+```
+
+### No background services
+
+Nothing needs to stay running. After `pnpm build`, the CLI, tests, and LSP all run in-process.
+
+| Goal | Command |
+|---|---|
+| Install deps | `pnpm install` (or `ni`) |
+| Build all packages | `pnpm build` |
+| Watch-build CLI only | `pnpm dev` |
+| Tests | `pnpm test` |
+| Lint / typecheck | `pnpm lint` / `pnpm typecheck` |
+| JSON smoke test | `pnpm smoke:json-report` (requires prior `pnpm build`) |
+| Docs site dev | `nr dev --filter website` (optional) |
+
+### Hello-world CLI scan
+
+Scan the in-repo fixture (intentionally has diagnostics; exit code 1 is expected):
+
+```bash
+pnpm build
+node packages/react-doctor/bin/react-doctor.js \
+  packages/core/tests/fixtures/basic-react \
+  --no-telemetry
+```
+
+Use `--json` for machine-readable output. Add `--no-score` to skip the hosted score API.
+
+### Optional components
+
+- **Website** (`packages/website`): `nr dev --filter website` — only when editing docs.
+- **VS Code extension**: `nr dev --filter vscode-react-doctor` — editor launches LSP separately.
+- **Hosted score API** (`https://www.react.doctor/api/score`): optional; scans work without it.
+- **Sentry telemetry**: disabled with `--no-telemetry` or `REACT_DOCTOR_NO_TELEMETRY=1`.
+
 ## Reference reading
 
 - `tmp/effect/.patterns/effect.md` — canonical Effect v4 idioms (cloned for reference,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,44 @@ Use `--json` for machine-readable output. Add `--no-score` to skip the hosted sc
 - **Hosted score API** (`https://www.react.doctor/api/score`): optional; scans work without it.
 - **Sentry telemetry**: disabled with `--no-telemetry` or `REACT_DOCTOR_NO_TELEMETRY=1`.
 
+### react-doctor-evals (RDE) — sibling eval harness
+
+**Required for rule research/validation workflows**, not for core CLI development. This repo is the canonical Effect v4 application that `react-doctor` core patterns were modeled on (`Runner.ts`, `Worker.ts`, `Schemas.ts`).
+
+**Checkout layout** (match local Million dev machines):
+
+| Repo | Path |
+|---|---|
+| `millionco/react-doctor` | `/workspace` (Cloud Agent workspace) |
+| `millionco/react-doctor-evals` | `~/Developer/react-doctor-evals` |
+
+Clone (private repo — Cloud Agent needs read access):
+
+```bash
+mkdir -p ~/Developer
+git clone https://github.com/millionco/react-doctor-evals.git ~/Developer/react-doctor-evals
+cd ~/Developer/react-doctor-evals
+pnpm install
+pnpm build   # if the repo defines a build script
+```
+
+**What RDE is for** (see `docs/HOW_TO_WRITE_A_RULE.md` and `.agents/skills/rule-validate/`):
+
+- **Parity checks** against `react-doctor` JSON/diagnostic output (complements `pnpm smoke:json-report`, which only validates schema shape).
+- **OSS rule validation**: scan many repos from `repos.json`, filter to a target rule, manually inspect hits for false positives.
+- **Idea validation** before implementing broad/heuristic rules.
+
+**Typical workflow after both repos are built:**
+
+1. Implement or change a rule in `react-doctor`.
+2. Run targeted unit tests in `packages/oxlint-plugin-react-doctor`.
+3. Use RDE to scan OSS repos and filter diagnostics to the target rule.
+4. Record eval results in PR descriptions (repos scanned, rootDir count, false positives).
+
+RDE may point at a local `react-doctor` checkout (workspace path `/workspace` in Cloud Agents). If RDE exposes env vars for the checkout path, set them to `/workspace` rather than `~/Developer/react-doctor`.
+
+**Sandbox note:** RDE can override oxlint timeouts via `REACT_DOCTOR_OXLINT_SPAWN_TIMEOUT_MS` when running under slow sandbox microVMs (see `packages/core/src/refs.ts`).
+
 ## Reference reading
 
 - `tmp/effect/.patterns/effect.md` — canonical Effect v4 idioms (cloned for reference,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,15 +404,15 @@ node --version   # must be >=22.18.0 (or ^20.19.0)
 
 Nothing needs to stay running. After `pnpm build`, the CLI, tests, and LSP all run in-process.
 
-| Goal | Command |
-|---|---|
-| Install deps | `pnpm install` (or `ni`) |
-| Build all packages | `pnpm build` |
-| Watch-build CLI only | `pnpm dev` |
-| Tests | `pnpm test` |
-| Lint / typecheck | `pnpm lint` / `pnpm typecheck` |
-| JSON smoke test | `pnpm smoke:json-report` (requires prior `pnpm build`) |
-| Docs site dev | `nr dev --filter website` (optional) |
+| Goal                 | Command                                                |
+| -------------------- | ------------------------------------------------------ |
+| Install deps         | `pnpm install` (or `ni`)                               |
+| Build all packages   | `pnpm build`                                           |
+| Watch-build CLI only | `pnpm dev`                                             |
+| Tests                | `pnpm test`                                            |
+| Lint / typecheck     | `pnpm lint` / `pnpm typecheck`                         |
+| JSON smoke test      | `pnpm smoke:json-report` (requires prior `pnpm build`) |
+| Docs site dev        | `nr dev --filter website` (optional)                   |
 
 ### Hello-world CLI scan
 
@@ -440,10 +440,10 @@ Use `--json` for machine-readable output. Add `--no-score` to skip the hosted sc
 
 **Checkout layout** (match local Million dev machines):
 
-| Repo | Path |
-|---|---|
-| `millionco/react-doctor` | `/workspace` (Cloud Agent workspace) |
-| `millionco/react-doctor-evals` | `~/Developer/react-doctor-evals` |
+| Repo                           | Path                                 |
+| ------------------------------ | ------------------------------------ |
+| `millionco/react-doctor`       | `/workspace` (Cloud Agent workspace) |
+| `millionco/react-doctor-evals` | `~/Developer/react-doctor-evals`     |
 
 Clone (private repo — Cloud Agent needs read access):
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting:

- Node.js version requirement (`>=22.18.0` for `vp lint` / TypeScript config loading)
- nvm PATH workaround for Cloud VM `/exec-daemon/node` (v22.14.0)
- Core dev commands (install, build, test, lint, smoke)
- Hello-world CLI scan against the `basic-react` fixture
- **react-doctor-evals (RDE)** sibling checkout at `~/Developer/react-doctor-evals`, clone/install steps, and when to use it for rule validation
- Optional components (website, extension, score API, telemetry)

VM update script also clones/installs `millionco/react-doctor-evals` when the Cloud Agent has repo access.

No runtime code changes — environment setup documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccf47c45-1e8f-4abb-969b-f38580f9c1ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccf47c45-1e8f-4abb-969b-f38580f9c1ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

