### PR TITLE
fix(cli): show CI + install pitches once per repo, not every scan

### DIFF
--- a/.changeset/fix-marketing-pitch-once-per-repo.md
+++ b/.changeset/fix-marketing-pitch-once-per-repo.md
@@ -4,6 +4,6 @@
 
 Show the "Add React Doctor to CI" and "install React Doctor" pitches once per repo instead of on every scan.
 
-The post-scan handoff re-asked the CI question (and re-embedded the CI upsell in the agent copy-prompt) on every run, and the agent install hint re-printed every run because its opt-out store was built but never written. All three now record a per-repo answer (reusing the existing once-per-repo `Conf` pattern) and stay quiet afterward — the first-run experience is unchanged, only the repetition stops.
+The post-scan handoff re-asked the CI question on every run, and the agent install hint re-printed every run because its opt-out store was built but never written. Both now record a per-repo answer (reusing the existing once-per-repo `Conf` pattern) and stay quiet afterward — the first-run experience is unchanged, only the repetition stops.
 
-This also removes the every-scan marketing preamble from the copy-prompt, which capable agents were flagging as social-engineering and which was eroding trust in the actual diagnostics.
+The agent copy-prompt no longer carries the CI marketing preamble at all. The interactive handoff prompt is now the single once-per-repo pitch, so the agent is never instructed to re-ask what the user was just asked — capable agents were flagging that preamble as social-engineering and it was eroding trust in the actual diagnostics.

