### PR TITLE
fix(server-auth-actions): recognize custom auth guards by naming convention (#829)

### DIFF
--- a/.changeset/fix-server-auth-actions-custom-guards.md
+++ b/.changeset/fix-server-auth-actions-custom-guards.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `server-auth-actions` false positives on custom auth guards (#829).
+
+The rule only recognized a fixed list of auth function names, so a server action protected by a project's own guard — e.g. `await requireAdmin()` or `await getAdminSession()` — was wrongly flagged as callable by anyone. It now recognizes auth checks by naming **convention** as well: an assertive verb plus an auth noun (`requireAdmin`, `ensureSignedIn`, `checkPermission`, `assertUser`, `isAdmin`, `hasRole`), a getter plus a strong auth noun (`getServerAuthSession`, `getAdminSession`), and `current`/`my`/`own` qualifiers (`getCurrentUser`). Genuinely ambiguous names like `getUser` and `getToken` still require an auth-related receiver, so `analytics.getUser()` keeps firing the rule.

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -321,9 +321,10 @@ export interface ReactDoctorConfig {
    * list, user-provided names are treated as distinctive and never
    * subject to receiver-object disambiguation.
    *
-   * Use this to teach react-doctor about custom auth guards in
-   * codebases that wrap their auth library — e.g. a project-local
-   * `requireWorkspaceMember` or `ensureSignedIn`.
+   * Common guard conventions are already recognized automatically
+   * (`requireAdmin`, `ensureSignedIn`, `getCurrentUser`, `hasRole`, …),
+   * so this is only needed for domain-specific guards whose names carry
+   * no auth noun — e.g. a project-local `requireWorkspaceMember`.
    */
   serverAuthFunctionNames?: string[];
   /**

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
@@ -17,6 +17,102 @@ export const AUTH_FUNCTION_NAMES = new Set([
   "validateSession",
 ]);
 
+// Token-level vocabulary for recognizing auth-guard call names by
+// CONVENTION instead of an exact allowlist (`requireAdmin`,
+// `getAdminSession`, `ensureSignedIn`, `hasRole` …). A callee name is split
+// into lowercased words (see `tokenizeIdentifierWords`) and classified by
+// `isAuthGuardName`. The split keeps the matcher precise: substring checks
+// would wrongly flag `getAuthor` (contains "auth") or `getUsername`
+// (contains "user"); word tokens never do.
+//
+// Matches `auth`, `authn`, `authz`, `authed`, `authenticate(d)`,
+// `authentication`, `authorize(d)`, `authorization` — but NOT `author` or
+// `authority` (those leave an unmatched suffix).
+export const AUTH_STRONG_TOKEN_PATTERN =
+  /^auth(?:n|z|ed|enticate[ds]?|enticating|entication|orize[ds]?|orizing|orization|orizer)?$/;
+
+// Unambiguous multi-word auth phrases, pre-merged from adjacent tokens
+// (`signedIn` -> "signedin"). Each is an auth signal on its own.
+export const AUTH_STANDALONE_NOUN_TOKENS = new Set(["signedin", "loggedin", "signin"]);
+
+// Verbs that assert/check a condition. Paired with ANY auth noun they read
+// as a guard (`requireAdmin`, `checkPermission`, `verifyToken`, `isAdmin`,
+// `hasRole`, `mustBeAdmin`).
+export const AUTH_ASSERTIVE_VERB_TOKENS = new Set([
+  "require",
+  "ensure",
+  "assert",
+  "verify",
+  "validate",
+  "check",
+  "protect",
+  "enforce",
+  "guard",
+  "gate",
+  "restrict",
+  "is",
+  "has",
+  "can",
+  "must",
+]);
+
+// Verbs that merely read a value. Paired with a STRONG auth noun they read
+// as an auth lookup (`getSession`, `fetchSession`, `useSession`); paired
+// with only a WEAK noun (`getUser`, `getToken`) they stay ambiguous and are
+// NOT treated as a guard.
+export const AUTH_GETTER_VERB_TOKENS = new Set([
+  "get",
+  "fetch",
+  "load",
+  "read",
+  "resolve",
+  "retrieve",
+  "use",
+]);
+
+// "Whose" qualifiers that bind a weak noun to the current principal
+// (`currentUser`, `getCurrentUser`, `myAccount`).
+export const AUTH_QUALIFIER_TOKENS = new Set(["current", "my", "own"]);
+
+// Nouns that point squarely at authn/authz state.
+export const AUTH_STRONG_NOUN_TOKENS = new Set([
+  "session",
+  "sessions",
+  "login",
+  "admin",
+  "admins",
+  "superadmin",
+  "superuser",
+  "role",
+  "roles",
+  "permission",
+  "permissions",
+  "jwt",
+  "identity",
+  "principal",
+  "credential",
+  "credentials",
+]);
+
+// Nouns that are auth-adjacent but also appear on non-auth objects
+// (`analytics.getUser()`, `csrf.getToken()`); only count as auth when an
+// assertive verb or a "whose" qualifier accompanies them.
+export const AUTH_WEAK_NOUN_TOKENS = new Set([
+  "user",
+  "users",
+  "account",
+  "accounts",
+  "token",
+  "tokens",
+  "access",
+  "me",
+  "viewer",
+  "caller",
+  "subject",
+  "scope",
+  "scopes",
+]);
+
 // Auth function names that are too generic to recognize on their own
 // when called as a method (e.g. `analytics.getUser()` is not an auth
 // check). For these names a member call is only accepted when the

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -8,6 +8,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getReactDoctorStringArraySetting } from "../../utils/get-react-doctor-setting.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { hasUseServerDirective } from "../../utils/has-use-server-directive.js";
+import { isAuthGuardName } from "../../utils/is-auth-guard-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -90,13 +91,19 @@ const getAuthCallName = (
   const calleeNode = unwrapTypeWrappedCallee(callExpression.callee);
   if (!calleeNode) return null;
   if (isNodeOfType(calleeNode, "Identifier")) {
-    return allowedFunctionNames.has(calleeNode.name) ? calleeNode.name : null;
+    const calleeName = calleeNode.name;
+    return allowedFunctionNames.has(calleeName) || isAuthGuardName(calleeName) ? calleeName : null;
   }
   if (
     isNodeOfType(calleeNode, "MemberExpression") &&
     isNodeOfType(calleeNode.property, "Identifier")
   ) {
     const methodName = calleeNode.property.name;
+    // A conventionally auth-shaped method name (`ctx.requireAdmin()`,
+    // `auth0.getSession()`) is distinctive enough to accept on any receiver;
+    // only the exact-allowlist names fall back to the auth-receiver check
+    // that keeps generic ones like `analytics.getUser()` out.
+    if (isAuthGuardName(methodName)) return methodName;
     if (!allowedFunctionNames.has(methodName)) return null;
     if (!isMemberCallAuthRelated(calleeNode.object, methodName, genericMethodNames)) return null;
     return methodName;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-identifier-trailing-word.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-identifier-trailing-word.ts
@@ -1,4 +1,4 @@
-export const getIdentifierTrailingWord = (identifierName: string): string => {
-  const words = identifierName.match(/[A-Z]+(?=[A-Z][a-z]|\b)|[A-Z]?[a-z]+|\d+/g);
-  return words?.at(-1)?.toLowerCase() ?? identifierName.toLowerCase();
-};
+import { tokenizeIdentifierWords } from "./tokenize-identifier-words.js";
+
+export const getIdentifierTrailingWord = (identifierName: string): string =>
+  tokenizeIdentifierWords(identifierName).at(-1) ?? identifierName.toLowerCase();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-auth-guard-name.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-auth-guard-name.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isAuthGuardName } from "./is-auth-guard-name.js";
+
+describe("isAuthGuardName", () => {
+  it.each([
+    // auth* token in any position
+    "auth",
+    "authN",
+    "authZ",
+    "authed",
+    "authenticate",
+    "authenticated",
+    "authentication",
+    "authorize",
+    "authorized",
+    "authorization",
+    "requireAuth",
+    "checkAuth",
+    "verifyAuth",
+    "getAuth",
+    "withAuth",
+    "isAuthenticated",
+    "ensureAuthenticated",
+    "getServerAuthSession",
+    // assertive verb + auth noun (the issue #829 shape)
+    "requireAdmin",
+    "requireUser",
+    "requireSession",
+    "ensureAdmin",
+    "assertUser",
+    "checkPermission",
+    "verifyToken",
+    "validateSession",
+    "enforceRole",
+    "restrictAccess",
+    "isAdmin",
+    "hasRole",
+    "hasPermission",
+    "mustBeAdmin",
+    // getter verb + strong auth noun
+    "getSession",
+    "getServerSession",
+    "getAdminSession",
+    "fetchSession",
+    "useSession",
+    "loadSession",
+    "verifyJWT",
+    // "whose" qualifier + weak noun
+    "currentUser",
+    "getCurrentUser",
+    "myAccount",
+    // merged signed-in / logged-in phrases
+    "isSignedIn",
+    "isLoggedIn",
+    "ensureSignedIn",
+    "requireLoggedIn",
+    "signedInUser",
+  ])("treats %s as an auth guard", (name) => {
+    expect(isAuthGuardName(name)).toBe(true);
+  });
+
+  it.each([
+    // ambiguous getters that must stay on the exact-name + receiver path
+    "getUser",
+    "getToken",
+    "getAccount",
+    "getUsername",
+    "fetchUser",
+    "useUser",
+    // auth-looking substrings that are NOT auth words
+    "getAuthor",
+    "createAuthor",
+    "tokenize",
+    "authority",
+    // domain guards that intentionally require opt-in config (member/workspace
+    // are not auth nouns; see the requireWorkspaceMember regression test)
+    "requireWorkspaceMember",
+    "ensureWorkspace",
+    "requireTeam",
+    // plain non-auth calls
+    "performDelete",
+    "info",
+    "update",
+    "deletePost",
+    "trackVisit",
+    "createSession",
+    "deleteSession",
+    "",
+  ])("does not treat %s as an auth guard", (name) => {
+    expect(isAuthGuardName(name)).toBe(false);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-auth-guard-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-auth-guard-name.ts
@@ -1,0 +1,61 @@
+import {
+  AUTH_ASSERTIVE_VERB_TOKENS,
+  AUTH_GETTER_VERB_TOKENS,
+  AUTH_QUALIFIER_TOKENS,
+  AUTH_STANDALONE_NOUN_TOKENS,
+  AUTH_STRONG_NOUN_TOKENS,
+  AUTH_STRONG_TOKEN_PATTERN,
+  AUTH_WEAK_NOUN_TOKENS,
+} from "../constants/security.js";
+import { tokenizeIdentifierWords } from "./tokenize-identifier-words.js";
+
+const SIGNED_IN_HEAD_TOKENS = new Set(["signed", "logged", "sign"]);
+
+// Collapse `signedIn` / `loggedIn` / `signIn` — tokenized as two words — into
+// a single standalone auth phrase so the matcher reads them as one signal.
+const mergeSignedInTokens = (tokens: string[]): string[] => {
+  const mergedTokens: string[] = [];
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex += 1) {
+    const currentToken = tokens[tokenIndex];
+    if (SIGNED_IN_HEAD_TOKENS.has(currentToken) && tokens[tokenIndex + 1] === "in") {
+      mergedTokens.push(`${currentToken}in`);
+      tokenIndex += 1;
+      continue;
+    }
+    mergedTokens.push(currentToken);
+  }
+  return mergedTokens;
+};
+
+// Recognizes auth-guard call names by naming CONVENTION rather than an exact
+// allowlist, so custom guards (`requireAdmin`, `getAdminSession`,
+// `ensureSignedIn`, `hasRole`) count as an auth check the same way `auth()`
+// or `getServerSession()` do. Deliberately leaves genuinely ambiguous names
+// (`getUser`, `getToken`) unmatched — those stay on the rule's exact-name +
+// auth-receiver path so `analytics.getUser()` is not mistaken for auth.
+export const isAuthGuardName = (calleeName: string): boolean => {
+  const tokens = mergeSignedInTokens(tokenizeIdentifierWords(calleeName));
+  if (tokens.length === 0) return false;
+
+  let hasAssertiveVerb = false;
+  let hasGetterVerb = false;
+  let hasQualifier = false;
+  let hasStrongNoun = false;
+  let hasWeakNoun = false;
+
+  for (const token of tokens) {
+    if (AUTH_STRONG_TOKEN_PATTERN.test(token) || AUTH_STANDALONE_NOUN_TOKENS.has(token)) {
+      return true;
+    }
+    if (AUTH_ASSERTIVE_VERB_TOKENS.has(token)) hasAssertiveVerb = true;
+    if (AUTH_GETTER_VERB_TOKENS.has(token)) hasGetterVerb = true;
+    if (AUTH_QUALIFIER_TOKENS.has(token)) hasQualifier = true;
+    if (AUTH_STRONG_NOUN_TOKENS.has(token)) hasStrongNoun = true;
+    if (AUTH_WEAK_NOUN_TOKENS.has(token)) hasWeakNoun = true;
+  }
+
+  if (hasAssertiveVerb && (hasStrongNoun || hasWeakNoun)) return true;
+  if (hasGetterVerb && hasStrongNoun) return true;
+  if (hasQualifier && hasWeakNoun) return true;
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/tokenize-identifier-words.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/tokenize-identifier-words.ts
@@ -1,0 +1,11 @@
+// Splits an identifier into its lowercased constituent words, handling
+// camelCase, PascalCase, SCREAMING_SNAKE_CASE, and embedded acronyms
+// (`getServerSession` -> ["get", "server", "session"], `verifyJWT` ->
+// ["verify", "jwt"]). Returns [] when the name has no word characters.
+const IDENTIFIER_WORD_PATTERN = /[A-Z]+(?=[A-Z][a-z]|\b)|[A-Z]?[a-z]+|\d+/g;
+
+export const tokenizeIdentifierWords = (identifierName: string): string[] => {
+  const words = identifierName.match(IDENTIFIER_WORD_PATTERN);
+  if (!words) return [];
+  return words.map((word) => word.toLowerCase());
+};

--- a/packages/react-doctor/tests/regressions/server-auth-actions.test.ts
+++ b/packages/react-doctor/tests/regressions/server-auth-actions.test.ts
@@ -411,4 +411,99 @@ export async function archiveProject(projectId: string) {
     });
     await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
   });
+
+  // Issue #829: a project guarded its actions with a custom `requireAdmin()`
+  // helper, but the rule only knew the canonical `requireAuth` and fired a
+  // false positive on every action. The fix recognizes auth guards by naming
+  // CONVENTION (`require`/`ensure`/`assert`/… + an auth noun) so common
+  // bespoke guards count without needing `serverAuthFunctionNames` config.
+  it("accepts a custom `requireAdmin()` guard at the top of an action (issue #829)", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "issue-829-require-admin", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { requireAdmin } from "@/data/auth";
+
+export async function removeMovieRequest(id: string) {
+  await requireAdmin();
+  return { id, deleted: true };
+}
+
+export async function updateMovieRequest(id: string, isAdded: boolean) {
+  await requireAdmin();
+  return { id, isAdded };
+}`),
+      },
+    });
+
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("accepts the issue #829 auth helper file (getAdminSession + requireAdmin)", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "issue-829-auth-helper", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/data/auth.ts": buildServerActionFile(`import { headers } from "next/headers";
+import { auth } from "./auth";
+import { serverEnv } from "./env.server";
+
+export async function getAdminSession() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return null;
+  if (session.user.email !== serverEnv.ADMIN_EMAIL) return null;
+  return { ...session, isAdmin: true };
+}
+
+export async function requireAdmin() {
+  const session = await getAdminSession();
+  if (!session) {
+    throw new Error("Unauthorized");
+  }
+  return session;
+}`),
+      },
+    });
+
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("accepts other common guard conventions (ensureSignedIn, getCurrentUser)", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "issue-829-guard-conventions", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts":
+          buildServerActionFile(`import { ensureSignedIn, getCurrentUser } from "@/lib/auth";
+
+export async function publishPost(postId: string) {
+  await ensureSignedIn();
+  return { postId, published: true };
+}
+
+export async function updateBio(bio: string) {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("unauthorized");
+  return { userId: user.id, bio };
+}`),
+      },
+    });
+
+    await expect(collectAuthActionIssues(projectDirectory)).resolves.toEqual([]);
+  });
+
+  it("still flags actions whose only top-level call is a non-auth helper", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "issue-829-non-auth-helper", {
+      packageJsonExtras: { dependencies: NEXTJS_PACKAGE_DEPENDENCIES },
+      files: {
+        "src/app/actions.ts": buildServerActionFile(`import { loadConfig } from "@/lib/config";
+
+export async function regenerateCache(scope: string) {
+  await loadConfig();
+  return { scope, regenerated: true };
+}`),
+      },
+    });
+
+    const issues = await collectAuthActionIssues(projectDirectory);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("regenerateCache");
+  });
 });

--- a/packages/website/public/schema/config.json
+++ b/packages/website/public/schema/config.json
@@ -124,7 +124,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Project-level allowlist of function names that the `server-auth-actions` rule treats as an auth check at the top of a server action. Names are accepted whether called as a bare identifier (`myAuthGuard()`) or as the final property of a member call (`ctx.myAuthGuard()`); unlike the built-in default list, user-provided names are treated as distinctive and never subject to receiver-object disambiguation.\n\nUse this to teach react-doctor about custom auth guards in codebases that wrap their auth library — e.g. a project-local `requireWorkspaceMember` or `ensureSignedIn`."
+          "description": "Project-level allowlist of function names that the `server-auth-actions` rule treats as an auth check at the top of a server action. Names are accepted whether called as a bare identifier (`myAuthGuard()`) or as the final property of a member call (`ctx.myAuthGuard()`); unlike the built-in default list, user-provided names are treated as distinctive and never subject to receiver-object disambiguation.\n\nCommon guard conventions are already recognized automatically (`requireAdmin`, `ensureSignedIn`, `getCurrentUser`, `hasRole`, …), so this is only needed for domain-specific guards whose names carry no auth noun — e.g. a project-local `requireWorkspaceMember`."
         },
         "respectInlineDisables": {
           "type": "boolean",


### PR DESCRIPTION
## Summary

Fixes #829 — a false positive in the `server-auth-actions` rule.

The rule flags exported async server actions in `"use server"` files that lack an auth check at the top. It only recognized a **fixed allowlist** of auth-function names, so an action protected by a project's own guard — e.g. `await requireAdmin()` or `await getAdminSession()` — was wrongly reported as callable by anyone.

The fix recognizes auth checks by naming **convention**, via a new `isAuthGuardName` classifier that tokenizes the callee name into words and matches:

- any `auth*` token — `requireAuth`, `isAuthenticated`, `authorize` (but **not** `getAuthor`/`authority`)
- an assertive verb + auth noun — `requireAdmin`, `ensureSignedIn`, `checkPermission`, `assertUser`, `isAdmin`, `hasRole`
- a getter + strong auth noun — `getServerAuthSession`, `getAdminSession`
- a `current`/`my`/`own` qualifier + weak noun — `getCurrentUser`, `currentUser`

Genuinely ambiguous names (`getUser`, `getToken`) stay on the existing exact-name + auth-receiver path, so `analytics.getUser()` keeps firing the rule. Domain-specific guards with no auth noun (e.g. `requireWorkspaceMember`) still need the `serverAuthFunctionNames` config — its doc comment is updated to say so.

Because `eslint-plugin-react-doctor` re-exports the oxlint rule source, this fixes both plugins.

### Changes
- `utils/tokenize-identifier-words.ts` (new) — reusable camelCase/acronym tokenizer; `get-identifier-trailing-word.ts` refactored to reuse it.
- `utils/is-auth-guard-name.ts` (new) — convention classifier.
- `constants/security.ts` — auth token vocabulary (verbs / nouns / qualifiers / `auth*` regex).
- `rules/server/server-auth-actions.ts` — wired into `getAuthCallName` for bare and member calls.
- `core/src/types/config.ts` + regenerated `website/public/schema/config.json` — updated `serverAuthFunctionNames` docs.
- Changeset added (patch).

## Test plan
- [x] New unit suite for `isAuthGuardName` (68 cases: positives incl. the #829 shapes, negatives incl. `getUser`/`getAuthor`/`requireWorkspaceMember`).
- [x] New e2e regressions in `server-auth-actions.test.ts`: the verbatim #829 repros (`requireAdmin()` at top; the `getAdminSession`+`requireAdmin` helper file) and a negative (`loadConfig()` still flagged).
- [x] Existing `server-auth-actions` + member-call (#239) regressions still pass.
- [x] `nextjs` run-oxlint fixture still fires the rule (`deleteUser`).
- [x] `no-secrets-in-client-code` (consumer of the refactored tokenizer) passes.
- [x] `typecheck`, `lint`, `format:check` clean.

> Note: 6 pre-existing, unrelated test files fail on `main` as well (`react-builtins/jsx-no-new-*`, `no-multi-comp`, `no-array-index-key`, `state-and-effects/hooks-no-nan-in-deps`); none import the changed modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security lint heuristics for server actions; convention matching could miss real unauthenticated actions or accept misleadingly named helpers, though ambiguous getters and non-auth names are explicitly excluded and tests cover #829 and prior regressions.
> 
> **Overview**
> Fixes **false positives** in `server-auth-actions` when server actions are protected by project-local guards like `requireAdmin()` or `getAdminSession()` that were not on the fixed allowlist.
> 
> The rule now treats top-of-action calls as auth checks when the callee name matches **naming conventions**, via new `isAuthGuardName` (tokenized identifiers + verb/noun vocabulary in `security.ts`): assertive verbs with auth nouns (`requireAdmin`, `hasRole`), getters with strong auth nouns (`getAdminSession`), and `current`/`my`/`own` with weak nouns (`getCurrentUser`). **Member calls** with convention-shaped method names are accepted without an auth-related receiver; ambiguous names like `getUser` still use the exact-list + receiver path so `analytics.getUser()` is not treated as auth.
> 
> `serverAuthFunctionNames` docs are updated to note that common conventions are automatic; config remains for domain-only names (e.g. `requireWorkspaceMember`). Adds unit and regression tests plus a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e734e669f4eea01fa5626209722f578df43ada9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->