### PR TITLE
fix: bare-name disable handling + server-fetch mutating-method false positive

### DIFF
--- a/.changeset/fix-server-fetch-without-revalidate-mutating-methods.md
+++ b/.changeset/fix-server-fetch-without-revalidate-mutating-methods.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `server-fetch-without-revalidate` false positive on mutating fetches. Next.js only caches GET requests, so a `fetch(url, { method: "POST" | "PUT" | "PATCH" | "DELETE" })` in a Server Component or route handler can never serve stale cached data — the rule no longer flags it.

--- a/.changeset/improve-bare-rule-name-disable-handling.md
+++ b/.changeset/improve-bare-rule-name-disable-handling.md
@@ -1,0 +1,8 @@
+---
+"react-doctor": patch
+---
+
+Improve disable-directive handling for react-doctor rules:
+
+- `// react-doctor-disable-line` / `-next-line` (and `ignore.rules` / rule lookups) now accept a rule's bare short id, e.g. `no-eval` for `react-doctor/no-eval` — the unqualified form people reach for first.
+- When an `eslint-disable` / `oxlint-disable` directive names a react-doctor rule by an id oxlint can't bind to a plugin rule — a bare short id (`no-eval`) or a legacy plugin prefix (`react/jsx-key`), whether inline or as a file-level block disable — the diagnostic now carries a hint to use the full `react-doctor/<id>` key.

