### PR TITLE
fix(server-sequential-independent-await): count nested-destructuring bindings as a dependency (#839)

### DIFF
--- a/.changeset/fix-sequential-await-nested-destructuring.md
+++ b/.changeset/fix-sequential-await-nested-destructuring.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `server-sequential-independent-await` false positive on awaits whose dependency flows through nested destructuring (#839).
+
+The rule's binding collector only saw top-level `Identifier` bindings and shallow object/array pattern elements, so names bound through a nested pattern — e.g. `const [{ slug }, { isEnabled }] = await Promise.all([...])` — were invisible. A follow-up `await client.fetch(BlogPostQuery, { slug }, isEnabled ? ... : ...)` that genuinely depended on those names was wrongly flagged as an independent waterfall. The collector now reuses the recursive `collectPatternNames` utility, so nested array/object patterns, defaulted bindings, and rest elements all count as a real dependency.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.test.ts
@@ -43,6 +43,18 @@ describe("server-sequential-independent-await", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("flags independent awaits even when the second re-binds a name the first bound", () => {
+    const code = `async function load() {
+  const { data } = await fetchPrimary();
+  const { data: secondary } = await fetchSecondary();
+  return secondary;
+}`;
+
+    const result = runRule(serverSequentialIndependentAwait, code);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("treats a defaulted destructured binding as a dependency", () => {
     const code = `async function load() {
   const { token = "anon" } = await fetchSession();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { serverSequentialIndependentAwait } from "./server-sequential-independent-await.js";
+
+describe("server-sequential-independent-await", () => {
+  it("flags two genuinely independent consecutive awaits", () => {
+    const code = `export default async function Page() {
+  const user = await fetchUser();
+  const posts = await fetchPosts();
+  return null;
+}`;
+
+    const result = runRule(serverSequentialIndependentAwait, code);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  // Regression for issue #839: the follow-up await depends on `slug`/`isEnabled`.
+  it("treats names bound by nested array/object destructuring as a dependency", () => {
+    const code = `export default async function Page({ params }) {
+  const [{ slug }, { isEnabled }] = await Promise.all([params, draftMode()]);
+  const data = await client.fetch(
+    BlogPostQuery,
+    { slug },
+    isEnabled ? { perspective: "drafts" } : { next: { revalidate: 3600 } },
+  );
+  return data;
+}`;
+
+    const result = runRule(serverSequentialIndependentAwait, code);
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("treats names bound by deeply nested object destructuring as a dependency", () => {
+    const code = `async function load() {
+  const { data: { id } } = await fetchUser();
+  const profile = await fetchProfile(id);
+  return profile;
+}`;
+
+    const result = runRule(serverSequentialIndependentAwait, code);
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("treats a defaulted destructured binding as a dependency", () => {
+    const code = `async function load() {
+  const { token = "anon" } = await fetchSession();
+  const profile = await fetchProfile(token);
+  return profile;
+}`;
+
+    const result = runRule(serverSequentialIndependentAwait, code);
+
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.test.ts
@@ -15,8 +15,7 @@ describe("server-sequential-independent-await", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  // Regression for issue #839: the follow-up await depends on `slug`/`isEnabled`.
-  it("treats names bound by nested array/object destructuring as a dependency", () => {
+  it("treats names bound by nested array/object destructuring as a dependency (#839)", () => {
     const code = `export default async function Page({ params }) {
   const [{ slug }, { isEnabled }] = await Promise.all([params, draftMode()]);
   const data = await client.fetch(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
@@ -16,10 +16,6 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // where the second's initializer reads no identifier introduced by the
 // first declaration. We require both declarations to be at the top
 // level of the same block to keep precision high.
-
-// Every name a declaration binds, recursing into nested object/array
-// patterns so a dependency like `const [{ slug }] = await …` isn't
-// mistaken for an independent await (issue #839).
 const collectDeclaredNames = (declaration: EsTreeNode): Set<string> => {
   const names = new Set<string>();
   if (!isNodeOfType(declaration, "VariableDeclaration")) return names;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
@@ -33,13 +33,22 @@ const declarationStartsWithAwait = (declaration: EsTreeNode): boolean => {
   return false;
 };
 
+// HACK: walk only each initializer, not the whole declaration. A name in
+// the next statement's binding pattern (e.g. `const { data: x } = await
+// b()` after `const { data } = await a()`) is a re-bind evaluated after
+// the await resolves, not a read of the first result — counting it would
+// miss the waterfall.
 const declarationReadsAnyName = (declaration: EsTreeNode, names: Set<string>): boolean => {
   if (names.size === 0) return false;
+  if (!isNodeOfType(declaration, "VariableDeclaration")) return false;
   let didRead = false;
-  walkAst(declaration, (child: EsTreeNode) => {
-    if (didRead) return;
-    if (isNodeOfType(child, "Identifier") && names.has(child.name)) didRead = true;
-  });
+  for (const declarator of declaration.declarations ?? []) {
+    if (!declarator.init) continue;
+    walkAst(declarator.init, (child: EsTreeNode) => {
+      if (didRead) return;
+      if (isNodeOfType(child, "Identifier") && names.has(child.name)) didRead = true;
+    });
+  }
   return didRead;
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
@@ -1,3 +1,4 @@
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -15,28 +16,15 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // where the second's initializer reads no identifier introduced by the
 // first declaration. We require both declarations to be at the top
 // level of the same block to keep precision high.
+
+// Every name a declaration binds, recursing into nested object/array
+// patterns so a dependency like `const [{ slug }] = await …` isn't
+// mistaken for an independent await (issue #839).
 const collectDeclaredNames = (declaration: EsTreeNode): Set<string> => {
   const names = new Set<string>();
   if (!isNodeOfType(declaration, "VariableDeclaration")) return names;
   for (const declarator of declaration.declarations ?? []) {
-    if (isNodeOfType(declarator.id, "Identifier")) {
-      names.add(declarator.id.name);
-    } else if (isNodeOfType(declarator.id, "ObjectPattern")) {
-      for (const property of declarator.id.properties ?? []) {
-        if (isNodeOfType(property, "Property") && isNodeOfType(property.value, "Identifier")) {
-          names.add(property.value.name);
-        } else if (
-          isNodeOfType(property, "RestElement") &&
-          isNodeOfType(property.argument, "Identifier")
-        ) {
-          names.add(property.argument.name);
-        }
-      }
-    } else if (isNodeOfType(declarator.id, "ArrayPattern")) {
-      for (const element of declarator.id.elements ?? []) {
-        if (isNodeOfType(element, "Identifier")) names.add(element.name);
-      }
-    }
+    collectPatternNames(declarator.id, names);
   }
   return names;
 };


### PR DESCRIPTION
## Why

Fixes #839. The `server-sequential-independent-await` rule ("Bugs: Sequential independent awaits") fired on awaits that are genuinely dependent when the dependency flows through a **nested** destructuring pattern. The rule's binding collector only recorded top-level identifiers and *shallow* object/array pattern elements, so names bound through a nested pattern were invisible — making a dependent follow-up await look like an independent waterfall.

Before:

```tsx
export default async function Page({ params }) {
  // names `slug`/`isEnabled` are bound through an array-of-object-pattern,
  // which the collector didn't see...
  const [{ slug }, { isEnabled }] = await Promise.all([params, draftMode()]);
  // ...so this dependent await was wrongly flagged as an independent waterfall.
  const data = await client.fetch(BlogPostQuery, { slug }, isEnabled ? ... : ...);
  return <BlogPostPageUI blogPost={data} />;
}
// ⚠ Bugs: Sequential independent awaits  (false positive)
```

After:

```
No diagnostic — the nested binding counts as a real dependency.
```

## What changed

- Routed `collectDeclaredNames` through the existing recursive `collectPatternNames` util instead of a duplicated shallow walk, so nested array/object patterns, defaulted bindings, and rest elements all count as a dependency (a DRY win — the rule was reimplementing a worse copy of an existing util).
- Added `server-sequential-independent-await.test.ts` covering the regression (nested array-of-object destructure, deeply-nested object destructure, defaulted binding) plus a positive case that must still fire.
- Added a patch changeset for `oxlint-plugin-react-doctor`.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/server/server-sequential-independent-await.test.ts` — 4/4 pass.
- Confirmed it's a true regression test: 3/4 fail on the old code, 4/4 pass with the fix.
- `pnpm --filter oxlint-plugin-react-doctor typecheck` — passes; format/lint clean for the changed files.

> Note: this branch has ~39 pre-existing test failures in unrelated rules (`react-builtins`, `state-and-effects`), confirmed to fail on the clean baseline too (likely fallout from the recent `oxc-parser 0.135.0` upgrade) — untouched by and unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped lint-rule heuristic fix with regression tests; no runtime or security impact.
> 
> **Overview**
> Fixes **false positives** in `server-sequential-independent-await` when a second `await` depends on names from **nested** destructuring (e.g. `const [{ slug }, { isEnabled }] = await Promise.all([...])` followed by `await client.fetch(..., { slug }, ...)`).
> 
> **Binding collection** now delegates to the shared recursive `collectPatternNames` instead of a shallow inline walk, so nested array/object patterns, defaults, and rest bindings count as declared dependencies.
> 
> **Dependency detection** now walks only each follow-up declarator’s **initializer** (not the whole declaration), so identifiers in the second statement’s binding pattern are not mistaken for reads of the first result—preserving warnings when two independent awaits re-bind the same name.
> 
> Adds focused rule tests and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fbd0130747a9e2f204d6b28a6077acd18d679e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->