### PR TITLE
fix: skip pnpm hardening check for monorepo sub-packages

### DIFF
--- a/.changeset/fix-pnpm-hardening-subpackages.md
+++ b/.changeset/fix-pnpm-hardening-subpackages.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Skip pnpm hardening check for monorepo sub-packages. Hardening settings are workspace-level and should only be checked at the workspace root or standalone pnpm projects.

--- a/packages/core/src/check-pnpm-hardening.ts
+++ b/packages/core/src/check-pnpm-hardening.ts
@@ -122,12 +122,12 @@ const buildHardeningDiagnostic = (input: BuildHardeningDiagnosticInput): Diagnos
   category: "Security",
 });
 
-export const checkPnpmHardening = (rootDirectory: string): Diagnostic[] => {
-  if (!isPnpmManagedProject(rootDirectory)) return [];
+export const checkPnpmHardening = (scanDirectory: string): Diagnostic[] => {
+  if (!isPnpmManagedProject(scanDirectory)) return [];
 
-  const workspacePath = path.join(rootDirectory, PNPM_WORKSPACE_FILE);
+  const workspacePath = path.join(scanDirectory, PNPM_WORKSPACE_FILE);
   const hasWorkspaceFile = isFile(workspacePath);
-  const monorepoRoot = findMonorepoRoot(rootDirectory);
+  const monorepoRoot = findMonorepoRoot(scanDirectory);
 
   if (!hasWorkspaceFile && monorepoRoot !== null) {
     const parentWorkspacePath = path.join(monorepoRoot, PNPM_WORKSPACE_FILE);

--- a/packages/core/src/check-pnpm-hardening.ts
+++ b/packages/core/src/check-pnpm-hardening.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { RECOMMENDED_PNPM_MINIMUM_RELEASE_AGE_MINUTES } from "./constants.js";
-import { isFile } from "./project-info/index.js";
+import { isFile, findMonorepoRoot } from "./project-info/index.js";
 import type { Diagnostic } from "./types/index.js";
 
 const PNPM_WORKSPACE_FILE = "pnpm-workspace.yaml";
@@ -126,7 +126,17 @@ export const checkPnpmHardening = (rootDirectory: string): Diagnostic[] => {
   if (!isPnpmManagedProject(rootDirectory)) return [];
 
   const workspacePath = path.join(rootDirectory, PNPM_WORKSPACE_FILE);
-  const workspaceContent = isFile(workspacePath) ? fs.readFileSync(workspacePath, "utf-8") : "";
+  const hasWorkspaceFile = isFile(workspacePath);
+  const monorepoRoot = findMonorepoRoot(rootDirectory);
+
+  if (!hasWorkspaceFile && monorepoRoot !== null) {
+    const parentWorkspacePath = path.join(monorepoRoot, PNPM_WORKSPACE_FILE);
+    if (isFile(parentWorkspacePath)) {
+      return [];
+    }
+  }
+
+  const workspaceContent = hasWorkspaceFile ? fs.readFileSync(workspacePath, "utf-8") : "";
   const settings = parseHardeningSettings(workspaceContent);
 
   const diagnostics: Diagnostic[] = [];

--- a/packages/core/src/check-pnpm-hardening.ts
+++ b/packages/core/src/check-pnpm-hardening.ts
@@ -127,11 +127,10 @@ export const checkPnpmHardening = (scanDirectory: string): Diagnostic[] => {
 
   const workspacePath = path.join(scanDirectory, PNPM_WORKSPACE_FILE);
   const hasWorkspaceFile = isFile(workspacePath);
-  const monorepoRoot = findMonorepoRoot(scanDirectory);
 
-  if (!hasWorkspaceFile && monorepoRoot !== null) {
-    const parentWorkspacePath = path.join(monorepoRoot, PNPM_WORKSPACE_FILE);
-    if (isFile(parentWorkspacePath)) {
+  if (!hasWorkspaceFile) {
+    const monorepoRoot = findMonorepoRoot(scanDirectory);
+    if (monorepoRoot !== null && isFile(path.join(monorepoRoot, PNPM_WORKSPACE_FILE))) {
       return [];
     }
   }

--- a/packages/core/tests/check-pnpm-hardening.test.ts
+++ b/packages/core/tests/check-pnpm-hardening.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import { checkPnpmHardening } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
 
 const FIXTURES_DIRECTORY = path.resolve(import.meta.dirname, "fixtures", "check-pnpm-hardening");
 
@@ -389,6 +390,13 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
     fs.rmSync(temporaryRoot, { recursive: true, force: true });
   });
 
+  const expectMissingHardeningWarnings = (diagnostics: Diagnostic[]) => {
+    expect(diagnostics).toHaveLength(2);
+    const messages = diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+    expect(messages).toContain("minimumReleaseAge");
+    expect(messages).toContain("trustPolicy");
+  };
+
   it("returns no diagnostics for a monorepo sub-package (parent has pnpm-workspace.yaml)", () => {
     const monorepoRoot = temporaryRoot;
     fs.writeFileSync(
@@ -465,11 +473,7 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
 
     const diagnostics = checkPnpmHardening(standaloneProject);
 
-    expect(diagnostics).toHaveLength(2);
-    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
-      "minimumReleaseAge",
-    );
-    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain("trustPolicy");
+    expectMissingHardeningWarnings(diagnostics);
   });
 
   it("returns diagnostics for the monorepo root itself", () => {
@@ -489,11 +493,7 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
 
     const diagnostics = checkPnpmHardening(monorepoRoot);
 
-    expect(diagnostics).toHaveLength(2);
-    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
-      "minimumReleaseAge",
-    );
-    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain("trustPolicy");
+    expectMissingHardeningWarnings(diagnostics);
   });
 
   it("returns diagnostics for a standalone pnpm project with packageManager field (no workspace)", () => {
@@ -510,11 +510,7 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
 
     const diagnostics = checkPnpmHardening(standaloneWithPackageManager);
 
-    expect(diagnostics).toHaveLength(2);
-    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
-      "minimumReleaseAge",
-    );
-    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain("trustPolicy");
+    expectMissingHardeningWarnings(diagnostics);
   });
 
   it("returns diagnostics for a standalone pnpm project with pnpm-lock.yaml only (no workspace)", () => {
@@ -531,10 +527,6 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
 
     const diagnostics = checkPnpmHardening(standaloneWithLock);
 
-    expect(diagnostics).toHaveLength(2);
-    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
-      "minimumReleaseAge",
-    );
-    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain("trustPolicy");
+    expectMissingHardeningWarnings(diagnostics);
   });
 });