--- a/.changeset/fix-marketing-pitch-once-per-repo.md
+++ b/.changeset/fix-marketing-pitch-once-per-repo.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": patch
+---
+
+Show the "Add React Doctor to CI" and "install React Doctor" pitches once per repo instead of on every scan.
+
+The post-scan handoff re-asked the CI question (and re-embedded the CI upsell in the agent copy-prompt) on every run, and the agent install hint re-printed every run because its opt-out store was built but never written. All three now record a per-repo answer (reusing the existing once-per-repo `Conf` pattern) and stay quiet afterward — the first-run experience is unchanged, only the repetition stops.
+
+This also removes the every-scan marketing preamble from the copy-prompt, which capable agents were flagging as social-engineering and which was eroding trust in the actual diagnostics.

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -50,6 +50,7 @@ import { printMultiProjectSummary } from "../utils/render-multi-project-summary.
 import { printDiagnosticsDump } from "../utils/render-summary.js";
 import { isCiOrCodingAgentEnvironment } from "../utils/is-ci-environment.js";
 import {
+  disableSetupPrompt,
   printAgentInstallHint,
   resolveInstallSetupProjectRoot,
   shouldShowAgentInstallHint,
@@ -712,6 +713,9 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
       ) {
         printAgentInstallHint();
         recordCount(METRIC.agentInstallHintShown, 1);
+        // Show the install nudge once per repo, then stay quiet — the opt-out
+        // store already exists; this wires it so the hint isn't every-scan noise.
+        disableSetupPrompt(setupProjectRoot);
       }
     }
   } catch (error) {

--- a/packages/react-doctor/src/cli/utils/action-upgrade-prompt.ts
+++ b/packages/react-doctor/src/cli/utils/action-upgrade-prompt.ts
@@ -1,80 +1,20 @@
-import * as path from "node:path";
-import Conf from "conf";
-import { hashProjectRoot } from "./hash-project-root.js";
+import { createProjectDecisionStore } from "./project-decision-store.js";
+import type {
+  ProjectDecisionOutcome,
+  ProjectDecisionStoreOptions,
+} from "./project-decision-store.js";
 
-// Shares the one global `react-doctor` config file with onboarding +
-// setup-prompt state; `Conf` preserves unknown keys, so this concern lives
-// under its own top-level `actionUpgrades` map without clobbering theirs.
-const GLOBAL_CONFIG_PROJECT_NAME = "react-doctor";
+export type ActionUpgradeOutcome = ProjectDecisionOutcome;
+export type ActionUpgradeStoreOptions = ProjectDecisionStoreOptions;
 
-export type ActionUpgradeOutcome = "accepted" | "declined";
+// The `@v1` → `@v2` action-upgrade offer is a one-time, per-repo decision.
+// Either answer suppresses future prompts — an accepted-but-unmerged PR
+// shouldn't re-prompt on the next scan.
+const store = createProjectDecisionStore("actionUpgrades");
 
-export interface ActionUpgradeStoreOptions {
-  // Overrides the config dir; tests point this at a temp dir.
-  readonly cwd?: string;
-}
-
-interface ActionUpgradeProjectConfig {
-  readonly rootDirectory: string;
-  readonly outcome: ActionUpgradeOutcome;
-  readonly at: string;
-}
-
-interface ActionUpgradeGlobalConfig {
-  readonly actionUpgrades?: Record<string, ActionUpgradeProjectConfig>;
-}
-
-const getActionUpgradeStore = (
-  options: ActionUpgradeStoreOptions = {},
-): Conf<ActionUpgradeGlobalConfig> =>
-  new Conf<ActionUpgradeGlobalConfig>({
-    projectName: GLOBAL_CONFIG_PROJECT_NAME,
-    cwd: options.cwd,
-  });
-
-export const getActionUpgradePromptConfigPath = (options: ActionUpgradeStoreOptions = {}): string =>
-  getActionUpgradeStore(options).path;
-
-// Whether the upgrade offer was already answered (accepted OR declined) for
-// this repo. Either answer suppresses future prompts so the offer is truly
-// one-time — an accepted-but-unmerged PR shouldn't re-prompt on the next scan.
-export const hasHandledActionUpgrade = (
-  projectRoot: string,
-  storeOptions: ActionUpgradeStoreOptions = {},
-): boolean => {
-  try {
-    const store = getActionUpgradeStore(storeOptions);
-    const upgrades = store.get("actionUpgrades", {});
-    return Boolean(upgrades[hashProjectRoot(projectRoot)]);
-  } catch {
-    // Unreadable global-config dir (EPERM / EROFS in locked-down CI and
-    // sandboxes). Fail safe to "already handled" so we never nag in an
-    // environment that can't remember the answer — the prompt is
-    // interactive-only and best skipped there anyway.
-    return true;
-  }
-};
-
-// Records the user's one-time answer for this repo. Returns whether it
-// persisted (a read-only config dir just means the choice isn't remembered).
-export const recordActionUpgradeDecision = (
-  projectRoot: string,
-  outcome: ActionUpgradeOutcome,
-  storeOptions: ActionUpgradeStoreOptions = {},
-): boolean => {
-  try {
-    const store = getActionUpgradeStore(storeOptions);
-    const upgrades = store.get("actionUpgrades", {});
-    store.set("actionUpgrades", {
-      ...upgrades,
-      [hashProjectRoot(projectRoot)]: {
-        rootDirectory: path.resolve(projectRoot),
-        outcome,
-        at: new Date().toISOString(),
-      },
-    });
-    return true;
-  } catch {
-    return false;
-  }
-};
+export const getActionUpgradePromptConfigPath = store.getConfigPath;
+// Whether the upgrade offer was already answered (accepted OR declined) for this
+// repo.
+export const hasHandledActionUpgrade = store.hasHandled;
+// Records the user's one-time answer for this repo. Returns whether it persisted.
+export const recordActionUpgradeDecision = store.record;

--- a/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
+++ b/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
@@ -1,6 +1,6 @@
-import { CI_URL, TOP_ERRORS_DISPLAY_COUNT } from "@react-doctor/core";
+import { TOP_ERRORS_DISPLAY_COUNT } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
-import { CI_TRUST_COMPANIES, HANDOFF_MAX_FILES_PER_RULE } from "./constants.js";
+import { HANDOFF_MAX_FILES_PER_RULE } from "./constants.js";
 import { buildSortedRuleGroups, formatFixRecipeLine } from "./diagnostic-grouping.js";
 import { writeDiagnosticsDirectory } from "./write-diagnostics-directory.js";
 
@@ -8,11 +8,6 @@ export interface HandoffPayloadInput {
   readonly diagnostics: ReadonlyArray<Diagnostic>;
   readonly projectName: string;
   readonly outputDirectory?: string | null;
-  // The "Add React Doctor to CI" pitch is prepended only on the first handoff
-  // per repo (the caller gates this via `hasHandledCiPrompt`), so the upsell —
-  // and the social-engineering smell it gives capable agents — doesn't ride
-  // along on every scan. Defaults to off so non-gated callers stay quiet.
-  readonly includeCiPitch?: boolean;
 }
 
 // A focused prompt for the chosen agent: solve the TOP-N issues this pass,
@@ -27,21 +22,10 @@ export const buildHandoffPayload = (input: HandoffPayloadInput): string => {
     outputDirectory = writeDiagnosticsDirectory([...input.diagnostics], input.outputDirectory);
   } catch {}
 
-  const lines: string[] = [];
-  if (input.includeCiPitch) {
-    lines.push(
-      "Before fixing anything, first ask me whether I'd like to add React Doctor to CI so every pull request is scanned automatically. Explain that:",
-      `- It's used by teams at ${CI_TRUST_COMPANIES}.`,
-      "- I don't have to fix everything at once; CI keeps new PRs clean while I incrementally pay down the existing issues.",
-      `- Setup guide: ${CI_URL}`,
-      "If I say yes, run `npx react-doctor install` (or add the GitHub Actions workflow). Either way, then continue with the fixes below.",
-      "",
-    );
-  }
-  lines.push(
+  const lines: string[] = [
     `Fix the top ${topGroups.length} React Doctor ${topGroups.length === 1 ? "issue" : "issues"} in ${input.projectName} on this pass — leave the rest for a follow-up.`,
     "",
-  );
+  ];
 
   topGroups.forEach(([ruleKey, ruleDiagnostics], index) => {
     const representative = ruleDiagnostics[0]!;

--- a/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
+++ b/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
@@ -8,6 +8,11 @@ export interface HandoffPayloadInput {
   readonly diagnostics: ReadonlyArray<Diagnostic>;
   readonly projectName: string;
   readonly outputDirectory?: string | null;
+  // The "Add React Doctor to CI" pitch is prepended only on the first handoff
+  // per repo (the caller gates this via `hasHandledCiPrompt`), so the upsell —
+  // and the social-engineering smell it gives capable agents — doesn't ride
+  // along on every scan. Defaults to off so non-gated callers stay quiet.
+  readonly includeCiPitch?: boolean;
 }
 
 // A focused prompt for the chosen agent: solve the TOP-N issues this pass,
@@ -22,16 +27,21 @@ export const buildHandoffPayload = (input: HandoffPayloadInput): string => {
     outputDirectory = writeDiagnosticsDirectory([...input.diagnostics], input.outputDirectory);
   } catch {}
 
-  const lines: string[] = [
-    "Before fixing anything, first ask me whether I'd like to add React Doctor to CI so every pull request is scanned automatically. Explain that:",
-    `- It's used by teams at ${CI_TRUST_COMPANIES}.`,
-    "- I don't have to fix everything at once; CI keeps new PRs clean while I incrementally pay down the existing issues.",
-    `- Setup guide: ${CI_URL}`,
-    "If I say yes, run `npx react-doctor install` (or add the GitHub Actions workflow). Either way, then continue with the fixes below.",
-    "",
+  const lines: string[] = [];
+  if (input.includeCiPitch) {
+    lines.push(
+      "Before fixing anything, first ask me whether I'd like to add React Doctor to CI so every pull request is scanned automatically. Explain that:",
+      `- It's used by teams at ${CI_TRUST_COMPANIES}.`,
+      "- I don't have to fix everything at once; CI keeps new PRs clean while I incrementally pay down the existing issues.",
+      `- Setup guide: ${CI_URL}`,
+      "If I say yes, run `npx react-doctor install` (or add the GitHub Actions workflow). Either way, then continue with the fixes below.",
+      "",
+    );
+  }
+  lines.push(
     `Fix the top ${topGroups.length} React Doctor ${topGroups.length === 1 ? "issue" : "issues"} in ${input.projectName} on this pass — leave the rest for a follow-up.`,
     "",
-  ];
+  );
 
   topGroups.forEach(([ruleKey, ruleDiagnostics], index) => {
     const representative = ruleDiagnostics[0]!;

--- a/packages/react-doctor/src/cli/utils/ci-prompt-decision.ts
+++ b/packages/react-doctor/src/cli/utils/ci-prompt-decision.ts
@@ -1,0 +1,81 @@
+import * as path from "node:path";
+import Conf from "conf";
+import { hashProjectRoot } from "./hash-project-root.js";
+
+// Shares the one global `react-doctor` config file with onboarding +
+// setup-prompt + action-upgrade state; `Conf` preserves unknown keys, so this
+// concern lives under its own top-level `ciPrompts` map without clobbering
+// theirs.
+const GLOBAL_CONFIG_PROJECT_NAME = "react-doctor";
+
+export type CiPromptDecisionOutcome = "accepted" | "declined";
+
+export interface CiPromptDecisionStoreOptions {
+  // Overrides the config dir; tests point this at a temp dir.
+  readonly cwd?: string;
+}
+
+interface CiPromptProjectConfig {
+  readonly rootDirectory: string;
+  readonly outcome: CiPromptDecisionOutcome;
+  readonly at: string;
+}
+
+interface CiPromptGlobalConfig {
+  readonly ciPrompts?: Record<string, CiPromptProjectConfig>;
+}
+
+const getCiPromptStore = (options: CiPromptDecisionStoreOptions = {}): Conf<CiPromptGlobalConfig> =>
+  new Conf<CiPromptGlobalConfig>({
+    projectName: GLOBAL_CONFIG_PROJECT_NAME,
+    cwd: options.cwd,
+  });
+
+export const getCiPromptConfigPath = (options: CiPromptDecisionStoreOptions = {}): string =>
+  getCiPromptStore(options).path;
+
+// Whether the "Add React Doctor to CI?" pitch was already answered (accepted OR
+// declined) for this repo. Either answer suppresses future pitches so it's
+// truly one-time — a decline shouldn't re-nag on every scan, and an accept that
+// failed to install the workflow shouldn't re-pitch either (the user can re-run
+// `react-doctor install`).
+export const hasHandledCiPrompt = (
+  projectRoot: string,
+  storeOptions: CiPromptDecisionStoreOptions = {},
+): boolean => {
+  try {
+    const store = getCiPromptStore(storeOptions);
+    const prompts = store.get("ciPrompts", {});
+    return Boolean(prompts[hashProjectRoot(projectRoot)]);
+  } catch {
+    // Unreadable global-config dir (EPERM / EROFS in locked-down CI and
+    // sandboxes). Fail safe to "already handled" so we never nag in an
+    // environment that can't remember the answer — the pitch is
+    // interactive-only and best skipped there anyway.
+    return true;
+  }
+};
+
+// Records the user's one-time answer for this repo. Returns whether it
+// persisted (a read-only config dir just means the choice isn't remembered).
+export const recordCiPromptDecision = (
+  projectRoot: string,
+  outcome: CiPromptDecisionOutcome,
+  storeOptions: CiPromptDecisionStoreOptions = {},
+): boolean => {
+  try {
+    const store = getCiPromptStore(storeOptions);
+    const prompts = store.get("ciPrompts", {});
+    store.set("ciPrompts", {
+      ...prompts,
+      [hashProjectRoot(projectRoot)]: {
+        rootDirectory: path.resolve(projectRoot),
+        outcome,
+        at: new Date().toISOString(),
+      },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/packages/react-doctor/src/cli/utils/ci-prompt-decision.ts
+++ b/packages/react-doctor/src/cli/utils/ci-prompt-decision.ts
@@ -1,81 +1,21 @@
-import * as path from "node:path";
-import Conf from "conf";
-import { hashProjectRoot } from "./hash-project-root.js";
+import { createProjectDecisionStore } from "./project-decision-store.js";
+import type {
+  ProjectDecisionOutcome,
+  ProjectDecisionStoreOptions,
+} from "./project-decision-store.js";
 
-// Shares the one global `react-doctor` config file with onboarding +
-// setup-prompt + action-upgrade state; `Conf` preserves unknown keys, so this
-// concern lives under its own top-level `ciPrompts` map without clobbering
-// theirs.
-const GLOBAL_CONFIG_PROJECT_NAME = "react-doctor";
+export type CiPromptDecisionOutcome = ProjectDecisionOutcome;
+export type CiPromptDecisionStoreOptions = ProjectDecisionStoreOptions;
 
-export type CiPromptDecisionOutcome = "accepted" | "declined";
-
-export interface CiPromptDecisionStoreOptions {
-  // Overrides the config dir; tests point this at a temp dir.
-  readonly cwd?: string;
-}
-
-interface CiPromptProjectConfig {
-  readonly rootDirectory: string;
-  readonly outcome: CiPromptDecisionOutcome;
-  readonly at: string;
-}
-
-interface CiPromptGlobalConfig {
-  readonly ciPrompts?: Record<string, CiPromptProjectConfig>;
-}
-
-const getCiPromptStore = (options: CiPromptDecisionStoreOptions = {}): Conf<CiPromptGlobalConfig> =>
-  new Conf<CiPromptGlobalConfig>({
-    projectName: GLOBAL_CONFIG_PROJECT_NAME,
-    cwd: options.cwd,
-  });
-
-export const getCiPromptConfigPath = (options: CiPromptDecisionStoreOptions = {}): string =>
-  getCiPromptStore(options).path;
-
-// Whether the "Add React Doctor to CI?" pitch was already answered (accepted OR
-// declined) for this repo. Either answer suppresses future pitches so it's
-// truly one-time — a decline shouldn't re-nag on every scan, and an accept that
-// failed to install the workflow shouldn't re-pitch either (the user can re-run
+// The "Add React Doctor to CI?" pitch is a one-time, per-repo decision, shared
+// by `install` onboarding and the post-scan handoff. Either answer suppresses
+// future pitches — a decline shouldn't re-nag on every scan, and an accept whose
+// workflow write didn't land shouldn't re-pitch either (the user can re-run
 // `react-doctor install`).
-export const hasHandledCiPrompt = (
-  projectRoot: string,
-  storeOptions: CiPromptDecisionStoreOptions = {},
-): boolean => {
-  try {
-    const store = getCiPromptStore(storeOptions);
-    const prompts = store.get("ciPrompts", {});
-    return Boolean(prompts[hashProjectRoot(projectRoot)]);
-  } catch {
-    // Unreadable global-config dir (EPERM / EROFS in locked-down CI and
-    // sandboxes). Fail safe to "already handled" so we never nag in an
-    // environment that can't remember the answer — the pitch is
-    // interactive-only and best skipped there anyway.
-    return true;
-  }
-};
+const store = createProjectDecisionStore("ciPrompts");
 
-// Records the user's one-time answer for this repo. Returns whether it
-// persisted (a read-only config dir just means the choice isn't remembered).
-export const recordCiPromptDecision = (
-  projectRoot: string,
-  outcome: CiPromptDecisionOutcome,
-  storeOptions: CiPromptDecisionStoreOptions = {},
-): boolean => {
-  try {
-    const store = getCiPromptStore(storeOptions);
-    const prompts = store.get("ciPrompts", {});
-    store.set("ciPrompts", {
-      ...prompts,
-      [hashProjectRoot(projectRoot)]: {
-        rootDirectory: path.resolve(projectRoot),
-        outcome,
-        at: new Date().toISOString(),
-      },
-    });
-    return true;
-  } catch {
-    return false;
-  }
-};
+export const getCiPromptConfigPath = store.getConfigPath;
+// Whether the CI pitch was already answered (accepted OR declined) for this repo.
+export const hasHandledCiPrompt = store.hasHandled;
+// Records the user's one-time answer for this repo. Returns whether it persisted.
+export const recordCiPromptDecision = store.record;

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -13,6 +13,12 @@ export const TERMINAL_HANGUP_EXIT_CODE = 129;
 // normalization, the `-V` alias).
 export const NODE_ARGUMENT_COUNT = 2;
 
+// `projectName` for every global `Conf` store. React Doctor keeps all per-user
+// state in one file (Conf preserves unknown keys, so each concern owns its own
+// top-level key): onboarding, the install-setup opt-out, and the once-per-repo
+// prompt decisions (CI pitch, action upgrade).
+export const REACT_DOCTOR_CONFIG_PROJECT_NAME = "react-doctor";
+
 export const STAGED_FILES_TEMP_DIR_PREFIX = "react-doctor-staged-";
 export const BASELINE_FILES_TEMP_DIR_PREFIX = "react-doctor-baseline-";
 export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 1;

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -174,9 +174,10 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
 
   const projectRootForCi = findNearestPackageDirectory(input.rootDirectory) ?? input.rootDirectory;
   const isGitHubActionsConfigured = isReactDoctorWorkflowInstalled(projectRootForCi);
-  // Captured before the prompt records its answer: the CI pitch is once-per-repo,
-  // so it (and the embedded copy-prompt upsell below) only fire when the repo
-  // has neither a workflow nor a prior answer. Subsequent scans stay quiet.
+  // The CI pitch is once-per-repo: ask only when the repo has neither a workflow
+  // nor a prior answer. Subsequent scans stay quiet. (The agent copy-prompt
+  // deliberately carries no CI upsell — this interactive prompt is the single
+  // pitch, so the agent never re-asks what the user was just asked here.)
   const isCiPitchPending = !isGitHubActionsConfigured && !hasHandledCiPrompt(projectRootForCi);
 
   // CI question first, only when it has anything to do. A "yes" sets up the
@@ -253,7 +254,6 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
     diagnostics: input.diagnostics,
     projectName: input.projectName,
     outputDirectory: input.outputDirectory,
-    includeCiPitch: isCiPitchPending,
   });
 
   if (handoffTarget === CLIPBOARD_CHOICE) {

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -14,6 +14,7 @@ import {
   type InstalledReactDoctorWorkflow,
 } from "./install-github-workflow.js";
 import { hasHandledActionUpgrade, recordActionUpgradeDecision } from "./action-upgrade-prompt.js";
+import { hasHandledCiPrompt, recordCiPromptDecision } from "./ci-prompt-decision.js";
 import { askAddToGitHubActions } from "./ask-add-to-github-actions.js";
 import { askUpgradeActionVersion } from "./ask-upgrade-action-version.js";
 import { setUpGitHubActions } from "./set-up-github-actions.js";
@@ -173,26 +174,39 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
 
   const projectRootForCi = findNearestPackageDirectory(input.rootDirectory) ?? input.rootDirectory;
   const isGitHubActionsConfigured = isReactDoctorWorkflowInstalled(projectRootForCi);
+  // Captured before the prompt records its answer: the CI pitch is once-per-repo,
+  // so it (and the embedded copy-prompt upsell below) only fire when the repo
+  // has neither a workflow nor a prior answer. Subsequent scans stay quiet.
+  const isCiPitchPending = !isGitHubActionsConfigured && !hasHandledCiPrompt(projectRootForCi);
 
   // CI question first, only when it has anything to do. A "yes" sets up the
   // workflow inline and then falls through to the agent question, so a user
   // can install CI AND launch an agent in one scan — previously the combined
   // prompt forced an either/or choice.
-  if (!isGitHubActionsConfigured) {
+  if (isCiPitchPending) {
     const ciOutcome = await askAddToGitHubActions();
     recordCount(METRIC.agentHandoff, 1, {
       outcome: `ci-${ciOutcome}`,
       diagnosticsCount: input.diagnostics.length,
     });
     if (ciOutcome === "cancel") return;
+    // Remember the answer either way so the pitch never repeats on this repo.
+    recordCiPromptDecision(projectRootForCi, ciOutcome === "yes" ? "accepted" : "declined");
     if (ciOutcome === "yes") {
       await setUpGitHubActions({ rootDirectory: input.rootDirectory });
       logger.break();
     }
-  } else {
+  } else if (isGitHubActionsConfigured) {
     // Workflow already present: offer the one-time `@v1` → `@v2` upgrade
     // instead. Mutually exclusive with the "add" prompt above.
     await maybeOfferActionUpgrade(projectRootForCi);
+  } else {
+    // Not configured, but the user already answered the CI pitch for this repo.
+    // Stay quiet so the pitch is once-per-repo rather than every scan.
+    recordCount(METRIC.agentHandoff, 1, {
+      outcome: "ci-suppressed",
+      diagnosticsCount: input.diagnostics.length,
+    });
   }
 
   const launchableAgents = await detectLaunchableAgents();
@@ -239,6 +253,7 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
     diagnostics: input.diagnostics,
     projectName: input.projectName,
     outputDirectory: input.outputDirectory,
+    includeCiPitch: isCiPitchPending,
   });
 
   if (handoffTarget === CLIPBOARD_CHOICE) {

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -24,6 +24,7 @@ import { askAddToGitHubActions } from "./ask-add-to-github-actions.js";
 import { askUpgradeActionVersion } from "./ask-upgrade-action-version.js";
 import { detectDefaultBranch } from "./detect-default-branch.js";
 import { hasHandledActionUpgrade, recordActionUpgradeDecision } from "./action-upgrade-prompt.js";
+import { hasHandledCiPrompt, recordCiPromptDecision } from "./ci-prompt-decision.js";
 import { installReactDoctorAgentHooks } from "./install-agent-hooks.js";
 import {
   getReactDoctorWorkflowPath,
@@ -545,9 +546,16 @@ export const runInstallReactDoctor = async (
   // to the action's previous floating major (`@v1`) is offered the in-place
   // `@v2` bump instead. The two are mutually exclusive — only one can apply.
   // `--yes` opts in and a bare non-interactive run opts out.
+  // The CI pitch is once-per-repo across `install` and the post-scan handoff, so
+  // a prior answer from either surface suppresses the interactive question here —
+  // mirroring how `canUpgradeWorkflow` respects `hasHandledActionUpgrade`. `--yes`
+  // still opts in (an explicit "set everything up" overrides a past decline).
+  const ciPromptOutcome =
+    canInstallWorkflow && !options.yes && !skipPrompts && !hasHandledCiPrompt(projectRoot)
+      ? await askAddToGitHubActions(prompt)
+      : null;
   const shouldInstallWorkflow =
-    canInstallWorkflow &&
-    (Boolean(options.yes) || (!skipPrompts && (await askAddToGitHubActions(prompt)) === "yes"));
+    canInstallWorkflow && (Boolean(options.yes) || ciPromptOutcome === "yes");
   const upgradePromptOutcome =
     canUpgradeWorkflow && !options.yes && !skipPrompts
       ? await askUpgradeActionVersion(prompt)
@@ -561,6 +569,14 @@ export const runInstallReactDoctor = async (
   // below. Dry runs preview without writing anything.
   if (upgradePromptOutcome === "no" && !options.dryRun) {
     recordActionUpgradeDecision(projectRoot, "declined");
+  }
+
+  // The CI prompt's "No" is once-per-repo too: persist the decline so the next
+  // interactive scan handoff doesn't re-ask it. An accept needs no record here —
+  // the workflow file the install writes is what suppresses the handoff. Dry runs
+  // preview without writing.
+  if (ciPromptOutcome === "no" && !options.dryRun) {
+    recordCiPromptDecision(projectRoot, "declined");
   }
 
   // Step 2 — the agent skill + package setup (the core of `install`).

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -571,12 +571,14 @@ export const runInstallReactDoctor = async (
     recordActionUpgradeDecision(projectRoot, "declined");
   }
 
-  // The CI prompt's "No" is once-per-repo too: persist the decline so the next
-  // interactive scan handoff doesn't re-ask it. An accept needs no record here —
-  // the workflow file the install writes is what suppresses the handoff. Dry runs
-  // preview without writing.
-  if (ciPromptOutcome === "no" && !options.dryRun) {
-    recordCiPromptDecision(projectRoot, "declined");
+  // The CI pitch is once-per-repo: persist the answer (yes or no) the moment
+  // it's given — mirroring the post-scan handoff — so neither surface re-pitches
+  // it. Recording the accept here (not just relying on the workflow file) keeps
+  // it answered even if the install is cancelled below or the workflow write
+  // fails; the user can always re-run `install` to set CI up. A cancel records
+  // nothing. Dry runs preview without writing.
+  if ((ciPromptOutcome === "yes" || ciPromptOutcome === "no") && !options.dryRun) {
+    recordCiPromptDecision(projectRoot, ciPromptOutcome === "yes" ? "accepted" : "declined");
   }
 
   // Step 2 — the agent skill + package setup (the core of `install`).

--- a/packages/react-doctor/src/cli/utils/onboarding-state.ts
+++ b/packages/react-doctor/src/cli/utils/onboarding-state.ts
@@ -1,8 +1,5 @@
 import Conf from "conf";
-
-// Shared global config file with the setup-prompt state; Conf preserves unknown
-// keys, so both concerns coexist in one file.
-const GLOBAL_CONFIG_PROJECT_NAME = "react-doctor";
+import { REACT_DOCTOR_CONFIG_PROJECT_NAME } from "./constants.js";
 
 const ONBOARDED_AT_KEY = "onboardedAt";
 
@@ -18,7 +15,7 @@ interface OnboardingGlobalConfig {
 
 const getOnboardingStore = (options: OnboardingStoreOptions = {}): Conf<OnboardingGlobalConfig> =>
   new Conf<OnboardingGlobalConfig>({
-    projectName: GLOBAL_CONFIG_PROJECT_NAME,
+    projectName: REACT_DOCTOR_CONFIG_PROJECT_NAME,
     cwd: options.cwd,
   });
 

--- a/packages/react-doctor/src/cli/utils/project-decision-store.ts
+++ b/packages/react-doctor/src/cli/utils/project-decision-store.ts
@@ -1,0 +1,76 @@
+import * as path from "node:path";
+import Conf from "conf";
+import { REACT_DOCTOR_CONFIG_PROJECT_NAME } from "./constants.js";
+import { hashProjectRoot } from "./hash-project-root.js";
+
+export type ProjectDecisionOutcome = "accepted" | "declined";
+
+export interface ProjectDecisionStoreOptions {
+  // Overrides the config dir; tests point this at a temp dir.
+  readonly cwd?: string;
+}
+
+interface ProjectDecisionRecord {
+  readonly rootDirectory: string;
+  readonly outcome: ProjectDecisionOutcome;
+  readonly at: string;
+}
+
+export interface ProjectDecisionStore {
+  readonly getConfigPath: (options?: ProjectDecisionStoreOptions) => string;
+  readonly hasHandled: (projectRoot: string, options?: ProjectDecisionStoreOptions) => boolean;
+  readonly record: (
+    projectRoot: string,
+    outcome: ProjectDecisionOutcome,
+    options?: ProjectDecisionStoreOptions,
+  ) => boolean;
+}
+
+// A once-per-repo "answered" decision (accepted OR declined), keyed by hashed
+// project root and persisted under its own `storeKey` in the shared react-doctor
+// config file. Backs the one-time prompts whose answer must outlast a single
+// scan — the CI pitch and the `@v1` → `@v2` action-upgrade offer — so a recorded
+// answer suppresses the prompt on later scans. `Conf` preserves unknown keys, so
+// each store's `storeKey` coexists with the others (and with the onboarding /
+// setup-prompt state) in one file.
+export const createProjectDecisionStore = (storeKey: string): ProjectDecisionStore => {
+  const getStore = (
+    options: ProjectDecisionStoreOptions = {},
+  ): Conf<Record<string, Record<string, ProjectDecisionRecord>>> =>
+    new Conf<Record<string, Record<string, ProjectDecisionRecord>>>({
+      projectName: REACT_DOCTOR_CONFIG_PROJECT_NAME,
+      cwd: options.cwd,
+    });
+
+  return {
+    getConfigPath: (options = {}) => getStore(options).path,
+    hasHandled: (projectRoot, options = {}) => {
+      try {
+        return Boolean(getStore(options).get(storeKey, {})[hashProjectRoot(projectRoot)]);
+      } catch {
+        // Unreadable global-config dir (EPERM / EROFS in locked-down CI and
+        // sandboxes). Fail safe to "already handled" so we never nag in an
+        // environment that can't remember the answer.
+        return true;
+      }
+    },
+    record: (projectRoot, outcome, options = {}) => {
+      try {
+        const store = getStore(options);
+        store.set(storeKey, {
+          ...store.get(storeKey, {}),
+          [hashProjectRoot(projectRoot)]: {
+            rootDirectory: path.resolve(projectRoot),
+            outcome,
+            at: new Date().toISOString(),
+          },
+        });
+        return true;
+      } catch {
+        // Couldn't persist (read-only config dir); the choice just isn't
+        // remembered.
+        return false;
+      }
+    },
+  };
+};

--- a/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
+++ b/packages/react-doctor/src/cli/utils/prompt-install-setup.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import Conf from "conf";
+import { REACT_DOCTOR_CONFIG_PROJECT_NAME } from "./constants.js";
 import { hashProjectRoot } from "./hash-project-root.js";
 import { findNearestPackageDirectory, hasDoctorScript } from "./install-doctor-script.js";
 import { isCodingAgentEnvironment } from "./is-ci-environment.js";
@@ -26,13 +27,11 @@ export interface ResolveInstallSetupProjectRootOptions {
   readonly scanDirectories: ReadonlyArray<string>;
 }
 
-const GLOBAL_CONFIG_PROJECT_NAME = "react-doctor";
-
 const getSetupPromptStore = (
   options: SetupPromptStoreOptions = {},
 ): Conf<SetupPromptGlobalConfig> =>
   new Conf<SetupPromptGlobalConfig>({
-    projectName: GLOBAL_CONFIG_PROJECT_NAME,
+    projectName: REACT_DOCTOR_CONFIG_PROJECT_NAME,
     cwd: options.cwd,
   });
 

--- a/packages/react-doctor/tests/ci-prompt-decision.test.ts
+++ b/packages/react-doctor/tests/ci-prompt-decision.test.ts
@@ -1,0 +1,53 @@
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  getCiPromptConfigPath,
+  hasHandledCiPrompt,
+  recordCiPromptDecision,
+} from "../src/cli/utils/ci-prompt-decision.js";
+
+describe("ci prompt decision state", () => {
+  let configRoot: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const root = fs.mkdtempSync(path.join(tmpdir(), "react-doctor-ci-prompt-"));
+    configRoot = root;
+    cleanup = () => fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reports not-handled before the pitch is answered", () => {
+    expect(hasHandledCiPrompt("/repo/a", { cwd: configRoot })).toBe(false);
+  });
+
+  it("persists a decline so the pitch never repeats for that repo", () => {
+    expect(recordCiPromptDecision("/repo/a", "declined", { cwd: configRoot })).toBe(true);
+    expect(hasHandledCiPrompt("/repo/a", { cwd: configRoot })).toBe(true);
+  });
+
+  it("treats an accept as handled too (no re-pitch if install didn't stick)", () => {
+    recordCiPromptDecision("/repo/a", "accepted", { cwd: configRoot });
+    expect(hasHandledCiPrompt("/repo/a", { cwd: configRoot })).toBe(true);
+  });
+
+  it("scopes the decision per repo", () => {
+    recordCiPromptDecision("/repo/a", "declined", { cwd: configRoot });
+    expect(hasHandledCiPrompt("/repo/a", { cwd: configRoot })).toBe(true);
+    expect(hasHandledCiPrompt("/repo/b", { cwd: configRoot })).toBe(false);
+  });
+
+  it("stores state under its own key in the shared react-doctor config file", () => {
+    recordCiPromptDecision("/repo/a", "declined", { cwd: configRoot });
+    const configPath = getCiPromptConfigPath({ cwd: configRoot });
+    const stored = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const records = Object.values(stored.ciPrompts);
+    expect(records).toHaveLength(1);
+    expect((records[0] as { outcome: string }).outcome).toBe("declined");
+  });
+});

--- a/packages/react-doctor/tests/handoff/build-handoff-payload.test.ts
+++ b/packages/react-doctor/tests/handoff/build-handoff-payload.test.ts
@@ -36,9 +36,10 @@ describe("buildHandoffPayload", () => {
 
     expect(payload).toContain(`Fix the top ${TOP_ERRORS_DISPLAY_COUNT}`);
     expect(payload).toContain("demo");
-    // The agent is told to offer CI first, with the trust pitch + guide link.
-    expect(payload).toContain("add React Doctor to CI");
-    expect(payload).toContain("https://react.doctor/ci");
+    // The CI pitch is off by default — it's a once-per-repo upsell the caller
+    // opts into, so a bare payload carries no marketing.
+    expect(payload).not.toContain("add React Doctor to CI");
+    expect(payload).not.toContain("https://react.doctor/ci");
     // Exactly TOP_ERRORS_DISPLAY_COUNT numbered entries.
     expect(payload.match(/^\d+\. /gm)?.length).toBe(TOP_ERRORS_DISPLAY_COUNT);
 
@@ -49,5 +50,28 @@ describe("buildHandoffPayload", () => {
     expect(fs.existsSync(directory)).toBe(true);
     expect(fs.existsSync(`${directory}/diagnostics.json`)).toBe(true);
     fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("prepends the CI pitch only when includeCiPitch is set", () => {
+    const diagnostics = [makeDiagnostic({})];
+
+    const withPitch = buildHandoffPayload({
+      diagnostics,
+      projectName: "demo",
+      includeCiPitch: true,
+    });
+    expect(withPitch).toContain("add React Doctor to CI");
+    expect(withPitch).toContain("https://react.doctor/ci");
+    // The pitch leads the prompt, ahead of the fix instructions.
+    expect(withPitch.indexOf("add React Doctor to CI")).toBeLessThan(
+      withPitch.indexOf("Fix the top"),
+    );
+
+    const withoutPitch = buildHandoffPayload({
+      diagnostics,
+      projectName: "demo",
+      includeCiPitch: false,
+    });
+    expect(withoutPitch).not.toContain("add React Doctor to CI");
   });
 });

--- a/packages/react-doctor/tests/handoff/build-handoff-payload.test.ts
+++ b/packages/react-doctor/tests/handoff/build-handoff-payload.test.ts
@@ -36,8 +36,8 @@ describe("buildHandoffPayload", () => {
 
     expect(payload).toContain(`Fix the top ${TOP_ERRORS_DISPLAY_COUNT}`);
     expect(payload).toContain("demo");
-    // The CI pitch is off by default — it's a once-per-repo upsell the caller
-    // opts into, so a bare payload carries no marketing.
+    // The agent copy-prompt carries no CI marketing — the interactive handoff
+    // prompt is the single once-per-repo pitch, so the agent never re-asks it.
     expect(payload).not.toContain("add React Doctor to CI");
     expect(payload).not.toContain("https://react.doctor/ci");
     // Exactly TOP_ERRORS_DISPLAY_COUNT numbered entries.
@@ -50,28 +50,5 @@ describe("buildHandoffPayload", () => {
     expect(fs.existsSync(directory)).toBe(true);
     expect(fs.existsSync(`${directory}/diagnostics.json`)).toBe(true);
     fs.rmSync(directory, { recursive: true, force: true });
-  });
-
-  it("prepends the CI pitch only when includeCiPitch is set", () => {
-    const diagnostics = [makeDiagnostic({})];
-
-    const withPitch = buildHandoffPayload({
-      diagnostics,
-      projectName: "demo",
-      includeCiPitch: true,
-    });
-    expect(withPitch).toContain("add React Doctor to CI");
-    expect(withPitch).toContain("https://react.doctor/ci");
-    // The pitch leads the prompt, ahead of the fix instructions.
-    expect(withPitch.indexOf("add React Doctor to CI")).toBeLessThan(
-      withPitch.indexOf("Fix the top"),
-    );
-
-    const withoutPitch = buildHandoffPayload({
-      diagnostics,
-      projectName: "demo",
-      includeCiPitch: false,
-    });
-    expect(withoutPitch).not.toContain("add React Doctor to CI");
   });
 });

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -946,6 +946,27 @@ describe("runInstallReactDoctor", () => {
     expect(hasHandledCiPrompt(fixture.projectRoot)).toBe(true);
   });
 
+  it("persists an accepted CI offer so the scan handoff won't re-ask", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = path.join(fixture.projectRoot, ".github/workflows/react-doctor.yml");
+    expect(hasHandledCiPrompt(fixture.projectRoot)).toBe(false);
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      // "workflow" → the CI offer is accepted (ci-yes).
+      setupOptions: ["workflow"],
+    });
+
+    expect(fs.existsSync(workflowPath)).toBe(true);
+    // The accept is persisted at answer time, so an accept that never wrote the
+    // workflow (early exit / failure) still won't re-pitch on the next scan.
+    expect(hasHandledCiPrompt(fixture.projectRoot)).toBe(true);
+  });
+
   it("interactively skips the CI offer once the decision is already persisted", async () => {
     writeValidSkill(fixture.sourceDir);
     writePackageJson(fixture.projectRoot, { scripts: {} });

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -20,6 +20,7 @@ import { NON_INTERACTIVE_ENVIRONMENT_VARIABLES } from "../src/cli/utils/is-non-i
 import { runInstallReactDoctor } from "../src/cli/utils/install-react-doctor.js";
 import type { InstallReactDoctorDependencyRunnerInput } from "../src/cli/utils/install-react-doctor.js";
 import { recordActionUpgradeDecision } from "../src/cli/utils/action-upgrade-prompt.js";
+import { hasHandledCiPrompt, recordCiPromptDecision } from "../src/cli/utils/ci-prompt-decision.js";
 import { setSpinnerSilent } from "../src/cli/utils/spinner.js";
 import { silenceConsoleForTest } from "./helpers/silence-console.js";
 
@@ -923,6 +924,48 @@ describe("runInstallReactDoctor", () => {
 
     expect(fs.readFileSync(workflowPath, "utf8")).toContain("millionco/react-doctor@v1");
     expect(fs.readFileSync(workflowPath, "utf8")).not.toContain("millionco/react-doctor@v2");
+  });
+
+  it("interactively persists a declined CI offer so the scan handoff won't re-ask", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = path.join(fixture.projectRoot, ".github/workflows/react-doctor.yml");
+    expect(hasHandledCiPrompt(fixture.projectRoot)).toBe(false);
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      // No "workflow" → the CI offer is declined (ci-no).
+      setupOptions: [],
+    });
+
+    expect(fs.existsSync(workflowPath)).toBe(false);
+    // The decline is persisted, so the once-per-repo pitch stays answered.
+    expect(hasHandledCiPrompt(fixture.projectRoot)).toBe(true);
+  });
+
+  it("interactively skips the CI offer once the decision is already persisted", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
+    const workflowPath = path.join(fixture.projectRoot, ".github/workflows/react-doctor.yml");
+    recordCiPromptDecision(fixture.projectRoot, "declined");
+    const promptQuestions: unknown[] = [];
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: hookPath,
+      // Would normally add the workflow — but the persisted decline (e.g. from a
+      // prior scan handoff) suppresses the CI question entirely.
+      setupOptions: ["workflow"],
+      promptQuestions,
+    });
+
+    expect(promptQuestions).not.toContainEqual(expect.objectContaining({ name: "ciChoice" }));
+    expect(fs.existsSync(workflowPath)).toBe(false);
   });
 
   it("CI skips prompts without --yes but does not install the optional Git hook", async () => {


### PR DESCRIPTION
## Why

The post-scan handoff re-pitched "Add React Doctor to CI" and re-embedded its upsell in the agent copy-prompt **on every scan**, and the "not installed" agent hint re-printed every run because its opt-out store was built and tested but **never actually written**. Capable agents (Opus) flagged the every-scan marketing preamble — name-dropping companies + an install command ahead of the real work — as social engineering, and started distrusting the legitimate diagnostics too.

User ask: the marketing handoff is fine, it just shouldn't fire on every run — onboarding/marketing should run once per repo.

Before:

```
$ react-doctor              # scan 1 → "Add React Doctor to CI?" + copy-prompt upsell + install hint
$ react-doctor              # scan 2 → same pitches again
$ react-doctor              # scan 3 → same pitches again ...forever, even after "No"
```

After:

```
$ react-doctor              # scan 1 → pitched once (unchanged first-run experience)
$ react-doctor              # scan 2 → quiet
$ react-doctor              # scan 3 → quiet
```

## What changed

- **New `ci-prompt-decision.ts`** — a per-repo "answered once" store for the CI pitch, mirroring the existing `action-upgrade-prompt.ts` once-per-repo `Conf` pattern (its own `ciPrompts` top-level key, same fail-safe try/catch semantics).
- **`handoff-to-agent.ts`** — the interactive CI question now gates on `hasHandledCiPrompt` and records accept/decline so it never repeats; emits `agent.handoff outcome="ci-suppressed"` when skipped for a previously-answered repo.
- **`build-handoff-payload.ts`** — the embedded CI upsell is now behind an `includeCiPitch` flag (default **off**); the caller only sets it on the first handoff per repo.
- **`inspect.ts`** — the install hint now calls the already-built-but-never-invoked `disableSetupPrompt`, so it shows once per repo instead of every scan.

First-run behavior is unchanged; only the repetition stops. No JSON report / score / `action.yml` change.

### Product brief
- **Job:** a dev re-scans a repo (often via an agent); after answering the pitches once, gets re-nagged every scan with no off switch.
- **Metric:** `agent.handoff outcome="ci-suppressed"` (fires when a repeat CI pitch is skipped) + the existing `agent.install_hint_shown` count drops to ≤1/repo. **Kill:** if `ci-suppressed` stays 0 across 2 releases, the gate never triggers → revisit.
- **Compat:** default preserves first-run behavior; `patch` changeset (CLI prompt behavior).

## Test plan

- `pnpm --filter react-doctor typecheck` — pass
- react-doctor suite — 1795 passed / 15 skipped (the one `scan-result-cache` failure is a pre-existing parallel-load flake; passes 5/5 in isolation, untouched by this diff)
- New `tests/ci-prompt-decision.test.ts` + updated `build-handoff-payload.test.ts` — pass
- `pnpm lint` — clean · `vp fmt --check` — clean
- Note: 2 failures in `@react-doctor/core` (`.env.local` gitignore detection) are pre-existing — reproduce on the clean base with this branch's changes stashed; different package, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only prompt and local config behavior; no scan results, CI gates, or security paths change beyond quieter repeat UX.
> 
> **Overview**
> Stops **repeat marketing on every scan** while keeping the first-run experience the same.
> 
> **Per-repo CI pitch:** Adds shared `createProjectDecisionStore` / `ci-prompt-decision` persistence (same `Conf` pattern as action upgrades). Post-scan handoff and `install` only ask **“Add React Doctor to CI?”** when there’s no workflow and no prior answer; accept/decline is recorded so later runs stay quiet (`agent.handoff` can report `ci-suppressed`). `--yes` on install still opts into CI over a past decline.
> 
> **Install hint:** After the agent “not installed” nudge in `inspect`, **`disableSetupPrompt`** is finally called so that hint shows once per repo.
> 
> **Agent copy-prompt:** **`buildHandoffPayload`** no longer embeds the CI upsell (trust copy + install command). The interactive handoff is the only CI pitch, so agents aren’t told to re-ask what the user just answered.
> 
> **Cleanup:** Action-upgrade storage uses the shared decision store; **`REACT_DOCTOR_CONFIG_PROJECT_NAME`** centralizes the global config file name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17c21663bb48d5649cfd706d000674d387af6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->