### PR TITLE
fix(scan): show full file count when handing off to dead-code analysis (#815)

### DIFF
--- a/.changeset/scan-progress-final-count.md
+++ b/.changeset/scan-progress-final-count.md
@@ -1,0 +1,8 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Show the full file total when the scan hands off to dead-code analysis, so the live counter no longer looks stuck below `N` (#815).
+
+The linter already emits a final `(N, N)` progress tick when its last batch finishes, but ora throttles renders to its frame interval — that last frame was overwritten by the `"Analyzing dead code…"` text before it ever painted, so the spinner appeared to freeze at whatever value the smooth-creep timer last drew (e.g. `80/165`). Every file was always scanned; only the counter looked short. The dead-code phase now reads `Scanned N files, analyzing dead code…`, keeping the complete count visible for the whole (longer) dead-code pass.

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -444,6 +444,16 @@ export const runInspect = <HooksR = never>(
       yield* scanProgress.fail(formatLintFailText(lintFailureState.reasonTag, process.version));
     }
 
+    // ora throttles renders to its frame interval, so the final `(N, N)`
+    // progress frame the linter emits on its last batch is overwritten by the
+    // next phase's text before it ever paints — the live counter looks frozen
+    // short of N even though every file was scanned (issue #815). Resolve the
+    // full total now and carry it into the dead-code label so "scanned N files"
+    // stays visible for the whole (longer) dead-code pass.
+    const totalFileCount =
+      lastReportedTotalFileCount || (lintIncludePaths?.length ?? project.sourceFileCount);
+    const scannedFilesLabel = `${totalFileCount} ${totalFileCount === 1 ? "file" : "files"}`;
+
     // Dead-code analysis only ever emits `"warning"`-severity diagnostics
     // (the `deslop` plugin, all `Maintainability`). Warnings show by
     // default, so this normally runs; only when the user opts out via
@@ -459,7 +469,7 @@ export const runInspect = <HooksR = never>(
     const deadCodeCollected =
       lintFailureState.didFail || !shouldRunDeadCode
         ? []
-        : yield* scanProgress.update("Analyzing dead code...").pipe(
+        : yield* scanProgress.update(`Scanned ${scannedFilesLabel}, analyzing dead code...`).pipe(
             Effect.andThen(
               Stream.runCollect(
                 applyPerElementPipeline(
@@ -486,8 +496,6 @@ export const runInspect = <HooksR = never>(
 
     const scanElapsedMilliseconds = Date.now() - scanStartTime;
     const scanElapsedSeconds = (scanElapsedMilliseconds / 1000).toFixed(1);
-    const totalFileCount =
-      lastReportedTotalFileCount || (lintIncludePaths?.length ?? project.sourceFileCount);
 
     if (!lintFailureState.didFail) {
       if (deadCodeFailureState.didFail) {
@@ -496,7 +504,7 @@ export const runInspect = <HooksR = never>(
         yield* scanProgress.stop();
       } else {
         yield* scanProgress.succeed(
-          `Scanned ${totalFileCount} ${totalFileCount === 1 ? "file" : "files"} in ${scanElapsedSeconds}s${workerCountSuffix}`,
+          `Scanned ${scannedFilesLabel} in ${scanElapsedSeconds}s${workerCountSuffix}`,
         );
       }
     }

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -443,8 +443,14 @@ describe("runInspect — scan progress phases", () => {
       "unused-file",
     ]);
     expect(phaseEvents).toEqual(["lint", "afterLint", "dead-code"]);
-    expect(result.progressEvents.map((event) => event.text)).toContain("Scanning...");
-    expect(result.progressEvents.map((event) => event.text)).toContain("Analyzing dead code...");
+    const progressTexts = result.progressEvents.map((event) => event.text);
+    expect(progressTexts).toContain("Scanning...");
+    // The dead-code phase carries the scanned file total so the counter never
+    // appears to stall short of N before the handoff (issue #815).
+    expect(
+      progressTexts.some((text) => /^Scanned \d+ files?, analyzing dead code\.\.\.$/.test(text)),
+      `dead-code phase should report the scanned file total, got: ${progressTexts.join(" | ")}`,
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #815 — the scan progress counter appeared to freeze short of the total (e.g. `80/165`) and then jump to `Analyzing dead code…`, making users think the rest of their files were skipped. **Every file was always scanned; only the counter looked stuck.**

**Root cause:** `spawn-batches.ts` already fires `onFileProgress(N, N)` when the last lint batch finishes, but ora throttles renders to its ~80 ms frame interval. In `run-inspect.ts` that final `N/N` text was immediately overwritten by `update("Analyzing dead code...")` before ora ever painted it, so the last *visible* frame showed wherever the 50 ms smooth-creep timer happened to be.

**Fix:** resolve the file total the moment lint finishes and fold it into the dead-code phase label, so the complete count stays visible for the whole (longer) dead-code pass instead of relying on a frame that never paints:

- Dead-code phase now reads `Scanned N files, analyzing dead code…`
- Reused the same `scannedFilesLabel` for the `✔ Scanned N files in Xs` success line (DRY)
- No artificial delay (kept CI/fast scans fast); avoided the `·` separator since terminal rows are tested against it

This only surfaces when dead-code analysis runs between lint and the summary (the reporter's Expo case). In diff / `--no-warnings` runs there is no intermediate phase — the `✔ Scanned N files` success line already paints immediately.

## Changes

- `packages/core/src/run-inspect.ts` — carry the scanned file total into the dead-code label; reuse it for the success line
- `packages/core/tests/run-inspect.test.ts` — assert the dead-code phase reports the scanned file total
- `.changeset/scan-progress-final-count.md` — patch bump (`@react-doctor/core`, `react-doctor`)

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] core suite — 837 passed
- [x] CLI suite — 1786 passed (incl. e2e terminal-visuals)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI progress copy and timing only; no change to which files are linted or how dead-code runs.
> 
> **Overview**
> Fixes **#815**: the live scan counter could look stuck below the real total (e.g. `80/165`) when lint finished, because **ora** throttles spinner updates and the dead-code phase immediately replaced the final `N/N` frame with plain `"Analyzing dead code..."`.
> 
> After lint completes, the orchestrator now resolves the **full file total** once and uses it for the dead-code spinner: **`Scanned N files, analyzing dead code...`**, so the complete count stays visible for the longer dead-code pass. The same **`scannedFilesLabel`** is reused for the **`✔ Scanned N files in Xs`** success line.
> 
> Tests assert the dead-code progress text matches that pattern; a changeset patches `@react-doctor/core` and `react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e231de2fa8cc1f003af21b6d121d428fb71dec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->