--- a/packages/core/tests/check-pnpm-hardening.test.ts
+++ b/packages/core/tests/check-pnpm-hardening.test.ts
@@ -83,16 +83,16 @@ const FIXTURE_EXPECTATIONS: ReadonlyArray<FixtureExpectation> = [
   {
     name: "package-manager-only",
     description:
-      "pnpm detected via `packageManager` field with no workspace yaml → warns on minimumReleaseAge + trustPolicy",
-    expectedRuleKeys: [HARDENING_RULE_KEY, HARDENING_RULE_KEY],
-    expectedSubstrings: ["minimumReleaseAge", "trustPolicy"],
+      "pnpm detected via `packageManager` field with no workspace yaml (inside workspace) → skipped (sub-package)",
+    expectedRuleKeys: [],
+    expectedSubstrings: [],
   },
   {
     name: "pnpm-lock-only",
     description:
-      "pnpm-lock.yaml alone is enough to detect a pnpm project; warns on minimumReleaseAge + trustPolicy",
-    expectedRuleKeys: [HARDENING_RULE_KEY, HARDENING_RULE_KEY],
-    expectedSubstrings: ["minimumReleaseAge", "trustPolicy"],
+      "pnpm-lock.yaml alone (inside workspace) → skipped (sub-package)",
+    expectedRuleKeys: [],
+    expectedSubstrings: [],
   },
   {
     name: "not-pnpm",
@@ -376,5 +376,157 @@ describe("checkPnpmHardening (parser edge cases)", () => {
     const diagnostics = checkPnpmHardening(projectDirectory);
 
     expect(diagnostics).toHaveLength(0);
+  });
+});
+
+describe("checkPnpmHardening (monorepo sub-packages)", () => {
+  let temporaryRoot: string;
+
+  beforeEach(() => {
+    temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-pnpm-monorepo-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  });
+
+  it("returns no diagnostics for a monorepo sub-package (parent has pnpm-workspace.yaml)", () => {
+    const monorepoRoot = temporaryRoot;
+    fs.writeFileSync(
+      path.join(monorepoRoot, "package.json"),
+      JSON.stringify({
+        name: "monorepo-root",
+        workspaces: ["packages/*"],
+      }),
+    );
+    fs.writeFileSync(path.join(monorepoRoot, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+
+    const subPackageDirectory = path.join(monorepoRoot, "packages", "sub-package");
+    fs.mkdirSync(subPackageDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(subPackageDirectory, "package.json"),
+      JSON.stringify({
+        name: "sub-package",
+        packageManager: "pnpm@9.0.0",
+        dependencies: { react: "^19.0.0" },
+      }),
+    );
+    fs.writeFileSync(path.join(subPackageDirectory, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+
+    const diagnostics = checkPnpmHardening(subPackageDirectory);
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("returns no diagnostics for a deeply nested monorepo sub-package", () => {
+    const monorepoRoot = temporaryRoot;
+    fs.writeFileSync(
+      path.join(monorepoRoot, "package.json"),
+      JSON.stringify({
+        name: "monorepo-root",
+        packageManager: "pnpm@9.0.0",
+      }),
+    );
+    fs.writeFileSync(path.join(monorepoRoot, "pnpm-workspace.yaml"), "packages:\n  - 'examples/**'\n");
+
+    const deepSubPackage = path.join(monorepoRoot, "examples", "advanced", "custom-server");
+    fs.mkdirSync(deepSubPackage, { recursive: true });
+    fs.writeFileSync(
+      path.join(deepSubPackage, "package.json"),
+      JSON.stringify({
+        name: "custom-server",
+        packageManager: "pnpm@9.0.0",
+        dependencies: { react: "^19.0.0" },
+      }),
+    );
+
+    const diagnostics = checkPnpmHardening(deepSubPackage);
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("returns diagnostics for a standalone pnpm project (no parent workspace)", () => {
+    const standaloneProject = path.join(temporaryRoot, "standalone");
+    fs.mkdirSync(standaloneProject, { recursive: true });
+    fs.writeFileSync(
+      path.join(standaloneProject, "package.json"),
+      JSON.stringify({
+        name: "standalone",
+        packageManager: "pnpm@9.0.0",
+        dependencies: { react: "^19.0.0" },
+      }),
+    );
+    fs.writeFileSync(path.join(standaloneProject, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+
+    const diagnostics = checkPnpmHardening(standaloneProject);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "minimumReleaseAge",
+    );
+    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain("trustPolicy");
+  });
+
+  it("returns diagnostics for the monorepo root itself", () => {
+    const monorepoRoot = temporaryRoot;
+    fs.writeFileSync(
+      path.join(monorepoRoot, "package.json"),
+      JSON.stringify({
+        name: "monorepo-root",
+        packageManager: "pnpm@9.0.0",
+        workspaces: ["packages/*"],
+      }),
+    );
+    fs.writeFileSync(path.join(monorepoRoot, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+
+    const diagnostics = checkPnpmHardening(monorepoRoot);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "minimumReleaseAge",
+    );
+    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain("trustPolicy");
+  });
+
+  it("returns diagnostics for a standalone pnpm project with packageManager field (no workspace)", () => {
+    const standaloneWithPackageManager = path.join(temporaryRoot, "standalone-pkg-mgr");
+    fs.mkdirSync(standaloneWithPackageManager, { recursive: true });
+    fs.writeFileSync(
+      path.join(standaloneWithPackageManager, "package.json"),
+      JSON.stringify({
+        name: "standalone-with-packagemanager",
+        packageManager: "pnpm@9.0.0",
+        dependencies: { react: "^19.0.0" },
+      }),
+    );
+
+    const diagnostics = checkPnpmHardening(standaloneWithPackageManager);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "minimumReleaseAge",
+    );
+    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain("trustPolicy");
+  });
+
+  it("returns diagnostics for a standalone pnpm project with pnpm-lock.yaml only (no workspace)", () => {
+    const standaloneWithLock = path.join(temporaryRoot, "standalone-lock");
+    fs.mkdirSync(standaloneWithLock, { recursive: true });
+    fs.writeFileSync(
+      path.join(standaloneWithLock, "package.json"),
+      JSON.stringify({
+        name: "standalone-with-lock",
+        dependencies: { react: "^19.0.0" },
+      }),
+    );
+    fs.writeFileSync(path.join(standaloneWithLock, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+
+    const diagnostics = checkPnpmHardening(standaloneWithLock);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain(
+      "minimumReleaseAge",
+    );
+    expect(diagnostics.map((diagnostic) => diagnostic.message).join("\n")).toContain("trustPolicy");
   });
 });

--- a/packages/core/tests/check-pnpm-hardening.test.ts
+++ b/packages/core/tests/check-pnpm-hardening.test.ts
@@ -89,8 +89,7 @@ const FIXTURE_EXPECTATIONS: ReadonlyArray<FixtureExpectation> = [
   },
   {
     name: "pnpm-lock-only",
-    description:
-      "pnpm-lock.yaml alone (inside workspace) → skipped (sub-package)",
+    description: "pnpm-lock.yaml alone (inside workspace) → skipped (sub-package)",
     expectedRuleKeys: [],
     expectedSubstrings: [],
   },
@@ -399,7 +398,10 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
         workspaces: ["packages/*"],
       }),
     );
-    fs.writeFileSync(path.join(monorepoRoot, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(monorepoRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n",
+    );
 
     const subPackageDirectory = path.join(monorepoRoot, "packages", "sub-package");
     fs.mkdirSync(subPackageDirectory, { recursive: true });
@@ -427,7 +429,10 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
         packageManager: "pnpm@9.0.0",
       }),
     );
-    fs.writeFileSync(path.join(monorepoRoot, "pnpm-workspace.yaml"), "packages:\n  - 'examples/**'\n");
+    fs.writeFileSync(
+      path.join(monorepoRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - 'examples/**'\n",
+    );
 
     const deepSubPackage = path.join(monorepoRoot, "examples", "advanced", "custom-server");
     fs.mkdirSync(deepSubPackage, { recursive: true });
@@ -477,7 +482,10 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
         workspaces: ["packages/*"],
       }),
     );
-    fs.writeFileSync(path.join(monorepoRoot, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(monorepoRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n",
+    );
 
     const diagnostics = checkPnpmHardening(monorepoRoot);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #878 — react-doctor was emitting `require-pnpm-hardening` diagnostics for monorepo sub-packages pointing to non-existent `pnpm-workspace.yaml` files.

## Root Cause

`checkPnpmHardening` ran on ANY pnpm-managed directory (including monorepo sub-packages that have `packageManager:"pnpm@..."` or `pnpm-lock.yaml`), then hardcoded `filePath: "pnpm-workspace.yaml"` even when that file didn't exist locally.

Hardening settings are **workspace-level** — they live in the workspace root's `pnpm-workspace.yaml` and apply to all packages in that workspace.

## The Fix

Only run the hardening check when:
1. The directory IS a workspace root (has `pnpm-workspace.yaml`), OR
2. The directory is pnpm-managed AND has no parent pnpm workspace root (standalone pnpm project)

This prevents sub-packages from emitting diagnostics about non-existent workspace files.

## Testing

- Added comprehensive unit tests covering:
  - Monorepo sub-packages: no diagnostics (the fix)
  - Standalone pnpm projects: still get warnings (preserved behavior)
  - Workspace roots: still get warnings (preserved behavior)
- All existing tests pass
- Parity validation on small dataset shows no pnpm-hardening regressions across the corpus

## Changes

- Modified `checkPnpmHardening()` to detect parent pnpm workspaces
- Renamed `rootDirectory` parameter to `scanDirectory` (matches call site)
- Added 4 new tests for monorepo scenarios
- Updated 2 existing fixture tests to reflect new behavior

Closes #878
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35d30e57-0316-4c62-a976-d65c08ab2c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35d30e57-0316-4c62-a976-d65c08ab2c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

