### PR TITLE
feat: React perf profiling harness (perf-agent, web + React Native) + react-doctor/runtime + skill

### DIFF
--- a/.agents/skills/react-doctor/SKILL.md
+++ b/.agents/skills/react-doctor/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: react-doctor
 description: Use when finishing a feature, fixing a bug, before committing React code, or when the user types `/doctor`, asks to scan, triage, or clean up React diagnostics. Covers lint, accessibility, bundle size, architecture. Includes a regression check and a full local-triage workflow that fetches the canonical playbook.
-version: "1.2.0"
+version: "1.3.0"
 ---
 
 # React Doctor
 
-Scans React codebases for security, performance, correctness, and architecture issues. Outputs a 0–100 health score.
+Scans React codebases for security, performance, correctness, and architecture issues. Outputs a 0 to 100 health score.
 
 ## After making React code changes:
 
@@ -16,11 +16,11 @@ If the score dropped, fix the regressions before committing.
 
 ## For general cleanup or code improvement:
 
-Run `npx react-doctor@latest --verbose` (the default `--scope full`) to scan the full codebase. Fix issues by severity — errors first, then warnings.
+Run `npx react-doctor@latest --verbose` (the default `--scope full`) to scan the full codebase. Fix issues by severity: errors first, then warnings.
 
-## /doctor — full local triage workflow
+## /doctor: full local triage workflow
 
-When the user types `/doctor`, says "run react doctor", or asks for a full triage / cleanup pass (not just a regression check), fetch the canonical local-triage playbook and follow every step in it:
+When the user types `/doctor`, says “run react doctor”, or asks for a full triage / cleanup pass (not just a regression check), fetch the canonical local-triage playbook and follow every step in it:
 
 ```bash
 curl --fail --silent --show-error \
@@ -28,7 +28,7 @@ curl --fail --silent --show-error \
   https://www.react.doctor/prompts/react-doctor-agent.md
 ```
 
-The playbook is the single source of truth — a scan → filter → triage → fix → validate loop that edits the working tree directly (never commits, never opens PRs). Updating the prompt at its source updates every agent on its next fetch — no skill reinstall needed.
+The playbook is the single source of truth: a scan → filter → triage → fix → validate loop that edits the working tree directly (never commits, never opens PRs). Updating the prompt at its source updates every agent on its next fetch, no skill reinstall needed.
 
 Pair it with the matching per-rule prompts at `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md` (fetched on demand inside the playbook) so each fix uses the canonical, reviewer-tested recipe.
 
@@ -38,7 +38,7 @@ When the user wants to understand a rule, disagrees with one, or wants to disabl
 
 ## Performance engineering
 
-When the user reports jank, slow interactions, dropped frames, excessive re-renders, or asks to profile / optimize React render performance, read [references/performance.md](references/performance.md) and follow it. It sets up the in-app profiling harness — shipped as `react-doctor/runtime` — and runs an evidence-driven profile → analyze → fix → re-profile loop against the real React DevTools profiler export, never guessing from code alone.
+When the user reports jank, slow interactions, dropped frames, excessive re-renders, or asks to profile / optimize React render performance, read [references/performance.md](references/performance.md) and follow it. It sets up the in-app profiling harness (shipped as `react-doctor/runtime`) and runs an evidence-driven profile → analyze → fix → re-profile loop against the real React DevTools profiler export, never guessing from code alone.
 
 ## Command
 

--- a/.agents/skills/react-doctor/SKILL.md
+++ b/.agents/skills/react-doctor/SKILL.md
@@ -36,6 +36,10 @@ Pair it with the matching per-rule prompts at `https://www.react.doctor/prompts/
 
 When the user wants to understand a rule, disagrees with one, or wants to disable / tune which rules run (not fix code), read [references/explain.md](references/explain.md) and follow it. Start with `npx react-doctor@latest rules explain <rule>`, then apply the narrowest control via `npx react-doctor@latest rules disable|set|category|ignore-tag …`, which edits your `doctor.config.*` (or `package.json#reactDoctor`).
 
+## Performance engineering
+
+When the user reports jank, slow interactions, dropped frames, excessive re-renders, or asks to profile / optimize React render performance, read [references/performance.md](references/performance.md) and follow it. It sets up the in-app profiling harness — shipped as `react-doctor/runtime` — and runs an evidence-driven profile → analyze → fix → re-profile loop against the real React DevTools profiler export, never guessing from code alone.
+
 ## Command
 
 ```bash

--- a/.agents/skills/react-doctor/references/performance.md
+++ b/.agents/skills/react-doctor/references/performance.md
@@ -1,9 +1,9 @@
 # Performance engineering (React render profiling loop)
 
-Profile and optimize React render performance with **runtime evidence** — the
-React DevTools profiler export — never by guessing from code alone. Use this
-when the user reports jank, slow interactions, dropped frames, excessive
-re-renders, or asks to "make this faster" / "optimize renders".
+Profile and optimize React render performance with **runtime evidence**: the
+React DevTools profiler export. Never guess from code alone. Use this when the
+user reports jank, slow interactions, dropped frames, excessive re-renders, or
+asks to “make this faster” or “optimize renders”.
 
 Same discipline as debug-agent: hypothesize → profile → analyze the export → fix
 the top evidence-backed opportunity → re-profile to verify → repeat. A change
@@ -12,10 +12,10 @@ that does not show up as fewer or cheaper renders in the export is not a fix.
 ## Setup (once per app)
 
 The harness ships with React Doctor under the `react-doctor/runtime` subpath. It
-drives the real DevTools profiler in-app — no Chrome extension, no manual
+drives the real DevTools profiler in-app, with no Chrome extension and no manual
 record/stop.
 
-1. Nothing extra to install — the DevTools backend (`react-devtools-inline`)
+1. Nothing extra to install: the DevTools backend (`react-devtools-inline`)
    ships as a dependency of `react-doctor`.
 
 2. For trustworthy timings, run against React's profiling build (alias
@@ -23,7 +23,7 @@ record/stop.
    Dev timings work but are inflated.
 
 3. Inject the harness bootstrap into the app entry, wrapped in cleanup markers
-   so it can be removed deterministically later:
+   so you can remove it deterministically later:
 
 ```ts
 // #region react-doctor perf
@@ -40,12 +40,12 @@ createReactPerfHarness(); // exposes window.__REACT_PERF__
 // #endregion
 ```
 
-`installReactDevtoolsBackend()` must execute before any React import — put it at
+`installReactDevtoolsBackend()` must execute before any React import: put it at
 the very top of the entry, or in a separate module imported first.
 
 ### React Native
 
-The same `react-doctor/runtime` import works on React Native — Metro resolves the
+The same `react-doctor/runtime` import works on React Native: Metro resolves the
 `react-native` export condition to the RN-safe build (it connects only the
 DevTools backend, never `react-dom`). The harness installs on `global` instead of
 `window`, so the defaults need no changes:
@@ -62,16 +62,16 @@ import { createReactPerfHarness } from "react-doctor/runtime";
 createReactPerfHarness(); // exposes global.__REACT_PERF__
 ```
 
-Drive it the same way (`global.__REACT_PERF__.start()` / `await stop()`), e.g.
+Drive it the same way (`global.__REACT_PERF__.start()` then `await stop()`), e.g.
 from a dev menu action or an e2e driver. On RN the export's per-commit timings
-(`commitData`, `changeDescriptions`) are exact; the component-tree `snapshots`
-are reconstructed best-effort from the operation stream (this is experimental
-and pending on-device verification), so prefer analyzing render counts /
-durations / change reasons over the flamegraph hierarchy.
+(`commitData`, `changeDescriptions`) are exact, but the harness reconstructs the
+component-tree `snapshots` best-effort from the operation stream (experimental,
+pending on-device verification). Prefer analyzing render counts, durations, and
+change reasons over the flamegraph hierarchy.
 
 ## The loop
 
-1. **Hypothesize** (3–5): why is it slow? Unstable callback/object props,
+1. **Hypothesize** (3 to 5): why is it slow? Unstable callback/object props,
    missing `memo`/`useMemo`, a context provider that is too broad, large
    unvirtualized lists, expensive children re-rendering on every parent commit.
 
@@ -79,12 +79,12 @@ durations / change reasons over the flamegraph hierarchy.
 
 ```js
 window.__REACT_PERF__.start();
-// drive the interaction: navigate, type, click — the exact repro
+// drive the interaction: navigate, type, click (the exact repro)
 const profile = await window.__REACT_PERF__.stop();
 ```
 
 Drive it via Playwright `page.evaluate(...)` for a repeatable scenario, or have
-the user click through. Save `profile` to a file — it is the canonical DevTools
+the user click through. Save `profile` to a file. It is the canonical DevTools
 `ProfilingDataExport` (version 5), re-importable into the DevTools Profiler UI
 and analyzable directly.
 
@@ -97,7 +97,7 @@ and analyzable directly.
    Rank opportunities: components that render most often, cost the most self
    time, or re-render with no meaningful prop change (memoization candidates).
 
-4. **Fix** the single top evidence-backed opportunity — the smallest change that
+4. **Fix** the single top evidence-backed opportunity: the smallest change that
    addresses the proven cause.
 
 5. **Verify.** Re-run the _same_ scenario and diff before/after: the target
@@ -109,7 +109,7 @@ and analyzable directly.
    `// #region react-doctor perf` … `// #endregion` block and grep to confirm
    none remain.
 
-## Notes
+## Profiling caveats
 
 - Keep the harness installed across fix attempts; remove it only when done
   (mirrors debug-agent keeping instrumentation until the fix is verified).

--- a/.agents/skills/react-doctor/references/performance.md
+++ b/.agents/skills/react-doctor/references/performance.md
@@ -1,0 +1,95 @@
+# Performance engineering (React render profiling loop)
+
+Profile and optimize React render performance with **runtime evidence** — the
+React DevTools profiler export — never by guessing from code alone. Use this
+when the user reports jank, slow interactions, dropped frames, excessive
+re-renders, or asks to "make this faster" / "optimize renders".
+
+Same discipline as debug-agent: hypothesize → profile → analyze the export → fix
+the top evidence-backed opportunity → re-profile to verify → repeat. A change
+that does not show up as fewer or cheaper renders in the export is not a fix.
+
+## Setup (once per app)
+
+The harness ships with React Doctor under the `react-doctor/runtime` subpath. It
+drives the real DevTools profiler in-app — no Chrome extension, no manual
+record/stop.
+
+1. Install the DevTools backend (an optional peer of `react-doctor`):
+
+```bash
+npm i -D react-devtools-inline
+```
+
+2. For trustworthy timings, run against React's profiling build (alias
+   `react-dom` → `react-dom/profiling` in your bundler) in a dev/non-prod build.
+   Dev timings work but are inflated.
+
+3. Inject the harness bootstrap into the app entry, wrapped in cleanup markers
+   so it can be removed deterministically later:
+
+```ts
+// #region react-doctor perf
+import { installReactDevtoolsBackend } from "react-doctor/runtime";
+installReactDevtoolsBackend(); // MUST run before React is imported
+// #endregion
+```
+
+```ts
+// after the app has mounted (e.g. end of main.tsx)
+// #region react-doctor perf
+import { createReactPerfHarness } from "react-doctor/runtime";
+createReactPerfHarness(); // exposes window.__REACT_PERF__
+// #endregion
+```
+
+`installReactDevtoolsBackend()` must execute before any React import — put it at
+the very top of the entry, or in a separate module imported first.
+
+## The loop
+
+1. **Hypothesize** (3–5): why is it slow? Unstable callback/object props,
+   missing `memo`/`useMemo`, a context provider that is too broad, large
+   unvirtualized lists, expensive children re-rendering on every parent commit.
+
+2. **Profile.** Drive the scenario, then collect the export:
+
+```js
+window.__REACT_PERF__.start();
+// drive the interaction: navigate, type, click — the exact repro
+const profile = await window.__REACT_PERF__.stop();
+```
+
+Drive it via Playwright `page.evaluate(...)` for a repeatable scenario, or have
+the user click through. Save `profile` to a file — it is the canonical DevTools
+`ProfilingDataExport` (version 5), re-importable into the DevTools Profiler UI
+and analyzable directly.
+
+3. **Analyze the export.** Aggregate `dataForRoots[].commitData[]`:
+   - per fiber: render count, summed `fiberActualDurations` / `fiberSelfDurations`
+   - `changeDescriptions[fiberID]` → _why_ it rendered (which props / state /
+     hooks / context changed), plus `isFirstMount` and `didHooksChange`
+   - `compiledWithForget` in the snapshots → already optimized by React Compiler
+
+   Rank opportunities: components that render most often, cost the most self
+   time, or re-render with no meaningful prop change (memoization candidates).
+
+4. **Fix** the single top evidence-backed opportunity — the smallest change that
+   addresses the proven cause.
+
+5. **Verify.** Re-run the _same_ scenario and diff before/after: the target
+   component's render count and self/actual duration must drop, and no other
+   component may regress. Run the scenario a few times and compare medians (dev
+   timings are noisy; StrictMode double-renders on mount).
+
+6. **Iterate** until the budget is met, then **clean up**: delete every
+   `// #region react-doctor perf` … `// #endregion` block and grep to confirm
+   none remain.
+
+## Notes
+
+- Keep the harness installed across fix attempts; remove it only when done
+  (mirrors debug-agent keeping instrumentation until the fix is verified).
+- The export omits scheduler `timelineData` for now; the per-commit render data
+  above is the signal.
+- Never claim a performance win without a before/after export diff.

--- a/.agents/skills/react-doctor/references/performance.md
+++ b/.agents/skills/react-doctor/references/performance.md
@@ -15,11 +15,8 @@ The harness ships with React Doctor under the `react-doctor/runtime` subpath. It
 drives the real DevTools profiler in-app — no Chrome extension, no manual
 record/stop.
 
-1. Install the DevTools backend (an optional peer of `react-doctor`):
-
-```bash
-npm i -D react-devtools-inline
-```
+1. Nothing extra to install — the DevTools backend (`react-devtools-inline`)
+   ships as a dependency of `react-doctor`.
 
 2. For trustworthy timings, run against React's profiling build (alias
    `react-dom` → `react-dom/profiling` in your bundler) in a dev/non-prod build.

--- a/.agents/skills/react-doctor/references/performance.md
+++ b/.agents/skills/react-doctor/references/performance.md
@@ -46,6 +46,32 @@ createReactPerfHarness(); // exposes window.__REACT_PERF__
 `installReactDevtoolsBackend()` must execute before any React import — put it at
 the very top of the entry, or in a separate module imported first.
 
+### React Native
+
+The same `react-doctor/runtime` import works on React Native — Metro resolves the
+`react-native` export condition to the RN-safe build (it connects only the
+DevTools backend, never `react-dom`). The harness installs on `global` instead of
+`window`, so the defaults need no changes:
+
+```ts
+// at the very top of index.js, before "react-native" / your App import
+import { installReactDevtoolsBackend } from "react-doctor/runtime";
+installReactDevtoolsBackend();
+```
+
+```ts
+// after the app registers (e.g. after AppRegistry.registerComponent)
+import { createReactPerfHarness } from "react-doctor/runtime";
+createReactPerfHarness(); // exposes global.__REACT_PERF__
+```
+
+Drive it the same way (`global.__REACT_PERF__.start()` / `await stop()`), e.g.
+from a dev menu action or an e2e driver. On RN the export's per-commit timings
+(`commitData`, `changeDescriptions`) are exact; the component-tree `snapshots`
+are reconstructed best-effort from the operation stream (this is experimental
+and pending on-device verification), so prefer analyzing render counts /
+durations / change reasons over the flamegraph hierarchy.
+
 ## The loop
 
 1. **Hypothesize** (3–5): why is it slow? Unstable callback/object props,

