### PR TITLE
feat(action): skip the PR comment + mark the status "skipped" when no React files change

### DIFF
--- a/.changeset/feat-skip-ci-comment-no-react-files.md
+++ b/.changeset/feat-skip-ci-comment-no-react-files.md
@@ -1,0 +1,16 @@
+---
+"react-doctor": patch
+---
+
+Add a per-project `scannedFileCount` to the JSON report's `projects[]` entries —
+the number of source files the scan's linter examined (the changed React-eligible
+files in diff mode, the whole source tree in a full scan). It's additive and
+optional, so the `schemaVersion` is unchanged and existing consumers are unaffected.
+
+This lets the GitHub Action tell "a PR that changed no React-eligible files" (the
+linter examined nothing — `scannedFileCount: 0` for every project) apart from "a
+clean scan of real React changes" (`scannedFileCount >= 1`), which previously
+produced identical reports. The Action now treats the former as a no-op: it skips
+the sticky PR comment entirely and the commit status reads "Skipped — no React
+files changed" instead of a zero-filled score line. A clean scan of real React
+changes still posts its "no issues 🎉" comment.

--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,13 @@ inputs:
     description: "Severity that fails the workflow: none (default; advisory — report findings but always exit 0), warning, or error."
     default: "none"
   comment:
-    description: "Create or update a sticky pull request summary comment."
+    description: "Create or update a sticky pull request summary comment. Automatically skipped when the pull request changes no React-eligible files (`.tsx`/`.jsx` or framework entry files)."
     default: "true"
   review-comments:
     description: "Post inline review comments on the changed lines that triggered diagnostics (pull requests only)."
     default: "true"
   commit-status:
-    description: "Publish a commit status with the score and error / warning counts, linking to the run. Surfaces the result on pushes to the default branch (where the PR comment is skipped). Requires `statuses: write` (skipped with a warning otherwise)."
+    description: 'Publish a commit status with the score and error / warning counts, linking to the run. Surfaces the result on pushes to the default branch (where the PR comment is skipped). Reads "Skipped" when the pull request changes no React-eligible files. Requires `statuses: write` (skipped with a warning otherwise).'
     default: "true"
   node-version:
     description: "Node.js version to use"
@@ -207,6 +207,7 @@ runs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_COMMENT_FILE: ${{ steps.render.outputs.comment-file }}
+        REACT_DOCTOR_SKIPPED: ${{ steps.render.outputs.skipped }}
       with:
         script: |
           const fs = require("fs");
@@ -216,6 +217,12 @@ runs:
           const body = fs.readFileSync(commentPath, "utf8").trim();
           if (!body) return;
 
