### PR TITLE
feat(rules): add 3 mined platform/correctness rules (batch 2)

### DIFF
--- a/.agents/skills/rde-eval/SKILL.md
+++ b/.agents/skills/rde-eval/SKILL.md
@@ -13,6 +13,15 @@ Test a react-doctor rule change against thousands of OSS repos with the
 - **cloud** — Vercel Sandbox microVMs (4 vCPU / 8 GB). Fan out to 50+ repos in
   parallel. Requires a **pushed** branch.
 
+> **Validating an oxlint lint rule? Use local.** Observed: cloud runs currently
+> fire only the **project-level analyzers** (dead-code, supply-chain, security —
+> ~15 rules) and **not the oxlint AST rule layer** (the 100+ per-element rules in
+> `oxlint-plugin-react-doctor`). A 139-repo cloud run produced 15 distinct rules /
+> **0** oxlint hits; the same corpus locally produced 150+ distinct rules / 1000s
+> of hits. So for any rule in the oxlint plugin, cloud will report a **misleading
+> 0** — run it **local**. Cloud is still valid for dead-code / supply-chain /
+> security rules. (Root cause not yet diagnosed — treat as a known limitation.)
+
 `$RD` is your react-doctor checkout — the one with the rule changes, at the
 **monorepo root** (the CLI appends `packages/react-doctor/...`). `$EVALS` is the
 react-doctor-evals checkout. Run every `node dist/cli.js` command from `$EVALS`.
@@ -26,8 +35,16 @@ cd $EVALS && git pull && pnpm install && pnpm build   # stale builds break cloud
 (cd $RD && pnpm build)                                # local mode needs the built bin
 ```
 
-Cloud mode also needs `$EVALS/.env.local` with `VERCEL_TOKEN`,
-`VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID` (run `node setup.mjs` once).
+Cloud mode also needs `$EVALS/.env.local` with **five** vars — the harness won't
+boot (or sandbox provisioning 403s) if any is missing:
+
+| var                 | how to get it                                                                                                                                                                                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VERCEL_TOKEN`      | vercel.com → Account Settings → Tokens (with access to the team). An empty/expired value provisions a `403 invalidToken`. Sanity-check: `curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $TOKEN" https://api.vercel.com/v2/user` → `200`. |
+| `VERCEL_TEAM_ID`    | `node setup.mjs`, or `orgId` in `$EVALS/.vercel/project.json`.                                                                                                                                                                                             |
+| `VERCEL_PROJECT_ID` | `node setup.mjs`, or `projectId` in `$EVALS/.vercel/project.json`. ⚠️ `vercel env pull` does **not** always write this one — copy it from `project.json` if absent.                                                                                        |
+| `AXIOM_DATASET`     | Axiom dashboard. **Required even though traces only ship when `NODE_ENV=production`** — the harness reads it at boot, so a missing value is a hard `ConfigError`, not a silent no-op.                                                                      |
+| `AXIOM_TOKEN`       | Axiom dashboard → API token.                                                                                                                                                                                                                               |
 
 ## Version specs
 