--- a/packages/perf-agent/README.md
+++ b/packages/perf-agent/README.md
@@ -1,14 +1,14 @@
 # @react-doctor/perf-agent
 
 An in-app React performance harness that drives the **React DevTools Profiler
-programmatically** — no Chrome extension, no manual record/stop. It produces the
-exact `ProfilingDataExport` (`version: 5`) the DevTools "export" button emits, so
-the output re-imports into the DevTools Profiler UI and feeds existing
-profiler-JSON analysis scripts unchanged.
+programmatically**, with no Chrome extension and no manual record/stop. It
+produces the exact `ProfilingDataExport` (`version: 5`) the DevTools export
+button emits, so the output re-imports into the DevTools Profiler UI and feeds
+existing profiler-JSON analysis scripts unchanged.
 
-This is the foundation for a debug-agent–style **perf loop**: an agent starts a
-profile, drives a scenario, stops, reads the export, optimizes, and re-profiles
-to verify — all with runtime evidence.
+This is the foundation for a **perf loop** modeled on debug-agent: an agent
+starts a profile, drives a scenario, stops, reads the export, optimizes, and
+re-profiles to verify, all with runtime evidence.
 
 ## How the DevTools setup works
 
@@ -17,9 +17,9 @@ The harness reuses the real DevTools backend + a headless frontend `Store`
 DevTools UI is never rendered; the `Store` collects commit timings and change
 descriptions on its own.
 
-1. `installReactDevtoolsBackend(window)` — installs the global hook. **Must run
+1. `installReactDevtoolsBackend(window)`: installs the global hook. **Must run
    before React loads.**
-2. `createReactPerfHarness(window)` — connects the headless `Store` and exposes
+2. `createReactPerfHarness(window)`: connects the headless `Store` and exposes
    `window.__REACT_PERF__`.
 3. `window.__REACT_PERF__.start()` → run the scenario → `await
 window.__REACT_PERF__.stop()` returns the canonical export.
@@ -40,6 +40,6 @@ For trustworthy timings, run against React's profiling build
 ## Payload
 
 The export is 1:1 with DevTools. `timelineData` (scheduler/lanes) is omitted for
-now — valid per the v5 schema ("old exported profiles won't contain this key") —
-and is a follow-up alongside the LoAF (Long Animation Frames) sidecar, the
+now, which is valid per the v5 schema (old exported profiles won't contain this
+key). It is a follow-up alongside the Long Animation Frames (LoAF) sidecar, the
 collector daemon, the Playwright scenario runner, and the agent skill.

--- a/packages/perf-agent/README.md
+++ b/packages/perf-agent/README.md
@@ -1,0 +1,45 @@
+# @react-doctor/perf-agent
+
+An in-app React performance harness that drives the **React DevTools Profiler
+programmatically** — no Chrome extension, no manual record/stop. It produces the
+exact `ProfilingDataExport` (`version: 5`) the DevTools "export" button emits, so
+the output re-imports into the DevTools Profiler UI and feeds existing
+profiler-JSON analysis scripts unchanged.
+
+This is the foundation for a debug-agent–style **perf loop**: an agent starts a
+profile, drives a scenario, stops, reads the export, optimizes, and re-profiles
+to verify — all with runtime evidence.
+
+## How the DevTools setup works
+
+The harness reuses the real DevTools backend + a headless frontend `Store`
+(via `react-devtools-inline`), connected by a synchronous in-page wall. The
+DevTools UI is never rendered; the `Store` collects commit timings and change
+descriptions on its own.
+
+1. `installReactDevtoolsBackend(window)` — installs the global hook. **Must run
+   before React loads.**
+2. `createReactPerfHarness(window)` — connects the headless `Store` and exposes
+   `window.__REACT_PERF__`.
+3. `window.__REACT_PERF__.start()` → run the scenario → `await
+window.__REACT_PERF__.stop()` returns the canonical export.
+
+```ts
+// entry-before-react.ts (imported first, before any React import)
+import { installReactDevtoolsBackend } from "@react-doctor/perf-agent";
+installReactDevtoolsBackend();
+
+// after React has mounted
+import { createReactPerfHarness } from "@react-doctor/perf-agent";
+createReactPerfHarness();
+```
+
+For trustworthy timings, run against React's profiling build
+(`react-dom/profiling` via a bundler alias) in a non-prod environment.
+
+## Payload
+
+The export is 1:1 with DevTools. `timelineData` (scheduler/lanes) is omitted for
+now — valid per the v5 schema ("old exported profiles won't contain this key") —
+and is a follow-up alongside the LoAF (Long Animation Frames) sidecar, the
+collector daemon, the Playwright scenario runner, and the agent skill.

--- a/packages/perf-agent/package.json
+++ b/packages/perf-agent/package.json
@@ -9,16 +9,25 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "react-native": "./dist/index.native.js",
+      "browser": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./native": {
+      "types": "./dist/index.native.d.ts",
+      "default": "./dist/index.native.js"
     },
     "./harness": {
       "types": "./dist/harness.d.ts",
+      "react-native": "./dist/harness.native.js",
+      "browser": "./dist/harness.js",
       "default": "./dist/harness.js"
     }
   },
   "scripts": {
     "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && cross-env NODE_ENV=production vp pack",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vp test run"
   },
   "dependencies": {
     "react-devtools-inline": "^6.1.5"

--- a/packages/perf-agent/package.json
+++ b/packages/perf-agent/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@react-doctor/perf-agent",
+  "version": "0.5.4",
+  "private": true,
+  "description": "Internal: in-app React performance harness that drives the DevTools Profiler programmatically and emits the canonical DevTools profiling export for agents to analyze.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./harness": {
+      "types": "./dist/harness.d.ts",
+      "default": "./dist/harness.js"
+    }
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && cross-env NODE_ENV=production vp pack",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react-devtools-inline": "^6.1.5"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0"
+  },
+  "peerDependencies": {
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.13.0"
+  }
+}

--- a/packages/perf-agent/src/common.ts
+++ b/packages/perf-agent/src/common.ts
@@ -1,0 +1,38 @@
+export { installReactDevtoolsBackend } from "./devtools/install-backend.js";
+export { createProfilingSession } from "./devtools/profiling-session.js";
+export type { ProfilingSession } from "./devtools/profiling-session.js";
+export { applyOperationsToTree } from "./devtools/operations/apply-operations-to-tree.js";
+export type { ApplyOperationsResult } from "./devtools/operations/apply-operations-to-tree.js";
+export { takeTreeSnapshot } from "./devtools/operations/take-tree-snapshot.js";
+export { assembleFrontendData } from "./devtools/operations/assemble-frontend-data.js";
+export type { AssembleFrontendDataInput } from "./devtools/operations/assemble-frontend-data.js";
+export type { ReactPerfHarness } from "./devtools/make-harness.js";
+export { serializeProfilingExport } from "./utils/serialize-profiling-export.js";
+export { parseElementDisplayName } from "./utils/parse-element-display-name.js";
+export type { ParsedElementDisplayName } from "./utils/parse-element-display-name.js";
+export type { DevtoolsElementTree, DevtoolsElementTreeNode } from "./types/element-tree.js";
+export type {
+  ReactProfilerCommitDataBackend,
+  ReactProfilerDataBackend,
+  ReactProfilerDataForRootBackend,
+  ReactProfilerSerializedElementBackend,
+} from "./types/profiling-backend.js";
+export type {
+  ReactProfilerChangeDescription,
+  ReactProfilerCommitDataExport,
+  ReactProfilerDataExport,
+  ReactProfilerDataForRootExport,
+  ReactProfilerSerializedElement,
+  ReactProfilerSnapshotNode,
+} from "./types/profiling-export.js";
+export type {
+  ReactProfilerCommitDataFrontend,
+  ReactProfilerDataForRootFrontend,
+  ReactProfilerDataFrontend,
+} from "./types/profiling-frontend.js";
+export type {
+  DevtoolsGlobal,
+  ReactDevtoolsProfilerStore,
+  ReactDevtoolsStore,
+  ReactDevtoolsWall,
+} from "./types/react-devtools.js";

--- a/packages/perf-agent/src/constants.ts
+++ b/packages/perf-agent/src/constants.ts
@@ -1,1 +1,20 @@
 export const PROFILING_EXPORT_VERSION = 5;
+
+// React DevTools operation opcodes (react-devtools-shared/src/constants.js).
+export const TREE_OPERATION_ADD = 1;
+export const TREE_OPERATION_REMOVE = 2;
+export const TREE_OPERATION_REORDER_CHILDREN = 3;
+export const TREE_OPERATION_UPDATE_TREE_BASE_DURATION = 4;
+export const TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS = 5;
+export const TREE_OPERATION_SET_SUBTREE_MODE = 7;
+export const TREE_OPERATION_APPLIED_ACTIVITY_SLICE_CHANGE = 13;
+
+// React DevTools element types (react-devtools-shared/src/frontend/types.js).
+export const ELEMENT_TYPE_CLASS = 1;
+export const ELEMENT_TYPE_FUNCTION = 5;
+export const ELEMENT_TYPE_FORWARD_REF = 6;
+export const ELEMENT_TYPE_MEMO = 8;
+export const ELEMENT_TYPE_ROOT = 11;
+export const ELEMENT_TYPE_VIRTUAL = 15;
+
+export const FORGET_WRAPPER_PREFIX = "Forget(";

--- a/packages/perf-agent/src/constants.ts
+++ b/packages/perf-agent/src/constants.ts
@@ -1,5 +1,10 @@
 export const PROFILING_EXPORT_VERSION = 5;
 
+// Upper bound on how long `stop()` waits for the backend to return profiling
+// data before settling (with whatever was collected), so a non-responding
+// backend can't hang the caller.
+export const PROFILING_STOP_TIMEOUT_MS = 30_000;
+
 // React DevTools operation opcodes (react-devtools-shared/src/constants.js).
 export const TREE_OPERATION_ADD = 1;
 export const TREE_OPERATION_REMOVE = 2;

--- a/packages/perf-agent/src/constants.ts
+++ b/packages/perf-agent/src/constants.ts
@@ -1,0 +1,1 @@
+export const PROFILING_EXPORT_VERSION = 5;

