### PR TITLE
docs(agents): add Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,3 +393,21 @@ git push --force origin v1   # the force applies to the moving major tag only
   gitignored)
 - `~/Developer/react-doctor-evals/src/` — sister application this codebase's runtime
   patterns are modeled on (Schemas.ts, Runner.ts, Worker.ts, errors.ts shapes)
+
+## Cursor Cloud specific instructions
+
+Dependencies are installed automatically on VM startup (`pnpm install --frozen-lockfile`).
+Standard commands live in the root `package.json` and the `## Testing` section above.
+
+- **Node version (non-obvious).** The lint/test tooling (`vp` / vite-plus) loads
+  `vite.config.ts`, which requires Node `^20.19.0 || >=22.18.0`. The VM's default
+  `/exec-daemon/node` is `v22.14.0` (too old → `pnpm lint` fails with
+  `ERR_UNKNOWN_FILE_EXTENSION ".ts"`). `~/.bashrc` prepends the nvm `v22.22.2` bin
+  ahead of it, so shells already use the right Node — just run the documented commands.
+- **Build before test.** Turbo enforces `build → test`; `pnpm test` triggers the
+  build automatically, but a standalone package test needs `pnpm build` first.
+- **Scoring needs the network.** The 0–100 score comes from the hosted score API.
+  `--no-score` (and its alias `--no-telemetry`) disables scoring, so JSON/terminal
+  runs with those flags show no score. The scan + diagnostics work fully offline; only
+  the score field requires network access.
+- Run the built CLI directly with `node packages/react-doctor/bin/react-doctor.js <dir>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for `react-doctor` and documents non-obvious startup caveats for future cloud agents. No application/source code is changed — only `AGENTS.md`.

The VM update script installs dependencies on startup:

```
pnpm -C /agent/repos/react-doctor install --frozen-lockfile
pnpm -C /agent/repos/react-doctor-evals install --frozen-lockfile
```

### Environment notes captured in `AGENTS.md`
- **Node version**: `vp` (vite-plus) loads `vite.config.ts`, requiring Node `>=22.18.0`. The VM default `/exec-daemon/node` is `v22.14.0`, so `~/.bashrc` prepends nvm `v22.22.2` ahead of it (lint otherwise fails with `ERR_UNKNOWN_FILE_EXTENSION ".ts"`).
- **Scoring needs network**: the 0–100 score comes from the hosted score API; `--no-score`/`--no-telemetry` disable it. Scan + diagnostics work fully offline.

### Verification (Node 22.22.2)
- `pnpm install --frozen-lockfile`
- `pnpm build` (8 packages)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 1798 passed, 15 skipped
- `pnpm smoke:json-report` — schema OK
- Ran the built CLI against a sample React project (9 diagnostics; score 60 "Needs work" with network).

[react_doctor_cli_scan.log](https://cursor.com/agents/bc-94f913bd-8c09-4113-a113-6c2e9a505d3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_doctor_cli_scan.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94f913bd-8c09-4113-a113-6c2e9a505d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94f913bd-8c09-4113-a113-6c2e9a505d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

