### PR TITLE
refactor: Effect v4 elegance pass — shared helpers, DRY, magic-number cleanup

### DIFF
--- a/packages/core/src/editor-scan.ts
+++ b/packages/core/src/editor-scan.ts
@@ -166,7 +166,16 @@ export const runEditorScan = async (input: EditorScanInput): Promise<EditorScanR
     // REACT_DOCTOR_OTLP_AUTH_HEADER are set; when they are, every
     // `runInspect` / `Service.method` span from this scan is exported,
     // giving editor scans the same observability as the CLI.
-  }).pipe(Effect.provide(layers), Effect.provide(layerOtlp));
+  }).pipe(
+    // Parent span for the whole editor scan (grandparent of `runInspect`'s
+    // own span). Placed before the provides so the OTLP tracer layer is in
+    // scope; only booleans are attributed so no scanned path leaks.
+    Effect.withSpan("runEditorScan", {
+      attributes: { "editor.lint": lint, "editor.runDeadCode": runDeadCode },
+    }),
+    Effect.provide(layers),
+    Effect.provide(layerOtlp),
+  );
 
   const exit = await Effect.runPromiseExit(program);
 

--- a/packages/core/src/editor-scan.ts
+++ b/packages/core/src/editor-scan.ts
@@ -10,6 +10,7 @@ import { layerOtlp } from "./observability.js";
 import { isProjectDiscoveryError } from "./project-info/index.js";
 import { OxlintConcurrency } from "./refs.js";
 import { runInspect } from "./run-inspect.js";
+import { messageFromUnknown } from "./utils/message-from-unknown.js";
 import { Config } from "./services/config.js";
 import { DeadCode } from "./services/dead-code.js";
 import { Files } from "./services/files.js";
@@ -206,6 +207,6 @@ export const runEditorScan = async (input: EditorScanInput): Promise<EditorScanR
     didDeadCodeFail: false,
     deadCodeFailureReason: null,
     lintPartialFailures: [],
-    error: error instanceof Error ? error.message : String(error),
+    error: messageFromUnknown(error),
   };
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,7 @@ export * from "./utils/has-published-fix-recipe.js";
 export * from "./utils/list-source-files.js";
 export * from "./utils/map-with-concurrency.js";
 export * from "./utils/match-glob-pattern.js";
+export * from "./utils/message-from-unknown.js";
 export * from "./utils/merge-react-doctor-configs.js";
 export * from "./utils/redact-sensitive-text.js";
 export * from "./utils/resolve-github-actions-score-metadata.js";

--- a/packages/core/src/load-config.ts
+++ b/packages/core/src/load-config.ts
@@ -9,6 +9,7 @@ import type { Jiti } from "jiti";
 import type { ReactDoctorConfig } from "./types/index.js";
 import { isFile, isPlainObject } from "./project-info/index.js";
 import { isProjectBoundary } from "./utils/is-project-boundary.js";
+import { messageFromUnknown } from "./utils/message-from-unknown.js";
 import { validateConfigTypes } from "./validate-config-types.js";
 
 const warn = (message: string): void => {
@@ -54,9 +55,6 @@ interface DirectoryConfigResult {
 
 // One jiti instance, reused across loads so its transform cache is warm.
 const jiti = createJiti(import.meta.url);
-
-const formatError = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error);
 
 const importDefaultExport = async (jitiInstance: Jiti, filePath: string): Promise<unknown> => {
   const imported = await jitiInstance.import<{ default?: unknown }>(filePath);
@@ -128,7 +126,7 @@ const loadModuleConfig = async (filePath: string): Promise<unknown> => {
       return await importDefaultExport(aliasJiti, filePath);
     } catch (retryError) {
       throw new Error(
-        `${formatError(error)} (retry with ${SELF_PACKAGE_IMPORT_SPECIFIER} aliased to the running react-doctor package also failed: ${formatError(retryError)})`,
+        `${messageFromUnknown(error)} (retry with ${SELF_PACKAGE_IMPORT_SPECIFIER} aliased to the running react-doctor package also failed: ${messageFromUnknown(retryError)})`,
         { cause: retryError },
       );
     }
@@ -199,7 +197,7 @@ const loadLegacyConfig = (directory: string): DirectoryConfigResult => {
     }
     warn(`${LEGACY_CONFIG_FILENAME} must contain an object, ignoring.`);
   } catch (error) {
-    warn(`Failed to load ${LEGACY_CONFIG_FILENAME}: ${formatError(error)}`);
+    warn(`Failed to load ${LEGACY_CONFIG_FILENAME}: ${messageFromUnknown(error)}`);
   }
   return { status: "invalid", loaded: null };
 };
