### PR TITLE
chore(changeset): downgrade clickable-locations to a patch bump

### DIFF
--- a/.changeset/feat-osc8-clickable-locations.md
+++ b/.changeset/feat-osc8-clickable-locations.md
@@ -1,5 +1,5 @@
 ---
-"react-doctor": minor
+"react-doctor": patch
 ---
 
 Make `file:line` diagnostic locations clickable in the terminal, and record which terminal each run uses.


### PR DESCRIPTION
## Why

The release PR (#827) currently bumps the fixed `react-doctor` package group to `0.6.0` solely on the OSC 8 clickable-locations changeset (#864), which is marked `minor`. That feature is an additive but small refinement — ship it in a patch release instead of rolling the whole group to a new minor.

Before:

```
"react-doctor": minor
```

After:

```
"react-doctor": patch
```

## What changed

- `.changeset/feat-osc8-clickable-locations.md`: bump level `minor` → `patch`. No content/behavior change.

## Test plan

- `pnpm changeset status` — not run (fresh workspace, `node_modules` not installed); the edit is a single frontmatter field and the changeset format is unchanged.
- Once merged, the next `version packages` PR will resolve the fixed group to a patch instead of `0.6.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only; no runtime, API, or build logic changes.
> 
> **Overview**
> This PR only edits **`.changeset/feat-osc8-clickable-locations.md`**: the frontmatter bump for `"react-doctor"` goes from `minor` to `patch`. The changeset body (OSC 8 hyperlinks for `file:line` locations, `terminalKind` telemetry, etc.) is unchanged.
> 
> **Effect:** the next `version packages` run will treat that feature as a patch-level release for the fixed `react-doctor` group instead of driving a minor (e.g. avoiding a `0.6.0`-style bump for this change alone).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ba40fb4b6838f8eca57fe24ad606e359f749a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->