### PR TITLE
fix(no-inline-exhaustive-style): skip Satori OG image components

### DIFF
--- a/.changeset/fix-inline-exhaustive-style-satori-og.md
+++ b/.changeset/fix-inline-exhaustive-style-satori-og.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Stop `no-inline-exhaustive-style` from flagging Satori (next/og, @vercel/og) OG-image components.
+
+OG components style everything inline because Satori rasterizes the JSX to a static image and supports no other styling channel — so the rule's "rebuilds every render" premise never applies, and an exhaustive `style={{…}}` is the only way to lay them out. The rule now shares the same `isGeneratedImageRenderContext` guard the sibling image rules already use (`alt-text`, `nextjs-no-img-element`, `no-unknown-property`): it short-circuits in Next.js metadata image routes (`opengraph-image.tsx`, `twitter-image.tsx`, `icon.tsx`, …) and skips JSX that flows into an `ImageResponse(...)`/`satori(...)` call, including a helper component resolved to that call. The expensive per-node generated-image lookup runs only once a style is large enough to report, so ordinary files pay nothing. Exhaustive inline styles in regular components are still flagged.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.regressions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noInlineExhaustiveStyle } from "./no-inline-exhaustive-style.js";
+
+describe("design/no-inline-exhaustive-style regressions", () => {
+  // OG components style everything inline because Satori (next/og,
+  // @vercel/og) supports no other styling channel and rasterizes the JSX
+  // to a static image — so the "rebuilds every render" cost never applies.
+  const EXHAUSTIVE_OG_STYLE = `export default function OG() {
+    return (
+      <div
+        style={{
+          display: "flex",
+          width: "100%",
+          height: "100%",
+          alignItems: "center",
+          justifyContent: "center",
+          flexDirection: "column",
+          backgroundColor: "white",
+          fontSize: 64,
+          color: "black",
+        }}
+      >
+        Hello
+      </div>
+    );
+  }`;
+
+  it("skips opengraph-image.tsx — exhaustive inline styles are required by Satori", () => {
+    const result = runRule(noInlineExhaustiveStyle, EXHAUSTIVE_OG_STYLE, {
+      filename: "/proj/app/opengraph-image.tsx",
+    });
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("skips twitter-image.tsx and icon.tsx metadata routes", () => {
+    const twitter = runRule(noInlineExhaustiveStyle, EXHAUSTIVE_OG_STYLE, {
+      filename: "/proj/app/twitter-image.tsx",
+    });
+    const icon = runRule(noInlineExhaustiveStyle, EXHAUSTIVE_OG_STYLE, {
+      filename: "/proj/app/icon.tsx",
+    });
+    expect(twitter.diagnostics).toEqual([]);
+    expect(icon.diagnostics).toEqual([]);
+  });
+
+  it("skips helper JSX in files that render through next/og ImageResponse", () => {
+    const result = runRule(
+      noInlineExhaustiveStyle,
+      `
+        import { ImageResponse } from "next/og";
+
+        const Card = () => (
+          <div
+            style={{
+              display: "flex",
+              width: 1200,
+              height: 630,
+              alignItems: "center",
+              justifyContent: "center",
+              flexDirection: "column",
+              backgroundColor: "white",
+              fontSize: 64,
+            }}
+          >
+            Card
+          </div>
+        );
+
+        export const GET = () => new ImageResponse(<Card />);
+      `,
+      { filename: "/proj/app/api/social-card.tsx" },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("skips inline JSX passed directly to satori()", () => {
+    const result = runRule(
+      noInlineExhaustiveStyle,
+      `
+        import satori from "satori";
+
+        export const render = () =>
+          satori(
+            <div
+              style={{
+                display: "flex",
+                width: 1200,
+                height: 630,
+                alignItems: "center",
+                justifyContent: "center",
+                flexDirection: "column",
+                backgroundColor: "black",
+                color: "white",
+              }}
+            >
+              Hi
+            </div>,
+            { width: 1200, height: 630 },
+          );
+      `,
+      { filename: "/proj/lib/og.tsx" },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags an exhaustive inline style in an ordinary component file", () => {
+    const result = runRule(noInlineExhaustiveStyle, EXHAUSTIVE_OG_STYLE, {
+      filename: "/proj/app/page.tsx",
+    });
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("inline style");
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-inline-exhaustive-style.ts
@@ -1,7 +1,9 @@
 import { INLINE_STYLE_PROPERTY_THRESHOLD } from "../../constants/design.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -13,21 +15,31 @@ export const noInlineExhaustiveStyle = defineRule({
   tags: ["test-noise", "react-jsx-only"],
   recommendation:
     "Move the styles to a CSS class, CSS module, Tailwind utilities, or a styled component. Big inline objects are hard to read and rebuild on every update.",
-  create: (context: RuleContext) => ({
-    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
-      const expression = getInlineStyleExpression(node);
-      if (!expression) return;
+  create: (context: RuleContext): RuleVisitors => {
+    if (isGeneratedImageRenderContext(context)) return {};
 
-      const propertyCount =
-        expression.properties?.filter((property: EsTreeNode) => isNodeOfType(property, "Property"))
-          .length ?? 0;
+    return {
+      JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
+        const expression = getInlineStyleExpression(node);
+        if (!expression) return;
 
-      if (propertyCount >= INLINE_STYLE_PROPERTY_THRESHOLD) {
+        const propertyCount =
+          expression.properties?.filter((property: EsTreeNode) =>
+            isNodeOfType(property, "Property"),
+          ).length ?? 0;
+
+        if (propertyCount < INLINE_STYLE_PROPERTY_THRESHOLD) return;
+
+        // Satori (next/og, @vercel/og) rasterizes this JSX to a static image,
+        // so its exhaustive inline styles never rebuild on render — the rule's
+        // premise doesn't hold. The walker marks the parent opening element.
+        if (isGeneratedImageRenderContext(context, node.parent ?? undefined)) return;
+
         context.report({
           node: expression,
           message: `This inline style has ${propertyCount} properties, which is hard to read & rebuilds every render. Move it to a CSS class, CSS module, or styled component.`,
         });
-      }
-    },
-  }),
+      },
+    };
+  },
 });


### PR DESCRIPTION
## Why

`no-inline-exhaustive-style` was the last of the four image-related rules that hadn't adopted the shared `isGeneratedImageRenderContext` guard, so it still fired on every Open Graph image component. OG components (`next/og`, `@vercel/og`, `satori`) style everything inline because Satori rasterizes the JSX to a static image and supports no other styling channel — so the rule's "rebuilds every render" premise never applies, and an exhaustive `style={{…}}` is the only way to lay them out.

Before:

```tsx
// app/opengraph-image.tsx — flagged (false positive)
export default function OG() {
  return (
    <div style={{ display: "flex", width: "100%", height: "100%",
      alignItems: "center", justifyContent: "center", flexDirection: "column",
      backgroundColor: "white", fontSize: 64, color: "black" }}>
      Hello
    </div>
  );
  //   ▲ "This inline style has 9 properties… Move it to a CSS class."
}
```

After:

```
no diagnostic — Satori OG components are skipped
```

## What changed

- `no-inline-exhaustive-style.ts` adopts the same `isGeneratedImageRenderContext` guard the sibling rules already use (`alt-text`, `nextjs-no-img-element`, `no-unknown-property`):
  - top-of-`create` filename short-circuit for Next.js metadata image routes (`opengraph-image.tsx`, `twitter-image.tsx`, `icon.tsx`, …)
  - per-node skip for JSX flowing into an `ImageResponse(...)` / `satori(...)` call, including a helper component resolved to that call (the parent `JSXOpeningElement` is what the generated-image walker marks)
- The expensive per-node generated-image lookup runs only **after** the property-count threshold is met, so ordinary files pay nothing.
- The ESLint plugin re-exports rules from the oxlint plugin, so the fix propagates automatically — no mirror change.
- Added `no-inline-exhaustive-style.regressions.test.ts` (5 cases) and a `patch` changeset for `oxlint-plugin-react-doctor`.

## Test plan

- `pnpm run test src/plugin/rules/design/no-inline-exhaustive-style.regressions.test.ts` → 5/5 pass (metadata-route filenames, inline `ImageResponse`, direct `satori()`, and a negative case proving ordinary components still fire).
- `pnpm --filter oxlint-plugin-react-doctor typecheck` → clean
- `pnpm lint` → exit 0
- `pnpm format:check` → all matched files correctly formatted

> [!NOTE]
> The full `oxlint-plugin-react-doctor` suite has 39 pre-existing failures (in `no-multi-comp`, `jsx-no-new-function-as-prop`, `jsx-no-new-object-as-prop`, `hooks-no-nan-in-deps`, `no-array-index-key`, `jsx-no-new-array-as-prop`). Confirmed by `git stash` that they fail identically on the clean baseline — unrelated to this change (different rules, no shared code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lint-rule exception using an existing shared guard; behavior for non-OG files is unchanged aside from added regression coverage.
> 
> **Overview**
> **`no-inline-exhaustive-style`** no longer reports large inline `style` objects in Satori / Next OG image code, where exhaustive inline styles are required and do not “rebuild every render.”
> 
> The rule now uses the shared **`isGeneratedImageRenderContext`** helper (same pattern as **`alt-text`** and related image rules): it bails out entirely for Next.js metadata image route filenames (`opengraph-image.tsx`, `twitter-image.tsx`, `icon.tsx`, etc.), and skips JSX that feeds **`ImageResponse`** or **`satori()`**, including helper components resolved to those calls. The per-node generated-image check runs only after the property-count threshold is met. **Ordinary components** with large inline styles are still flagged.
> 
> Adds **`no-inline-exhaustive-style.regressions.test.ts`** and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae13765e046c680e7b7c28252cb6eadba5740e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->