### PR TITLE
docs(agents): add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,7 +437,7 @@ git push --force origin v2   # the force applies to the moving major tag only
   `format:check` / `smoke:json-report`) are documented in the Testing section
   above. To exercise the CLI end-to-end after `pnpm build`, run the bin against
   any React project: `node packages/react-doctor/bin/react-doctor.js <dir>
-  --yes --no-score` (use `--no-score`/`--no-telemetry` to skip the network score
+--yes --no-score` (use `--no-score`/`--no-telemetry` to skip the network score
   API + Sentry; add `--verbose` for the full per-rule list, `--json` for the
   schema report).
 - **Optional website** (`packages/website`, Next.js): start with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,3 +416,30 @@ git push --force origin v2   # the force applies to the moving major tag only
   gitignored)
 - `~/Developer/react-doctor-evals/src/` — sister application this codebase's runtime
   patterns are modeled on (Schemas.ts, Runner.ts, Worker.ts, errors.ts shapes)
+
+## Cursor Cloud specific instructions
+
+- **Node version gotcha (most important).** `pnpm lint` / `pnpm format` /
+  `pnpm format:check` (vite-plus / oxlint) load the TypeScript config
+  `vite.config.ts`, which requires Node `^20.19.0 || >=22.18.0`. The Cloud VM's
+  daemon-pinned `node` on `PATH` (`/exec-daemon/node`) is **v22.14.0**, which
+  satisfies the repo `engines` but is below the lint tool's `>=22.18.0` floor, so
+  lint/format fail with `ERR_UNKNOWN_FILE_EXTENSION` for `.ts` if run with it.
+  The agent's `~/.bashrc` is configured to prefer an nvm-managed Node 22
+  (`>=22.18`) on `PATH`, so a fresh shell already runs the right node — just run
+  the commands normally. If `node --version` ever shows `22.14.0`, run
+  `nvm use 22` (or open a fresh shell) before linting/formatting.
+- **`ni`/`nr` (@antfu/ni) are NOT installed here.** Despite the General Rules
+  above, use `pnpm` / `pnpm run <script>` directly in this environment
+  (e.g. `pnpm dev`, `pnpm test`, `pnpm build`).
+- **The product is a CLI** — there is no app server, database, or external
+  service to run. Standard checks (`pnpm test` / `lint` / `typecheck` /
+  `format:check` / `smoke:json-report`) are documented in the Testing section
+  above. To exercise the CLI end-to-end after `pnpm build`, run the bin against
+  any React project: `node packages/react-doctor/bin/react-doctor.js <dir>
+  --yes --no-score` (use `--no-score`/`--no-telemetry` to skip the network score
+  API + Sentry; add `--verbose` for the full per-rule list, `--json` for the
+  schema report).
+- **Optional website** (`packages/website`, Next.js): start with
+  `pnpm --filter website dev` (serves on `http://localhost:3000`). It is a
+  marketing/docs satellite, not part of the diagnostic product.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cloud Agent development environment for this repo and documents the durable, non-obvious gotchas for future agents in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section.

No product code changed — only `AGENTS.md`.

### Key learnings captured
- **Node version gotcha:** `pnpm lint` / `pnpm format` load `vite.config.ts` (a TS config) which needs Node `>=22.18.0`. The daemon-pinned `/exec-daemon/node` is `v22.14.0` (passes `engines`, fails the lint tool). The agent's `~/.bashrc` now prefers an nvm-managed Node 22 (`>=22.18`) on `PATH` so fresh shells already work.
- `ni`/`nr` (@antfu/ni) are not installed in the Cloud VM — use `pnpm` directly.
- The product is a CLI (no server/DB). End-to-end run: `node packages/react-doctor/bin/react-doctor.js <dir> --yes --no-score`.
- Optional Next.js website: `pnpm --filter website dev` → `http://localhost:3000`.

### Environment verification
- `pnpm install`, `pnpm build` — succeed.
- `pnpm lint`, `pnpm format:check`, `pnpm typecheck` — pass.
- `pnpm test` — 1798 passed / 15 skipped.
- `pnpm smoke:json-report` — OK.
- CLI scanned a sample React project and detected 7 issues (`no-array-index-as-key`, `exhaustive-deps`, `click-events-have-key-events`, …) with a valid `schemaVersion: 1` JSON report.
- Website dev server serves HTTP 200.

### Demo

[react_doctor_cli_and_website_demo.mp4](https://cursor.com/agents/bc-c4ceb70d-aa35-4d9c-b325-6fd78692356c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_doctor_cli_and_website_demo.mp4)

[react-doctor CLI scan output](https://cursor.com/agents/bc-c4ceb70d-aa35-4d9c-b325-6fd78692356c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_scan_output.webp)
[React Doctor website homepage](https://cursor.com/agents/bc-c4ceb70d-aa35-4d9c-b325-6fd78692356c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebsite_homepage.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4ceb70d-aa35-4d9c-b325-6fd78692356c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4ceb70d-aa35-4d9c-b325-6fd78692356c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