@@ -226,7 +224,7 @@ const loadConfigFromDirectory = async (directory: string): Promise<DirectoryConf
       warn(`${CONFIG_BASENAME}.${extension} must export an object, ignoring.`);
       sawBrokenConfigFile = true;
     } catch (error) {
-      warn(`Failed to load ${CONFIG_BASENAME}.${extension}: ${formatError(error)}`);
+      warn(`Failed to load ${CONFIG_BASENAME}.${extension}: ${messageFromUnknown(error)}`);
       sawBrokenConfigFile = true;
     }
   }

--- a/packages/core/src/neutralize-disable-directives.ts
+++ b/packages/core/src/neutralize-disable-directives.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { readDirectoryEntries } from "./project-info/index.js";
 import { IGNORED_DIRECTORIES } from "./constants.js";
 import { isLintableSourceFile } from "./utils/is-lintable-source-file.js";
+import { messageFromUnknown } from "./utils/message-from-unknown.js";
 import { Git } from "./services/git.js";
 
 const DISABLE_DIRECTIVE_PATTERN = /(eslint|oxlint)-disable/;
@@ -115,7 +116,7 @@ export const neutralizeDisableDirectives = async (
         // Silently swallowing left source files with `eslint_disable` /
         // `oxlint_disable` (neutralized form) and no signal anything broke.
         process.stderr.write(
-          `[react-doctor] Failed to restore inline disable directives in ${absolutePath}: ${error instanceof Error ? error.message : String(error)}\n` +
+          `[react-doctor] Failed to restore inline disable directives in ${absolutePath}: ${messageFromUnknown(error)}\n` +
             `[react-doctor] Run: git checkout -- ${absolutePath}\n`,
         );
       }

--- a/packages/core/src/project-info/find-expo-version.ts
+++ b/packages/core/src/project-info/find-expo-version.ts
@@ -1,19 +1,6 @@
 import type { PackageJson } from "../types/index.js";
 import { findInWorkspacePackageJsons } from "./find-in-workspace-package-jsons.js";
-
-// Read the declared `expo` spec from any dependency section. All four are
-// consulted (not just runtime + dev) so detection matches the framework /
-// RN-workspace gates, which also treat `peer`/`optional` `expo` as Expo. The
-// `typeof` guard keeps a malformed non-string entry (e.g. `"expo": 54`) from
-// reaching `getLowestDependencyMajor`'s `.trim()` and aborting the scan.
-const getExpoDependencySpec = (packageJson: PackageJson): string | null => {
-  const spec =
-    packageJson.dependencies?.expo ??
-    packageJson.devDependencies?.expo ??
-    packageJson.peerDependencies?.expo ??
-    packageJson.optionalDependencies?.expo;
-  return typeof spec === "string" ? spec : null;
-};
+import { getDependencySpec } from "./utils/get-dependency-spec.js";
 
 // The declared `expo` package version spec, looked up in the root manifest
 // and then each workspace package — react-doctor's "is this an Expo
@@ -30,4 +17,6 @@ export const findExpoVersion = (
   rootDirectory: string,
   rootPackageJson: PackageJson,
 ): string | null =>
-  findInWorkspacePackageJsons(rootDirectory, rootPackageJson, getExpoDependencySpec);
+  findInWorkspacePackageJsons(rootDirectory, rootPackageJson, (packageJson) =>
+    getDependencySpec(packageJson, "expo"),
+  );

--- a/packages/core/src/project-info/find-nextjs-version.ts
+++ b/packages/core/src/project-info/find-nextjs-version.ts
@@ -1,19 +1,6 @@
 import type { PackageJson } from "../types/index.js";
 import { findInWorkspacePackageJsons } from "./find-in-workspace-package-jsons.js";
-
-// Read the declared `next` spec from any dependency section. All four are
-// consulted so detection matches the framework gate, which also treats
-// `peer`/`optional` `next` as Next.js. The `typeof` guard keeps a malformed
-// non-string entry (e.g. `"next": 15`) from reaching `getLowestDependencyMajor`'s
-// `.trim()` and aborting the scan.
-const getNextjsDependencySpec = (packageJson: PackageJson): string | null => {
-  const spec =
-    packageJson.dependencies?.next ??
-    packageJson.devDependencies?.next ??
-    packageJson.peerDependencies?.next ??
-    packageJson.optionalDependencies?.next;
-  return typeof spec === "string" ? spec : null;
-};
+import { getDependencySpec } from "./utils/get-dependency-spec.js";
 
 // The declared `next` package version spec, looked up in the root manifest and
 // then each workspace package — the signal the `nextjs:15` capability gate