--- a/packages/perf-agent/src/devtools/create-profiler-store.native.ts
+++ b/packages/perf-agent/src/devtools/create-profiler-store.native.ts
@@ -125,10 +125,19 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
       emit("isProfiling");
     },
     stopProfiling: () => {
+      const wasProfiling = isProfiling;
       isProfiling = false;
       emit("isProfiling");
-      // Always tell the backend to stop, even with no renderer observed, so it
-      // never stays in recording mode after a startProfiling.
+      if (!wasProfiling) {
+        // No active session: don't fetch, and don't surface stale data from a
+        // previous session.
+        profilingData = null;
+        isProcessingData = false;
+        emit("isProcessingData");
+        return;
+      }
+      // A session was active: tell the backend to stop even with no renderer
+      // observed, so it never stays in recording mode.
       frontendBridge.send("stopProfiling");
       if (rendererID === null) {
         isProcessingData = false;

--- a/packages/perf-agent/src/devtools/create-profiler-store.native.ts
+++ b/packages/perf-agent/src/devtools/create-profiler-store.native.ts
@@ -87,20 +87,23 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
   });
 
   frontendBridge.addListener("profilingData", (payload) => {
-    if (!isProfilerDataBackend(payload)) {
-      // A malformed payload must still settle processing, else `stop()` hangs.
-      isProcessingData = false;
-      emit("isProcessingData");
-      return;
+    // Any malformed/partial payload (top-level or per-commit) must still settle
+    // processing and leave profilingData null, so `stop()` resolves with null
+    // rather than hanging or rejecting with a TypeError.
+    if (isProfilerDataBackend(payload)) {
+      try {
+        profilingData = assembleFrontendData({
+          dataBackend: payload,
+          operationsByRootID,
+          snapshotsByRootID,
+        });
+      } catch {
+        profilingData = null;
+      }
     }
-    profilingData = assembleFrontendData({
-      dataBackend: payload,
-      operationsByRootID,
-      snapshotsByRootID,
-    });
     isProcessingData = false;
     emit("isProcessingData");
-    emit("profilingData");
+    if (profilingData !== null) emit("profilingData");
   });
 
   activateBackend(target, { bridge: createBackendBridge(target, wall) });

--- a/packages/perf-agent/src/devtools/create-profiler-store.native.ts
+++ b/packages/perf-agent/src/devtools/create-profiler-store.native.ts
@@ -87,7 +87,12 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
   });
 
   frontendBridge.addListener("profilingData", (payload) => {
-    if (!isProfilerDataBackend(payload)) return;
+    if (!isProfilerDataBackend(payload)) {
+      // A malformed payload must still settle processing, else `stop()` hangs.
+      isProcessingData = false;
+      emit("isProcessingData");
+      return;
+    }
     profilingData = assembleFrontendData({
       dataBackend: payload,
       operationsByRootID,
@@ -119,13 +124,15 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
     stopProfiling: () => {
       isProfiling = false;
       emit("isProfiling");
+      // Always tell the backend to stop, even with no renderer observed, so it
+      // never stays in recording mode after a startProfiling.
+      frontendBridge.send("stopProfiling");
       if (rendererID === null) {
         isProcessingData = false;
         emit("isProcessingData");
         return;
       }
       isProcessingData = true;
-      frontendBridge.send("stopProfiling");
       frontendBridge.send("getProfilingData", { rendererID });
     },
     get isProcessingData() {

--- a/packages/perf-agent/src/devtools/create-profiler-store.native.ts
+++ b/packages/perf-agent/src/devtools/create-profiler-store.native.ts
@@ -111,6 +111,10 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
 
   const profilerStore: ReactDevtoolsProfilerStore = {
     startProfiling: () => {
+      // Sessions are serial: ignore a start while one is recording or its stop
+      // is still finalizing, so an in-flight getProfilingData response can't be
+      // merged into a new session's buffers.
+      if (isProfiling || isProcessingData) return;
       operationsByRootID.clear();
       snapshotsByRootID.clear();
       profilingData = null;
@@ -125,6 +129,9 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
       emit("isProfiling");
     },
     stopProfiling: () => {
+      // A stop is already finalizing: let that in-flight request settle every
+      // waiter instead of racing it and clearing its state.
+      if (isProcessingData) return;
       const wasProfiling = isProfiling;
       isProfiling = false;
       emit("isProfiling");
@@ -132,7 +139,6 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
         // No active session: don't fetch, and don't surface stale data from a
         // previous session.
         profilingData = null;
-        isProcessingData = false;
         emit("isProcessingData");
         return;
       }
@@ -140,7 +146,6 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
       // observed, so it never stays in recording mode.
       frontendBridge.send("stopProfiling");
       if (rendererID === null) {
-        isProcessingData = false;
         emit("isProcessingData");
         return;
       }

--- a/packages/perf-agent/src/devtools/create-profiler-store.native.ts
+++ b/packages/perf-agent/src/devtools/create-profiler-store.native.ts
@@ -2,6 +2,7 @@ import {
   activate as activateBackend,
   createBridge as createBackendBridge,
 } from "react-devtools-inline/backend";
+import { PROFILING_STOP_TIMEOUT_MS } from "../constants.js";
 import type { DevtoolsElementTree } from "../types/element-tree.js";
 import type { ReactProfilerDataBackend } from "../types/profiling-backend.js";
 import type { ReactProfilerDataFrontend } from "../types/profiling-frontend.js";
@@ -51,6 +52,19 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
   let isProfiling = false;
   let isProcessingData = false;
   let profilingData: ReactProfilerDataFrontend | null = null;
+  let processingTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // Clears the in-flight stop state and notifies waiters. Used by both the
+  // profilingData response and the timeout guard so a non-responding backend
+  // can't leave isProcessingData stuck true (which would wedge later sessions).
+  const settleProcessing = (): void => {
+    if (processingTimer !== undefined) {
+      clearTimeout(processingTimer);
+      processingTimer = undefined;
+    }
+    isProcessingData = false;
+    emit("isProcessingData");
+  };
 
   const wallListeners: Array<(message: ReactDevtoolsWallMessage) => void> = [];
   const wall: ReactDevtoolsWall = {
@@ -87,6 +101,9 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
   });
 
   frontendBridge.addListener("profilingData", (payload) => {
+    // Ignore responses we're not awaiting (already timed out, or no active
+    // stop) so a late/stale response can't mutate state after stop() resolved.
+    if (!isProcessingData) return;
     // Any malformed/partial payload (top-level or per-commit) must still settle
     // processing and leave profilingData null, so `stop()` resolves with null
     // rather than hanging or rejecting with a TypeError.
@@ -101,8 +118,7 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
         profilingData = null;
       }
     }
-    isProcessingData = false;
-    emit("isProcessingData");
+    settleProcessing();
     if (profilingData !== null) emit("profilingData");
   });
 
@@ -151,6 +167,9 @@ export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactD
       }
       isProcessingData = true;
       frontendBridge.send("getProfilingData", { rendererID });
+      // Self-heal if the backend never responds, so isProcessingData can't stay
+      // stuck true and wedge later start/stop calls.
+      processingTimer = setTimeout(settleProcessing, PROFILING_STOP_TIMEOUT_MS);
     },
     get isProcessingData() {
       return isProcessingData;

--- a/packages/perf-agent/src/devtools/create-profiler-store.native.ts
+++ b/packages/perf-agent/src/devtools/create-profiler-store.native.ts
@@ -1,0 +1,151 @@
+import {
+  activate as activateBackend,
+  createBridge as createBackendBridge,
+} from "react-devtools-inline/backend";
+import type { DevtoolsElementTree } from "../types/element-tree.js";
+import type { ReactProfilerDataBackend } from "../types/profiling-backend.js";
+import type { ReactProfilerDataFrontend } from "../types/profiling-frontend.js";
+import type { ReactProfilerSnapshotNode } from "../types/profiling-export.js";
+import type {
+  DevtoolsGlobal,
+  ReactDevtoolsBridge,
+  ReactDevtoolsProfilerEvent,
+  ReactDevtoolsProfilerStore,
+  ReactDevtoolsStore,
+  ReactDevtoolsWall,
+  ReactDevtoolsWallMessage,
+} from "../types/react-devtools.js";
+import { applyOperationsToTree } from "./operations/apply-operations-to-tree.js";
+import { assembleFrontendData } from "./operations/assemble-frontend-data.js";
+import { takeTreeSnapshot } from "./operations/take-tree-snapshot.js";
+
+const isProfilerDataBackend = (value: unknown): value is ReactProfilerDataBackend =>
+  typeof value === "object" &&
+  value !== null &&
+  "dataForRoots" in value &&
+  Array.isArray(value.dataForRoots) &&
+  "rendererID" in value &&
+  typeof value.rendererID === "number";
+
+/**
+ * React Native implementation. The DevTools frontend Store can't run here (it
+ * pulls in `react-dom`/`fs`), so we connect only the RN-safe DevTools backend
+ * over a custom wall and assemble the export ourselves: backend `getProfilingData`
+ * supplies the per-commit timings; we observe `operations` on the wall to keep
+ * an element tree for the snapshots.
+ *
+ * Experimental: the bridge handshake mirrors the documented inline pattern but
+ * has not been verified on a device. Snapshot reconstruction handles the
+ * fixed-width operation opcodes and bails on the variable-width Suspense ops.
+ */
+export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactDevtoolsStore => {
+  const eventListeners = new Map<ReactDevtoolsProfilerEvent, Set<() => void>>();
+  const emit = (event: ReactDevtoolsProfilerEvent): void => {
+    for (const listener of eventListeners.get(event) ?? []) listener();
+  };
+
+  const tree: DevtoolsElementTree = new Map();
+  const operationsByRootID = new Map<number, Array<Array<number>>>();
+  const snapshotsByRootID = new Map<number, Map<number, ReactProfilerSnapshotNode>>();
+  let rendererID: number | null = null;
+  let isProfiling = false;
+  let isProcessingData = false;
+  let profilingData: ReactProfilerDataFrontend | null = null;
+
+  const wallListeners: Array<(message: ReactDevtoolsWallMessage) => void> = [];
+  const wall: ReactDevtoolsWall = {
+    listen: (listener) => {
+      wallListeners.push(listener);
+    },
+    send: (event, payload) => {
+      for (const listener of wallListeners) listener({ event, payload });
+    },
+  };
+
+  const frontendBridge: ReactDevtoolsBridge = createBackendBridge(target, wall);
+
+  frontendBridge.addListener("getSavedPreferences", () => {
+    frontendBridge.send("savedPreferences", {
+      appendComponentStack: true,
+      breakOnConsoleErrors: false,
+      componentFilters: [],
+      showInlineWarningsAndErrors: true,
+      hideConsoleLogsInStrictMode: false,
+    });
+  });
+
+  frontendBridge.addListener("operations", (payload) => {
+    if (!Array.isArray(payload)) return;
+    const rootID = payload[1] ?? 0;
+    if (isProfiling) {
+      const bucket = operationsByRootID.get(rootID) ?? [];
+      bucket.push(payload);
+      operationsByRootID.set(rootID, bucket);
+    }
+    const result = applyOperationsToTree(tree, payload);
+    rendererID = result.rendererID;
+  });
+
+  frontendBridge.addListener("profilingData", (payload) => {
+    if (!isProfilerDataBackend(payload)) return;
+    profilingData = assembleFrontendData({
+      dataBackend: payload,
+      operationsByRootID,
+      snapshotsByRootID,
+    });
+    isProcessingData = false;
+    emit("isProcessingData");
+    emit("profilingData");
+  });
+
+  activateBackend(target, { bridge: createBackendBridge(target, wall) });
+  frontendBridge.send("getProfilingStatus");
+
+  const profilerStore: ReactDevtoolsProfilerStore = {
+    startProfiling: () => {
+      operationsByRootID.clear();
+      snapshotsByRootID.clear();
+      profilingData = null;
+      for (const node of tree.values()) {
+        if (node.parentID === 0) snapshotsByRootID.set(node.id, takeTreeSnapshot(tree, node.id));
+      }
+      isProfiling = true;
+      frontendBridge.send("startProfiling", {
+        recordChangeDescriptions: true,
+        recordTimeline: false,
+      });
+      emit("isProfiling");
+    },
+    stopProfiling: () => {
+      isProfiling = false;
+      emit("isProfiling");
+      if (rendererID === null) {
+        isProcessingData = false;
+        emit("isProcessingData");
+        return;
+      }
+      isProcessingData = true;
+      frontendBridge.send("stopProfiling");
+      frontendBridge.send("getProfilingData", { rendererID });
+    },
+    get isProcessingData() {
+      return isProcessingData;
+    },
+    get didRecordCommits() {
+      return profilingData !== null && profilingData.dataForRoots.size > 0;
+    },
+    get profilingData() {
+      return profilingData;
+    },
+    addListener: (event, listener) => {
+      const set = eventListeners.get(event) ?? new Set();
+      set.add(listener);
+      eventListeners.set(event, set);
+    },
+    removeListener: (event, listener) => {
+      eventListeners.get(event)?.delete(listener);
+    },
+  };
+
+  return { profilerStore };
+};

--- a/packages/perf-agent/src/devtools/create-profiler-store.ts
+++ b/packages/perf-agent/src/devtools/create-profiler-store.ts
@@ -1,0 +1,37 @@
+import {
+  activate as activateBackend,
+  createBridge as createBackendBridge,
+} from "react-devtools-inline/backend";
+import { createBridge as createFrontendBridge, createStore } from "react-devtools-inline/frontend";
+import type {
+  ReactDevtoolsStore,
+  ReactDevtoolsWall,
+  ReactDevtoolsWallMessage,
+} from "../types/react-devtools.js";
+
+/**
+ * Connects a headless DevTools frontend Store to the already-installed backend
+ * over a synchronous in-page wall. The Store collects operations + commit
+ * timings on its own; the DevTools UI component is never rendered.
+ */
+export const createProfilerStore = (targetWindow: Window = window): ReactDevtoolsStore => {
+  const listeners: Array<(message: ReactDevtoolsWallMessage) => void> = [];
+  const wall: ReactDevtoolsWall = {
+    listen: (listener) => {
+      listeners.push(listener);
+    },
+    send: (event, payload) => {
+      for (const listener of listeners) listener({ event, payload });
+    },
+  };
+
+  const frontendBridge = createFrontendBridge(targetWindow, wall);
+  const store = createStore(frontendBridge);
+
+  // Activate only after the frontend bridge + store exist, else the backend
+  // emits the initial tree before the store is listening (per the DevTools
+  // inline contract).
+  activateBackend(targetWindow, { bridge: createBackendBridge(targetWindow, wall) });
+
+  return store;
+};

--- a/packages/perf-agent/src/devtools/create-profiler-store.ts
+++ b/packages/perf-agent/src/devtools/create-profiler-store.ts
@@ -4,17 +4,21 @@ import {
 } from "react-devtools-inline/backend";
 import { createBridge as createFrontendBridge, createStore } from "react-devtools-inline/frontend";
 import type {
+  DevtoolsGlobal,
   ReactDevtoolsStore,
   ReactDevtoolsWall,
   ReactDevtoolsWallMessage,
 } from "../types/react-devtools.js";
 
 /**
- * Connects a headless DevTools frontend Store to the already-installed backend
- * over a synchronous in-page wall. The Store collects operations + commit
- * timings on its own; the DevTools UI component is never rendered.
+ * Web implementation: connects a headless DevTools frontend Store to the
+ * already-installed backend over a synchronous in-page wall. The Store collects
+ * operations + commit timings on its own; the DevTools UI is never rendered.
+ *
+ * React Native uses `create-profiler-store.native.ts` instead — the frontend
+ * Store pulls in `react-dom`/`fs`, which an RN bundle cannot resolve.
  */
-export const createProfilerStore = (targetWindow: Window = window): ReactDevtoolsStore => {
+export const createProfilerStore = (target: DevtoolsGlobal = globalThis): ReactDevtoolsStore => {
   const listeners: Array<(message: ReactDevtoolsWallMessage) => void> = [];
   const wall: ReactDevtoolsWall = {
     listen: (listener) => {
@@ -25,13 +29,13 @@ export const createProfilerStore = (targetWindow: Window = window): ReactDevtool
     },
   };
 
-  const frontendBridge = createFrontendBridge(targetWindow, wall);
+  const frontendBridge = createFrontendBridge(target, wall);
   const store = createStore(frontendBridge);
 
   // Activate only after the frontend bridge + store exist, else the backend
   // emits the initial tree before the store is listening (per the DevTools
   // inline contract).
-  activateBackend(targetWindow, { bridge: createBackendBridge(targetWindow, wall) });
+  activateBackend(target, { bridge: createBackendBridge(target, wall) });
 
   return store;
 };

--- a/packages/perf-agent/src/devtools/install-backend.ts
+++ b/packages/perf-agent/src/devtools/install-backend.ts
@@ -1,14 +1,16 @@
 import { initialize as initializeBackend } from "react-devtools-inline/backend";
+import type { DevtoolsGlobal } from "../types/react-devtools.js";
 
 let isBackendInstalled = false;
 
 /**
- * Installs the DevTools global hook on the target window. MUST run before React
+ * Installs the DevTools global hook on the target global. MUST run before React
  * is loaded (before any import/script that pulls in React), otherwise React
- * never connects to the hook and no commits are recorded.
+ * never connects to the hook and no commits are recorded. Defaults to
+ * `globalThis` so it works on both web (`window`) and React Native (`global`).
  */
-export const installReactDevtoolsBackend = (targetWindow: Window = window): void => {
+export const installReactDevtoolsBackend = (target: DevtoolsGlobal = globalThis): void => {
   if (isBackendInstalled) return;
-  initializeBackend(targetWindow);
+  initializeBackend(target);
   isBackendInstalled = true;
 };

--- a/packages/perf-agent/src/devtools/install-backend.ts
+++ b/packages/perf-agent/src/devtools/install-backend.ts
@@ -1,7 +1,10 @@
 import { initialize as initializeBackend } from "react-devtools-inline/backend";
 import type { DevtoolsGlobal } from "../types/react-devtools.js";
 
-let isBackendInstalled = false;
+// Track per target, not a single boolean, so installing on a second global
+// (e.g. an iframe/worker) still wires that global's hook instead of silently
+// skipping it.
+const installedTargets = new WeakSet<DevtoolsGlobal>();
 
 /**
  * Installs the DevTools global hook on the target global. MUST run before React
@@ -10,7 +13,7 @@ let isBackendInstalled = false;
  * `globalThis` so it works on both web (`window`) and React Native (`global`).
  */
 export const installReactDevtoolsBackend = (target: DevtoolsGlobal = globalThis): void => {
-  if (isBackendInstalled) return;
+  if (installedTargets.has(target)) return;
   initializeBackend(target);
-  isBackendInstalled = true;
+  installedTargets.add(target);
 };

--- a/packages/perf-agent/src/devtools/install-backend.ts
+++ b/packages/perf-agent/src/devtools/install-backend.ts
@@ -1,0 +1,14 @@
+import { initialize as initializeBackend } from "react-devtools-inline/backend";
+
+let isBackendInstalled = false;
+
+/**
+ * Installs the DevTools global hook on the target window. MUST run before React
+ * is loaded (before any import/script that pulls in React), otherwise React
+ * never connects to the hook and no commits are recorded.
+ */
+export const installReactDevtoolsBackend = (targetWindow: Window = window): void => {
+  if (isBackendInstalled) return;
+  initializeBackend(targetWindow);
+  isBackendInstalled = true;
+};

--- a/packages/perf-agent/src/devtools/make-harness.ts
+++ b/packages/perf-agent/src/devtools/make-harness.ts
@@ -1,0 +1,35 @@
+import type { ReactProfilerDataExport } from "../types/profiling-export.js";
+import type { DevtoolsGlobal, ReactDevtoolsStore } from "../types/react-devtools.js";
+import { createProfilingSession } from "./profiling-session.js";
+import { installReactDevtoolsBackend } from "./install-backend.js";
+
+export interface ReactPerfHarness {
+  start: () => void;
+  stop: () => Promise<ReactProfilerDataExport | null>;
+}
+
+declare global {
+  interface Window {
+    __REACT_PERF__?: ReactPerfHarness;
+  }
+  // React Native exposes `global`, not `window`.
+  // eslint-disable-next-line vars-on-top, no-var
+  var __REACT_PERF__: ReactPerfHarness | undefined;
+}
+
+/**
+ * Wires the DevTools backend + a profiler store + a profiling session, then
+ * exposes `__REACT_PERF__` on the target global. The store factory is the only
+ * platform-specific piece (web frontend Store vs. the RN backend collector).
+ */
+export const makeReactPerfHarness = (
+  createProfilerStore: (target: DevtoolsGlobal) => ReactDevtoolsStore,
+  target: DevtoolsGlobal,
+): ReactPerfHarness => {
+  installReactDevtoolsBackend(target);
+  const store = createProfilerStore(target);
+  const session = createProfilingSession(store);
+  const harness: ReactPerfHarness = { start: session.start, stop: session.stop };
+  target.__REACT_PERF__ = harness;
+  return harness;
+};

--- a/packages/perf-agent/src/devtools/operations/apply-operations-to-tree.ts
+++ b/packages/perf-agent/src/devtools/operations/apply-operations-to-tree.ts
@@ -1,0 +1,150 @@
+import {
+  ELEMENT_TYPE_ROOT,
+  TREE_OPERATION_ADD,
+  TREE_OPERATION_APPLIED_ACTIVITY_SLICE_CHANGE,
+  TREE_OPERATION_REMOVE,
+  TREE_OPERATION_REORDER_CHILDREN,
+  TREE_OPERATION_SET_SUBTREE_MODE,
+  TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS,
+  TREE_OPERATION_UPDATE_TREE_BASE_DURATION,
+} from "../../constants.js";
+import type { DevtoolsElementTree } from "../../types/element-tree.js";
+import { parseElementDisplayName } from "../../utils/parse-element-display-name.js";
+
+export interface ApplyOperationsResult {
+  rendererID: number;
+  rootID: number;
+  // True when an unknown / variable-width opcode (e.g. a Suspense op) was hit
+  // and parsing stopped early to avoid desyncing the tree.
+  bailed: boolean;
+}
+
+const decodeString = (operations: Array<number>, left: number, right: number): string => {
+  let result = "";
+  for (let index = left; index <= right; index++) {
+    result += String.fromCodePoint(operations[index] ?? 0);
+  }
+  return result;
+};
+
+/**
+ * Port of the tree-mutating half of React DevTools' `Store.onBridgeOperations`.
+ * Applies one operations array to a mutable element tree so we can later take a
+ * snapshot for the profiling export. Handles the fixed-width opcodes; bails
+ * (without mutating further) on the variable-width Suspense opcodes, which we
+ * cannot size without the full Store.
+ */
+export const applyOperationsToTree = (
+  tree: DevtoolsElementTree,
+  operations: Array<number>,
+): ApplyOperationsResult => {
+  const rendererID = operations[0] ?? 0;
+  const rootID = operations[1] ?? 0;
+
+  let cursor = 2;
+  const stringTable: Array<string | null> = [null];
+  const stringTableSize = operations[cursor] ?? 0;
+  cursor++;
+  const stringTableEnd = cursor + stringTableSize;
+  while (cursor < stringTableEnd) {
+    const nextLength = operations[cursor] ?? 0;
+    cursor++;
+    stringTable.push(decodeString(operations, cursor, cursor + nextLength - 1));
+    cursor += nextLength;
+  }
+
+  while (cursor < operations.length) {
+    const operation = operations[cursor];
+    switch (operation) {
+      case TREE_OPERATION_ADD: {
+        const id = operations[cursor + 1] ?? 0;
+        const type = operations[cursor + 2] ?? 0;
+        cursor += 3;
+        if (type === ELEMENT_TYPE_ROOT) {
+          // isStrictModeCompliant, profilerFlags, supportsStrictMode, hasOwnerMetadata
+          cursor += 4;
+          tree.set(id, {
+            id,
+            parentID: 0,
+            type,
+            displayName: null,
+            hocDisplayNames: null,
+            key: null,
+            compiledWithForget: false,
+            children: [],
+          });
+        } else {
+          const parentID = operations[cursor] ?? 0;
+          cursor++;
+          cursor++; // ownerID
+          const rawDisplayName = stringTable[operations[cursor] ?? 0] ?? null;
+          cursor++;
+          const key = stringTable[operations[cursor] ?? 0] ?? null;
+          cursor++;
+          cursor++; // namePropStringID
+          const parsed = parseElementDisplayName(rawDisplayName, type);
+          tree.set(id, {
+            id,
+            parentID,
+            type,
+            displayName: parsed.formattedDisplayName,
+            hocDisplayNames: parsed.hocDisplayNames,
+            key,
+            compiledWithForget: parsed.compiledWithForget,
+            children: [],
+          });
+          const parent = tree.get(parentID);
+          if (parent !== undefined) parent.children.push(id);
+        }
+        break;
+      }
+      case TREE_OPERATION_REMOVE: {
+        const removeLength = operations[cursor + 1] ?? 0;
+        cursor += 2;
+        for (let removeIndex = 0; removeIndex < removeLength; removeIndex++) {
+          const id = operations[cursor] ?? 0;
+          cursor++;
+          const node = tree.get(id);
+          if (node !== undefined) {
+            const parent = tree.get(node.parentID);
+            if (parent !== undefined) {
+              const childIndex = parent.children.indexOf(id);
+              if (childIndex >= 0) parent.children.splice(childIndex, 1);
+            }
+            tree.delete(id);
+          }
+        }
+        break;
+      }
+      case TREE_OPERATION_REORDER_CHILDREN: {
+        const id = operations[cursor + 1] ?? 0;
+        const numChildren = operations[cursor + 2] ?? 0;
+        cursor += 3;
+        const reordered: Array<number> = [];
+        for (let childIndex = 0; childIndex < numChildren; childIndex++) {
+          reordered.push(operations[cursor + childIndex] ?? 0);
+        }
+        cursor += numChildren;
+        const node = tree.get(id);
+        if (node !== undefined) node.children = reordered;
+        break;
+      }
+      case TREE_OPERATION_UPDATE_TREE_BASE_DURATION:
+        cursor += 3;
+        break;
+      case TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS:
+        cursor += 4;
+        break;
+      case TREE_OPERATION_SET_SUBTREE_MODE:
+        cursor += 3;
+        break;
+      case TREE_OPERATION_APPLIED_ACTIVITY_SLICE_CHANGE:
+        cursor += 2;
+        break;
+      default:
+        return { rendererID, rootID, bailed: true };
+    }
+  }
+
+  return { rendererID, rootID, bailed: false };
+};

--- a/packages/perf-agent/src/devtools/operations/assemble-frontend-data.ts
+++ b/packages/perf-agent/src/devtools/operations/assemble-frontend-data.ts
@@ -1,0 +1,71 @@
+import type {
+  ReactProfilerCommitDataBackend,
+  ReactProfilerDataBackend,
+} from "../../types/profiling-backend.js";
+import type {
+  ReactProfilerSerializedElement,
+  ReactProfilerSnapshotNode,
+} from "../../types/profiling-export.js";
+import type {
+  ReactProfilerCommitDataFrontend,
+  ReactProfilerDataForRootFrontend,
+  ReactProfilerDataFrontend,
+} from "../../types/profiling-frontend.js";
+import { parseElementDisplayName } from "../../utils/parse-element-display-name.js";
+
+export interface AssembleFrontendDataInput {
+  dataBackend: ReactProfilerDataBackend;
+  operationsByRootID: Map<number, Array<Array<number>>>;
+  snapshotsByRootID: Map<number, Map<number, ReactProfilerSnapshotNode>>;
+}
+
+const convertCommitData = (
+  commit: ReactProfilerCommitDataBackend,
+): ReactProfilerCommitDataFrontend => ({
+  changeDescriptions:
+    commit.changeDescriptions === null ? null : new Map(commit.changeDescriptions),
+  duration: commit.duration,
+  effectDuration: commit.effectDuration,
+  fiberActualDurations: new Map(commit.fiberActualDurations),
+  fiberSelfDurations: new Map(commit.fiberSelfDurations),
+  passiveEffectDuration: commit.passiveEffectDuration,
+  priorityLevel: commit.priorityLevel,
+  timestamp: commit.timestamp,
+  updaters:
+    commit.updaters === null
+      ? null
+      : commit.updaters.map(
+          (element): ReactProfilerSerializedElement => ({
+            displayName: parseElementDisplayName(element.displayName, element.type)
+              .formattedDisplayName,
+            id: element.id,
+            key: element.key,
+            type: element.type,
+          }),
+        ),
+});
+
+/**
+ * Port of React DevTools' `prepareProfilingDataFrontendFromBackendAndStore`
+ * (timeline omitted): merges the backend's per-commit timings with the
+ * operations + snapshots we observed on the wall into the frontend-shaped data
+ * that `serializeProfilingExport` turns into the canonical v5 export.
+ */
+export const assembleFrontendData = ({
+  dataBackend,
+  operationsByRootID,
+  snapshotsByRootID,
+}: AssembleFrontendDataInput): ReactProfilerDataFrontend => {
+  const dataForRoots = new Map<number, ReactProfilerDataForRootFrontend>();
+  for (const root of dataBackend.dataForRoots) {
+    dataForRoots.set(root.rootID, {
+      commitData: root.commitData.map(convertCommitData),
+      displayName: root.displayName,
+      initialTreeBaseDurations: new Map(root.initialTreeBaseDurations),
+      operations: operationsByRootID.get(root.rootID) ?? [],
+      rootID: root.rootID,
+      snapshots: snapshotsByRootID.get(root.rootID) ?? new Map(),
+    });
+  }
+  return { dataForRoots, timelineData: [], imported: false };
+};

--- a/packages/perf-agent/src/devtools/operations/take-tree-snapshot.ts
+++ b/packages/perf-agent/src/devtools/operations/take-tree-snapshot.ts
@@ -1,0 +1,30 @@
+import type { DevtoolsElementTree } from "../../types/element-tree.js";
+import type { ReactProfilerSnapshotNode } from "../../types/profiling-export.js";
+
+/**
+ * Walks the reconstructed element tree from a root into the `snapshots` map the
+ * DevTools profiling export expects (id → node). Mirrors the Store's
+ * `_takeProfilingSnapshotRecursive`.
+ */
+export const takeTreeSnapshot = (
+  tree: DevtoolsElementTree,
+  rootID: number,
+): Map<number, ReactProfilerSnapshotNode> => {
+  const snapshots = new Map<number, ReactProfilerSnapshotNode>();
+  const visit = (id: number): void => {
+    const node = tree.get(id);
+    if (node === undefined) return;
+    snapshots.set(id, {
+      id: node.id,
+      children: node.children.slice(),
+      displayName: node.displayName,
+      hocDisplayNames: node.hocDisplayNames,
+      key: node.key,
+      type: node.type,
+      compiledWithForget: node.compiledWithForget,
+    });
+    for (const childID of node.children) visit(childID);
+  };
+  visit(rootID);
+  return snapshots;
+};

--- a/packages/perf-agent/src/devtools/profiling-session.ts
+++ b/packages/perf-agent/src/devtools/profiling-session.ts
@@ -21,16 +21,22 @@ export const createProfilingSession = (store: ReactDevtoolsStore): ProfilingSess
       profilerStore.startProfiling();
     },
     stop: async () => {
+      // Register the listener BEFORE calling stopProfiling: a store may emit
+      // `isProcessingData` synchronously inside stopProfiling (e.g. the native
+      // store when no renderer attached), which would be missed if we awaited
+      // after the call.
+      const settled = waitForStoreEvent(
+        profilerStore,
+        "isProcessingData",
+        () => profilerStore.isProcessingData === false,
+      );
+
       profilerStore.stopProfiling();
 
       // The backend serializes asynchronously over the bridge; `isProcessingData`
       // flips true while it works and back to false once the frontend has merged
       // every renderer's data.
-      await waitForStoreEvent(
-        profilerStore,
-        "isProcessingData",
-        () => profilerStore.isProcessingData === false,
-      );
+      await settled;
 
       const { profilingData } = profilerStore;
       return profilingData === null ? null : serializeProfilingExport(profilingData);

--- a/packages/perf-agent/src/devtools/profiling-session.ts
+++ b/packages/perf-agent/src/devtools/profiling-session.ts
@@ -1,0 +1,39 @@
+import type { ReactProfilerDataExport } from "../types/profiling-export.js";
+import type { ReactDevtoolsStore } from "../types/react-devtools.js";
+import { serializeProfilingExport } from "../utils/serialize-profiling-export.js";
+import { waitForStoreEvent } from "../utils/wait-for-store-event.js";
+
+export interface ProfilingSession {
+  start: () => void;
+  stop: () => Promise<ReactProfilerDataExport | null>;
+}
+
+/**
+ * Wraps the DevTools `ProfilerStore` start/stop lifecycle. `stop()` resolves
+ * once the backend has finished serializing the session, returning the
+ * canonical DevTools export — or `null` when no commits were recorded.
+ */
+export const createProfilingSession = (store: ReactDevtoolsStore): ProfilingSession => {
+  const { profilerStore } = store;
+
+  return {
+    start: () => {
+      profilerStore.startProfiling();
+    },
+    stop: async () => {
+      profilerStore.stopProfiling();
+
+      // The backend serializes asynchronously over the bridge; `isProcessingData`
+      // flips true while it works and back to false once the frontend has merged
+      // every renderer's data.
+      await waitForStoreEvent(
+        profilerStore,
+        "isProcessingData",
+        () => profilerStore.isProcessingData === false,
+      );
+
+      const { profilingData } = profilerStore;
+      return profilingData === null ? null : serializeProfilingExport(profilingData);
+    },
+  };
+};

--- a/packages/perf-agent/src/devtools/profiling-session.ts
+++ b/packages/perf-agent/src/devtools/profiling-session.ts
@@ -1,3 +1,4 @@
+import { PROFILING_STOP_TIMEOUT_MS } from "../constants.js";
 import type { ReactProfilerDataExport } from "../types/profiling-export.js";
 import type { ReactDevtoolsStore } from "../types/react-devtools.js";
 import { serializeProfilingExport } from "../utils/serialize-profiling-export.js";
@@ -29,6 +30,7 @@ export const createProfilingSession = (store: ReactDevtoolsStore): ProfilingSess
         profilerStore,
         "isProcessingData",
         () => profilerStore.isProcessingData === false,
+        PROFILING_STOP_TIMEOUT_MS,
       );
 
       profilerStore.stopProfiling();

--- a/packages/perf-agent/src/harness.native.ts
+++ b/packages/perf-agent/src/harness.native.ts
@@ -1,4 +1,4 @@
-import { createProfilerStore } from "./devtools/create-profiler-store.js";
+import { createProfilerStore } from "./devtools/create-profiler-store.native.js";
 import { makeReactPerfHarness } from "./devtools/make-harness.js";
 import type { ReactPerfHarness } from "./devtools/make-harness.js";
 import type { DevtoolsGlobal } from "./types/react-devtools.js";
@@ -6,9 +6,9 @@ import type { DevtoolsGlobal } from "./types/react-devtools.js";
 export type { ReactPerfHarness } from "./devtools/make-harness.js";
 
 /**
- * Web entry. Wires the harness with the DevTools frontend Store and exposes
- * `window.__REACT_PERF__`. `installReactDevtoolsBackend` must already have run
- * before React loaded.
+ * React Native entry. Wires the harness with the RN-safe backend collector and
+ * exposes `global.__REACT_PERF__`. `installReactDevtoolsBackend` must already
+ * have run before React loaded.
  */
 export const createReactPerfHarness = (target: DevtoolsGlobal = globalThis): ReactPerfHarness =>
   makeReactPerfHarness(createProfilerStore, target);

--- a/packages/perf-agent/src/harness.ts
+++ b/packages/perf-agent/src/harness.ts
@@ -1,0 +1,38 @@
+import { createProfilerStore } from "./devtools/create-profiler-store.js";
+import { createProfilingSession } from "./devtools/profiling-session.js";
+import { installReactDevtoolsBackend } from "./devtools/install-backend.js";
+import type { ReactProfilerDataExport } from "./types/profiling-export.js";
+
+export interface ReactPerfHarness {
+  start: () => void;
+  stop: () => Promise<ReactProfilerDataExport | null>;
+}
+
+declare global {
+  interface Window {
+    __REACT_PERF__?: ReactPerfHarness;
+  }
+}
+
+/**
+ * Wires the DevTools backend + headless Store + a profiling session, then
+ * exposes `window.__REACT_PERF__` so an automation driver (Playwright `evaluate`,
+ * the daemon, or a human) can start/stop a profile and pull the export.
+ *
+ * `installReactDevtoolsBackend` must already have run before React loaded; this
+ * is a no-op if the backend isn't installed in time (React simply won't have
+ * connected to the hook).
+ */
+export const createReactPerfHarness = (targetWindow: Window = window): ReactPerfHarness => {
+  installReactDevtoolsBackend(targetWindow);
+  const store = createProfilerStore(targetWindow);
+  const session = createProfilingSession(store);
+
+  const harness: ReactPerfHarness = {
+    start: session.start,
+    stop: session.stop,
+  };
+
+  targetWindow.__REACT_PERF__ = harness;
+  return harness;
+};

--- a/packages/perf-agent/src/index.native.ts
+++ b/packages/perf-agent/src/index.native.ts
@@ -1,0 +1,3 @@
+export * from "./common.js";
+export { createProfilerStore } from "./devtools/create-profiler-store.native.js";
+export { createReactPerfHarness } from "./harness.native.js";

--- a/packages/perf-agent/src/index.ts
+++ b/packages/perf-agent/src/index.ts
@@ -1,25 +1,3 @@
+export * from "./common.js";
 export { createProfilerStore } from "./devtools/create-profiler-store.js";
-export { createProfilingSession } from "./devtools/profiling-session.js";
-export type { ProfilingSession } from "./devtools/profiling-session.js";
-export { installReactDevtoolsBackend } from "./devtools/install-backend.js";
 export { createReactPerfHarness } from "./harness.js";
-export type { ReactPerfHarness } from "./harness.js";
-export { serializeProfilingExport } from "./utils/serialize-profiling-export.js";
-export type {
-  ReactProfilerChangeDescription,
-  ReactProfilerCommitDataExport,
-  ReactProfilerDataExport,
-  ReactProfilerDataForRootExport,
-  ReactProfilerSerializedElement,
-  ReactProfilerSnapshotNode,
-} from "./types/profiling-export.js";
-export type {
-  ReactProfilerCommitDataFrontend,
-  ReactProfilerDataForRootFrontend,
-  ReactProfilerDataFrontend,
-} from "./types/profiling-frontend.js";
-export type {
-  ReactDevtoolsProfilerStore,
-  ReactDevtoolsStore,
-  ReactDevtoolsWall,
-} from "./types/react-devtools.js";

--- a/packages/perf-agent/src/index.ts
+++ b/packages/perf-agent/src/index.ts
@@ -1,0 +1,25 @@
+export { createProfilerStore } from "./devtools/create-profiler-store.js";
+export { createProfilingSession } from "./devtools/profiling-session.js";
+export type { ProfilingSession } from "./devtools/profiling-session.js";
+export { installReactDevtoolsBackend } from "./devtools/install-backend.js";
+export { createReactPerfHarness } from "./harness.js";
+export type { ReactPerfHarness } from "./harness.js";
+export { serializeProfilingExport } from "./utils/serialize-profiling-export.js";
+export type {
+  ReactProfilerChangeDescription,
+  ReactProfilerCommitDataExport,
+  ReactProfilerDataExport,
+  ReactProfilerDataForRootExport,
+  ReactProfilerSerializedElement,
+  ReactProfilerSnapshotNode,
+} from "./types/profiling-export.js";
+export type {
+  ReactProfilerCommitDataFrontend,
+  ReactProfilerDataForRootFrontend,
+  ReactProfilerDataFrontend,
+} from "./types/profiling-frontend.js";
+export type {
+  ReactDevtoolsProfilerStore,
+  ReactDevtoolsStore,
+  ReactDevtoolsWall,
+} from "./types/react-devtools.js";

--- a/packages/perf-agent/src/types/devtools-inline-backend.d.ts
+++ b/packages/perf-agent/src/types/devtools-inline-backend.d.ts
@@ -1,0 +1,13 @@
+// Types for `react-devtools-inline/backend`, which ships Flow source with no
+// TypeScript types. Wired in via tsconfig `paths`.
+import type { ReactDevtoolsBridge, ReactDevtoolsWall } from "./react-devtools.js";
+
+export const initialize: (windowOrGlobal: unknown) => void;
+export const createBridge: (
+  windowOrGlobal: unknown,
+  wall: ReactDevtoolsWall,
+) => ReactDevtoolsBridge;
+export const activate: (
+  windowOrGlobal: unknown,
+  options?: { bridge?: ReactDevtoolsBridge },
+) => void;

--- a/packages/perf-agent/src/types/devtools-inline-frontend.d.ts
+++ b/packages/perf-agent/src/types/devtools-inline-frontend.d.ts
@@ -1,0 +1,13 @@
+// Types for `react-devtools-inline/frontend`, which ships Flow source with no
+// TypeScript types. Wired in via tsconfig `paths`.
+import type {
+  ReactDevtoolsBridge,
+  ReactDevtoolsStore,
+  ReactDevtoolsWall,
+} from "./react-devtools.js";
+
+export const createBridge: (
+  windowOrGlobal: unknown,
+  wall: ReactDevtoolsWall,
+) => ReactDevtoolsBridge;
+export const createStore: (bridge: ReactDevtoolsBridge) => ReactDevtoolsStore;

--- a/packages/perf-agent/src/types/element-tree.ts
+++ b/packages/perf-agent/src/types/element-tree.ts
@@ -1,0 +1,12 @@
+export interface DevtoolsElementTreeNode {
+  id: number;
+  parentID: number;
+  type: number;
+  displayName: string | null;
+  hocDisplayNames: Array<string> | null;
+  key: number | string | null;
+  compiledWithForget: boolean;
+  children: Array<number>;
+}
+
+export type DevtoolsElementTree = Map<number, DevtoolsElementTreeNode>;

--- a/packages/perf-agent/src/types/profiling-backend.ts
+++ b/packages/perf-agent/src/types/profiling-backend.ts
@@ -1,0 +1,38 @@
+import type { ReactProfilerChangeDescription } from "./profiling-export.js";
+
+export interface ReactProfilerSerializedElementBackend {
+  displayName: string | null;
+  id: number;
+  key: number | string | null;
+  type: number;
+}
+
+export interface ReactProfilerCommitDataBackend {
+  changeDescriptions: Array<[number, ReactProfilerChangeDescription]> | null;
+  duration: number;
+  effectDuration: number | null;
+  fiberActualDurations: Array<[number, number]>;
+  fiberSelfDurations: Array<[number, number]>;
+  passiveEffectDuration: number | null;
+  priorityLevel: string | null;
+  timestamp: number;
+  updaters: Array<ReactProfilerSerializedElementBackend> | null;
+}
+
+export interface ReactProfilerDataForRootBackend {
+  commitData: Array<ReactProfilerCommitDataBackend>;
+  displayName: string;
+  initialTreeBaseDurations: Array<[number, number]>;
+  rootID: number;
+}
+
+/**
+ * What the DevTools renderer interface returns from `getProfilingData()` over
+ * the bridge. On the web the DevTools Store merges this with its own tree
+ * snapshots; on React Native we assemble the export from this plus the
+ * operations we observe on the wall.
+ */
+export interface ReactProfilerDataBackend {
+  dataForRoots: Array<ReactProfilerDataForRootBackend>;
+  rendererID: number;
+}

--- a/packages/perf-agent/src/types/profiling-export.ts
+++ b/packages/perf-agent/src/types/profiling-export.ts
@@ -1,0 +1,59 @@
+export interface ReactProfilerChangeDescription {
+  context: Array<string> | boolean | null;
+  didHooksChange: boolean;
+  isFirstMount: boolean;
+  props: Array<string> | null;
+  state: Array<string> | null;
+  hooks?: Array<number> | null;
+}
+
+export interface ReactProfilerSnapshotNode {
+  id: number;
+  children: Array<number>;
+  displayName: string | null;
+  hocDisplayNames: Array<string> | null;
+  key: number | string | null;
+  type: number;
+  compiledWithForget: boolean;
+}
+
+export interface ReactProfilerSerializedElement {
+  displayName: string | null;
+  id: number;
+  key: number | string | null;
+  type: number;
+}
+
+export interface ReactProfilerCommitDataExport {
+  changeDescriptions: Array<[number, ReactProfilerChangeDescription]> | null;
+  duration: number;
+  effectDuration: number | null;
+  fiberActualDurations: Array<[number, number]>;
+  fiberSelfDurations: Array<[number, number]>;
+  passiveEffectDuration: number | null;
+  priorityLevel: string | null;
+  timestamp: number;
+  updaters: Array<ReactProfilerSerializedElement> | null;
+}
+
+export interface ReactProfilerDataForRootExport {
+  commitData: Array<ReactProfilerCommitDataExport>;
+  displayName: string;
+  initialTreeBaseDurations: Array<[number, number]>;
+  operations: Array<Array<number>>;
+  rootID: number;
+  snapshots: Array<[number, ReactProfilerSnapshotNode]>;
+}
+
+/**
+ * Byte-compatible with React DevTools' `ProfilingDataExport`. A file shaped
+ * like this re-imports into the DevTools Profiler UI and feeds the existing
+ * "analyze the profiler JSON" scripts unchanged. `timelineData` is omitted
+ * here (valid per the v5 schema: "old exported profiles won't contain this
+ * key") and is a follow-up.
+ */
+export interface ReactProfilerDataExport {
+  version: 5;
+  dataForRoots: Array<ReactProfilerDataForRootExport>;
+  timelineData?: Array<unknown>;
+}

--- a/packages/perf-agent/src/types/profiling-frontend.ts
+++ b/packages/perf-agent/src/types/profiling-frontend.ts
@@ -1,0 +1,38 @@
+import type {
+  ReactProfilerChangeDescription,
+  ReactProfilerSerializedElement,
+  ReactProfilerSnapshotNode,
+} from "./profiling-export.js";
+
+export interface ReactProfilerCommitDataFrontend {
+  changeDescriptions: Map<number, ReactProfilerChangeDescription> | null;
+  duration: number;
+  effectDuration: number | null;
+  fiberActualDurations: Map<number, number>;
+  fiberSelfDurations: Map<number, number>;
+  passiveEffectDuration: number | null;
+  priorityLevel: string | null;
+  timestamp: number;
+  updaters: Array<ReactProfilerSerializedElement> | null;
+}
+
+export interface ReactProfilerDataForRootFrontend {
+  commitData: Array<ReactProfilerCommitDataFrontend>;
+  displayName: string;
+  initialTreeBaseDurations: Map<number, number>;
+  operations: Array<Array<number>>;
+  rootID: number;
+  snapshots: Map<number, ReactProfilerSnapshotNode>;
+}
+
+/**
+ * The in-memory shape DevTools' `ProfilerStore.profilingData` exposes after a
+ * session completes (Maps, not serialized tuples). We convert it to
+ * `ReactProfilerDataExport` ourselves because the DevTools converter lives in
+ * the unpublished `react-devtools-shared` internal package.
+ */
+export interface ReactProfilerDataFrontend {
+  dataForRoots: Map<number, ReactProfilerDataForRootFrontend>;
+  timelineData: Array<unknown>;
+  imported: boolean;
+}

--- a/packages/perf-agent/src/types/react-devtools.ts
+++ b/packages/perf-agent/src/types/react-devtools.ts
@@ -1,5 +1,9 @@
 import type { ReactProfilerDataFrontend } from "./profiling-frontend.js";
 
+// The global object the DevTools hook is installed on: `window` on the web,
+// `global` on React Native. `globalThis` covers both.
+export type DevtoolsGlobal = typeof globalThis;
+
 export interface ReactDevtoolsWallMessage {
   event: string;
   payload: unknown;
@@ -16,6 +20,9 @@ export interface ReactDevtoolsWall {
 }
 
 export interface ReactDevtoolsBridge {
+  send: (event: string, payload?: unknown) => void;
+  addListener: (event: string, listener: (payload: unknown) => void) => void;
+  removeListener: (event: string, listener: (payload: unknown) => void) => void;
   shutdown: () => void;
 }
 

--- a/packages/perf-agent/src/types/react-devtools.ts
+++ b/packages/perf-agent/src/types/react-devtools.ts
@@ -1,0 +1,36 @@
+import type { ReactProfilerDataFrontend } from "./profiling-frontend.js";
+
+export interface ReactDevtoolsWallMessage {
+  event: string;
+  payload: unknown;
+}
+
+/**
+ * The transport DevTools uses between its backend and frontend. We supply a
+ * synchronous in-page wall so both halves live in the same window with no
+ * iframe and no `postMessage` round-trip.
+ */
+export interface ReactDevtoolsWall {
+  listen: (listener: (message: ReactDevtoolsWallMessage) => void) => void;
+  send: (event: string, payload: unknown) => void;
+}
+
+export interface ReactDevtoolsBridge {
+  shutdown: () => void;
+}
+
+export type ReactDevtoolsProfilerEvent = "isProcessingData" | "isProfiling" | "profilingData";
+
+export interface ReactDevtoolsProfilerStore {
+  startProfiling: () => void;
+  stopProfiling: () => void;
+  readonly isProcessingData: boolean;
+  readonly didRecordCommits: boolean;
+  readonly profilingData: ReactProfilerDataFrontend | null;
+  addListener: (event: ReactDevtoolsProfilerEvent, listener: () => void) => void;
+  removeListener: (event: ReactDevtoolsProfilerEvent, listener: () => void) => void;
+}
+
+export interface ReactDevtoolsStore {
+  readonly profilerStore: ReactDevtoolsProfilerStore;
+}

--- a/packages/perf-agent/src/utils/parse-element-display-name.ts
+++ b/packages/perf-agent/src/utils/parse-element-display-name.ts
@@ -1,0 +1,58 @@
+import {
+  ELEMENT_TYPE_CLASS,
+  ELEMENT_TYPE_FORWARD_REF,
+  ELEMENT_TYPE_FUNCTION,
+  ELEMENT_TYPE_MEMO,
+  ELEMENT_TYPE_VIRTUAL,
+  FORGET_WRAPPER_PREFIX,
+} from "../constants.js";
+
+export interface ParsedElementDisplayName {
+  formattedDisplayName: string | null;
+  hocDisplayNames: Array<string> | null;
+  compiledWithForget: boolean;
+}
+
+const isCompositeType = (type: number): boolean =>
+  type === ELEMENT_TYPE_CLASS ||
+  type === ELEMENT_TYPE_FORWARD_REF ||
+  type === ELEMENT_TYPE_FUNCTION ||
+  type === ELEMENT_TYPE_MEMO ||
+  type === ELEMENT_TYPE_VIRTUAL;
+
+/**
+ * Port of React DevTools' `parseElementDisplayNameFromBackend`: unwraps the
+ * `Forget(...)` compiler marker and splits HOC wrappers (`withRouter(Foo)` →
+ * name `Foo`, hocs `["withRouter"]`).
+ */
+export const parseElementDisplayName = (
+  displayName: string | null,
+  type: number,
+): ParsedElementDisplayName => {
+  if (displayName === null) {
+    return { formattedDisplayName: null, hocDisplayNames: null, compiledWithForget: false };
+  }
+
+  if (displayName.startsWith(FORGET_WRAPPER_PREFIX)) {
+    const unwrapped = displayName.slice(FORGET_WRAPPER_PREFIX.length, displayName.length - 1);
+    const inner = parseElementDisplayName(unwrapped, type);
+    return {
+      formattedDisplayName: inner.formattedDisplayName,
+      hocDisplayNames: inner.hocDisplayNames,
+      compiledWithForget: true,
+    };
+  }
+
+  if (isCompositeType(type) && displayName.includes("(")) {
+    const matches = displayName.match(/[^()]+/g);
+    if (matches !== null) {
+      return {
+        formattedDisplayName: matches[matches.length - 1] ?? displayName,
+        hocDisplayNames: matches.slice(0, -1),
+        compiledWithForget: false,
+      };
+    }
+  }
+
+  return { formattedDisplayName: displayName, hocDisplayNames: null, compiledWithForget: false };
+};

--- a/packages/perf-agent/src/utils/serialize-profiling-export.ts
+++ b/packages/perf-agent/src/utils/serialize-profiling-export.ts
@@ -1,0 +1,50 @@
+import { PROFILING_EXPORT_VERSION } from "../constants.js";
+import type {
+  ReactProfilerCommitDataExport,
+  ReactProfilerDataExport,
+  ReactProfilerDataForRootExport,
+} from "../types/profiling-export.js";
+import type {
+  ReactProfilerCommitDataFrontend,
+  ReactProfilerDataForRootFrontend,
+  ReactProfilerDataFrontend,
+} from "../types/profiling-frontend.js";
+
+const serializeCommitData = (
+  commitData: ReactProfilerCommitDataFrontend,
+): ReactProfilerCommitDataExport => ({
+  changeDescriptions:
+    commitData.changeDescriptions === null
+      ? null
+      : Array.from(commitData.changeDescriptions.entries()),
+  duration: commitData.duration,
+  effectDuration: commitData.effectDuration,
+  fiberActualDurations: Array.from(commitData.fiberActualDurations.entries()),
+  fiberSelfDurations: Array.from(commitData.fiberSelfDurations.entries()),
+  passiveEffectDuration: commitData.passiveEffectDuration,
+  priorityLevel: commitData.priorityLevel,
+  timestamp: commitData.timestamp,
+  updaters: commitData.updaters,
+});
+
+const serializeDataForRoot = (
+  dataForRoot: ReactProfilerDataForRootFrontend,
+): ReactProfilerDataForRootExport => ({
+  commitData: dataForRoot.commitData.map(serializeCommitData),
+  displayName: dataForRoot.displayName,
+  initialTreeBaseDurations: Array.from(dataForRoot.initialTreeBaseDurations.entries()),
+  operations: dataForRoot.operations,
+  rootID: dataForRoot.rootID,
+  snapshots: Array.from(dataForRoot.snapshots.entries()),
+});
+
+/**
+ * Mirrors DevTools' internal `prepareProfilingDataExport`: turns the Map-backed
+ * in-memory profiling data into the tuple-array `version: 5` export.
+ */
+export const serializeProfilingExport = (
+  profilingData: ReactProfilerDataFrontend,
+): ReactProfilerDataExport => ({
+  version: PROFILING_EXPORT_VERSION,
+  dataForRoots: Array.from(profilingData.dataForRoots.values()).map(serializeDataForRoot),
+});

--- a/packages/perf-agent/src/utils/wait-for-store-event.ts
+++ b/packages/perf-agent/src/utils/wait-for-store-event.ts
@@ -1,0 +1,18 @@
+import type {
+  ReactDevtoolsProfilerEvent,
+  ReactDevtoolsProfilerStore,
+} from "../types/react-devtools.js";
+
+export const waitForStoreEvent = (
+  profilerStore: ReactDevtoolsProfilerStore,
+  event: ReactDevtoolsProfilerEvent,
+  isSettled: () => boolean,
+): Promise<void> =>
+  new Promise((resolve) => {
+    const handleEvent = (): void => {
+      if (!isSettled()) return;
+      profilerStore.removeListener(event, handleEvent);
+      resolve();
+    };
+    profilerStore.addListener(event, handleEvent);
+  });

--- a/packages/perf-agent/src/utils/wait-for-store-event.ts
+++ b/packages/perf-agent/src/utils/wait-for-store-event.ts
@@ -3,16 +3,30 @@ import type {
   ReactDevtoolsProfilerStore,
 } from "../types/react-devtools.js";
 
+/**
+ * Resolves when `event` fires and `isSettled()` returns true. When `timeoutMs`
+ * is given, also resolves after that long without a settling event — a guard so
+ * a non-responding backend (no `profilingData` message) can't hang the caller.
+ */
 export const waitForStoreEvent = (
   profilerStore: ReactDevtoolsProfilerStore,
   event: ReactDevtoolsProfilerEvent,
   isSettled: () => boolean,
+  timeoutMs?: number,
 ): Promise<void> =>
   new Promise((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const handleEvent = (): void => {
       if (!isSettled()) return;
+      if (timer !== undefined) clearTimeout(timer);
       profilerStore.removeListener(event, handleEvent);
       resolve();
     };
     profilerStore.addListener(event, handleEvent);
+    if (timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        profilerStore.removeListener(event, handleEvent);
+        resolve();
+      }, timeoutMs);
+    }
   });

--- a/packages/perf-agent/tests/operations.test.ts
+++ b/packages/perf-agent/tests/operations.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vite-plus/test";
+import { applyOperationsToTree } from "../src/devtools/operations/apply-operations-to-tree.js";
+import { takeTreeSnapshot } from "../src/devtools/operations/take-tree-snapshot.js";
+import { assembleFrontendData } from "../src/devtools/operations/assemble-frontend-data.js";
+import { serializeProfilingExport } from "../src/utils/serialize-profiling-export.js";
+import { parseElementDisplayName } from "../src/utils/parse-element-display-name.js";
+import type { DevtoolsElementTree } from "../src/types/element-tree.js";
+
+const RENDERER_ID = 1;
+const ROOT_ID = 1;
+const ELEMENT_TYPE_FUNCTION = 5;
+const ELEMENT_TYPE_ROOT = 11;
+
+// Operations for: root(1) > App(2) > Child(3), encoded per the documented
+// React DevTools operations format (string table + ADD opcodes).
+const buildAddOperations = (): Array<number> => {
+  const stringTable = [
+    3,
+    "A".codePointAt(0)!,
+    "p".codePointAt(0)!,
+    "p".codePointAt(0)!,
+    5,
+    "C".codePointAt(0)!,
+    "h".codePointAt(0)!,
+    "i".codePointAt(0)!,
+    "l".codePointAt(0)!,
+    "d".codePointAt(0)!,
+  ];
+  return [
+    RENDERER_ID,
+    ROOT_ID,
+    stringTable.length,
+    ...stringTable,
+    // ADD root: op, id, type, isStrictModeCompliant, profilerFlags, supportsStrictMode, hasOwnerMetadata
+    1,
+    1,
+    ELEMENT_TYPE_ROOT,
+    1,
+    1,
+    0,
+    0,
+    // ADD App: op, id, type, parentID, ownerID, displayNameStringID(1="App"), keyStringID(0), namePropStringID(0)
+    1,
+    2,
+    ELEMENT_TYPE_FUNCTION,
+    1,
+    0,
+    1,
+    0,
+    0,
+    // ADD Child: op, id, type, parentID(2), ownerID, displayNameStringID(2="Child"), key, nameProp
+    1,
+    3,
+    ELEMENT_TYPE_FUNCTION,
+    2,
+    0,
+    2,
+    0,
+    0,
+  ];
+};
+
+describe("applyOperationsToTree", () => {
+  it("reconstructs the element tree from ADD operations", () => {
+    const tree: DevtoolsElementTree = new Map();
+    const result = applyOperationsToTree(tree, buildAddOperations());
+
+    expect(result.rendererID).toBe(RENDERER_ID);
+    expect(result.rootID).toBe(ROOT_ID);
+    expect(result.bailed).toBe(false);
+    expect(tree.size).toBe(3);
+    expect(tree.get(2)?.displayName).toBe("App");
+    expect(tree.get(2)?.parentID).toBe(1);
+    expect(tree.get(1)?.children).toEqual([2]);
+    expect(tree.get(2)?.children).toEqual([3]);
+    expect(tree.get(3)?.displayName).toBe("Child");
+  });
+
+  it("bails on unknown/variable-width opcodes without throwing", () => {
+    const tree: DevtoolsElementTree = new Map();
+    // valid string table (empty) + a Suspense opcode (8) we cannot size
+    const result = applyOperationsToTree(tree, [RENDERER_ID, ROOT_ID, 0, 8, 99]);
+    expect(result.bailed).toBe(true);
+  });
+});
+
+describe("takeTreeSnapshot", () => {
+  it("walks the tree into snapshot nodes", () => {
+    const tree: DevtoolsElementTree = new Map();
+    applyOperationsToTree(tree, buildAddOperations());
+    const snapshots = takeTreeSnapshot(tree, ROOT_ID);
+
+    expect([...snapshots.keys()]).toEqual([1, 2, 3]);
+    expect(snapshots.get(2)?.displayName).toBe("App");
+    expect(snapshots.get(2)?.children).toEqual([3]);
+  });
+});
+
+describe("parseElementDisplayName", () => {
+  it("unwraps the Forget compiler marker", () => {
+    const parsed = parseElementDisplayName("Forget(App)", ELEMENT_TYPE_FUNCTION);
+    expect(parsed.formattedDisplayName).toBe("App");
+    expect(parsed.compiledWithForget).toBe(true);
+  });
+
+  it("splits HOC wrappers", () => {
+    const parsed = parseElementDisplayName("withRouter(Page)", ELEMENT_TYPE_FUNCTION);
+    expect(parsed.formattedDisplayName).toBe("Page");
+    expect(parsed.hocDisplayNames).toEqual(["withRouter"]);
+  });
+});
+
+describe("assembleFrontendData + serializeProfilingExport", () => {
+  it("merges backend commit data with snapshots into a v5 export", () => {
+    const tree: DevtoolsElementTree = new Map();
+    const operations = buildAddOperations();
+    applyOperationsToTree(tree, operations);
+
+    const frontend = assembleFrontendData({
+      dataBackend: {
+        rendererID: RENDERER_ID,
+        dataForRoots: [
+          {
+            rootID: ROOT_ID,
+            displayName: "App",
+            initialTreeBaseDurations: [[2, 1.5]],
+            commitData: [
+              {
+                changeDescriptions: [
+                  [
+                    2,
+                    {
+                      context: null,
+                      didHooksChange: false,
+                      isFirstMount: true,
+                      props: null,
+                      state: null,
+                    },
+                  ],
+                ],
+                duration: 4.2,
+                effectDuration: null,
+                fiberActualDurations: [[2, 4.2]],
+                fiberSelfDurations: [[2, 2.1]],
+                passiveEffectDuration: null,
+                priorityLevel: "Normal",
+                timestamp: 10,
+                updaters: null,
+              },
+            ],
+          },
+        ],
+      },
+      operationsByRootID: new Map([[ROOT_ID, [operations]]]),
+      snapshotsByRootID: new Map([[ROOT_ID, takeTreeSnapshot(tree, ROOT_ID)]]),
+    });
+
+    const exported = serializeProfilingExport(frontend);
+
+    expect(exported.version).toBe(5);
+    expect(exported.dataForRoots).toHaveLength(1);
+    const root = exported.dataForRoots[0]!;
+    expect(root.rootID).toBe(ROOT_ID);
+    expect(root.commitData[0]!.fiberActualDurations).toEqual([[2, 4.2]]);
+    expect(root.snapshots.map(([id]) => id)).toEqual([1, 2, 3]);
+    expect(root.operations).toHaveLength(1);
+  });
+});

--- a/packages/perf-agent/tests/profiling-session.test.ts
+++ b/packages/perf-agent/tests/profiling-session.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createProfilingSession } from "../src/devtools/profiling-session.js";
+import type { ReactProfilerDataFrontend } from "../src/types/profiling-frontend.js";
+import type {
+  ReactDevtoolsProfilerEvent,
+  ReactDevtoolsStore,
+} from "../src/types/react-devtools.js";
+
+interface FakeStoreOptions {
+  emitSyncOnStop: boolean;
+  data: ReactProfilerDataFrontend | null;
+}
+
+const createFakeStore = (options: FakeStoreOptions): ReactDevtoolsStore => {
+  const listeners = new Map<ReactDevtoolsProfilerEvent, Set<() => void>>();
+  let isProcessingData = false;
+  const emit = (event: ReactDevtoolsProfilerEvent): void => {
+    for (const listener of listeners.get(event) ?? []) listener();
+  };
+  return {
+    profilerStore: {
+      startProfiling: () => {},
+      stopProfiling: () => {
+        if (options.emitSyncOnStop) {
+          // Reproduces the native no-renderer path: emits synchronously inside
+          // stopProfiling, before stop() would historically register a listener.
+          isProcessingData = false;
+          emit("isProcessingData");
+        } else {
+          isProcessingData = true;
+          queueMicrotask(() => {
+            isProcessingData = false;
+            emit("isProcessingData");
+          });
+        }
+      },
+      get isProcessingData() {
+        return isProcessingData;
+      },
+      get didRecordCommits() {
+        return options.data !== null;
+      },
+      get profilingData() {
+        return options.data;
+      },
+      addListener: (event, listener) => {
+        const set = listeners.get(event) ?? new Set();
+        set.add(listener);
+        listeners.set(event, set);
+      },
+      removeListener: (event, listener) => {
+        listeners.get(event)?.delete(listener);
+      },
+    },
+  };
+};
+
+describe("createProfilingSession.stop", () => {
+  it("resolves when the store emits isProcessingData synchronously inside stopProfiling", async () => {
+    const session = createProfilingSession(createFakeStore({ emitSyncOnStop: true, data: null }));
+    session.start();
+    expect(await session.stop()).toBeNull();
+  });
+
+  it("resolves with the serialized export on async completion", async () => {
+    const data: ReactProfilerDataFrontend = {
+      dataForRoots: new Map([
+        [
+          1,
+          {
+            commitData: [],
+            displayName: "App",
+            initialTreeBaseDurations: new Map(),
+            operations: [],
+            rootID: 1,
+            snapshots: new Map(),
+          },
+        ],
+      ]),
+      timelineData: [],
+      imported: false,
+    };
+    const session = createProfilingSession(createFakeStore({ emitSyncOnStop: false, data }));
+    session.start();
+    const result = await session.stop();
+    expect(result?.version).toBe(5);
+    expect(result?.dataForRoots).toHaveLength(1);
+  });
+});

--- a/packages/perf-agent/tests/wait-for-store-event.test.ts
+++ b/packages/perf-agent/tests/wait-for-store-event.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+import { waitForStoreEvent } from "../src/utils/wait-for-store-event.js";
+import type {
+  ReactDevtoolsProfilerEvent,
+  ReactDevtoolsProfilerStore,
+} from "../src/types/react-devtools.js";
+
+const createStub = (): {
+  store: ReactDevtoolsProfilerStore;
+  emit: (event: ReactDevtoolsProfilerEvent) => void;
+} => {
+  const listeners = new Map<ReactDevtoolsProfilerEvent, Set<() => void>>();
+  const store: ReactDevtoolsProfilerStore = {
+    startProfiling: () => {},
+    stopProfiling: () => {},
+    isProcessingData: false,
+    didRecordCommits: false,
+    profilingData: null,
+    addListener: (event, listener) => {
+      const set = listeners.get(event) ?? new Set();
+      set.add(listener);
+      listeners.set(event, set);
+    },
+    removeListener: (event, listener) => {
+      listeners.get(event)?.delete(listener);
+    },
+  };
+  const emit = (event: ReactDevtoolsProfilerEvent): void => {
+    for (const listener of listeners.get(event) ?? []) listener();
+  };
+  return { store, emit };
+};
+
+describe("waitForStoreEvent", () => {
+  it("resolves via the timeout when no settling event arrives", async () => {
+    const { store } = createStub();
+    await waitForStoreEvent(store, "isProcessingData", () => false, 20);
+    expect(true).toBe(true);
+  });
+
+  it("resolves when the event fires and the predicate is satisfied", async () => {
+    const { store, emit } = createStub();
+    let settled = false;
+    const promise = waitForStoreEvent(store, "isProcessingData", () => settled, 1000);
+    settled = true;
+    emit("isProcessingData");
+    await promise;
+    expect(settled).toBe(true);
+  });
+});

--- a/packages/perf-agent/tsconfig.json
+++ b/packages/perf-agent/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "paths": {
+      "react-devtools-inline/backend": ["./src/types/devtools-inline-backend.d.ts"],
+      "react-devtools-inline/frontend": ["./src/types/devtools-inline-frontend.d.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/perf-agent/vite.config.ts
+++ b/packages/perf-agent/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  pack: [
+    {
+      entry: { index: "./src/index.ts", harness: "./src/harness.ts" },
+      deps: {
+        // The harness runs inside the host app, which already ships React.
+        // Keep React and the (heavy) DevTools bundle external so the harness
+        // dist stays small and shares the app's single React instance.
+        neverBundle: ["react", "react-dom", "react-devtools-inline"],
+      },
+      dts: true,
+      target: "es2022",
+      platform: "browser",
+      fixedExtension: false,
+    },
+  ],
+});

--- a/packages/perf-agent/vite.config.ts
+++ b/packages/perf-agent/vite.config.ts
@@ -3,11 +3,18 @@ import { defineConfig } from "vite-plus";
 export default defineConfig({
   pack: [
     {
-      entry: { index: "./src/index.ts", harness: "./src/harness.ts" },
+      entry: {
+        index: "./src/index.ts",
+        harness: "./src/harness.ts",
+        "index.native": "./src/index.native.ts",
+        "harness.native": "./src/harness.native.ts",
+      },
       deps: {
         // The harness runs inside the host app, which already ships React.
         // Keep React and the (heavy) DevTools bundle external so the harness
-        // dist stays small and shares the app's single React instance.
+        // dist stays small and shares the app's single React instance. The web
+        // entries import `react-devtools-inline/frontend`; the native entries
+        // import only `react-devtools-inline/backend` (no react-dom/fs).
         neverBundle: ["react", "react-dom", "react-devtools-inline"],
       },
       dts: true,
@@ -16,4 +23,7 @@ export default defineConfig({
       fixedExtension: false,
     },
   ],
+  test: {
+    testTimeout: 10_000,
+  },
 });

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -46,6 +46,10 @@
     "./api": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "default": "./dist/runtime.js"
     }
   },
   "scripts": {
@@ -76,11 +80,20 @@
     "@react-doctor/api": "workspace:*",
     "@react-doctor/core": "workspace:*",
     "@react-doctor/language-server": "workspace:*",
+    "@react-doctor/perf-agent": "workspace:*",
     "@types/babel__code-frame": "^7.27.0",
     "@types/prompts": "^2.4.9",
     "@xterm/headless": "^6.0.0",
     "commander": "^14.0.3",
     "ora": "^9.4.0"
+  },
+  "peerDependencies": {
+    "react-devtools-inline": "^6.1.5"
+  },
+  "peerDependenciesMeta": {
+    "react-devtools-inline": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "^20.19.0 || >=22.13.0"

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -73,6 +73,7 @@
     "oxlint": ">=1.66.0 <1.67.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "prompts": "^2.4.2",
+    "react-devtools-inline": "^6.1.5",
     "typescript": ">=5.0.4 <7",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",
@@ -88,14 +89,6 @@
     "@xterm/headless": "^6.0.0",
     "commander": "^14.0.3",
     "ora": "^9.4.0"
-  },
-  "peerDependencies": {
-    "react-devtools-inline": "^6.1.5"
-  },
-  "peerDependenciesMeta": {
-    "react-devtools-inline": {
-      "optional": true
-    }
   },
   "engines": {
     "node": "^20.19.0 || >=22.13.0"

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -49,6 +49,8 @@
     },
     "./runtime": {
       "types": "./dist/runtime.d.ts",
+      "react-native": "./dist/runtime.native.js",
+      "browser": "./dist/runtime.js",
       "default": "./dist/runtime.js"
     }
   },

