### PR TITLE
refactor: elegance pass — remove dead code, dead branches, and redundant abstractions

### DIFF
--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -10,6 +10,7 @@ import {
   DEAD_CODE_WORKER_MAX_OLD_SPACE_MB,
   DEAD_CODE_WORKER_TIMEOUT_MS,
   MILLISECONDS_PER_SECOND,
+  TSCONFIG_FILENAMES,
 } from "./constants.js";
 import { toCanonicalPath } from "./utils/to-canonical-path.js";
 import { toRelativePath } from "./utils/to-relative-path.js";
@@ -90,8 +91,6 @@ interface DeadCodeWorkerFailureMessage {
   readonly ok: false;
   readonly error: DeadCodeWorkerError;
 }
-
-const TSCONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"];
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -12,6 +12,7 @@ import {
   MILLISECONDS_PER_SECOND,
   TSCONFIG_FILENAMES,
 } from "./constants.js";
+import { isRecord } from "./utils/is-record.js";
 import { toCanonicalPath } from "./utils/to-canonical-path.js";
 import { toRelativePath } from "./utils/to-relative-path.js";
 
@@ -91,9 +92,6 @@ interface DeadCodeWorkerFailureMessage {
   readonly ok: false;
   readonly error: DeadCodeWorkerError;
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 // Runs in a child PROCESS (node -e), not a worker_thread — see
 // `createDeadCodeWorker`. Reads the worker input as JSON on stdin and

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -189,6 +189,12 @@ export const ES_TARGET_YEAR_BY_NAME: Readonly<Record<string, number>> = {
 };
 
 /**
+ * tsconfig filenames probed when resolving a project's TypeScript
+ * compiler options — the root config first, then a monorepo base config.
+ */
+export const TSCONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"] as const;
+
+/**
  * Project-config files that `StagedFiles.materialize` copies into
  * the temp directory alongside staged sources so oxlint resolves
  * `tsconfig` / `package.json` / lint configs the same way it would

--- a/packages/core/src/dead-code/collect-dead-code-patterns.ts
+++ b/packages/core/src/dead-code/collect-dead-code-patterns.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { collectIgnorePatterns } from "../collect-ignore-patterns.js";
 import { readIgnoreFile } from "../read-ignore-file.js";
+import { isRecord } from "../utils/is-record.js";
 
 interface KnipWorkspaceConfig {
   readonly entry?: unknown;
@@ -15,9 +16,6 @@ interface KnipConfig {
 }
 
 const KNIP_JSON_FILENAME = "knip.json";
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const readJsonFileSafe = (filePath: string): unknown | null => {
   let rawContents: string;

--- a/packages/core/src/resolve-compatible-node.ts
+++ b/packages/core/src/resolve-compatible-node.ts
@@ -10,10 +10,10 @@ interface NodeVersion {
   patch: number;
 }
 
-interface NodeResolution {
-  binaryPath: string;
-  isCurrentNode: boolean;
-  version: string;
+export interface NodeResolution {
+  readonly binaryPath: string;
+  readonly isCurrentNode: boolean;
+  readonly version: string;
 }
 
 const parseNodeVersion = (versionString: string): NodeVersion => {

--- a/packages/core/src/runners/oxlint/resolve-paths.ts
+++ b/packages/core/src/runners/oxlint/resolve-paths.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
+import { TSCONFIG_FILENAMES } from "../../constants.js";
 
 const esmRequire = createRequire(import.meta.url);
 
@@ -16,8 +17,6 @@ export const resolveOxlintBinary = (): string => {
 // accepts as-is. Works in dev (workspace symlink), in npm installs
 // (node_modules/.pnpm/...), and from pnpm dlx / npx temp directories.
 export const resolvePluginPath = (): string => esmRequire.resolve("oxlint-plugin-react-doctor");
-
-const TSCONFIG_FILENAMES = ["tsconfig.json", "tsconfig.base.json"];
 
 export const resolveTsConfigRelativePath = (rootDirectory: string): string | null => {
   for (const filename of TSCONFIG_FILENAMES) {

--- a/packages/core/src/runners/oxlint/resolve-use-call-binding.ts
+++ b/packages/core/src/runners/oxlint/resolve-use-call-binding.ts
@@ -258,7 +258,7 @@ const isIdentifierShadowedByLocalBinding = (
 ): boolean => {
   let currentNode: ts.Node | undefined = identifier.parent;
   while (currentNode) {
-    if (isScopeNode(currentNode)) {
+    if (isScopeBoundary(currentNode)) {
       if (scopeContainsNonImportBinding(currentNode, currentNode, identifier.text)) return true;
     }
     if (currentNode === sourceFile) return false;
@@ -543,8 +543,6 @@ const findResolutionInScope = (
   return resolution;
 };
 
-const isScopeNode = isScopeBoundary;
-
 const resolveIdentifierBinding = (
   identifier: ts.Identifier,
   reactImportBindings: ReactImportBindings,
@@ -553,7 +551,7 @@ const resolveIdentifierBinding = (
 ): BindingResolution | null => {
   let currentNode: ts.Node | undefined = identifier.parent;
   while (currentNode) {
-    if (isScopeNode(currentNode)) {
+    if (isScopeBoundary(currentNode)) {
       const resolution = findResolutionInScope(
         currentNode,
         identifier.text,

--- a/packages/core/src/services/node-resolver.ts
+++ b/packages/core/src/services/node-resolver.ts
@@ -5,13 +5,10 @@ import {
   installNodeViaNvm as installNodeViaNvmSync,
   isNvmInstalled as isNvmInstalledSync,
   resolveNodeForOxlint as resolveNodeForOxlintSync,
+  type NodeResolution,
 } from "../resolve-compatible-node.js";
 
-export interface NodeResolution {
-  readonly binaryPath: string;
-  readonly isCurrentNode: boolean;
-  readonly version: string;
-}
+export type { NodeResolution };
 
 /**
  * `NodeResolver` wraps the imperative node-detection / nvm helpers

--- a/packages/core/src/utils/is-record.ts
+++ b/packages/core/src/utils/is-record.ts
@@ -1,0 +1,4 @@
+// Narrows an unknown value to a string-keyed object (excludes null and
+// arrays) for safe property access when decoding loosely-typed JSON.
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/language-server/src/core/overlay.ts
+++ b/packages/language-server/src/core/overlay.ts
@@ -6,6 +6,7 @@ import {
   STAGED_FILES_PROJECT_CONFIG_FILENAMES,
 } from "@react-doctor/core";
 import type { TextProvider } from "../types.js";
+import { toProjectRelative } from "../utils/to-project-relative.js";
 
 const OVERLAY_TEMP_PREFIX = "react-doctor-lsp-";
 
@@ -34,12 +35,6 @@ export interface MaterializeOverlayInput {
   /** Reads the live text of a file (open buffer first, then disk). */
   readonly readText: TextProvider;
 }