@@ -26,4 +13,6 @@ export const findNextjsVersion = (
   rootDirectory: string,
   rootPackageJson: PackageJson,
 ): string | null =>
-  findInWorkspacePackageJsons(rootDirectory, rootPackageJson, getNextjsDependencySpec);
+  findInWorkspacePackageJsons(rootDirectory, rootPackageJson, (packageJson) =>
+    getDependencySpec(packageJson, "next"),
+  );

--- a/packages/core/src/project-info/find-shopify-flash-list-version.ts
+++ b/packages/core/src/project-info/find-shopify-flash-list-version.ts
@@ -1,19 +1,13 @@
 import type { PackageJson } from "../types/index.js";
 import { findInWorkspacePackageJsons } from "./find-in-workspace-package-jsons.js";
+import { getDependencySpec } from "./utils/get-dependency-spec.js";
 
 export const SHOPIFY_FLASH_LIST_PACKAGE_NAME = "@shopify/flash-list";
-
-const getShopifyFlashListDependencySpec = (packageJson: PackageJson): string | null => {
-  const spec =
-    packageJson.dependencies?.[SHOPIFY_FLASH_LIST_PACKAGE_NAME] ??
-    packageJson.devDependencies?.[SHOPIFY_FLASH_LIST_PACKAGE_NAME] ??
-    packageJson.peerDependencies?.[SHOPIFY_FLASH_LIST_PACKAGE_NAME] ??
-    packageJson.optionalDependencies?.[SHOPIFY_FLASH_LIST_PACKAGE_NAME];
-  return typeof spec === "string" ? spec : null;
-};
 
 export const findShopifyFlashListVersion = (
   rootDirectory: string,
   rootPackageJson: PackageJson,
 ): string | null =>
-  findInWorkspacePackageJsons(rootDirectory, rootPackageJson, getShopifyFlashListDependencySpec);
+  findInWorkspacePackageJsons(rootDirectory, rootPackageJson, (packageJson) =>
+    getDependencySpec(packageJson, SHOPIFY_FLASH_LIST_PACKAGE_NAME),
+  );

--- a/packages/core/src/project-info/read-package-json.ts
+++ b/packages/core/src/project-info/read-package-json.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { PackageJson } from "../types/index.js";
+import { isErrnoException } from "../utils/is-errno-exception.js";
 
 const cachedPackageJsons = new Map<string, PackageJson>();
 