+          // A skipped scan (no React-eligible files changed) gets no fresh
+          // comment — but an existing one is refreshed to the "skipped" note so a
+          // prior run's findings don't linger as stale feedback after the React
+          // changes were reverted out of the PR.
+          const skipped = process.env.REACT_DOCTOR_SKIPPED === "true";
+
           const marker = "<!-- react-doctor:summary -->";
           try {
             const { data: comments } = await github.rest.issues.listComments({
@@ -224,6 +231,7 @@ runs:
               per_page: 100,
             });
             const previous = comments.find((comment) => comment.body?.startsWith(marker));
+            if (skipped && !previous) return;
             if (previous) {
               await github.rest.issues.updateComment({
                 ...context.repo,
@@ -409,6 +417,7 @@ runs:
         REACT_DOCTOR_SCORE: ${{ steps.render.outputs.score }}
         REACT_DOCTOR_ERROR_COUNT: ${{ steps.render.outputs.error-count }}
         REACT_DOCTOR_WARNING_COUNT: ${{ steps.render.outputs.warning-count }}
+        REACT_DOCTOR_SKIPPED: ${{ steps.render.outputs.skipped }}
         REACT_DOCTOR_SCAN_EXIT: ${{ steps.scan.outputs.exit-code }}
         # On a PR the merge ref's parent is the reviewed commit; `github.sha`
         # covers push runs.
@@ -423,6 +432,7 @@ runs:
           const errorCount = Number(process.env.REACT_DOCTOR_ERROR_COUNT || "0");
           const warningCount = Number(process.env.REACT_DOCTOR_WARNING_COUNT || "0");
           const scanExit = process.env.REACT_DOCTOR_SCAN_EXIT;
+          const skipped = process.env.REACT_DOCTOR_SKIPPED === "true";
           const isPullRequest = context.eventName === "pull_request";
 
           const pluralize = (count, noun) => `${count} ${noun}${count === 1 ? "" : "s"}`;
@@ -431,8 +441,12 @@ runs:
           // it as a failure so this status can't show green while the PR gate (which
           // uses `${SCAN_STATUS:-1}`) fails the run.
           const scanFailed = scanExit !== "0";
-          // `score` is empty when the scan couldn't produce one (crash / aborted).
-          const description = score ? `Score: ${score}/100 · ${counts}` : scanFailed ? "Scan could not complete" : counts;
+          // A skipped scan (no React-eligible files changed) reads "Skipped" rather
+          // than a zero-filled score line. `score` is empty when the scan couldn't
+          // produce one (crash / aborted).
+          const description = skipped
+            ? "Skipped — no React files changed"
+            : score ? `Score: ${score}/100 · ${counts}` : scanFailed ? "Scan could not complete" : counts;
 
           // Advisory on pushes (a default-branch health-trend signal that must
           // never turn the branch red); on a PR the status mirrors the gate so it

--- a/packages/core/src/build-json-report.ts
+++ b/packages/core/src/build-json-report.ts
@@ -57,6 +57,9 @@ export const buildJsonReport = (input: BuildJsonReportInput): JsonReport => {
     score: result.score,
     skippedChecks: result.skippedChecks,
     ...(result.skippedCheckReasons ? { skippedCheckReasons: result.skippedCheckReasons } : {}),
+    ...(typeof result.scannedFileCount === "number"
+      ? { scannedFileCount: result.scannedFileCount }
+      : {}),
     elapsedMilliseconds: result.elapsedMilliseconds,
   }));
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -93,6 +93,7 @@ export class JsonReportProjectEntry extends Schema.Class<JsonReportProjectEntry>
   score: Schema.Unknown,
   skippedChecks: Schema.Array(Schema.String),
   skippedCheckReasons: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  scannedFileCount: Schema.optional(Schema.Number),
   elapsedMilliseconds: Schema.Number,
 }) {}
 

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -249,6 +249,16 @@ export interface JsonReportProjectEntry {
   skippedChecks: string[];
   /** Human-readable explanation per skipped check. See `InspectResult.skippedCheckReasons`. */
   skippedCheckReasons?: Record<string, string>;
+  /**
+   * Number of source files this scan's linter examined. In diff / changed
+   * mode it's the count of changed React-eligible files (`.tsx`/`.jsx` plus
+   * framework entry files); in a full scan it's the whole source tree. `0`
+   * in a diff scan means the changed files held nothing React Doctor lints —
+   * the GitHub Action reads that as "nothing to report" (skips the PR comment;
+   * the commit status says "skipped"). Optional: absent on reports from
+   * constructors that don't track it (e.g. `toJsonReport`).
+   */
+  scannedFileCount?: number;
   elapsedMilliseconds: number;
 }
 

--- a/packages/react-doctor/tests/github-action-comment.test.ts
+++ b/packages/react-doctor/tests/github-action-comment.test.ts
@@ -50,6 +50,7 @@ const buildProjectEntry = (
   diagnostics,
   score: { score: 81, label: "Good" },
   skippedChecks: [],
+  scannedFileCount: 2,
   elapsedMilliseconds: 123,
   ...overrides,
 });
@@ -246,7 +247,7 @@ describe("render-github-action-comment", () => {
     expect(comment).not.toContain("| Score |");
   });
 