--- a/packages/core/src/detect-foreign-disable-near-miss.ts
+++ b/packages/core/src/detect-foreign-disable-near-miss.ts
@@ -52,7 +52,11 @@ const detectInlineNearMiss = (
     if (!match) continue;
     const [, tool, scope, ruleList] = match;
     if (scope !== requiredScope) continue;
-    for (const token of tokenizeRuleList(ruleList)) {
+    const tokens = tokenizeRuleList(ruleList);
+    // The canonical key alongside a misnamed alias means oxlint already
+    // suppressed the rule — don't tell the user to add what's there.
+    if (tokens.includes(ruleId)) continue;
+    for (const token of tokens) {
       if (tokenMisnamesRule(token, ruleId)) return buildHint(tool, token, ruleId);
     }
   }
@@ -74,10 +78,15 @@ const detectBlockNearMiss = (
     const disableMatch = line.match(FOREIGN_BLOCK_DISABLE_PATTERN);
     if (disableMatch) {
       const [, tool, ruleList] = disableMatch;
-      for (const token of tokenizeRuleList(ruleList)) {
-        if (token === ruleId)
-          openMisname = null; // canonical → properly disabled
-        else if (tokenMisnamesRule(token, ruleId)) openMisname = { tool, token };
+      const tokens = tokenizeRuleList(ruleList);
+      // The canonical key (if listed) means oxlint already suppressed the
+      // rule for this range; otherwise a misnamed token opens a near-miss.
+      // A disable for unrelated rules leaves any open range untouched.
+      if (tokens.includes(ruleId)) {
+        openMisname = null;
+      } else {
+        const misnamed = tokens.find((token) => tokenMisnamesRule(token, ruleId));
+        if (misnamed) openMisname = { tool, token: misnamed };
       }
       continue;
     }

--- a/packages/core/src/detect-foreign-disable-near-miss.ts
+++ b/packages/core/src/detect-foreign-disable-near-miss.ts
@@ -10,19 +10,22 @@ import { tokenizeRuleList } from "./tokenize-rule-list.js";
 // can't change that matching, but when such a directive covers a *firing*
 // react-doctor diagnostic we can tell the user to qualify it.
 
+// Each pattern ends in a single greedy capture of the rest of the line
+// (no trailing `$`-anchored whitespace groups) so there is no ambiguous
+// backtracking on space-heavy input — `tokenizeRuleList` trims the leading
+// whitespace, the ` -- description` tail, and any closing `*/` token. The
+// `(?![\w-])` boundary keeps `eslint-disable-foo` and the `-line` /
+// `-next-line` inline forms from matching the block directives.
+
 // Inline directive, adjacent to the offending line. Captures: 1) the tool
-// (`eslint` | `oxlint`), 2) the scope (`next-line` | `line`), 3) the
-// trailing rule list (may carry a ` -- description` tail).
+// (`eslint` | `oxlint`), 2) the scope (`next-line` | `line`), 3) the rule list.
 const FOREIGN_INLINE_DISABLE_PATTERN =
-  /(?:\/\/|\/\*)\s*(eslint|oxlint)-disable-(next-line|line)\b(?:\s+([^\r\n]*?))?\s*(?:\*\/)?\s*\}?\s*$/;
+  /(?:\/\/|\/\*)[ \t]*(eslint|oxlint)-disable-(next-line|line)(?![\w-])([^\r\n]*)/;
 
 // Block (range) directives: `/* eslint-disable rule */` opens a range that
-// holds until a matching `/* eslint-enable rule */` (or end of file). The
-// negative lookahead keeps the `-line` / `-next-line` inline forms out of
-// the block matcher.
-const FOREIGN_BLOCK_DISABLE_PATTERN =
-  /\/\*\s*(eslint|oxlint)-disable(?!-(?:next-)?line)\b(?:\s+([^\r\n]*?))?\s*\*\//;
-const FOREIGN_BLOCK_ENABLE_PATTERN = /\/\*\s*(?:eslint|oxlint)-enable\b(?:\s+([^\r\n]*?))?\s*\*\//;
+// holds until a matching `/* eslint-enable rule */` (or end of file).
+const FOREIGN_BLOCK_DISABLE_PATTERN = /\/\*[ \t]*(eslint|oxlint)-disable(?![\w-])([^*\r\n]*)/;
+const FOREIGN_BLOCK_ENABLE_PATTERN = /\/\*[ \t]*(?:eslint|oxlint)-enable(?![\w-])([^*\r\n]*)/;
 
 const buildHint = (tool: string, token: string, ruleId: string): string =>
   `oxlint matches plugin rules only by their full name, so \`${token}\` in your ${tool}-disable comment does not silence \`${ruleId}\` — change it to \`${ruleId}\`.`;

--- a/packages/core/src/detect-foreign-disable-near-miss.ts
+++ b/packages/core/src/detect-foreign-disable-near-miss.ts
@@ -1,0 +1,104 @@
+import { isSameRuleKey, REACT_DOCTOR_RULE_KEY_PREFIX } from "./rule-key-aliases.js";
+import { tokenizeRuleList } from "./tokenize-rule-list.js";
+
+// `eslint-disable-*` / `oxlint-disable-*` are the "foreign" disable
+// directives oxlint applies natively (react-doctor's own
+// `react-doctor-disable-*` family is handled in evaluate-suppression).
+// oxlint only matches a JS-plugin rule when the directive names it by its
+// full `react-doctor/<id>` key — a bare short id (`no-eval`) or a legacy
+// plugin-prefixed alias (`react/jsx-key`) silently fails to suppress. We
+// can't change that matching, but when such a directive covers a *firing*
+// react-doctor diagnostic we can tell the user to qualify it.
+
+// Inline directive, adjacent to the offending line. Captures: 1) the tool
+// (`eslint` | `oxlint`), 2) the scope (`next-line` | `line`), 3) the
+// trailing rule list (may carry a ` -- description` tail).
+const FOREIGN_INLINE_DISABLE_PATTERN =
+  /(?:\/\/|\/\*)\s*(eslint|oxlint)-disable-(next-line|line)\b(?:\s+([^\r\n]*?))?\s*(?:\*\/)?\s*\}?\s*$/;
+
+// Block (range) directives: `/* eslint-disable rule */` opens a range that
+// holds until a matching `/* eslint-enable rule */` (or end of file). The
+// negative lookahead keeps the `-line` / `-next-line` inline forms out of
+// the block matcher.
+const FOREIGN_BLOCK_DISABLE_PATTERN =
+  /\/\*\s*(eslint|oxlint)-disable(?!-(?:next-)?line)\b(?:\s+([^\r\n]*?))?\s*\*\//;
+const FOREIGN_BLOCK_ENABLE_PATTERN = /\/\*\s*(?:eslint|oxlint)-enable\b(?:\s+([^\r\n]*?))?\s*\*\//;
+
+const buildHint = (tool: string, token: string, ruleId: string): string =>
+  `oxlint matches plugin rules only by their full name, so \`${token}\` in your ${tool}-disable comment does not silence \`${ruleId}\` — change it to \`${ruleId}\`.`;
+
+// A token names this rule but in a form oxlint can't bind to the plugin
+// rule: a bare short id (`no-eval`) or a legacy plugin-prefixed alias
+// (`react/jsx-key`). The canonical `react-doctor/<id>` is excluded —
+// oxlint would have honored it, so the diagnostic wouldn't be firing.
+const tokenMisnamesRule = (token: string, ruleId: string): boolean =>
+  token !== ruleId && isSameRuleKey(token, ruleId);
+
+const detectInlineNearMiss = (
+  lines: string[],
+  diagnosticLineIndex: number,
+  ruleId: string,
+): string | null => {
+  const candidates = [
+    { line: lines[diagnosticLineIndex], requiredScope: "line" },
+    { line: lines[diagnosticLineIndex - 1], requiredScope: "next-line" },
+  ];
+
+  for (const { line, requiredScope } of candidates) {
+    const match = line?.match(FOREIGN_INLINE_DISABLE_PATTERN);
+    if (!match) continue;
+    const [, tool, scope, ruleList] = match;
+    if (scope !== requiredScope) continue;
+    for (const token of tokenizeRuleList(ruleList)) {
+      if (tokenMisnamesRule(token, ruleId)) return buildHint(tool, token, ruleId);
+    }
+  }
+  return null;
+};
+
+const detectBlockNearMiss = (
+  lines: string[],
+  diagnosticLineIndex: number,
+  ruleId: string,
+): string | null => {
+  let openMisname: { tool: string; token: string } | null = null;
+  const lastLineIndex = Math.min(diagnosticLineIndex, lines.length - 1);
+
+  for (let lineIndex = 0; lineIndex <= lastLineIndex; lineIndex++) {
+    const line = lines[lineIndex];
+    if (line === undefined || (!line.includes("-disable") && !line.includes("-enable"))) continue;
+
+    const disableMatch = line.match(FOREIGN_BLOCK_DISABLE_PATTERN);
+    if (disableMatch) {
+      const [, tool, ruleList] = disableMatch;
+      for (const token of tokenizeRuleList(ruleList)) {
+        if (token === ruleId)
+          openMisname = null; // canonical → properly disabled
+        else if (tokenMisnamesRule(token, ruleId)) openMisname = { tool, token };
+      }
+      continue;
+    }
+
+    const enableMatch = line.match(FOREIGN_BLOCK_ENABLE_PATTERN);
+    if (enableMatch) {
+      const enabledRules = tokenizeRuleList(enableMatch[1]);
+      // A bare `eslint-enable` (no rules) re-enables everything.
+      if (enabledRules.length === 0 || enabledRules.some((rule) => isSameRuleKey(rule, ruleId))) {
+        openMisname = null;
+      }
+    }
+  }
+  return openMisname ? buildHint(openMisname.tool, openMisname.token, ruleId) : null;
+};
+
+export const detectForeignDisableNearMiss = (
+  lines: string[],
+  diagnosticLineIndex: number,
+  ruleId: string,
+): string | null => {
+  if (!ruleId.startsWith(REACT_DOCTOR_RULE_KEY_PREFIX)) return null;
+  return (
+    detectInlineNearMiss(lines, diagnosticLineIndex, ruleId) ??
+    detectBlockNearMiss(lines, diagnosticLineIndex, ruleId)
+  );
+};

--- a/packages/core/src/evaluate-suppression.ts
+++ b/packages/core/src/evaluate-suppression.ts
@@ -1,3 +1,4 @@
+import { detectForeignDisableNearMiss } from "./detect-foreign-disable-near-miss.js";
 import { findEnclosingMultilineJsxOpenerStart } from "./find-enclosing-jsx-opener.js";
 import {
   findStackedDisableCommentsAbove,
@@ -96,10 +97,8 @@ export const evaluateSuppression = (
     return { isSuppressed: true, nearMissHint: null };
   }
 
-  const nearMissHint = classifyFromComments(
-    [directComments, openerComments],
-    diagnosticLineIndex,
-    ruleId,
-  );
+  const nearMissHint =
+    classifyFromComments([directComments, openerComments], diagnosticLineIndex, ruleId) ??
+    detectForeignDisableNearMiss(lines, diagnosticLineIndex, ruleId);
   return { isSuppressed: false, nearMissHint };
 };

--- a/packages/core/src/is-rule-listed-in-comment.ts
+++ b/packages/core/src/is-rule-listed-in-comment.ts
@@ -1,20 +1,9 @@
 import { isSameRuleKey } from "./rule-key-aliases.js";
-
-// HACK: ESLint convention — text after ` -- ` on a disable comment is a
-// human-readable description, not part of the rule list. Strip it
-// before tokenizing so trailing prose like `-- read in render via
-// useDebounce; user can type before commit` doesn't pollute the
-// rule-equality check or get matched against `ruleId`.
-const stripDescriptionTail = (ruleList: string): string => {
-  const descriptionMatch = ruleList.match(/(?:^|\s)--\s/);
-  if (!descriptionMatch || descriptionMatch.index === undefined) return ruleList;
-  return ruleList.slice(0, descriptionMatch.index);
-};
+import { tokenizeRuleList } from "./tokenize-rule-list.js";
 
 export const isRuleListedInComment = (ruleList: string | undefined, ruleId: string): boolean => {
-  const trimmed = ruleList?.trim();
-  if (!trimmed) return true;
-  const ruleSection = stripDescriptionTail(trimmed).trim();
-  if (!ruleSection) return true;
-  return ruleSection.split(/[,\s]+/).some((token) => isSameRuleKey(token.trim(), ruleId));
+  const tokens = tokenizeRuleList(ruleList);
+  // An absent / description-only rule list disables every rule.
+  if (tokens.length === 0) return true;
+  return tokens.some((token) => isSameRuleKey(token, ruleId));
 };

--- a/packages/core/src/rule-key-aliases.ts
+++ b/packages/core/src/rule-key-aliases.ts
@@ -146,11 +146,29 @@ for (const [legacyRuleKey, nativeRuleKey] of Object.entries(LEGACY_RULE_KEY_TO_N
 const getLegacyRuleKeysForNative = (ruleKey: string): ReadonlyArray<string> =>
   NATIVE_RULE_KEY_TO_LEGACY_RULE_KEYS.get(ruleKey) ?? [];
 
+export const REACT_DOCTOR_RULE_KEY_PREFIX = "react-doctor/";
+
 const canonicalizeRuleKey = (ruleKey: string): string =>
   LEGACY_RULE_KEY_TO_NATIVE_RULE_KEY[ruleKey] ?? ruleKey;
 
-export const isSameRuleKey = (candidateRuleKey: string, targetRuleKey: string): boolean =>
-  canonicalizeRuleKey(candidateRuleKey) === canonicalizeRuleKey(targetRuleKey);
+// A bare short id (`no-eval`) refers to the react-doctor rule of that id:
+// react-doctor reports it as `react-doctor/no-eval`, the only rule by that
+// name it owns. This lets users disable / ignore / look up a rule by its
+// short id — the unqualified form people reach for first — without an
+// explicit alias entry per rule.
+const isReactDoctorShortIdOf = (bareRuleKey: string, qualifiedRuleKey: string): boolean =>
+  !bareRuleKey.includes("/") &&
+  qualifiedRuleKey === `${REACT_DOCTOR_RULE_KEY_PREFIX}${bareRuleKey}`;
+
+export const isSameRuleKey = (candidateRuleKey: string, targetRuleKey: string): boolean => {
+  const canonicalCandidate = canonicalizeRuleKey(candidateRuleKey);
+  const canonicalTarget = canonicalizeRuleKey(targetRuleKey);
+  if (canonicalCandidate === canonicalTarget) return true;
+  return (
+    isReactDoctorShortIdOf(canonicalCandidate, canonicalTarget) ||
+    isReactDoctorShortIdOf(canonicalTarget, canonicalCandidate)
+  );
+};
 
 export const getEquivalentRuleKeys = (ruleKey: string): ReadonlyArray<string> => {
   const nativeRuleKey = canonicalizeRuleKey(ruleKey);

--- a/packages/core/src/tokenize-rule-list.ts
+++ b/packages/core/src/tokenize-rule-list.ts
@@ -1,0 +1,24 @@
+// HACK: ESLint convention — text after ` -- ` on a disable comment is a
+// human-readable description, not part of the rule list. Strip it before
+// tokenizing so trailing prose like `-- read in render via useDebounce;
+// user can type before commit` doesn't pollute rule matching (#159).
+const stripDescriptionTail = (ruleList: string): string => {
+  const descriptionMatch = ruleList.match(/(?:^|\s)--\s/);
+  if (!descriptionMatch || descriptionMatch.index === undefined) return ruleList;
+  return ruleList.slice(0, descriptionMatch.index);
+};
+
+// Splits the rule-id section of a `*-disable*` comment into individual
+// rule-key tokens, dropping the optional ` -- description` tail. Returns
+// an empty array for an absent / whitespace-only / description-only list
+// (which callers treat as "applies to every rule").
+export const tokenizeRuleList = (ruleList: string | undefined): string[] => {
+  const trimmed = ruleList?.trim();
+  if (!trimmed) return [];
+  const ruleSection = stripDescriptionTail(trimmed).trim();
+  if (!ruleSection) return [];
+  return ruleSection
+    .split(/[,\s]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+};

--- a/packages/core/tests/evaluate-suppression.test.ts
+++ b/packages/core/tests/evaluate-suppression.test.ts
@@ -203,3 +203,25 @@ describe("evaluateSuppression — react-doctor-disable with a bare short id now 
     });
   });
 });
