### PR TITLE
feat(cli): add --debug to surface the run's Sentry trace id

### DIFF
--- a/.changeset/feat-debug-trace-id.md
+++ b/.changeset/feat-debug-trace-id.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": minor
+---
+
+Add a `--debug` flag that prints the run's Sentry trace id at the end of a scan.
+
+When something looks wrong, run `react-doctor --debug`: it forces a Sentry performance trace for that run (even if `SENTRY_TRACES_SAMPLE_RATE` was turned down) and prints `Sentry trace (mention this when reporting): <id>` as the last line so the id can be pasted into a bug report for maintainers to pull the full trace. It prints on both outcomes — a clean run and a crash (the crash's trace is surfaced even when it happens before the scan span starts). The line goes to stderr, so `--json` / `--score` stdout stays machine-clean. Combining `--debug` with `--no-score` / `--no-telemetry` is rejected up front, since those flags disable the Sentry reporting `--debug` depends on. Telemetry also gains a low-cardinality `debug` run tag so adoption of the flag is visible.

--- a/.changeset/feat-debug-trace-id.md
+++ b/.changeset/feat-debug-trace-id.md
@@ -1,5 +1,5 @@
 ---
-"react-doctor": minor
+"react-doctor": patch
 ---
 
 Add a `--debug` flag that prints the run's Sentry trace id at the end of a scan.

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -16,6 +16,7 @@ import {
   toRelativePath,
 } from "@react-doctor/core";
 import { inspect } from "../../inspect.js";
+import { flushSentry } from "../../instrument.js";
 import type {
   DiffInfo,
   InspectResult,
@@ -30,6 +31,7 @@ import { getStagedSourceFiles, materializeStagedFiles } from "../utils/get-stage
 import type { InspectFlags } from "../utils/inspect-flags.js";
 import { filterDiagnosticsByCategories } from "../utils/filter-diagnostics-by-categories.js";
 import { handleError, handleUserError } from "../utils/handle-error.js";
+import { isDebugFlagEnabled } from "../utils/is-debug-flag.js";
 import { isExpectedUserError } from "../utils/is-expected-user-error.js";
 import { handoffToAgent } from "../utils/handoff-to-agent.js";
 import { migrateLegacyConfig } from "../utils/migrate-legacy-config.js";
@@ -725,6 +727,11 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
     // issue" block so they don't become triage noise.
     const isUserError = isExpectedUserError(error);
     const sentryEventId = isUserError ? undefined : await reportErrorToSentry(error);
+    // `--debug` prints the run's trace id from the exit handler. A user error
+    // skips `reportErrorToSentry` (and its flush), so a trace recorded when the
+    // scan span started would never be delivered — flush here so the printed id
+    // resolves in Sentry. Cheap no-op for the already-flushed non-user path.
+    if (isDebugFlagEnabled()) await flushSentry();
     if (isJsonMode) {
       writeJsonErrorReport(error, sentryEventId);
       process.exitCode = 1;

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -19,9 +19,11 @@ import { applyColorPreference } from "./utils/apply-color-preference.js";
 import { exitGracefully } from "./utils/exit-gracefully.js";
 import { guardStdin } from "./utils/guard-stdin.js";
 import { handleError, handleUserError } from "./utils/handle-error.js";
+import { isDebugFlagEnabled } from "./utils/is-debug-flag.js";
 import { isExpectedUserError } from "./utils/is-expected-user-error.js";
 import { isJsonModeActive, writeJsonErrorReport } from "./utils/json-mode.js";
 import { normalizeHelpInvocation } from "./utils/normalize-help-command.js";
+import { printDebugTrace } from "./utils/print-debug-trace.js";
 import { assertNoRemovedFlags } from "./utils/removed-cli-flags.js";
 import { reportErrorToSentry } from "./utils/report-error.js";
 import { stripUnknownCliFlags } from "./utils/strip-unknown-cli-flags.js";
@@ -32,6 +34,14 @@ initializeSentry();
 
 process.on("SIGINT", exitGracefully);
 process.on("SIGTERM", exitGracefully);
+// `--debug`: surface the run's Sentry trace id as the very last line, on every
+// exit path. An exit handler (not a `.then`) is the one choke point that also
+// covers the error funnels, which `process.exit()` after rendering — by then
+// the trace has flushed (success path awaits `flushSentry`; error path awaits
+// `reportErrorToSentry`'s flush), so the printed id always resolves in Sentry.
+process.on("exit", () => {
+  if (isDebugFlagEnabled()) printDebugTrace();
+});
 unrefStdin();
 // HACK: a terminal that vanishes while an interactive prompt is reading
 // stdin makes Node raise `read EIO` on the raw-mode handle; with no listener
@@ -111,6 +121,10 @@ const program = new Command()
     "skip dead-code analysis (unused files / exports / dependencies, circular imports)",
   )
   .option("--verbose", "show every rule and per-file details (default shows top 3 rules)")
+  .option(
+    "--debug",
+    "force a Sentry trace and print its id at the end (paste it into a bug report)",
+  )
   .option("--output-dir <dir>", "directory for the full diagnostics dump (default: a temp folder)")
   .option("--score", "output only the score")
   .option("--json", "output a single structured JSON report (suppresses other output)")
@@ -328,7 +342,8 @@ Promise.resolve()
   .then(() => assertNoRemovedFlags(process.argv))
   .then(() => program.parseAsync(argv))
   // Deliver any queued performance transaction before the process exits on the
-  // success path; error funnels flush via `reportErrorToSentry`.
+  // success path; error funnels flush via `reportErrorToSentry`. The `--debug`
+  // trace id is printed from the `exit` handler above, after this flush.
   .then(() => flushSentry())
   .catch(async (error: unknown) => {
     // Mirror the per-command policy at the top-level funnel: expected,

--- a/packages/react-doctor/src/cli/utils/active-run-trace.ts
+++ b/packages/react-doctor/src/cli/utils/active-run-trace.ts
@@ -18,3 +18,17 @@ export const setActiveRunTrace = (trace: ActiveRunTrace | null): void => {
 };
 
 export const getActiveRunTrace = (): ActiveRunTrace | null => activeRunTrace;
+
+// The most recent run's trace id, kept for the `--debug` end-of-run print.
+// Unlike `activeRunTrace` (the error-linking handle, cleared after each run by
+// `resetSentryRunState`), this persists past the reset so it can be read once
+// the command has finished and the trace has flushed. Recorded for every run
+// span — including a concurrent workspace batch, where the last member to start
+// wins; any one project's trace is a fine entry point for a debug pointer.
+let lastRunTraceId: string | null = null;
+
+export const recordRunTraceId = (traceId: string): void => {
+  lastRunTraceId = traceId;
+};
+
+export const getLastRunTraceId = (): string | null => lastRunTraceId;

--- a/packages/react-doctor/src/cli/utils/build-run-context.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-context.ts
@@ -7,6 +7,7 @@ import {
   isCodingAgentEnvironment,
   isOfficialGithubAction,
 } from "./is-ci-environment.js";
+import { isDebugFlagEnabled } from "./is-debug-flag.js";
 import { isGitHookEnvironment } from "./is-git-hook-environment.js";
 import { isNonInteractiveEnvironment } from "./is-non-interactive-environment.js";
 import { isJsonModeActive } from "./json-mode.js";
@@ -39,6 +40,9 @@ export interface RunContext {
   // "ci"/"unknown". Reveals where the CLI is actually used.
   terminalKind: string;
   jsonMode: boolean;
+  // User passed `--debug` (forces a Sentry trace and prints its id). Tracks
+  // adoption of the diagnostic flag.
+  debug: boolean;
   // Package-manager / runner the CLI was launched through (npm, pnpm, yarn,
   // bun, or "unknown"), derived from `npm_config_user_agent`. Distinguishes
   // `npx react-doctor` (npm) from `pnpm dlx` / global installs in triage.
@@ -109,6 +113,7 @@ export const buildRunContext = (): RunContext => {
     interactive: !isNonInteractiveEnvironment(),
     terminalKind: detectTerminalKind(),
     jsonMode: isJsonModeActive(),
+    debug: isDebugFlagEnabled(),
     invokedVia: detectInvokedVia(),
   };
 };

--- a/packages/react-doctor/src/cli/utils/build-sentry-scope.ts
+++ b/packages/react-doctor/src/cli/utils/build-sentry-scope.ts
@@ -37,6 +37,7 @@ export const buildSentryScope = (runContext: RunContext = buildRunContext()): Se
     interactive: runContext.interactive,
     terminalKind: runContext.terminalKind,
     jsonMode: runContext.jsonMode,
+    debug: runContext.debug,
     invokedVia: runContext.invokedVia,
     nodeMajor: runContext.nodeMajor,
   };

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -109,11 +109,15 @@ export const SENTRY_DSN =
 // associates artifacts with (`scripts/sentry-sourcemaps.mjs`).
 export const SENTRY_RELEASE_PREFIX = "react-doctor";
 
+// Sample every trace (100%). `--debug` forces this for the run so the trace id
+// it prints always points to a delivered trace, even when the env opted down.
+export const FULL_TRACES_SAMPLE_RATE = 1;
+
 // Default Sentry performance-tracing sample rate. Each CLI invocation becomes
 // one transaction; runs are low-frequency (vs. web traffic) so full sampling
 // gives the richest crash-correlated traces. Tunable per-run via the
 // `SENTRY_TRACES_SAMPLE_RATE` env var (set to `0` to disable tracing entirely).
-export const SENTRY_DEFAULT_TRACES_SAMPLE_RATE = 1;
+export const SENTRY_DEFAULT_TRACES_SAMPLE_RATE = FULL_TRACES_SAMPLE_RATE;
 
 // Upper bound on how long the CLI blocks waiting for Sentry to deliver queued
 // events (errors + transactions) before the process exits. The CLI tears down

--- a/packages/react-doctor/src/cli/utils/inspect-flags.ts
+++ b/packages/react-doctor/src/cli/utils/inspect-flags.ts
@@ -6,6 +6,9 @@ export interface InspectFlags {
   lint?: boolean;
   deadCode?: boolean;
   verbose?: boolean;
+  // Forces a Sentry trace and prints its id at the end. Conflicts with
+  // --no-score / --no-telemetry, which disable the telemetry it needs.
+  debug?: boolean;
   outputDir?: string;
   score?: boolean;
   json?: boolean;

--- a/packages/react-doctor/src/cli/utils/is-debug-flag.ts
+++ b/packages/react-doctor/src/cli/utils/is-debug-flag.ts
@@ -1,0 +1,10 @@
+/**
+ * Whether the user passed `--debug` (surface the run's Sentry trace id, and
+ * force performance tracing on so there's a trace to surface). Read straight
+ * from argv rather than Commander's parsed flags because `initializeSentry()`
+ * runs before Commander parses — the same reason `shouldEnableSentry()` reads
+ * `--no-score` from argv. Sharing this one reader keeps the init-time sampling
+ * override and the end-of-run print in agreement.
+ */
+export const isDebugFlagEnabled = (argv: ReadonlyArray<string> = process.argv): boolean =>
+  argv.includes("--debug");

--- a/packages/react-doctor/src/cli/utils/print-debug-trace.ts
+++ b/packages/react-doctor/src/cli/utils/print-debug-trace.ts
@@ -1,0 +1,36 @@
+import * as Sentry from "@sentry/node";
+import { highlighter } from "@react-doctor/core";
+import { getLastRunTraceId } from "./active-run-trace.js";
+
+/**
+ * The `--debug` end-of-run line, pure so it's testable without the Sentry SDK.
+ * Mirrors the crash-reference phrasing in `handle-error.ts` ("mention this when
+ * reporting") so users learn one habit for both paths. A `null` trace says why,
+ * so `--debug` never silently does nothing.
+ */
+export const buildDebugTraceMessage = (traceId: string | null): string =>
+  traceId === null
+    ? "Sentry trace unavailable for this run (no trace was recorded)."
+    : `Sentry trace (mention this when reporting): ${traceId}`;
+
+/**
+ * Prints the run's Sentry trace id to stderr at the end of a `--debug` run, so
+ * maintainers can pull the full trace from a pasted id. Runs from the process
+ * `exit` handler, so it's the last line on both the success path and the error
+ * funnels (which `process.exit()` before the promise chain could resume).
+ *
+ * Writes straight to `process.stderr` (not `Console`) for three reasons: the
+ * exit handler is synchronous, JSON mode patches the global console to no-ops —
+ * a diagnostic the user explicitly asked for must survive that — and stderr
+ * keeps `--json` / `--score` stdout machine-clean. The write is wrapped because
+ * a diagnostic must never throw out of an exit handler.
+ */
+export const printDebugTrace = (): void => {
+  // Sentry off ⇒ nothing to surface. `--debug` with `--no-score` /
+  // `--no-telemetry` is rejected up front (validateModeFlags), so this is only
+  // reachable from tests / the library, where a debug line would be noise.
+  if (!Sentry.isInitialized()) return;
+  try {
+    process.stderr.write(`${highlighter.dim(buildDebugTraceMessage(getLastRunTraceId()))}\n`);
+  } catch {}
+};

--- a/packages/react-doctor/src/cli/utils/report-error.ts
+++ b/packages/react-doctor/src/cli/utils/report-error.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/node";
 import { isReactDoctorError } from "@react-doctor/core";
-import { getActiveRunTrace } from "./active-run-trace.js";
+import { getActiveRunTrace, recordRunTraceId } from "./active-run-trace.js";
 import { buildSentryScope } from "./build-sentry-scope.js";
 import { METRIC, SENTRY_FLUSH_TIMEOUT_MS } from "./constants.js";
 import { isExpectedUserError } from "./is-expected-user-error.js";
@@ -54,6 +54,11 @@ export const reportErrorToSentry = async (error: unknown): Promise<string | unde
           sampleRand: Math.random(),
         });
       }
+      // Surface the trace this crash is attached to for `--debug`, even when no
+      // scan span ran (a pre-scan throw has no run trace, but the captured event
+      // still belongs to the scope's trace). When `runTrace` exists this is the
+      // same id; otherwise it's the scope's own (matching the captured event).
+      recordRunTraceId(scope.getPropagationContext().traceId);
       return Sentry.captureException(error);
     });
     await Sentry.flush(SENTRY_FLUSH_TIMEOUT_MS);