-
-const toProjectRelative = (projectDirectory: string, filePath: string): string | null => {
-  const relative = path.relative(projectDirectory, filePath).replace(/\\/g, "/");
-  if (relative.length === 0 || relative.startsWith("../") || path.isAbsolute(relative)) return null;
-  return relative;
-};
 
 /**
  * Writes the live (possibly unsaved) content of the target files into a

--- a/packages/language-server/src/core/scan-runner.ts
+++ b/packages/language-server/src/core/scan-runner.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { runEditorScan, type Diagnostic as CoreDiagnostic } from "@react-doctor/core";
+import {
+  computeConfigFingerprint,
+  runEditorScan,
+  type Diagnostic as CoreDiagnostic,
+} from "@react-doctor/core";
 import {
   SILENT_LOGGER,
   type CancellationToken,
@@ -11,7 +15,7 @@ import {
   type TextProvider,
 } from "../types.js";
 import { normalizeFsPath } from "../text/uri.js";
-import { computeConfigFingerprint } from "../utils/compute-config-fingerprint.js";
+import { toProjectRelative } from "../utils/to-project-relative.js";
 import { createLintCache, type FileStat, type LintCache } from "./lint-cache.js";
 import { materializeOverlay, type OverlaySnapshot } from "./overlay.js";
 
@@ -40,12 +44,6 @@ export interface ScanRunner {
   /** Flush all caches to disk (on shutdown). */
   readonly dispose: () => void;
 }
