### PR TITLE
fix: gate the Socket supply-chain check on security axes, not the overall score

### DIFF
--- a/.changeset/supply-chain-gate-security-axes.md
+++ b/.changeset/supply-chain-gate-security-axes.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+The Socket supply-chain check now gates on the security axes (supply chain, vulnerability) instead of Socket's `overall` score, and the diagnostic names the exact axis that failed. Socket's `overall` is its lowest axis, so a package with perfect security scores could fail the Security gate purely on quality/maintenance — `@types/bun` was reported as having a "supply-chain score of 48" while socket.dev showed Supply Chain 100 (issue #770). Known-bad packages (`event-stream@3.3.6`, vulnerable `minimist`/`lodash` releases) are still flagged via their vulnerability axis, and the reported number now always matches the axis named on the socket.dev package page.

--- a/packages/core/src/check-supply-chain.ts
+++ b/packages/core/src/check-supply-chain.ts
@@ -65,15 +65,41 @@ type SocketScore = Schema.Schema.Type<typeof SocketScoreSchema>;
 
 const decodeArtifact = Schema.decodeUnknownOption(SocketArtifactSchema);
 
+interface ScoreAxis {
+  readonly key: keyof SocketScore;
+  readonly label: string;
+  /** Whether a low value on this axis fails the check (see GATED_AXES). */
+  readonly gates: boolean;
+}
+
 // The non-`overall` axes, paired with the label shown in the diagnostic so a
 // developer immediately sees which dimension dragged the score down.
-const SCORE_AXES: ReadonlyArray<{ readonly key: keyof SocketScore; readonly label: string }> = [
-  { key: "supplyChain", label: "supply chain" },
-  { key: "vulnerability", label: "vulnerability" },
-  { key: "maintenance", label: "maintenance" },
-  { key: "quality", label: "quality" },
-  { key: "license", label: "license" },
+const SCORE_AXES: ReadonlyArray<ScoreAxis> = [
+  { key: "supplyChain", label: "supply chain", gates: true },
+  { key: "vulnerability", label: "vulnerability", gates: true },
+  { key: "maintenance", label: "maintenance", gates: false },
+  { key: "quality", label: "quality", gates: false },
+  { key: "license", label: "license", gates: false },
 ];
+
+// Only the security axes decide the gate. Socket's `overall` is its lowest
+// axis, so gating on it let a pure quality/maintenance dip fail this
+// Security-category check — e.g. `@types/bun@1.3.14` scores quality 48 with
+// every security axis at 100 (issue #770). `supplyChain` covers typosquats /
+// install scripts / compromised maintainers; `vulnerability` covers known
+// CVEs (what flags the compromised `event-stream@3.3.6`). The remaining axes
+// still appear in the diagnostic's axis breakdown as context.
+const GATED_AXES: ReadonlyArray<ScoreAxis> = SCORE_AXES.filter((axis) => axis.gates);
+
+// The axis that decides the gate for one score: the lowest of the gated
+// axes. A tie keeps `supplyChain`, matching the rule's name.
+const worstGatedAxis = (score: SocketScore): ScoreAxis => {
+  let worst = GATED_AXES[0];
+  for (const axis of GATED_AXES) {
+    if (score[axis.key] < score[worst.key]) worst = axis;
+  }
+  return worst;
+};
 
 const clampScore = (value: number): number => {
   if (!Number.isFinite(value)) return SUPPLY_CHAIN_DEFAULT_MIN_SCORE;
@@ -320,16 +346,20 @@ const formatAxisScores = (score: SocketScore): string =>
 const buildLowScoreDiagnostic = (
   dependency: DependencyToScore,
   score: SocketScore,
+  failingAxis: ScoreAxis,
   options: ResolvedSupplyChainOptions,
 ): Diagnostic => {
-  const overall = toHundred(score.overall);
   const packagePageUrl = `${SOCKET_PACKAGE_PAGE_BASE}/${dependency.name}/overview/${dependency.version}`;
   return {
     filePath: "package.json",
     plugin: SUPPLY_CHAIN_PLUGIN,
     rule: SUPPLY_CHAIN_RULE,
     severity: options.severity,
-    message: `\`${dependency.name}\` (declared in package.json as "${dependency.spec}", scored at ${dependency.version}) has a Socket supply-chain score of ${overall}/${SOCKET_SCORE_SCALE} (below the minimum of ${options.minScore}). Axis scores — ${formatAxisScores(score)}.`,
+    // Name the exact axis that failed so the number matches what the user
+    // sees on the socket.dev package page (issue #770: calling `overall` a
+    // "supply-chain score" read as a false positive when the supplyChain
+    // axis itself was 100).
+    message: `\`${dependency.name}\` (declared in package.json as "${dependency.spec}", scored at ${dependency.version}) has a Socket ${failingAxis.label} score of ${toHundred(score[failingAxis.key])}/${SOCKET_SCORE_SCALE} (below the minimum of ${options.minScore}). Axis scores — ${formatAxisScores(score)}.`,
     help: `Update or replace the \`"${dependency.name}": "${dependency.spec}"\` entry in package.json. Review ${dependency.name} on Socket: ${packagePageUrl}. Or raise \`supplyChain.minScore\` if you have vetted and accepted this package.`,
     url: packagePageUrl,
     // Anchor to the dependency's declaration so the CLI / editor points at the
@@ -388,7 +418,9 @@ export const collectSupplyChainScores = (
  * Scores every direct dependency in the project's `package.json` against
  * Socket.dev's free PURL endpoint (the same one Socket Firewall's free tier
  * uses — no API key) and returns a diagnostic for each dependency whose
- * Socket `overall` score is below the configured `minScore`.
+ * worst Socket *security* axis — supply chain or vulnerability — is below
+ * the configured `minScore`. The quality / maintenance / license axes are
+ * reported as context but never gate (see GATED_AXES).
  *
  * Lookups run with bounded concurrency via `Effect.forEach`. The check is
  * total/fail-open: each per-package lookup already recovers to `null`
@@ -416,8 +448,9 @@ export const checkSupplyChain = (input: SupplyChainCheckInput): Effect.Effect<Di
     for (let index = 0; index < dependencies.length; index += 1) {
       const score = scores[index];
       if (!score) continue;
-      if (toHundred(score.overall) >= options.minScore) continue;
-      diagnostics.push(buildLowScoreDiagnostic(dependencies[index], score, options));
+      const worstAxis = worstGatedAxis(score);
+      if (toHundred(score[worstAxis.key]) >= options.minScore) continue;
+      diagnostics.push(buildLowScoreDiagnostic(dependencies[index], score, worstAxis, options));
     }
     return diagnostics;
   });

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -434,10 +434,11 @@ export const SUPPLY_CHAIN_PLUGIN = "socket";
 export const SUPPLY_CHAIN_RULE = "low-supply-chain-score";
 export const SUPPLY_CHAIN_CATEGORY = "Security";
 
-// Default minimum acceptable Socket score (0..100). A dependency scoring
-// below this fails the check. Tuned to Socket's own "needs review" band —
-// most healthy, widely-used packages sit comfortably above it. Overridable
-// per project via `supplyChain.minScore`.
+// Default minimum acceptable Socket score (0..100), applied to the security
+// axes (supply chain, vulnerability) — a dependency whose worst security
+// axis scores below this fails the check. Tuned to Socket's own "needs
+// review" band — most healthy, widely-used packages sit comfortably above
+// it. Overridable per project via `supplyChain.minScore`.
 export const SUPPLY_CHAIN_DEFAULT_MIN_SCORE = 50;
 
 // Socket scores arrive normalized 0..1; multiply by this to present the

--- a/packages/core/src/services/supply-chain.ts
+++ b/packages/core/src/services/supply-chain.ts
@@ -14,7 +14,8 @@ interface SupplyChainInput {
  * `SupplyChain` scores the project's direct dependencies against Socket.dev's
  * free, keyless PURL endpoint — the same lookup Socket Firewall's free tier
  * (`sfw`) performs — and streams a diagnostic for each dependency whose
- * Socket score falls below the configured `supplyChain.minScore`.
+ * worst Socket security axis (supply chain or vulnerability) falls below
+ * the configured `supplyChain.minScore`.
  *
  * Runs by default (one network request per dependency); the orchestrator
  * provides `layerOf([])` only when the user opts out via

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -141,11 +141,11 @@ export interface SurfaceControls {
  *
  * Mirrors how Socket Firewall's free tier (`sfw`) works: each direct
  * dependency's PURL is looked up against Socket's keyless
- * `firewall-api.socket.dev/purl/<purl>` endpoint, which returns a
- * supply-chain score (0–100 once normalized). A dependency scoring below
- * `minScore` produces a diagnostic; at the default `severity: "error"` it
- * fails the scan (non-zero CI exit), the same way an error-severity lint
- * finding does.
+ * `firewall-api.socket.dev/purl/<purl>` endpoint, which returns per-axis
+ * scores (0–100 once normalized). A dependency whose worst security axis
+ * (supply chain or vulnerability) scores below `minScore` produces a
+ * diagnostic; at the default `severity: "error"` it fails the scan
+ * (non-zero CI exit), the same way an error-severity lint finding does.
  */
 export interface SupplyChainConfig {
   /**
@@ -157,8 +157,9 @@ export interface SupplyChainConfig {
   enabled?: boolean;
   /**
    * Minimum acceptable Socket score on a 0–100 scale. A direct dependency
-   * whose Socket `overall` score is below this is flagged. Default: `50`.
-   * Values outside `0..100` are clamped.
+   * whose worst Socket *security* axis — supply chain or vulnerability — is
+   * below this is flagged; the quality / maintenance / license axes never
+   * gate. Default: `50`. Values outside `0..100` are clamped.
    */
   minScore?: number;
   /**

--- a/packages/core/tests/check-supply-chain.test.ts
+++ b/packages/core/tests/check-supply-chain.test.ts
@@ -1,0 +1,149 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { checkSupplyChain } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
+
+// Per-axis Socket scores in the API's normalized 0..1 range. `overall` is
+// Socket's lowest axis, mirroring how the real endpoint computes it.
+interface AxisScores {
+  readonly supplyChain: number;
+  readonly vulnerability: number;
+  readonly maintenance: number;
+  readonly quality: number;
+  readonly license: number;
+}
+
+const socketArtifactLine = (axes: AxisScores): string =>
+  JSON.stringify({
+    id: "test-artifact",
+    type: "npm",
+    score: { ...axes, overall: Math.min(...Object.values(axes)) },
+  });
+
+// Stubs the free Socket PURL endpoint with one canned artifact per package
+// name (the NDJSON body shape the real endpoint streams).
+const stubSocketApi = (scoresByPackageName: Record<string, AxisScores>): void => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const requestUrl = decodeURIComponent(String(input));
+      const matched = Object.entries(scoresByPackageName).find(([name]) =>
+        requestUrl.includes(`pkg:npm/${name}@`),
+      );
+      const body = matched ? socketArtifactLine(matched[1]) : "";
+      return new Response(body, { status: 200 });
+    }),
+  );
+};
+
+let projectDirectory: string;
+
+const writePackageJson = (dependencies: Record<string, string>): void => {
+  fs.writeFileSync(
+    path.join(projectDirectory, "package.json"),
+    `${JSON.stringify({ name: "fixture", version: "1.0.0", dependencies }, null, 2)}\n`,
+  );
+};
+
+const runCheck = async (): Promise<Diagnostic[]> =>
+  Effect.runPromise(checkSupplyChain({ rootDirectory: projectDirectory, userConfig: null }));
+
+describe("checkSupplyChain — security-axis gating", () => {
+  beforeEach(() => {
+    projectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-supply-chain-"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    fs.rmSync(projectDirectory, { recursive: true, force: true });
+  });
+
+  it("does not flag a package whose security axes are healthy but quality drags `overall` below the minimum (issue #770, @types/bun)", async () => {
+    writePackageJson({ "@types/bun": "^1.3.14" });
+    stubSocketApi({
+      "@types/bun": {
+        supplyChain: 1,
+        vulnerability: 1,
+        maintenance: 0.92,
+        quality: 0.48,
+        license: 1,
+      },
+    });
+
+    expect(await runCheck()).toEqual([]);
+  });
+
+  it("flags a vulnerability-driven low score and names the vulnerability axis (event-stream@3.3.6 shape)", async () => {
+    writePackageJson({ "event-stream": "3.3.6" });
+    stubSocketApi({
+      "event-stream": {
+        supplyChain: 1,
+        vulnerability: 0.25,
+        maintenance: 1,
+        quality: 1,
+        license: 1,
+      },
+    });
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].rule).toBe("low-supply-chain-score");
+    expect(diagnostics[0].message).toContain("has a Socket vulnerability score of 25/100");
+    expect(diagnostics[0].message).not.toContain("supply chain score of 25");
+    // The full axis breakdown stays in the message as context.
+    expect(diagnostics[0].message).toContain("supply chain 100, vulnerability 25");
+  });
+
+  it("flags a supplyChain-driven low score and names the supply chain axis", async () => {
+    writePackageJson({ "evil-typosquat": "1.0.0" });
+    stubSocketApi({
+      "evil-typosquat": {
+        supplyChain: 0.2,
+        vulnerability: 1,
+        maintenance: 1,
+        quality: 1,
+        license: 1,
+      },
+    });
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("has a Socket supply chain score of 20/100");
+  });
+
+  it("headlines the worst security axis when both gate below the minimum", async () => {
+    writePackageJson({ "doubly-bad": "2.0.0" });
+    stubSocketApi({
+      "doubly-bad": {
+        supplyChain: 0.4,
+        vulnerability: 0.1,
+        maintenance: 1,
+        quality: 1,
+        license: 1,
+      },
+    });
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("has a Socket vulnerability score of 10/100");
+  });
+
+  it("does not flag a security axis exactly at the minimum score", async () => {
+    writePackageJson({ "borderline-pkg": "1.0.0" });
+    stubSocketApi({
+      "borderline-pkg": {
+        supplyChain: 0.5,
+        vulnerability: 1,
+        maintenance: 0.1,
+        quality: 0.1,
+        license: 0.1,
+      },
+    });
+
+    expect(await runCheck()).toEqual([]);
+  });
+});

--- a/packages/website/public/schema/config.json
+++ b/packages/website/public/schema/config.json
@@ -48,6 +48,10 @@
         "lint": {
           "type": "boolean"
         },
+        "supplyChain": {
+          "$ref": "#/definitions/SupplyChainConfig",
+          "description": "Socket.dev supply-chain score gate. Runs by default; set `supplyChain: { enabled: false }` to opt out. See  {@link  SupplyChainConfig } . Every direct dependency is scored against Socket's free PURL endpoint and a low score fails the scan (at the default `severity: \"error\"`)."
+        },
         "deadCode": {
           "type": "boolean",
           "description": "Whether to run dead-code analysis (via `deslop-js`) alongside lint. Reports unused files, unused exports, unused dependencies, and circular imports under the \"Maintainability\" category. Default: `true`. Always skipped in `--diff` / `--staged` modes because reachability is a whole-project property."
@@ -183,6 +187,33 @@
         "files"
       ],
       "additionalProperties": false
+    },
+    "SupplyChainConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to run the Socket supply-chain score check. Default: `true`. Set to `false` to opt out — the check performs one network request per direct dependency. It is always skipped in `--diff` / `--staged` mode and in editor scans regardless of this setting."
+        },
+        "minScore": {
+          "type": "number",
+          "description": "Minimum acceptable Socket score on a 0–100 scale. A direct dependency whose worst Socket *security* axis — supply chain or vulnerability — is below this is flagged; the quality / maintenance / license axes never gate. Default: `50`. Values outside `0..100` are clamped."
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning"
+          ],
+          "description": "Severity for a below-threshold dependency. `\"error\"` (default) fails the scan at the standard `blocking: \"error\"` gate; `\"warning\"` keeps the finding advisory."
+        },
+        "includeDevDependencies": {
+          "type": "boolean",
+          "description": "Whether to score `devDependencies` in addition to `dependencies`. Default: `true`."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Configuration for the Socket.dev supply-chain score check (the `SupplyChain` service). Runs by default; set `enabled: false` to opt out (it performs one network request per direct dependency).\n\nMirrors how Socket Firewall's free tier (`sfw`) works: each direct dependency's PURL is looked up against Socket's keyless `firewall-api.socket.dev/purl/<purl>` endpoint, which returns per-axis scores (0–100 once normalized). A dependency whose worst security axis (supply chain or vulnerability) scores below `minScore` produces a diagnostic; at the default `severity: \"error\"` it fails the scan (non-zero CI exit), the same way an error-severity lint finding does."
     },
     "BlockingLevel": {
       "type": "string",


### PR DESCRIPTION
## Why

Catches a false positive in the Socket supply-chain gate. Closes #770.

Socket's `overall` score is the *minimum* of its five axes, and the check gated on it while the diagnostic called the number a "supply-chain score". A package whose security axes are perfect could fail the Security gate purely on code quality — and the message pointed users at the wrong metric.

Before (for `@types/bun@1.3.14`, whose Socket page shows Supply Chain 100 / Vulnerability 100 / Quality 49):

```text
error socket/low-supply-chain-score
`@types/bun` … has a Socket supply-chain score of 48/100 (below the minimum of 50). …
```

After: `@types/bun` passes (no diagnostic), while genuinely risky packages still fail and the message names the exact axis that failed:

```text
error socket/low-supply-chain-score
`event-stream` (declared in package.json as "3.3.6", scored at 3.3.6) has a Socket vulnerability score of 25/100 (below the minimum of 50). Axis scores — supply chain 100, vulnerability 25, maintenance 100, quality 100, license 100.
```

## What changed

- `checkSupplyChain` now gates on the worst *security* axis — `supplyChain` (typosquats, install scripts, compromised maintainers) and `vulnerability` (known CVEs) — instead of Socket's `overall`. Quality / maintenance / license still appear in the axis breakdown but never gate.
- The diagnostic headline names the failing axis, so the reported number always matches what the user sees on the socket.dev package page.
- Rule id (`socket/low-supply-chain-score`), config keys, and severity semantics are unchanged, so existing configs keep working. The `--sfw` listing still shows Socket's `overall`, mirroring socket.dev's own package score.
- Regenerated `packages/website/public/schema/config.json` — it was missing the whole `supplyChain` section since #747; it now carries the corrected `minScore` description.
- Added `packages/core/tests/check-supply-chain.test.ts` (stubbed fetch): the issue's `@types/bun` shape passes; vulnerability-driven and supplyChain-driven failures fire with the right axis named; worst-axis headline when both fail; exact-minimum boundary passes.

## Eval results

RDE was not run — this is a dependency-metadata check, not a lint rule, so there is no AST surface to eval. Validated instead against the live Socket API: `@types/bun@1.3.14` (overall 48, security axes 100) no longer flagged; `event-stream@3.3.6`, `minimist@1.2.0`, and `lodash@4.17.4` all still flagged via their vulnerability axis.

## Test plan

- `pnpm --filter @react-doctor/core vp test run tests/check-supply-chain.test.ts` — 5/5 pass
- `nr test` — all packages pass except one pre-existing, environment-specific failure in `check-expo-project.test.ts` that also fails on a clean checkout of `main` on this machine (unrelated to this change)
- `nr typecheck` — 11/11
- `nr lint`, `nr format:check` — clean
- `nr smoke:json-report` — OK

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which dependencies fail CI Security checks (fewer false positives, same config keys); behavior shift is intentional but affects default scan outcomes for projects with low quality/maintenance scores.
> 
> **Overview**
> Fixes false positives in the Socket **Security** supply-chain gate (#770) by no longer using Socket's `overall` score (the minimum of all axes) to pass or fail dependencies.
> 
> **Gating** now uses only the worst of **supply chain** and **vulnerability** against `supplyChain.minScore`; quality, maintenance, and license still appear in the axis breakdown but never block the scan. Packages like `@types/bun` with perfect security scores but low quality no longer fail.
> 
> **Diagnostics** headline the axis that actually failed (e.g. "Socket vulnerability score of 25/100") so the number matches socket.dev. Rule id, config keys, and `--sfw` overall display are unchanged.
> 
> Adds `check-supply-chain.test.ts` (stubbed fetch) and restores **`supplyChain`** in the public config JSON schema with updated `minScore` docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9bf282d2e7138cc8d8561c379277b225ec4bcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->