### PR TITLE
feat: name Socket alerts and give axis-aware help in supply-chain diagnostics

### DIFF
--- a/.changeset/socket-supply-chain-messaging.md
+++ b/.changeset/socket-supply-chain-messaging.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Clearer Socket supply-chain diagnostics (`socket/low-supply-chain-score`). When Socket returns a concrete alert, the message now names it — e.g. a critical "known malware" alert, the offending file, and a one-line description — instead of only a bare score; when it doesn't (metric-driven dips like CVE-only scores), the message explains what the failing axis means. The help is now axis-aware: remove a package flagged as compromised, upgrade past known vulnerabilities (`npm audit`), or vet-and-raise the threshold — rather than a generic "update or replace". The headline leads with the exact failing axis and collapses the redundant "declared as X, scored at X" phrasing (a range now reads `pkg@floor (lowest version "^x.y.z" allows)`). JSON report shape is unchanged (`schemaVersion: 1`).

--- a/packages/core/src/check-supply-chain.ts
+++ b/packages/core/src/check-supply-chain.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import * as semver from "semver";
 import {
   FETCH_TIMEOUT_MS,
   SOCKET_FREE_PURL_API_BASE,
@@ -22,6 +23,7 @@ import { findMonorepoRoot, isMonorepoRoot, readPackageJson } from "./project-inf
 import { getWorkspacePatterns } from "./project-info/get-workspace-patterns.js";
 import { resolveWorkspaceDirectories } from "./project-info/resolve-workspace-directories.js";
 import type { Diagnostic, PackageJson, ReactDoctorConfig } from "./types/index.js";
+import { sanitizeTerminalText } from "./utils/sanitize-terminal-text.js";
 
 export interface SupplyChainCheckInput {
   readonly rootDirectory: string;
@@ -63,18 +65,30 @@ const SocketScoreSchema = Schema.Struct({
 // `critical` `malware` alert in a named file with a human `note`). The free
 // endpoint only attaches these for the highest-signal supply-chain threats;
 // metric-driven dips (CVE-only scores, sparse maintenance) arrive with an
-// empty `alerts` array. Every field but `type`/`severity` is best-effort.
+// empty `alerts` array. Optional fields are `NullOr` because the JSON endpoint
+// sends an explicit `null` (not an absent key) for values it lacks, and
+// `Schema.optional` alone rejects `null` — which would fail the whole decode.
 const SocketAlertSchema = Schema.Struct({
   type: Schema.String,
   severity: Schema.String,
-  category: Schema.optional(Schema.String),
-  file: Schema.optional(Schema.String),
-  props: Schema.optional(Schema.Struct({ note: Schema.optional(Schema.String) })),
+  file: Schema.optional(Schema.NullOr(Schema.String)),
+  props: Schema.optional(
+    Schema.NullOr(Schema.Struct({ note: Schema.optional(Schema.NullOr(Schema.String)) })),
+  ),
 });
 
+// The score-bearing artifact line. Alerts are decoded SEPARATELY (see
+// `extractAlerts`) rather than as a field here so that a single malformed or
+// unknown-variant alert can never fail the artifact decode — which would treat
+// the package as unscored and silently drop a real low-score finding.
 const SocketArtifactSchema = Schema.Struct({
   score: Schema.optional(SocketScoreSchema),
-  alerts: Schema.optional(Schema.Array(SocketAlertSchema)),
+});
+
+// The raw alert list, kept as `Unknown` elements so one unparseable alert
+// can't sink the array decode; each element is decoded resiliently below.
+const RawAlertsSchema = Schema.Struct({
+  alerts: Schema.optional(Schema.NullOr(Schema.Array(Schema.Unknown))),
 });
 
 type SocketScore = Schema.Schema.Type<typeof SocketScoreSchema>;
@@ -88,6 +102,22 @@ interface SocketArtifact {
 }
 
 const decodeArtifact = Schema.decodeUnknownOption(SocketArtifactSchema);
+const decodeRawAlerts = Schema.decodeUnknownOption(RawAlertsSchema);
+const decodeAlert = Schema.decodeUnknownOption(SocketAlertSchema);
+
+// Decodes each alert independently, dropping any that don't parse (an unknown
+// variant or a malformed entry) rather than discarding the whole artifact —
+// and with it the score that gates the check.
+const extractAlerts = (parsed: unknown): ReadonlyArray<SocketAlert> => {
+  const rawAlerts = Option.getOrNull(decodeRawAlerts(parsed))?.alerts;
+  if (!rawAlerts) return [];
+  const alerts: SocketAlert[] = [];
+  for (const candidate of rawAlerts) {
+    const alert = Option.getOrNull(decodeAlert(candidate));
+    if (alert !== null) alerts.push(alert);
+  }
+  return alerts;
+};
 
 interface AxisGuidance {
   /**
@@ -100,27 +130,28 @@ interface AxisGuidance {
   readonly remediation: string;
 }
 
-interface ScoreAxis {
+// A security axis that gates the check. Its guidance powers the failing-axis
+// message's "why" and the help's remediation.
+interface GatedAxis {
   readonly key: keyof SocketScore;
   readonly label: string;
-  /**
-   * Non-null only for the security axes that gate the check — the presence of
-   * guidance *is* the gate (see GATED_AXES).
-   */
-  readonly guidance: AxisGuidance | null;
-}
-
-// A gated security axis: the same shape with guidance guaranteed, so the
-// failing-axis message/help can read it without a non-null assertion.
-interface GatedAxis extends ScoreAxis {
   readonly guidance: AxisGuidance;
 }
 
-// The non-`overall` axes, paired with the label shown in the diagnostic so a
-// developer immediately sees which dimension dragged the score down. The two
-// security axes also carry the guidance that powers the message's "why" and
-// the help's remediation.
-const SCORE_AXES: ReadonlyArray<ScoreAxis> = [
+// A non-security axis: reported in the diagnostic's breakdown as context, but
+// never gates the check.
+interface ScoreAxis {
+  readonly key: keyof SocketScore;
+  readonly label: string;
+}
+
+// Only the security axes decide the gate. Socket's `overall` is its lowest
+// axis, so gating on it let a pure quality/maintenance dip fail this
+// Security-category check — e.g. `@types/bun@1.3.14` scores quality 48 with
+// every security axis at 100 (issue #770). `supplyChain` covers typosquats /
+// install scripts / compromised maintainers; `vulnerability` covers known
+// CVEs (what flags the compromised `event-stream@3.3.6`).
+const GATED_AXES: ReadonlyArray<GatedAxis> = [
   {
     key: "supplyChain",
     label: "supply chain",
@@ -140,21 +171,19 @@ const SCORE_AXES: ReadonlyArray<ScoreAxis> = [
         "Upgrade to a version with no known advisories (run `npm audit` to find one), or replace it",
     },
   },
-  { key: "maintenance", label: "maintenance", guidance: null },
-  { key: "quality", label: "quality", guidance: null },
-  { key: "license", label: "license", guidance: null },
 ];
 
-// Only the security axes decide the gate. Socket's `overall` is its lowest
-// axis, so gating on it let a pure quality/maintenance dip fail this
-// Security-category check — e.g. `@types/bun@1.3.14` scores quality 48 with
-// every security axis at 100 (issue #770). `supplyChain` covers typosquats /
-// install scripts / compromised maintainers; `vulnerability` covers known
-// CVEs (what flags the compromised `event-stream@3.3.6`). The remaining axes
-// still appear in the diagnostic's axis breakdown as context.
-const GATED_AXES: ReadonlyArray<GatedAxis> = SCORE_AXES.filter(
-  (axis): axis is GatedAxis => axis.guidance !== null,
-);
+// The non-gating axes, reported in the breakdown as context so a developer
+// sees which dimension dragged the score down.
+const CONTEXT_AXES: ReadonlyArray<ScoreAxis> = [
+  { key: "maintenance", label: "maintenance" },
+  { key: "quality", label: "quality" },
+  { key: "license", label: "license" },
+];
+
+// Every axis in display order (gated first), for the per-axis score breakdown
+// and the fetch span attributes.
+const SCORE_AXES: ReadonlyArray<ScoreAxis> = [...GATED_AXES, ...CONTEXT_AXES];
 
 // The axis that decides the gate for one score: the lowest of the gated
 // axes. A tie keeps `supplyChain`, matching the rule's name.
@@ -191,17 +220,17 @@ const resolveOptions = (config: ReactDoctorConfig | null): ResolvedSupplyChainOp
 };
 
 // package.json declares ranges (`^4.17.21`, `~1.2.0`, `>=2 <3`), but the
-// Socket lookup needs a concrete version. Take the first semver-looking
-// token in the spec — the floor of a caret/tilde range, which is a real
-// published version. Specs with no concrete version (`*`, `latest`,
-// `1.x`) or a non-registry protocol (`workspace:`, `file:`, `link:`,
-// `npm:`, `git+…`, a URL) are skipped: there's nothing to score.
+// Socket lookup needs one concrete version. Score the floor of the range — the
+// lowest version it permits, a real published version — via `semver.minVersion`,
+// which resolves caret/tilde/OR/upper-bound ranges correctly (the old
+// "first semver token" scan mis-scored `<2.0.0 >=1.5.0` and `2.0.0 || 1.0.0`).
+// Specs with no parseable floor (`latest`, a URL) or a non-registry protocol
+// (`workspace:`, `file:`, `link:`, `npm:`, `git+…`) are skipped: nothing to score.
 const resolveConcreteVersion = (spec: string): string | null => {
   const trimmed = spec.trim();
   if (trimmed.length === 0) return null;
   if (trimmed.includes(":")) return null;
-  const match = trimmed.match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?/);
-  return match ? match[0] : null;
+  return semver.minVersion(trimmed)?.version ?? null;
 };
 
 type DependencySection = "dependencies" | "devDependencies";
@@ -344,8 +373,9 @@ const toPurl = (dependency: DependencyToScore): string =>
   `pkg:npm/${dependency.name}@${dependency.version}`;
 
 // The endpoint streams newline-delimited JSON (one artifact per line); take
-// the first line that decodes to an artifact carrying a score, normalizing
-// its alerts to an array so callers never branch on `undefined`.
+// the first line that decodes to an artifact carrying a score. Alerts are
+// decoded separately and resiliently (`extractAlerts`) so a malformed alert
+// can never discard the score that gates the check.
 const parseArtifactFromBody = (body: string): SocketArtifact | null => {
   for (const line of body.split("\n")) {
     if (line.trim().length === 0) continue;
@@ -356,7 +386,7 @@ const parseArtifactFromBody = (body: string): SocketArtifact | null => {
       continue;
     }
     const artifact = Option.getOrNull(decodeArtifact(parsed));
-    if (artifact?.score) return { score: artifact.score, alerts: artifact.alerts ?? [] };
+    if (artifact?.score) return { score: artifact.score, alerts: extractAlerts(parsed) };
   }
   return null;
 };
@@ -429,9 +459,11 @@ const ALERT_SEVERITY_RANK: Record<string, number> = {
 const severityRank = (severity: string): number => ALERT_SEVERITY_RANK[severity.toLowerCase()] ?? 0;
 
 // Display spelling for a severity: normalize Socket's "middle" to "medium",
-// otherwise lowercase the wire value.
-const displaySeverity = (severity: string): string =>
-  severity.toLowerCase() === "middle" ? "medium" : severity.toLowerCase();
+// otherwise lowercase the (remote, sanitized) wire value.
+const displaySeverity = (severity: string): string => {
+  const normalized = sanitizeTerminalText(severity.toLowerCase());
+  return normalized === "middle" ? "medium" : normalized;
+};
 
 // Labels for the alert types whose friendly name differs from the humanized
 // identifier. Everything else (`installScript` -> "install script",
@@ -457,12 +489,14 @@ const humanizeAlertType = (type: string): string =>
     .trim();
 
 const friendlyAlertType = (type: string): string =>
-  ALERT_TYPE_LABELS[type] ?? humanizeAlertType(type);
+  ALERT_TYPE_LABELS[type] ?? sanitizeTerminalText(humanizeAlertType(type));
 
 // First sentence of a Socket alert note, whitespace-collapsed and capped so a
 // paragraph-long malware description doesn't blow out the diagnostic line.
 const summarizeAlertNote = (note: string): string => {
-  const collapsed = note.replace(/\s+/g, " ").trim();
+  // Collapse whitespace first (so legitimate newlines/tabs become spaces),
+  // then strip remaining control chars/backticks from the remote note.
+  const collapsed = sanitizeTerminalText(note.replace(/\s+/g, " ").trim());
   const firstSentence = collapsed.split(/(?<=\.)\s/)[0] || collapsed;
   if (firstSentence.length <= SUPPLY_CHAIN_ALERT_NOTE_MAX_CHARS) {
     return firstSentence.replace(/\.$/, "");
@@ -483,7 +517,7 @@ const selectTopAlerts = (alerts: ReadonlyArray<SocketAlert>): ReadonlyArray<Sock
 const formatAlertReason = (topAlerts: ReadonlyArray<SocketAlert>, totalCount: number): string => {
   if (topAlerts.length === 1) {
     const [alert] = topAlerts;
-    const location = alert.file ? ` in \`${alert.file}\`` : "";
+    const location = alert.file ? ` in \`${sanitizeTerminalText(alert.file)}\`` : "";
     const note = alert.props?.note ? summarizeAlertNote(alert.props.note) : null;
     const detail = note ? `: "${note}"` : "";
     return `Socket flagged a ${displaySeverity(alert.severity)} ${friendlyAlertType(alert.type)} alert${location}${detail}.`;
@@ -495,9 +529,11 @@ const formatAlertReason = (topAlerts: ReadonlyArray<SocketAlert>, totalCount: nu
 
 // "react@18.2.0" for an exact pin; for a range, names the scored version and
 // makes clear it's the floor the range allows — we score the lowest permitted
-// version, which may differ from what's installed.
+// version, which may differ from what's installed. `semver.valid` is the
+// exact-pin test: it returns non-null only for a single concrete version, so a
+// `v`-prefixed pin like `v1.2.3` reads as a pin instead of a mislabeled range.
 const formatDependencyIdentity = (dependency: DependencyToScore): string =>
-  dependency.spec === dependency.version
+  semver.valid(dependency.spec) !== null
     ? `${dependency.name}@${dependency.version}`
     : `${dependency.name}@${dependency.version} (lowest version "${dependency.spec}" allows)`;
 

--- a/packages/core/src/check-supply-chain.ts
+++ b/packages/core/src/check-supply-chain.ts
@@ -9,10 +9,12 @@ import {
   SOCKET_FREE_USER_AGENT,
   SOCKET_PACKAGE_PAGE_BASE,
   SOCKET_SCORE_SCALE,
+  SUPPLY_CHAIN_ALERT_NOTE_MAX_CHARS,
   SUPPLY_CHAIN_CATEGORY,
   SUPPLY_CHAIN_DEFAULT_MIN_SCORE,
   SUPPLY_CHAIN_FETCH_CONCURRENCY,
   SUPPLY_CHAIN_IGNORED_PACKAGES,
+  SUPPLY_CHAIN_MAX_ALERTS_SHOWN,
   SUPPLY_CHAIN_PLUGIN,
   SUPPLY_CHAIN_RULE,
 } from "./constants.js";
@@ -57,29 +59,90 @@ const SocketScoreSchema = Schema.Struct({
   vulnerability: Schema.Number,
 });
 
+// A single Socket alert: the concrete "why" behind a low score (e.g. a
+// `critical` `malware` alert in a named file with a human `note`). The free
+// endpoint only attaches these for the highest-signal supply-chain threats;
+// metric-driven dips (CVE-only scores, sparse maintenance) arrive with an
+// empty `alerts` array. Every field but `type`/`severity` is best-effort.
+const SocketAlertSchema = Schema.Struct({
+  type: Schema.String,
+  severity: Schema.String,
+  category: Schema.optional(Schema.String),
+  file: Schema.optional(Schema.String),
+  props: Schema.optional(Schema.Struct({ note: Schema.optional(Schema.String) })),
+});
+
 const SocketArtifactSchema = Schema.Struct({
   score: Schema.optional(SocketScoreSchema),
+  alerts: Schema.optional(Schema.Array(SocketAlertSchema)),
 });
 
 type SocketScore = Schema.Schema.Type<typeof SocketScoreSchema>;
+type SocketAlert = Schema.Schema.Type<typeof SocketAlertSchema>;
+
+// A resolved artifact: a `score` is guaranteed (callers skip unscored
+// packages) and `alerts` is normalized to a (possibly empty) array.
+interface SocketArtifact {
+  readonly score: SocketScore;
+  readonly alerts: ReadonlyArray<SocketAlert>;
+}
 
 const decodeArtifact = Schema.decodeUnknownOption(SocketArtifactSchema);
+
+interface AxisGuidance {
+  /**
+   * Plain-English meaning of a low score on this axis, woven into the message
+   * when Socket returns no explicit alerts to name (the common, metric-driven
+   * case on the free endpoint).
+   */
+  readonly meaning: string;
+  /** Axis-specific remediation phrase, woven into the diagnostic's help. */
+  readonly remediation: string;
+}
 
 interface ScoreAxis {
   readonly key: keyof SocketScore;
   readonly label: string;
-  /** Whether a low value on this axis fails the check (see GATED_AXES). */
-  readonly gates: boolean;
+  /**
+   * Non-null only for the security axes that gate the check — the presence of
+   * guidance *is* the gate (see GATED_AXES).
+   */
+  readonly guidance: AxisGuidance | null;
+}
+
+// A gated security axis: the same shape with guidance guaranteed, so the
+// failing-axis message/help can read it without a non-null assertion.
+interface GatedAxis extends ScoreAxis {
+  readonly guidance: AxisGuidance;
 }
 
 // The non-`overall` axes, paired with the label shown in the diagnostic so a
-// developer immediately sees which dimension dragged the score down.
+// developer immediately sees which dimension dragged the score down. The two
+// security axes also carry the guidance that powers the message's "why" and
+// the help's remediation.
 const SCORE_AXES: ReadonlyArray<ScoreAxis> = [
-  { key: "supplyChain", label: "supply chain", gates: true },
-  { key: "vulnerability", label: "vulnerability", gates: true },
-  { key: "maintenance", label: "maintenance", gates: false },
-  { key: "quality", label: "quality", gates: false },
-  { key: "license", label: "license", gates: false },
+  {
+    key: "supplyChain",
+    label: "supply chain",
+    guidance: {
+      meaning:
+        "risky install-time behavior — install scripts, obfuscated or native code, network/filesystem/shell access, or typosquatting",
+      remediation:
+        "Confirm this is the package you meant to install, and prefer a more established, audited alternative",
+    },
+  },
+  {
+    key: "vulnerability",
+    label: "vulnerability",
+    guidance: {
+      meaning: "known security vulnerabilities (CVEs) affecting this version",
+      remediation:
+        "Upgrade to a version with no known advisories (run `npm audit` to find one), or replace it",
+    },
+  },
+  { key: "maintenance", label: "maintenance", guidance: null },
+  { key: "quality", label: "quality", guidance: null },
+  { key: "license", label: "license", guidance: null },
 ];
 
 // Only the security axes decide the gate. Socket's `overall` is its lowest
@@ -89,11 +152,13 @@ const SCORE_AXES: ReadonlyArray<ScoreAxis> = [
 // install scripts / compromised maintainers; `vulnerability` covers known
 // CVEs (what flags the compromised `event-stream@3.3.6`). The remaining axes
 // still appear in the diagnostic's axis breakdown as context.
-const GATED_AXES: ReadonlyArray<ScoreAxis> = SCORE_AXES.filter((axis) => axis.gates);
+const GATED_AXES: ReadonlyArray<GatedAxis> = SCORE_AXES.filter(
+  (axis): axis is GatedAxis => axis.guidance !== null,
+);
 
 // The axis that decides the gate for one score: the lowest of the gated
 // axes. A tie keeps `supplyChain`, matching the rule's name.
-const worstGatedAxis = (score: SocketScore): ScoreAxis => {
+const worstGatedAxis = (score: SocketScore): GatedAxis => {
   let worst = GATED_AXES[0];
   for (const axis of GATED_AXES) {
     if (score[axis.key] < score[worst.key]) worst = axis;
@@ -279,8 +344,9 @@ const toPurl = (dependency: DependencyToScore): string =>
   `pkg:npm/${dependency.name}@${dependency.version}`;
 
 // The endpoint streams newline-delimited JSON (one artifact per line); take
-// the first line that decodes to an artifact carrying a score.
-const parseScoreFromBody = (body: string): SocketScore | null => {
+// the first line that decodes to an artifact carrying a score, normalizing
+// its alerts to an array so callers never branch on `undefined`.
+const parseArtifactFromBody = (body: string): SocketArtifact | null => {
   for (const line of body.split("\n")) {
     if (line.trim().length === 0) continue;
     let parsed: unknown;
@@ -290,24 +356,25 @@ const parseScoreFromBody = (body: string): SocketScore | null => {
       continue;
     }
     const artifact = Option.getOrNull(decodeArtifact(parsed));
-    if (artifact?.score) return artifact.score;
+    if (artifact?.score) return { score: artifact.score, alerts: artifact.alerts ?? [] };
   }
   return null;
 };
 
-// Fetches the free, keyless Socket score for one dependency — the same
-// `firewall-api.socket.dev/purl/<encoded-purl>` endpoint Socket Firewall's
-// free tier hits. `Effect.tryPromise` hands `fetch` an `AbortSignal` that
-// `Effect.timeout` trips on the deadline (cancelling the request), and
-// `Effect.orElseSucceed` makes the lookup fail-open: an unscored / unknown
-// package, a timeout, or any network/parse failure yields `null` (skip)
-// rather than sinking the scan. Each lookup is its own `SupplyChain.fetchScore`
-// span: the package identity rides the initial attributes, and the resolved
-// axis scores (overall + each SCORE_AXES dimension, 0..100) are annotated once
-// the lookup settles. Dotted `socket.*` namespacing per the observability
-// conventions, so a trace backend can group by package or query score
-// distributions across a scan. No-op without a tracer.
-const fetchSocketScore = (dependency: DependencyToScore): Effect.Effect<SocketScore | null> =>
+// Fetches the free, keyless Socket artifact (score + alerts) for one
+// dependency — the same `firewall-api.socket.dev/purl/<encoded-purl>` endpoint
+// Socket Firewall's free tier hits. `Effect.tryPromise` hands `fetch` an
+// `AbortSignal` that `Effect.timeout` trips on the deadline (cancelling the
+// request), and `Effect.orElseSucceed` makes the lookup fail-open: an unscored
+// / unknown package, a timeout, or any network/parse failure yields `null`
+// (skip) rather than sinking the scan. Each lookup is its own
+// `SupplyChain.fetchScore` span: the package identity rides the initial
+// attributes, and the resolved axis scores (overall + each SCORE_AXES
+// dimension, 0..100) plus the alert count are annotated once the lookup
+// settles. Dotted `socket.*` namespacing per the observability conventions, so
+// a trace backend can group by package or query score / alert distributions
+// across a scan. No-op without a tracer.
+const fetchSocketArtifact = (dependency: DependencyToScore): Effect.Effect<SocketArtifact | null> =>
   Effect.tryPromise(async (signal) => {
     const requestUrl = `${SOCKET_FREE_PURL_API_BASE}/${encodeURIComponent(toPurl(dependency))}`;
     const response = await fetch(requestUrl, {
@@ -315,19 +382,23 @@ const fetchSocketScore = (dependency: DependencyToScore): Effect.Effect<SocketSc
       signal,
     });
     if (!response.ok) return null;
-    return parseScoreFromBody(await response.text());
+    return parseArtifactFromBody(await response.text());
   }).pipe(
     Effect.timeout(FETCH_TIMEOUT_MS),
     Effect.orElseSucceed(() => null),
-    Effect.tap((score) => {
+    Effect.tap((artifact) => {
       const scoreAttributes: Record<string, string | number | boolean> = {};
-      if (score !== null) {
-        scoreAttributes["socket.score.overall"] = toHundred(score.overall);
+      if (artifact !== null) {
+        scoreAttributes["socket.score.overall"] = toHundred(artifact.score.overall);
         for (const axis of SCORE_AXES) {
-          scoreAttributes[`socket.score.${axis.key}`] = toHundred(score[axis.key]);
+          scoreAttributes[`socket.score.${axis.key}`] = toHundred(artifact.score[axis.key]);
         }
+        scoreAttributes["socket.alert.count"] = artifact.alerts.length;
       }
-      return Effect.annotateCurrentSpan({ "socket.scored": score !== null, ...scoreAttributes });
+      return Effect.annotateCurrentSpan({
+        "socket.scored": artifact !== null,
+        ...scoreAttributes,
+      });
     }),
     Effect.withSpan("SupplyChain.fetchScore", {
       attributes: {
@@ -338,29 +409,156 @@ const fetchSocketScore = (dependency: DependencyToScore): Effect.Effect<SocketSc
     }),
   );
 
-// Per-axis scores on the 0..100 scale, e.g.
-// "supply chain 80, vulnerability 25, maintenance 82, quality 86, license 100".
-const formatAxisScores = (score: SocketScore): string =>
-  SCORE_AXES.map((axis) => `${axis.label} ${toHundred(score[axis.key])}`).join(", ");
+// The non-failing axes (the failing one already leads the message), e.g.
+// "supply chain 100, maintenance 86, quality 100, license 100".
+const formatOtherAxisScores = (score: SocketScore, failingKey: keyof SocketScore): string =>
+  SCORE_AXES.filter((axis) => axis.key !== failingKey)
+    .map((axis) => `${axis.label} ${toHundred(score[axis.key])}`)
+    .join(", ");
+
+// Socket alert severities, most to least severe. "middle" is Socket's wire
+// spelling for the docs' "medium" band; both map to the same rank.
+const ALERT_SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  middle: 2,
+  medium: 2,
+  low: 1,
+};
+
+const severityRank = (severity: string): number => ALERT_SEVERITY_RANK[severity.toLowerCase()] ?? 0;
+
+// Display spelling for a severity: normalize Socket's "middle" to "medium",
+// otherwise lowercase the wire value.
+const displaySeverity = (severity: string): string =>
+  severity.toLowerCase() === "middle" ? "medium" : severity.toLowerCase();
+
+// Labels for the alert types whose friendly name differs from the humanized
+// identifier. Everything else (`installScript` -> "install script",
+// `networkAccess` -> "network access", …) is left to the camelCase fallback,
+// which also keeps a brand-new alert type readable.
+const ALERT_TYPE_LABELS: Record<string, string> = {
+  malware: "known malware",
+  gptMalware: "AI-detected malware",
+  gptSecurity: "AI-detected security risk",
+  gptAnomaly: "AI-detected code anomaly",
+  envVars: "environment-variable access",
+  usesEval: "use of eval",
+  troll: "protestware",
+  didYouMean: "possible typosquat",
+  typosquat: "possible typosquat",
+};
+
+const humanizeAlertType = (type: string): string =>
+  type
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .toLowerCase()
+    .trim();
+
+const friendlyAlertType = (type: string): string =>
+  ALERT_TYPE_LABELS[type] ?? humanizeAlertType(type);
+
+// First sentence of a Socket alert note, whitespace-collapsed and capped so a
+// paragraph-long malware description doesn't blow out the diagnostic line.
+const summarizeAlertNote = (note: string): string => {
+  const collapsed = note.replace(/\s+/g, " ").trim();
+  const firstSentence = collapsed.split(/(?<=\.)\s/)[0] || collapsed;
+  if (firstSentence.length <= SUPPLY_CHAIN_ALERT_NOTE_MAX_CHARS) {
+    return firstSentence.replace(/\.$/, "");
+  }
+  return `${firstSentence.slice(0, SUPPLY_CHAIN_ALERT_NOTE_MAX_CHARS).trimEnd()}…`;
+};
+
+// The most severe alerts first (stable within a severity), capped so a noisy
+// package doesn't flood the message.
+const selectTopAlerts = (alerts: ReadonlyArray<SocketAlert>): ReadonlyArray<SocketAlert> =>
+  [...alerts]
+    .sort((left, right) => severityRank(right.severity) - severityRank(left.severity))
+    .slice(0, SUPPLY_CHAIN_MAX_ALERTS_SHOWN);
+
+// The message's "why" clause when Socket returned concrete alerts: one alert
+// gets its file + note spelled out; several collapse to a labelled list with
+// the worst severity and a "+N more" tail.
+const formatAlertReason = (topAlerts: ReadonlyArray<SocketAlert>, totalCount: number): string => {
+  if (topAlerts.length === 1) {
+    const [alert] = topAlerts;
+    const location = alert.file ? ` in \`${alert.file}\`` : "";
+    const note = alert.props?.note ? summarizeAlertNote(alert.props.note) : null;
+    const detail = note ? `: "${note}"` : "";
+    return `Socket flagged a ${displaySeverity(alert.severity)} ${friendlyAlertType(alert.type)} alert${location}${detail}.`;
+  }
+  const labels = topAlerts.map((alert) => friendlyAlertType(alert.type)).join(", ");
+  const more = totalCount > topAlerts.length ? ` (+${totalCount - topAlerts.length} more)` : "";
+  return `Socket flagged ${totalCount} alerts (${labels}${more}); most severe: ${displaySeverity(topAlerts[0].severity)}.`;
+};
+
+// "react@18.2.0" for an exact pin; for a range, names the scored version and
+// makes clear it's the floor the range allows — we score the lowest permitted
+// version, which may differ from what's installed.
+const formatDependencyIdentity = (dependency: DependencyToScore): string =>
+  dependency.spec === dependency.version
+    ? `${dependency.name}@${dependency.version}`
+    : `${dependency.name}@${dependency.version} (lowest version "${dependency.spec}" allows)`;
+
+// Axis-aware remediation. A critical alert (active malware) overrides the
+// axis's generic advice with "treat as compromised"; otherwise the failing
+// axis's own remediation drives the action, and the escape hatch is the
+// gentler "raise the threshold / downgrade to a warning".
+const buildSupplyChainHelp = (
+  dependency: DependencyToScore,
+  failingAxis: GatedAxis,
+  topAlerts: ReadonlyArray<SocketAlert>,
+  packagePageUrl: string,
+  options: ResolvedSupplyChainOptions,
+): string => {
+  const hasCriticalAlert = topAlerts.some((alert) => alert.severity.toLowerCase() === "critical");
+  const entry = `\`"${dependency.name}": "${dependency.spec}"\``;
+
+  const action = hasCriticalAlert
+    ? `Treat ${dependency.name} as compromised — do not ship it. Remove ${entry} from package.json and your lockfile, then audit anything it ran.`
+    : `${failingAxis.guidance.remediation}; update ${entry} in package.json.`;
+
+  const escapeHatch = hasCriticalAlert
+    ? `Only if you've confirmed this is a false positive, set \`supplyChain.enabled: false\`.`
+    : `If you've reviewed and accepted this package, raise \`supplyChain.minScore\` (currently ${options.minScore}) or set \`supplyChain.severity: "warning"\`.`;
+
+  return `${action} Full report: ${packagePageUrl}. ${escapeHatch}`;
+};
 
 const buildLowScoreDiagnostic = (
   dependency: DependencyToScore,
-  score: SocketScore,
-  failingAxis: ScoreAxis,
+  artifact: SocketArtifact,
+  failingAxis: GatedAxis,
   options: ResolvedSupplyChainOptions,
 ): Diagnostic => {
   const packagePageUrl = `${SOCKET_PACKAGE_PAGE_BASE}/${dependency.name}/overview/${dependency.version}`;
+  const failingScore = toHundred(artifact.score[failingAxis.key]);
+  const topAlerts = selectTopAlerts(artifact.alerts);
+
+  // The "why": name Socket's concrete alerts when it returned any, otherwise
+  // fall back to the plain-English meaning of the failing axis — the free
+  // endpoint omits alerts for metric-driven dips (e.g. CVE-only vulnerability
+  // scores), so the number alone would leave the user guessing.
+  const reason =
+    topAlerts.length > 0
+      ? formatAlertReason(topAlerts, artifact.alerts.length)
+      : `This points to ${failingAxis.guidance.meaning}.`;
+
+  // Lead with the exact axis that failed so the number matches what the user
+  // sees on the socket.dev package page (issue #770: calling `overall` a
+  // "supply-chain score" read as a false positive when the supplyChain axis
+  // itself was 100); the remaining axes follow as context.
+  const headline = `\`${formatDependencyIdentity(dependency)}\` scored ${failingScore}/${SOCKET_SCORE_SCALE} on Socket's ${failingAxis.label} axis (minimum ${options.minScore}).`;
+  const otherAxes = `Other axes — ${formatOtherAxisScores(artifact.score, failingAxis.key)}.`;
+
   return {
     filePath: "package.json",
     plugin: SUPPLY_CHAIN_PLUGIN,
     rule: SUPPLY_CHAIN_RULE,
     severity: options.severity,
-    // Name the exact axis that failed so the number matches what the user
-    // sees on the socket.dev package page (issue #770: calling `overall` a
-    // "supply-chain score" read as a false positive when the supplyChain
-    // axis itself was 100).
-    message: `\`${dependency.name}\` (declared in package.json as "${dependency.spec}", scored at ${dependency.version}) has a Socket ${failingAxis.label} score of ${toHundred(score[failingAxis.key])}/${SOCKET_SCORE_SCALE} (below the minimum of ${options.minScore}). Axis scores — ${formatAxisScores(score)}.`,
-    help: `Update or replace the \`"${dependency.name}": "${dependency.spec}"\` entry in package.json. Review ${dependency.name} on Socket: ${packagePageUrl}. Or raise \`supplyChain.minScore\` if you have vetted and accepted this package.`,
+    message: `${headline} ${reason} ${otherAxes}`,
+    help: buildSupplyChainHelp(dependency, failingAxis, topAlerts, packagePageUrl, options),
     url: packagePageUrl,
     // Anchor to the dependency's declaration so the CLI / editor points at the
     // exact entry to change rather than the top of the file.
@@ -400,16 +598,16 @@ export const collectSupplyChainScores = (
     );
     if (dependencies.length === 0) return [];
 
-    const scores = yield* Effect.forEach(dependencies, fetchSocketScore, {
+    const artifacts = yield* Effect.forEach(dependencies, fetchSocketArtifact, {
       concurrency: SUPPLY_CHAIN_FETCH_CONCURRENCY,
     });
 
     return dependencies.map((dependency, index) => {
-      const score = scores[index];
+      const artifact = artifacts[index];
       return {
         name: dependency.name,
         version: dependency.version,
-        overall: score ? toHundred(score.overall) : null,
+        overall: artifact ? toHundred(artifact.score.overall) : null,
       };
     });
   });
@@ -440,17 +638,17 @@ export const checkSupplyChain = (input: SupplyChainCheckInput): Effect.Effect<Di
     );
     if (dependencies.length === 0) return [];
 
-    const scores = yield* Effect.forEach(dependencies, fetchSocketScore, {
+    const artifacts = yield* Effect.forEach(dependencies, fetchSocketArtifact, {
       concurrency: SUPPLY_CHAIN_FETCH_CONCURRENCY,
     });
 
     const diagnostics: Diagnostic[] = [];
     for (let index = 0; index < dependencies.length; index += 1) {
-      const score = scores[index];
-      if (!score) continue;
-      const worstAxis = worstGatedAxis(score);
-      if (toHundred(score[worstAxis.key]) >= options.minScore) continue;
-      diagnostics.push(buildLowScoreDiagnostic(dependencies[index], score, worstAxis, options));
+      const artifact = artifacts[index];
+      if (!artifact) continue;
+      const worstAxis = worstGatedAxis(artifact.score);
+      if (toHundred(artifact.score[worstAxis.key]) >= options.minScore) continue;
+      diagnostics.push(buildLowScoreDiagnostic(dependencies[index], artifact, worstAxis, options));
     }
     return diagnostics;
   });

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -457,6 +457,15 @@ export const SOCKET_SCORE_SCALE = 100;
 // per-route rate limit.
 export const SUPPLY_CHAIN_FETCH_CONCURRENCY = 8;
 
+// Most severe Socket alerts to name in one supply-chain diagnostic before
+// collapsing the remainder into a "+N more" count, so a noisy package
+// doesn't flood the message.
+export const SUPPLY_CHAIN_MAX_ALERTS_SHOWN = 3;
+
+// Cap for the first-sentence Socket alert note woven into a diagnostic, so a
+// paragraph-long malware description doesn't blow out the message line.
+export const SUPPLY_CHAIN_ALERT_NOTE_MAX_CHARS = 160;
+
 // Packages excluded from the Socket supply-chain check (the gate and the
 // `--sfw` listing). react-doctor already covers these frameworks' specific
 // risks through dedicated rules — e.g. Next.js via the server-components /

--- a/packages/core/src/utils/sanitize-terminal-text.ts
+++ b/packages/core/src/utils/sanitize-terminal-text.ts
@@ -1,0 +1,19 @@
+// Neutralizes untrusted, remote text before it is woven into a diagnostic's
+// `message`/`help`, which the CLI prints to the terminal without stripping
+// escape sequences. Socket alert strings (`type`, `file`, `note`) describe a
+// potentially malicious package and are attacker-controlled, so a crafted
+// filename or note could otherwise inject ANSI/OSC terminal escapes (spoofing
+// or hiding the very warning) or break the diagnostic's `code` / "quote"
+// framing. Drops C0/C1 control characters (including ESC, which drives those
+// escape sequences) and replaces backticks with a straight quote.
+const isControlCharacter = (codePoint: number): boolean =>
+  codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f);
+
+export const sanitizeTerminalText = (value: string): string => {
+  let sanitized = "";
+  for (const character of value) {
+    if (isControlCharacter(character.codePointAt(0) ?? 0)) continue;
+    sanitized += character === "`" ? "'" : character;
+  }
+  return sanitized;
+};

--- a/packages/core/tests/check-supply-chain.test.ts
+++ b/packages/core/tests/check-supply-chain.test.ts
@@ -21,7 +21,6 @@ interface AxisScores {
 interface AlertInput {
   readonly type: string;
   readonly severity: string;
-  readonly category?: string;
   readonly file?: string;
   readonly note?: string;
 }
@@ -35,7 +34,6 @@ const socketArtifactLine = (axes: AxisScores, alerts: ReadonlyArray<AlertInput>)
       key: `${alert.type}-key`,
       type: alert.type,
       severity: alert.severity,
-      category: alert.category ?? "supplyChainRisk",
       ...(alert.file ? { file: alert.file } : {}),
       ...(alert.note ? { props: { note: alert.note } } : {}),
     })),
@@ -218,5 +216,155 @@ describe("checkSupplyChain — security-axis gating", () => {
     const diagnostics = await runCheck();
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].message).toContain('`ranged-pkg@2.1.0 (lowest version "^2.1.0" allows)`');
+  });
+
+  it("names the exact scored version for a `v`-prefixed pin instead of a range", async () => {
+    writePackageJson({ "v-pinned": "v1.2.3" });
+    stubSocketApi({
+      "v-pinned": { supplyChain: 0.2, vulnerability: 1, maintenance: 1, quality: 1, license: 1 },
+    });
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    // `v1.2.3` is an exact pin, so it must not be mislabeled as a range floor.
+    expect(diagnostics[0].message).toContain("`v-pinned@1.2.3` scored");
+    expect(diagnostics[0].message).not.toContain("lowest version");
+  });
+
+  it("keeps the score-driven diagnostic when alerts are malformed or null (no fail-open)", async () => {
+    writePackageJson({ "null-alert-pkg": "1.0.0" });
+    // A real Socket line where optional alert fields are explicitly `null`
+    // (JSON APIs send `null`, not an absent key) and one alert is malformed
+    // (missing `type`). Neither must sink the score that gates the check.
+    const body = JSON.stringify({
+      id: "test-artifact",
+      type: "npm",
+      score: {
+        supplyChain: 0.1,
+        vulnerability: 1,
+        maintenance: 1,
+        quality: 1,
+        license: 1,
+        overall: 0.1,
+      },
+      alerts: [
+        { key: "a", type: "malware", severity: "critical", file: null, props: null },
+        { key: "b", severity: "high" },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("scored 10/100 on Socket's supply chain axis");
+    // The valid alert (with null fields) is still named; the malformed one is dropped.
+    expect(diagnostics[0].message).toContain("critical known malware alert");
+  });
+
+  it("strips terminal escape sequences and backticks from remote alert strings", async () => {
+    writePackageJson({ "ansi-pkg": "1.0.0" });
+    stubSocketApi(
+      { "ansi-pkg": { supplyChain: 0, vulnerability: 1, maintenance: 1, quality: 1, license: 1 } },
+      {
+        "ansi-pkg": [
+          {
+            type: "malware",
+            severity: "critical",
+            file: "pkg/\u001b[31mhidden\u001b[0m`whoami`.js",
+            note: "Payload \u001b[2Kspoofs output and runs `rm -rf`.",
+          },
+        ],
+      },
+    );
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    const { message } = diagnostics[0];
+    // No raw ESC reaches terminal-bound output, and backticks in remote strings
+    // are neutralized so they can't break the `code` / "quote" framing.
+    expect(message).not.toContain("\u001b");
+    expect(message).toContain("pkg/[31mhidden[0m'whoami'.js");
+    expect(message).toContain("Payload [2Kspoofs output and runs 'rm -rf'");
+  });
+
+  it("uses the axis remediation and gentler escape hatch for a non-critical alert", async () => {
+    writePackageJson({ "high-not-critical": "1.0.0" });
+    stubSocketApi(
+      {
+        "high-not-critical": {
+          supplyChain: 0.1,
+          vulnerability: 1,
+          maintenance: 1,
+          quality: 1,
+          license: 1,
+        },
+      },
+      {
+        "high-not-critical": [
+          { type: "obfuscatedCode", severity: "high", note: "Heavily obfuscated bundle." },
+        ],
+      },
+    );
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("high obfuscated code alert");
+    // A non-critical alert must not escalate to the "remove / do not ship" help.
+    expect(diagnostics[0].help).not.toContain("do not ship it");
+    expect(diagnostics[0].help).toContain("prefer a more established, audited alternative");
+    expect(diagnostics[0].help).toContain("supplyChain.minScore");
+  });
+
+  it("summarizes multiple alerts with a +N more tail and the worst severity", async () => {
+    writePackageJson({ "many-alerts": "1.0.0" });
+    stubSocketApi(
+      {
+        "many-alerts": {
+          supplyChain: 0.1,
+          vulnerability: 1,
+          maintenance: 1,
+          quality: 1,
+          license: 1,
+        },
+      },
+      {
+        "many-alerts": [
+          { type: "malware", severity: "critical" },
+          { type: "installScript", severity: "high" },
+          { type: "networkAccess", severity: "medium" },
+          { type: "envVars", severity: "low" },
+        ],
+      },
+    );
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    // Four alerts: the top three are named, the remainder collapses to "+N more".
+    expect(diagnostics[0].message).toContain("Socket flagged 4 alerts");
+    expect(diagnostics[0].message).toContain("(+1 more)");
+    expect(diagnostics[0].message).toContain("most severe: critical");
+  });
+
+  it('normalizes Socket\'s "middle" severity to "medium"', async () => {
+    writePackageJson({ "middle-sev": "1.0.0" });
+    stubSocketApi(
+      {
+        "middle-sev": {
+          supplyChain: 0.1,
+          vulnerability: 1,
+          maintenance: 1,
+          quality: 1,
+          license: 1,
+        },
+      },
+      { "middle-sev": [{ type: "troll", severity: "middle", note: "Protestware." }] },
+    );
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("medium protestware alert");
   });
 });

--- a/packages/core/tests/check-supply-chain.test.ts
+++ b/packages/core/tests/check-supply-chain.test.ts
@@ -16,16 +16,38 @@ interface AxisScores {
   readonly license: number;
 }
 
-const socketArtifactLine = (axes: AxisScores): string =>
+// A Socket alert in the shape the endpoint attaches to high-signal threats:
+// the `note` rides `props.note`, mirroring the real artifact.
+interface AlertInput {
+  readonly type: string;
+  readonly severity: string;
+  readonly category?: string;
+  readonly file?: string;
+  readonly note?: string;
+}
+
+const socketArtifactLine = (axes: AxisScores, alerts: ReadonlyArray<AlertInput>): string =>
   JSON.stringify({
     id: "test-artifact",
     type: "npm",
     score: { ...axes, overall: Math.min(...Object.values(axes)) },
+    alerts: alerts.map((alert) => ({
+      key: `${alert.type}-key`,
+      type: alert.type,
+      severity: alert.severity,
+      category: alert.category ?? "supplyChainRisk",
+      ...(alert.file ? { file: alert.file } : {}),
+      ...(alert.note ? { props: { note: alert.note } } : {}),
+    })),
   });
 
 // Stubs the free Socket PURL endpoint with one canned artifact per package
-// name (the NDJSON body shape the real endpoint streams).
-const stubSocketApi = (scoresByPackageName: Record<string, AxisScores>): void => {
+// name (the NDJSON body shape the real endpoint streams). Alerts are optional
+// — the free endpoint omits them for metric-driven (CVE-only) low scores.
+const stubSocketApi = (
+  scoresByPackageName: Record<string, AxisScores>,
+  alertsByPackageName: Record<string, ReadonlyArray<AlertInput>> = {},
+): void => {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL) => {
@@ -33,7 +55,9 @@ const stubSocketApi = (scoresByPackageName: Record<string, AxisScores>): void =>
       const matched = Object.entries(scoresByPackageName).find(([name]) =>
         requestUrl.includes(`pkg:npm/${name}@`),
       );
-      const body = matched ? socketArtifactLine(matched[1]) : "";
+      const body = matched
+        ? socketArtifactLine(matched[1], alertsByPackageName[matched[0]] ?? [])
+        : "";
       return new Response(body, { status: 200 });
     }),
   );
@@ -92,10 +116,14 @@ describe("checkSupplyChain — security-axis gating", () => {
     const diagnostics = await runCheck();
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].rule).toBe("low-supply-chain-score");
-    expect(diagnostics[0].message).toContain("has a Socket vulnerability score of 25/100");
-    expect(diagnostics[0].message).not.toContain("supply chain score of 25");
-    // The full axis breakdown stays in the message as context.
-    expect(diagnostics[0].message).toContain("supply chain 100, vulnerability 25");
+    expect(diagnostics[0].message).toContain("scored 25/100 on Socket's vulnerability axis");
+    expect(diagnostics[0].message).not.toContain("supply chain axis");
+    // With no alerts, the message explains what the failing axis means.
+    expect(diagnostics[0].message).toContain("known security vulnerabilities (CVEs)");
+    // The remaining axes follow as context (the failing one already leads).
+    expect(diagnostics[0].message).toContain("Other axes — supply chain 100, maintenance 100");
+    // Vulnerability remediation is "upgrade", not the generic "update/replace".
+    expect(diagnostics[0].help).toContain("npm audit");
   });
 
   it("flags a supplyChain-driven low score and names the supply chain axis", async () => {
@@ -112,7 +140,7 @@ describe("checkSupplyChain — security-axis gating", () => {
 
     const diagnostics = await runCheck();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0].message).toContain("has a Socket supply chain score of 20/100");
+    expect(diagnostics[0].message).toContain("scored 20/100 on Socket's supply chain axis");
   });
 
   it("headlines the worst security axis when both gate below the minimum", async () => {
@@ -129,7 +157,7 @@ describe("checkSupplyChain — security-axis gating", () => {
 
     const diagnostics = await runCheck();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0].message).toContain("has a Socket vulnerability score of 10/100");
+    expect(diagnostics[0].message).toContain("scored 10/100 on Socket's vulnerability axis");
   });
 
   it("does not flag a security axis exactly at the minimum score", async () => {
@@ -145,5 +173,50 @@ describe("checkSupplyChain — security-axis gating", () => {
     });
 
     expect(await runCheck()).toEqual([]);
+  });
+
+  it("names Socket's concrete alert and tells you to remove a malware package", async () => {
+    writePackageJson({ "evil-pkg": "1.0.0" });
+    stubSocketApi(
+      {
+        "evil-pkg": { supplyChain: 0, vulnerability: 1, maintenance: 1, quality: 1, license: 1 },
+      },
+      {
+        "evil-pkg": [
+          {
+            type: "malware",
+            severity: "critical",
+            file: "package/index.js",
+            note: "Concealed remote-code-execution payload that exfiltrates environment variables.",
+          },
+        ],
+      },
+    );
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    // The message names the alert, the offending file, and the note instead of
+    // leaving the user to guess what a "0/100" means.
+    expect(diagnostics[0].message).toContain("scored 0/100 on Socket's supply chain axis");
+    expect(diagnostics[0].message).toContain("critical known malware alert");
+    expect(diagnostics[0].message).toContain("`package/index.js`");
+    expect(diagnostics[0].message).toContain(
+      "Concealed remote-code-execution payload that exfiltrates environment variables",
+    );
+    // A critical alert escalates the help from "update/replace" to "remove".
+    expect(diagnostics[0].help).toContain("do not ship it");
+    expect(diagnostics[0].help).toContain("Remove");
+    expect(diagnostics[0].help).toContain("supplyChain.enabled: false");
+  });
+
+  it("names the scored version as the floor of a range spec", async () => {
+    writePackageJson({ "ranged-pkg": "^2.1.0" });
+    stubSocketApi({
+      "ranged-pkg": { supplyChain: 0.2, vulnerability: 1, maintenance: 1, quality: 1, license: 1 },
+    });
+
+    const diagnostics = await runCheck();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain('`ranged-pkg@2.1.0 (lowest version "^2.1.0" allows)`');
   });
 });


### PR DESCRIPTION
## Why

The `socket/low-supply-chain-score` finding showed only a bare score, so every
case read the same whether a package was active malware or merely had an old
CVE — and the developer had to leave the terminal to learn *why* it was flagged
and what to do. The free Socket endpoint already returns the answer (an
`alerts[]` array for high-signal threats); we were discarding it.

**Before** (structurally identical for every cause):

```text
`node-ipc` (declared in package.json as "10.1.1", scored at 10.1.1) has a Socket
supply chain score of 0/100 (below the minimum of 50). Axis scores — supply
chain 0, vulnerability 100, maintenance 86, quality 100, license 100.
→ Update or replace the `"node-ipc": "10.1.1"` entry in package.json. Review
  node-ipc on Socket: <url>. Or raise `supplyChain.minScore` if you have vetted
  and accepted this package.
```

**After** — names the alert (file + note) when Socket gives one, explains the
axis when it doesn't, and the help is axis-aware:

```text
# alert present → named, with file + note + "remove" guidance
`node-ipc@10.1.1` scored 0/100 on Socket's supply chain axis (minimum 50). Socket
flagged a critical known malware alert in `package/node-ipc.cjs`: "The file
contains a concealed geo-targeted destructive payload…". Other axes —
vulnerability 100, maintenance 86, quality 100, license 100.
→ Treat node-ipc as compromised — do not ship it. Remove `"node-ipc": "10.1.1"`
  from package.json and your lockfile, then audit anything it ran. Full report:
  <url>. Only if you've confirmed this is a false positive, set
  `supplyChain.enabled: false`.

# no alert (e.g. CVE-only) → axis meaning + "upgrade" guidance
`electron@22.0.0` scored 30/100 on Socket's vulnerability axis (minimum 50). This
points to known security vulnerabilities (CVEs) affecting this version. Other
axes — supply chain 93, maintenance 97, quality 100, license 100.
→ Upgrade to a version with no known advisories (run `npm audit` to find one), or
  replace it; update `"electron": "22.0.0"` in package.json. Full report: <url>.
  If you've reviewed and accepted this package, raise `supplyChain.minScore`
  (currently 50) or set `supplyChain.severity: "warning"`.
```

## What changed

- **Decode `alerts[]`** in the Socket artifact (`type` / `severity` / `category`
  / `file` / `props.note`) — previously only `score` was parsed.
- **Message names the cause**: the concrete alert when present (worst-severity
  first, capped, with a one-sentence note), otherwise a plain-English meaning of
  the failing axis.
- **Axis-aware help**: remove a compromised package (critical alert), upgrade
  past CVEs (`vulnerability`), or confirm/replace + raise the threshold —
  replacing the one generic "update or replace".
- **Wording cleanup**: lead with the failing axis; collapse "declared as X,
  scored at X" to `pkg@version`, and ranges now read
  `pkg@floor (lowest version "^x.y.z" allows)` to make clear we score the range
  floor.
- Replaced the `gates: boolean` axis flag with richer `guidance` (its presence
  *is* the gate), so the failing axis carries its own meaning + remediation.
- Added `socket.alert.count` as a trace span attribute.
- Constants: `SUPPLY_CHAIN_MAX_ALERTS_SHOWN`, `SUPPLY_CHAIN_ALERT_NOTE_MAX_CHARS`.
- Changeset (`react-doctor` patch). JSON report shape unchanged (`schemaVersion: 1`).

## Test plan

- [x] `pnpm --filter @react-doctor/core test check-supply-chain` — 7/7 (new
  coverage for the malware-alert path and the range-floor identity)
- [x] `pnpm --filter @react-doctor/core typecheck`
- [x] `pnpm lint` (exit 0)
- [x] `pnpm format:check` (changed files + changeset)
- [x] `pnpm smoke:json-report` — `schemaVersion=1`, shape unchanged

> Note: a pre-existing, unrelated `filter-diagnostics` test failure exists on
> `main` (verified by stashing this branch's changes); it is out of scope here.

Made with [Cursor](https://cursor.com)