### PR TITLE
fix(action): resolve PR changed-file paths against the scanned directory (#858)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,7 @@ runs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_CHANGED_FILES: ${{ runner.temp }}/react-doctor-changed-files.txt
+        INPUT_DIRECTORY: ${{ inputs.directory }}
       with:
         script: |
           const fs = require("fs");
@@ -87,10 +88,25 @@ runs:
             );
             return;
           }
+          // `pulls.listFiles` returns repo-root-relative paths (e.g. `UI/src/foo.tsx`),
+          // but the CLI resolves `--changed-files-from` entries relative to the scanned
+          // `directory` (its diff detection runs `git diff --relative`, so its native
+          // path contract is scan-relative). Strip the `directory` prefix — and drop
+          // files outside it — so a subdirectory scan (`directory: UI`) doesn't double
+          // up to `UI/UI/src/...`, which misses every base read and reports pre-existing
+          // issues as newly introduced. Matches the review-comments step's mapping.
+          const directoryPrefix = (process.env.INPUT_DIRECTORY || ".")
+            .replace(/^\.\/?/, "")
+            .replace(/\/$/, "");
           const includedStatuses = new Set(["added", "modified", "renamed"]);
           const changedFiles = files
             .filter((file) => includedStatuses.has(file.status))
-            .map((file) => file.filename);
+            .map((file) => file.filename)
+            .flatMap((filename) => {
+              if (!directoryPrefix) return [filename];
+              const scopedPrefix = `${directoryPrefix}/`;
+              return filename.startsWith(scopedPrefix) ? [filename.slice(scopedPrefix.length)] : [];
+            });
           fs.writeFileSync(outputPath, changedFiles.join("\n") + (changedFiles.length ? "\n" : ""));
           core.setOutput("path", outputPath);
 

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -80,11 +80,29 @@ describe("GitHub Action contract", () => {
     expect(actionYaml).not.toContain("actions/github-script@v7");
     expect(prFilesStep).toContain("github.rest.pulls.listFiles");
     expect(prFilesStep).toContain('new Set(["added", "modified", "renamed"])');
-    expect(prFilesStep).toContain(".map((file) => file.filename);");
+    expect(prFilesStep).toContain(".map((file) => file.filename)");
     expect(prFilesStep).toContain('core.setOutput("path", outputPath)');
     expect(prFilesStep).not.toContain("filename)h");
     expect(actionYaml).not.toContain("git fetch origin");
     expect(actionYaml).not.toContain('git checkout "$HEAD_REF"');
+  });
+
+  it("rewrites repo-relative PR paths to the scanned directory for --changed-files-from", () => {
+    const prFilesStep = normalizeWhitespace(extractStep(readActionYaml(), "- id: pr-files"));
+
+    // The GitHub API returns repo-root-relative paths, but the CLI resolves
+    // --changed-files-from entries relative to the scanned `directory`. The step
+    // must strip the `directory` prefix (and drop files outside it) so a
+    // subdirectory scan (`directory: UI`) doesn't double up to `UI/UI/src/...`
+    // and miss every base read — the bug in issue #858.
+    expect(prFilesStep).toContain("INPUT_DIRECTORY: ${{ inputs.directory }}");
+    expect(prFilesStep).toContain("const directoryPrefix = (process.env.INPUT_DIRECTORY");
+    expect(prFilesStep).toContain('.replace(/^\\.\\/?/, "")');
+    expect(prFilesStep).toContain('.replace(/\\/$/, "")');
+    expect(prFilesStep).toContain("const scopedPrefix = `${directoryPrefix}/`;");
+    expect(prFilesStep).toContain(
+      "filename.startsWith(scopedPrefix) ? [filename.slice(scopedPrefix.length)] : []",
+    );
   });
 
   it("falls back to a full-project scan when listing PR files is not permitted", () => {

--- a/packages/react-doctor/tests/regressions/action-subdirectory-baseline-paths.test.ts
+++ b/packages/react-doctor/tests/regressions/action-subdirectory-baseline-paths.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression for #858: a GitHub Action scan of a subdirectory
+ * (`directory: UI`) in baseline mode reported every pre-existing issue in
+ * touched files as newly introduced.
+ *
+ * Root cause: the action wrote repo-root-relative changed-file paths
+ * (`UI/src/widget.tsx`) into `--changed-files-from`, but the CLI resolves
+ * those entries relative to the *scanned* directory. Scanning `UI/`, the
+ * path doubled to `UI/UI/src/widget.tsx`, so baseline base reads via
+ * `git show <base>:./UI/src/widget.tsx` (cwd `UI/`) missed →
+ * `baseTotalCount: 0` → every finding looked new.
+ *
+ * The fix strips the `directory` prefix in the action so paths are
+ * scan-relative (`src/widget.tsx`) — exactly what `react-doctor --scope
+ * changed` produces natively. This test drives the CLI consumer the way
+ * the action does (subdirectory scan + `includePaths` + `baseline`) and
+ * proves the two path forms diverge at the base read.
+ */
+
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vite-plus/test";
+import { inspect } from "../../src/inspect.js";
+import { clearConfigCache } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "@react-doctor/core";
+import { commitAll, initGitRepo, writeFile, writeJson } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-858-subdir-baseline-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+// `no-array-index-key` fires once per `key={index}` usage, so the finding
+// count is deterministic: N usages → N diagnostics. It's `defaultEnabled:
+// false`, so the config override turns it on for both the head and base
+// passes (baseline reuses the same user config).
+const RULE = "react-doctor/no-array-index-key";
+const CONFIG_OVERRIDE: ReactDoctorConfig = { rules: { [RULE]: "warn" } };
+
+// One `key={index}` per mapped row → exactly `findingCount` diagnostics.
+const widget = (findingCount: number): string => {
+  const rows = Array.from(
+    { length: findingCount },
+    (_, row) => `      {rows[${row}].map((item, index) => <li key={index}>{item}</li>)}`,
+  );
+  return [
+    "export const Widget = ({ rows }: { rows: string[][] }) => (",
+    "  <ul>",
+    ...rows,
+    "  </ul>",
+    ");",
+    "",
+  ].join("\n");
+};
+
+describe("#858: subdirectory baseline resolves changed-file paths against the scan dir", () => {
+  it("scan-relative paths read base content; repo-relative paths miss it", async () => {
+    clearConfigCache();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const repoDir = path.join(tempRoot, "monorepo");
+    const uiDir = path.join(repoDir, "UI");
+    const widgetRelative = path.join("src", "widget.tsx");
+    try {
+      // A monorepo whose React app lives under UI/ (git root is the repo root).
+      writeJson(path.join(repoDir, "package.json"), { name: "monorepo-root", private: true });
+      writeJson(path.join(uiDir, "package.json"), {
+        name: "ui",
+        dependencies: { react: "^19.0.0", "react-dom": "^19.0.0" },
+      });
+      writeJson(path.join(uiDir, "tsconfig.json"), {
+        compilerOptions: { jsx: "preserve", strict: false, target: "es2022", module: "esnext" },
+      });
+
+      // Base: two pre-existing index-key findings, committed.
+      writeFile(path.join(uiDir, widgetRelative), widget(2));
+      initGitRepo(repoDir);
+      const baseRef = commitAll(repoDir, "init UI app with two findings");
+
+      // Head: add a third finding to the same file (the PR's change).
+      writeFile(path.join(uiDir, widgetRelative), widget(3));
+
+      const scanUi = (includePaths: string[], baseline: { ref: string } | null) =>
+        inspect(uiDir, {
+          lint: true,
+          deadCode: false,
+          noScore: true,
+          silent: true,
+          includePaths,
+          baseline,
+          configOverride: CONFIG_OVERRIDE,
+        });
+      const findings = (result: Awaited<ReturnType<typeof scanUi>>): number =>
+        result.diagnostics.filter((diagnostic) => diagnostic.rule === "no-array-index-key").length;
+
+      // A baseline-free head scan = the full finding set in the changed file
+      // (relational reference, so the assertions don't hard-code the rule's
+      // per-usage report count).
+      const headOnly = await scanUi([widgetRelative], null);
+      expect(headOnly.skippedChecks).not.toContain("lint");
+      const headTotal = findings(headOnly);
+      expect(headTotal).toBeGreaterThan(0);
+
+      // The fix: scan-relative paths, as the patched action now emits.
+      const fixed = await scanUi([widgetRelative], { ref: baseRef });
+      expect(fixed.baselineDelta).toBeDefined();
+      // Base content WAS read (nonzero base total) — the core of the fix.
+      expect(fixed.baselineDelta?.baseTotalCount).toBeGreaterThan(0);
+      // The PR-introduced findings show...
+      expect(findings(fixed)).toBeGreaterThan(0);
+      // ...but pre-existing ones are subtracted, not re-reported as new.
+      expect(findings(fixed)).toBeLessThan(headTotal);
+
+      // The bug: repo-relative paths (the pre-fix action output) double the
+      // prefix, so `git show <base>:./UI/src/widget.tsx` misses and the base
+      // count collapses to 0 — the exact signal in #858 (every finding "new").
+      const buggy = await scanUi([path.join("UI", widgetRelative)], { ref: baseRef });
+      expect(buggy.baselineDelta?.baseTotalCount).toBe(0);
+    } finally {
+      consoleSpy.mockRestore();
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #858.

## What was broken

When the Action scans a subdirectory (`directory: UI`) in baseline mode (`scope: changed`), it reported **every** issue in touched files as newly introduced, producing false-positive PR failures.

Root cause: the `pr-files` step wrote repo-root-relative paths from `pulls.listFiles` (`UI/src/foo.tsx`) into `--changed-files-from`, but the CLI resolves those entries relative to the scanned `directory`. Its native diff detection runs `git diff --relative` (`packages/core/src/services/git.ts`), so the CLI's path contract is **scan-relative**. With `directory: UI` the path doubled to `UI/UI/src/foo.tsx` → baseline base reads via `git show <base>:UI/UI/...` missed → `baseTotalCount: 0` → every pre-existing finding mislabeled "new".

The system can't self-correct downstream: base materialization deliberately treats a missing base file as a *new* file (`materialize-baseline-files.ts`), so `baseTotalCount: 0` is ambiguous with a genuinely clean base. Normalization must happen where the repo-root context exists — the Action.

## The fix

Strip the `directory` prefix in `pr-files` (and drop files outside it) so the changed-file list is **isomorphic to what `react-doctor --scope changed` produces natively**. Mirrors the `directoryPrefix` mapping the review-comments step already uses.

- `directory: UI` → `UI/src/foo.tsx` becomes `src/foo.tsx`
- `directory: .` / empty → unchanged (root scans unaffected)
- strict `UI/` match (a `UIkit/` lookalike is not caught)

## Product brief

- **Job** — a team gating PRs on issues *they introduced* under a monorepo subdir (`directory: UI`, `scope: changed`, `blocking: error`). Today they're blocked by pre-existing issues, so their only escape is `blocking: none` (gate off) — defeating the feature.
- **Change** — smallest possible: normalize paths in `pr-files`. No new input/output.
- **Reuse** — reused the existing `directoryPrefix` idiom from the review-comments step; no new surface.
- **Metric** — already wired: the wide event emits `baseline.baseTotal` / `baseline.new` / `baseline.degraded` (`build-run-event.ts`). Health query = baseline runs where `baseline.baseTotal = 0 AND baseline.new > 0` should drop after release.
- **Compat** — behavior-preserving for `directory: .`. No changeset (the Action is versioned via git tags, not Changesets). `--changed-files-from` is internal hidden plumbing, so no public-surface change.
- **Kill** — if `baseline.baseTotal = 0 AND baseline.new > 0` stays elevated 2 releases after the tag ships, the fix isn't reaching users (stale pin) — investigate, don't add surface.

## Tests

- Updated the `pr-files` contract assertion + added a regression test asserting the prefix-stripping (`github-action.test.ts`, 11/11).
- Verified locally: `typecheck` 5/5, `lint` exit 0, `format:check` clean.

## ⚠️ Required follow-up after merge (maintainer)

This touches `action.yml`, so it needs an Action tag — and I found the floating major has **drifted**: `v2` currently points at an *older* commit than `v2.1.0` (the "move `vN`" step was skipped on the last release). After merge:

```bash
git tag -a v2.1.1 <merge-commit> -m "react-doctor action v2.1.1"
git tag -fa v2 <merge-commit> -m "react-doctor action v2 (floating major -> v2.1.1)"
git push origin v2.1.1
git push --force origin v2
```

Moving `v2` forward also un-stales the pointer (consumers on `@v2` jump past the commits the stale pointer was missing). `v1` is the legacy line, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow path-normalization in the GitHub Action only; root scans (`directory: .`) are unchanged, with regression tests covering the subdirectory baseline case.
> 
> **Overview**
> Fixes **false-positive “new issue” reports** when the GitHub Action scans a monorepo subdirectory (`directory: UI`) with baseline/`scope: changed` on pull requests.
> 
> The **`pr-files` step** now passes **`INPUT_DIRECTORY`** into its script and rewrites paths from `pulls.listFiles` (repo-root-relative, e.g. `UI/src/foo.tsx`) into **scan-relative** paths (e.g. `src/foo.tsx`) by stripping the `directory` prefix and dropping files outside that prefix. That matches how the CLI resolves `--changed-files-from` and the **`directoryPrefix`** pattern already used for inline review comments, avoiding doubled paths like `UI/UI/...` that broke baseline base reads (`baseTotalCount: 0`).
> 
> **Tests:** contract assertions in `github-action.test.ts` for the new mapping, plus a regression test that proves scan-relative vs repo-relative `includePaths` diverge on baseline base reads for a `UI/` scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad93e3cc279055035485cd992382e0d11ff0842c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->