--- a/packages/react-doctor/src/runtime.native.ts
+++ b/packages/react-doctor/src/runtime.native.ts
@@ -1,0 +1,4 @@
+// React Native build, published as `react-doctor/runtime` under the
+// `react-native` condition. Re-exports the RN-safe perf harness, which connects
+// only the DevTools backend (no `react-dom`/`fs`) so it bundles under Metro.
+export * from "@react-doctor/perf-agent/native";

--- a/packages/react-doctor/src/runtime.ts
+++ b/packages/react-doctor/src/runtime.ts
@@ -1,0 +1,5 @@
+// Browser-only entry, published as `react-doctor/runtime`. Re-exports the
+// in-app performance harness so an application can install the React DevTools
+// profiling hook and drive profiles programmatically (see the `react-doctor`
+// skill's performance-engineering reference).
+export * from "@react-doctor/perf-agent";

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -167,6 +167,20 @@ export default defineConfig({
       fixedExtension: false,
     },
     {
+      // Browser entry published as `react-doctor/runtime`: the in-app
+      // performance harness. Bundles @react-doctor/perf-agent; keeps React and
+      // the DevTools backend external so the harness shares the host app's
+      // single React instance and DevTools hook.
+      entry: { runtime: "./src/runtime.ts" },
+      deps: {
+        neverBundle: ["react", "react-dom", "react-devtools-inline"],
+      },
+      dts: true,
+      target: "es2022",
+      platform: "browser",
+      fixedExtension: false,
+    },
+    {
       // Dedicated language-server entry the bin shim fast-paths to for
       // `react-doctor experimental-lsp`. Inlines @react-doctor/language-server + core;
       // keeps the engine + LSP transport external (the vscode-* libs use

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -171,7 +171,7 @@ export default defineConfig({
       // performance harness. Bundles @react-doctor/perf-agent; keeps React and
       // the DevTools backend external so the harness shares the host app's
       // single React instance and DevTools hook.
-      entry: { runtime: "./src/runtime.ts" },
+      entry: { runtime: "./src/runtime.ts", "runtime.native": "./src/runtime.native.ts" },
       deps: {
         neverBundle: ["react", "react-dom", "react-devtools-inline"],
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,22 @@ importers:
         specifier: ^25.6.0
         version: 25.6.0
 
+  packages/perf-agent:
+    dependencies:
+      react:
+        specifier: '>=16.8'
+        version: 19.2.5
+      react-devtools-inline:
+        specifier: ^6.1.5
+        version: 6.1.5
+      react-dom:
+        specifier: '>=16.8'
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+
   packages/react-doctor:
     dependencies:
       '@babel/code-frame':
@@ -872,89 +888,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1069,24 +1101,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.4':
     resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.4':
     resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.4':
     resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.4':
     resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
@@ -1195,48 +1231,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.132.0':
     resolution: {integrity: sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
     resolution: {integrity: sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
     resolution: {integrity: sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
     resolution: {integrity: sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
     resolution: {integrity: sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.132.0':
     resolution: {integrity: sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.132.0':
     resolution: {integrity: sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.132.0':
     resolution: {integrity: sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==}
@@ -1316,41 +1360,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -1424,48 +1476,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.46.0':
     resolution: {integrity: sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
     resolution: {integrity: sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
     resolution: {integrity: sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.46.0':
     resolution: {integrity: sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.46.0':
     resolution: {integrity: sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.46.0':
     resolution: {integrity: sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.46.0':
     resolution: {integrity: sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.46.0':
     resolution: {integrity: sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==}
@@ -1568,48 +1628,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.66.0':
     resolution: {integrity: sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.66.0':
     resolution: {integrity: sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.66.0':
     resolution: {integrity: sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.66.0':
     resolution: {integrity: sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.66.0':
     resolution: {integrity: sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.66.0':
     resolution: {integrity: sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.66.0':
     resolution: {integrity: sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.66.0':
     resolution: {integrity: sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==}
@@ -1677,66 +1745,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1908,24 +1989,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2177,24 +2262,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-arm64-musl@0.1.20':
     resolution: {integrity: sha512-Oh/pxMdTLR/wsDl/OONjItjLOeTewFBLuKkH5RQmcI9g3AVqKzLj1/uawujgysBI5E25tonRRK7I2q/zu8Uqvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@voidzero-dev/vite-plus-linux-x64-gnu@0.1.20':
     resolution: {integrity: sha512-msO1ZoUX5aSK8L6kN1C3XQO4CcH9aFsNPRSNcO1cjk1kTnaLyVYzkVxgvbh3vk7nzZAAMkmyZ4SlMpqJrdahrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
     resolution: {integrity: sha512-U93urREvg23ZFDkxKkkfWWIOI4GI9erhbWAZpXG+GeYqygWKrVC6PUTXiuexVg3/CFg2sSMTdm1W6V7TFG5hYA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@voidzero-dev/vite-plus-test@0.1.20':
     resolution: {integrity: sha512-vy2dJYw1bhgQ/+BrQrfwPlSKzQ2mm3YLJ9kGF7Yo0UJ2P3XKpshtgFIWLjSg/IASnC93OAx0c/7j3NM0I1RMuA==}
@@ -2847,24 +2936,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3180,6 +3273,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-devtools-inline@6.1.5:
+    resolution: {integrity: sha512-8FbBqZrOk4k4uWgkDNj7CVb975oKOMuPYZMQi4UHVW1RhbnEFOVZ7cdKvv6tbzbhy2D1aFwfj1T58atSoedEKQ==}
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
@@ -3278,6 +3374,10 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  source-map-js@0.6.2:
+    resolution: {integrity: sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==}
+    engines: {node: '>=0.10.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3288,6 +3388,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sourcemap-codec@1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -6122,6 +6226,11 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-devtools-inline@6.1.5:
+    dependencies:
+      source-map-js: 0.6.2
+      sourcemap-codec: 1.4.8
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -6257,6 +6366,8 @@ snapshots:
 
   slash@3.0.0: {}
 
+  source-map-js@0.6.2: {}
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -6267,6 +6378,8 @@ snapshots:
 
   source-map@0.6.1:
     optional: true
+
+  sourcemap-codec@1.4.8: {}
 
   spawndamnit@3.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      react-devtools-inline:
+        specifier: ^6.1.5
+        version: 6.1.5
       typescript:
         specifier: '>=5.0.4 <7'
         version: 5.9.3
@@ -232,6 +235,9 @@ importers:
       '@react-doctor/language-server':
         specifier: workspace:*
         version: link:../language-server
+      '@react-doctor/perf-agent':
+        specifier: workspace:*
+        version: link:../perf-agent
       '@types/babel__code-frame':
         specifier: ^7.27.0
         version: 7.27.0

--- a/skills/react-doctor/SKILL.md
+++ b/skills/react-doctor/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: react-doctor
 description: Use when finishing a feature, fixing a bug, before committing React code, or when the user types `/doctor`, asks to scan, triage, or clean up React diagnostics. Covers lint, accessibility, bundle size, architecture. Includes a regression check and a full local-triage workflow that fetches the canonical playbook.
-version: "1.2.0"
+version: "1.3.0"
 ---
 
 # React Doctor
 
-Scans React codebases for security, performance, correctness, and architecture issues. Outputs a 0–100 health score.
+Scans React codebases for security, performance, correctness, and architecture issues. Outputs a 0 to 100 health score.
 
 ## After making React code changes:
 
@@ -16,11 +16,11 @@ If the score dropped, fix the regressions before committing.
 
 ## For general cleanup or code improvement:
 
-Run `npx react-doctor@latest --verbose` (the default `--scope full`) to scan the full codebase. Fix issues by severity — errors first, then warnings.
+Run `npx react-doctor@latest --verbose` (the default `--scope full`) to scan the full codebase. Fix issues by severity: errors first, then warnings.
 
-## /doctor — full local triage workflow
+## /doctor: full local triage workflow
 
-When the user types `/doctor`, says "run react doctor", or asks for a full triage / cleanup pass (not just a regression check), fetch the canonical local-triage playbook and follow every step in it:
+When the user types `/doctor`, says “run react doctor”, or asks for a full triage / cleanup pass (not just a regression check), fetch the canonical local-triage playbook and follow every step in it:
 
 ```bash
 curl --fail --silent --show-error \
@@ -28,7 +28,7 @@ curl --fail --silent --show-error \
   https://www.react.doctor/prompts/react-doctor-agent.md
 ```
 
-The playbook is the single source of truth — a scan → filter → triage → fix → validate loop that edits the working tree directly (never commits, never opens PRs). Updating the prompt at its source updates every agent on its next fetch — no skill reinstall needed.
+The playbook is the single source of truth: a scan → filter → triage → fix → validate loop that edits the working tree directly (never commits, never opens PRs). Updating the prompt at its source updates every agent on its next fetch, no skill reinstall needed.
 
 Pair it with the matching per-rule prompts at `https://www.react.doctor/prompts/rules/<plugin>/<rule>.md` (fetched on demand inside the playbook) so each fix uses the canonical, reviewer-tested recipe.
 
@@ -38,7 +38,7 @@ When the user wants to understand a rule, disagrees with one, or wants to disabl
 
 ## Performance engineering
 
-When the user reports jank, slow interactions, dropped frames, excessive re-renders, or asks to profile / optimize React render performance, read [references/performance.md](references/performance.md) and follow it. It sets up the in-app profiling harness — shipped as `react-doctor/runtime` — and runs an evidence-driven profile → analyze → fix → re-profile loop against the real React DevTools profiler export, never guessing from code alone.
+When the user reports jank, slow interactions, dropped frames, excessive re-renders, or asks to profile / optimize React render performance, read [references/performance.md](references/performance.md) and follow it. It sets up the in-app profiling harness (shipped as `react-doctor/runtime`) and runs an evidence-driven profile → analyze → fix → re-profile loop against the real React DevTools profiler export, never guessing from code alone.
 
 ## Command
 

--- a/skills/react-doctor/SKILL.md
+++ b/skills/react-doctor/SKILL.md
@@ -36,6 +36,10 @@ Pair it with the matching per-rule prompts at `https://www.react.doctor/prompts/
 
 When the user wants to understand a rule, disagrees with one, or wants to disable / tune which rules run (not fix code), read [references/explain.md](references/explain.md) and follow it. Start with `npx react-doctor@latest rules explain <rule>`, then apply the narrowest control via `npx react-doctor@latest rules disable|set|category|ignore-tag …`, which edits your `doctor.config.*` (or `package.json#reactDoctor`).
 
+## Performance engineering
+
+When the user reports jank, slow interactions, dropped frames, excessive re-renders, or asks to profile / optimize React render performance, read [references/performance.md](references/performance.md) and follow it. It sets up the in-app profiling harness — shipped as `react-doctor/runtime` — and runs an evidence-driven profile → analyze → fix → re-profile loop against the real React DevTools profiler export, never guessing from code alone.
+
 ## Command
 
 ```bash

--- a/skills/react-doctor/references/performance.md
+++ b/skills/react-doctor/references/performance.md
@@ -1,9 +1,9 @@
 # Performance engineering (React render profiling loop)
 
-Profile and optimize React render performance with **runtime evidence** — the
-React DevTools profiler export — never by guessing from code alone. Use this
-when the user reports jank, slow interactions, dropped frames, excessive
-re-renders, or asks to "make this faster" / "optimize renders".
+Profile and optimize React render performance with **runtime evidence**: the
+React DevTools profiler export. Never guess from code alone. Use this when the
+user reports jank, slow interactions, dropped frames, excessive re-renders, or
+asks to “make this faster” or “optimize renders”.
 
 Same discipline as debug-agent: hypothesize → profile → analyze the export → fix
 the top evidence-backed opportunity → re-profile to verify → repeat. A change
@@ -12,10 +12,10 @@ that does not show up as fewer or cheaper renders in the export is not a fix.
 ## Setup (once per app)
 
 The harness ships with React Doctor under the `react-doctor/runtime` subpath. It
-drives the real DevTools profiler in-app — no Chrome extension, no manual
+drives the real DevTools profiler in-app, with no Chrome extension and no manual
 record/stop.
 
-1. Nothing extra to install — the DevTools backend (`react-devtools-inline`)
+1. Nothing extra to install: the DevTools backend (`react-devtools-inline`)
    ships as a dependency of `react-doctor`.
 
 2. For trustworthy timings, run against React's profiling build (alias
@@ -23,7 +23,7 @@ record/stop.
    Dev timings work but are inflated.
 
 3. Inject the harness bootstrap into the app entry, wrapped in cleanup markers
-   so it can be removed deterministically later:
+   so you can remove it deterministically later:
 
 ```ts
 // #region react-doctor perf
@@ -40,12 +40,12 @@ createReactPerfHarness(); // exposes window.__REACT_PERF__
 // #endregion
 ```
 
-`installReactDevtoolsBackend()` must execute before any React import — put it at
+`installReactDevtoolsBackend()` must execute before any React import: put it at
 the very top of the entry, or in a separate module imported first.
 
 ### React Native
 
-The same `react-doctor/runtime` import works on React Native — Metro resolves the
+The same `react-doctor/runtime` import works on React Native: Metro resolves the
 `react-native` export condition to the RN-safe build (it connects only the
 DevTools backend, never `react-dom`). The harness installs on `global` instead of
 `window`, so the defaults need no changes:
@@ -62,16 +62,16 @@ import { createReactPerfHarness } from "react-doctor/runtime";
 createReactPerfHarness(); // exposes global.__REACT_PERF__
 ```
 
-Drive it the same way (`global.__REACT_PERF__.start()` / `await stop()`), e.g.
+Drive it the same way (`global.__REACT_PERF__.start()` then `await stop()`), e.g.
 from a dev menu action or an e2e driver. On RN the export's per-commit timings
-(`commitData`, `changeDescriptions`) are exact; the component-tree `snapshots`
-are reconstructed best-effort from the operation stream (this is experimental
-and pending on-device verification), so prefer analyzing render counts /
-durations / change reasons over the flamegraph hierarchy.
+(`commitData`, `changeDescriptions`) are exact, but the harness reconstructs the
+component-tree `snapshots` best-effort from the operation stream (experimental,
+pending on-device verification). Prefer analyzing render counts, durations, and
+change reasons over the flamegraph hierarchy.
 
 ## The loop
 
-1. **Hypothesize** (3–5): why is it slow? Unstable callback/object props,
+1. **Hypothesize** (3 to 5): why is it slow? Unstable callback/object props,
    missing `memo`/`useMemo`, a context provider that is too broad, large
    unvirtualized lists, expensive children re-rendering on every parent commit.
 
@@ -79,12 +79,12 @@ durations / change reasons over the flamegraph hierarchy.
 
 ```js
 window.__REACT_PERF__.start();
-// drive the interaction: navigate, type, click — the exact repro
+// drive the interaction: navigate, type, click (the exact repro)
 const profile = await window.__REACT_PERF__.stop();
 ```
 
 Drive it via Playwright `page.evaluate(...)` for a repeatable scenario, or have
-the user click through. Save `profile` to a file — it is the canonical DevTools
+the user click through. Save `profile` to a file. It is the canonical DevTools
 `ProfilingDataExport` (version 5), re-importable into the DevTools Profiler UI
 and analyzable directly.
 
@@ -97,7 +97,7 @@ and analyzable directly.
    Rank opportunities: components that render most often, cost the most self
    time, or re-render with no meaningful prop change (memoization candidates).
 
-4. **Fix** the single top evidence-backed opportunity — the smallest change that
+4. **Fix** the single top evidence-backed opportunity: the smallest change that
    addresses the proven cause.
 
 5. **Verify.** Re-run the _same_ scenario and diff before/after: the target
@@ -109,7 +109,7 @@ and analyzable directly.
    `// #region react-doctor perf` … `// #endregion` block and grep to confirm
    none remain.
 
-## Notes
+## Profiling caveats
 
 - Keep the harness installed across fix attempts; remove it only when done
   (mirrors debug-agent keeping instrumentation until the fix is verified).

--- a/skills/react-doctor/references/performance.md
+++ b/skills/react-doctor/references/performance.md
@@ -1,0 +1,95 @@
+# Performance engineering (React render profiling loop)
+
+Profile and optimize React render performance with **runtime evidence** — the
+React DevTools profiler export — never by guessing from code alone. Use this
+when the user reports jank, slow interactions, dropped frames, excessive
+re-renders, or asks to "make this faster" / "optimize renders".
+
+Same discipline as debug-agent: hypothesize → profile → analyze the export → fix
+the top evidence-backed opportunity → re-profile to verify → repeat. A change
+that does not show up as fewer or cheaper renders in the export is not a fix.
+
+## Setup (once per app)
+
+The harness ships with React Doctor under the `react-doctor/runtime` subpath. It
+drives the real DevTools profiler in-app — no Chrome extension, no manual
+record/stop.
+
+1. Install the DevTools backend (an optional peer of `react-doctor`):
+
+```bash
+npm i -D react-devtools-inline
+```
+
+2. For trustworthy timings, run against React's profiling build (alias
+   `react-dom` → `react-dom/profiling` in your bundler) in a dev/non-prod build.
+   Dev timings work but are inflated.
+
+3. Inject the harness bootstrap into the app entry, wrapped in cleanup markers
+   so it can be removed deterministically later:
+
+```ts
+// #region react-doctor perf
+import { installReactDevtoolsBackend } from "react-doctor/runtime";
+installReactDevtoolsBackend(); // MUST run before React is imported
+// #endregion
+```
+
+```ts
+// after the app has mounted (e.g. end of main.tsx)
+// #region react-doctor perf
+import { createReactPerfHarness } from "react-doctor/runtime";
+createReactPerfHarness(); // exposes window.__REACT_PERF__
+// #endregion
+```
+
+`installReactDevtoolsBackend()` must execute before any React import — put it at
+the very top of the entry, or in a separate module imported first.
+
+## The loop
+
+1. **Hypothesize** (3–5): why is it slow? Unstable callback/object props,
+   missing `memo`/`useMemo`, a context provider that is too broad, large
+   unvirtualized lists, expensive children re-rendering on every parent commit.
+
+2. **Profile.** Drive the scenario, then collect the export:
+
+```js
+window.__REACT_PERF__.start();
+// drive the interaction: navigate, type, click — the exact repro
+const profile = await window.__REACT_PERF__.stop();
+```
+
+Drive it via Playwright `page.evaluate(...)` for a repeatable scenario, or have
+the user click through. Save `profile` to a file — it is the canonical DevTools
+`ProfilingDataExport` (version 5), re-importable into the DevTools Profiler UI
+and analyzable directly.
+
+3. **Analyze the export.** Aggregate `dataForRoots[].commitData[]`:
+   - per fiber: render count, summed `fiberActualDurations` / `fiberSelfDurations`
+   - `changeDescriptions[fiberID]` → _why_ it rendered (which props / state /
+     hooks / context changed), plus `isFirstMount` and `didHooksChange`
+   - `compiledWithForget` in the snapshots → already optimized by React Compiler
+
+   Rank opportunities: components that render most often, cost the most self
+   time, or re-render with no meaningful prop change (memoization candidates).
+
+4. **Fix** the single top evidence-backed opportunity — the smallest change that
+   addresses the proven cause.
+
+5. **Verify.** Re-run the _same_ scenario and diff before/after: the target
+   component's render count and self/actual duration must drop, and no other
+   component may regress. Run the scenario a few times and compare medians (dev
+   timings are noisy; StrictMode double-renders on mount).
+
+6. **Iterate** until the budget is met, then **clean up**: delete every
+   `// #region react-doctor perf` … `// #endregion` block and grep to confirm
+   none remain.
+
+## Notes
+
+- Keep the harness installed across fix attempts; remove it only when done
+  (mirrors debug-agent keeping instrumentation until the fix is verified).
+- The export omits scheduler `timelineData` for now; the per-commit render data
+  above is the signal.
+- Never claim a performance win without a before/after export diff.

--- a/skills/react-doctor/references/performance.md
+++ b/skills/react-doctor/references/performance.md
@@ -15,11 +15,8 @@ The harness ships with React Doctor under the `react-doctor/runtime` subpath. It
 drives the real DevTools profiler in-app — no Chrome extension, no manual
 record/stop.
 
-1. Install the DevTools backend (an optional peer of `react-doctor`):
-
-```bash
-npm i -D react-devtools-inline
-```
+1. Nothing extra to install — the DevTools backend (`react-devtools-inline`)
+   ships as a dependency of `react-doctor`.
 
 2. For trustworthy timings, run against React's profiling build (alias
    `react-dom` → `react-dom/profiling` in your bundler) in a dev/non-prod build.

--- a/skills/react-doctor/references/performance.md
+++ b/skills/react-doctor/references/performance.md
@@ -46,6 +46,32 @@ createReactPerfHarness(); // exposes window.__REACT_PERF__
 `installReactDevtoolsBackend()` must execute before any React import — put it at
 the very top of the entry, or in a separate module imported first.
 
+### React Native
+
+The same `react-doctor/runtime` import works on React Native — Metro resolves the
+`react-native` export condition to the RN-safe build (it connects only the
+DevTools backend, never `react-dom`). The harness installs on `global` instead of
+`window`, so the defaults need no changes:
+
+```ts
+// at the very top of index.js, before "react-native" / your App import
+import { installReactDevtoolsBackend } from "react-doctor/runtime";
+installReactDevtoolsBackend();
+```
+
+```ts
+// after the app registers (e.g. after AppRegistry.registerComponent)
+import { createReactPerfHarness } from "react-doctor/runtime";
+createReactPerfHarness(); // exposes global.__REACT_PERF__
+```
+
+Drive it the same way (`global.__REACT_PERF__.start()` / `await stop()`), e.g.
+from a dev menu action or an e2e driver. On RN the export's per-commit timings
+(`commitData`, `changeDescriptions`) are exact; the component-tree `snapshots`
+are reconstructed best-effort from the operation stream (this is experimental
+and pending on-device verification), so prefer analyzing render counts /
+durations / change reasons over the flamegraph hierarchy.
+
 ## The loop
 
 1. **Hypothesize** (3–5): why is it slow? Unstable callback/object props,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A debug-agent–style **React performance loop**: profile, optimize, and re-profile with runtime evidence — on **both web and React Native**. Three pieces:

1. **`@react-doctor/perf-agent`** — drives the **DevTools Profiler programmatically** (no Chrome extension, no manual record/stop) and emits the **exact** `ProfilingDataExport` (`version: 5`) the DevTools "export" button produces (re-imports into the Profiler UI; feeds existing profiler-JSON scripts).
2. **`react-doctor/runtime`** — a published subpath re-exporting the harness, with a `react-native` condition for RN.
3. **`react-doctor` skill → "Performance engineering"** — a `references/performance.md` playbook (profile → analyze → fix → re-profile), mirroring debug-agent's discipline, with an RN section.

## DevTools setup (web)

Reuses the real DevTools backend + a **headless** frontend `Store` (`react-devtools-inline`) over a synchronous in-page wall; the UI is never rendered. `install-backend` → `create-profiler-store` → `profiling-session` (`start()` / `await stop()`) → `serialize-profiling-export` (reimplements DevTools' internal `prepareProfilingDataExport`, since it lives in the unpublished `react-devtools-shared`). `harness.ts` exposes `window.__REACT_PERF__`.

`react-devtools-inline` ships as a **regular dependency** of `react-doctor` — the harness backend resolves out of the box, no separate install.

## React Native support

The frontend `Store` can't run on RN (pulls in `react-dom`/`fs`). So:

- **Platform-neutral core** — installs on `globalThis` (`window` web / `global` RN); `__REACT_PERF__` on either.
- **Platform-split store via package `exports` conditions** — web uses `react-devtools-inline/frontend`; **native** connects only the RN-safe `react-devtools-inline/backend` (needs just `react`) over a custom wall and assembles the export itself. Verified the native bundle never pulls the frontend/`react-dom`/`fs` chunk.
- **Pure, unit-tested cores ported from React DevTools**: operations→element-tree reader (fixed-width opcodes, **bails safely** on variable-width Suspense ops), tree-snapshot, backend+operations→frontend assembler, plus `Forget(...)`/HOC name parsing.
- RN per-commit timings (`commitData`, `changeDescriptions`) are **exact**; component-tree `snapshots` are best-effort. Native bridge wiring mirrors the documented inline pattern but is **experimental, pending on-device verification**.

`react-doctor/runtime` gains a `react-native` export condition → `runtime.native` re-exports `@react-doctor/perf-agent/native` (backend-only, Metro-bundleable).

## Skill

`performance.md` (shipped in the CLI's `dist/skills/`, synced to `.agents/`) documents setup (no extra install; profiling build; inject the harness in `// #region react-doctor perf` markers), the loop, **and a React Native subsection**.

## Notes / follow-ups

- `timelineData` (scheduler/lanes) omitted — valid per the v5 schema.
- Web wiring is typechecked/built; native wiring needs on-device verification (lands with the Playwright/e2e driver).
- Planned next: collector daemon, Playwright scenario runner, **LoAF** sidecar, `timelineData`.
- Public-surface adds on `react-doctor` (`./runtime` + `react-native` condition + the `react-devtools-inline` dep); promoting `@react-doctor/perf-agent` to a published package would go through the product-thinking pass (it's `private`/bundled today).

## Verification

- `pnpm --filter @react-doctor/perf-agent typecheck && build && test` ✅ (6 tests; native chunk imports only `react-devtools-inline/backend`)
- `turbo run typecheck` (all) ✅ · `turbo run build --filter=react-doctor` ✅ (`dist/runtime.native.js` backend-only; `dist/skills/.../performance.md` shipped)
- `pnpm lint` ✅ (exit 0) · `pnpm format` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a00e49cc-53f5-4e92-9699-13dd3b4ad63d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a00e49cc-53f5-4e92-9699-13dd3b4ad63d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