-
-const toProjectRelative = (projectDirectory: string, filePath: string): string | null => {
-  const relative = path.relative(projectDirectory, filePath).replace(/\\/g, "/");
-  if (relative.length === 0 || relative.startsWith("../") || path.isAbsolute(relative)) return null;
-  return relative;
-};
 
 /**
  * Resolves a diagnostic's (possibly relative, possibly overlay-temp)

--- a/packages/language-server/src/utils/compute-config-fingerprint.ts
+++ b/packages/language-server/src/utils/compute-config-fingerprint.ts
@@ -1,1 +1,0 @@
-export { computeConfigFingerprint } from "@react-doctor/core";

--- a/packages/language-server/src/utils/to-project-relative.ts
+++ b/packages/language-server/src/utils/to-project-relative.ts
@@ -1,0 +1,10 @@
+import * as path from "node:path";
+
+// Normalizes an absolute file path to a forward-slash path relative to
+// the project root, or null when it escapes the project (so callers can
+// skip paths outside the scanned tree).
+export const toProjectRelative = (projectDirectory: string, filePath: string): string | null => {
+  const relative = path.relative(projectDirectory, filePath).replace(/\\/g, "/");
+  if (relative.length === 0 || relative.startsWith("../") || path.isAbsolute(relative)) return null;
+  return relative;
+};

--- a/packages/language-server/tests/unit/lint-cache.test.ts
+++ b/packages/language-server/tests/unit/lint-cache.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import type { Diagnostic as CoreDiagnostic } from "@react-doctor/core";
-import { computeConfigFingerprint } from "../../src/utils/compute-config-fingerprint.js";
+import { computeConfigFingerprint } from "@react-doctor/core";
 import { createLintCache } from "../../src/core/lint-cache.js";
 
 let projectDir: string;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/nextjs.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/nextjs.ts
@@ -23,8 +23,6 @@ export const METADATA_EXPORT_NAMES = ["metadata", "generateMetadata"];
 export const INTERNAL_PAGE_PATH_PATTERN =
   /\/(?:(?:\((?:dashboard|admin|settings|account|internal|manage|console|portal|auth|onboarding|app|ee|protected)\))|(?:dashboard|admin|settings|account|internal|manage|console|portal))\//i;
 
-export const OG_ROUTE_PATTERN = /\/og\b/i;
-
 export const PAGES_DIRECTORY_PATTERN = /\/pages\//;
 
 export const NEXTJS_NAVIGATION_FUNCTIONS = new Set([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.ts
@@ -1,15 +1,13 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
-import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isInteractiveElement } from "../../utils/is-interactive-element.js";
+import { isPresentationRole } from "../../utils/is-presentation-role.js";
 import { isPureEventBlockerHandler } from "../../utils/is-pure-event-blocker-handler.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import { HTML_TAGS } from "../../constants/html-tags.js";
-
-const PRESENTATION_ROLES: ReadonlySet<string> = new Set(["presentation", "none"]);
 
 const MESSAGE =
   "Keyboard users can't trigger this click handler because there's no keyboard one, so add `onKeyUp`, `onKeyDown`, or `onKeyPress`.";
@@ -41,14 +39,8 @@ export const clickEventsHaveKeyEvents = defineRule({
         if (isPureEventBlockerHandler(onClick)) return;
 
         if (isHiddenFromScreenReader(node, context.settings)) return;
-
-        // Presentational role (presentation / none) → not perceivable
-        // by AT, so skip.
-        const roleAttribute = hasJsxPropIgnoreCase(node.attributes, "role");
-        if (roleAttribute) {
-          const roleValue = getJsxPropStringValue(roleAttribute);
-          if (roleValue && PRESENTATION_ROLES.has(roleValue)) return;
-        }
+        // Presentational role (presentation / none) → not perceivable by AT.
+        if (isPresentationRole(node)) return;
         const hasKeyHandler = KEY_HANDLERS.some((handler) =>
           hasJsxPropIgnoreCase(node.attributes, handler),
         );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/html-has-lang.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/html-has-lang.ts
@@ -25,11 +25,10 @@ const resolveSettings = (
 };
 
 // Evaluate a JSX attribute value to a "valid lang" verdict:
-//   "ok"      — non-empty static value, or a non-static expression
-//                (which we conservatively assume is dynamic and OK)
-//   "missing" — no value at all
-//   "empty"   — value is statically empty / falsy
-type LangVerdict = "ok" | "missing" | "empty";
+//   "ok"    — non-empty static value, or a non-static expression
+//             (which we conservatively assume is dynamic and OK)
+//   "empty" — value is statically empty / falsy
+type LangVerdict = "ok" | "empty";
 
 const evaluateLang = (attributeValue: EsTreeNode | null | undefined): LangVerdict => {
   if (!attributeValue) return "ok"; // bare attr <html lang /> — OXC accepts
@@ -81,24 +80,14 @@ export const htmlHasLang = defineRule({
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         const tag = getElementType(node, context.settings);
         if (!tagSet.has(tag)) return;
-        // <html {...props} /> — can't verify lang; flag.
-        const hasSpread = node.attributes.some((attribute) =>
-          isNodeOfType(attribute as EsTreeNode, "JSXSpreadAttribute"),
-        );
         const lang = hasJsxPropIgnoreCase(node.attributes, "lang");
         if (!lang) {
           context.report({ node: node.name, message: MESSAGE });
           return;
         }
         const verdict = evaluateLang(lang.value as EsTreeNode | null | undefined);
-        if (verdict === "missing" || verdict === "empty") {
+        if (verdict === "empty") {
           context.report({ node: lang, message: MESSAGE });
-          return;
-        }
-        // Spread attribute counts as missing only when there's no
-        // valid lang value either.
-        if (hasSpread && !lang) {
-          context.report({ node: node.name, message: MESSAGE });
         }
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/display-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/display-name.ts
@@ -379,7 +379,7 @@ export const displayName = defineRule({
   category: "Architecture",
   create: (context) => {
     const settings = resolveSettings(context.settings);
-    const ignoreNamed = settings.ignoreTranspilerName ? false : true;
+    const ignoreNamed = !settings.ignoreTranspilerName;
 
     const reportAt = (node: EsTreeNode): void => {
       context.report({ node, message: MESSAGE });
@@ -540,8 +540,6 @@ export const displayName = defineRule({
             return;
           }
         }
-        // Suppress unused warning.
-        void isCreateElementCall;
         reportAt(node as EsTreeNode);
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-curly-brace-presence.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-curly-brace-presence.ts
@@ -103,13 +103,6 @@ const isAllowedStringLikeInContainer = (
   containsUtf8Escape(text) ||
   hasAdjacentExpressionContainerSibling(container);
 
-// Helper: extracts the no-substitution template's cooked value if the
-// expression is a single-quasi template literal; else null.
-const singleQuasiTemplateValue = (expression: EsTreeNode): string | null => {
-  if (!isNodeOfType(expression, "TemplateLiteral")) return null;
-  return getStaticTemplateLiteralValue(expression);
-};
-
 const checkExpressionContainer = (
   container: EsTreeNodeOfType<"JSXExpressionContainer">,
   parentIsAttribute: boolean,
@@ -164,8 +157,6 @@ const checkExpressionContainer = (
     if (isAllowedStringLikeInContainer(rawSource, container, parentIsAttribute)) return;
     context.report({ node: container, message: UNNECESSARY_BRACES_MESSAGE });
   }
-  // Suppress unused-name warning for helper used in older code path.
-  void singleQuasiTemplateValue;
 };
 
 const isScriptElement = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">): boolean =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
@@ -336,11 +336,7 @@ export const noUnstableNestedComponents = defineRule({
     const settings = resolveSettings(context.settings);
     const renderPropRegex = compileGlob(settings.propNamePattern);
 
-    const reportCandidate = (
-      candidateNode: EsTreeNode,
-      reportNode: EsTreeNode,
-      candidateName: string | null,
-    ): void => {
+    const reportCandidate = (candidateNode: EsTreeNode, reportNode: EsTreeNode): void => {
       if (isFirstArgumentOfHocCall(candidateNode)) return;
       if (isReturnOfMapCallback(candidateNode)) return;
       const propInfo = isComponentDeclaredInProp(candidateNode);
@@ -351,13 +347,10 @@ export const noUnstableNestedComponents = defineRule({
       }
       const enclosing = findEnclosingComponent(candidateNode);
       if (!enclosing) return;
-      // Skip if outer doesn't actually look like a component (require
-      // its body to contain JSX).
       context.report({
         node: reportNode,
         message: buildMessage(enclosing.name),
       });
-      void candidateName;
     };
 
     const checkFunctionLike = (
@@ -375,7 +368,7 @@ export const noUnstableNestedComponents = defineRule({
         propInfo !== null ||
         isObjectCallbackCandidate(node as EsTreeNode);
       if (!isCandidate) return;
-      reportCandidate(node as EsTreeNode, node as EsTreeNode, inferredName);
+      reportCandidate(node as EsTreeNode, node as EsTreeNode);
     };
 
     return {
@@ -391,18 +384,18 @@ export const noUnstableNestedComponents = defineRule({
         // tldraw, `class Tool extends BaseTool`, etc.) as a nested React
         // component candidate.
         if (!isReactClassComponent(node as EsTreeNode)) return;
-        reportCandidate(node as EsTreeNode, node as EsTreeNode, node.id.name);
+        reportCandidate(node as EsTreeNode, node as EsTreeNode);
       },
       ClassExpression(node: EsTreeNodeOfType<"ClassExpression">) {
         const inferredName = node.id?.name ?? inferFunctionLikeName(node as EsTreeNode);
         if (!inferredName || !isReactComponentName(inferredName)) return;
         if (!isReactClassComponent(node as EsTreeNode)) return;
-        reportCandidate(node as EsTreeNode, node as EsTreeNode, inferredName);
+        reportCandidate(node as EsTreeNode, node as EsTreeNode);
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isHocCallee(node)) return;
         if (!hocCallContainsComponent(node)) return;
-        reportCandidate(node as EsTreeNode, node as EsTreeNode, null);
+        reportCandidate(node as EsTreeNode, node as EsTreeNode);
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isCreateElementCall } from "../../utils/is-create-element-call.js";
+import { isEs6Component } from "../../utils/is-es6-component.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
@@ -92,34 +93,13 @@ const expressionContainsJsxOrCreateElement = (root: EsTreeNode): boolean => {
 // True iff `classNode` extends React.Component / PureComponent (or a
 // bare `Component` / `PureComponent` symbol — matches the import shape
 // most React class components actually use).
-const classExtendsReactComponent = (classNode: EsTreeNode): boolean => {
-  const superClass = (classNode as { superClass?: EsTreeNode | null }).superClass;
-  if (!superClass) return false;
-  if (
-    isNodeOfType(superClass, "Identifier") &&
-    (superClass.name === "Component" || superClass.name === "PureComponent")
-  ) {
-    return true;
-  }
-  if (
-    isNodeOfType(superClass, "MemberExpression") &&
-    isNodeOfType(superClass.object, "Identifier") &&
-    superClass.object.name === "React" &&
-    isNodeOfType(superClass.property, "Identifier") &&
-    (superClass.property.name === "Component" || superClass.property.name === "PureComponent")
-  ) {
-    return true;
-  }
-  return false;
-};
-
 // Returns true when `classNode` is a *React* class — either by
 // explicit `extends React.Component` / `extends Component` lineage, or
 // by containing JSX / `React.createElement(...)` in any method body.
 // Catches both the canonical class-component shape and the rare hybrid
 // case where a class declares JSX in render without `extends`.
 const isReactClassComponent = (classNode: EsTreeNode): boolean => {
-  if (classExtendsReactComponent(classNode)) return true;
+  if (isEs6Component(classNode)) return true;
   return expressionContainsJsxOrCreateElement(classNode);
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -4,6 +4,7 @@ import { normalizeFilename } from "../../utils/normalize-filename.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
+import { isEs6Component } from "../../utils/is-es6-component.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import {
@@ -74,27 +75,6 @@ type ExportType =
   | { kind: "non-component"; reportNode: EsTreeNode }
   | { kind: "allowed" }
   | { kind: "react-context"; reportNode: EsTreeNode };
-
-const classExtendsReactComponent = (classNode: EsTreeNode): boolean => {
-  const superClass = (classNode as { superClass?: EsTreeNode | null }).superClass;
-  if (!superClass) return false;
-  if (
-    isNodeOfType(superClass, "Identifier") &&
-    (superClass.name === "Component" || superClass.name === "PureComponent")
-  ) {
-    return true;
-  }
-  if (
-    isNodeOfType(superClass, "MemberExpression") &&
-    isNodeOfType(superClass.object, "Identifier") &&
-    superClass.object.name === "React" &&
-    isNodeOfType(superClass.property, "Identifier") &&
-    (superClass.property.name === "Component" || superClass.property.name === "PureComponent")
-  ) {
-    return true;
-  }
-  return false;
-};
 
 const isReactCreateContext = (initializer: EsTreeNode | null | undefined): boolean => {
   if (!initializer) return false;
@@ -474,7 +454,7 @@ export const onlyExportComponents = defineRule({
               if ((stripped as EsTreeNodeOfType<"ClassDeclaration">).id) {
                 const idNode = (stripped as EsTreeNodeOfType<"ClassDeclaration">).id!;
                 isExportedNodeIds.add(stripped);
-                if (isReactComponentName(idNode.name) && classExtendsReactComponent(stripped)) {
+                if (isReactComponentName(idNode.name) && isEs6Component(stripped)) {
                   hasReactExport = true;
                 } else {
                   exports.push({ kind: "non-component", reportNode: idNode });
@@ -546,7 +526,7 @@ export const onlyExportComponents = defineRule({
                 isExportedNodeIds.add(declaration);
                 if (
                   isReactComponentName(declaration.id.name) &&
-                  classExtendsReactComponent(declaration as EsTreeNode)
+                  isEs6Component(declaration as EsTreeNode)
                 ) {
                   exports.push({ kind: "react-component" });
                 } else {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -644,10 +644,6 @@ export const onlyExportComponents = defineRule({
             }
           }
         }
-        // Suppress unused warning.
-        void exportContainsName;
-
-        // Report.
         if (hasAnyExports && hasReactExport) {
           for (const entry of exports) {
             if (entry.kind === "non-component") {
@@ -670,36 +666,3 @@ export const onlyExportComponents = defineRule({
     };
   },
 });
-
-// Quick helper: does the program export the given name (declarator
-// inside an export, function declaration with export, or specifier)?
-const exportContainsName = (allNodes: ReadonlyArray<EsTreeNode>, name: string): boolean => {
-  for (const child of allNodes) {
-    if (isNodeOfType(child, "ExportNamedDeclaration")) {
-      const declaration = child.declaration;
-      if (isNodeOfType(declaration, "FunctionDeclaration") && declaration.id?.name === name) {
-        return true;
-      }
-      if (isNodeOfType(declaration, "ClassDeclaration") && declaration.id?.name === name) {
-        return true;
-      }
-      if (isNodeOfType(declaration, "VariableDeclaration")) {
-        for (const declarator of declaration.declarations) {
-          if (isNodeOfType(declarator.id, "Identifier") && declarator.id.name === name) {
-            return true;
-          }
-        }
-      }
-      for (const specifier of child.specifiers ?? []) {
-        if (!isNodeOfType(specifier, "ExportSpecifier")) continue;
-        const local = (specifier as { local?: EsTreeNode }).local;
-        if (local && isNodeOfType(local, "Identifier") && local.name === name) return true;
-      }
-    }
-    if (isNodeOfType(child, "ExportDefaultDeclaration")) {
-      const decl = child.declaration as EsTreeNode;
-      if (isNodeOfType(decl, "Identifier") && decl.name === name) return true;
-    }
-  }
-  return false;
-};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/semantic/control-flow-graph.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/semantic/control-flow-graph.ts
@@ -4,12 +4,8 @@ import { isFunctionLike } from "../utils/is-function-like.js";
 import { isNodeOfType } from "../utils/is-node-of-type.js";
 
 // Per-function CFG. Mirrors the subset of `oxc_cfg` we need to answer:
-//
-//   1. "Is this AST node guaranteed to execute on every call to its
-//      enclosing function?" (isUnconditionalFromEntry — used by
-//      rules-of-hooks)
-//   2. "Does this AST node always run before the function returns?"
-//      (dominatesExit — used by some semantic rules)
+// "Is this AST node guaranteed to execute on every call to its
+// enclosing function?" (isUnconditionalFromEntry — used by rules-of-hooks)
 //
 // Edges have just two kinds: uncond (sequential fall-through) and cond
 // (any conditional branch — true / false / loop / case / etc.). The
@@ -44,7 +40,6 @@ export interface ControlFlowAnalysis {
   readonly cfgFor: (functionLike: EsTreeNode) => FunctionCfg | null;
   readonly enclosingFunction: (node: EsTreeNode) => EsTreeNode | null;
   readonly isUnconditionalFromEntry: (node: EsTreeNode) => boolean;
-  readonly dominatesExit: (node: EsTreeNode) => boolean;
 }
 
 interface CfgBuilder {
@@ -499,52 +494,9 @@ const computeUnconditionalSet = (cfg: FunctionCfg): Set<BasicBlock> => {
   return unconditional;
 };
 
-// Reverse BFS from exit following all edges; record each block whose
-// every successor either reaches exit or is exit itself. Approximation
-// of "dominates exit": a block dominates exit iff every forward path
-// from it reaches exit. We compute the contrapositive: blocks from
-// which a path to a non-exit terminal sink exists are NOT dominators.
-const computeDominatesExit = (cfg: FunctionCfg): Set<BasicBlock> => {
-  // Simple approximation: start from exit, walk backwards. Every block
-  // we reach has at least one path TO exit. For "dominates exit" (every
-  // path reaches it), we'd need a more careful analysis. For our use
-  // cases (rules-of-hooks doesn't need this; exhaustive-deps optionally
-  // uses it for "always runs before return"), we ship a conservative
-  // answer: a block dominates exit iff exit is its only reachable sink.
-  const reachableToExit = new Set<BasicBlock>();
-  const queue: BasicBlock[] = [cfg.exit];
-  while (queue.length > 0) {
-    const block = queue.shift()!;
-    if (reachableToExit.has(block)) continue;
-    reachableToExit.add(block);
-    for (const edge of block.predecessors) queue.push(edge.from);
-  }
-  // Now mark blocks where EVERY successor leads to exit (recursive).
-  const dominatesExit = new Set<BasicBlock>();
-  const visit = (block: BasicBlock): boolean => {
-    if (block === cfg.exit) return true;
-    if (dominatesExit.has(block)) return true;
-    if (block.successors.length === 0) return false;
-    // To avoid infinite recursion in cycles, use a temp marker.
-    dominatesExit.add(block);
-    let allReach = true;
-    for (const edge of block.successors) {
-      if (!visit(edge.to)) {
-        allReach = false;
-        break;
-      }
-    }
-    if (!allReach) dominatesExit.delete(block);
-    return allReach;
-  };
-  for (const block of cfg.blocks) visit(block);
-  return dominatesExit;
-};
-
 interface FunctionCfgEntry {
   cfg: FunctionCfg;
   unconditionalSet: Set<BasicBlock>;
-  dominatesExitSet: Set<BasicBlock>;
 }
 
 // Walks the AST building a CFG for every function-like node + the
@@ -559,7 +511,6 @@ export const analyzeControlFlow = (program: EsTreeNode): ControlFlowAnalysis => 
     functionCfgs.set(functionNode, {
       cfg,
       unconditionalSet: computeUnconditionalSet(cfg),
-      dominatesExitSet: computeDominatesExit(cfg),
     });
   };
 
@@ -616,20 +567,9 @@ export const analyzeControlFlow = (program: EsTreeNode): ControlFlowAnalysis => 
     return entry.unconditionalSet.has(block);
   };
 
-  const dominatesExit = (node: EsTreeNode): boolean => {
-    const owner = enclosingFunction(node);
-    if (!owner) return true;
-    const entry = functionCfgs.get(owner);
-    if (!entry) return true;
-    const block = entry.cfg.blockOf(node);
-    if (!block) return true;
-    return entry.dominatesExitSet.has(block);
-  };
-
   return {
     cfgFor,
     enclosingFunction,
     isUnconditionalFromEntry,
-    dominatesExit,
   };
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-image-render-context.ts
@@ -25,7 +25,7 @@ type GeneratedImageRendererCall =
   | EsTreeNodeOfType<"CallExpression">
   | EsTreeNodeOfType<"NewExpression">;
 
-export const isGeneratedImageRenderFilename = (rawFilename: string | undefined): boolean => {
+const isGeneratedImageRenderFilename = (rawFilename: string | undefined): boolean => {
   if (!rawFilename) return false;
   const filename = normalizeFilename(rawFilename);
   return isNextjsMetadataImageRouteFilename(filename);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/non-react-jsx-dialect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/non-react-jsx-dialect.ts
@@ -11,7 +11,7 @@ import { isNodeOfType } from "./is-node-of-type.js";
 //   1. an import from the dialect's runtime package, OR
 //   2. distinctively-Solid syntax in the file (`classList={...}`,
 //      which only Solid's JSX recognises)
-export const NON_REACT_JSX_DIALECT_PACKAGES: ReadonlySet<string> = new Set([
+const NON_REACT_JSX_DIALECT_PACKAGES: ReadonlySet<string> = new Set([
   "solid-js",
   "solid-js/web",
   "solid-js/store",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-with-semantic-context.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-with-semantic-context.ts
@@ -26,10 +26,10 @@ import type { ControlFlowAnalysis } from "../semantic/control-flow-graph.js";
 // wrapper walks every visited node's parent chain on first invocation
 // (see `captureRootIfNeeded` below) and the analyses are only read from
 // inside visitor bodies that fire AFTER that capture. The stubs satisfy
-// the type system. `isUnconditionalFromEntry` / `dominatesExit` default
-// to `false` (the conservative answer) so that if the capture ever
-// fails, `rules-of-hooks` errs toward flagging a possible violation
-// rather than silently allowing one.
+// the type system. `isUnconditionalFromEntry` defaults to `false` (the
+// conservative answer) so that if the capture ever fails,
+// `rules-of-hooks` errs toward flagging a possible violation rather
+// than silently allowing one.
 const buildFallbackScopes = (): ScopeAnalysis => ({
   rootScope: {
     id: 0,
@@ -52,7 +52,6 @@ const FALLBACK_CFG: ControlFlowAnalysis = {
   cfgFor: () => null,
   enclosingFunction: () => null,
   isUnconditionalFromEntry: () => false,
-  dominatesExit: () => false,
 };
 
 export const wrapWithSemanticContext = (rule: Rule): HostRule => ({

--- a/packages/react-doctor/src/cli/utils/action-upgrade-prompt.ts
+++ b/packages/react-doctor/src/cli/utils/action-upgrade-prompt.ts
@@ -1,11 +1,4 @@
 import { createProjectDecisionStore } from "./project-decision-store.js";
-import type {
-  ProjectDecisionOutcome,
-  ProjectDecisionStoreOptions,
-} from "./project-decision-store.js";
-
-export type ActionUpgradeOutcome = ProjectDecisionOutcome;
-export type ActionUpgradeStoreOptions = ProjectDecisionStoreOptions;
 
 // The `@v1` → `@v2` action-upgrade offer is a one-time, per-repo decision.
 // Either answer suppresses future prompts — an accepted-but-unmerged PR

--- a/packages/react-doctor/src/cli/utils/ci-prompt-decision.ts
+++ b/packages/react-doctor/src/cli/utils/ci-prompt-decision.ts
@@ -1,11 +1,4 @@
 import { createProjectDecisionStore } from "./project-decision-store.js";
-import type {
-  ProjectDecisionOutcome,
-  ProjectDecisionStoreOptions,
-} from "./project-decision-store.js";
-
-export type CiPromptDecisionOutcome = ProjectDecisionOutcome;
-export type CiPromptDecisionStoreOptions = ProjectDecisionStoreOptions;
 
 // The "Add React Doctor to CI?" pitch is a one-time, per-repo decision, shared
 // by `install` onboarding and the post-scan handoff. Either answer suppresses

--- a/packages/react-doctor/src/cli/utils/scan-result-cache.ts
+++ b/packages/react-doctor/src/cli/utils/scan-result-cache.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
@@ -17,6 +16,7 @@ import {
   SCAN_RESULT_CACHE_MAX_ENTRY_COUNT,
   SCAN_RESULT_CACHE_SCHEMA_VERSION,
 } from "./constants.js";
+import { runGit } from "./git-hook-shared.js";
 import type { ResolvedInspectOptions } from "../../inspect.js";
 
 interface StringUnknownRecord {
@@ -116,18 +116,6 @@ const stringifyStableJson = (value: unknown): string | null => {
 };
 
 const hashString = (value: string): string => crypto.createHash("sha1").update(value).digest("hex");
-
-const runGit = (directory: string, args: ReadonlyArray<string>): string | null => {
-  try {
-    return execFileSync("git", [...args], {
-      cwd: directory,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return null;
-  }
-};
 
 const readHeadSha = (projectDirectory: string): string | null =>
   runGit(projectDirectory, ["rev-parse", "HEAD"]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A codebase-wide elegance / simplification pass. The full repo (9 packages, ~1,371 source files, ~152k LOC) was audited for bad architecture, dead code, low-value comments, and over-abstraction, then **behavior-preserving simplifications** were applied with `AGENTS.md` as the bar. Each change is verified by typecheck + lint + the relevant test suite locally, and by the full CI matrix.

## Dead code & dead surface
- Removed the `dominatesExit` control-flow surface (interface field, `computeDominatesExit`, per-entry set, fallback stub) — computed for every function CFG but consumed by no rule or test.
- Removed `exportContainsName` / `singleQuasiTemplateValue` helpers kept alive only by `void` statements, plus `void isCreateElementCall` noise and the unused `candidateName` param in `no-unstable-nested-components`.
- Removed unused `OG_ROUTE_PATTERN`, unused CLI type aliases, the unreachable `hasSpread` branch in `html-has-lang`, and the double-negative in `display-name`.

## De-duplication / reduced abstraction
- `react-builtins`: both `only-export-components` and `no-unstable-nested-components` reuse the existing **`isEs6Component`** util instead of a byte-identical local `classExtendsReactComponent`.
- `a11y`: `click-events-have-key-events` reuses the shared **`isPresentationRole`** util instead of a re-declared role set + inline check.
- `language-server`: extracted the duplicated **`toProjectRelative`** into one util; deleted the pass-through `compute-config-fingerprint.ts` re-export (import straight from `@react-doctor/core`).
- `react-doctor` CLI: `scan-result-cache` reuses the exported **`runGit`** from `git-hook-shared` instead of a private copy.
- `core`: a single **`NodeResolution`** type (shared by the resolver + service) and a shared **`isRecord`** util replacing two identical copies.
- Inlined the pointless `isScopeNode = isScopeBoundary` alias and tightened unnecessary `export`s.

## Discipline notes (deliberately NOT changed)
To keep this strictly behavior-preserving, I skipped audit suggestions that would alter behavior or are subjective:
- `walkAst` rewrites of hand-rolled walks whose per-node traversal differs (e.g. `expressionReadsStateValue` only descends computed member properties).
- Swapping `innerExpression`/local strippers for `stripParenExpression` (the shared util peels extra TS wrappers — a behavior change).
- Mass comment removal in complex rules: the large header blocks document real scope/parity/v2 decisions, so only inline restating-comments were trimmed.
- `isRecord → isPlainObject` (stricter prototype check is a behavior change) and the inverted env-flag parsers.

## Verification
- ✅ `pnpm typecheck`, `pnpm lint` (only pre-existing fixture warnings), `pnpm test` (1796 passed / 17 skipped) — identical to baseline.
- ✅ Full `core` suite (846), `language-server` (60), and targeted rule tests for every touched rule pass.
- ✅ Bugbot: no bugs found.
- ✅ CI matrix (ubuntu/macos/windows, Node 20–26) — the authoritative check for the oxlint-plugin rule tests (whose native-binary fixture cases can't run in the dev sandbox).

## Audit roadmap (follow-ups, larger/riskier)
Unify component/hook-name + JSX-detection helpers across react-builtins; one shared implicit-ARIA-role resolver (fixes a `no-redundant-roles` drift); split god-modules (`server.ts`, `inspect.ts`, `git.ts`, `scope-analysis.ts`); reconcile the `Diagnostic`/`JsonReport` interface-vs-schema duplication; make config caching honor its TTL.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2b9603c-ed23-478a-9590-2d66c70bc7ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2b9603c-ed23-478a-9590-2d66c70bc7ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