--- a/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
+++ b/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
@@ -12,6 +12,7 @@ const ROOT_FLAG_SPEC: CliFlagSpec = {
   longOptionsWithoutValues: new Set([
     "--color",
     "--dead-code",
+    "--debug",
     "--help",
     "--json",
     "--json-compact",

--- a/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
+++ b/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
@@ -31,4 +31,13 @@ export const validateModeFlags = (flags: InspectFlags): void => {
       "Cannot combine --score with --no-telemetry; --score prints the score that --no-telemetry disables.",
     );
   }
+  // `--debug` surfaces the run's Sentry trace id, but `--no-score` /
+  // `--no-telemetry` turn off the Sentry reporting that produces it — so the
+  // combination can never do anything. Reject it instead of silently no-op'ing.
+  if (flags.debug && (flags.score === false || flags.telemetry === false)) {
+    const disablingFlag = flags.score === false ? "--no-score" : "--no-telemetry";
+    throw new CliInputError(
+      `Cannot combine --debug with ${disablingFlag}; ${disablingFlag} disables the Sentry reporting --debug needs to capture a trace.`,
+    );
+  }
 };

--- a/packages/react-doctor/src/cli/utils/with-sentry-run-span.ts
+++ b/packages/react-doctor/src/cli/utils/with-sentry-run-span.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 import type { ProjectInfo } from "@react-doctor/core";
 import { isSentryTracingEnabled } from "../../instrument.js";
-import { setActiveRunTrace } from "./active-run-trace.js";
+import { recordRunTraceId, setActiveRunTrace } from "./active-run-trace.js";
 import { buildSentryScope } from "./build-sentry-scope.js";
 import { buildSentryProjectContext, setSentryProjectInfo } from "./build-sentry-project-context.js";
 import { TRACE_FLAG_SAMPLED } from "./constants.js";
@@ -58,8 +58,11 @@ export const withSentryRunSpan = <T>(
   return Sentry.startSpan(
     { name: `react-doctor ${command}`, op: "cli.inspect", attributes: toSpanAttributes(tags) },
     (rootSpan) => {
+      const spanContext = rootSpan.spanContext();
+      // Remembered for the `--debug` end-of-run print, which reads it after the
+      // span has ended and the run-scoped error-linking handle has been reset.
+      recordRunTraceId(spanContext.traceId);
       if (options.concurrentScan !== true) {
-        const spanContext = rootSpan.spanContext();
         setActiveRunTrace({
           traceId: spanContext.traceId,
           spanId: spanContext.spanId,

--- a/packages/react-doctor/src/instrument.ts
+++ b/packages/react-doctor/src/instrument.ts
@@ -1,6 +1,11 @@
 import * as Sentry from "@sentry/node";
 import { buildSentryScope } from "./cli/utils/build-sentry-scope.js";
-import { SENTRY_DSN, SENTRY_FLUSH_TIMEOUT_MS } from "./cli/utils/constants.js";
+import {
+  FULL_TRACES_SAMPLE_RATE,
+  SENTRY_DSN,
+  SENTRY_FLUSH_TIMEOUT_MS,
+} from "./cli/utils/constants.js";
+import { isDebugFlagEnabled } from "./cli/utils/is-debug-flag.js";
 import { scrubSentryEvent } from "./cli/utils/scrub-sentry-event.js";
 import { scrubSentryMetric } from "./cli/utils/scrub-sentry-metric.js";
 import {
@@ -76,7 +81,11 @@ export const flushSentry = async (): Promise<void> => {
 export const initializeSentry = (): void => {
   if (isInitialized || !shouldEnableSentry()) return;
   isInitialized = true;
-  resolvedTracesSampleRate = resolveTracesSampleRate();
+  // `--debug` forces full sampling so the trace id it prints at the end of the
+  // run always resolves to a delivered trace, overriding a downsampled env.
+  resolvedTracesSampleRate = isDebugFlagEnabled()
+    ? FULL_TRACES_SAMPLE_RATE
+    : resolveTracesSampleRate();
   const { tags, contexts } = buildSentryScope();
   Sentry.init({
     dsn: process.env.SENTRY_DSN || SENTRY_DSN,

--- a/packages/react-doctor/tests/build-sentry-scope.test.ts
+++ b/packages/react-doctor/tests/build-sentry-scope.test.ts
@@ -23,6 +23,7 @@ const baseRunContext: RunContext = {
   interactive: false,
   terminalKind: "ci",
   jsonMode: true,
+  debug: false,
   invokedVia: "pnpm",
 };
 
@@ -69,6 +70,7 @@ describe("buildSentryScope", () => {
       interactive: false,
       terminalKind: "ci",
       jsonMode: true,
+      debug: false,
       invokedVia: "pnpm",
       nodeMajor: 22,
     });

--- a/packages/react-doctor/tests/is-debug-flag.test.ts
+++ b/packages/react-doctor/tests/is-debug-flag.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isDebugFlagEnabled } from "../src/cli/utils/is-debug-flag.js";
+
+describe("isDebugFlagEnabled", () => {
+  it("is true when --debug appears anywhere in argv", () => {
+    expect(isDebugFlagEnabled(["node", "react-doctor", ".", "--debug"])).toBe(true);
+    expect(isDebugFlagEnabled(["node", "react-doctor", "--debug", "--json"])).toBe(true);
+  });
+
+  it("is false when --debug is absent", () => {
+    expect(isDebugFlagEnabled(["node", "react-doctor", "."])).toBe(false);
+    expect(isDebugFlagEnabled(["node", "react-doctor", "--verbose"])).toBe(false);
+  });
+
+  it("does not match a value that merely contains the word debug", () => {
+    expect(isDebugFlagEnabled(["node", "react-doctor", "--project", "debug"])).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/print-debug-trace.test.ts
+++ b/packages/react-doctor/tests/print-debug-trace.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildDebugTraceMessage } from "../src/cli/utils/print-debug-trace.js";
+
+describe("buildDebugTraceMessage", () => {
+  it("prints the trace id with the report-it hint when one was captured", () => {
+    const message = buildDebugTraceMessage("abc123def456");
+    expect(message).toContain("abc123def456");
+    expect(message).toContain("mention this when reporting");
+  });
+
+  it("notes when no trace was recorded for this run", () => {
+    const message = buildDebugTraceMessage(null);
+    expect(message).toContain("no trace was recorded");
+  });
+});

--- a/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
+++ b/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
@@ -14,6 +14,7 @@ describe("stripUnknownCliFlags", () => {
     expect(
       stripUserArguments([
         ".",
+        "--debug",
         "--no-score",
         "--project",
         "web",
@@ -27,6 +28,7 @@ describe("stripUnknownCliFlags", () => {
       ]),
     ).toEqual([
       ".",
+      "--debug",
       "--no-score",
       "--project",
       "web",

--- a/packages/react-doctor/tests/validate-mode-flags.test.ts
+++ b/packages/react-doctor/tests/validate-mode-flags.test.ts
@@ -16,6 +16,19 @@ describe("validateModeFlags", () => {
     expect(() => validateModeFlags({ telemetry: false })).not.toThrow();
   });
 
+  it("rejects --debug combined with --no-score or --no-telemetry (the trace it needs is off)", () => {
+    expect(() => validateModeFlags({ debug: true, score: false })).toThrow(
+      "Cannot combine --debug with --no-score",
+    );
+    expect(() => validateModeFlags({ debug: true, telemetry: false })).toThrow(
+      "Cannot combine --debug with --no-telemetry",
+    );
+  });
+
+  it("allows --debug on its own", () => {
+    expect(() => validateModeFlags({ debug: true })).not.toThrow();
+  });
+
   it("allows --yes and --full together (skip prompts + force a full scan are orthogonal)", () => {
     expect(() => validateModeFlags({ yes: true, full: true })).not.toThrow();
   });

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -105,5 +105,6 @@ Options:
   --no-score         skip the score API and share URL
   --staged           scan only staged (git index) files for pre-commit hooks
   --blocking <level>  severity that fails CI: error (default), warning, none
+  --debug            force a Sentry trace and print its id at the end (paste it into a bug report)
   -h, --help         display help for command
 ```


### PR DESCRIPTION
## Why

When a scan produces a wrong-but-not-crashed result, a user has no precise pointer to hand maintainers — the crash "Reference" event id only exists when the run throws. `--debug` gives a Sentry trace id for *any* run (clean, blocking, or crash) so it can be pasted into a bug report and the full trace pulled in Sentry.

Before:

```
$ react-doctor              # results look off — nothing to quote to maintainers
```

After:

```
$ react-doctor --debug
  ... normal scan output ...
  Sentry trace (mention this when reporting): 8b20df8e905001f639ae5a45df070eed

$ react-doctor --no-telemetry --debug
  Cannot combine --debug with --no-telemetry; --no-telemetry disables the Sentry reporting --debug needs to capture a trace.
```

## What changed

- **`--debug` flag** (root/inspect command): forces full trace sampling for the run and prints the trace id as the last line.
- **Prints on every exit path** via a single `process.on("exit")` handler — covers the success path *and* the error funnels (which `process.exit()` before the promise chain resumes). By exit time the trace has flushed (success awaits `flushSentry`, errors await `reportErrorToSentry`'s flush), so the id always resolves.
- **Pre-scan crashes too**: `reportErrorToSentry` records the trace the captured event is attached to, so even a throw before the scan span starts yields a usable id.
- **Conflict guard**: `--debug` with `--no-score` / `--no-telemetry` is rejected up front (`validateModeFlags`) — those flags disable the Sentry reporting it depends on. Renders as a clean one-line user error (no Sentry capture, no "open an issue" block).
- **stderr only**, so `--json` / `--score` stdout stays machine-clean (survives JSON mode's silenced global console).
- **Telemetry**: a low-cardinality `debug` run tag rides every event/metric/wide-event (`build-run-context` → `build-sentry-scope`) so flag adoption is queryable.
- New focused utils: `is-debug-flag.ts` (one argv reader, shared by init + print) and `print-debug-trace.ts`. Magic `1` centralized as `FULL_TRACES_SAMPLE_RATE`. Docs updated in `llms.txt`. Changeset added (`react-doctor` minor).

## Product brief

- **Job:** a user/maintainer debugging a wrong result needs a precise Sentry pointer; today only crashes get one.
- **Reuse:** truffler found no existing trace printer — extended `active-run-trace.ts` (same datum, longer lifetime) rather than a parallel store.
- **Metric:** `debug` run tag (adoption); success = queryable, low absolute usage is fine for a support tool.
- **Compat:** default off, opt-in, behavior unchanged when absent → `react-doctor` minor changeset. No JSON/score/action changes.
- **Kill:** remove if the `debug` tag is true in <~0.1% of runs over 3 releases and never cited in a triaged issue.

## Test plan

- `nr typecheck` ✓ · `nr lint` ✓ · `nr format` ✓
- `nr test` (react-doctor) ✓ — **1822 passed**, 15 skipped, 0 failed. New tests: `is-debug-flag`, `print-debug-trace`, `validate-mode-flags` (conflict), `strip-unknown-cli-flags` / `build-sentry-scope` updates.
- Manual smoke (bogus `127.0.0.1` DSN so nothing reaches prod Sentry):
  - `--debug` → prints trace id once; overrides `SENTRY_TRACES_SAMPLE_RATE=0`.
  - `--json --debug` → valid JSON on stdout, trace id on stderr.
  - error path (user error + scan-time error) → debug line still printed last.
  - `--no-telemetry --debug` / `--no-score --debug` → clean one-line error, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in diagnostic only; default runs unchanged. Touches Sentry init and exit paths but guarded by flag conflicts and no change to core scan logic.
> 
> **Overview**
> Adds an opt-in **`--debug`** flag so users can paste a **Sentry trace id** into bug reports when a scan looks wrong but does not crash.
> 
> **`--debug`** forces **100% trace sampling** for that run (overriding a lowered `SENTRY_TRACES_SAMPLE_RATE`), records the trace id from the inspect span and from error capture (including pre-scan failures), and prints **`Sentry trace (mention this when reporting): <id>`** on **stderr** as the **last line** via a **`process.on("exit")`** handler so success, crash, and `process.exit()` error paths are covered. **`--json` / `--score` stdout** stays clean; user-error paths still **flush Sentry** when debug is on so the printed id resolves.
> 
> **`validateModeFlags`** rejects **`--debug`** with **`--no-score`** or **`--no-telemetry`**. Run telemetry gets a low-cardinality **`debug`** tag. Docs (`llms.txt`) and tests cover argv detection, message text, flag stripping, and conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad93fd3edb2e6613d82c491c7e284a1a55ee297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->