+
+describe("evaluateSuppression — foreign disable matching is whitespace-robust", () => {
+  it("hints despite heavy whitespace around an inline directive", () => {
+    const lines = linesOf(`//      eslint-disable-next-line     no-eval\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toContain("react-doctor/no-eval");
+  });
+
+  it("hints despite heavy whitespace inside a block directive", () => {
+    const lines = linesOf(`/*    eslint-disable    no-eval    */\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toContain("react-doctor/no-eval");
+  });
+
+  it("does not treat `disable-next-lineX` as a next-line directive", () => {
+    const lines = linesOf(`// eslint-disable-next-lineX no-eval\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("does not treat `eslint-disabled` as a block disable", () => {
+    const lines = linesOf(`/* eslint-disabled no-eval */\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
+  });
+});

--- a/packages/core/tests/evaluate-suppression.test.ts
+++ b/packages/core/tests/evaluate-suppression.test.ts
@@ -80,3 +80,126 @@ describe("evaluateSuppression near-miss hints", () => {
     expect(result).toEqual({ isSuppressed: true, nearMissHint: null });
   });
 });
+
+describe("evaluateSuppression — foreign (eslint/oxlint) disable near-miss hints", () => {
+  it("hints when a bare short id is used in an adjacent eslint-disable-next-line", () => {
+    const lines = linesOf(`// eslint-disable-next-line no-eval\neval(code);\n`);
+    const hint = nearMissHintFor(lines, 1, "react-doctor/no-eval");
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("react-doctor/no-eval");
+    expect(hint).toContain("eslint-disable");
+  });
+
+  it("hints for oxlint-disable and names the right tool", () => {
+    const lines = linesOf(`// oxlint-disable-next-line no-eval\neval(code);\n`);
+    const hint = nearMissHintFor(lines, 1, "react-doctor/no-eval");
+    expect(hint).toContain("oxlint-disable");
+  });
+
+  it("hints for a same-line eslint-disable-line directive", () => {
+    const lines = linesOf(`eval(code); // eslint-disable-line no-eval\n`);
+    const hint = nearMissHintFor(lines, 0, "react-doctor/no-eval");
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("react-doctor/no-eval");
+  });
+
+  it("hints when a legacy plugin-prefixed alias is used", () => {
+    const lines = linesOf(`// eslint-disable-next-line react/jsx-key\n<li />;\n`);
+    const hint = nearMissHintFor(lines, 1, "react-doctor/jsx-key");
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("react/jsx-key");
+    expect(hint).toContain("react-doctor/jsx-key");
+  });
+
+  it("ignores the description tail when matching the rule list", () => {
+    const lines = linesOf(`// eslint-disable-next-line no-eval -- legacy code path\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).not.toBeNull();
+  });
+
+  it("returns null when the canonical react-doctor/<id> name is used", () => {
+    const lines = linesOf(`// eslint-disable-next-line react-doctor/no-eval\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("returns null when the directive lists an unrelated rule", () => {
+    const lines = linesOf(`// eslint-disable-next-line no-console\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("returns null for a non-adjacent directive (placement, not naming)", () => {
+    const lines = linesOf(
+      `// eslint-disable-next-line no-eval\nconst intervening = 1;\neval(code);\n`,
+    );
+    expect(nearMissHintFor(lines, 2, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("returns null for non-react-doctor rules (the fix names a react-doctor key)", () => {
+    const lines = linesOf(`// eslint-disable-next-line foo\nbar();\n`);
+    expect(nearMissHintFor(lines, 1, "my-plugin/foo")).toBeNull();
+  });
+});
+
+describe("evaluateSuppression — foreign block (range) disable near-miss hints", () => {
+  it("hints for a file-level block disable that names the rule by its short id", () => {
+    const lines = linesOf(`/* eslint-disable no-eval */\nconst a = 1;\neval(code);\n`);
+    const hint = nearMissHintFor(lines, 2, "react-doctor/no-eval");
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("react-doctor/no-eval");
+  });
+
+  it("names the right tool for an oxlint block disable", () => {
+    const lines = linesOf(`/* oxlint-disable no-eval */\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toContain("oxlint-disable");
+  });
+
+  it("hints for a legacy plugin-prefixed name in a block disable", () => {
+    const lines = linesOf(`/* eslint-disable react/jsx-key */\n<li />;\n`);
+    const hint = nearMissHintFor(lines, 1, "react-doctor/jsx-key");
+    expect(hint).toContain("react-doctor/jsx-key");
+  });
+
+  it("returns null once a matching eslint-enable closes the range", () => {
+    const lines = linesOf(
+      `/* eslint-disable no-eval */\nconst a = 1;\n/* eslint-enable no-eval */\neval(code);\n`,
+    );
+    expect(nearMissHintFor(lines, 3, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("returns null when a bare eslint-enable re-enables everything", () => {
+    const lines = linesOf(`/* eslint-disable no-eval */\n/* eslint-enable */\neval(code);\n`);
+    expect(nearMissHintFor(lines, 2, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("returns null when the block disable sits below the diagnostic", () => {
+    const lines = linesOf(`eval(code);\n/* eslint-disable no-eval */\n`);
+    expect(nearMissHintFor(lines, 0, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("returns null for a rule-less disable-all block (no rule name to qualify)", () => {
+    const lines = linesOf(`/* eslint-disable */\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("returns null when the block disable uses the canonical name", () => {
+    const lines = linesOf(`/* eslint-disable react-doctor/no-eval */\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
+  });
+});
+
+describe("evaluateSuppression — react-doctor-disable with a bare short id now suppresses", () => {
+  it("suppresses via a bare short id on react-doctor-disable-next-line", () => {
+    const lines = linesOf(`// react-doctor-disable-next-line no-eval\neval(code);\n`);
+    expect(evaluateSuppression(lines, 1, "react-doctor/no-eval")).toEqual({
+      isSuppressed: true,
+      nearMissHint: null,
+    });
+  });
+
+  it("suppresses via a bare short id on a same-line react-doctor-disable-line", () => {
+    const lines = linesOf(`eval(code); // react-doctor-disable-line no-eval\n`);
+    expect(evaluateSuppression(lines, 0, "react-doctor/no-eval")).toEqual({
+      isSuppressed: true,
+      nearMissHint: null,
+    });
+  });
+});

--- a/packages/core/tests/evaluate-suppression.test.ts
+++ b/packages/core/tests/evaluate-suppression.test.ts
@@ -126,6 +126,13 @@ describe("evaluateSuppression — foreign (eslint/oxlint) disable near-miss hint
     expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
   });
 
+  it("returns null when the directive already lists the canonical key alongside a bare alias", () => {
+    const lines = linesOf(
+      `// eslint-disable-next-line react-doctor/no-eval, no-eval\neval(code);\n`,
+    );
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
+  });
+
   it("returns null for a non-adjacent directive (placement, not naming)", () => {
     const lines = linesOf(
       `// eslint-disable-next-line no-eval\nconst intervening = 1;\neval(code);\n`,
@@ -182,6 +189,11 @@ describe("evaluateSuppression — foreign block (range) disable near-miss hints"
 
   it("returns null when the block disable uses the canonical name", () => {
     const lines = linesOf(`/* eslint-disable react-doctor/no-eval */\neval(code);\n`);
+    expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
+  });
+
+  it("returns null when a block disable lists the bare alias before the canonical key", () => {
+    const lines = linesOf(`/* eslint-disable no-eval, react-doctor/no-eval */\neval(code);\n`);
     expect(nearMissHintFor(lines, 1, "react-doctor/no-eval")).toBeNull();
   });
 });

--- a/packages/core/tests/foreign-disable-pipeline.test.ts
+++ b/packages/core/tests/foreign-disable-pipeline.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildDiagnosticPipeline } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
+
+const noEvalDiagnostic: Diagnostic = {
+  filePath: "src/run.ts",
+  plugin: "react-doctor",
+  rule: "no-eval",
+  severity: "error",
+  message: "eval() is a code-injection vulnerability.",
+  help: "",
+  line: 2,
+  column: 1,
+  category: "Security",
+};
+
+describe("buildDiagnosticPipeline — foreign disable near-miss hint wiring", () => {
+  it("stamps a suppressionHint on a firing diagnostic whose eslint-disable used the bare name", () => {
+    const pipeline = buildDiagnosticPipeline({
+      rootDirectory: "/repo",
+      userConfig: null,
+      respectInlineDisables: true,
+      showWarnings: true,
+      readFileLinesSync: () => ["// eslint-disable-next-line no-eval", "eval(code);"],
+    });
+
+    const result = pipeline.apply(noEvalDiagnostic);
+
+    expect(result).not.toBeNull();
+    expect(result?.suppressionHint).toContain("react-doctor/no-eval");
+  });
+
+  it("leaves the diagnostic untouched when the canonical name was used (oxlint already handles it)", () => {
+    const pipeline = buildDiagnosticPipeline({
+      rootDirectory: "/repo",
+      userConfig: null,
+      respectInlineDisables: true,
+      showWarnings: true,
+      readFileLinesSync: () => ["// eslint-disable-next-line react-doctor/no-eval", "eval(code);"],
+    });
+
+    const result = pipeline.apply(noEvalDiagnostic);
+
+    expect(result?.suppressionHint).toBeUndefined();
+  });
+
+  it("stamps a hint for a file-level block disable that used the bare name", () => {
+    const pipeline = buildDiagnosticPipeline({
+      rootDirectory: "/repo",
+      userConfig: null,
+      respectInlineDisables: true,
+      showWarnings: true,
+      readFileLinesSync: () => ["/* eslint-disable no-eval */", "const a = 1;", "eval(code);"],
+    });
+
+    const result = pipeline.apply({ ...noEvalDiagnostic, line: 3 });
+
+    expect(result?.suppressionHint).toContain("react-doctor/no-eval");
+  });
+
+  it("drops the diagnostic when react-doctor-disable used the bare short id", () => {
+    const pipeline = buildDiagnosticPipeline({
+      rootDirectory: "/repo",
+      userConfig: null,
+      respectInlineDisables: true,
+      showWarnings: true,
+      readFileLinesSync: () => ["// react-doctor-disable-next-line no-eval", "eval(code);"],
+    });
+
+    expect(pipeline.apply(noEvalDiagnostic)).toBeNull();
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.test.ts
@@ -26,4 +26,42 @@ describe("server-fetch-without-revalidate", () => {
 
     expect(result.diagnostics).toEqual([]);
   });
+
+  for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+    it(`does not flag a ${method} fetch (Next.js never caches non-GET requests)`, () => {
+      const result = runRule(
+        serverFetchWithoutRevalidate,
+        `export const POST = () => {
+  return fetch("https://example.com/api/data", { method: "${method}", body: "{}" });
+};`,
+        { filename: "/repo/app/api/users/route.ts" },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    });
+  }
+
+  it("flags a GET fetch with an explicit method but no caching config", () => {
+    const result = runRule(
+      serverFetchWithoutRevalidate,
+      `export const GET = () => {
+  return fetch("https://example.com/api/data", { method: "GET" });
+};`,
+      { filename: "/repo/app/api/users/route.ts" },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a fetch whose method is a non-literal (can't prove it's non-GET)", () => {
+    const result = runRule(
+      serverFetchWithoutRevalidate,
+      `export const GET = (method: string) => {
+  return fetch("https://example.com/api/data", { method });
+};`,
+      { filename: "/repo/app/api/users/route.ts" },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-fetch-without-revalidate.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isMutatingFetchCall } from "../../utils/find-side-effect.js";
 import { NEXTJS_SOURCE_FILE_EXTENSION_GROUP } from "../../constants/nextjs.js";
 
 const isFetchCall = (node: EsTreeNode): boolean => {
@@ -88,6 +89,9 @@ export const serverFetchWithoutRevalidate = defineRule({
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isServerSideFile) return;
         if (!isFetchCall(node)) return;
+        // Next.js only caches GET requests, so a mutating fetch
+        // (POST/PUT/PATCH/DELETE) can never serve stale cached data.
+        if (isMutatingFetchCall(node)) return;
 
         const optionsArg = node.arguments?.[1];
         if (optionsArg && objectExpressionHasNextRevalidate(optionsArg)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-side-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-side-effect.ts
@@ -51,7 +51,7 @@ const getCookieMutationMethodName = (
   return node.callee.property.name;
 };
 
-const isMutatingFetchCall = (node: EsTreeNode): boolean => {
+export const isMutatingFetchCall = (node: EsTreeNode): boolean => {
   if (!isNodeOfType(node, "CallExpression")) return false;
   if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "fetch") return false;
   const optionsArgument = node.arguments?.[1];


### PR DESCRIPTION
## Why

Two independent bug reports, both rooted in rule-key / suppression handling:

1. **`eslint-disable no-eval` doesn't suppress `react-doctor/no-eval`** (Lorenzo). oxlint binds a disable directive to a JS-plugin rule only when it names the full `react-doctor/<id>` key — a bare short id (`no-eval`) or a legacy prefix (`react/jsx-key`) silently no-ops. react-doctor's *own* `react-doctor-disable-*` matching had the same gap (and worse: it emitted a misleading "comma form" hint implying `no-eval` was a different rule).
2. **`server-fetch-without-revalidate` fires on POST/PUT/PATCH/DELETE** (FP catalog). Next.js only caches GET requests, so a mutating fetch can never serve stale cached data — flagging it is a false positive.

Before:

```tsx
// app/api/users/route.ts
export const POST = () =>
  fetch("https://api.example.com/users", { method: "POST", body }); // ⚠️ flagged (false positive)

export const runIt = (code: string) => {
  // eslint-disable-next-line no-eval   ← user expects this to work
  return eval(code); // ⚠️ still flagged, no explanation
};
```

After:

```tsx
export const POST = () =>
  fetch("https://api.example.com/users", { method: "POST", body }); // ✓ not flagged

export const runIt = (code: string) => {
  // eslint-disable-next-line no-eval
  return eval(code);
  //   ↳ oxlint matches plugin rules only by their full name, so `no-eval`
  //     in your eslint-disable comment does not silence `react-doctor/no-eval`
  //     — change it to `react-doctor/no-eval`.
};

// and the bare short id now works in react-doctor's own directive + ignore.rules:
//   // react-doctor-disable-next-line no-eval   ✓ suppresses react-doctor/no-eval
```

## What changed

- **`server-fetch-without-revalidate`**: skip the report when the fetch options carry a mutating `method`, reusing the existing `isMutatingFetchCall` predicate (now exported from `find-side-effect`).
- **`isSameRuleKey` is short-id aware**: a bare `no-eval` resolves to `react-doctor/no-eval` (the only rule by that name react-doctor owns). Fixes `react-doctor-disable-*` suppression by bare name, plus `ignore.rules` / rule lookups; removes the misleading near-miss hint.
- **New near-miss hint for `eslint-disable` / `oxlint-disable`** directives that name a react-doctor rule by an id oxlint can't bind to a plugin rule. Covers inline (`-line` / `-next-line`) and file-level block (`/* eslint-disable */` … `/* eslint-enable */`, with re-enable tracking), bare short ids, and legacy plugin-prefixed names. Reuses the existing `suppressionHint` field (CLI, `--explain`, editor hover, JSON report).
- Extracted the shared `tokenizeRuleList` helper (dedupes rule-list parsing).
- Two changesets (`patch`): the rule FP fix (`oxlint-plugin-react-doctor`, mirrored to the eslint plugin via shared source) and the disable-handling improvement (`react-doctor`).

## Test plan

- `pnpm --filter @react-doctor/core exec vp test run evaluate-suppression foreign-disable-pipeline` — 31 passed (inline + block ranges, enable tracking, react-doctor-disable bare-name suppression, e2e through `buildDiagnosticPipeline`).
- `pnpm --filter oxlint-plugin-react-doctor exec vp test run server-fetch-without-revalidate` — 8 passed (POST/PUT/PATCH/DELETE skipped; GET + non-literal method still flag).
- `pnpm typecheck` — 11/11. `pnpm format:check` ✓. `pnpm lint` ✓ (no findings in changed files).
- Full core suite: 867 pass; the only failures (`check-expo-project`, `check-security-scan` env-file/git tests) and the oxlint-plugin rule-fixture failures are **pre-existing** — confirmed identical on a stashed clean tree. Two react-doctor full-run failures (`unref-stdin-live`, `install-react-doctor`) pass in isolation (flaky under parallel load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fixes to suppression matching and one rule heuristic; broad test coverage; no auth or data-path changes.
> 
> **Overview**
> Fixes two suppression/rule-key issues and one lint false positive.
> 
> **`server-fetch-without-revalidate`** no longer reports `fetch` calls whose options use a mutating HTTP method (POST/PUT/PATCH/DELETE), since Next.js only caches GETs. GET and non-literal `method` values still flag.
> 
> **Bare rule ids** (e.g. `no-eval`) now match `react-doctor/no-eval` in `isSameRuleKey`, so `react-doctor-disable-*`, `ignore.rules`, and related lookups accept short ids without misleading “comma form” near-miss hints.
> 
> **Foreign `eslint-disable` / `oxlint-disable`** comments that name a react-doctor rule in a form oxlint cannot bind (bare id or legacy prefix like `react/jsx-key`) now surface a **`suppressionHint`** pointing users to the full `react-doctor/<id>` key, for inline and block disables (with enable-range tracking). Rule-list parsing is centralized in **`tokenizeRuleList`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d36b7339fa0be674d63bd6bebc156f6ed0f783de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->