### PR TITLE
fix(url-prefilled-privileged-action): recognize validators wrapping reads behind a receiver chain (#837)

### DIFF
--- a/.changeset/fix-url-prefilled-privileged-action-validator-receiver-chain.md
+++ b/.changeset/fix-url-prefilled-privileged-action-validator-receiver-chain.md
@@ -1,0 +1,11 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `url-prefilled-privileged-action` false positive when a validating helper
+wraps a read behind a receiver chain. The validator-suppression lookbehind only
+recognized `validator(searchParams.get(...))` or `validator(new URLSearchParams(...))`
+directly — real code reads through a receiver (`sanitizeNext(url.searchParams.get(...))`,
+`validateNext(request.nextUrl.searchParams.get(...))`), and that intervening `url.`
+broke the match so validated reads kept firing. The lookbehind now allows an optional
+receiver member-chain between the helper's `(` and the read.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/url-prefilled-privileged-action.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/url-prefilled-privileged-action.regressions.test.ts
@@ -34,4 +34,44 @@ describe("security-scan/url-prefilled-privileged-action — regressions", () => 
     });
     expect(findings).toHaveLength(0);
   });
+
+  it("stays silent when a validating helper wraps a read behind a receiver chain (issue #837)", () => {
+    const findings = runScanRule(urlPrefilledPrivilegedAction, {
+      relativePath: "src/app/auth/route.ts",
+      content: `import { resolveSafeAuthCallbackURL } from "~/lib/auth-callback";\nurl.searchParams.set("callbackURL",\n  resolveSafeAuthCallbackURL(url.searchParams.get("callbackURL")));\n`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent when an aliased sanitize helper wraps a read off url.searchParams (issue #837)", () => {
+    const findings = runScanRule(urlPrefilledPrivilegedAction, {
+      relativePath: "src/app/auth/route.ts",
+      content: `const safe = sanitizeAuthCallbackURL(url.searchParams.get("callbackURL"));\n`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent when a validator wraps a deep receiver chain (request.nextUrl.searchParams)", () => {
+    const findings = runScanRule(urlPrefilledPrivilegedAction, {
+      relativePath: "src/middleware.ts",
+      content: `const next = validateNext(request.nextUrl.searchParams.get("next"));\n`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("still flags a non-validating wrapper around a receiver-chain read", () => {
+    const findings = runScanRule(urlPrefilledPrivilegedAction, {
+      relativePath: "src/app/auth/route.ts",
+      content: `const cb = resolveURL(url.searchParams.get("callbackUrl"));\n`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("still flags a raw receiver-chain read with no wrapping helper", () => {
+    const findings = runScanRule(urlPrefilledPrivilegedAction, {
+      relativePath: "src/app/auth/route.ts",
+      content: `const cb = url.searchParams.get("callbackUrl");\n`,
+    });
+    expect(findings).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/url-prefilled-privileged-action.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/url-prefilled-privileged-action.ts
@@ -6,9 +6,13 @@ import { scanByPattern } from "./utils/scan-by-pattern.js";
 // window matches `from "next/..."` imports and any file mentioning users.
 // No `email`/`user`: prefilled emails and username route params are benign
 // booking/contact UX, not privileged actions. The lookbehind skips reads
-// already wrapped in a validating helper (`getRelativeNextPath(...get("next"))`).
+// already wrapped in a validating helper — the validator name matches as an
+// infix (`getRelativeNextPath`, `resolveSafeAuthCallbackURL`), and the
+// `(?:[\w$]+\s*\.\s*){0,4}` segment allows a receiver chain between the
+// helper's `(` and the read (`sanitizeNext(url.searchParams.get(...))`,
+// `validateNext(request.nextUrl.searchParams.get(...))`).
 const PRIVILEGED_QUERY_PARAM_PATTERN =
-  /(?<!(?:safe|valid|sanitiz|relativ|allowlist|whitelist)[\w$]*\(\s*(?:new\s+)?)\b(?:searchParams|useSearchParams\s*\(\s*\)|URLSearchParams\s*\([^)]{0,120}\))(?:[?!])?\.get(?:All)?\s*\(\s*["'](?:userstoinvite|role|permission|sharingaction|invite|admin|next|continue|returnTo|redirect_uri|callbackUrl)["']|\bsearchParams\.(?:userstoinvite|role|permission|sharingaction|invite|admin|returnTo|redirect_uri|callbackUrl)\b/i;
+  /(?<!(?:safe|valid|sanitiz|relativ|allowlist|whitelist)[\w$]*\(\s*(?:new\s+)?(?:[\w$]+\s*\.\s*){0,4})\b(?:searchParams|useSearchParams\s*\(\s*\)|URLSearchParams\s*\([^)]{0,120}\))(?:[?!])?\.get(?:All)?\s*\(\s*["'](?:userstoinvite|role|permission|sharingaction|invite|admin|next|continue|returnTo|redirect_uri|callbackUrl)["']|\bsearchParams\.(?:userstoinvite|role|permission|sharingaction|invite|admin|returnTo|redirect_uri|callbackUrl)\b/i;
 
 export const urlPrefilledPrivilegedAction = defineRule({
   id: "url-prefilled-privileged-action",


### PR DESCRIPTION
## Summary

Fixes #837 — `url-prefilled-privileged-action` false positive when the flagged read **is** validated by a helper, but the helper wraps the read behind a receiver chain.

### Root cause

The negative lookbehind that suppresses validator-wrapped reads ended in `\(\s*(?:new\s+)?` — it only recognized a validator when its open-paren *immediately* preceded the matched token, or `new URLSearchParams(...)` (which is why the existing `getRelativeNextPath(new URLSearchParams(...))` test already passed). But real code reads through a receiver object:

```ts
sanitizeNext(url.searchParams.get("callbackURL"))
validateNext(request.nextUrl.searchParams.get("next"))
```

That intervening `url.` / `request.nextUrl.` broke the lookbehind, so validated reads kept firing.

The issue's other two hypotheses were red herrings:
- **infix prefix** — the alternation has no word anchor, so `Safe`/`sanitiz` already match as infixes (that's how `relativ` inside `getRelativeNextPath` works today).
- **`as`-aliased import** — repro form (b) calls the aliased name `sanitizeAuthCallbackURL` directly, which already matches `sanitiz`; only the `url.` receiver was breaking it.

### Fix

Add an optional, bounded receiver member-chain to the lookbehind tail:

```
\(\s*(?:new\s+)?(?:[\w$]+\s*\.\s*){0,4}
```

The `{0,4}` bound + the literal `(` separator keep it ReDoS-safe (a pathological 5k-segment input matches in ~0.4ms).

### Tests

- New regression tests: both issue repro forms + a deep `request.nextUrl.` chain → **silent**
- Guard tests: raw reads and non-validating wrappers (`resolveURL(...)`) → **still fire** (no false negatives)
- `url-prefilled-privileged-action` suite: 9/9 pass
- `typecheck` ✓ · `lint` exit 0 ✓ · `format` ✓

The ESLint plugin imports rules from `oxlint-plugin-react-doctor`, so this is a single-source-of-truth change — no mirror edit needed. Added a `patch` changeset.

> [!NOTE]
> The full oxlint-plugin suite has 39 pre-existing failures in unrelated AST rules (`no-multi-comp`, `jsx-no-new-*-as-prop`, `hooks-no-nan-in-deps`, `no-array-index-key`), confirmed to fail identically on a clean tree (likely fallout from the recent `oxc-parser 0.135.0` bump). Not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule regex tweak with targeted regression and guard tests; no runtime auth or app behavior changes.
> 
> **Overview**
> Fixes **false positives** in `url-prefilled-privileged-action` when privileged query reads are already wrapped in validating helpers (`safe`/`valid`/`sanitiz`/etc.) but the read sits behind a **receiver chain** (`url.searchParams.get(...)`, `request.nextUrl.searchParams.get(...)`).
> 
> The validator-suppression **negative lookbehind** now allows an optional bounded segment `(?:[\w$]+\s*\.\s*){0,4}` between the helper’s `(` and the matched read, so patterns like `resolveSafeAuthCallbackURL(url.searchParams.get("callbackURL"))` are suppressed again.
> 
> Adds **regression tests** for issue #837 (receiver and deep chains stay silent) plus **guard tests** so raw reads and non-validating wrappers still report. Includes a **patch** changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57f7c05319578d8fa4e8b2091e3b8699dc6693f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->