### PR TITLE
fix(only-export-components): skip framework route/special files (#776)

### DIFF
--- a/.changeset/only-export-components-framework-route-files.md
+++ b/.changeset/only-export-components-framework-route-files.md
@@ -1,0 +1,10 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`only-export-components` now recognizes the route/special files of every file-routing framework react-doctor covers and skips them, so the documented "co-export config/metadata next to the default component" shape stops producing false-positive "non-component export" warnings:
+
+- **Next.js** — App Router (`page`, `layout`, `loading`, `error`, `not-found`, `template`, `default`, `global-error`, `route`) and Pages Router (`_app`, `_document`, `_error`) special files, plus metadata image routes (`opengraph-image`, `twitter-image`, `icon`, `apple-icon`, incl. numbered variants), which fixes the `alt` / `size` / `contentType` / `revalidate` exports in `opengraph-image.tsx` ([#776](https://github.com/millionco/react-doctor/issues/776)).
+- **Expo Router** — `_layout` and the `+html` / `+not-found` / `+native-intent` reserved files.
+- **TanStack Router / Start** — `__root` and `*.lazy` route modules.
+- **Remix / React Router** — `root`, `entry.client`, and `entry.server` modules.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components-tables.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components-tables.ts
@@ -52,6 +52,12 @@ export const NON_FAST_REFRESH_PATH_SEGMENTS: ReadonlyArray<string> = [
 // `ReactDOM.render(...)` once and never participate in Fast Refresh
 // (the dev server reloads the whole page when these change). Mixed
 // exports and local components in these files are fine.
+//
+// This set holds only the *generic* (framework-agnostic) entry-point
+// names. Framework-specific route / special files (Next.js, Expo Router,
+// TanStack Router, Remix / React Router) are detected by the dedicated
+// `is-<framework>-*-filename` helpers in `../../utils/`, which
+// `only-export-components` consults alongside this set.
 export const ENTRY_POINT_BASENAMES: ReadonlySet<string> = new Set([
   "main.tsx",
   "main.jsx",
@@ -66,38 +72,6 @@ export const ENTRY_POINT_BASENAMES: ReadonlySet<string> = new Set([
   "client.jsx",
   "server.tsx",
   "server.jsx",
-  // Next.js App Router page boundaries — re-rendered on full reload,
-  // commonly co-export `metadata`, `generateMetadata`, `revalidate`,
-  // etc. alongside the page component.
-  "page.tsx",
-  "page.jsx",
-  "layout.tsx",
-  "layout.jsx",
-  "loading.tsx",
-  "loading.jsx",
-  "error.tsx",
-  "error.jsx",
-  "not-found.tsx",
-  "not-found.jsx",
-  "template.tsx",
-  "template.jsx",
-  "default.tsx",
-  "default.jsx",
-  "global-error.tsx",
-  "global-error.jsx",
-  "route.tsx",
-  "route.jsx",
-  // Expo Router layout files — same role as Next.js `layout.tsx` but
-  // prefixed with `_` per Expo Router convention.
-  "_layout.tsx",
-  "_layout.jsx",
-  // Next.js Pages Router special files
-  "_app.tsx",
-  "_app.jsx",
-  "_document.tsx",
-  "_document.jsx",
-  "_error.tsx",
-  "_error.jsx",
   // Root App component — by convention the single-render root of a CRA
   // / Vite / Expo app, mounted directly from main/index. Co-exports of
   // helper components and constants are conventional here.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -143,6 +143,80 @@ describe("react-builtins/only-export-components — regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  // Framework route/special files are skipped via
+  // `isFrameworkRouteOrSpecialFilename`: their bundler plugins own HMR
+  // and they co-export documented config/metadata next to the default
+  // component. Each case co-exports a non-component value an ordinary
+  // component file WOULD be flagged for, proving the skip is wired in.
+  // The Next.js metadata-image cases are issue #776 (the `size` object
+  // export was the original false positive).
+  it.each([
+    [
+      "Next.js opengraph-image metadata (#776)",
+      "src/app/opengraph-image.tsx",
+      `import { ImageResponse } from "next/og";
+       export const alt = "Open Source Showcase";
+       export const size = { width: 1200, height: 630 };
+       export const contentType = "image/png";
+       export const revalidate = 86400;
+       export default function Image() {
+         return new ImageResponse(<div>OG</div>, { ...size });
+       }`,
+    ],
+    [
+      "Next.js twitter-image metadata (#776)",
+      "app/about/twitter-image.tsx",
+      `export const size = { width: 1200, height: 630 };
+       export default function Image() {
+         return <div>About</div>;
+       }`,
+    ],
+    [
+      "Next.js Pages Router _document.tsx",
+      "pages/_document.tsx",
+      `export const config = { amp: true };
+       export default function Document() {
+         return <html />;
+       }`,
+    ],
+    [
+      "Expo Router +not-found special file",
+      "app/+not-found.tsx",
+      `export const screenOptions = { headerShown: false };
+       export default function NotFoundScreen() {
+         return <View />;
+       }`,
+    ],
+    [
+      "TanStack Router __root.tsx (no factory call required)",
+      "src/routes/__root.tsx",
+      `export const queryClient = new QueryClient();
+       export default function RootComponent() {
+         return <Outlet />;
+       }`,
+    ],
+    [
+      "TanStack Router *.lazy.tsx route file",
+      "src/routes/about.lazy.tsx",
+      `export const routeConfig = { staleTime: 1000 };
+       export default function AboutPage() {
+         return <div>About</div>;
+       }`,
+    ],
+    [
+      "Remix / React Router root.tsx module",
+      "app/root.tsx",
+      `export const headerLinks = [{ rel: "stylesheet", href: "/app.css" }];
+       export default function App() {
+         return <Outlet />;
+       }`,
+    ],
+  ])("skips framework route/special files — %s", (_label, filename, code) => {
+    const result = runRule(onlyExportComponents, code, { filename });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("still flags non-component exports in ordinary component files", () => {
     const mixedFile = `
       export const formatProfile = (profile) => profile.name.trim();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -1,4 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { isFrameworkRouteOrSpecialFilename } from "../../utils/is-framework-route-or-special-filename.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -385,6 +386,14 @@ const isFileNameAllowed = (filename: string | undefined, checkJS: boolean): bool
   // in HMR — they get full reloaded when changed. Local-component and
   // mixed-export warnings are unactionable here.
   if (isEntryPointFile(filename)) return false;
+  // Framework route / special files (Next.js App + Pages Router and
+  // metadata image routes, Expo Router layouts, TanStack Router root /
+  // lazy routes, Remix / React Router root + entry modules). Their
+  // bundler plugins own HMR for these modules, and by framework contract
+  // they co-export route segment config / `metadata` / `alt` / `size` /
+  // loaders / actions alongside the default component — the documented
+  // shape, not a Fast Refresh hazard.
+  if (isFrameworkRouteOrSpecialFilename(filename)) return false;
   // Icon / asset / utility collection files (`icons.tsx`, `*Icon.tsx`,
   // `*Logo.tsx`, `sprite.tsx`, `assets.tsx`, `utils.tsx`, `tokens.tsx`,
   // `theme.tsx`, `constants.tsx`, etc.) hold non-state-bearing exports

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isFrameworkRouteOrSpecialFilename } from "./is-framework-route-or-special-filename.js";
+
+describe("isFrameworkRouteOrSpecialFilename", () => {
+  it.each([
+    // Next.js App + Pages Router special files and metadata image routes.
+    "app/page.tsx",
+    "app/dashboard/layout.jsx",
+    "app/global-error.tsx",
+    "app/api/route.ts",
+    "pages/_app.tsx",
+    "pages/_document.tsx",
+    "pages/_error.jsx",
+    "app/opengraph-image.tsx",
+    "app/blog/twitter-image2.tsx",
+    "app/apple-icon1.tsx",
+    // Expo Router.
+    "app/_layout.tsx",
+    "src/app/(tabs)/_layout.jsx",
+    "app/+not-found.tsx",
+    "app/+native-intent.ts",
+    // TanStack Router / Start.
+    "src/routes/__root.tsx",
+    "src/routes/posts/$postId.lazy.tsx",
+    // Remix / React Router.
+    "app/root.tsx",
+    "app/entry.client.tsx",
+    "app/entry.server.jsx",
+  ])("recognizes framework route/special file %s", (filename) => {
+    expect(isFrameworkRouteOrSpecialFilename(filename)).toBe(true);
+  });
+
+  it.each([
+    // Ordinary component / route files with no distinctive basename keep
+    // going through the rule's AST / export-name detection.
+    "components/Page.tsx",
+    "src/layout-helpers.tsx",
+    "app/index.tsx",
+    "app/routes/about.tsx",
+    "src/components/Root.tsx",
+    "app/entry.tsx",
+    "src/lazy.tsx",
+    undefined,
+  ])("does not recognize ordinary file %s", (filename) => {
+    expect(isFrameworkRouteOrSpecialFilename(filename)).toBe(false);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
@@ -15,14 +15,14 @@ const FRAMEWORK_ROUTE_FILE_PATTERNS: ReadonlyArray<RegExp> = [
   // Next.js App Router + Pages Router special files. (Metadata image
   // routes — opengraph-image, icon, … — are matched separately below.)
   new RegExp(
-    `^(page|layout|loading|error|not-found|template|default|global-error|route|_app|_document|_error)\\.${ext}$`,
+    `^(page|layout|loading|error|not-found|template|default|global-error|route|_app|_document|_error)\\.${sourceFileExtensionGroup}$`,
   ),
   // Expo Router: `_layout` segment wrapper + `+`-prefixed reserved files.
-  new RegExp(`^(_layout|\\+html|\\+not-found|\\+native-intent)\\.${ext}$`),
+  new RegExp(`^(_layout|\\+html|\\+not-found|\\+native-intent)\\.${sourceFileExtensionGroup}$`),
   // TanStack Router / Start: `__root` root route + `*.lazy` split routes.
-  new RegExp(`(?:^__root|\\.lazy)\\.${ext}$`),
+  new RegExp(`(?:^__root|\\.lazy)\\.${sourceFileExtensionGroup}$`),
   // Remix / React Router: `root` route module + client/server entries.
-  new RegExp(`^(root|entry\\.client|entry\\.server)\\.${ext}$`),
+  new RegExp(`^(root|entry\\.client|entry\\.server)\\.${sourceFileExtensionGroup}$`),
 ];
 
 export const isFrameworkRouteOrSpecialFilename = (rawFilename: string | undefined): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
@@ -9,7 +9,8 @@ import { isNextjsMetadataImageRouteFilename } from "./is-nextjs-metadata-image-r
 // exports are the documented shape, not a Fast Refresh hazard. Matched
 // by basename (the same JS/TS module extensions Next.js resolves) so a
 // deep route path resolves the same as a shallow one.
-const ext = NEXTJS_SOURCE_FILE_EXTENSION_GROUP;
+const sourceFileExtensionGroup = NEXTJS_SOURCE_FILE_EXTENSION_GROUP;
+
 const FRAMEWORK_ROUTE_FILE_PATTERNS: ReadonlyArray<RegExp> = [
   // Next.js App Router + Pages Router special files. (Metadata image
   // routes — opengraph-image, icon, … — are matched separately below.)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
@@ -1,0 +1,32 @@
+import * as path from "node:path";
+import { NEXTJS_SOURCE_FILE_EXTENSION_GROUP } from "../constants/nextjs.js";
+import { isNextjsMetadataImageRouteFilename } from "./is-nextjs-metadata-image-route-filename.js";
+
+// Route / special files from the React frameworks with file-based
+// routing. Each framework's bundler plugin owns HMR for these modules,
+// and by contract they co-export route config / metadata / data
+// functions next to the default component — so those non-component
+// exports are the documented shape, not a Fast Refresh hazard. Matched
+// by basename (the same JS/TS module extensions Next.js resolves) so a
+// deep route path resolves the same as a shallow one.
+const ext = NEXTJS_SOURCE_FILE_EXTENSION_GROUP;
+const FRAMEWORK_ROUTE_FILE_PATTERNS: ReadonlyArray<RegExp> = [
+  // Next.js App Router + Pages Router special files. (Metadata image
+  // routes — opengraph-image, icon, … — are matched separately below.)
+  new RegExp(
+    `^(page|layout|loading|error|not-found|template|default|global-error|route|_app|_document|_error)\\.${ext}$`,
+  ),
+  // Expo Router: `_layout` segment wrapper + `+`-prefixed reserved files.
+  new RegExp(`^(_layout|\\+html|\\+not-found|\\+native-intent)\\.${ext}$`),
+  // TanStack Router / Start: `__root` root route + `*.lazy` split routes.
+  new RegExp(`(?:^__root|\\.lazy)\\.${ext}$`),
+  // Remix / React Router: `root` route module + client/server entries.
+  new RegExp(`^(root|entry\\.client|entry\\.server)\\.${ext}$`),
+];
+
+export const isFrameworkRouteOrSpecialFilename = (rawFilename: string | undefined): boolean => {
+  if (!rawFilename) return false;
+  if (isNextjsMetadataImageRouteFilename(rawFilename)) return true;
+  const basename = path.basename(rawFilename);
+  return FRAMEWORK_ROUTE_FILE_PATTERNS.some((pattern) => pattern.test(basename));
+};


### PR DESCRIPTION
## Summary

`only-export-components` flagged the documented metadata exports in Next.js `opengraph-image.tsx` (`alt` / `size` / `contentType` / `revalidate`) as "non-component exports" ([#776](https://github.com/millionco/react-doctor/issues/776)). The `size = { ... }` object specifically tripped the rule.

These files aren't Fast Refresh boundaries — their bundler plugin owns HMR and they co-export config/metadata next to the default export by framework contract. This generalizes the fix to **every file-routing framework react-doctor covers** via one reusable, tested helper, `isFrameworkRouteOrSpecialFilename`:

- **Next.js** — App Router (`page`, `layout`, `loading`, `error`, `not-found`, `template`, `default`, `global-error`, `route`) + Pages Router (`_app`, `_document`, `_error`), plus metadata image routes (`opengraph-image`, `twitter-image`, `icon`, `apple-icon`, incl. numbered variants).
- **Expo Router** — `_layout` and the `+html` / `+not-found` / `+native-intent` reserved files.
- **TanStack Router / Start** — `__root` and `*.lazy` route modules.
- **Remix / React Router** — `root`, `entry.client`, `entry.server` modules.

The rule's framework knowledge moves out of the flat `ENTRY_POINT_BASENAMES` set (now generic entry points only) into the single helper, which reuses the existing `NEXTJS_SOURCE_FILE_EXTENSION_GROUP` and composes the existing `isNextjsMetadataImageRouteFilename`.

## Behavior preservation

- All OXC fixtures run with an empty filename, so filename-based skipping can't affect them.
- Plain `routes/` files and Remix route modules keep going through the existing `createFileRoute(...)` AST detection / route-module export-name allowlist — only distinctive basenames are skipped.

## Test plan

- [x] New unit tests for `isFrameworkRouteOrSpecialFilename` (recognizes / does-not-recognize tables).
- [x] New rule-level regression tests (data-driven) for each framework, incl. the #776 `opengraph-image` / `twitter-image` cases.
- [x] Existing `only-export-components` suite + `#708` / `#758` regressions still pass.
- [x] `tsc --noEmit`, `vp fmt --check`, `vp lint` clean.
- [x] Full package suite: no new failures (pre-existing unrelated failures unchanged).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only behavior change with targeted filename skips and regression tests; ordinary component files remain enforced.
> 
> **Overview**
> **`only-export-components`** now skips framework route and special files via a new **`isFrameworkRouteOrSpecialFilename`** helper, so documented co-exports (e.g. Next.js `opengraph-image` **`alt` / `size` / `contentType` / `revalidate`**, fixing [#776](https://github.com/millionco/react-doctor/issues/776)) no longer trigger false “non-component export” warnings.
> 
> Framework-specific basenames are removed from **`ENTRY_POINT_BASENAMES`** (left as generic entry points only) and centralized in basename regexes for **Next.js** (App/Pages Router + metadata image routes), **Expo Router**, **TanStack Router** (`__root`, `*.lazy`), and **Remix / React Router** (`root`, `entry.client`, `entry.server`). The rule calls the helper in **`isFileNameAllowed`** to skip analysis for those paths; ordinary component files still get flagged.
> 
> Unit tests cover the helper and data-driven rule regressions per framework; a changeset documents the patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3bb9387ba2e04f44b93e6d88dcb24c0a08e7c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->