@@ -67,6 +84,25 @@ node dist/cli.js parity "$B" "$C" --verbose                # +added / -removed b
 node dist/cli.js parity "$B" "$C" --json > parity.json     # machine-readable
 ```
 
+## Force a fresh run (cache)
+
+Results are cached per spec in `$EVALS/.evals/<sanitized-spec>.jsonl`. Re-running
+the same spec logs `N repos already processed. continuing…` and **serves the
+cache as-is — including repos that previously errored**, so a failed run blocks
+its own retry and returns stale/empty results. To force a clean run, delete that
+spec's file first:
+
+```sh
+# cloud (git: spec) — slashes/colons become dashes
+rm "$EVALS/.evals/https---github-com-millionco-react-doctor-<branch>.jsonl"
+# local (path: spec) — the absolute path with slashes → dashes
+rm "$EVALS/.evals/-Users-...-<your-rd-checkout>.jsonl"
+```
+
+Tip: check `wc -l` on the file and confirm entries aren't all `"error"` before
+trusting a digest. Pinning a commit SHA (`git:…@<sha>`) instead of a branch name
+is also a fresh cache key.
+
 ## Read the diff
 
 - `+` = your branch adds a diagnostic; `-` = drops one.
@@ -95,4 +131,17 @@ positives found) into rule-validate's eval table.
   repos can hit the 8 GB cap. Skip that repo.
 - `CreateSandboxError` / `InstallDepsError: npm install exited 1` — usually a
   stale evals build shipped to the worker. `cd $EVALS && git pull && pnpm install && pnpm build`.
+- `ConfigError: Expected string … ["AXIOM_DATASET"]` — `.env.local` is missing
+  `AXIOM_DATASET` / `AXIOM_TOKEN`. Set both (required at boot even with tracing off).
+- `403 … "invalidToken": true` on sandbox create — `VERCEL_TOKEN` is empty or
+  expired. Refresh it; verify with the `curl … /v2/user → 200` check above.
+- `Service not found: rde/WorkerPool` — the `run` command's layer stack doesn't
+  provide the pool service. `Runner.layerWorkerPool` must
+  `Layer.provide(WorkerPool.layer)` (its `Worker` + `WorkerPoolConfig` deps are
+  supplied by the command). Without it, `--pool vercel` dies before any scan.
+- Whole run crashes mid-way on one repo (e.g. `ENOENT … pnpm-workspace.yaml` →
+  schema-decode defect) — a single repo's `PlatformError` must not be fatal. The
+  per-repo invoke in `Runner.run` isolates defects with `Effect.catchDefect`
+  (fold into `Repository.WithFailure`); otherwise one odd monorepo takes down all
+  N scans.
 - No Vercel creds — drop `--runner worker-pool --pool vercel`; local is the default.

--- a/.changeset/perf-a11y-rules-batch-2.md
+++ b/.changeset/perf-a11y-rules-batch-2.md
@@ -1,0 +1,9 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Add 3 new rules (mining batch 2), each validated with an OSS noise sweep (0 false positives across ~2,800 diagnostics in react-use, radix-ui/primitives, excalidraw, mantine):
+
+- `no-document-write` (Performance): `document.write()`/`document.writeln()` blocks parsing and is ignored or wipes the page after load.
+- `no-sync-xhr` (Performance): a synchronous `XMLHttpRequest` (`.open(method, url, false)`) freezes the main thread until the request finishes.
+- `no-string-false-on-boolean-attribute` (Bugs): `disabled="false"` and friends pass the string `"false"`, which is truthy, so the boolean attribute is applied even when you wrote "false". Targets a curated set of true HTML boolean attributes on intrinsic elements; excludes enumerated attrs (`aria-*`, `contentEditable`, `draggable`, `spellCheck`) and custom components.

--- a/docs/rule-candidates-backlog.md
+++ b/docs/rule-candidates-backlog.md
@@ -141,5 +141,26 @@ container sizing, CSS width/height all work). Lighthouse's `unsized-images` audi
 runtime against computed styles; a syntax rule would false-positive on every image sized by an
 external/global stylesheet. Moved to the not-statically-sound list below.
 
+### Mining batch 2 — SHIPPED (3) + evidence-based drops
+
+Each shipped rule passed an OSS noise sweep (react-use, radix-ui/primitives, excalidraw, mantine;
+~2,800 diagnostics): **0 false positives**.
+
+- **`no-document-write`** (Performance) — `document.write()`/`writeln()`.
+- **`no-sync-xhr`** (Performance) — `.open(method, url, false)` synchronous XHR.
+- **`no-string-false-on-boolean-attribute`** (Bugs) — `disabled="false"` etc. (truthy string applies
+  the boolean). Curated boolean-attr set on intrinsic elements only; excludes `aria-*`/enumerated.
+
+**Dropped after the sweep (real but too noisy / FP-prone):**
+
+- `no-accumulator-spread-in-reduce` — 29 hits across the 4 repos, all idiomatic small-data style
+  merges (`[...styles].reduce((acc,i)=>({...acc,...}))`). The pattern is genuinely O(n^2) but a
+  static rule can't tell a 3-item merge from a 10k-row one, so default-on is too noisy. Revisit as
+  opt-in / default-off with a large-source heuristic.
+- `no-redundant-live-region` — both real-world hits were false positives: an intentional
+  `role="status"` + dynamic `aria-live` override (radix toast) and a defensive explicit
+  `aria-live="polite"` (mantine carousel). axe does not flag this pattern; the "redundant" framing is
+  contentious. Dropped.
+
 > Raw per-cluster candidate detail (bad/good for all ~200) was produced in `/tmp/rd-mine/*.md`
 > (ephemeral). Ask to persist any cluster's full detail into the repo if needed.

--- a/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
+++ b/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
@@ -94,6 +94,7 @@ const RULES_NOT_PORTED_FROM_EXTERNAL = new Set([
   "dialog-has-accessible-name",
   "no-create-ref-in-function-component",
   "no-call-component-as-function",
+  "no-string-false-on-boolean-attribute",
 ]);
 
 // Rule ids whose source files are kept on disk but intentionally NOT

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -172,6 +172,7 @@ import { noDirectStateMutation } from "./rules/state-and-effects/no-direct-state
 import { noDisabledZoom } from "./rules/design/no-disabled-zoom.js";
 import { noDistractingElements } from "./rules/a11y/no-distracting-elements.js";
 import { noDocumentStartViewTransition } from "./rules/view-transitions/no-document-start-view-transition.js";
+import { noDocumentWrite } from "./rules/js-performance/no-document-write.js";
 import { noDynamicImportPath } from "./rules/bundle-size/no-dynamic-import-path.js";
 import { noEffectChain } from "./rules/state-and-effects/no-effect-chain.js";
 import { noEffectEventHandler } from "./rules/state-and-effects/no-effect-event-handler.js";
@@ -242,7 +243,9 @@ import { noSetState } from "./rules/react-builtins/no-set-state.js";
 import { noSetStateInRender } from "./rules/state-and-effects/no-set-state-in-render.js";
 import { noSideTabBorder } from "./rules/design/no-side-tab-border.js";
 import { noStaticElementInteractions } from "./rules/a11y/no-static-element-interactions.js";
+import { noStringFalseOnBooleanAttribute } from "./rules/react-builtins/no-string-false-on-boolean-attribute.js";
 import { noStringRefs } from "./rules/react-builtins/no-string-refs.js";
+import { noSyncXhr } from "./rules/js-performance/no-sync-xhr.js";
 import { noThisInSfc } from "./rules/react-builtins/no-this-in-sfc.js";
 import { noTinyText } from "./rules/design/no-tiny-text.js";
 import { noTransitionAll } from "./rules/performance/no-transition-all.js";
@@ -2317,6 +2320,17 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-document-write",
+    id: "no-document-write",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noDocumentWrite,
+      framework: "global",
+      category: "Performance",
+    },
+  },
+  {
     key: "react-doctor/no-dynamic-import-path",
     id: "no-dynamic-import-path",
     source: "react-doctor",
@@ -3130,6 +3144,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-string-false-on-boolean-attribute",
+    id: "no-string-false-on-boolean-attribute",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noStringFalseOnBooleanAttribute,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(noStringFalseOnBooleanAttribute.requires ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/no-string-refs",
     id: "no-string-refs",
     source: "react-doctor",
@@ -3139,6 +3165,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(noStringRefs.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-sync-xhr",
+    id: "no-sync-xhr",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noSyncXhr,
+      framework: "global",
+      category: "Performance",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noDocumentWrite } from "./no-document-write.js";
+
+describe("no-document-write", () => {
+  it("flags `document.write(...)`", () => {
+    const result = runRule(noDocumentWrite, `document.write("<p>hi</p>");`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("document.write()");
+  });
+
+  it("flags `document.writeln(...)`", () => {
+    const result = runRule(noDocumentWrite, `document.writeln("x");`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag `document.createElement(...)`", () => {
+    const result = runRule(noDocumentWrite, `const el = document.createElement("div");`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a `.write` on another object (e.g. a stream)", () => {
+    const result = runRule(noDocumentWrite, `stream.write("chunk");`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a computed `document[expr]()` access", () => {
+    const result = runRule(noDocumentWrite, `document[method]("x");`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.ts
@@ -1,0 +1,32 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+const MESSAGE =
+  "`document.write()` blocks parsing, is ignored (or wipes the page) after load, and is flagged by browsers as a performance anti-pattern. Build DOM nodes or set `innerHTML`/`textContent` on a target element instead.";
+
+const WRITE_METHODS = new Set(["write", "writeln"]);
+
+// `document.write(...)` / `document.writeln(...)` with a non-computed
+// `document` member callee.
+export const noDocumentWrite = defineRule({
+  id: "no-document-write",
+  title: "document.write is an anti-pattern",
+  severity: "warn",
+  recommendation:
+    "Don't use `document.write()`/`document.writeln()`. Append DOM nodes or set `innerHTML`/`textContent` on a specific element instead.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const callee = node.callee;
+      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+      if (!isNodeOfType(callee.object, "Identifier") || callee.object.name !== "document") return;
+      if (
+        !isNodeOfType(callee.property, "Identifier") ||
+        !WRITE_METHODS.has(callee.property.name)
+      ) {
+        return;
+      }
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
 
 const MESSAGE =
   "`document.write()` blocks parsing, is ignored (or wipes the page) after load, and is flagged by browsers as a performance anti-pattern. Build DOM nodes or set `innerHTML`/`textContent` on a target element instead.";
@@ -11,11 +12,11 @@ const WRITE_METHODS = new Set(["write", "writeln"]);
 // `document` member callee.
 export const noDocumentWrite = defineRule({
   id: "no-document-write",
-  title: "document.write is an anti-pattern",
+  title: "document.write/writeln",
   severity: "warn",
   recommendation:
     "Don't use `document.write()`/`document.writeln()`. Append DOM nodes or set `innerHTML`/`textContent` on a specific element instead.",
-  create: (context) => ({
+  create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const callee = node.callee;
       if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noSyncXhr } from "./no-sync-xhr.js";
+
+describe("no-sync-xhr", () => {
+  it("flags `xhr.open(method, url, false)`", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const xhr = new XMLHttpRequest(); xhr.open("GET", "/api", false);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("synchronous");
+  });
+
+  it("does not flag an async open (third arg true)", () => {
+    const result = runRule(noSyncXhr, `xhr.open("GET", "/api", true);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an open with no async argument (defaults to async)", () => {
+    const result = runRule(noSyncXhr, `xhr.open("GET", "/api");`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-open method with a false argument", () => {
+    const result = runRule(noSyncXhr, `widget.toggle("a", "b", false);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a dynamic async flag", () => {
+    const result = runRule(noSyncXhr, `xhr.open("GET", url, isSync);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.ts
@@ -3,6 +3,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
 
 const MESSAGE =
   "A synchronous `XMLHttpRequest` (`.open(method, url, false)`) freezes the main thread until the request finishes, blocking all rendering and input. Use `fetch()` or an async XHR (`open(method, url, true)`).";
@@ -20,7 +21,7 @@ export const noSyncXhr = defineRule({
   severity: "warn",
   recommendation:
     "Never open an XMLHttpRequest synchronously (`async` = `false`). It blocks the main thread. Use `fetch()` or pass `true` and handle the response asynchronously.",
-  create: (context) => ({
+  create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       const callee = node.callee;
       if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.ts
@@ -1,0 +1,33 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+const MESSAGE =
+  "A synchronous `XMLHttpRequest` (`.open(method, url, false)`) freezes the main thread until the request finishes, blocking all rendering and input. Use `fetch()` or an async XHR (`open(method, url, true)`).";
+
+const isFalseLiteral = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "Literal") && node.value === false;
+
+// `<receiver>.open(method, url, false)` — the canonical synchronous-XHR
+// signature. The literal `false` third argument (the `async` flag) is the
+// distinctive, high-precision marker; we don't need to prove the receiver is
+// an XMLHttpRequest.
+export const noSyncXhr = defineRule({
+  id: "no-sync-xhr",
+  title: "Synchronous XMLHttpRequest",
+  severity: "warn",
+  recommendation:
+    "Never open an XMLHttpRequest synchronously (`async` = `false`). It blocks the main thread. Use `fetch()` or pass `true` and handle the response asynchronously.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const callee = node.callee;
+      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+      if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "open") return;
+      const asyncArgument = node.arguments?.[2];
+      if (!asyncArgument || !isFalseLiteral(stripParenExpression(asyncArgument))) return;
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.test.ts
@@ -13,12 +13,14 @@ describe("no-string-false-on-boolean-attribute", () => {
     expect(result.diagnostics[0].message).toContain("truthy");
   });
 
-  it('flags `checked="true"` (should be boolean)', () => {
+  it('flags `checked="true"` with a value-appropriate message (not the "false" wording)', () => {
     const result = runRule(
       noStringFalseOnBooleanAttribute,
       `const A = () => <input type="checkbox" checked="true" />;`,
     );
     expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain('not the string "true"');
+    expect(result.diagnostics[0].message).not.toContain('wrote "false"');
   });
 
   it('flags `readOnly="false"` (React camelCase)', () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noStringFalseOnBooleanAttribute } from "./no-string-false-on-boolean-attribute.js";
+
+describe("no-string-false-on-boolean-attribute", () => {
+  it('flags `disabled="false"` (the truthy-string footgun)', () => {
+    const result = runRule(
+      noStringFalseOnBooleanAttribute,
+      `const A = () => <button disabled="false">Save</button>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("truthy");
+  });
+
+  it('flags `checked="true"` (should be boolean)', () => {
+    const result = runRule(
+      noStringFalseOnBooleanAttribute,
+      `const A = () => <input type="checkbox" checked="true" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it('flags `readOnly="false"` (React camelCase)', () => {
+    const result = runRule(
+      noStringFalseOnBooleanAttribute,
+      `const A = () => <input readOnly="false" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the boolean-expression form", () => {
+    const result = runRule(
+      noStringFalseOnBooleanAttribute,
+      `const A = ({ off }) => <button disabled={false} hidden={off}>x</button>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the shorthand form", () => {
+    const result = runRule(noStringFalseOnBooleanAttribute, `const A = () => <input disabled />;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('does not flag enumerated attributes that take "false" (aria-*, contentEditable, draggable)', () => {
+    const result = runRule(
+      noStringFalseOnBooleanAttribute,
+      `const A = () => <div aria-pressed="false" contentEditable="false" draggable="false" spellCheck="false" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-boolean string attribute", () => {
+    const result = runRule(
+      noStringFalseOnBooleanAttribute,
+      `const A = () => <input value="false" placeholder="false" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('does not flag a custom component `<Toggle disabled="false">`', () => {
+    const result = runRule(
+      noStringFalseOnBooleanAttribute,
+      `const A = () => <Toggle disabled="false" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.test.ts
@@ -11,6 +11,10 @@ describe("no-string-false-on-boolean-attribute", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].message).toContain("truthy");
+    // Suggest the boolean-false form to keep it off, never the bare
+    // shorthand (which would turn the attribute ON).
+    expect(result.diagnostics[0].message).toContain("disabled={false}");
+    expect(result.diagnostics[0].message).toContain("keep it off");
   });
 
   it('flags `checked="true"` with a value-appropriate message (not the "false" wording)', () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
@@ -54,13 +54,13 @@ export const noStringFalseOnBooleanAttribute = defineRule({
         if (value !== "false" && value !== "true") continue;
 
         const attributeName = attribute.name.name;
-        const explanation =
+        const guidance =
           value === "false"
-            ? `which React treats as truthy, so the attribute is applied even though you wrote "false"`
-            : `but a boolean attribute takes a boolean, not the string "true"`;
+            ? `which React treats as truthy, so the attribute is applied even though you wrote "false". Use \`${attributeName}={false}\` (or omit the attribute) to keep it off`
+            : `but a boolean attribute takes a boolean, not the string "true". Use \`${attributeName}\` or \`${attributeName}={true}\``;
         context.report({
           node: attribute,
-          message: `\`${attributeName}="${value}"\` passes the string "${value}", ${explanation}. Use \`${attributeName}\` or \`${attributeName}={${value}}\`.`,
+          message: `\`${attributeName}="${value}"\` passes the string "${value}", ${guidance}.`,
         });
       }
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
@@ -35,7 +35,7 @@ export const noStringFalseOnBooleanAttribute = defineRule({
   title: "String true/false on a boolean attribute",
   severity: "warn",
   recommendation:
-    'Use the boolean form on boolean attributes: `disabled` / `disabled={true}` / `disabled={false}` — not `disabled="false"`. A non-empty string is truthy, so `="false"` actually turns the attribute ON.',
+    'Use the boolean form on boolean attributes: `disabled` / `disabled={true}` / `disabled={false}`, not `disabled="false"`. A non-empty string is truthy, so `="false"` actually turns the attribute ON.',
   create: (context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       // Only intrinsic elements — a JSXIdentifier starting with a lowercase

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
@@ -1,0 +1,62 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// True HTML boolean attributes: presence means "on", absence means "off".
+// Deliberately EXCLUDES enumerated attributes that legitimately take the
+// string "false" — `contentEditable`, `draggable`, `spellCheck`, `aria-*`,
+// `translate`, `autoComplete` — and `hidden` (now also enumerable as
+// `hidden="until-found"`).
+const BOOLEAN_ATTRIBUTES = new Set([
+  "disabled",
+  "checked",
+  "readonly",
+  "required",
+  "selected",
+  "multiple",
+  "autofocus",
+  "autoplay",
+  "controls",
+  "loop",
+  "muted",
+  "open",
+  "reversed",
+  "default",
+  "novalidate",
+  "formnovalidate",
+  "playsinline",
+  "itemscope",
+  "allowfullscreen",
+]);
+
+export const noStringFalseOnBooleanAttribute = defineRule({
+  id: "no-string-false-on-boolean-attribute",
+  title: "String true/false on a boolean attribute",
+  severity: "warn",
+  recommendation:
+    'Use the boolean form on boolean attributes: `disabled` / `disabled={true}` / `disabled={false}` — not `disabled="false"`. A non-empty string is truthy, so `="false"` actually turns the attribute ON.',
+  create: (context) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      // Custom components own their prop semantics (`<Foo disabled="false">`
+      // may take a real string), so only intrinsic lowercase elements.
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+      const firstChar = node.name.name[0];
+      if (!firstChar || firstChar !== firstChar.toLowerCase()) return;
+
+      for (const attribute of node.attributes) {
+        if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+        if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
+        if (!BOOLEAN_ATTRIBUTES.has(attribute.name.name.toLowerCase())) continue;
+
+        const value = getJsxPropStringValue(attribute);
+        if (value !== "false" && value !== "true") continue;
+
+        context.report({
+          node: attribute,
+          message: `\`${attribute.name.name}="${value}"\` passes the string "${value}", which React treats as truthy — the attribute is applied even when you wrote "false". Use \`${attribute.name.name}\` or \`${attribute.name.name}={${value}}\`.`,
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
@@ -53,9 +53,14 @@ export const noStringFalseOnBooleanAttribute = defineRule({
         const value = getJsxPropStringValue(attribute);
         if (value !== "false" && value !== "true") continue;
 
+        const attributeName = attribute.name.name;
+        const explanation =
+          value === "false"
+            ? `which React treats as truthy, so the attribute is applied even though you wrote "false"`
+            : `but a boolean attribute takes a boolean, not the string "true"`;
         context.report({
           node: attribute,
-          message: `\`${attribute.name.name}="${value}"\` passes the string "${value}", which React treats as truthy — the attribute is applied even when you wrote "false". Use \`${attribute.name.name}\` or \`${attribute.name.name}={${value}}\`.`,
+          message: `\`${attributeName}="${value}"\` passes the string "${value}", ${explanation}. Use \`${attributeName}\` or \`${attributeName}={${value}}\`.`,
         });
       }
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
@@ -38,11 +38,12 @@ export const noStringFalseOnBooleanAttribute = defineRule({
     'Use the boolean form on boolean attributes: `disabled` / `disabled={true}` / `disabled={false}` — not `disabled="false"`. A non-empty string is truthy, so `="false"` actually turns the attribute ON.',
   create: (context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      // Custom components own their prop semantics (`<Foo disabled="false">`
-      // may take a real string), so only intrinsic lowercase elements.
+      // Only intrinsic elements — a JSXIdentifier starting with a lowercase
+      // ASCII letter (a-z). Custom components start uppercase and own their
+      // prop semantics (`<Foo disabled="false">` may take a real string).
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-      const firstChar = node.name.name[0];
-      if (!firstChar || firstChar !== firstChar.toLowerCase()) return;
+      const firstCharacter = node.name.name.charCodeAt(0);
+      if (firstCharacter < 97 || firstCharacter > 122) return;
 
       for (const attribute of node.attributes) {
         if (!isNodeOfType(attribute, "JSXAttribute")) continue;


### PR DESCRIPTION
## Why

Second mining batch off `docs/rule-candidates-backlog.md`. Each shipped rule passed an OSS noise sweep before inclusion — and two candidates were **dropped on sweep evidence**, which is the point of the low-noise bar.

## What changed (3 rules, all 0 FP in the sweep)

- **`no-document-write`** (Performance) — `document.write()`/`document.writeln()` blocks parsing and is ignored/wipes the page after load.
  ```js
  document.write("<p>…</p>"); // bad → build DOM nodes / set innerHTML on a target
  ```
- **`no-sync-xhr`** (Performance) — synchronous `XMLHttpRequest` freezes the main thread.
  ```js
  xhr.open("GET", "/api", false); // bad → fetch() or async XHR (true)
  ```
- **`no-string-false-on-boolean-attribute`** (Bugs) — a non-empty string is truthy, so `disabled="false"` actually renders the element **disabled**.
  ```jsx
  <button disabled="false" />        // bad: rendered disabled!
  <button disabled={false} />        // good
  ```
  Curated set of true HTML boolean attributes on **intrinsic elements only**; excludes enumerated attrs (`aria-*`, `contentEditable`, `draggable`, `spellCheck`) and custom components.

## Eval / noise sweep

Built the branch CLI and scanned react-use, radix-ui/primitives, excalidraw, mantine (**~2,787 diagnostics**), filtered to the new rules and manually inspected.

| Rule | Hits | FPs |
| --- | --- | --- |
| `no-document-write` | 0 | 0 |
| `no-sync-xhr` | 0 | 0 |
| `no-string-false-on-boolean-attribute` | 0 | 0 |

(0 hits = quiet on good code; positives are covered by adversarial unit tests.)

### Dropped after the sweep (evidence-based)
- **`no-accumulator-spread-in-reduce`** — 29 hits, all idiomatic small-data style merges (`[...styles].reduce((acc,i)=>({...acc,...}))`). Genuinely O(n²), but a static rule can't distinguish a 3-item merge from a 10k-row one → too noisy default-on. Deferred to opt-in.
- **`no-redundant-live-region`** — both hits were false positives (intentional `role="status"`+dynamic `aria-live` override in radix toast; defensive explicit `aria-live` in mantine). axe doesn't flag this. Dropped.

## Test plan
- [x] adversarial unit tests for all 3 (18 passing)
- [x] `typecheck` (incl. `gen`), `lint`, `fmt --check` clean
- [x] OSS noise sweep, 0 FP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint rules with targeted matchers and 0-FP OSS sweep; docs/skill changes only affect contributors running evals.
> 
> **Overview**
> Adds **mining batch 2**: three new default-on oxlint rules with unit tests and registry wiring, plus a patch changeset for `oxlint-plugin-react-doctor`.
> 
> **`no-document-write`** (Performance) flags `document.write` / `document.writeln`. **`no-sync-xhr`** (Performance) flags `.open(method, url, false)`. **`no-string-false-on-boolean-attribute`** (Bugs) flags string `"true"`/`"false"` on curated HTML boolean attrs on intrinsic elements only (excludes enumerated attrs and custom components). `no-string-false-on-boolean-attribute` is listed in `RULES_NOT_PORTED_FROM_EXTERNAL` so `customRulesOnly` still ships it from the `react-builtins` bucket.
> 
> Docs record an OSS noise sweep (0 FPs on the three rules) and **drop** `no-accumulator-spread-in-reduce` and `no-redundant-live-region` on sweep evidence. The **rde-eval** skill gains guidance to validate oxlint rules **locally** (cloud runs miss the oxlint layer), required cloud env vars, cache invalidation, and extra troubleshooting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bce02502022f77226dff212932054b51060689a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->