### PR TITLE
fix(nextjs-missing-metadata): stop flagging pages that inherit layout metadata

### DIFF
--- a/.changeset/nextjs-missing-metadata-inherited-layout.md
+++ b/.changeset/nextjs-missing-metadata-inherited-layout.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Fix a false positive in `nextjs-missing-metadata` (#775): an App Router page is no longer flagged as "missing metadata for search previews" when it inherits `metadata` / `generateMetadata` from a co-located or ancestor `layout.*`. Next.js merges metadata down the segment chain, so a page covered by a parent layout's title/description already has search-preview metadata. The rule now walks up the App Router directory tree (bounded, stopping at `app/`) and stays quiet when an ancestor layout supplies metadata; pages with no metadata anywhere in the chain are still flagged.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/nextjs.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/nextjs.ts
@@ -5,6 +5,21 @@ export const PAGE_OR_LAYOUT_FILE_PATTERN = new RegExp(
   `/(page|layout)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
 );
 
+// Candidate `layout.*` filenames an App Router directory walk probes. Mirrors
+// the extensions in NEXTJS_SOURCE_FILE_EXTENSION_GROUP so `.mts`/`.mjs`
+// layouts are recognized too.
+export const LAYOUT_FILE_NAMES = [
+  "layout.tsx",
+  "layout.jsx",
+  "layout.ts",
+  "layout.js",
+  "layout.mts",
+  "layout.mjs",
+];
+
+// Export names that give an App Router page its search-preview metadata.
+export const METADATA_EXPORT_NAMES = ["metadata", "generateMetadata"];
+
 export const INTERNAL_PAGE_PATH_PATTERN =
   /\/(?:(?:\((?:dashboard|admin|settings|account|internal|manage|console|portal|auth|onboarding|app|ee|protected)\))|(?:dashboard|admin|settings|account|internal|manage|console|portal))\//i;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.cross-file.test.ts
@@ -143,6 +143,26 @@ describe("nextjs-missing-metadata — cross-file", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not flag a page under a nested 'app' route segment that inherits root metadata", () => {
+    writeFile(
+      "app/layout.tsx",
+      `
+        export const metadata = { title: "Site" };
+        export default function RootLayout({ children }) {
+          return <html><body>{children}</body></html>;
+        }
+      `,
+    );
+    const pagePath = writeFile("app/app/page.tsx", PAGE_WITHOUT_METADATA);
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a page when an ancestor layout.mts exports metadata", () => {
     writeFile(
       "app/layout.mts",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.cross-file.test.ts
@@ -1,0 +1,145 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { nextjsMissingMetadata } from "./nextjs-missing-metadata.js";
+
+let temporaryDirectory: string;
+
+beforeEach(() => {
+  temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "missing-metadata-xfile-"));
+});
+
+afterEach(() => {
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+const writeFile = (relativePath: string, contents: string): string => {
+  const absolutePath = path.join(temporaryDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, "utf8");
+  return absolutePath;
+};
+
+const PAGE_WITHOUT_METADATA = `
+  export default function Page() {
+    return <main>Home</main>;
+  }
+`;
+
+describe("nextjs-missing-metadata — cross-file", () => {
+  it("does not flag a page when a co-located layout exports metadata", () => {
+    writeFile(
+      "app/layout.tsx",
+      `
+        import type { Metadata } from "next";
+        export const metadata: Metadata = { title: "Home", description: "Welcome" };
+        export default function RootLayout({ children }) {
+          return <html><body>{children}</body></html>;
+        }
+      `,
+    );
+    const pagePath = writeFile("app/page.tsx", PAGE_WITHOUT_METADATA);
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a nested page when an ancestor layout exports metadata", () => {
+    writeFile(
+      "app/layout.tsx",
+      `
+        export const metadata = { title: "Site" };
+        export default function RootLayout({ children }) {
+          return <html><body>{children}</body></html>;
+        }
+      `,
+    );
+    const pagePath = writeFile("app/blog/[slug]/page.tsx", PAGE_WITHOUT_METADATA);
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a page when an ancestor layout exports generateMetadata", () => {
+    writeFile(
+      "app/layout.tsx",
+      `
+        export async function generateMetadata() {
+          return { title: "Dynamic" };
+        }
+        export default function RootLayout({ children }) {
+          return <html><body>{children}</body></html>;
+        }
+      `,
+    );
+    const pagePath = writeFile("app/page.tsx", PAGE_WITHOUT_METADATA);
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the layout re-exports metadata via an export specifier", () => {
+    writeFile(
+      "app/layout.tsx",
+      `
+        const metadata = { title: "Site" };
+        export { metadata };
+        export default function RootLayout({ children }) {
+          return <html><body>{children}</body></html>;
+        }
+      `,
+    );
+    const pagePath = writeFile("app/page.tsx", PAGE_WITHOUT_METADATA);
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a page when the ancestor layout has no metadata export", () => {
+    writeFile(
+      "app/layout.tsx",
+      `
+        export default function RootLayout({ children }) {
+          return <html><body>{children}</body></html>;
+        }
+      `,
+    );
+    const pagePath = writeFile("app/page.tsx", PAGE_WITHOUT_METADATA);
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a page when no layout exists in the segment chain", () => {
+    const pagePath = writeFile("app/page.tsx", PAGE_WITHOUT_METADATA);
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.cross-file.test.ts
@@ -142,4 +142,84 @@ describe("nextjs-missing-metadata — cross-file", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("does not flag a page when an ancestor layout.mts exports metadata", () => {
+    writeFile(
+      "app/layout.mts",
+      `
+        export const metadata = { title: "Site" };
+        export default function RootLayout({ children }) {
+          return <html><body>{children}</body></html>;
+        }
+      `,
+    );
+    const pagePath = writeFile("app/page.tsx", PAGE_WITHOUT_METADATA);
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a page that exports metadata via an export specifier", () => {
+    const pagePath = writeFile(
+      "app/page.tsx",
+      `
+        const metadata = { title: "Home" };
+        export { metadata };
+        export default function Page() {
+          return <main>Home</main>;
+        }
+      `,
+    );
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a page that renames a local binding to the metadata export", () => {
+    const pagePath = writeFile(
+      "app/page.tsx",
+      `
+        const pageMeta = { title: "Home" };
+        export { pageMeta as metadata };
+        export default function Page() {
+          return <main>Home</main>;
+        }
+      `,
+    );
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a page that exports a non-metadata binding aliased from metadata", () => {
+    const pagePath = writeFile(
+      "app/page.tsx",
+      `
+        const metadata = { title: "Home" };
+        export { metadata as somethingElse };
+        export default function Page() {
+          return <main>Home</main>;
+        }
+      `,
+    );
+
+    const result = runRule(nextjsMissingMetadata, fs.readFileSync(pagePath, "utf8"), {
+      filename: pagePath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
@@ -5,6 +5,7 @@ import type { Rule } from "../../utils/rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { hasAncestorMetadataLayout } from "../../utils/find-ancestor-metadata-layout.js";
 
 export const nextjsMissingMetadata = defineRule<Rule>({
   id: "nextjs-missing-metadata",
@@ -36,13 +37,16 @@ export const nextjsMissingMetadata = defineRule<Rule>({
         return false;
       });
 
-      if (!hasMetadataExport) {
-        context.report({
-          node: programNode,
-          message:
-            "This page has no metadata, so search engines and social previews get no title or description.",
-        });
-      }
+      if (hasMetadataExport) return;
+      // A page inherits metadata merged down the segment chain, so skip the
+      // directory walk only once the cheap in-file check comes up empty.
+      if (hasAncestorMetadataLayout(context.filename ?? "")) return;
+
+      context.report({
+        node: programNode,
+        message:
+          "This page has no metadata, so search engines and social previews get no title or description.",
+      });
     },
   }),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-missing-metadata.ts
@@ -1,4 +1,8 @@
-import { INTERNAL_PAGE_PATH_PATTERN, PAGE_FILE_PATTERN } from "../../constants/nextjs.js";
+import {
+  INTERNAL_PAGE_PATH_PATTERN,
+  METADATA_EXPORT_NAMES,
+  PAGE_FILE_PATTERN,
+} from "../../constants/nextjs.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
 import type { Rule } from "../../utils/rule.js";
@@ -28,13 +32,20 @@ export const nextjsMissingMetadata = defineRule<Rule>({
           return declaration.declarations?.some(
             (declarator) =>
               isNodeOfType(declarator.id, "Identifier") &&
-              (declarator.id.name === "metadata" || declarator.id.name === "generateMetadata"),
+              METADATA_EXPORT_NAMES.includes(declarator.id.name),
           );
         }
         if (isNodeOfType(declaration, "FunctionDeclaration")) {
           return declaration.id?.name === "generateMetadata";
         }
-        return false;
+        // Specifier form: `export { metadata }`, `export { x as metadata }`,
+        // or a re-export `export { metadata } from "./meta"`.
+        return (statement.specifiers ?? []).some(
+          (specifier) =>
+            isNodeOfType(specifier, "ExportSpecifier") &&
+            isNodeOfType(specifier.exported, "Identifier") &&
+            METADATA_EXPORT_NAMES.includes(specifier.exported.name),
+        );
       });
 
       if (hasMetadataExport) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-ancestor-metadata-layout.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-ancestor-metadata-layout.ts
@@ -1,36 +1,12 @@
-import * as path from "node:path";
-import { CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS } from "../constants/thresholds.js";
+import { METADATA_EXPORT_NAMES } from "../constants/nextjs.js";
 import { doesModuleExportName } from "./does-module-export-name.js";
+import { hasAncestorLayoutMatching } from "./has-ancestor-layout-matching.js";
 
-const LAYOUT_FILE_NAMES = ["layout.tsx", "layout.jsx", "layout.ts", "layout.js"];
-const METADATA_EXPORT_NAMES = ["metadata", "generateMetadata"];
-
-// Walks up the App Router directory tree from `pageFilename` looking for an
-// ancestor `layout.*` that exports `metadata` or `generateMetadata`. Next.js
-// merges metadata down the segment chain, so a page inheriting a
-// title/description from a parent (or co-located) layout already has
-// search-preview metadata and must not be flagged. The page's own directory
-// is included (a co-located layout wraps the page); the file being linted is
-// skipped so it can't match itself. The climb stops at the `app/` root and is
-// bounded so a file outside any project can't walk to `/`.
-export const hasAncestorMetadataLayout = (pageFilename: string): boolean => {
-  const normalizedPage = pageFilename.replaceAll("\\", "/");
-  let currentDirectory = path.dirname(normalizedPage);
-
-  for (let level = 0; level < CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS; level++) {
-    for (const layoutFileName of LAYOUT_FILE_NAMES) {
-      const layoutPath = path.join(currentDirectory, layoutFileName);
-      if (layoutPath.replaceAll("\\", "/") === normalizedPage) continue;
-      if (
-        METADATA_EXPORT_NAMES.some((exportName) => doesModuleExportName(layoutPath, exportName))
-      ) {
-        return true;
-      }
-    }
-    if (path.basename(currentDirectory) === "app") break;
-    const parentDirectory = path.dirname(currentDirectory);
-    if (parentDirectory === currentDirectory) break;
-    currentDirectory = parentDirectory;
-  }
-  return false;
-};
+// True when the page inherits metadata from a co-located or ancestor
+// `layout.*`. Next.js merges metadata down the segment chain, so a page
+// covered by a parent layout's title/description already has search-preview
+// metadata and must not be flagged.
+export const hasAncestorMetadataLayout = (pageFilename: string): boolean =>
+  hasAncestorLayoutMatching(pageFilename, (layoutPath) =>
+    METADATA_EXPORT_NAMES.some((exportName) => doesModuleExportName(layoutPath, exportName)),
+  );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-ancestor-metadata-layout.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-ancestor-metadata-layout.ts
@@ -1,0 +1,36 @@
+import * as path from "node:path";
+import { CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS } from "../constants/thresholds.js";
+import { doesModuleExportName } from "./does-module-export-name.js";
+
+const LAYOUT_FILE_NAMES = ["layout.tsx", "layout.jsx", "layout.ts", "layout.js"];
+const METADATA_EXPORT_NAMES = ["metadata", "generateMetadata"];
+
+// Walks up the App Router directory tree from `pageFilename` looking for an
+// ancestor `layout.*` that exports `metadata` or `generateMetadata`. Next.js
+// merges metadata down the segment chain, so a page inheriting a
+// title/description from a parent (or co-located) layout already has
+// search-preview metadata and must not be flagged. The page's own directory
+// is included (a co-located layout wraps the page); the file being linted is
+// skipped so it can't match itself. The climb stops at the `app/` root and is
+// bounded so a file outside any project can't walk to `/`.
+export const hasAncestorMetadataLayout = (pageFilename: string): boolean => {
+  const normalizedPage = pageFilename.replaceAll("\\", "/");
+  let currentDirectory = path.dirname(normalizedPage);
+
+  for (let level = 0; level < CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS; level++) {
+    for (const layoutFileName of LAYOUT_FILE_NAMES) {
+      const layoutPath = path.join(currentDirectory, layoutFileName);
+      if (layoutPath.replaceAll("\\", "/") === normalizedPage) continue;
+      if (
+        METADATA_EXPORT_NAMES.some((exportName) => doesModuleExportName(layoutPath, exportName))
+      ) {
+        return true;
+      }
+    }
+    if (path.basename(currentDirectory) === "app") break;
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) break;
+    currentDirectory = parentDirectory;
+  }
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-ancestor-suspense-layout.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-ancestor-suspense-layout.ts
@@ -1,34 +1,13 @@
-import * as path from "node:path";
-import { CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS } from "../constants/thresholds.js";
 import { astMentionsSuspense } from "./ast-mentions-suspense.js";
+import { hasAncestorLayoutMatching } from "./has-ancestor-layout-matching.js";
 import { parseSourceFile } from "./parse-source-file.js";
 
-const LAYOUT_FILE_NAMES = ["layout.tsx", "layout.jsx", "layout.ts", "layout.js"];
-
-// Walks up the App Router directory tree from `pageFilename` looking for
-// an ancestor `layout.*` that establishes a <Suspense> boundary (the
-// same file-level proxy `astMentionsSuspense` uses). A parent layout
-// that wraps `{children}` in <Suspense> provides the boundary for the
-// page, so the page's own useSearchParams() is already covered and must
-// not be flagged. The page's own directory IS included (a co-located
-// `layout.tsx` wraps `page.tsx`); the file being linted is skipped so a
-// layout never matches itself. The climb stops at the `app/` root and
-// is bounded so a file outside any project can't walk to `/`.
-export const hasAncestorSuspenseLayout = (pageFilename: string): boolean => {
-  const normalizedPage = pageFilename.replaceAll("\\", "/");
-  let currentDirectory = path.dirname(normalizedPage);
-
-  for (let level = 0; level < CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS; level++) {
-    for (const layoutFileName of LAYOUT_FILE_NAMES) {
-      const layoutPath = path.join(currentDirectory, layoutFileName);
-      if (layoutPath.replaceAll("\\", "/") === normalizedPage) continue;
-      const programRoot = parseSourceFile(layoutPath);
-      if (programRoot && astMentionsSuspense(programRoot)) return true;
-    }
-    if (path.basename(currentDirectory) === "app") break;
-    const parentDirectory = path.dirname(currentDirectory);
-    if (parentDirectory === currentDirectory) break;
-    currentDirectory = parentDirectory;
-  }
-  return false;
-};
+// True when an ancestor `layout.*` establishes a <Suspense> boundary (the same
+// file-level proxy `astMentionsSuspense` uses). A parent layout that wraps
+// `{children}` in <Suspense> provides the boundary for the page, so the page's
+// own useSearchParams() is already covered and must not be flagged.
+export const hasAncestorSuspenseLayout = (pageFilename: string): boolean =>
+  hasAncestorLayoutMatching(pageFilename, (layoutPath) => {
+    const programRoot = parseSourceFile(layoutPath);
+    return Boolean(programRoot && astMentionsSuspense(programRoot));
+  });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-ancestor-layout-matching.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-ancestor-layout-matching.ts
@@ -6,7 +6,9 @@ import { CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS } from "../constants/thresholds.js
 // `matchesLayout` for each candidate ancestor `layout.*`. The page's own
 // directory is included (a co-located layout wraps the page); the file being
 // linted is skipped so it can't match itself. Returns true on the first match.
-// The climb stops at the `app/` root and is bounded so a file outside any
+// The climb stops at the OUTERMOST `app/` directory — nested `app` segments
+// (e.g. the `/app` route at `app/app/page.tsx`) are walked through so the page
+// still reaches the real root layout — and is bounded so a file outside any
 // project can't walk to `/`.
 export const hasAncestorLayoutMatching = (
   pageFilename: string,
@@ -21,8 +23,10 @@ export const hasAncestorLayoutMatching = (
       if (layoutPath.replaceAll("\\", "/") === normalizedPage) continue;
       if (matchesLayout(layoutPath)) return true;
     }
-    if (path.basename(currentDirectory) === "app") break;
     const parentDirectory = path.dirname(currentDirectory);
+    const isOutermostAppDirectory =
+      path.basename(currentDirectory) === "app" && path.basename(parentDirectory) !== "app";
+    if (isOutermostAppDirectory) break;
     if (parentDirectory === currentDirectory) break;
     currentDirectory = parentDirectory;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-ancestor-layout-matching.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-ancestor-layout-matching.ts
@@ -1,0 +1,30 @@
+import * as path from "node:path";
+import { LAYOUT_FILE_NAMES } from "../constants/nextjs.js";
+import { CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS } from "../constants/thresholds.js";
+
+// Walks up the App Router directory tree from `pageFilename`, calling
+// `matchesLayout` for each candidate ancestor `layout.*`. The page's own
+// directory is included (a co-located layout wraps the page); the file being
+// linted is skipped so it can't match itself. Returns true on the first match.
+// The climb stops at the `app/` root and is bounded so a file outside any
+// project can't walk to `/`.
+export const hasAncestorLayoutMatching = (
+  pageFilename: string,
+  matchesLayout: (layoutPath: string) => boolean,
+): boolean => {
+  const normalizedPage = pageFilename.replaceAll("\\", "/");
+  let currentDirectory = path.dirname(normalizedPage);
+
+  for (let level = 0; level < CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS; level++) {
+    for (const layoutFileName of LAYOUT_FILE_NAMES) {
+      const layoutPath = path.join(currentDirectory, layoutFileName);
+      if (layoutPath.replaceAll("\\", "/") === normalizedPage) continue;
+      if (matchesLayout(layoutPath)) return true;
+    }
+    if (path.basename(currentDirectory) === "app") break;
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) break;
+    currentDirectory = parentDirectory;
+  }
+  return false;
+};


### PR DESCRIPTION
## Why

`nextjs-missing-metadata` flagged App Router pages as "missing metadata for search previews" even when they inherit `metadata` / `generateMetadata` from a co-located or ancestor `layout.*`. Next.js merges metadata down the segment chain (root layout → … → page), so a page covered by a parent layout's title/description already has search-preview metadata — the warning was a false positive (#775).

Before:

```tsx
// app/layout.tsx
export const metadata: Metadata = {
  title: { default: "Acme", template: "%s | Acme" },
  description: "...",
};

// app/page.tsx — flagged even though it inherits the layout's title/description
export default function Page() {
  return <main>Home</main>;
}
```

After:

```tsx
// app/page.tsx — no longer flagged (inherits metadata from app/layout.tsx)
export default function Page() {
  return <main>Home</main>;
}
```

## What changed

- Added `hasAncestorMetadataLayout` util that walks up the App Router tree (bounded by `CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS`, stopping at `app/`) and returns true when a co-located or ancestor `layout.*` exports `metadata` / `generateMetadata`. Reuses the existing `doesModuleExportName` rather than re-parsing.
- `nextjs-missing-metadata` consults it after the cheap in-file check, so it stays quiet when an ancestor layout supplies metadata.
- Pages with no metadata anywhere in the segment chain are still flagged.
- Added cross-file tests: co-located layout, nested/ancestor layout, `generateMetadata`, `export { metadata }` specifier form, plus the two must-still-flag cases (layout without metadata; no layout at all).

Eval: RDE not run — this is a targeted false-positive fix scoped to one existing rule's cross-file inheritance, covered by unit + integration tests.

## Test plan

- `vp test run src/plugin/rules/nextjs/nextjs-missing-metadata.cross-file.test.ts` — 6 passed
- `vp test run src/plugin/rules/nextjs` — 26 passed
- `vp test run packages/react-doctor/tests/run-oxlint/nextjs.test.ts` (integration) — 34 passed
- `pnpm typecheck` (oxlint-plugin-react-doctor) — clean
- `vp lint` + `vp fmt --check` on touched files — clean

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lint-rule false-positive fix with shared refactor of existing cross-file layout walking; behavior for truly missing metadata is preserved and covered by new tests.
> 
> **Overview**
> Fixes a **false positive** in `nextjs-missing-metadata` (#775): App Router pages are no longer warned when they inherit `metadata` or `generateMetadata` from a co-located or ancestor `layout.*`, matching Next.js segment metadata merging.
> 
> The rule now treats **export specifiers** on the page (`export { metadata }`, `export { x as metadata }`) as satisfying the in-file check, then runs a **bounded walk** up the `app/` tree via new `hasAncestorMetadataLayout`, which reuses `doesModuleExportName` on candidate layouts. Pages with no metadata anywhere in the chain still get flagged.
> 
> Ancestor layout walking is **factored** into shared `hasAncestorLayoutMatching` (with updated stop logic for nested `app/` route segments and `.mts`/`.mjs` layouts); `hasAncestorSuspenseLayout` delegates to it. Shared constants `LAYOUT_FILE_NAMES` and `METADATA_EXPORT_NAMES` centralize layout filenames and export names. Cross-file tests cover inheritance, `generateMetadata`, specifier forms, and remaining positive cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224df6060236ed88a0db2207e9ff7e9e97ff7a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->