### PR TITLE
fix(cli): show the source code frame in `why <file>:<line>`

### DIFF
--- a/.changeset/fix-why-show-code-frame.md
+++ b/.changeset/fix-why-show-code-frame.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+Show a syntax-highlighted source snippet in `react-doctor why <file>:<line>`.
+
+The `buildCodeFrame` util already powers the source frames in the scan summary, but the `why` command (the single-location explain path) never called it — so explaining a diagnostic printed the rule, category, help, and suppression hint with no view of the offending code. It now renders the same code frame directly under the headline, with the caret on the offending column (or the whole line span for a multi-site diagnostic). When the file can't be read or the line is minified, it falls back to the existing text-only output.

--- a/packages/react-doctor/src/cli/utils/run-explain.ts
+++ b/packages/react-doctor/src/cli/utils/run-explain.ts
@@ -2,8 +2,10 @@ import { highlighter, toRelativePath } from "@react-doctor/core";
 import { cliLogger as logger } from "./cli-logger.js";
 import { inspect } from "../../inspect.js";
 import type { Diagnostic, InspectOptions, ReactDoctorConfig } from "@react-doctor/core";
+import { buildCodeFrame } from "./build-code-frame.js";
 import { buildDiagnosticIssueUrl } from "./build-diagnostic-issue-url.js";
 import { findOwningProjectDirectory } from "./find-owning-project.js";
+import { indentMultilineText } from "./indent-multiline-text.js";
 import { parseFileLineArgument } from "./parse-file-line-argument.js";
 import { selectProjects } from "./select-projects.js";
 