@@ -17,8 +18,8 @@ const readPackageJsonUncached = (packageJsonPath: string): PackageJson => {
     if (error instanceof SyntaxError) {
       return {};
     }
-    if (error instanceof Error && "code" in error) {
-      const { code } = error as { code: string };
+    if (isErrnoException(error)) {
+      const { code } = error;
       // EISDIR — packageJsonPath unexpectedly pointed at a directory.
       // EACCES / EPERM — POSIX denial and macOS TCC denial respectively
       // (e.g., a package.json inside ~/Library/Accounts when the scan

--- a/packages/core/src/project-info/utils/get-dependency-spec.ts
+++ b/packages/core/src/project-info/utils/get-dependency-spec.ts
@@ -1,0 +1,15 @@
+import type { PackageJson } from "../../types/index.js";
+
+// Reads a package's declared version spec from any of the four dependency
+// sections (runtime → dev → peer → optional), so detection matches the
+// framework / RN-workspace gates that also treat `peer`/`optional` entries as
+// present. The `typeof` guard keeps a malformed non-string entry (e.g.
+// `"expo": 54`) from reaching downstream `.trim()` parsing and aborting the scan.
+export const getDependencySpec = (packageJson: PackageJson, packageName: string): string | null => {
+  const spec =
+    packageJson.dependencies?.[packageName] ??
+    packageJson.devDependencies?.[packageName] ??
+    packageJson.peerDependencies?.[packageName] ??
+    packageJson.optionalDependencies?.[packageName];
+  return typeof spec === "string" ? spec : null;
+};

--- a/packages/core/src/project-info/utils/read-directory-entries.ts
+++ b/packages/core/src/project-info/utils/read-directory-entries.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import { isErrnoException } from "../../utils/is-errno-exception.js";
 
 // Discovery crawls an unknown tree best-effort: a directory we can't enumerate
 // is skipped, never a crash. These are the "can't read this path" codes —
@@ -14,11 +15,10 @@ const IGNORABLE_READDIR_ERROR_CODES = new Set([
   "ENAMETOOLONG",
 ]);
 
-const isIgnorableReaddirError = (error: unknown): boolean => {
-  if (typeof error !== "object" || error === null) return false;
-  const errorCode = (error as NodeJS.ErrnoException).code;
-  return typeof errorCode === "string" && IGNORABLE_READDIR_ERROR_CODES.has(errorCode);
-};
+const isIgnorableReaddirError = (error: unknown): boolean =>
+  isErrnoException(error) &&
+  typeof error.code === "string" &&
+  IGNORABLE_READDIR_ERROR_CODES.has(error.code);
 
 export const readDirectoryEntries = (directoryPath: string): fs.Dirent[] => {
   try {

--- a/packages/core/src/read-file-lines-node.ts
+++ b/packages/core/src/read-file-lines-node.ts
@@ -1,10 +1,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-export const createNodeReadFileLinesSync = (
-  rootDirectory: string,
-): ((filePath: string) => string[] | null) => {
-  return (filePath: string): string[] | null => {
+export const createNodeReadFileLinesSync =
+  (rootDirectory: string) =>
+  (filePath: string): string[] | null => {
     const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(rootDirectory, filePath);
     try {
       return fs.readFileSync(absolutePath, "utf-8").split("\n");
@@ -12,4 +11,3 @@ export const createNodeReadFileLinesSync = (
       return null;
     }
   };
-};

--- a/packages/core/src/read-ignore-file.ts
+++ b/packages/core/src/read-ignore-file.ts
@@ -1,6 +1,7 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as fs from "node:fs";
+import { isErrnoException } from "./utils/is-errno-exception.js";
 
 // HACK: per gitignore spec, a leading `\#` means a literal `#` in the
 // pattern (used to match files literally named `#config`), and `\!`
@@ -25,7 +26,7 @@ export const readIgnoreFile = (filePath: string): string[] => {
   try {
     content = fs.readFileSync(filePath, "utf-8");
   } catch (error) {
-    const errnoCode = (error as NodeJS.ErrnoException | null)?.code;
+    const errnoCode = isErrnoException(error) ? error.code : undefined;
     if (errnoCode && errnoCode !== "ENOENT") {
       Effect.runSync(Console.warn(`Could not read ignore file ${filePath}: ${errnoCode}`));
     }

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -19,7 +19,7 @@ import { checkReactNativeProject } from "./check-react-native-project.js";
 import { checkReactServerComponentsAdvisory } from "./check-react-server-components-advisory.js";
 import { checkReducedMotion } from "./check-reduced-motion.js";
 import { checkSecurityScan } from "./check-security-scan.js";
-import { DEFAULT_SHOW_WARNINGS } from "./constants.js";
+import { DEFAULT_SHOW_WARNINGS, MILLISECONDS_PER_SECOND } from "./constants.js";
 import { highlighter } from "./highlighter.js";
 import { computeExplicitLintIncludePaths } from "./explicit-lint-include-paths.js";
 import { deadCodeMaySurfaceWhenWarningsHidden } from "./utils/dead-code-may-surface.js";
@@ -495,7 +495,7 @@ export const runInspect = <HooksR = never>(
     const deadCodeFailureState = yield* Ref.get(deadCodeFailure);
 
     const scanElapsedMilliseconds = Date.now() - scanStartTime;
-    const scanElapsedSeconds = (scanElapsedMilliseconds / 1000).toFixed(1);
+    const scanElapsedSeconds = (scanElapsedMilliseconds / MILLISECONDS_PER_SECOND).toFixed(1);
 
     if (!lintFailureState.didFail) {
       if (deadCodeFailureState.didFail) {

--- a/packages/core/src/runners/oxlint/plugin-resolution.ts
+++ b/packages/core/src/runners/oxlint/plugin-resolution.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import type { OxlintRuleSeverity } from "oxlint-plugin-react-doctor";
+import { messageFromUnknown } from "../../utils/message-from-unknown.js";
 import { warnConfigIssue } from "../../utils/warn-config-issue.js";
 
 export interface JsPluginEntry {
@@ -144,7 +145,7 @@ export const resolveUserPlugin = (
       : candidateRequire.resolve(spec);
   } catch (error) {
     warnConfigIssue(
-      `config.plugins entry "${spec}" could not be resolved from ${configSourceDirectory}: ${error instanceof Error ? error.message : String(error)}`,
+      `config.plugins entry "${spec}" could not be resolved from ${configSourceDirectory}: ${messageFromUnknown(error)}`,
     );
     return null;
   }

--- a/packages/core/src/runners/oxlint/spawn-oxlint.ts
+++ b/packages/core/src/runners/oxlint/spawn-oxlint.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import {
+  MILLISECONDS_PER_SECOND,
   OXLINT_OUTPUT_MAX_BYTES,
   OXLINT_SPAWN_TIMEOUT_MS as DEFAULT_OXLINT_SPAWN_TIMEOUT_MS,
 } from "../../constants.js";
@@ -67,7 +68,7 @@ export const spawnOxlint = (
         new ReactDoctorError({
           reason: new OxlintBatchExceeded({
             kind: "timeout",
-            detail: `${spawnTimeoutMs / 1000}s budget exceeded`,
+            detail: `${spawnTimeoutMs / MILLISECONDS_PER_SECOND}s budget exceeded`,
           }),
         }),
       );

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -381,6 +381,15 @@ export class Git extends Context.Service<
               }),
             });
           }),
+          // One span per actual subprocess invocation. The subcommand
+          // (`args[0]`) is safe to attribute; full args/paths are omitted so
+          // no scanned path leaks into an exported trace.
+          Effect.withSpan("git.exec", {
+            attributes: {
+              "git.command": input.command,
+              "git.subcommand": input.args[0] ?? "",
+            },
+          }),
         );
 
       const runGit = (
@@ -421,7 +430,7 @@ export class Git extends Context.Service<
           ]);
           if (candidates.status !== 0) return null;
           return trimOrNull(candidates.stdout.split("\n")[0] ?? "");
-        });
+        }).pipe(Effect.withSpan("Git.defaultBranch"));
 
       const branchExists = (
         directory: string,
@@ -492,7 +501,10 @@ export class Git extends Context.Service<
           const result = resultOption.value;
           if (result.status !== 0) return null;
           return parseGithubViewerPermission(result.stdout);
-        }).pipe(Effect.catch(() => Effect.succeed(null)));
+        }).pipe(
+          Effect.catch(() => Effect.succeed(null)),
+          Effect.withSpan("Git.githubViewerPermission"),
+        );
 
       /**
        * Resolves a `--diff A..B` / `A...B` commit range into a changed-file
@@ -677,7 +689,7 @@ export class Git extends Context.Service<
               changedFiles: splitNullSeparated(diff.stdout),
               isCurrentChanges: false,
             } satisfies GitDiffSelection;
-          }),
+          }).pipe(Effect.withSpan("Git.diffSelection")),
         stagedFilePaths: (directory) =>
           runGit(directory, [
             "diff",
@@ -737,7 +749,7 @@ export class Git extends Context.Service<
             // Status 128 = "not a git repo" → caller should fall back.
             if (result.status === 128) return null;
             return { status: result.status, stdout: result.stdout } satisfies GitGrepResult;
-          }),
+          }).pipe(Effect.withSpan("Git.grep")),
         changedLineRanges: ({ directory, baseRef, cached, files }) =>
           Effect.gen(function* () {
             if (files.length === 0) return [];
@@ -757,7 +769,7 @@ export class Git extends Context.Service<
             ]);
             if (result.status !== 0) return null;
             return parseChangedLineRanges(result.stdout);
-          }),
+          }).pipe(Effect.withSpan("Git.changedLineRanges")),
       });
     }),
   ).pipe(

--- a/packages/core/src/services/staged-files.ts
+++ b/packages/core/src/services/staged-files.ts
@@ -55,9 +55,10 @@ export class StagedFiles extends Context.Service<
       const git = yield* Git;
       return StagedFiles.of({
         discoverSourceFiles: (directory) =>
-          git
-            .stagedFilePaths(directory)
-            .pipe(Effect.map((entries) => entries.filter(isLintableSourceFile))),
+          git.stagedFilePaths(directory).pipe(
+            Effect.map((entries) => entries.filter(isLintableSourceFile)),
+            Effect.withSpan("StagedFiles.discoverSourceFiles"),
+          ),
         materialize: ({ directory, stagedFiles, tempDirectory }) =>
           // Per-file git failures (missing binary, buffer overflow, spawn
           // errors) must NOT sink the whole snapshot — `materializeSourceTree`
@@ -80,6 +81,7 @@ export class StagedFiles extends Context.Service<
                   cleanup: tree.cleanup,
                 }) satisfies StagedSnapshot,
             ),
+            Effect.withSpan("StagedFiles.materialize"),
           ),
       });
     }),

--- a/packages/core/src/utils/is-errno-exception.ts
+++ b/packages/core/src/utils/is-errno-exception.ts
@@ -1,0 +1,2 @@
+export const isErrnoException = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error;

--- a/packages/core/src/utils/match-glob-pattern.ts
+++ b/packages/core/src/utils/match-glob-pattern.ts
@@ -1,5 +1,6 @@
 import picomatch from "picomatch";
 import { MAX_GLOB_PATTERN_LENGTH_CHARS, MAX_GLOB_PATTERN_WILDCARD_COUNT } from "../constants.js";
+import { messageFromUnknown } from "./message-from-unknown.js";
 
 export class InvalidGlobPatternError extends Error {
   public readonly pattern: string;
@@ -58,7 +59,7 @@ export const compileGlobPattern = (rawPattern: string): RegExp => {
   } catch (caughtError) {
     throw new InvalidGlobPatternError(
       rawPattern,
-      caughtError instanceof Error ? caughtError.message : String(caughtError),
+      messageFromUnknown(caughtError),
     );
   }
 };

--- a/packages/core/src/utils/match-glob-pattern.ts
+++ b/packages/core/src/utils/match-glob-pattern.ts
@@ -57,10 +57,7 @@ export const compileGlobPattern = (rawPattern: string): RegExp => {
   try {
     return picomatch.makeRe(normalizeGlobPattern(rawPattern), PICOMATCH_OPTIONS);
   } catch (caughtError) {
-    throw new InvalidGlobPatternError(
-      rawPattern,
-      messageFromUnknown(caughtError),
-    );
+    throw new InvalidGlobPatternError(rawPattern, messageFromUnknown(caughtError));
   }
 };
 

--- a/packages/core/src/utils/message-from-unknown.ts
+++ b/packages/core/src/utils/message-from-unknown.ts
@@ -1,0 +1,2 @@
+export const messageFromUnknown = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);

--- a/packages/language-server/src/core/lint-cache.ts
+++ b/packages/language-server/src/core/lint-cache.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { Diagnostic as CoreDiagnostic } from "@react-doctor/core";
+import { messageFromUnknown, type Diagnostic as CoreDiagnostic } from "@react-doctor/core";
 import {
   CACHE_FILENAME_HASH_LENGTH_CHARS,
   LINT_CACHE_PERSIST_DEBOUNCE_MS,
@@ -102,7 +102,7 @@ export const createLintCache = (input: {
       fs.renameSync(tempPath, cacheFilePath);
     } catch (error) {
       logger.warn(
-        `Failed to persist lint cache: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to persist lint cache: ${messageFromUnknown(error)}`,
       );
     }
   };

--- a/packages/language-server/src/core/lint-cache.ts
+++ b/packages/language-server/src/core/lint-cache.ts
@@ -101,9 +101,7 @@ export const createLintCache = (input: {
       fs.writeFileSync(tempPath, JSON.stringify(payload));
       fs.renameSync(tempPath, cacheFilePath);
     } catch (error) {
-      logger.warn(
-        `Failed to persist lint cache: ${messageFromUnknown(error)}`,
-      );
+      logger.warn(`Failed to persist lint cache: ${messageFromUnknown(error)}`);
     }
   };
 

--- a/packages/language-server/src/core/project-graph.ts
+++ b/packages/language-server/src/core/project-graph.ts
@@ -48,9 +48,7 @@ export const createProjectGraph = (options: ProjectGraphOptions): ProjectGraph =
           }
         }
       } catch (error) {
-        logger.warn(
-          `Project discovery failed for ${root}: ${messageFromUnknown(error)}`,
-        );
+        logger.warn(`Project discovery failed for ${root}: ${messageFromUnknown(error)}`);
       }
     }
     // Deepest-first so owning-project resolution can take the first match.

--- a/packages/language-server/src/core/project-graph.ts
+++ b/packages/language-server/src/core/project-graph.ts
@@ -6,6 +6,7 @@ import {
   clearPackageJsonCache,
   clearProjectCache,
   discoverReactSubprojects,
+  messageFromUnknown,
 } from "@react-doctor/core";
 import { SILENT_LOGGER, type Logger, type ProjectGraph, type WorkspaceProject } from "../types.js";
 
@@ -48,7 +49,7 @@ export const createProjectGraph = (options: ProjectGraphOptions): ProjectGraph =
         }
       } catch (error) {
         logger.warn(
-          `Project discovery failed for ${root}: ${error instanceof Error ? error.message : String(error)}`,
+          `Project discovery failed for ${root}: ${messageFromUnknown(error)}`,
         );
       }
     }

--- a/packages/language-server/src/diagnostics/manager.ts
+++ b/packages/language-server/src/diagnostics/manager.ts
@@ -19,8 +19,6 @@ export interface DiagnosticsManagerOptions {
   readonly logger?: Logger;
 }
 
-const toUri = (absoluteFilePath: string): string => fsPathToUri(absoluteFilePath);
-
 /**
  * Owns the published-diagnostic state. Maps scan outcomes to LSP
  * diagnostics, publishes complete per-URI replacement sets (so the
@@ -61,7 +59,7 @@ export class DiagnosticsManager {
 
     for (const [fsPath, coreDiagnostics] of outcome.byFile) {
       if (isProtectedPath(fsPath)) continue;
-      const uri = toUri(fsPath);
+      const uri = fsPathToUri(fsPath);
       const text = this.textProvider(fsPath);
       const lspDiagnostics = coreDiagnostics.map((diagnostic) =>
         toLspDiagnostic({ diagnostic, fsPath, text }),
@@ -91,7 +89,7 @@ export class DiagnosticsManager {
     for (const fsPath of outcome.requestedPaths) {
       if (isProtectedPath(fsPath)) continue;
       if (outcome.byFile.has(fsPath)) continue;
-      const uri = toUri(fsPath);
+      const uri = fsPathToUri(fsPath);
       if (this.byUri.has(uri)) this.byUri.delete(uri);
       this.publish(uri, []);
     }
@@ -126,7 +124,7 @@ export class DiagnosticsManager {
     const set = this.projectUris.get(project) ?? new Set<string>();
     for (const uri of liveUris) set.add(uri);
     for (const fsPath of outcome.requestedPaths) {
-      const uri = toUri(fsPath);
+      const uri = fsPathToUri(fsPath);
       if (!liveUris.has(uri)) set.delete(uri);
     }
     this.projectUris.set(project, set);
@@ -160,7 +158,7 @@ export class DiagnosticsManager {
     const tracked = this.projectUris.get(project);
     if (!tracked) return;
     const liveUris = new Set<string>();
-    for (const fsPath of liveFsPaths) liveUris.add(toUri(fsPath));
+    for (const fsPath of liveFsPaths) liveUris.add(fsPathToUri(fsPath));
     for (const uri of [...tracked]) {
       if (liveUris.has(uri)) continue;
       this.byUri.delete(uri);

--- a/packages/language-server/src/runtime/scheduler.ts
+++ b/packages/language-server/src/runtime/scheduler.ts
@@ -1,3 +1,5 @@
+import { messageFromUnknown } from "@react-doctor/core";
+import { DOCUMENT_CHANGE_DEBOUNCE_MS, MIN_SCAN_CONCURRENCY } from "../constants.js";
 import {
   SILENT_LOGGER,
   type CancellationToken,
@@ -28,8 +30,8 @@ const keyOf = (request: Pick<ScanRequestInput, "projectDirectory" | "files">): s
  * keeps large monorepos responsive.
  */
 export const createScheduler = (options: SchedulerOptions): Scheduler => {
-  const debounceMs = options.debounceMs ?? 300;
-  const concurrency = Math.max(1, options.concurrency ?? 2);
+  const debounceMs = options.debounceMs ?? DOCUMENT_CHANGE_DEBOUNCE_MS;
+  const concurrency = Math.max(1, options.concurrency ?? MIN_SCAN_CONCURRENCY);
   const reservedInteractiveSlots = Math.max(0, options.reservedInteractiveSlots ?? 0);
   // Background scans never occupy the reserved slots, so an interactive /
   // save scan can always start while a big workspace scan churns.
@@ -90,7 +92,7 @@ export const createScheduler = (options: SchedulerOptions): Scheduler => {
         .catch((error: unknown) => {
           if (options.onError) options.onError(error, request);
           else
-            logger.error(`Scan failed: ${error instanceof Error ? error.message : String(error)}`);
+            logger.error(`Scan failed: ${messageFromUnknown(error)}`);
         })
         .finally(() => {
           running -= 1;

--- a/packages/language-server/src/runtime/scheduler.ts
+++ b/packages/language-server/src/runtime/scheduler.ts
@@ -91,8 +91,7 @@ export const createScheduler = (options: SchedulerOptions): Scheduler => {
         })
         .catch((error: unknown) => {
           if (options.onError) options.onError(error, request);
-          else
-            logger.error(`Scan failed: ${messageFromUnknown(error)}`);
+          else logger.error(`Scan failed: ${messageFromUnknown(error)}`);
         })
         .finally(() => {
           running -= 1;

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -410,9 +410,7 @@ export const createServer = (
         if (outcome.request.priority === "background") scanTelemetry.accumulate(outcome);
       },
       onError: (error, request) =>
-        logger.error(
-          `Scan of ${request.projectDirectory} threw: ${messageFromUnknown(error)}`,
-        ),
+        logger.error(`Scan of ${request.projectDirectory} threw: ${messageFromUnknown(error)}`),
       onIdleChange: (idle) => {
         void setBusy(!idle);
         // The scheduler draining is the reliable "burst settled" signal

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { listSourceFiles, resolveNodeForOxlint } from "@react-doctor/core";
+import { listSourceFiles, messageFromUnknown, resolveNodeForOxlint } from "@react-doctor/core";
 import {
   CodeActionKind,
   CodeActionTriggerKind,
@@ -411,7 +411,7 @@ export const createServer = (
       },
       onError: (error, request) =>
         logger.error(
-          `Scan of ${request.projectDirectory} threw: ${error instanceof Error ? error.message : String(error)}`,
+          `Scan of ${request.projectDirectory} threw: ${messageFromUnknown(error)}`,
         ),
       onIdleChange: (idle) => {
         void setBusy(!idle);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A full-codebase audit of the Effect-relevant packages (`core`, `api`, `react-doctor`, `language-server`) against the documented **Effect v4** conventions in `AGENTS.md` and the installed `effect@4.0.0-beta.70` API, followed by genuine Effect v4 observability work plus safe DRY/consistency refinements.

### Audit finding: the codebase is already Effect-v4 clean

A cross-cutting audit found **zero** hard v4 violations (no umbrella `effect` imports, no `try/catch` in `Effect.gen`, no bare terminal `yield*`, no `catchAll`/`matchTag`, no `as const` in layers, no `message =`, no `!!`). The project already uses per-module imports, `Effect.catch`/`catchReasons`/`catchTag`, `Service.of`, `get message()`, and `restoreLegacyThrow` correctly. So this is an **elegance + observability** pass, not a "fix bad Effect code" pass.

## Changes

**1. Effect v4 OTel spans across the git/staged scan path** (the one real `Effect.fn`/`withSpan` gap the audit flagged)
- `git.ts`: one `git.exec` span per actual subprocess at the `runCommand` chokepoint (command + subcommand attributes only — no paths leak into traces), plus method-level `Effect.withSpan` on the orchestrating methods (`defaultBranch`, `githubViewerPermission`, `diffSelection`, `grep`, `changedLineRanges`).
- `staged-files.ts`: spans on `discoverSourceFiles` + `materialize`.
- `editor-scan.ts`: a `runEditorScan` parent span (placed inside the OTLP provide so the tracer is in scope; booleans-only attributes).
- This completes the documented `runInspect → Service.method → subprocess` parent/child span model for the previously-uninstrumented Git path. Spans are a no-op without a tracer layer, so behavior is unchanged.

**2. Shared error/errno helpers**
- New `messageFromUnknown` and `isErrnoException` core utilities (one-utility-per-file) replace scattered `error instanceof Error ? error.message : String(error)` ternaries (core ×4 + language-server ×4 + load-config) and `as NodeJS.ErrnoException` casts (×3).

**3. DRY + magic-number cleanup**
- New `getDependencySpec` util replaces three byte-identical per-package spec getters (`expo`/`next`/`@shopify/flash-list`).
- `MILLISECONDS_PER_SECOND` for the inline `/1000` conversions; scheduler defaults use `DOCUMENT_CHANGE_DEBOUNCE_MS` / `MIN_SCAN_CONCURRENCY`.
- Inlined the `toUri` identity wrapper; simplified `createNodeReadFileLinesSync`.

## Verification

- `pnpm typecheck` — green (11/11)
- `pnpm lint` / `pnpm format:check` — green (only intentional test-fixture warnings)
- `pnpm test` — **1815 passed / 15 skipped**, identical to baseline (no regressions)
- **Bugbot** — no bugs found
- Branch merged up to date with `main`

## Notes / out of scope

To keep the suite green, larger speculative rewrites were intentionally deferred (own PRs): converting the imperative `run-oxlint.ts` / `check-dead-code.ts` orchestrators to full Effect pipelines, migrating CLI commands from `cliLogger` to `yield* Console.*`, and removing the `Effect.runSync` bridges in the hot `run-inspect.ts` streaming path. None are correctness issues.

### `/rde parity`
This PR changes **no lint rules** (only `core`/`api`/`language-server` infra), so RDE parity is trivially preserved. I could not post the `/rde parity` PR comment from this environment (`gh` is read-only; no PR-comment tool). Please add it manually if you want the bot to run anyway.

### Tooling note
Lint/format require Node `>=22.18.0`; the VM default is `22.14.0`, so they must run with the nvm `22.22.2` toolchain (`export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"`). Worth pinning in the cloud-agent env config.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4542e34-36d9-42ac-9975-2683c53bb27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4542e34-36d9-42ac-9975-2683c53bb27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

