### PR TITLE
feat(cli): clickable OSC-8 file locations + terminalKind telemetry

### DIFF
--- a/.changeset/feat-osc8-clickable-locations.md
+++ b/.changeset/feat-osc8-clickable-locations.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": minor
+---
+
+Make `file:line` diagnostic locations clickable in the terminal, and record which terminal each run uses.
+
+Diagnostic locations are now wrapped in OSC 8 hyperlinks pointing at each file's absolute path, so supporting terminals (iTerm2, WezTerm, Kitty, Windows Terminal, VS Code, and other VTE-based emulators) turn them into click-to-open links — even in monorepo scans where the displayed path is relative to a sub-project root rather than the terminal's cwd. The visible text is unchanged (`src/App.tsx:12`), the link rides in escape sequences, and terminals without OSC 8 support print it exactly as before. Hyperlinks are auto-detected per terminal and can be forced on/off with the standard `FORCE_HYPERLINK` env var; they are off for non-TTYs, CI, and coding agents (whose output parsers shouldn't see the escapes).
+
+Telemetry also gains a `terminalKind` run tag (neovim, vscode, iterm, wezterm, kitty, windows-terminal, …) so we can see where React Doctor is actually run. It is a low-cardinality enum with no path, username, or secret.

--- a/packages/react-doctor/src/cli/utils/build-code-frame.ts
+++ b/packages/react-doctor/src/cli/utils/build-code-frame.ts
@@ -1,11 +1,11 @@
 import * as fs from "node:fs";
-import * as path from "node:path";
 import { codeFrameColumns } from "@babel/code-frame";
 import {
   CODE_FRAME_LINES_ABOVE,
   CODE_FRAME_LINES_BELOW,
   CODE_FRAME_MAX_LINE_LENGTH_CHARS,
 } from "@react-doctor/core";
+import { resolveAbsolutePath } from "./resolve-absolute-path.js";
 
 interface CodeFrameInput {
   readonly filePath: string;
@@ -31,9 +31,7 @@ interface CodeFrameInput {
 export const buildCodeFrame = (input: CodeFrameInput): string | null => {
   if (input.line <= 0) return null;
 
-  const absolutePath = path.isAbsolute(input.filePath)
-    ? input.filePath
-    : path.resolve(input.rootDirectory || ".", input.filePath);
+  const absolutePath = resolveAbsolutePath(input.filePath, input.rootDirectory);
 
   let source: string;
   try {

--- a/packages/react-doctor/src/cli/utils/build-run-context.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-context.ts
@@ -1,3 +1,4 @@
+import { detectTerminalKind } from "./detect-terminal-kind.js";
 import {
   detectCiEventName,
   detectCiProvider,
@@ -34,6 +35,9 @@ export interface RunContext {
   viaAction: boolean;
   codingAgent: string | null;
   interactive: boolean;
+  // Terminal emulator / editor hosting the run (nvim, vscode, iterm, …), or
+  // "ci"/"unknown". Reveals where the CLI is actually used.
+  terminalKind: string;
   jsonMode: boolean;
   // Package-manager / runner the CLI was launched through (npm, pnpm, yarn,
   // bun, or "unknown"), derived from `npm_config_user_agent`. Distinguishes
@@ -103,6 +107,7 @@ export const buildRunContext = (): RunContext => {
     viaAction: isOfficialGithubAction(),
     codingAgent: detectCodingAgent(),
     interactive: !isNonInteractiveEnvironment(),
+    terminalKind: detectTerminalKind(),
     jsonMode: isJsonModeActive(),
     invokedVia: detectInvokedVia(),
   };

--- a/packages/react-doctor/src/cli/utils/build-sentry-scope.ts
+++ b/packages/react-doctor/src/cli/utils/build-sentry-scope.ts
@@ -35,6 +35,7 @@ export const buildSentryScope = (runContext: RunContext = buildRunContext()): Se
     viaAction: runContext.viaAction,
     codingAgent: runContext.codingAgent,
     interactive: runContext.interactive,
+    terminalKind: runContext.terminalKind,
     jsonMode: runContext.jsonMode,
     invokedVia: runContext.invokedVia,
     nodeMajor: runContext.nodeMajor,

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -87,6 +87,10 @@ export const RIGHT_EDGE_SAFETY_COLUMNS = 1;
 // (`│ ` … ` │` in box-text.ts). Reserved when fitting a box to the terminal.
 export const BOX_BORDER_WIDTH_CHARS = 4;
 
+// Minimum `VTE_VERSION` (GNOME Terminal, Tilix, and other VTE-based emulators)
+// that renders OSC 8 hyperlinks — VTE added support in 0.50 (reported as 5000).
+export const MINIMUM_VTE_VERSION_FOR_HYPERLINKS = 5000;
+
 // Last-resort fallback when buildJsonReportError itself throws — keeps
 // stdout valid JSON so downstream parsers don't see a half-written report.
 export const INTERNAL_ERROR_JSON_FALLBACK =

--- a/packages/react-doctor/src/cli/utils/detect-terminal-kind.ts
+++ b/packages/react-doctor/src/cli/utils/detect-terminal-kind.ts
@@ -1,0 +1,43 @@
+import { isCiEnvironment } from "./is-ci-environment.js";
+
+// TERM_PROGRAM value -> stable terminal label. The host editor/terminal sets
+// this, so it survives shells launched inside it. First match wins.
+const TERMINAL_BY_TERM_PROGRAM: ReadonlyArray<readonly [string, string]> = [
+  ["vscode", "vscode"],
+  ["iTerm.app", "iterm"],
+  ["Apple_Terminal", "apple-terminal"],
+  ["WezTerm", "wezterm"],
+  ["ghostty", "ghostty"],
+  ["Hyper", "hyper"],
+  ["Tabby", "tabby"],
+  ["rio", "rio"],
+];
+
+/**
+ * Best-effort label for the terminal emulator / editor hosting the CLI,
+ * derived from terminal-identity env vars. Recorded as the `terminalKind` run
+ * tag so we can see where React Doctor is actually run (nvim, VS Code, iTerm,
+ * …) — the split Sentry can't otherwise see. Low-cardinality and free of any
+ * username/path/secret, so it's safe as a tag. Editor terminals (nvim/vim)
+ * win over the outer emulator because that's the surface a user is reading in;
+ * "ci" marks a run with no interactive terminal; "unknown" when nothing matches.
+ */
+export const detectTerminalKind = (env: NodeJS.ProcessEnv = process.env): string => {
+  if (env.NVIM) return "neovim";
+  if (env.VIM_TERMINAL) return "vim";
+
+  const termProgram = env.TERM_PROGRAM;
+  if (termProgram) {
+    for (const [marker, label] of TERMINAL_BY_TERM_PROGRAM) {
+      if (termProgram === marker) return label;
+    }
+  }
+
+  if (env.KITTY_WINDOW_ID || env.TERM === "xterm-kitty") return "kitty";
+  if (env.WT_SESSION) return "windows-terminal";
+  if (env.ALACRITTY_WINDOW_ID || env.TERM === "alacritty") return "alacritty";
+  if (env.VTE_VERSION) return "vte";
+  if (env.TMUX) return "tmux";
+  if (isCiEnvironment()) return "ci";
+  return "unknown";
+};

--- a/packages/react-doctor/src/cli/utils/detect-terminal-kind.ts
+++ b/packages/react-doctor/src/cli/utils/detect-terminal-kind.ts
@@ -38,6 +38,6 @@ export const detectTerminalKind = (env: NodeJS.ProcessEnv = process.env): string
   if (env.ALACRITTY_WINDOW_ID || env.TERM === "alacritty") return "alacritty";
   if (env.VTE_VERSION) return "vte";
   if (env.TMUX) return "tmux";
-  if (isCiEnvironment()) return "ci";
+  if (isCiEnvironment(env)) return "ci";
   return "unknown";
 };

--- a/packages/react-doctor/src/cli/utils/format-hyperlink.ts
+++ b/packages/react-doctor/src/cli/utils/format-hyperlink.ts
@@ -1,0 +1,15 @@
+// OSC 8 terminal hyperlink: ESC ] 8 ; <params> ; <uri> ST  <text>  ESC ] 8 ; ; ST
+// Terminals that support it render <text> as a clickable link to <uri>; every
+// other terminal ignores the escape sequences and prints <text> unchanged, so
+// emitting these is safe wherever the link cannot hurt (see supports-hyperlinks).
+// OSC = Operating System Command introducer (ESC ]); ST = String Terminator (ESC \\).
+const OSC = "\u001B]";
+const ST = "\u001B\\";
+
+/**
+ * Wraps `text` in an OSC 8 hyperlink pointing at `uri`. The visible characters
+ * are exactly `text`; the link is carried in escape sequences a capable
+ * terminal turns into a click target.
+ */
+export const formatHyperlink = (text: string, uri: string): string =>
+  `${OSC}8;;${uri}${ST}${text}${OSC}8;;${ST}`;

--- a/packages/react-doctor/src/cli/utils/is-ci-environment.ts
+++ b/packages/react-doctor/src/cli/utils/is-ci-environment.ts
@@ -81,10 +81,9 @@ const FALSY_CI_FLAG_VALUES = new Set(["", "0", "false"]);
 const isCiFlagSet = (value: string | undefined): boolean =>
   value !== undefined && !FALSY_CI_FLAG_VALUES.has(value.toLowerCase());
 
-export const isCiEnvironment = (): boolean =>
-  CI_ENVIRONMENT_VARIABLES.some((environmentVariable) =>
-    Boolean(process.env[environmentVariable]),
-  ) || isCiFlagSet(process.env.CI);
+export const isCiEnvironment = (env: NodeJS.ProcessEnv = process.env): boolean =>
+  CI_ENVIRONMENT_VARIABLES.some((environmentVariable) => Boolean(env[environmentVariable])) ||
+  isCiFlagSet(env.CI);
 
 // Resolves the CI provider brand for telemetry, falling back to "unknown" for a
 // bare `CI` flag. Returns null when there's no CI signal at all.

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -12,9 +12,12 @@ import {
   TOP_ERRORS_DISPLAY_COUNT,
 } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
+import { pathToFileURL } from "node:url";
 import { boxText } from "./box-text.js";
 import { buildCodeFrame } from "./build-code-frame.js";
 import { buildSectionDivider } from "./build-section-divider.js";
+import { formatHyperlink } from "./format-hyperlink.js";
+import { resolveAbsolutePath } from "./resolve-absolute-path.js";
 import {
   BOX_BORDER_WIDTH_CHARS,
   CATEGORY_COUNTUP_FRAME_DELAY_MS,
@@ -280,13 +283,32 @@ const clusterNearbyDiagnostics = (diagnostics: Diagnostic[]): DiagnosticCluster[
   return clusters;
 };
 
-const formatClusterLocation = (cluster: DiagnosticCluster): string => {
+// The bare `file:line` (or `file:line-endLine`, or just `file` when line-less)
+// text for a cluster's lead site.
+const formatClusterLocationText = (cluster: DiagnosticCluster): string => {
+  const { filePath } = cluster.diagnostics[0]!;
+  if (cluster.startLine <= 0) return filePath;
+  if (cluster.endLine > cluster.startLine)
+    return `${filePath}:${cluster.startLine}-${cluster.endLine}`;
+  return `${filePath}:${cluster.startLine}`;
+};
+
+// The displayed file location for a cluster: the relative `file:line` text,
+// optionally wrapped in an OSC 8 hyperlink to the file's absolute path so
+// supporting terminals/editors make it clickable. The visible characters are
+// identical either way (the link rides in escape sequences), and the dim
+// "(test file)" tag stays outside the link.
+const formatClusterLocation = (
+  cluster: DiagnosticCluster,
+  resolveSourceRoot: SourceRootResolver,
+  hyperlinks: boolean,
+): string => {
   const lead = cluster.diagnostics[0]!;
   const contextTag = formatFileContextTag(lead);
-  if (cluster.startLine <= 0) return `${lead.filePath}${contextTag}`;
-  if (cluster.endLine > cluster.startLine)
-    return `${lead.filePath}:${cluster.startLine}-${cluster.endLine}${contextTag}`;
-  return `${lead.filePath}:${cluster.startLine}${contextTag}`;
+  const location = formatClusterLocationText(cluster);
+  if (!hyperlinks) return `${location}${contextTag}`;
+  const absolutePath = resolveAbsolutePath(lead.filePath, resolveSourceRoot(lead));
+  return `${formatHyperlink(location, pathToFileURL(absolutePath).href)}${contextTag}`;
 };
 
 // The location + inline code frame for a cluster of nearby same-file
@@ -301,12 +323,15 @@ const buildDiagnosticClusterLines = (
   cluster: DiagnosticCluster,
   resolveSourceRoot: SourceRootResolver,
   renderCodeFrame: boolean,
+  hyperlinks: boolean,
 ): ReadonlyArray<string> => {
   const lead = cluster.diagnostics[0]!;
   const isMultiSite = cluster.diagnostics.length > 1;
   const lines: string[] = [
     "",
-    highlighter.gray(`${TOP_ERROR_DETAIL_INDENT}${formatClusterLocation(cluster)}`),
+    highlighter.gray(
+      `${TOP_ERROR_DETAIL_INDENT}${formatClusterLocation(cluster, resolveSourceRoot, hyperlinks)}`,
+    ),
   ];
   const codeFrame = renderCodeFrame
     ? buildCodeFrame({
@@ -345,6 +370,7 @@ const buildRuleDetailBlock = (
   resolveSourceRoot: SourceRootResolver,
   renderEverySite: boolean,
   isAgentEnvironment: boolean,
+  hyperlinks: boolean,
 ): ReadonlyArray<string> => {
   const representative = pickRepresentativeDiagnostic(ruleDiagnostics);
   const { severity } = representative;
@@ -419,7 +445,9 @@ const buildRuleDetailBlock = (
     isCollapsedWarningGroup && representative.help.includes(representative.filePath);
   if (!skipSharedLocation) {
     for (const cluster of clusterNearbyDiagnostics(sites)) {
-      lines.push(...buildDiagnosticClusterLines(cluster, resolveSourceRoot, renderCodeFrame));
+      lines.push(
+        ...buildDiagnosticClusterLines(cluster, resolveSourceRoot, renderCodeFrame, hyperlinks),
+      );
     }
   }
 
@@ -487,6 +515,7 @@ interface TopErrorsSection {
 const buildTopErrorsSection = (
   diagnostics: Diagnostic[],
   resolveSourceRoot: SourceRootResolver,
+  hyperlinks: boolean,
   rulePriority?: ReadonlyMap<string, number>,
 ): TopErrorsSection => {
   const errorRuleGroups = selectErrorRuleGroups(diagnostics, rulePriority);
@@ -504,7 +533,16 @@ const buildTopErrorsSection = (
   const blockOffsets: number[] = [];
   for (const [ruleKey, ruleDiagnostics] of topRuleGroups) {
     blockOffsets.push(lines.length);
-    lines.push(...buildRuleDetailBlock(ruleKey, ruleDiagnostics, resolveSourceRoot, false, false));
+    lines.push(
+      ...buildRuleDetailBlock(
+        ruleKey,
+        ruleDiagnostics,
+        resolveSourceRoot,
+        false,
+        false,
+        hyperlinks,
+      ),
+    );
     lines.push("");
   }
   return { lines, blockOffsets };
@@ -579,6 +617,11 @@ export const printDiagnostics = (
   // First-run onboarding reveal. Defaults to an instant, static render so
   // normal runs print the whole report at once.
   onboarding: DiagnosticsOnboarding = {},
+  // Wrap each `file:line` location in an OSC 8 hyperlink to the file's absolute
+  // path, making it clickable in supporting terminals. Defaults to off so the
+  // output stays plain text (and tests render deterministically); the CLI turns
+  // it on only for capable, human-driven terminals (see supports-hyperlinks).
+  hyperlinks = false,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     // The beat played before each top-error block reveals; a no-op off onboarding.
@@ -598,7 +641,12 @@ export const printDiagnostics = (
     // the reveal between errors. Empty in verbose (lists every rule, not top-N).
     let topErrorBlockOffsets: ReadonlyArray<number> = [];
     if (!isVerbose) {
-      const topErrors = buildTopErrorsSection(diagnostics, resolveSourceRoot, rulePriority);
+      const topErrors = buildTopErrorsSection(
+        diagnostics,
+        resolveSourceRoot,
+        hyperlinks,
+        rulePriority,
+      );
       detailLines = topErrors.lines;
       topErrorBlockOffsets = topErrors.blockOffsets;
     } else {
@@ -610,6 +658,7 @@ export const printDiagnostics = (
           resolveSourceRoot,
           true,
           isAgentEnvironment,
+          hyperlinks,
         );
         return [...block, ""];
       });

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -12,6 +12,7 @@ import { isCodingAgentEnvironment } from "./is-ci-environment.js";
 import { canAnimateOnboarding } from "./onboarding-pacing.js";
 import { formatElapsedTime, printDiagnostics } from "./render-diagnostics.js";
 import { printFooter, printSummary } from "./render-summary.js";
+import { shouldRenderHyperlinks } from "./should-render-hyperlinks.js";
 
 interface ProjectScanEntry {
   readonly projectName: string;
@@ -148,6 +149,7 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
         buildRulePriorityMap(completedScans.map((scan) => scan.result.score)),
         isCodingAgentEnvironment(),
         { animateCountUp: animateRender },
+        shouldRenderHyperlinks(process.stdout),
       );
     }
 

--- a/packages/react-doctor/src/cli/utils/resolve-absolute-path.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-absolute-path.ts
@@ -1,0 +1,10 @@
+import * as path from "node:path";
+
+/**
+ * Resolves a diagnostic's `filePath` (relative to its project root, or
+ * already absolute) to an absolute path. Shared by the code-frame reader and
+ * the terminal hyperlink builder so both turn a relative path into the same
+ * on-disk location.
+ */
+export const resolveAbsolutePath = (filePath: string, rootDirectory: string): string =>
+  path.isAbsolute(filePath) ? filePath : path.resolve(rootDirectory || ".", filePath);

--- a/packages/react-doctor/src/cli/utils/should-render-hyperlinks.ts
+++ b/packages/react-doctor/src/cli/utils/should-render-hyperlinks.ts
@@ -1,0 +1,10 @@
+import { isCodingAgentEnvironment } from "./is-ci-environment.js";
+import { supportsHyperlinks } from "./supports-hyperlinks.js";
+
+/**
+ * Whether to emit OSC 8 clickable `file:line` locations for this run: a
+ * hyperlink-capable terminal AND not a coding agent (whose output parsers
+ * would choke on the escape sequences).
+ */
+export const shouldRenderHyperlinks = (stream: NodeJS.WriteStream = process.stdout): boolean =>
+  supportsHyperlinks(stream) && !isCodingAgentEnvironment();

--- a/packages/react-doctor/src/cli/utils/supports-hyperlinks.ts
+++ b/packages/react-doctor/src/cli/utils/supports-hyperlinks.ts
@@ -1,0 +1,47 @@
+import { MINIMUM_VTE_VERSION_FOR_HYPERLINKS } from "./constants.js";
+import { isCiEnvironment } from "./is-ci-environment.js";
+
+// TERM_PROGRAM values for terminals that render OSC 8 hyperlinks. Conservative
+// allowlist: a terminal not on it is treated as incapable so the escape bytes
+// never leak as visible garbage in an older emulator.
+const HYPERLINK_CAPABLE_TERM_PROGRAMS = new Set([
+  "iTerm.app",
+  "WezTerm",
+  "vscode",
+  "Hyper",
+  "ghostty",
+  "Tabby",
+  "rio",
+]);
+
+const parseVteVersion = (raw: string | undefined): number => {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+/**
+ * Whether `stream` is a terminal that renders OSC 8 hyperlinks. Auto-detected
+ * from terminal-identity env vars; the de-facto `FORCE_HYPERLINK` env var
+ * overrides detection (`FORCE_HYPERLINK=0`/`false` forces off, any other value
+ * forces on), mirroring how the ecosystem's terminal libraries gate the same
+ * feature. Off for non-TTYs, `TERM=dumb`, and CI (whose log viewers render the
+ * raw escape rather than a link). Unknown terminals default to off.
+ */
+export const supportsHyperlinks = (
+  stream: NodeJS.WriteStream = process.stdout,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean => {
+  const forced = env.FORCE_HYPERLINK;
+  if (forced !== undefined && forced !== "") {
+    return forced !== "0" && forced.toLowerCase() !== "false";
+  }
+
+  if (stream.isTTY !== true) return false;
+  if (env.TERM === "dumb") return false;
+  if (isCiEnvironment()) return false;
+
+  if (env.WT_SESSION) return true;
+  if (env.KITTY_WINDOW_ID || env.TERM === "xterm-kitty") return true;
+  if (parseVteVersion(env.VTE_VERSION) >= MINIMUM_VTE_VERSION_FOR_HYPERLINKS) return true;
+  return Boolean(env.TERM_PROGRAM && HYPERLINK_CAPABLE_TERM_PROGRAMS.has(env.TERM_PROGRAM));
+};

--- a/packages/react-doctor/src/cli/utils/supports-hyperlinks.ts
+++ b/packages/react-doctor/src/cli/utils/supports-hyperlinks.ts
@@ -38,7 +38,7 @@ export const supportsHyperlinks = (
 
   if (stream.isTTY !== true) return false;
   if (env.TERM === "dumb") return false;
-  if (isCiEnvironment()) return false;
+  if (isCiEnvironment(env)) return false;
 
   if (env.WT_SESSION) return true;
   if (env.KITTY_WINDOW_ID || env.TERM === "xterm-kitty") return true;

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -51,6 +51,7 @@ import { computeProjectedScore } from "./cli/utils/compute-score-projection.js";
 import { buildRulePriorityMap } from "./cli/utils/diagnostic-grouping.js";
 import { filterDiagnosticsByCategories } from "./cli/utils/filter-diagnostics-by-categories.js";
 import { printDiagnostics } from "./cli/utils/render-diagnostics.js";
+import { shouldRenderHyperlinks } from "./cli/utils/should-render-hyperlinks.js";
 import { isNonInteractiveEnvironment } from "./cli/utils/is-non-interactive-environment.js";
 import {
   canAnimateOnboarding,
@@ -900,6 +901,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
     const animateRender =
       !options.silent && !options.verbose && canAnimateOnboarding(process.stdout);
     const pause = onboardingSectionPause(animateRender);
+    const useHyperlinks = shouldRenderHyperlinks(process.stdout);
     const demotedDiagnosticCount = diagnostics.length - surfaceDiagnostics.length;
     const isDiffMode = options.includePaths.length > 0;
     const lintSourceFileCount = isDiffMode ? options.includePaths.length : project.sourceFileCount;
@@ -955,6 +957,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       buildRulePriorityMap([score]),
       isCodingAgentEnvironment(),
       { sectionPause: pause, animateCountUp: animateRender },
+      useHyperlinks,
     );
     if (options.isNonInteractiveEnvironment && options.outputSurface !== "prComment") {
       yield* printAgentGuidance();

--- a/packages/react-doctor/tests/build-run-context.test.ts
+++ b/packages/react-doctor/tests/build-run-context.test.ts
@@ -46,6 +46,10 @@ describe("buildRunContext", () => {
     expect(buildRunContext().invokedVia).toBe("unknown");
   });
 
+  it("records a terminalKind label for where the run is hosted", () => {
+    expect(typeof buildRunContext().terminalKind).toBe("string");
+  });
+
   it("reports the running Node major version", () => {
     const expectedMajor = Number.parseInt(process.versions.node.split(".", 1)[0] ?? "", 10);
     expect(buildRunContext().nodeMajor).toBe(expectedMajor);

--- a/packages/react-doctor/tests/build-sentry-scope.test.ts
+++ b/packages/react-doctor/tests/build-sentry-scope.test.ts
@@ -21,6 +21,7 @@ const baseRunContext: RunContext = {
   viaAction: true,
   codingAgent: null,
   interactive: false,
+  terminalKind: "ci",
   jsonMode: true,
   invokedVia: "pnpm",
 };
@@ -66,6 +67,7 @@ describe("buildSentryScope", () => {
       viaAction: true,
       codingAgent: null,
       interactive: false,
+      terminalKind: "ci",
       jsonMode: true,
       invokedVia: "pnpm",
       nodeMajor: 22,

--- a/packages/react-doctor/tests/detect-terminal-kind.test.ts
+++ b/packages/react-doctor/tests/detect-terminal-kind.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 import { detectTerminalKind } from "../src/cli/utils/detect-terminal-kind.js";
 
-// Build a clean env so a stray host var (running these tests inside iTerm,
-// VS Code, tmux, …) can't leak into the assertions.
+// detectTerminalKind is a pure function of the env it's given (including its CI
+// fallback), so each case passes an isolated env — no host var (iTerm, VS Code,
+// or the CI runner this suite runs in) can leak into the assertions.
 const env = (overrides: Record<string, string>): NodeJS.ProcessEnv => ({ ...overrides });
 
 describe("detectTerminalKind", () => {

--- a/packages/react-doctor/tests/detect-terminal-kind.test.ts
+++ b/packages/react-doctor/tests/detect-terminal-kind.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+import { detectTerminalKind } from "../src/cli/utils/detect-terminal-kind.js";
+
+// Build a clean env so a stray host var (running these tests inside iTerm,
+// VS Code, tmux, …) can't leak into the assertions.
+const env = (overrides: Record<string, string>): NodeJS.ProcessEnv => ({ ...overrides });
+
+describe("detectTerminalKind", () => {
+  it("reports neovim from $NVIM even inside another emulator", () => {
+    expect(detectTerminalKind(env({ NVIM: "/tmp/nvim.sock", TERM_PROGRAM: "iTerm.app" }))).toBe(
+      "neovim",
+    );
+  });
+
+  it("reports vim from $VIM_TERMINAL", () => {
+    expect(detectTerminalKind(env({ VIM_TERMINAL: "9.0" }))).toBe("vim");
+  });
+
+  it("maps known TERM_PROGRAM values to stable labels", () => {
+    expect(detectTerminalKind(env({ TERM_PROGRAM: "vscode" }))).toBe("vscode");
+    expect(detectTerminalKind(env({ TERM_PROGRAM: "iTerm.app" }))).toBe("iterm");
+    expect(detectTerminalKind(env({ TERM_PROGRAM: "WezTerm" }))).toBe("wezterm");
+    expect(detectTerminalKind(env({ TERM_PROGRAM: "Apple_Terminal" }))).toBe("apple-terminal");
+    expect(detectTerminalKind(env({ TERM_PROGRAM: "ghostty" }))).toBe("ghostty");
+  });
+
+  it("detects kitty, Windows Terminal, and alacritty from their own markers", () => {
+    expect(detectTerminalKind(env({ TERM: "xterm-kitty" }))).toBe("kitty");
+    expect(detectTerminalKind(env({ KITTY_WINDOW_ID: "1" }))).toBe("kitty");
+    expect(detectTerminalKind(env({ WT_SESSION: "abc" }))).toBe("windows-terminal");
+    expect(detectTerminalKind(env({ ALACRITTY_WINDOW_ID: "1" }))).toBe("alacritty");
+  });
+
+  it("falls back to tmux, then unknown, when no emulator identifies itself", () => {
+    expect(detectTerminalKind(env({ TMUX: "/tmp/tmux-1/default" }))).toBe("tmux");
+    expect(detectTerminalKind(env({}))).toBe("unknown");
+  });
+});

--- a/packages/react-doctor/tests/format-hyperlink.test.ts
+++ b/packages/react-doctor/tests/format-hyperlink.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatHyperlink } from "../src/cli/utils/format-hyperlink.js";
+
+const ESCAPE = String.fromCharCode(27);
+
+describe("formatHyperlink", () => {
+  it("wraps the text in an OSC 8 hyperlink to the URI", () => {
+    const result = formatHyperlink("src/App.tsx:12", "file:///repo/src/App.tsx");
+    expect(result).toBe(
+      `${ESCAPE}]8;;file:///repo/src/App.tsx${ESCAPE}\\src/App.tsx:12${ESCAPE}]8;;${ESCAPE}\\`,
+    );
+  });
+
+  it("keeps the visible characters exactly equal to the text", () => {
+    const result = formatHyperlink("location", "file:///x");
+    // Stripping the OSC 8 escape sequences leaves only the original text, so
+    // terminals that ignore the escapes show an unchanged location.
+    const visible = result.replaceAll(
+      new RegExp(`${ESCAPE}\\]8;;[^${ESCAPE}]*${ESCAPE}\\\\`, "g"),
+      "",
+    );
+    expect(visible).toBe("location");
+  });
+});

--- a/packages/react-doctor/tests/render-diagnostics-hyperlinks.test.ts
+++ b/packages/react-doctor/tests/render-diagnostics-hyperlinks.test.ts
@@ -1,3 +1,5 @@
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vite-plus/test";
 import * as Effect from "effect/Effect";
 import type { Diagnostic } from "@react-doctor/core";
@@ -43,7 +45,10 @@ describe("printDiagnostics hyperlinks", () => {
     const output = await captureOutput(() =>
       Effect.runPromise(printDiagnostics([diagnostic], false, "/repo", undefined, false, {}, true)),
     );
-    expect(output).toContain(`${ESCAPE}]8;;file:///repo/src/App.tsx`);
+    // Derive the expected URI the way the renderer does, so the absolute-path
+    // form matches on every platform (Windows resolves to `file:///C:/repo/…`).
+    const expectedUri = pathToFileURL(path.resolve("/repo", diagnostic.filePath)).href;
+    expect(output).toContain(`${ESCAPE}]8;;${expectedUri}`);
     // The visible location text is still present and unchanged.
     expect(output).toContain("src/App.tsx:12");
   });

--- a/packages/react-doctor/tests/render-diagnostics-hyperlinks.test.ts
+++ b/packages/react-doctor/tests/render-diagnostics-hyperlinks.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as Effect from "effect/Effect";
+import type { Diagnostic } from "@react-doctor/core";
+import { printDiagnostics } from "../src/cli/utils/render-diagnostics.js";
+
+const ESCAPE = String.fromCharCode(27);
+
+const diagnostic: Diagnostic = {
+  filePath: "src/App.tsx",
+  plugin: "react-doctor",
+  rule: "no-array-index-key",
+  severity: "error",
+  message: "Using the array index as a key breaks reconciliation when the list reorders.",
+  help: "",
+  line: 12,
+  column: 5,
+  category: "Bugs",
+} as Diagnostic;
+
+const captureOutput = async (run: () => Promise<void>): Promise<string> => {
+  const chunks: string[] = [];
+  const consoleObject = globalThis.console as unknown as Record<string, unknown>;
+  const originals = new Map<string, unknown>();
+  const sink =
+    () =>
+    (...args: unknown[]) => {
+      chunks.push(args.join(" ") + "\n");
+    };
+  for (const key of ["log", "info", "warn", "error"]) {
+    originals.set(key, consoleObject[key]);
+    consoleObject[key] = sink();
+  }
+  try {
+    await run();
+  } finally {
+    for (const [key, original] of originals) consoleObject[key] = original;
+  }
+  return chunks.join("");
+};
+
+describe("printDiagnostics hyperlinks", () => {
+  it("wraps the location in an OSC 8 link to the absolute file:// URI when enabled", async () => {
+    const output = await captureOutput(() =>
+      Effect.runPromise(printDiagnostics([diagnostic], false, "/repo", undefined, false, {}, true)),
+    );
+    expect(output).toContain(`${ESCAPE}]8;;file:///repo/src/App.tsx`);
+    // The visible location text is still present and unchanged.
+    expect(output).toContain("src/App.tsx:12");
+  });
+
+  it("emits a plain relative location with no escape sequences by default", async () => {
+    const output = await captureOutput(() =>
+      Effect.runPromise(printDiagnostics([diagnostic], false, "/repo")),
+    );
+    expect(output).toContain("src/App.tsx:12");
+    expect(output).not.toContain("file://");
+    expect(output).not.toContain(`${ESCAPE}]8;;`);
+  });
+});

--- a/packages/react-doctor/tests/supports-hyperlinks.test.ts
+++ b/packages/react-doctor/tests/supports-hyperlinks.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { supportsHyperlinks } from "../src/cli/utils/supports-hyperlinks.js";
+
+// supportsHyperlinks reads CI markers off the real process.env (via
+// isCiEnvironment), so neutralize them — otherwise the "capable terminal"
+// cases would always resolve false when the suite itself runs in CI.
+const CI_MARKERS = ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"] as const;
+
+const ttyStream = { isTTY: true } as unknown as NodeJS.WriteStream;
+const pipeStream = { isTTY: false } as unknown as NodeJS.WriteStream;
+
+describe("supportsHyperlinks", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const marker of CI_MARKERS) {
+      saved[marker] = process.env[marker];
+      delete process.env[marker];
+    }
+  });
+
+  afterEach(() => {
+    for (const marker of CI_MARKERS) {
+      if (saved[marker] === undefined) delete process.env[marker];
+      else process.env[marker] = saved[marker];
+    }
+  });
+
+  it("is true for a capable terminal attached to a TTY", () => {
+    expect(supportsHyperlinks(ttyStream, { TERM_PROGRAM: "iTerm.app" })).toBe(true);
+    expect(supportsHyperlinks(ttyStream, { WT_SESSION: "abc" })).toBe(true);
+    expect(supportsHyperlinks(ttyStream, { TERM: "xterm-kitty" })).toBe(true);
+    expect(supportsHyperlinks(ttyStream, { VTE_VERSION: "6003" })).toBe(true);
+  });
+
+  it("is false off a TTY, for dumb terminals, and unknown emulators", () => {
+    expect(supportsHyperlinks(pipeStream, { TERM_PROGRAM: "iTerm.app" })).toBe(false);
+    expect(supportsHyperlinks(ttyStream, { TERM: "dumb", TERM_PROGRAM: "iTerm.app" })).toBe(false);
+    expect(supportsHyperlinks(ttyStream, { TERM_PROGRAM: "Apple_Terminal" })).toBe(false);
+    expect(supportsHyperlinks(ttyStream, {})).toBe(false);
+    expect(supportsHyperlinks(ttyStream, { VTE_VERSION: "4000" })).toBe(false);
+  });
+
+  it("honors FORCE_HYPERLINK over auto-detection", () => {
+    // Forces on even off a TTY / unknown terminal.
+    expect(supportsHyperlinks(pipeStream, { FORCE_HYPERLINK: "1" })).toBe(true);
+    // Forces off even on a capable terminal.
+    expect(supportsHyperlinks(ttyStream, { FORCE_HYPERLINK: "0", TERM_PROGRAM: "iTerm.app" })).toBe(
+      false,
+    );
+    expect(
+      supportsHyperlinks(ttyStream, { FORCE_HYPERLINK: "false", TERM_PROGRAM: "iTerm.app" }),
+    ).toBe(false);
+  });
+
+  it("is false in CI even on a capable terminal", () => {
+    process.env.CI = "true";
+    expect(supportsHyperlinks(ttyStream, { TERM_PROGRAM: "iTerm.app" })).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/supports-hyperlinks.test.ts
+++ b/packages/react-doctor/tests/supports-hyperlinks.test.ts
@@ -1,31 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from "vite-plus/test";
 import { supportsHyperlinks } from "../src/cli/utils/supports-hyperlinks.js";
 
-// supportsHyperlinks reads CI markers off the real process.env (via
-// isCiEnvironment), so neutralize them — otherwise the "capable terminal"
-// cases would always resolve false when the suite itself runs in CI.
-const CI_MARKERS = ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI"] as const;
-
+// supportsHyperlinks is a pure function of (stream, env) — including its CI
+// check — so each case passes an isolated env and a stub stream; the CI runner
+// this suite runs in can't leak into the assertions.
 const ttyStream = { isTTY: true } as unknown as NodeJS.WriteStream;
 const pipeStream = { isTTY: false } as unknown as NodeJS.WriteStream;
 
 describe("supportsHyperlinks", () => {
-  const saved: Record<string, string | undefined> = {};
-
-  beforeEach(() => {
-    for (const marker of CI_MARKERS) {
-      saved[marker] = process.env[marker];
-      delete process.env[marker];
-    }
-  });
-
-  afterEach(() => {
-    for (const marker of CI_MARKERS) {
-      if (saved[marker] === undefined) delete process.env[marker];
-      else process.env[marker] = saved[marker];
-    }
-  });
-
   it("is true for a capable terminal attached to a TTY", () => {
     expect(supportsHyperlinks(ttyStream, { TERM_PROGRAM: "iTerm.app" })).toBe(true);
     expect(supportsHyperlinks(ttyStream, { WT_SESSION: "abc" })).toBe(true);
@@ -54,7 +36,9 @@ describe("supportsHyperlinks", () => {
   });
 
   it("is false in CI even on a capable terminal", () => {
-    process.env.CI = "true";
-    expect(supportsHyperlinks(ttyStream, { TERM_PROGRAM: "iTerm.app" })).toBe(false);
+    expect(supportsHyperlinks(ttyStream, { CI: "true", TERM_PROGRAM: "iTerm.app" })).toBe(false);
+    expect(
+      supportsHyperlinks(ttyStream, { GITHUB_ACTIONS: "true", TERM_PROGRAM: "iTerm.app" }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

The CLI prints `file:line` diagnostic locations as plain text, so they aren't clickable in terminals/editors — and in monorepo scans the displayed path is relative to a *sub-project* root, not the terminal cwd, so even keyboard navigation (nvim `gF`, VS Code's link detector) silently fails. Sentry also has no signal for which terminals people run in, so we can't size who'd benefit.

This wraps each location in an OSC 8 hyperlink to the file's **absolute** path (clickable in capable terminals, fixes the monorepo case), and adds a `terminalKind` telemetry tag so we can see the actual terminal split next release.

Before:

```
✖ Bugs: Using the array index as a key …
    src/App.tsx:12        ← plain text; not clickable; wrong cwd in a monorepo
```

After:

```
✖ Bugs: Using the array index as a key …
    src/App.tsx:12        ← same visible text, now an OSC 8 link to file:///repo/src/App.tsx
```

(Terminals without OSC 8 support render the line exactly as before — the link rides in escape sequences.)

## What changed

- **OSC 8 hyperlinks** — `format-hyperlink.ts` wraps the location; `render-diagnostics.ts` threads a `hyperlinks` flag through the render chain and links to `pathToFileURL(absolutePath)`. Visible characters are unchanged.
- **Capability detection** — `supports-hyperlinks.ts` (iTerm2/WezTerm/Kitty/Windows Terminal/VS Code/VTE≥0.50), gated by `should-render-hyperlinks.ts`: a capable TTY **and** not a coding agent (whose output parsers shouldn't see escapes). Off for non-TTY, CI, `TERM=dumb`; `FORCE_HYPERLINK` overrides.
- **Telemetry** — `detect-terminal-kind.ts` adds a low-cardinality `terminalKind` run tag (neovim, vscode, iterm, wezterm, kitty, windows-terminal, …) to the run context + Sentry scope. No path/username/secret.
- **Dedup** — extracted `resolve-absolute-path.ts`, shared by `build-code-frame.ts` and the new hyperlink path.
- No new CLI flag; `--absolute-paths` was intentionally **not** added.

## Test plan

- `nr typecheck` — 11/11 ✓
- `turbo run test --filter=react-doctor` — 1812 passed, 0 failed ✓ (4 new test files: format-hyperlink, supports-hyperlinks, detect-terminal-kind, render-diagnostics-hyperlinks)
- `pnpm format:check` ✓ · `pnpm lint` exit 0 (only pre-existing fixture warnings) ✓
- e2e terminal-visuals snapshots unchanged (default `hyperlinks=false`; subprocess uses a pipe → no TTY → no escapes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI presentation and telemetry only; hyperlinks default off in tests/pipes and are gated away from agents and CI logs.
> 
> **Overview**
> Diagnostic **`file:line`** output can now be **OSC 8 hyperlinks** to each file’s absolute `file://` URI while keeping the same visible text (`src/App.tsx:12`). **`printDiagnostics`** takes a **`hyperlinks`** flag (default off); **`inspect`** and **multi-project summary** turn it on via **`shouldRenderHyperlinks`**, which requires a capable TTY and blocks **coding agents**. Detection lives in **`supports-hyperlinks`** (allowlisted terminals, Kitty/Windows Terminal/VTE version, **`FORCE_HYPERLINK`**); links stay off for non-TTY, CI, and **`TERM=dumb`**.
> 
> **`resolve-absolute-path`** is shared by code frames and link targets so monorepo-relative paths resolve against each diagnostic’s project root. Run telemetry adds low-cardinality **`terminalKind`** (**`detect-terminal-kind`**) on the run context and Sentry tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905f67538d84dcfed4f1b8756519dec7a4b2afb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->