### PR TITLE
test(oxlint-plugin): green the rule suite and run it in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "turbo run dev --filter=react-doctor",
     "build": "turbo run build",
-    "test": "turbo run test --filter=react-doctor --filter=@react-doctor/core --filter=@react-doctor/api --filter=@react-doctor/language-server",
+    "test": "turbo run test --filter=react-doctor --filter=@react-doctor/core --filter=@react-doctor/api --filter=@react-doctor/language-server --filter=oxlint-plugin-react-doctor",
     "test:public-react-repos": "REACT_DOCTOR_PUBLIC_REPOS=1 vp test run packages/react-doctor/tests/public-react-repos.test.ts",
     "typecheck": "turbo run typecheck",
     "lint": "vp lint",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
@@ -71,15 +71,20 @@ export const DIVERGENCES: Record<string, OxcDivergence> = {
     reason: "Intentional: default allowAsProps=true to allow render-prop components.",
   },
   "jsx-no-new-function-as-prop": {
-    // OXC flags inline-handler-as-prop on any JSX element. We skip
-    // intrinsic HTML elements (`<button>`, `<a>`, ...) because
-    // neither React nor the browser memoizes DOM event listeners,
-    // so a "new function per render" on intrinsic elements has zero
-    // measurable cost. fail[9-12] all exercise the
-    // `<button onClick={...}/>` / `<a onClick={...}/>` shape on
-    // intrinsic elements.
-    failSkips: [9, 10, 11, 12],
-    reason: "Intentional: skip intrinsic HTML elements (no memo concern).",
+    // Two intentional skips:
+    // (1) intrinsic HTML elements (fail[9-12]) — `<button onClick={...}/>`
+    //     / `<a onClick={...}/>`: neither React nor the browser memoizes
+    //     DOM event listeners, so a "new function per render" on intrinsic
+    //     elements has zero measurable cost.
+    // (2) non-memoised consumers (fail[0-8]) — OXC flags an inline handler
+    //     on ANY consumer. We only fire when same-file analysis PROVES the
+    //     consumer is `memo`-wrapped, because a fresh function reference
+    //     only breaks a memoized child (see `memoStatusForJsxOpeningName`).
+    //     OXC's fixtures pass plain/unknown consumers, so our gate
+    //     suppresses them. The gated (memoised-consumer) path is covered by
+    //     `jsx-no-new-function-as-prop.regressions.test.ts`.
+    failSkips: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    reason: "Intentional: skip intrinsic HTML elements + non-memoised consumers (memo-gated rule).",
   },
   "jsx-no-jsx-as-prop": {
     // OXC flags any JSX passed as a prop. We skip well-known "slot"
@@ -93,7 +98,7 @@ export const DIVERGENCES: Record<string, OxcDivergence> = {
     reason: "Intentional: skip known slot-prop names (icon, tooltip, fallback, render*, etc.).",
   },
   "jsx-no-new-object-as-prop": {
-    // Two unrelated skips merged:
+    // Three skips merged:
     // (1) `style` / `dangerouslySetInnerHTML` (fail[5]) — these are
     //     React-mandated object-shape APIs and the perf footgun is
     //     unactionable on non-memoized components, where almost every
@@ -103,9 +108,16 @@ export const DIVERGENCES: Record<string, OxcDivergence> = {
     //     receive inline literals by design (chart / animation libs,
     //     design systems). The perf footgun the rule targets is
     //     hot-path identity changes; these are one-time setup.
-    failSkips: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+    // (3) non-memoised consumers (fail[9-14]) — like
+    //     `jsx-no-new-function-as-prop`, we only fire when same-file
+    //     analysis proves the consumer is `memo`-wrapped. OXC's
+    //     render-local-binding fixtures (`const x = {}; <Bar x={x}/>`)
+    //     pass plain consumers, so the memo gate suppresses them. The
+    //     gated path is covered by
+    //     `jsx-no-new-object-as-prop.regressions.test.ts`.
+    failSkips: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
     reason:
-      "Intentional: skip `style` / `dangerouslySetInnerHTML` + configuration-shape prop names.",
+      "Intentional: skip `style` / `dangerouslySetInnerHTML` + config-shape props + non-memoised consumers.",
   },
   "jsx-no-new-array-as-prop": {
     // OXC's fixtures use `<Item list={[...]}/>` to test inline-array
@@ -115,6 +127,33 @@ export const DIVERGENCES: Record<string, OxcDivergence> = {
     // convention. fail[0-10] all exercise the `list` prop pattern.
     failSkips: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     reason: "Intentional: skip data-collection prop names (list, items, options, data, etc.).",
+  },
+  "no-multi-comp": {
+    // OXC flags a file with 2+ components. React Doctor intentionally
+    // only flags 3+: a "1 main + 1 sub-component" file (e.g.
+    // `ErrorBoundary` + `OptionalErrorBoundary`) is idiomatic
+    // co-location, not a smell — see the `flagged.length <= 2` guard in
+    // the rule, plus the barrel / feature-module exemptions. Every OXC
+    // fail fixture here declares exactly 2 components, so all 20 fall
+    // below our threshold. The 3+ behaviour and the exemptions are
+    // covered by `no-multi-comp.regressions.test.ts`.
+    failSkips: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+    reason:
+      "Intentional: flag only 3+ components (OXC flags 2+); idiomatic 2-component co-location is allowed.",
+  },
+  "no-array-index-key": {
+    // OXC flags any key expression that incorporates the array index,
+    // including arithmetic. React Doctor's composite-key heuristic
+    // deliberately skips `<expr> + index` shapes because an offset is
+    // often a stable global scheme (`key={page * pageSize + index}`,
+    // which produces a unique-across-pages key). fail[2] (`key={1 +
+    // index}`) is the degenerate constant-offset case that the same
+    // heuristic also skips — a minor accepted false-negative on a
+    // default-OFF rule. The direct `key={index}` cases (fail[0-1,
+    // 3-20]) still fire.
+    failSkips: [2],
+    reason:
+      "Intentional: composite-key heuristic skips `<expr> + index`, incl. the constant `1 + index`.",
   },
   "style-prop-object": {
     // OXC flags `style="..."` on any JSX element. We only flag it on

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-array-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-array-as-prop.regressions.test.ts
@@ -14,9 +14,11 @@ describe("react-builtins/jsx-no-new-array-as-prop — regressions", () => {
   // `arr.concat(a, b)` (multi-element) also allocate a new array.
   // NOTE: use a non-skipped prop name (`payload` rather than `list` /
   // `items` / `data`) so the data-array-prop-name skip doesn't
-  // suppress the rule.
+  // suppress the rule, and declare `Item` as a same-file `memo(...)`
+  // consumer so the memoised-consumer gate doesn't suppress it either.
+  const memoisedConsumer = `import { memo } from "react";\nconst Item = memo(() => null);\n`;
   it("flags arrow with zero-arg .concat() (shallow copy)", () =>
-    expectFail(`const Foo = () => (<Item payload={arr1.concat()} />)`));
+    expectFail(`${memoisedConsumer}const Foo = () => (<Item payload={arr1.concat()} />)`));
   it("flags arrow with multi-arg .concat(a, b)", () =>
-    expectFail(`const Foo = () => (<Item payload={arr1.concat(a, b)} />)`));
+    expectFail(`${memoisedConsumer}const Foo = () => (<Item payload={arr1.concat(a, b)} />)`));
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-function-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-function-as-prop.regressions.test.ts
@@ -17,14 +17,47 @@ const expectPass = (code: string): void => {
 // Hand-written coverage for the memoised-consumer gate. OXC flags an
 // inline handler on ANY consumer; React Doctor only fires when same-file
 // analysis proves the consumer is `memo`-wrapped (a fresh function
-// reference only breaks a memoized child). The OXC fail fixtures pass
-// plain/unknown consumers and are skipped in `oxc-divergences.ts`, so
-// these tests are the only fail-coverage for the rule's actual contract.
-const memoisedConsumer = `import { memo } from "react";\nconst Item = memo(() => null);\n`;
+// reference only breaks a memoized child). Every OXC fail fixture passes
+// a plain/unknown consumer and is therefore skipped in
+// `oxc-divergences.ts`, so these tests are the only fail-coverage for the
+// rule. They mirror the detection SHAPES the OXC fixtures exercised
+// (inline fn, `.bind`, `new Function`, logical / conditional fallbacks,
+// render-local bindings), but against a same-file `memo()` consumer so
+// the gate doesn't suppress them.
+const memoised = (jsx: string): string =>
+  `import { memo } from "react";\nconst Item = memo(() => null);\n${jsx}`;
 
 describe("react-builtins/jsx-no-new-function-as-prop — regressions", () => {
-  it("flags an inline function passed to a same-file memo()-wrapped consumer", () => {
-    expectFail(`${memoisedConsumer}const Foo = () => <Item prop={() => true} />;`);
+  it("flags an inline arrow function", () => {
+    expectFail(memoised(`const Foo = () => <Item prop={() => true} />;`));
+  });
+
+  it("flags an inline function expression", () => {
+    expectFail(memoised(`const Foo = () => <Item prop={function () { return true; }} />;`));
+  });
+
+  it("flags a `.bind()` call", () => {
+    expectFail(memoised(`const Foo = ({ handler }) => <Item prop={handler.bind(null)} />;`));
+  });
+
+  it("flags a `new Function(...)` expression", () => {
+    expectFail(memoised(`const Foo = () => <Item prop={new Function("a", "return a")} />;`));
+  });
+
+  it("flags a logical-fallback handler (`cb || (() => {})`)", () => {
+    expectFail(memoised(`const Foo = ({ cb }) => <Item prop={cb || (() => {})} />;`));
+  });
+
+  it("flags a conditional handler (`cond ? cb : () => {}`)", () => {
+    expectFail(memoised(`const Foo = ({ cond, cb }) => <Item prop={cond ? cb : () => {}} />;`));
+  });
+
+  it("flags a render-local function declaration binding", () => {
+    expectFail(
+      memoised(
+        `const Foo = () => { function handler(e) { doThing(e); } return <Item prop={handler} />; };`,
+      ),
+    );
   });
 
   it("does not flag the same inline function on a non-memoised consumer", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-function-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-function-as-prop.regressions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jsxNoNewFunctionAsProp } from "./jsx-no-new-function-as-prop.js";
+
+const expectFail = (code: string): void => {
+  const result = runRule(jsxNoNewFunctionAsProp, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics.length).toBeGreaterThan(0);
+};
+
+const expectPass = (code: string): void => {
+  const result = runRule(jsxNoNewFunctionAsProp, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(0);
+};
+
+// Hand-written coverage for the memoised-consumer gate. OXC flags an
+// inline handler on ANY consumer; React Doctor only fires when same-file
+// analysis proves the consumer is `memo`-wrapped (a fresh function
+// reference only breaks a memoized child). The OXC fail fixtures pass
+// plain/unknown consumers and are skipped in `oxc-divergences.ts`, so
+// these tests are the only fail-coverage for the rule's actual contract.
+const memoisedConsumer = `import { memo } from "react";\nconst Item = memo(() => null);\n`;
+
+describe("react-builtins/jsx-no-new-function-as-prop — regressions", () => {
+  it("flags an inline function passed to a same-file memo()-wrapped consumer", () => {
+    expectFail(`${memoisedConsumer}const Foo = () => <Item prop={() => true} />;`);
+  });
+
+  it("does not flag the same inline function on a non-memoised consumer", () => {
+    expectPass(`const Item = () => null;\nconst Foo = () => <Item prop={() => true} />;`);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-object-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-object-as-prop.regressions.test.ts
@@ -15,23 +15,44 @@ const expectPass = (code: string): void => {
 };
 
 // Hand-written coverage for the memoised-consumer gate (mirrors
-// `jsx-no-new-function-as-prop`). OXC's render-local-binding fixtures
-// (`const x = {}; <Bar x={x}/>`) use plain consumers and are skipped in
-// `oxc-divergences.ts`; these tests cover both the inline-object and the
-// render-local-binding paths against a memoised consumer. A plain `foo`
-// prop is used (not `config`/`options`/`style`/etc.) so the config-shape
-// / always-fresh prop-name skips don't suppress the rule.
-const memoisedConsumer = `import { memo } from "react";\nconst Item = memo(() => null);\n`;
+// `jsx-no-new-function-as-prop`). Every OXC fail fixture passes a plain
+// consumer and is skipped in `oxc-divergences.ts`, so these tests are the
+// only fail-coverage for the rule. They mirror the object-producing
+// SHAPES the OXC fixtures exercised (inline literal, `Object.assign` /
+// `Object.create` / `new Object` / `Object()`, logical / conditional
+// fallbacks, render-local binding) against a same-file `memo()` consumer.
+// A plain `foo` prop is used (not `config`/`options`/`style`/etc.) so the
+// config-shape / always-fresh prop-name skips don't suppress the rule.
+const memoised = (jsx: string): string =>
+  `import { memo } from "react";\nconst Item = memo(() => null);\n${jsx}`;
 
 describe("react-builtins/jsx-no-new-object-as-prop — regressions", () => {
-  it("flags an inline object passed to a same-file memo()-wrapped consumer", () => {
-    expectFail(`${memoisedConsumer}const Foo = () => <Item foo={{ a: 1 }} />;`);
+  it("flags an inline object literal", () => {
+    expectFail(memoised(`const Foo = () => <Item foo={{ a: 1 }} />;`));
   });
 
-  it("flags a render-local object binding passed to a memoised consumer", () => {
-    expectFail(
-      `${memoisedConsumer}const Foo = () => { const value = {}; return <Item foo={value} />; };`,
-    );
+  it("flags `Object.assign(...)`", () => {
+    expectFail(memoised(`const Foo = ({ base }) => <Item foo={Object.assign({}, base)} />;`));
+  });
+
+  it("flags `Object.create(...)`", () => {
+    expectFail(memoised(`const Foo = () => <Item foo={Object.create(null)} />;`));
+  });
+
+  it("flags `new Object()`", () => {
+    expectFail(memoised(`const Foo = () => <Item foo={new Object()} />;`));
+  });
+
+  it("flags a logical-fallback object (`value || { a: 1 }`)", () => {
+    expectFail(memoised(`const Foo = ({ value }) => <Item foo={value || { a: 1 }} />;`));
+  });
+
+  it("flags a conditional object (`cond ? value : {}`)", () => {
+    expectFail(memoised(`const Foo = ({ cond, value }) => <Item foo={cond ? value : {}} />;`));
+  });
+
+  it("flags a render-local object binding", () => {
+    expectFail(memoised(`const Foo = () => { const value = {}; return <Item foo={value} />; };`));
   });
 
   it("does not flag the same object on a non-memoised consumer", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-object-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-object-as-prop.regressions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jsxNoNewObjectAsProp } from "./jsx-no-new-object-as-prop.js";
+
+const expectFail = (code: string): void => {
+  const result = runRule(jsxNoNewObjectAsProp, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics.length).toBeGreaterThan(0);
+};
+
+const expectPass = (code: string): void => {
+  const result = runRule(jsxNoNewObjectAsProp, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(0);
+};
+
+// Hand-written coverage for the memoised-consumer gate (mirrors
+// `jsx-no-new-function-as-prop`). OXC's render-local-binding fixtures
+// (`const x = {}; <Bar x={x}/>`) use plain consumers and are skipped in
+// `oxc-divergences.ts`; these tests cover both the inline-object and the
+// render-local-binding paths against a memoised consumer. A plain `foo`
+// prop is used (not `config`/`options`/`style`/etc.) so the config-shape
+// / always-fresh prop-name skips don't suppress the rule.
+const memoisedConsumer = `import { memo } from "react";\nconst Item = memo(() => null);\n`;
+
+describe("react-builtins/jsx-no-new-object-as-prop — regressions", () => {
+  it("flags an inline object passed to a same-file memo()-wrapped consumer", () => {
+    expectFail(`${memoisedConsumer}const Foo = () => <Item foo={{ a: 1 }} />;`);
+  });
+
+  it("flags a render-local object binding passed to a memoised consumer", () => {
+    expectFail(
+      `${memoisedConsumer}const Foo = () => { const value = {}; return <Item foo={value} />; };`,
+    );
+  });
+
+  it("does not flag the same object on a non-memoised consumer", () => {
+    expectPass(`const Item = () => null;\nconst Foo = () => <Item foo={{ a: 1 }} />;`);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noMultiComp } from "./no-multi-comp.js";
+
+const expectFail = (code: string): void => {
+  const result = runRule(noMultiComp, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics.length).toBeGreaterThan(0);
+};
+
+const expectPass = (code: string): void => {
+  const result = runRule(noMultiComp, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(0);
+};
+
+// Hand-written coverage for React Doctor's intentional divergence from
+// OXC: OXC flags 2+ components per file, we flag only 3+ (see the
+// `no-multi-comp` entry in `oxc-divergences.ts` — every OXC fail fixture
+// declares exactly 2 components, so they are all skipped there). These
+// tests guard the 3+ threshold and the feature-module exemption that the
+// OXC fixtures can't.
+describe("react-builtins/no-multi-comp — regressions", () => {
+  it("does not flag a 2-component file (idiomatic main + helper co-location)", () => {
+    expectPass(`const Foo = () => <div />; const Bar = () => <div />;`);
+  });
+
+  it("flags a 3-component file", () => {
+    expectFail(`const Foo = () => <div />; const Bar = () => <div />; const Baz = () => <div />;`);
+  });
+
+  it("counts null-returning components toward the 3+ threshold", () => {
+    expectFail(`const Foo = () => null; const Bar = () => null; const Baz = () => null;`);
+  });
+
+  it("does not flag a small feature module (1-2 exports + private helper)", () => {
+    expectPass(
+      `export const Foo = () => <div />; export const Bar = () => <div />; function Helper() { return <span />; }`,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.test.ts
@@ -22,7 +22,7 @@ describe("hooks-no-nan-in-deps", () => {
     // — `Object.is(NaN, NaN) === true`, so the hook does NOT re-run on
     // every render. Regression guard against the previous wording that
     // wrongly claimed it "always reruns".
-    expect(result.diagnostics[0].message).toContain("silently breaks your hook");
+    expect(result.diagnostics[0].message).toContain("Object.is");
     expect(result.diagnostics[0].message).not.toContain("always rerun");
   });
 


### PR DESCRIPTION
## Why

The `oxlint-plugin-react-doctor` rule suite had ~39 red tests on `main`, undetected because the root `pnpm test` filter never ran the package (it's been excluded since at least Apr 2026). They are **not** environment issues — they were a stale assertion plus several intentional divergences from the upstream OXC fixtures that were never registered. This greens the suite and adds the package to CI so it can't silently rot again.

Before:

```
$ pnpm --filter oxlint-plugin-react-doctor test
 Test Files  6 failed | 227 passed (233)
      Tests  39 failed | 7223 passed | 49 skipped (7311)
# e.g. no-multi-comp / jsx-no-new-*-as-prop: "expected 0 to be greater than 0"
#      hooks-no-nan-in-deps: expected message to contain "silently breaks your hook"
# ...and CI stayed green because it never ran this package.
```

After:

```
$ pnpm --filter oxlint-plugin-react-doctor test
 Test Files  236 passed (236)
      Tests  7235 passed | 85 skipped (7320)
```

## What changed

- **Registered intentional divergences** in `__fixtures__/oxc-divergences.ts` (each verified to still fire once its gating condition is met, so none is a dead rule):
  - `no-multi-comp` — flags 3+ components (OXC flags 2+); every OXC fail fixture has exactly 2.
  - `jsx-no-new-{function,object}-as-prop` — only fire when same-file analysis proves the consumer is `memo`-wrapped; OXC fixtures use plain consumers.
  - `no-array-index-key` — composite-key heuristic skips `<expr> + index` (incl. the constant `1 + index`); direct `key={index}` still fires.
- **Fixed the stale assertion** in `hooks-no-nan-in-deps.test.ts` — the rule message was reworded in #737 to the Object.is phrasing; the test now asserts that (it's the rule that's correct).
- **Added hand-written regression coverage** for the rules whose OXC fail-cases are now fully skipped (`no-multi-comp`, `jsx-no-new-function`, `jsx-no-new-object`), matching the existing `jsx-key` / `jsx-no-new-array` local `expectFail`/`expectPass` idiom; fixed the `jsx-no-new-array` regression test to use a memoised consumer.
- **Added `oxlint-plugin-react-doctor` to the root test filter** so CI now runs the suite. (`eslint-plugin-react-doctor` stays excluded — it has zero test files; a separate follow-up.)

No published runtime behavior changed (test code + test-only fixture config + CI filter), so no changeset.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test` → 236 files, 7235 passed, 0 failing
- `pnpm exec turbo run test --filter=oxlint-plugin-react-doctor` (CI path: build + test) → green
- `pnpm --filter oxlint-plugin-react-doctor typecheck`, `vp lint`, `vp fmt --check` on touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and CI filter updates; no published lint rule runtime behavior is modified.
> 
> **Overview**
> Fixes ~39 failing `oxlint-plugin-react-doctor` tests that CI never ran because the root **`pnpm test`** turbo filter omitted that package.
> 
> **`oxc-divergences.ts`** now documents and skips upstream OXC fixtures that disagree with intentional rule behavior: memo-gated **`jsx-no-new-function-as-prop`** / **`jsx-no-new-object-as-prop`**, 3+ threshold **`no-multi-comp`**, and composite-key **`no-array-index-key`** (`1 + index`).
> 
> New **`.regressions.test.ts`** files exercise those gated paths (memo consumers, 3-component files, exemptions). **`jsx-no-new-array-as-prop`** regressions use a memoised consumer so they aren’t suppressed by the same gate.
> 
> **`hooks-no-nan-in-deps.test.ts`** expects the current **`Object.is`** wording instead of the old “silently breaks your hook” message.
> 
> Root **`package.json`** adds **`oxlint-plugin-react-doctor`** to the test filter so the full suite runs in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beebe164cac516cc2d70661b8485a447bce11b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->