@@ -72,6 +74,14 @@ export const runExplain = async (
     logger.log(
       `${severitySymbol} ${colorizedRule} ${highlighter.dim(`(${severityLabel})`)} — ${diagnostic.message}`,
     );
+    const codeFrame = buildCodeFrame({
+      filePath: diagnostic.filePath,
+      line: diagnostic.line,
+      column: diagnostic.column,
+      endLine: diagnostic.endLine,
+      rootDirectory: targetDirectory,
+    });
+    if (codeFrame) logger.log(indentMultilineText(codeFrame, "  "));
     if (diagnostic.category) logger.dim(`  Category: ${diagnostic.category}`);
     if (diagnostic.help) logger.dim(`  ${diagnostic.help}`);
     logger.dim(

--- a/packages/react-doctor/tests/run-explain.test.ts
+++ b/packages/react-doctor/tests/run-explain.test.ts
@@ -1,0 +1,94 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vite-plus/test";
+import { inspect } from "../src/inspect.js";
+import { runExplain } from "../src/cli/utils/run-explain.js";
+import { setupReactProject } from "./regressions/_helpers.js";
+
+vi.mock("ora", () => ({
+  default: () => ({
+    text: "",
+    start: function () {
+      return this;
+    },
+    stop: function () {
+      return this;
+    },
+    succeed: () => {},
+    fail: () => {},
+  }),
+}));
+
+// The babel code frame is syntax-highlighted, so strip its SGR color
+// escapes (ESC [ ... m) before asserting on the plain structural layout.
+const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+const stripAnsi = (text: string): string => text.replace(ANSI_ESCAPE_PATTERN, "");
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-run-explain-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("runExplain", () => {
+  // Regression: `buildCodeFrame` was wired into the scan summary but never
+  // into the single-location `why` path, so explaining a diagnostic showed
+  // the rule + help but not the offending source. Prove the frame renders.
+  it("renders a source code frame for the explained diagnostic", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "with-issue", {
+      files: {
+        "src/item-list.tsx": [
+          "export const ItemList = ({ items }: { items: string[] }) => (",
+          "  <ul>",
+          "    {items.map((item, index) => (",
+          "      <li key={index}>{item}</li>",
+          "    ))}",
+          "  </ul>",
+          ");",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    const scanResult = await inspect(projectDirectory, {
+      lint: true,
+      deadCode: false,
+      silent: true,
+      noScore: true,
+    });
+    expect(scanResult.diagnostics.length).toBeGreaterThan(0);
+
+    const target = scanResult.diagnostics[0]!;
+    const relativeFilePath = path.relative(
+      projectDirectory,
+      path.resolve(projectDirectory, target.filePath),
+    );
+    const sourceLines = fs
+      .readFileSync(path.join(projectDirectory, relativeFilePath), "utf8")
+      .split("\n");
+    const offendingLine = sourceLines[target.line - 1] ?? "";
+
+    const loggedLines: string[] = [];
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      loggedLines.push(args.join(" "));
+    });
+    try {
+      await runExplain(`${relativeFilePath}:${target.line}`, {
+        resolvedDirectory: projectDirectory,
+        userConfig: null,
+        scanOptions: { lint: true, deadCode: false },
+        projectFlag: undefined,
+      });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+
+    const output = stripAnsi(loggedLines.join("\n"));
+    // The headline (existing behavior) plus the babel code frame (the fix):
+    // the `>` gutter marks the offending line and its source text is shown.
+    expect(output).toContain(`${target.plugin}/${target.rule}`);
+    expect(output).toContain(`> ${target.line} |`);
+    expect(output).toContain(offendingLine.trim());
+  });
+});


### PR DESCRIPTION
## Why

`buildCodeFrame` already powers the source frames in the scan summary, but the single-location explain path (`react-doctor why <file>:<line>`) never called it — so explaining a diagnostic printed the rule, category, help, and suppression hint with **no view of the offending code**. This wires the existing util into that path (the quick win Greptile flagged).

Before:

```
⚠ react-doctor/no-array-index-key (warn) — Avoid using the array index as a key.
  Category: Correctness
  Use a stable, unique id from the item (e.g. user.id) so React can match elements across renders.
  If this needs follow-up or looks like a false positive, open: <github-issue-url>
  No nearby react-doctor-disable-next-line comment was detected — add one immediately above this line to suppress.
```

After:

```
⚠ react-doctor/no-array-index-key (warn) — Avoid using the array index as a key.
    7 |       {users.map((user, index) => (
  > 8 |         <li key={index}>{user.name}</li>
      |               ^
    9 |       ))}
  Category: Correctness
  Use a stable, unique id from the item (e.g. user.id) so React can match elements across renders.
  If this needs follow-up or looks like a false positive, open: <github-issue-url>
  No nearby react-doctor-disable-next-line comment was detected — add one immediately above this line to suppress.
```

The only delta is the frame inserted under the headline: one line of context above/below, the `>` gutter on the offending line, and the `^` caret at the column (or the whole line span for a multi-site diagnostic). In a real terminal the snippet is syntax-highlighted.

## What changed

- `run-explain.ts`: build the code frame from the diagnostic's `filePath`/`line`/`column`/`endLine` (root = the scanned project dir) and log it indented under the headline. Reuses `buildCodeFrame` + `indentMultilineText` — no new helpers.
- Guarded with `if (codeFrame)` so the existing text-only output is the graceful fallback when the file can't be read or the line is minified (`buildCodeFrame` returns `null`).
- New `tests/run-explain.test.ts`: scans a fixture with a real diagnostic, runs `runExplain`, asserts the babel gutter (`> N |`) and the offending source line appear — fails without the wire-up, so it locks the fix in.
- Changeset: `react-doctor` patch.

## Test plan

- `pnpm --filter react-doctor exec vp test run tests/run-explain.test.ts tests/build-code-frame.test.ts` — 5/5 pass
- `pnpm typecheck` — 11/11
- `pnpm lint` / `pnpm format:check` — clean on changed files
- Note: the full monorepo suite has ~44 pre-existing failures in unrelated packages (`oxlint-plugin` rule fixtures, `core` security/expo, `api` diagnose). Verified independent of this branch — they reproduce identically on a clean `origin/main` tree with these changes stashed (rule engine emitting 0 diagnostics; looks like an oxlint-runtime/environment issue, orthogonal to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only explain output reuses an existing util with a null fallback; no auth, data, or scan logic changes.
> 
> **Overview**
> **`react-doctor why <file>:<line>`** now prints the same syntax-highlighted source snippet as the scan summary, directly under each diagnostic headline.
> 
> `run-explain.ts` calls the existing **`buildCodeFrame`** helper (with **`indentMultilineText`**) using the diagnostic’s path, line, column, and optional **`endLine`**, scoped to the scanned project directory. If framing fails (unreadable file, minified line, etc.), output stays text-only because the frame is only logged when **`buildCodeFrame`** returns a string.
> 
> A regression test in **`run-explain.test.ts`** asserts the gutter and offending source line appear in explain output. Changeset: **`react-doctor`** patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ecf4652195c8e34e395ce49ae36c34a38034bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->