### PR TITLE
fix(no-danger): ship default-off so it stops blanket-flagging safe dangerouslySetInnerHTML

### DIFF
--- a/.changeset/fix-no-danger-default-off.md
+++ b/.changeset/fix-no-danger-default-off.md
@@ -1,0 +1,11 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Ship `no-danger` default-off so it no longer blanket-flags safe `dangerouslySetInnerHTML`.
+
+`no-danger` is the absolutist oxc port — it flags **every** `dangerouslySetInnerHTML` with zero content awareness, so it fired Security warnings on the canonical-safe idioms that React Doctor's own content-aware detectors deliberately exempt: escaped JSON-LD, theme-init `<script>` templates, CSS-variable `<style>` injection, and sanitized / `safe`-named values. Two default-on Security rules judged the same prop and disagreed.
+
+The content-aware rules are now the canonical default-on detectors for `dangerouslySetInnerHTML`: `dangerous-html-sink` (dynamic/tainted markup, with the style-tag / static-template / sanitizer exemptions) and `unsafe-json-in-html` (the unescaped-`JSON.stringify` breakout case). `no-danger` remains available opt-in (`"react-doctor/no-danger": "warn"`) for teams that want the stricter "never use `dangerouslySetInnerHTML` at all" policy (oxc / `eslint-plugin-react` parity).
+
+Score impact: repos using these safe idioms will see fewer Security findings and a correspondingly **higher** score. A CI gate pinned to a fixed threshold may pass where it previously failed. Re-enable `no-danger` in config to restore the old behavior.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-danger.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-danger.regressions.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { runScanRule } from "../../../test-utils/run-scan-rule.js";
+import { dangerousHtmlSink } from "../security-scan/dangerous-html-sink.js";
+import { unsafeJsonInHtml } from "../security-scan/unsafe-json-in-html.js";
+import { noDanger } from "./no-danger.js";
+
+// `no-danger` is the absolutist oxc port: it flags EVERY
+// `dangerouslySetInnerHTML` with zero content awareness. It is shipped
+// default-off so the content-aware Security detectors — `dangerous-html-sink`
+// (dynamic/tainted markup) and `unsafe-json-in-html` (the JSON-breakout case) —
+// are the canonical default-on rules. These regressions pin that contract:
+// the canonical-safe idioms stay clean by default, while genuinely-risky markup
+// is still caught.
+
+// Asserts both default-on `dangerouslySetInnerHTML` detectors stay silent — the
+// contract that lets `no-danger` ship default-off without re-flagging safe code.
+const expectDefaultDetectorsSilent = (content: string): void => {
+  const file = { relativePath: "src/component.tsx", content };
+  expect(runScanRule(dangerousHtmlSink, file)).toHaveLength(0);
+  expect(runScanRule(unsafeJsonInHtml, file)).toHaveLength(0);
+};
+
+describe("react-builtins/no-danger — demotion regressions", () => {
+  it("ships default-off so it never blanket-flags by default", () => {
+    expect(noDanger.defaultEnabled).toBe(false);
+  });
+
+  it("still flags every dangerouslySetInnerHTML when opted in", () => {
+    const result = runRule(noDanger, `<div dangerouslySetInnerHTML={{ __html: "x" }} />;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});
+
+describe("dangerouslySetInnerHTML — canonical-safe uses stay clean by default", () => {
+  it("stays silent on a theme-init <script> (static template, no interpolation)", () => {
+    const content = `export const ThemeScript = () => (
+  <script
+    dangerouslySetInnerHTML={{
+      __html: \`(function(){try{var t=localStorage.getItem('theme');document.documentElement.dataset.theme=t||'system';}catch(e){}})()\`,
+    }}
+  />
+);
+`;
+    expectDefaultDetectorsSilent(content);
+  });
+
+  it("stays silent on CSS-variable injection via <style>", () => {
+    const content = `export const Brand = ({ brandColor }: { brandColor: string }) => (
+  <style dangerouslySetInnerHTML={{ __html: \`:root{--brand:\${brandColor}}\` }} />
+);
+`;
+    expectDefaultDetectorsSilent(content);
+  });
+
+  it("stays silent on a sanitized (DOMPurify) value", () => {
+    const content = `export const Bio = ({ userBio }: { userBio: string }) => (
+  <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(userBio) }} />
+);
+`;
+    expectDefaultDetectorsSilent(content);
+  });
+
+  it("stays silent on JSON-LD whose JSON is HTML-escaped at the sink", () => {
+    const content = `export const Seo = ({ jsonLd }: { jsonLd: object }) => (
+  <script
+    type="application/ld+json"
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\\\u003c") }}
+  />
+);
+`;
+    expectDefaultDetectorsSilent(content);
+  });
+});
+
+describe("dangerouslySetInnerHTML — genuinely-risky markup is still caught", () => {
+  it("flags unescaped JSON-LD via the precise unsafe-json-in-html rule", () => {
+    const content = `export const Seo = ({ structuredData }: { structuredData: object }) => (
+  <script
+    type="application/ld+json"
+    dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+  />
+);
+`;
+    expect(
+      runScanRule(unsafeJsonInHtml, { relativePath: "src/seo.tsx", content }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("flags HTML built from a dynamic prop value", () => {
+    const content = `export const Article = ({ userHtml }: { userHtml: string }) => (
+  <div dangerouslySetInnerHTML={{ __html: userHtml }} />
+);
+`;
+    expect(
+      runScanRule(dangerousHtmlSink, { relativePath: "src/article.tsx", content }).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-danger.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-danger.ts
@@ -15,6 +15,15 @@ export const noDanger = defineRule({
   title: "Raw HTML injection can run unsafe markup",
   severity: "warn",
   category: "Security",
+  // Default off: this is the absolutist oxc port — it flags EVERY
+  // `dangerouslySetInnerHTML` with zero content awareness, so it fires on the
+  // canonical-safe idioms (escaped JSON-LD, theme-init `<script>`, CSS-var
+  // `<style>`, sanitized/`safe`-named values). The default-on Security
+  // detectors are the content-aware `dangerous-html-sink` (dynamic/tainted
+  // markup) and `unsafe-json-in-html` (the JSON-breakout case), which exempt
+  // those idioms. Opt in to enforce the stricter "never use
+  // `dangerouslySetInnerHTML` at all" policy (oxc / eslint-plugin-react parity).
+  defaultEnabled: false,
   recommendation:
     "Render trusted content as React children so attacker-controlled HTML cannot run in users' browsers.",
   create: (context) => ({

--- a/packages/react-doctor/tests/regressions/cli-and-output.test.ts
+++ b/packages/react-doctor/tests/regressions/cli-and-output.test.ts
@@ -55,9 +55,9 @@ const MemoChild = memo((props: { payload: { label: string } }) => {
   return <span>{props.payload.label}</span>;
 });
 
-export const App = () => (
+export const App = ({ html }: { html: string }) => (
   <>
-    <div dangerouslySetInnerHTML={{ __html: "<strong>Unsafe</strong>" }} />
+    <div dangerouslySetInnerHTML={{ __html: html }} />
     <MemoChild payload={{ label: "slow" }} />
   </>
 );

--- a/packages/react-doctor/tests/rule-config-units.test.ts
+++ b/packages/react-doctor/tests/rule-config-units.test.ts
@@ -103,9 +103,11 @@ describe("resolveEffectiveRuleSeverity", () => {
   const entry = findRequiredRule("react-doctor/no-danger");
 
   it("falls back to the registry default when nothing overrides it", () => {
-    const result = resolveEffectiveRuleSeverity(null, entry);
+    const defaultOnEntry = catalog.find((candidate) => candidate.defaultEnabled);
+    if (!defaultOnEntry) throw new Error("Expected at least one default-enabled rule");
+    const result = resolveEffectiveRuleSeverity(null, defaultOnEntry);
     expect(result.source).toBe("default");
-    expect(result.value).toBe(entry.defaultSeverity);
+    expect(result.value).toBe(defaultOnEntry.defaultSeverity);
   });
 
   it("prefers a rule-level override (including legacy keys)", () => {


### PR DESCRIPTION
## Why

`no-danger` is the absolutist oxc port — it flags **every** `dangerouslySetInnerHTML` with zero content awareness, double-firing Security warnings on the canonical-safe idioms that React Doctor's own content-aware detectors deliberately exempt. Two default-on Security rules judged the same prop and disagreed; the blunt one always won.

Before (all flagged by `no-danger`, even though safe):

```tsx
<style dangerouslySetInnerHTML={{ __html: `:root{--brand:${color}}` }} />
<div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(bio) }} />
<script type="application/ld+json"
  dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }} />
```

After: clean by default. `dangerous-html-sink` (dynamic/tainted markup) and `unsafe-json-in-html` (unescaped-`JSON.stringify` breakout) remain default-on and still flag genuinely-risky cases. `no-danger` stays available opt-in (`"react-doctor/no-danger": "warn"`) for strict oxc / `eslint-plugin-react` parity.

## What changed

- `no-danger` now ships `defaultEnabled: false` (opt-in).
- The content-aware `dangerous-html-sink` + `unsafe-json-in-html` are the canonical default-on `dangerouslySetInnerHTML` detectors (unchanged — they already exempt the safe idioms).
- Added `no-danger.regressions.test.ts`: demotion invariant, opt-in still fires, four canonical-safe idioms stay clean by default, genuinely-risky markup still caught by the precise rules.
- Updated `rule-config-units` (default-fallback test now uses a generically-found default-on rule) and the `cli-and-output` category-filter fixture (static `__html` string → dynamic prop, so its Security finding comes from `dangerous-html-sink`).

## Score impact (breaking-ish for CI gates)

Repos using these safe idioms get **fewer** Security findings and a correspondingly **higher** score; a CI gate pinned to a fixed threshold may pass where it previously failed. Re-enable `no-danger` in config to restore the old behavior. Captured in the changeset (`oxlint-plugin-react-doctor: patch`, fixed-group bumps all packages).

## Test plan

- `nr test no-danger` (oxlint-plugin) — 46/46
- `nr test rule-config-units cli-and-output` (react-doctor) — pass
- `nr typecheck` — 11/11 · `pnpm -w run lint` — exit 0 · `pnpm -w run format:check` — exit 0
- RDE: not run — this flips a default rather than adding detection logic, so there's no new false-positive surface; coverage-loss risk is pinned by the regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Security lint behavior and scan scores (CI thresholds), though detection logic for risky HTML is unchanged and opt-in restores the old strict rule.
> 
> **Overview**
> **`react-doctor/no-danger` is now opt-in (`defaultEnabled: false`)** instead of running by default. It still flags every `dangerouslySetInnerHTML` when enabled; default scans no longer get duplicate Security noise on patterns the content-aware rules already treat as safe.
> 
> **Default-on Security coverage for HTML sinks is unchanged in intent:** `dangerous-html-sink` and `unsafe-json-in-html` remain the primary detectors for risky markup. Teams that want strict “never use `dangerouslySetInnerHTML`” parity can set `"react-doctor/no-danger": "warn"` in config.
> 
> **Tests and fixtures** lock in the demotion (`no-danger.regressions.test.ts`), adjust the category-filter fixture to use dynamic `__html` so Security findings come from `dangerous-html-sink`, and fix the rule-config default-severity fallback test to use a generic default-on rule.
> 
> **Score / CI:** fewer Security findings on common safe idioms → higher scores; fixed score gates may start passing unless `no-danger` is re-enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e817b93a752ad77b311bd9edeb039cc11e2e14b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->