-  it("renders a no-scan report as a plain success line, not a zero-filled table", () => {
+  it("marks a diff scan that changed no React-eligible source files as skipped", () => {
     const { comment, outputs } = runRenderer(
       buildReport({
         projects: [],
@@ -262,14 +263,84 @@ describe("render-github-action-comment", () => {
       }),
     );
 
-    // A scan that matched no files is just a pass — a clean one-liner, no table,
-    // no "Unavailable" score, no "no scan" explanation.
+    // A PR that touched nothing React Doctor lints isn't a finding and isn't a
+    // "clean pass" worth a comment — it's a no-op. The body reads "skipped" (for
+    // the job summary), and `skipped=true` tells the Action to suppress the
+    // sticky PR comment + mark the commit status "Skipped".
+    expect(comment).toContain("React Doctor skipped this pull request");
+    expect(comment).not.toContain("No React Doctor issues found");
+    expect(comment).not.toContain("found no issues");
+    expect(outputs).toContain("skipped=true");
+  });
+
+  it("marks a diff scan whose changed files examined zero eligible files as skipped", () => {
+    const { comment, outputs } = runRenderer(
+      buildReport({
+        diagnostics: [],
+        // The PR changed a `.ts` file with no JSX — scanned, but the JSX include
+        // filter left nothing for the linter (`scannedFileCount: 0`).
+        projects: [buildProjectEntry([], { diagnostics: [], scannedFileCount: 0, score: null })],
+        summary: {
+          errorCount: 0,
+          warningCount: 0,
+          affectedFileCount: 0,
+          totalDiagnosticCount: 0,
+          score: null,
+          scoreLabel: null,
+        },
+      }),
+    );
+
+    expect(comment).toContain("React Doctor skipped this pull request");
+    expect(outputs).toContain("skipped=true");
+  });
+
+  it("does NOT skip a clean scan of real React changes (eligible files examined)", () => {
+    const { comment, outputs } = runRenderer(
+      buildReport({
+        diagnostics: [],
+        // `scannedFileCount: 2` (the fixture default) → React Doctor examined
+        // real React files and they were clean. Still earns a "no issues" comment.
+        projects: [buildProjectEntry([], { diagnostics: [] })],
+        summary: {
+          errorCount: 0,
+          warningCount: 0,
+          affectedFileCount: 0,
+          totalDiagnosticCount: 0,
+          score: 100,
+          scoreLabel: "Great",
+        },
+      }),
+    );
+
+    expect(comment).toContain("**React Doctor** found no issues. 🎉");
+    expect(comment).not.toContain("skipped this pull request");
+    expect(outputs).toContain("skipped=false");
+  });
+
+  it("does NOT skip a full-scope scan with no projects (clean success, not a no-op)", () => {
+    const { comment, outputs } = runRenderer(
+      buildReport({
+        mode: "full",
+        diff: null,
+        projects: [],
+        diagnostics: [],
+        summary: {
+          errorCount: 0,
+          warningCount: 0,
+          affectedFileCount: 0,
+          totalDiagnosticCount: 0,
+          score: null,
+          scoreLabel: null,
+        },
+      }),
+    );
+
+    // `scope: full` is an explicit "scan everything" request, so an empty result
+    // is a clean pass worth reporting — not the diff-mode "nothing changed" skip.
     expect(comment).toContain("No React Doctor issues found. 🎉");
-    expect(comment).not.toContain("but none matched the files covered by its enabled checks");
-    expect(comment).not.toContain("| Score |");
-    expect(comment).not.toContain("Unavailable");
-    expect(comment).toContain("<sub>Reviewed by [React Doctor](https://react.doctor) for commit");
-    expect(outputs).toContain("score=");
+    expect(comment).not.toContain("skipped this pull request");
+    expect(outputs).toContain("skipped=false");
   });
 
   it("renders incomplete checks as an explicit caveat", () => {

--- a/scripts/render-github-action-comment.mjs
+++ b/scripts/render-github-action-comment.mjs
@@ -53,6 +53,12 @@ const COPY = {
   // which is a pass, not a finding.
   cleanSuccess: "No React Doctor issues found. 🎉",
 
+  // Skipped — a pull request that changed no React-eligible files, so React
+  // Doctor examined nothing it lints. Rendered into the job summary; the sticky
+  // PR comment is suppressed and the commit status reads "Skipped" (both keyed
+  // off the `skipped` output, set by `isSkippedScan`).
+  skipped: "React Doctor skipped this pull request — it changed no React files.",
+
   // Error body.
   errorIntro: "React Doctor could not complete this scan.",
   errorFallbackMessage: "React Doctor failed before completing the scan.",
@@ -311,8 +317,25 @@ const buildErrorBody = (report) => {
   ]);
 };
 
-const buildCleanSuccessBody = () =>
-  renderLines([MARKER, "", COPY.cleanSuccess, "", buildReviewFooter(false)]);
+// A one-liner body (marker + message + footer) for the no-finding outcomes:
+// a clean pass and a skipped no-op.
+const buildSingleLineBody = (line) => renderLines([MARKER, "", line, "", buildReviewFooter(false)]);
+
+// A pull-request scan that examined no React-eligible files and surfaced
+// nothing. The changed files held no `.tsx`/`.jsx` (or framework entry) source
+// React Doctor lints — `scannedFileCount` is 0 for every project (or there are
+// no projects at all) — so there's nothing to report. Distinct from a clean
+// scan of real React changes (`scannedFileCount >= 1`), which still earns a
+// "no issues 🎉" comment. Guarded to never fire on a failed/incomplete scan,
+// and only on a diff/baseline run (`report.diff` is null for `scope: full`,
+// which always reports).
+const isSkippedScan = (report) => {
+  if (!report.ok) return false;
+  if (!report.diff) return false;
+  if ((report.summary?.totalDiagnosticCount ?? 0) > 0) return false;
+  if (hasIncompleteChecks(report)) return false;
+  return (report.projects ?? []).every((project) => project.scannedFileCount === 0);
+};
 
 // Unified body for every successful scan (baseline, diff, full). The lead line
 // adapts to the mode; the error/warning lists are shared.
@@ -336,7 +359,7 @@ const buildCommentBody = (report) => {
   // A scan that matched no files (no changed/staged source, or nothing covered
   // by the enabled checks) is a pass, not a special case — render a plain
   // success line rather than a metrics table full of zeros.
-  if ((report.projects ?? []).length === 0) return buildCleanSuccessBody();
+  if ((report.projects ?? []).length === 0) return buildSingleLineBody(COPY.cleanSuccess);
   return buildIssuesBody(report);
 };
 
@@ -345,13 +368,18 @@ if (!report) {
   console.warn(COPY.noReportWarning);
   process.exit(0);
 }
-const body = buildCommentBody(report);
+const skipped = isSkippedScan(report);
+const body = skipped ? buildSingleLineBody(COPY.skipped) : buildCommentBody(report);
 
 if (commentPath) {
   fs.writeFileSync(commentPath, body.endsWith("\n") ? body : `${body}\n`);
 } else {
   process.stdout.write(body.endsWith("\n") ? body : `${body}\n`);
 }
+
+// The Action reads this to suppress the sticky PR comment (it still mirrors the
+// body into the job summary + commit status, which read "skipped").
+appendOutput("skipped", skipped ? "true" : "false");
 
 appendOutput(
   "score",


### PR DESCRIPTION
## Why

A pull request that touches **no React-eligible files** (docs, backend `.ts`, config, dep bumps) still drew a sticky `No React Doctor issues found 🎉` PR comment and a green `Score:` commit status — noise that trains reviewers to ignore the bot. The JSON report couldn't tell that case apart from a clean scan of *real* React changes: both produced 0 diagnostics and a score.

The fix surfaces the linter's already-computed per-project `scannedFileCount` so the Action can distinguish "examined nothing React Doctor lints" from "examined real React files, all clean".

Before:

```
PR changes only src/util.ts (no JSX)
→ comment posted: "No React Doctor issues found 🎉"
→ commit status: "Score: 100/100 · 0 errors · 0 warnings"
```

After:

```
PR changes only src/util.ts (no JSX)
→ no PR comment posted
→ commit status: "Skipped — no React files changed"
→ job summary: "React Doctor skipped this pull request — it changed no React files."

PR changes src/Hello.tsx (clean) → still comments "no issues 🎉"  (unchanged)
```

## What changed

- **`@react-doctor/core`** — added optional per-project `scannedFileCount` to the JSON report (`JsonReportProjectEntry` interface + schema + `buildJsonReport`). Additive; `schemaVersion` unchanged. In diff mode it's the count of changed React-eligible files (`.tsx`/`.jsx` + framework entries); in a full scan, the whole source tree.
- **`scripts/render-github-action-comment.mjs`** — `isSkippedScan` fires only for a diff/baseline scan that examined `0` eligible files across all projects, has `0` diagnostics, and no incomplete checks. Emits a new `skipped` output and a short "skipped" body for the job summary. (Also consolidated the two near-identical no-finding body builders into one `buildSingleLineBody`.)
- **`action.yml`** — PR-comment step skips creating a comment when `skipped=true` (refreshes an existing one to the skipped note so prior findings don't linger as stale feedback); commit-status step reads `Skipped — no React files changed`; input docs updated.
- Changeset (`react-doctor`, patch) + render-comment tests for the skip cases.

## Product brief

- **Job:** a dev/CI runs the Action on every PR; today they can't suppress the no-op comment without disabling comments entirely (which also kills it for real React PRs).
- **Reuse:** extended the existing `scannedFileCount` (already on `InspectResult` and the Sentry wide event) to the wire schema — no new concept, flag, or config.
- **Metric:** reuse the wide-event `scannedFileCount` + `viaAction` tags — the skip rate = share of action diff runs with `scannedFileCount === 0` and `totalDiagnostics === 0`.
- **Compat:** on by default (can't over-suppress a real React PR — those have `scannedFileCount >= 1`); additive JSON field; changeset added.
- **Kill:** revert the render-script gate (keep the harmless field) if the skip path effectively never fires (< 1% of action diff runs) after 2 releases.

## Test plan

- `pnpm typecheck` · `pnpm lint` · `pnpm format:check` — pass
- `pnpm smoke:json-report` — pass (new field validates against the schema)
- render-comment tests **14/14** (4 new/updated skip cases), action tests **42/42**, report-builder tests pass
- End-to-end on a real git fixture: non-JSX diff → `scannedFileCount: 0` → renders skipped + `skipped=true`; `.tsx` diff → `scannedFileCount: 1` → not skipped

> ⚠️ Two pre-existing `@react-doctor/core` test failures (`check-security-scan` / `check-expo-project` `.env`-gitignore tests) reproduce identically on the clean base with this branch stashed — environmental (a global git `excludesfile` ignoring `.env`), unrelated to this change.

## Follow-up (release)

`action.yml` + the render script changed, so this needs a new `vX.Y.Z` tag + the floating major moved to it **at release** per AGENTS.md (not done from this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON field and CI presentation logic only; skip path is narrowly gated and covered by new render-comment tests, with no auth or data-handling changes.
> 
> **Overview**
> PRs that only touch non-React files (docs, plain `.ts`, config) no longer get a misleading **"no issues 🎉"** sticky comment or a **Score: 100/100** status. The change threads the linter’s existing **`scannedFileCount`** into each **`projects[]`** entry on the JSON report (optional field, **`schemaVersion` unchanged**).
> 
> **`render-github-action-comment.mjs`** adds **`isSkippedScan`**: on diff/baseline runs with zero diagnostics, no incomplete checks, and **`scannedFileCount === 0`** for every project (or no projects), it emits **`skipped=true`** and a short skipped message for the job summary. Clean scans of real React changes (**`scannedFileCount >= 1`**) and **`scope: full`** runs are unchanged.
> 
> **`action.yml`** suppresses creating a new sticky comment when skipped (but still updates an existing one so old findings don’t linger), and sets commit status to **"Skipped — no React files changed"**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd37b63bd5e589fa9b2c9265eba58984351c7202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->