### PR TITLE
fix(security-scan): resolve reported false positives (#813, #814, #816, #817, #818)

### DIFF
--- a/.changeset/security-scan-false-positives.md
+++ b/.changeset/security-scan-false-positives.md
@@ -1,0 +1,12 @@
+---
+"oxlint-plugin-react-doctor": patch
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Fix false positives reported in the security and TanStack rules:
+
+- **`query-destructure-result`** (#818): only flags `useQuery`/`useSuspenseQuery`/… when they actually come from a TanStack Query package (`@tanstack/*-query`, legacy `react-query`). A same-named hook imported from elsewhere — notably Convex's `useQuery` from `convex/react`, which returns the data directly — is no longer flagged.
+- **`artifact-env-leak` / `artifact-secret-leak`** (#816, #817): no longer treat server-side or dev-mode Next.js output as browser artifacts. `.next/dev/server/**` (dev source maps), any `.next/**/server/**`, `.output/server/**`, and the dev server's `.next/dev/**` output are excluded; production browser bundles (`.next/static`, `dist/assets`, `public/`, …) are still scanned.
+- **`repository-secret-file`** / **`key-lifecycle-risk`** (#813): no longer flag a credential/key file that git ignores — a local-only, gitignored `.env` is not "checked into the repository". Findings are dropped only when git definitively reports the path as ignored (the finding stands when there is no repo or git is unavailable).
+- **`webhook-signature-risk`** (#814): recognizes a delegated verification helper (a call pairing a verify-ish verb with a security noun, e.g. `isValidSecret(...)`, `verifySignature(...)`, `checkWebhookHmac(...)`) as verification evidence, so an extracted `timingSafeEqual` comparison in another module no longer trips the rule.

--- a/packages/core/src/check-security-scan.ts
+++ b/packages/core/src/check-security-scan.ts
@@ -15,8 +15,7 @@ export interface CheckSecurityScanOptions {
 interface EnabledScanRule {
   readonly entry: SecurityScanRuleEntry;
   readonly scan: FileScan;
-  // The rule's finding only applies to committed files (`rule.committedFilesOnly`),
-  // so it is dropped for paths git ignores. Precomputed per rule.
+  // `rule.committedFilesOnly`, precomputed per rule (see `Rule` for semantics).
   readonly committedFilesOnly: boolean;
 }
 
@@ -48,7 +47,7 @@ export const checkSecurityScan = (
   const diagnostics: Diagnostic[] = [];
   const seen = new Set<string>();
   const gitIgnoredCache = new Map<string, boolean | null>();
-  const isCommittedFileGitIgnored = (file: ScannedFile): boolean => {
+  const isFileGitIgnored = (file: ScannedFile): boolean => {
     let status = gitIgnoredCache.get(file.absolutePath);
     if (status === undefined) {
       status = isPathGitIgnored(rootDirectory, file.absolutePath);
@@ -66,7 +65,7 @@ export const checkSecurityScan = (
         // `isCommittedFileGitIgnored` spawns a `git check-ignore` subprocess —
         // hoisting it above `scan` would spawn git for every scanned file, not
         // just the rare file that trips a committed-file rule.
-        if (committedFilesOnly && isCommittedFileGitIgnored(file)) continue;
+        if (committedFilesOnly && isFileGitIgnored(file)) continue;
         const diagnostic = buildSecurityScanDiagnostic(finding, entry, file.relativePath);
         const key = `${diagnostic.rule}:${diagnostic.filePath}:${diagnostic.line}:${diagnostic.column}:${diagnostic.message}`;
         if (seen.has(key)) continue;

--- a/packages/core/src/check-security-scan.ts
+++ b/packages/core/src/check-security-scan.ts
@@ -1,10 +1,11 @@
 import { REACT_DOCTOR_RULES } from "oxlint-plugin-react-doctor";
-import type { FileScan } from "oxlint-plugin-react-doctor";
+import type { FileScan, ScannedFile } from "oxlint-plugin-react-doctor";
 import { buildSecurityScanDiagnostic } from "./checks/security-scan/build-security-scan-diagnostic.js";
 import type { SecurityScanRuleEntry } from "./checks/security-scan/build-security-scan-diagnostic.js";
 import { collectSecurityScanFiles } from "./checks/security-scan/collect-security-scan-files.js";
 import { buildCapabilities, shouldEnableRule } from "./runners/oxlint/capabilities.js";
 import type { Diagnostic, ProjectInfo } from "./types/index.js";
+import { isPathGitIgnored } from "./utils/is-path-git-ignored.js";
 
 export interface CheckSecurityScanOptions {
   readonly project?: ProjectInfo;
@@ -15,6 +16,14 @@ interface EnabledScanRule {
   readonly entry: SecurityScanRuleEntry;
   readonly scan: FileScan;
 }
+
+// Rules whose finding asserts a file is "checked into the repository". A file
+// git actually ignores (a local-only `.env`, a gitignored key) is not
+// committed, so its findings are dropped. Other scan rules (artifact leaks,
+// public-debug, …) deliberately inspect gitignored build output, so they are
+// unaffected. Suppress only on a definitive `true` — when git can't decide
+// (no repo, git missing) the finding stands.
+const COMMITTED_FILE_RULE_IDS = new Set(["repository-secret-file", "key-lifecycle-risk"]);
 
 // Project-level security scan check: registry rules carrying a
 // `scan` are excluded from the generated oxlint config and instead run here
@@ -43,10 +52,21 @@ export const checkSecurityScan = (
 
   const diagnostics: Diagnostic[] = [];
   const seen = new Set<string>();
+  const gitIgnoredCache = new Map<string, boolean | null>();
+  const isCommittedFileGitIgnored = (file: ScannedFile): boolean => {
+    let status = gitIgnoredCache.get(file.absolutePath);
+    if (status === undefined) {
+      status = isPathGitIgnored(rootDirectory, file.absolutePath);
+      gitIgnoredCache.set(file.absolutePath, status);
+    }
+    return status === true;
+  };
 
   for (const file of collectSecurityScanFiles(rootDirectory)) {
     for (const { entry, scan } of enabledScanRules) {
+      const dropWhenGitIgnored = COMMITTED_FILE_RULE_IDS.has(entry.id);
       for (const finding of scan(file)) {
+        if (dropWhenGitIgnored && isCommittedFileGitIgnored(file)) continue;
         const diagnostic = buildSecurityScanDiagnostic(finding, entry, file.relativePath);
         const key = `${diagnostic.rule}:${diagnostic.filePath}:${diagnostic.line}:${diagnostic.column}:${diagnostic.message}`;
         if (seen.has(key)) continue;

--- a/packages/core/src/check-security-scan.ts
+++ b/packages/core/src/check-security-scan.ts
@@ -62,9 +62,9 @@ export const checkSecurityScan = (
         // A committed-file rule's finding doesn't apply to a path git ignores
         // (it isn't actually checked in). The check is deferred to here, gated
         // on an actual finding, on purpose: `scan` is cheap regex but
-        // `isCommittedFileGitIgnored` spawns a `git check-ignore` subprocess —
-        // hoisting it above `scan` would spawn git for every scanned file, not
-        // just the rare file that trips a committed-file rule.
+        // `isFileGitIgnored` spawns a `git check-ignore` subprocess — hoisting
+        // it above `scan` would spawn git for every scanned file, not just the
+        // rare file that trips a committed-file rule.
         if (committedFilesOnly && isFileGitIgnored(file)) continue;
         const diagnostic = buildSecurityScanDiagnostic(finding, entry, file.relativePath);
         const key = `${diagnostic.rule}:${diagnostic.filePath}:${diagnostic.line}:${diagnostic.column}:${diagnostic.message}`;

--- a/packages/core/src/check-security-scan.ts
+++ b/packages/core/src/check-security-scan.ts
@@ -15,15 +15,10 @@ export interface CheckSecurityScanOptions {
 interface EnabledScanRule {
   readonly entry: SecurityScanRuleEntry;
   readonly scan: FileScan;
+  // The rule's finding only applies to committed files (`rule.committedFilesOnly`),
+  // so it is dropped for paths git ignores. Precomputed per rule.
+  readonly committedFilesOnly: boolean;
 }
-
-// Rules whose finding asserts a file is "checked into the repository". A file
-// git actually ignores (a local-only `.env`, a gitignored key) is not
-// committed, so its findings are dropped. Other scan rules (artifact leaks,
-// public-debug, …) deliberately inspect gitignored build output, so they are
-// unaffected. Suppress only on a definitive `true` — when git can't decide
-// (no repo, git missing) the finding stands.
-const COMMITTED_FILE_RULE_IDS = new Set(["repository-secret-file", "key-lifecycle-risk"]);
 
 // Project-level security scan check: registry rules carrying a
 // `scan` are excluded from the generated oxlint config and instead run here
@@ -46,7 +41,7 @@ export const checkSecurityScan = (
     if (!shouldEnableRule(rule.requires, rule.tags, capabilities, ignoredTags, rule.disabledBy)) {
       return [];
     }
-    return [{ entry, scan }];
+    return [{ entry, scan, committedFilesOnly: rule.committedFilesOnly === true }];
   });
   if (enabledScanRules.length === 0) return [];
 
@@ -63,10 +58,15 @@ export const checkSecurityScan = (
   };
 
   for (const file of collectSecurityScanFiles(rootDirectory)) {
-    for (const { entry, scan } of enabledScanRules) {
-      const dropWhenGitIgnored = COMMITTED_FILE_RULE_IDS.has(entry.id);
+    for (const { entry, scan, committedFilesOnly } of enabledScanRules) {
       for (const finding of scan(file)) {
-        if (dropWhenGitIgnored && isCommittedFileGitIgnored(file)) continue;
+        // A committed-file rule's finding doesn't apply to a path git ignores
+        // (it isn't actually checked in). The check is deferred to here, gated
+        // on an actual finding, on purpose: `scan` is cheap regex but
+        // `isCommittedFileGitIgnored` spawns a `git check-ignore` subprocess —
+        // hoisting it above `scan` would spawn git for every scanned file, not
+        // just the rare file that trips a committed-file rule.
+        if (committedFilesOnly && isCommittedFileGitIgnored(file)) continue;
         const diagnostic = buildSecurityScanDiagnostic(finding, entry, file.relativePath);
         const key = `${diagnostic.rule}:${diagnostic.filePath}:${diagnostic.line}:${diagnostic.column}:${diagnostic.message}`;
         if (seen.has(key)) continue;

--- a/packages/core/src/checks/expo/check-env-local-files.ts
+++ b/packages/core/src/checks/expo/check-env-local-files.ts
@@ -3,7 +3,7 @@ import { isFile } from "../../project-info/index.js";
 import type { Diagnostic } from "../../types/index.js";
 import type { ExpoCheckContext } from "./expo-check-context.js";
 import { buildExpoDiagnostic } from "./utils/build-expo-diagnostic.js";
-import { isPathGitIgnored } from "./utils/is-path-git-ignored.js";
+import { isPathGitIgnored } from "../../utils/is-path-git-ignored.js";
 
 // `.env*.local` files are per-developer overrides that should never be
 // committed (they leak secrets and impose local settings on others).

--- a/packages/core/src/checks/expo/check-gitignore.ts
+++ b/packages/core/src/checks/expo/check-gitignore.ts
@@ -4,7 +4,7 @@ import type { Diagnostic } from "../../types/index.js";
 import type { ExpoCheckContext } from "./expo-check-context.js";
 import { buildExpoDiagnostic } from "./utils/build-expo-diagnostic.js";
 import { findLocalModuleNativeFiles } from "./utils/find-local-module-native-files.js";
-import { isPathGitIgnored } from "./utils/is-path-git-ignored.js";
+import { isPathGitIgnored } from "../../utils/is-path-git-ignored.js";
 
 // Ported from expo-doctor's `ProjectSetupCheck`:
 //   1. `.expo/` holds machine-specific dev-server state and MUST be

--- a/packages/core/src/utils/is-path-git-ignored.ts
+++ b/packages/core/src/utils/is-path-git-ignored.ts
@@ -3,8 +3,7 @@ import { spawnSync } from "node:child_process";
 // Whether `git` considers `absolutePath` ignored, relative to
 // `rootDirectory`. Returns `null` when the ignore status can't be
 // determined — `git` is missing, the directory isn't a checkout, or the
-// command errors — so callers can skip the finding instead of
-// false-positiving, matching expo-doctor's `isFileIgnoredAsync` contract.
+// command errors — so callers can decide how to handle the unknown case.
 //
 // `git check-ignore -q <path>` exits 0 when the path is ignored, 1 when
 // it is not, and 128 on any other error (no repo, bad cwd, …). The index

--- a/packages/core/tests/check-security-scan.test.ts
+++ b/packages/core/tests/check-security-scan.test.ts
@@ -533,6 +533,21 @@ describe("checkSecurityScan", () => {
     expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("artifact-secret-leak");
   });
 
+  // A `server` segment only marks server build output DIRECTLY under the build
+  // root. A production client bundle for an App Router route literally named
+  // `server` lives under `.next/static/.../server/` and must still be scanned.
+  it("still reports secrets in a .next/static client bundle under a route named 'server'", () => {
+    writeFile(".next/static/chunks/app/server/page.js", `const key = "AKIAABCDEFGHIJKLMNOP";`);
+
+    expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("artifact-secret-leak");
+  });
+
+  it("does not flag production .next/server build output", () => {
+    writeFile(".next/server/chunks/route.js", `const key = "AKIAABCDEFGHIJKLMNOP";`);
+
+    expect(checkSecurityScan(temporaryRoot)).toEqual([]);
+  });
+
   it("does not flag a webhook handler that delegates to an extracted verification helper", () => {
     writeFile(
       "app/api/webhook/route.ts",

--- a/packages/core/tests/check-security-scan.test.ts
+++ b/packages/core/tests/check-security-scan.test.ts
@@ -23,12 +23,31 @@ const rulesOf = (diagnostics: ReadonlyArray<Diagnostic>): ReadonlySet<string> =>
 const fixtureRules = (fixtureName: string): ReadonlySet<string> =>
   rulesOf(checkSecurityScan(path.join(FIXTURES_DIRECTORY, fixtureName)));
 
+const setOrDeleteEnv = (name: string, value: string | undefined): void => {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+};
+
+let originalGitConfigGlobal: string | undefined;
+let originalGitConfigSystem: string | undefined;
+
 beforeEach(() => {
   temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-security-scan-"));
+  // Hermetic git: a runner's ambient global/system config (e.g. a
+  // `core.excludesFile` that ignores `.env`) must not change `check-ignore`'s
+  // verdict — both the test's `git init` and the scan's internal
+  // `git check-ignore` inherit this env, so the committed-file gitignore tests
+  // stay deterministic regardless of the host's git setup.
+  originalGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL;
+  originalGitConfigSystem = process.env.GIT_CONFIG_SYSTEM;
+  process.env.GIT_CONFIG_GLOBAL = "/dev/null";
+  process.env.GIT_CONFIG_SYSTEM = "/dev/null";
 });
 
 afterEach(() => {
   fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  setOrDeleteEnv("GIT_CONFIG_GLOBAL", originalGitConfigGlobal);
+  setOrDeleteEnv("GIT_CONFIG_SYSTEM", originalGitConfigSystem);
 });
 
 describe("checkSecurityScan", () => {
@@ -530,6 +549,25 @@ describe("checkSecurityScan", () => {
     );
 
     expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("webhook-signature-risk");
+  });
+
+  // The verification-suppression regex pairs a verb run, a noun run, and a
+  // trailing run. With unbounded `[A-Za-z]*` runs an identifier-shaped string
+  // with no closing `(` triggers cubic backtracking (ReDoS) that hangs the
+  // whole scan for minutes; the bounded `[A-Za-z]{0,40}` runs keep it linear
+  // (sub-millisecond on this input). The generous bound only has to separate
+  // "linear scan overhead" from "catastrophic hang", so it cannot flake.
+  it("scans a webhook handler with a pathological identifier run without ReDoS backtracking", () => {
+    const pathologicalRun = `valid${"a".repeat(20_000)}`;
+    writeFile(
+      "app/api/webhook-redos/route.ts",
+      `export const POST = async (request) => {\n  const ${pathologicalRun} = request.headers.get("x-sig");\n  const event = await request.json();\n  return Response.json({ ok: event.type });\n};`,
+    );
+
+    const startedAt = Date.now();
+    const rules = rulesOf(checkSecurityScan(temporaryRoot));
+    expect(Date.now() - startedAt).toBeLessThan(8_000);
+    expect(rules).toContain("webhook-signature-risk");
   });
 
   it("does not flag a gitignored env file (not checked into the repository)", () => {

--- a/packages/core/tests/check-security-scan.test.ts
+++ b/packages/core/tests/check-security-scan.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
@@ -490,6 +491,60 @@ describe("checkSecurityScan", () => {
     );
 
     expect(checkSecurityScan(temporaryRoot)).toEqual([]);
+  });
+
+  it("does not treat .next/dev/server dev source maps as browser artifacts", () => {
+    writeFile(
+      ".next/dev/server/chunks/ssr.js.map",
+      `window.__ENV__ = { AWS_SECRET_ACCESS_KEY: "x", AWS_ACCESS_KEY_ID: "AKIAABCDEFGHIJKLMNOP" };`,
+    );
+
+    expect(checkSecurityScan(temporaryRoot)).toEqual([]);
+  });
+
+  it("does not treat dev-mode .next/dev output as a browser artifact", () => {
+    writeFile(".next/dev/static/chunks/app.js", `const key = "AKIAABCDEFGHIJKLMNOP";`);
+
+    expect(checkSecurityScan(temporaryRoot)).toEqual([]);
+  });
+
+  it("still reports secrets in production .next/static output", () => {
+    writeFile(".next/static/chunks/app.js", `const key = "AKIAABCDEFGHIJKLMNOP";`);
+
+    expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("artifact-secret-leak");
+  });
+
+  it("does not flag a webhook handler that delegates to an extracted verification helper", () => {
+    writeFile(
+      "app/api/webhook/route.ts",
+      `import { isValidSecret } from "./verify";\nexport const POST = async (request) => {\n  const token = request.headers.get("x-webhook-token");\n  if (!isValidSecret(token, process.env.PROVIDER_SECRET)) return new Response("no", { status: 401 });\n  const event = await request.json();\n  return Response.json({ ok: event.type });\n};`,
+    );
+
+    expect(checkSecurityScan(temporaryRoot)).toEqual([]);
+  });
+
+  it("still flags a webhook handler with no verification at all", () => {
+    writeFile(
+      "app/api/webhook-bare/route.ts",
+      `export const POST = async (request) => {\n  const event = await request.json();\n  return Response.json({ ok: event.type });\n};`,
+    );
+
+    expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("webhook-signature-risk");
+  });
+
+  it("does not flag a gitignored env file (not checked into the repository)", () => {
+    spawnSync("git", ["init"], { cwd: temporaryRoot, stdio: "ignore" });
+    writeFile(".gitignore", ".env\n");
+    writeFile(".env", "NEXT_PUBLIC_API_SECRET=local-only-value\n");
+
+    expect(checkSecurityScan(temporaryRoot)).toEqual([]);
+  });
+
+  it("flags a non-gitignored env file checked into the repository", () => {
+    spawnSync("git", ["init"], { cwd: temporaryRoot, stdio: "ignore" });
+    writeFile(".env", "NEXT_PUBLIC_API_SECRET=committed-value\n");
+
+    expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("repository-secret-file");
   });
 
   it("does not treat ordinary package dist output as browser-shipped artifact output", () => {

--- a/packages/core/tests/check-security-scan.test.ts
+++ b/packages/core/tests/check-security-scan.test.ts
@@ -551,23 +551,27 @@ describe("checkSecurityScan", () => {
     expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("webhook-signature-risk");
   });
 
-  // The verification-suppression regex pairs a verb run, a noun run, and a
-  // trailing run. With unbounded `[A-Za-z]*` runs an identifier-shaped string
-  // with no closing `(` triggers cubic backtracking (ReDoS) that hangs the
-  // whole scan for minutes; the bounded `[A-Za-z]{0,40}` runs keep it linear
-  // (sub-millisecond on this input). The generous bound only has to separate
-  // "linear scan overhead" from "catastrophic hang", so it cannot flake.
-  it("scans a webhook handler with a pathological identifier run without ReDoS backtracking", () => {
-    const pathologicalRun = `valid${"a".repeat(20_000)}`;
-    writeFile(
-      "app/api/webhook-redos/route.ts",
-      `export const POST = async (request) => {\n  const ${pathologicalRun} = request.headers.get("x-sig");\n  const event = await request.json();\n  return Response.json({ ok: event.type });\n};`,
-    );
+  // ReDoS guard for the webhook verification regex (verb run + noun run +
+  // trailing run). A regression to unbounded `[A-Za-z]*` makes it backtrack
+  // cubically on a long identifier-like run with no closing `(` — minutes on
+  // this input. The rule's scan is invoked in isolation (not the whole-tree
+  // walk) so the assertion is about the regex, not machine-dependent scan
+  // overhead: the bounded `{0,40}` runs finish in well under a millisecond.
+  it("webhook-signature-risk scan stays linear on a pathological identifier run", () => {
+    const webhookEntry = REACT_DOCTOR_RULES.find((entry) => entry.id === "webhook-signature-risk");
+    const scan = webhookEntry?.rule.scan;
+    if (!scan) throw new Error("webhook-signature-risk must define a scan");
 
+    const content = `export async function POST(request) {\n  const ${"valid".repeat(5_000)} = 1;\n  const event = await request.json();\n  return Response.json({ ok: event.type });\n}\n`;
     const startedAt = Date.now();
-    const rules = rulesOf(checkSecurityScan(temporaryRoot));
-    expect(Date.now() - startedAt).toBeLessThan(8_000);
-    expect(rules).toContain("webhook-signature-risk");
+    const findings = scan({
+      absolutePath: path.join(temporaryRoot, "app/api/webhook/route.ts"),
+      relativePath: "app/api/webhook/route.ts",
+      content,
+      isGeneratedBundle: false,
+    });
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    expect(findings).toHaveLength(1);
   });
 
   it("does not flag a gitignored env file (not checked into the repository)", () => {
@@ -581,6 +585,18 @@ describe("checkSecurityScan", () => {
   it("flags a non-gitignored env file checked into the repository", () => {
     spawnSync("git", ["init"], { cwd: temporaryRoot, stdio: "ignore" });
     writeFile(".env", "NEXT_PUBLIC_API_SECRET=committed-value\n");
+
+    expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("repository-secret-file");
+  });
+
+  // A force-added file is tracked, so `git check-ignore` reports it as NOT
+  // ignored (the index takes precedence over a matching ignore rule) — the
+  // committed secret must still be flagged.
+  it("flags a force-added env file even when a .gitignore rule matches it", () => {
+    spawnSync("git", ["init"], { cwd: temporaryRoot, stdio: "ignore" });
+    writeFile(".gitignore", ".env\n");
+    writeFile(".env", "NEXT_PUBLIC_API_SECRET=committed-value\n");
+    spawnSync("git", ["add", "-f", ".env"], { cwd: temporaryRoot, stdio: "ignore" });
 
     expect(rulesOf(checkSecurityScan(temporaryRoot))).toContain("repository-secret-file");
   });

--- a/packages/core/tests/fixtures/basic-react/src/convex-query-usage.tsx
+++ b/packages/core/tests/fixtures/basic-react/src/convex-query-usage.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from "convex/react";
+
+// Convex's `useQuery` shares the name but returns a single value, not a
+// `{ data, isLoading, ... }` result object. The import source is `convex/react`,
+// so `query-destructure-result` must NOT fire here (#818).
+export const ConvexWholeResult = () => {
+  const contact = useQuery("contacts:get", { id: "1" });
+  return <div>{String(contact)}</div>;
+};

--- a/packages/core/tests/fixtures/basic-react/src/tanstack-query-destructure.tsx
+++ b/packages/core/tests/fixtures/basic-react/src/tanstack-query-destructure.tsx
@@ -1,0 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
+
+// A whole-result assignment from a genuine TanStack `useQuery` import — the
+// import source is `@tanstack/react-query`, so `query-destructure-result` fires.
+export const TanstackWholeResult = () => {
+  const query = useQuery({ queryKey: ["todos"], queryFn: () => fetch("/api/todos") });
+  return <div>{String(query.data)}</div>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/key-lifecycle-risk.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/key-lifecycle-risk.ts
@@ -9,6 +9,7 @@ export const keyLifecycleRisk = defineRule({
   id: "key-lifecycle-risk",
   title: "Long-lived key material in repository",
   severity: "error",
+  committedFilesOnly: true,
   recommendation:
     "Remove private keys from source, rotate exposed credentials, prefer short-lived deploy credentials, and document revocation/expiry for release keys.",
   // A key-shaped env NAME is how CI correctly references a secret store —

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/repository-secret-file.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/repository-secret-file.ts
@@ -14,6 +14,7 @@ export const repositorySecretFile = defineRule({
   id: "repository-secret-file",
   title: "Secret file checked into repository",
   severity: "error",
+  committedFilesOnly: true,
   recommendation:
     "Remove committed env files, service-account credentials, npm auth tokens, and webhook URLs; rotate exposed values and keep only redacted examples in source.",
   scan: (file) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
@@ -25,8 +25,10 @@ const isNonShippedBuildArtifactPath = (relativePath: string): boolean => {
   for (let index = 0; index < segments.length; index += 1) {
     if (!SERVER_BUILD_ROOT_SEGMENTS.has(segments[index])) continue;
     // `.next/dev/**`: transient dev output (incl. the `.next/dev/server` build).
+    // The whole subtree is excluded, so no trailing-segment guard is needed.
     if (segments[index] === ".next" && segments[index + 1] === "dev") return true;
-    // `<root>/server/<file>`: server build output, directly under the root.
+    // `<root>/server/<file>`: server build output directly under the root. The
+    // trailing-segment guard avoids matching a file literally named `server`.
     if (segments[index + 1] === "server" && index + 2 < segments.length) return true;
   }
   return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
@@ -1,16 +1,31 @@
 import { BROWSER_ARTIFACT_PATH_PATTERNS } from "../../../constants/security-scan.js";
 
-// Build output that never reaches end users in production, so it is not a
-// "browser artifact": any `.next/**/server` (e.g. `.next/server`,
-// `.next/dev/server`, `.next/standalone/.next/server`) and `.output/server`
-// server build output, plus the dev server's transient output (`.next/dev/**`,
-// which Next.js Turbopack writes during `next dev`). Production browser bundles
-// live in `.next/static`, `.output/public`, `dist/assets`, `public/`, etc.
-// `(?:[^/]+\/)*server` matches `server` at any depth and is ReDoS-safe (each
-// repeated segment must consume a `/`, so there is no ambiguous overlap).
-const isNonShippedBuildArtifactPath = (relativePath: string): boolean =>
-  /(?:^|\/)(?:\.next\/(?:[^/]+\/)*server|\.output\/server)\//.test(relativePath) ||
-  /(?:^|\/)\.next\/dev\//.test(relativePath);
+// Next.js (`.next`) and Nitro/Nuxt (`.output`) emit build trees that never
+// reach end users in production, so they are not "browser artifacts":
+//   - a `server/` directory at ANY depth below the build root (`.next/server`,
+//     `.next/dev/server`, `.next/standalone/.next/server`, `.output/server`) —
+//     its `.js.map` source maps bundle library source (PEM markers, env
+//     helpers) that would otherwise read as a leaked secret (#816, #817);
+//   - the dev server's entire transient output (`.next/dev/**`, written by
+//     `next dev`), which is never deployed.
+// Production browser bundles live in `.next/static`, `.output/public`,
+// `dist/assets`, `public/`, etc. and are still scanned.
+//
+// A segment walk (not a regex) is used on purpose: an equivalent
+// `(?:[^/]+\/)*server` pattern is polynomial on uncontrolled path strings
+// (CodeQL flags it), whereas splitting on `/` and indexing is linear.
+const SERVER_BUILD_ROOT_SEGMENTS = new Set([".next", ".output"]);
+
+const isNonShippedBuildArtifactPath = (relativePath: string): boolean => {
+  const segments = relativePath.split("/");
+  const buildRootIndex = segments.findIndex((segment) => SERVER_BUILD_ROOT_SEGMENTS.has(segment));
+  if (buildRootIndex === -1) return false;
+  if (segments[buildRootIndex] === ".next" && segments[buildRootIndex + 1] === "dev") return true;
+  // A `server` directory (not a file literally named `server`) anywhere below
+  // the build root: it must have at least one path segment after it.
+  const serverSegmentIndex = segments.indexOf("server", buildRootIndex + 1);
+  return serverSegmentIndex !== -1 && serverSegmentIndex < segments.length - 1;
+};
 
 export const isBrowserArtifactPath = (
   relativePath: string,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
@@ -1,13 +1,19 @@
 import { BROWSER_ARTIFACT_PATH_PATTERNS } from "../../../constants/security-scan.js";
 
-const isServerOnlyBuildArtifactPath = (relativePath: string): boolean =>
-  /(?:^|\/)(?:\.next\/server|\.output\/server)\//.test(relativePath);
+// Build output that never reaches end users in production, so it is not a
+// "browser artifact": server build output (`.next/server`, `.next/dev/server`,
+// `.output/server`) and the dev server's transient output (`.next/dev/**`,
+// which Next.js Turbopack writes during `next dev`). Production browser bundles
+// live in `.next/static`, `.output/public`, `dist/assets`, `public/`, etc.
+const isNonShippedBuildArtifactPath = (relativePath: string): boolean =>
+  /(?:^|\/)(?:\.next\/(?:[^/]+\/)?server|\.output\/server)\//.test(relativePath) ||
+  /(?:^|\/)\.next\/dev\//.test(relativePath);
 
 export const isBrowserArtifactPath = (
   relativePath: string,
   isGeneratedBundle: boolean,
 ): boolean => {
-  if (isServerOnlyBuildArtifactPath(relativePath)) return false;
+  if (isNonShippedBuildArtifactPath(relativePath)) return false;
   if (isGeneratedBundle) return true;
   if (relativePath.endsWith(".map")) return true;
   return BROWSER_ARTIFACT_PATH_PATTERNS.some((pattern) => pattern.test(relativePath));

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
@@ -1,12 +1,15 @@
 import { BROWSER_ARTIFACT_PATH_PATTERNS } from "../../../constants/security-scan.js";
 
 // Build output that never reaches end users in production, so it is not a
-// "browser artifact": server build output (`.next/server`, `.next/dev/server`,
-// `.output/server`) and the dev server's transient output (`.next/dev/**`,
+// "browser artifact": any `.next/**/server` (e.g. `.next/server`,
+// `.next/dev/server`, `.next/standalone/.next/server`) and `.output/server`
+// server build output, plus the dev server's transient output (`.next/dev/**`,
 // which Next.js Turbopack writes during `next dev`). Production browser bundles
 // live in `.next/static`, `.output/public`, `dist/assets`, `public/`, etc.
+// `(?:[^/]+\/)*server` matches `server` at any depth and is ReDoS-safe (each
+// repeated segment must consume a `/`, so there is no ambiguous overlap).
 const isNonShippedBuildArtifactPath = (relativePath: string): boolean =>
-  /(?:^|\/)(?:\.next\/(?:[^/]+\/)?server|\.output\/server)\//.test(relativePath) ||
+  /(?:^|\/)(?:\.next\/(?:[^/]+\/)*server|\.output\/server)\//.test(relativePath) ||
   /(?:^|\/)\.next\/dev\//.test(relativePath);
 
 export const isBrowserArtifactPath = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-browser-artifact-path.ts
@@ -2,12 +2,16 @@ import { BROWSER_ARTIFACT_PATH_PATTERNS } from "../../../constants/security-scan
 
 // Next.js (`.next`) and Nitro/Nuxt (`.output`) emit build trees that never
 // reach end users in production, so they are not "browser artifacts":
-//   - a `server/` directory at ANY depth below the build root (`.next/server`,
-//     `.next/dev/server`, `.next/standalone/.next/server`, `.output/server`) —
-//     its `.js.map` source maps bundle library source (PEM markers, env
-//     helpers) that would otherwise read as a leaked secret (#816, #817);
+//   - a `server/` directory DIRECTLY under a build root — `.next/server`,
+//     `.output/server`, and the standalone `.next/standalone/.next/server`.
+//     Its `.js.map` source maps bundle library source (PEM markers, env
+//     helpers) that would otherwise read as a leaked secret (#816, #817).
+//     `server` must sit directly under the root: a `server` folder nested
+//     elsewhere (e.g. a `.next/static/.../server` App Router route bundle) is
+//     still production browser output and MUST keep being scanned.
 //   - the dev server's entire transient output (`.next/dev/**`, written by
-//     `next dev`), which is never deployed.
+//     `next dev`), which is never deployed — this also covers the dev server
+//     build at `.next/dev/server`.
 // Production browser bundles live in `.next/static`, `.output/public`,
 // `dist/assets`, `public/`, etc. and are still scanned.
 //
@@ -18,13 +22,14 @@ const SERVER_BUILD_ROOT_SEGMENTS = new Set([".next", ".output"]);
 
 const isNonShippedBuildArtifactPath = (relativePath: string): boolean => {
   const segments = relativePath.split("/");
-  const buildRootIndex = segments.findIndex((segment) => SERVER_BUILD_ROOT_SEGMENTS.has(segment));
-  if (buildRootIndex === -1) return false;
-  if (segments[buildRootIndex] === ".next" && segments[buildRootIndex + 1] === "dev") return true;
-  // A `server` directory (not a file literally named `server`) anywhere below
-  // the build root: it must have at least one path segment after it.
-  const serverSegmentIndex = segments.indexOf("server", buildRootIndex + 1);
-  return serverSegmentIndex !== -1 && serverSegmentIndex < segments.length - 1;
+  for (let index = 0; index < segments.length; index += 1) {
+    if (!SERVER_BUILD_ROOT_SEGMENTS.has(segments[index])) continue;
+    // `.next/dev/**`: transient dev output (incl. the `.next/dev/server` build).
+    if (segments[index] === ".next" && segments[index + 1] === "dev") return true;
+    // `<root>/server/<file>`: server build output, directly under the root.
+    if (segments[index + 1] === "server" && index + 2 < segments.length) return true;
+  }
+  return false;
 };
 
 export const isBrowserArtifactPath = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.regressions.test.ts
@@ -26,4 +26,23 @@ describe("security-scan/webhook-signature-risk — regressions", () => {
     });
     expect(findings).toHaveLength(0);
   });
+
+  it("stays silent when verification is delegated to an extracted helper (#814)", () => {
+    const findings = runScanRule(webhookSignatureRisk, {
+      relativePath: "src/app/api/webhooks/provider/route.ts",
+      content: `import { isValidSecret } from "./verify";\nexport async function POST(request: Request) {\n  const token = request.headers.get("x-webhook-token");\n  if (!isValidSecret(token, process.env.PROVIDER_SECRET)) return new Response("no", { status: 401 });\n  const event = await request.json();\n  return Response.json({ ok: event.type });\n}\n`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  // Guard against catastrophic backtracking: the verification regex must run in
+  // linear time on a long identifier-like run. If it regresses to nested
+  // unbounded `[A-Za-z]*`, this scan hangs and the test times out.
+  it("does not catastrophically backtrack on a long verb-like run (ReDoS guard)", () => {
+    const findings = runScanRule(webhookSignatureRisk, {
+      relativePath: "src/app/api/webhooks/x/route.ts",
+      content: `export async function POST(request: Request) {\n  const ${"valid".repeat(5000)} = 1;\n  const event = await request.json();\n  return Response.json({ ok: true });\n}\n`,
+    });
+    expect(findings).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.ts
@@ -11,12 +11,15 @@ const WEBHOOK_ENTRYPOINT_PATTERN =
 // Reading a `*-signature` header or delegating to a verification helper is
 // evidence even when the HMAC math lives in another module. The last
 // alternative matches a call to a helper whose name pairs a verify-ish verb
-// with a security noun (`isValidSecret(...)`, `verifySignature(...)`,
+// with a webhook-security noun (`isValidSecret(...)`, `verifySignature(...)`,
 // `checkWebhookHmac(...)`), so an extracted timing-safe comparison still counts.
-// The letter runs around the verb/noun are length-bounded (not `[A-Za-z]*`) so
-// a long identifier-like run cannot cause catastrophic regex backtracking.
+// `token` is deliberately excluded from the nouns — a generic `validateToken(…)`
+// auth check is not signature verification (the `webhook` noun still covers
+// `verifyWebhookToken`). The letter runs around the verb/noun are
+// length-bounded (not `[A-Za-z]*`) so a long identifier-like run cannot cause
+// catastrophic regex backtracking.
 const WEBHOOK_SIGNATURE_VERIFICATION_PATTERN =
-  /verifySignature|verify.*signature|verify\w*(?:Webhook|Auth)|constructEvent|createHmac|timingSafeEqual|svix|webhookSecret|stripe\.webhooks|["'][\w-]*signature["']|\b[A-Za-z]{0,40}(?:verif|valid|check|assert|authenticat|compare|guard)[A-Za-z]{0,40}(?:secret|signature|hmac|webhook|digest|token)[A-Za-z]{0,40}\s*\(/i;
+  /verifySignature|verify.*signature|verify\w*(?:Webhook|Auth)|constructEvent|createHmac|timingSafeEqual|svix|webhookSecret|stripe\.webhooks|["'][\w-]*signature["']|\b[A-Za-z]{0,40}(?:verif|valid|check|assert|authenticat|compare|guard)[A-Za-z]{0,40}(?:secret|signature|hmac|webhook|digest)[A-Za-z]{0,40}\s*\(/i;
 
 // `webhookUrl` mentions mark code SENDING to a webhook (outbound), where
 // signature verification is the receiver's job, not this file's. A webhook

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.ts
@@ -8,10 +8,13 @@ const WEBHOOK_HANDLER_PATTERN =
 const WEBHOOK_ENTRYPOINT_PATTERN =
   /\b(?:export\s+(?:async\s+)?function\s+POST|export\s+const\s+(?:POST|handler|webhook)|webhookHandler|webhookRoute)\b/i;
 
-// Reading a `*-signature` header or delegating to a `verifyWebhook*` helper
-// is verification evidence even when the HMAC math lives in another module.
+// Reading a `*-signature` header or delegating to a verification helper is
+// evidence even when the HMAC math lives in another module. The last
+// alternative matches a call to a helper whose name pairs a verify-ish verb
+// with a security noun (`isValidSecret(...)`, `verifySignature(...)`,
+// `checkWebhookHmac(...)`), so an extracted timing-safe comparison still counts.
 const WEBHOOK_SIGNATURE_VERIFICATION_PATTERN =
-  /verifySignature|verify.*signature|verify\w*(?:Webhook|Auth)|constructEvent|createHmac|timingSafeEqual|svix|webhookSecret|stripe\.webhooks|["'][\w-]*signature["']/i;
+  /verifySignature|verify.*signature|verify\w*(?:Webhook|Auth)|constructEvent|createHmac|timingSafeEqual|svix|webhookSecret|stripe\.webhooks|["'][\w-]*signature["']|\b[A-Za-z]*(?:verif|valid|check|assert|authenticat|compare|guard)[A-Za-z]*(?:secret|signature|hmac|webhook|digest|token)[A-Za-z]*\s*\(/i;
 
 // `webhookUrl` mentions mark code SENDING to a webhook (outbound), where
 // signature verification is the receiver's job, not this file's. A webhook

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.ts
@@ -13,8 +13,10 @@ const WEBHOOK_ENTRYPOINT_PATTERN =
 // alternative matches a call to a helper whose name pairs a verify-ish verb
 // with a security noun (`isValidSecret(...)`, `verifySignature(...)`,
 // `checkWebhookHmac(...)`), so an extracted timing-safe comparison still counts.
+// The letter runs around the verb/noun are length-bounded (not `[A-Za-z]*`) so
+// a long identifier-like run cannot cause catastrophic regex backtracking.
 const WEBHOOK_SIGNATURE_VERIFICATION_PATTERN =
-  /verifySignature|verify.*signature|verify\w*(?:Webhook|Auth)|constructEvent|createHmac|timingSafeEqual|svix|webhookSecret|stripe\.webhooks|["'][\w-]*signature["']|\b[A-Za-z]*(?:verif|valid|check|assert|authenticat|compare|guard)[A-Za-z]*(?:secret|signature|hmac|webhook|digest|token)[A-Za-z]*\s*\(/i;
+  /verifySignature|verify.*signature|verify\w*(?:Webhook|Auth)|constructEvent|createHmac|timingSafeEqual|svix|webhookSecret|stripe\.webhooks|["'][\w-]*signature["']|\b[A-Za-z]{0,40}(?:verif|valid|check|assert|authenticat|compare|guard)[A-Za-z]{0,40}(?:secret|signature|hmac|webhook|digest|token)[A-Za-z]{0,40}\s*\(/i;
 
 // `webhookUrl` mentions mark code SENDING to a webhook (outbound), where
 // signature verification is the receiver's job, not this file's. A webhook

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/webhook-signature-risk.ts
@@ -8,18 +8,28 @@ const WEBHOOK_HANDLER_PATTERN =
 const WEBHOOK_ENTRYPOINT_PATTERN =
   /\b(?:export\s+(?:async\s+)?function\s+POST|export\s+const\s+(?:POST|handler|webhook)|webhookHandler|webhookRoute)\b/i;
 
-// Reading a `*-signature` header or delegating to a verification helper is
-// evidence even when the HMAC math lives in another module. The last
-// alternative matches a call to a helper whose name pairs a verify-ish verb
-// with a webhook-security noun (`isValidSecret(...)`, `verifySignature(...)`,
-// `checkWebhookHmac(...)`), so an extracted timing-safe comparison still counts.
-// `token` is deliberately excluded from the nouns — a generic `validateToken(…)`
-// auth check is not signature verification (the `webhook` noun still covers
-// `verifyWebhookToken`). The letter runs around the verb/noun are
-// length-bounded (not `[A-Za-z]*`) so a long identifier-like run cannot cause
-// catastrophic regex backtracking.
-const WEBHOOK_SIGNATURE_VERIFICATION_PATTERN =
-  /verifySignature|verify.*signature|verify\w*(?:Webhook|Auth)|constructEvent|createHmac|timingSafeEqual|svix|webhookSecret|stripe\.webhooks|["'][\w-]*signature["']|\b[A-Za-z]{0,40}(?:verif|valid|check|assert|authenticat|compare|guard)[A-Za-z]{0,40}(?:secret|signature|hmac|webhook|digest)[A-Za-z]{0,40}\s*\(/i;
+// In-file verification evidence: a known SDK call, a timing-safe comparison, a
+// provider helper, or a read of a `*-signature` header/config name.
+const WEBHOOK_VERIFICATION_SIGNAL_PATTERN =
+  /verifySignature|verify.*signature|verify\w*(?:Webhook|Auth)|constructEvent|createHmac|timingSafeEqual|svix|webhookSecret|stripe\.webhooks|["'][\w-]*signature["']/;
+
+// A call to a verification helper whose name pairs a verify-ish verb with a
+// webhook-security noun (`isValidSecret(...)`, `verifySignature(...)`,
+// `checkWebhookHmac(...)`), so an extracted timing-safe comparison in another
+// module still counts. `token` is deliberately excluded from the nouns — a
+// generic `validateToken(…)` auth check is not signature verification (the
+// `webhook` noun still covers `verifyWebhookToken`). The letter runs around the
+// verb/noun are length-bounded (not `[A-Za-z]*`) so a long identifier-like run
+// cannot cause catastrophic regex backtracking.
+const WEBHOOK_VERIFICATION_HELPER_CALL_PATTERN =
+  /\b[A-Za-z]{0,40}(?:verif|valid|check|assert|authenticat|compare|guard)[A-Za-z]{0,40}(?:secret|signature|hmac|webhook|digest)[A-Za-z]{0,40}\s*\(/;
+
+// Either kind of evidence suppresses the finding (composed case-insensitively
+// from the two readable sub-patterns above).
+const WEBHOOK_SIGNATURE_VERIFICATION_PATTERN = new RegExp(
+  `${WEBHOOK_VERIFICATION_SIGNAL_PATTERN.source}|${WEBHOOK_VERIFICATION_HELPER_CALL_PATTERN.source}`,
+  "i",
+);
 
 // `webhookUrl` mentions mark code SENDING to a webhook (outbound), where
 // signature verification is the receiver's job, not this file's. A webhook

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { queryDestructureResult } from "./query-destructure-result.js";
+
+describe("tanstack-query/query-destructure-result", () => {
+  it("flags a whole-result assignment from TanStack Query useQuery", () => {
+    const result = runRule(
+      queryDestructureResult,
+      `import { useQuery } from "@tanstack/react-query";\nconst query = useQuery(options);`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags useQuery from the legacy react-query package", () => {
+    const result = runRule(
+      queryDestructureResult,
+      `import { useQuery } from "react-query";\nconst query = useQuery(options);`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag Convex useQuery imported from convex/react", () => {
+    const result = runRule(
+      queryDestructureResult,
+      `import { useQuery } from "convex/react";\nconst contact = useQuery(api.contacts.getContact, { contactId });`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an aliased Convex useQuery", () => {
+    const result = runRule(
+      queryDestructureResult,
+      `import { useQuery as useConvexQuery } from "convex/react";\nconst contact = useConvexQuery(api.contacts.getContact);`,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags useQuery with no import in the file (preserves prior behavior)", () => {
+    const result = runRule(queryDestructureResult, `const query = useQuery(options);`);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.ts
@@ -1,8 +1,18 @@
 import { TANSTACK_QUERY_HOOKS } from "../../constants/tanstack.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// TanStack Query packages (`@tanstack/react-query`, `@tanstack/vue-query`,
+// `@tanstack/query-core`, the Angular `*-query-experimental`, …) plus the
+// legacy `react-query`. A `useQuery` imported from anything else — notably
+// Convex's `convex/react`, whose `useQuery` returns the data directly — must
+// not be treated as a TanStack result object.
+const TANSTACK_QUERY_PACKAGE_PATTERN = /^@tanstack\/[\w-]*query[\w-]*$/;
+const isTanstackQuerySource = (source: string): boolean =>
+  TANSTACK_QUERY_PACKAGE_PATTERN.test(source) || source === "react-query";
 
 export const queryDestructureResult = defineRule({
   id: "query-destructure-result",
@@ -22,6 +32,12 @@ export const queryDestructureResult = defineRule({
         : null;
 
       if (!calleeName || !TANSTACK_QUERY_HOOKS.has(calleeName)) return;
+
+      // Only flag when the hook actually comes from TanStack Query. A hook of
+      // the same name imported from another library (e.g. `convex/react`) does
+      // not return a tracked result object, so destructuring it would be wrong.
+      const importSource = getImportSourceForName(node, calleeName);
+      if (importSource !== null && !isTanstackQuerySource(importSource)) return;
 
       context.report({
         node: node.id,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.ts
@@ -36,6 +36,12 @@ export const queryDestructureResult = defineRule({
       // Only flag when the hook actually comes from TanStack Query. A hook of
       // the same name imported from another library (e.g. `convex/react`) does
       // not return a tracked result object, so destructuring it would be wrong.
+      // `null` (no import in this file — a global, an auto-import, or a call
+      // before its declaration) still fires, preserving prior behavior. A
+      // `useQuery` re-exported through a LOCAL module reports that module as its
+      // source and is intentionally skipped: a per-file rule can't follow the
+      // re-export chain, and firing on an unverified local source would
+      // re-introduce the Convex false positive this gate exists to prevent.
       const importSource = getImportSourceForName(node, calleeName);
       if (importSource !== null && !isTanstackQuerySource(importSource)) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.ts
@@ -1,9 +1,9 @@
 import { TANSTACK_QUERY_HOOKS } from "../../constants/tanstack.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { RuleContext } from "../../utils/rule-context.js";
 import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
 
 // TanStack Query packages (`@tanstack/react-query`, `@tanstack/vue-query`,
 // `@tanstack/query-core`, the Angular `*-query-experimental`, …) plus the

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
@@ -134,3 +134,16 @@ export const getImportedNameFromModule = (
   if (info.source !== moduleSource) return null;
   return info.imported;
 };
+
+// Module a local binding was imported from, or null when it has no import in
+// the enclosing module (a global, a re-export, or a same-name local). Lets a
+// rule disambiguate same-named hooks from different libraries (e.g. TanStack
+// Query's `useQuery` vs Convex's `useQuery` from `convex/react`).
+export const getImportSourceForName = (
+  contextNode: EsTreeNode,
+  localIdentifierName: string,
+): string | null => {
+  const lookup = getImportLookup(contextNode);
+  if (!lookup) return null;
+  return lookup.get(localIdentifierName)?.source ?? null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/rule.ts
@@ -74,6 +74,12 @@ export interface Rule {
   // generated oxlint config and executed by @react-doctor/core's
   // check-security-scan environment check over a whole-tree walk.
   scan?: FileScan;
+  // When `true`, the rule's finding only applies to files actually committed
+  // to the repository (its message asserts the file is "checked in"). The scan
+  // host drops findings for paths git ignores, so a local-only gitignored file
+  // (e.g. a `.env` in `.gitignore`) is not flagged. Lets a scan rule declare
+  // this without coupling the host to specific rule ids.
+  committedFilesOnly?: boolean;
   recommendation?: string;
   create: (context: RuleContext) => RuleVisitors;
 }

--- a/packages/react-doctor/tests/run-oxlint/tanstack-query.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/tanstack-query.test.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { beforeAll, describe, expect, it } from "vite-plus/test";
 import type { Diagnostic } from "@react-doctor/core";
 import { runOxlint } from "@react-doctor/core";
@@ -18,6 +19,38 @@ describe("runOxlint", () => {
   });
 
   describe("tanstack-query false-positive freedom", () => {
+    // #818: `query-destructure-result` keys on the `useQuery` name, but only
+    // TanStack's hook returns a `{ data, ... }` result worth destructuring.
+    // Convex's same-named hook returns a scalar, so the rule must defer to the
+    // import source. Scoped to the two fixtures so it is independent of the
+    // shared whole-project run above.
+    it("flags a TanStack useQuery whole-result but not a Convex useQuery (#818)", async () => {
+      const scopedDiagnostics = await runOxlint({
+        rootDirectory: BASIC_REACT_DIRECTORY,
+        project: buildTestProject({
+          rootDirectory: BASIC_REACT_DIRECTORY,
+          hasTanStackQuery: true,
+        }),
+        includePaths: [
+          path.join(BASIC_REACT_DIRECTORY, "src/tanstack-query-destructure.tsx"),
+          path.join(BASIC_REACT_DIRECTORY, "src/convex-query-usage.tsx"),
+        ],
+      });
+      const destructureFindings = scopedDiagnostics.filter(
+        (diagnostic) => diagnostic.rule === "query-destructure-result",
+      );
+      expect(
+        destructureFindings.some((diagnostic) =>
+          diagnostic.filePath.includes("tanstack-query-destructure"),
+        ),
+      ).toBe(true);
+      expect(
+        destructureFindings.some((diagnostic) =>
+          diagnostic.filePath.includes("convex-query-usage"),
+        ),
+      ).toBe(false);
+    });
+
     it("does not flag useMutation that calls setQueryData (or any other cache-update method)", () => {
       const mutationLines = basicReactDiagnostics
         .filter(


### PR DESCRIPTION
Fixes a batch of false positives reported today.

Closes #818
Closes #817
Closes #816
Closes #814
Closes #813

## Summary

| Issue | Rule | Fix |
|---|---|---|
| #818 | `query-destructure-result` | Only flag `useQuery`/`useSuspenseQuery`/… when imported from a TanStack Query package (`@tanstack/*-query`, legacy `react-query`). Convex's `useQuery` from `convex/react` (which returns data directly) and other same-named hooks are skipped. |
| #816, #817 | `artifact-env-leak`, `artifact-secret-leak` | Stop treating server/dev-mode Next output as a browser artifact: exclude `.next/**/server/**`, `.next/dev/**` (dev server output, incl. the `.next/dev/server/*.js.map` source maps), and `.output/server/**`. Production bundles (`.next/static`, `dist/assets`, `public/`) are still scanned. |
| #813 | `repository-secret-file`, `key-lifecycle-risk` | Don't flag a credential/key file that **git ignores** — a local-only, gitignored `.env` is not checked into the repo. Suppressed only when git definitively reports the path ignored (the finding stands when there's no repo / git is unavailable). |
| #814 | `webhook-signature-risk` | Recognize a delegated verification helper call (verify-ish verb + security noun: `isValidSecret(...)`, `verifySignature(...)`, `checkWebhookHmac(...)`) as verification evidence, so an extracted `timingSafeEqual` comparison in another module no longer trips the rule. |

Also moves `is-path-git-ignored` to a shared `@react-doctor/core` util (was expo-only).

## Test plan
- [x] New `query-destructure-result.test.ts` (TanStack flagged, Convex/aliased/legacy handled)
- [x] New `check-security-scan` cases: `.next/dev/server` + `.next/dev` quiet, production `.next/static` still flagged; webhook helper quiet + bare handler still flagged; gitignored `.env` quiet + committed `.env` flagged
- [x] Regression suites for the touched rules pass (`artifact-env-leak`, `webhook-signature-risk`, `repository-secret-file`, registry)
- [x] `pnpm test` (core + cli + api + ls), `pnpm typecheck`, `pnpm lint`, `pnpm format:check`

Note: 6 unrelated `react-builtins` test files fail locally on a clean `main` checkout (an `oxc-parser` native-binding mismatch in my local toolchain); they're untouched by this PR and verified to fail identically with the changes stashed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-scan exclusions and git-ignore gating change when findings appear; mistakes could hide real leaks, though gitignored-only suppression and conservative artifact paths limit that. TanStack import-source gating is narrow and well-tested.
> 
> **Overview**
> Reduces false positives across **security scan** rules and **TanStack Query** linting without weakening checks on real production/browser and committed-secret exposure.
> 
> **TanStack `query-destructure-result` (#818):** Whole-result assignments are flagged only when the hook is imported from TanStack Query (`@tanstack/*-query`, `react-query`), using new `getImportSourceForName`. Convex and other same-named hooks (e.g. `convex/react`) are skipped; no import in file still reports (prior behavior).
> 
> **Artifact leaks (#816, #817):** `is-browser-artifact-path` excludes non-shipped build output via a linear path walk: `.next/dev/**`, `<.next|.output>/server/**`, while **`.next/static`** (including routes named `server`) remains scanned.
> 
> **Committed secrets (#813):** `repository-secret-file` and `key-lifecycle-risk` gain `committedFilesOnly`; `checkSecurityScan` drops findings when `git check-ignore` says the path is ignored (cached, only after a finding). Force-added tracked `.env` files still flag.
> 
> **Webhooks (#814):** `webhook-signature-risk` treats delegated helper calls (`isValidSecret`, `verifySignature`, etc.) as verification evidence, with bounded regex to avoid ReDoS.
> 
> `isPathGitIgnored` is shared under `@react-doctor/core` (Expo checks updated). Broad test coverage and hermetic git in security-scan tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2739af564b3cd6ce6d8839e487f84b64470e36b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->