### PR TITLE
fix(supply-chain): skip dist-tags and wildcards instead of crashing (#807)

### DIFF
--- a/.changeset/supply-chain-dist-tag-crash.md
+++ b/.changeset/supply-chain-dist-tag-crash.md
@@ -1,0 +1,10 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Fix a supply-chain scan crash on npm dist-tags and wildcards (#807).
+
+`resolveConcreteVersion` called `semver.minVersion(spec)` directly, but `semver` **throws** (`TypeError: Invalid comparator: latest`) on a non-range spec instead of returning `null`. Any full scan — or PR scan touching `package.json` — containing a dist-tag like `"trigger.dev": "latest"` (or `"next"`) crashed before the Socket fail-open path could run (regression from #804, affecting 0.5.3–0.5.5).
+
+The spec is now validated with `semver.validRange` before resolving its floor: dist-tags and other non-ranges are skipped (nothing to score), as is a wildcard-only range (`*`/`x`/`X`), which previously resolved to a synthetic `0.0.0` and scored a version nobody pinned. Real ranges (`^1.2.3`, `1.x`, `>=2 <3`) and protocol/URL specs (`workspace:`, `file:`, `npm:`, `git+…`) are unchanged.

--- a/packages/core/src/check-supply-chain.ts
+++ b/packages/core/src/check-supply-chain.ts
@@ -222,12 +222,18 @@ const resolveOptions = (config: ReactDoctorConfig | null): ResolvedSupplyChainOp
 // lowest version it permits, a real published version — via `semver.minVersion`,
 // which resolves caret/tilde/OR/upper-bound ranges correctly (the old
 // "first semver token" scan mis-scored `<2.0.0 >=1.5.0` and `2.0.0 || 1.0.0`).
-// Specs with no parseable floor (`latest`, a URL) or a non-registry protocol
-// (`workspace:`, `file:`, `link:`, `npm:`, `git+…`) are skipped: nothing to score.
+// Specs with no parseable floor (`latest`, `*`, a URL) or a non-registry
+// protocol (`workspace:`, `file:`, `link:`, `npm:`, `git+…`) are skipped:
+// nothing to score.
 const resolveConcreteVersion = (spec: string): string | null => {
   const trimmed = spec.trim();
   if (trimmed.length === 0) return null;
   if (trimmed.includes(":")) return null;
+  // `semver.minVersion` *throws* on a bare dist-tag (`latest`, `next`) rather
+  // than returning null, so validate first. `validRange` collapses a pure
+  // wildcard to `"*"`, whose only floor is a synthetic `0.0.0` — skip it too.
+  const range = semver.validRange(trimmed);
+  if (range === null || range === "*") return null;
   return semver.minVersion(trimmed)?.version ?? null;
 };
 

--- a/packages/core/tests/check-supply-chain.test.ts
+++ b/packages/core/tests/check-supply-chain.test.ts
@@ -231,6 +231,52 @@ describe("checkSupplyChain — security-axis gating", () => {
     expect(diagnostics[0].message).not.toContain("lowest version");
   });
 
+  // `semver.minVersion` throws (rather than returning null) on a dist-tag like
+  // `latest`/`next`, and resolves a wildcard to a synthetic `0.0.0`. Each of
+  // these specs has no concrete floor to score, so it must be skipped — never
+  // crash the scan (issue #807) and never fetch a fabricated version.
+  it.each([
+    ["a dist-tag", "latest"],
+    ["the `next` dist-tag", "next"],
+    ["a bare wildcard", "*"],
+    ["an `x` wildcard", "x"],
+    ["a `workspace:` protocol", "workspace:*"],
+    ["a `file:` protocol", "file:../local"],
+    ["an `npm:` alias", "npm:other-pkg@1.2.3"],
+    ["a git URL", "git+https://example.com/owner/repo.git"],
+    ["a tarball URL", "https://example.com/pkg/foo-1.2.3.tgz"],
+  ])("skips %s spec without crashing or scoring it", async (_label, spec) => {
+    writePackageJson({ "unresolvable-pkg": spec });
+    // Stub a failing score: if the spec were (mis)resolved to a concrete
+    // version it would flag here. An empty result proves it was skipped.
+    stubSocketApi({
+      "unresolvable-pkg": {
+        supplyChain: 0,
+        vulnerability: 1,
+        maintenance: 1,
+        quality: 1,
+        license: 1,
+      },
+    });
+
+    expect(await runCheck()).toEqual([]);
+  });
+
+  it("does not crash on a dist-tag and still scores resolvable siblings (issue #807, trigger.dev@latest)", async () => {
+    // The exact regression shape: a real dep beside an npm dist-tag. PR #804
+    // made this throw `TypeError: Invalid comparator: latest` on every scan.
+    writePackageJson({ react: "^19.0.0", "trigger.dev": "latest" });
+    stubSocketApi({
+      react: { supplyChain: 0.2, vulnerability: 1, maintenance: 1, quality: 1, license: 1 },
+      "trigger.dev": { supplyChain: 0, vulnerability: 1, maintenance: 1, quality: 1, license: 1 },
+    });
+
+    const diagnostics = await runCheck();
+    // The dist-tag is skipped (not crashed on); the resolvable sibling still scores.
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("`react@19.0.0");
+  });
+
   it("keeps the score-driven diagnostic when alerts are malformed or null (no fail-open)", async () => {
     writePackageJson({ "null-alert-pkg": "1.0.0" });
     // A real Socket line where optional alert fields are explicitly `null`


### PR DESCRIPTION
## Why

`react-doctor` 0.5.3–0.5.5 crash on any full scan (or PR scan touching `package.json`) whose dependencies include an npm dist-tag like `"trigger.dev": "latest"`. PR #804 swapped `resolveConcreteVersion()` to call `semver.minVersion(spec)` directly, but semver **throws** on a non-range spec instead of returning `null`, and that synchronous throw lands before the Socket fail-open path can catch it. Fixes #807.

Before:

```jsonc
// package.json
{ "dependencies": { "react": "^19.0.0", "trigger.dev": "latest" } }
```
```console
$ npx react-doctor@0.5.5 . --json --no-score
TypeError: Invalid comparator: latest
```

After:

```console
$ react-doctor . --json --no-score
# no crash — the dist-tag is skipped (nothing concrete to score),
# resolvable deps are still scored normally
```

## What changed

- `packages/core/src/check-supply-chain.ts` — `resolveConcreteVersion()` now validates with `semver.validRange()` before calling `semver.minVersion()`. A spec whose range is `null` (dist-tags like `latest`/`next`) is skipped, and a wildcard-only range (`*`/`x`/`X`, which `validRange` collapses to `"*"`) is skipped too — it would otherwise resolve to a synthetic `0.0.0` and score a version nobody pinned. Real ranges (`^1.2.3`, `1.x`, `>=2 <3`) and protocol/URL specs (`workspace:`, `file:`, `npm:`, `git+…`) behave exactly as before.
- `packages/core/tests/check-supply-chain.test.ts` — added coverage: a parametrized sweep over `latest`/`next`/`*`/`x`/`workspace:`/`file:`/`npm:`/git URL/tarball URL (each skipped, no crash) and the exact #807 repro (`react` + `trigger.dev@latest`) asserting the dist-tag is skipped while the resolvable sibling still scores.
- `.changeset/supply-chain-dist-tag-crash.md` — patch bump for `@react-doctor/core` + `react-doctor`.

## Test plan

- `pnpm --filter @react-doctor/core build && pnpm --filter @react-doctor/core exec vp test run check-supply-chain` — 23 passing.
- Verified the new tests genuinely catch the regression: reverting the fix and rebuilding makes exactly the dist-tag/wildcard cases fail (`Invalid comparator` throw + synthetic-`0.0.0` flag); restoring the fix makes them green.
- `tsc --noEmit`, `vp lint`, `vp fmt --check` clean on the touched files.
- Real CLI smoke test against the minimal repro: exits `0`, no `Invalid comparator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized guard in version resolution with broad test coverage; no auth or data-path changes, and intended behavior for real semver ranges is unchanged.
> 
> **Overview**
> Fixes a **supply-chain scan crash** when `package.json` lists npm dist-tags (`latest`, `next`) or bare wildcards (`*`, `x`). After #804, `resolveConcreteVersion` called `semver.minVersion` directly; semver **throws** on those specs, aborting the whole scan before Socket’s fail-open handling could run.
> 
> **`resolveConcreteVersion`** now gates on `semver.validRange` first: non-ranges and pure `*` are skipped (no concrete floor to score). Wildcard-only specs are also skipped so they are not mis-scored as synthetic `0.0.0`. Normal semver ranges and `:` protocol specs behave as before.
> 
> Tests cover skipped spec shapes and the **`react` + `trigger.dev@latest`** regression; a changeset patches `@react-doctor/core` and `react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9502b4d357331f0cb2a45321e3b4add1e79829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->