### PR TITLE
feat(cli): warn before mass-fixing a migration-scale bucket

### DIFF
--- a/.changeset/migration-scale-advisory.md
+++ b/.changeset/migration-scale-advisory.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": patch
+---
+
+Warn before mass-fixing a migration-scale bucket. When a single rule spans many files (≥ `MIGRATION_SCALE_RULE_FILE_COUNT`, default 40) — e.g. `manual-memoization` firing across hundreds of files — the report now prints a "Migration-scale change — sample before you sweep" advisory naming the rule(s), explaining the review risk, and pointing at `npx react-doctor@latest <path>` to scope the work down one area at a time.
+
+The same guidance reaches coding agents: a new "Agent guidance" line and an inline note on any migration-scale bucket in the agent handoff prompt tell the agent to fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before sweeping the rest — instead of mass-fixing a broad pattern in one unreviewed pass.
+
+A new wide-event attribute (`migration.largestRuleBucketFiles`, plus `…Sites` / `…Rule`) records the widest-blast-radius rule per scan so the threshold can be calibrated against real runs. No change to the score, exit code, or JSON report.

--- a/.changeset/migration-scale-advisory.md
+++ b/.changeset/migration-scale-advisory.md
@@ -2,8 +2,8 @@
 "react-doctor": patch
 ---
 
-Warn before mass-fixing a migration-scale bucket. When a single rule spans many files (≥ `MIGRATION_SCALE_RULE_FILE_COUNT`, default 40) — e.g. `manual-memoization` firing across hundreds of files — the report now prints a "Migration-scale change — sample before you sweep" advisory naming the rule(s), explaining the review risk, and pointing at `npx react-doctor@latest <path>` to scope the work down one area at a time.
+Warn before mass-fixing a migration-scale bucket. When a single rule spans dozens of files (≥ `MIGRATION_SCALE_RULE_FILE_COUNT`, default 40), the report now prints a "Migration-scale change: sample before you sweep" advisory. It names the rule(s), explains the review risk, and points at `npx react-doctor@latest <path>` to scope the work down one area at a time.
 
-The same guidance reaches coding agents: a new "Agent guidance" line and an inline note on any migration-scale bucket in the agent handoff prompt tell the agent to fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before sweeping the rest — instead of mass-fixing a broad pattern in one unreviewed pass.
+The same guidance reaches coding agents. A new "Agent guidance" line and an inline note on any migration-scale bucket in the agent handoff prompt tell the agent to fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before changing the rest, instead of mass-fixing a broad pattern in one unreviewed pass.
 
-A new wide-event attribute (`migration.largestRuleBucketFiles`, plus `…Sites` / `…Rule`) records the widest-blast-radius rule per scan so the threshold can be calibrated against real runs. No change to the score, exit code, or JSON report.
+A new wide-event attribute (`migration.largestRuleBucketFiles`, plus `migration.largestRuleBucketSites` and `migration.largestRuleBucketRule`) records the widest-blast-radius rule per scan, so the threshold can be calibrated against real runs. No change to the score, exit code, or JSON report.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -393,6 +393,17 @@ export const FIX_GROUP_ID_LENGTH_CHARS = 16;
 // "Top N errors you should fix" header above the category breakdown.
 export const TOP_ERRORS_DISPLAY_COUNT = 3;
 
+// A single rule firing across this many distinct files is a migration, not a
+// quick fix: a mechanical sweep this wide is hard to review and easy to get
+// subtly wrong everywhere at once, so it warrants a sampled, owner-approved
+// rollout rather than a blind fix-all. Set above a normal review-sized PR
+// (the agent playbook caps a fix bucket near ~30 files) so the advisory means
+// "more than one PR's worth" and stays rare on ordinary repos. Files — not raw
+// site count — gauge the review burden, so the gate keys on a rule's blast
+// radius. Calibrate against the `migration.largestRuleBucketFiles` wide-event
+// attribute.
+export const MIGRATION_SCALE_RULE_FILE_COUNT = 40;
+
 // Source-context window rendered around each top-error site in the
 // inline code frame (lines above / below the offending line).
 export const CODE_FRAME_LINES_ABOVE = 1;

--- a/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
+++ b/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
@@ -3,6 +3,7 @@ import type { Diagnostic } from "@react-doctor/core";
 import { HANDOFF_MAX_FILES_PER_RULE } from "./constants.js";
 import {
   buildSortedRuleGroups,
+  findMigrationScaleBuckets,
   formatFixRecipeLine,
   getSharedFixSiteCount,
 } from "./diagnostic-grouping.js";
@@ -20,6 +21,9 @@ export interface HandoffPayloadInput {
 // than dumping every issue inline.
 export const buildHandoffPayload = (input: HandoffPayloadInput): string => {
   const topGroups = buildSortedRuleGroups(input.diagnostics).slice(0, TOP_ERRORS_DISPLAY_COUNT);
+  const migrationScaleBuckets = new Map(
+    findMigrationScaleBuckets(input.diagnostics).map((bucket) => [bucket.ruleKey, bucket]),
+  );
 
   let outputDirectory: string | null = null;
   try {
@@ -56,6 +60,12 @@ export const buildHandoffPayload = (input: HandoffPayloadInput): string => {
     }
     const remainingFiles = uniqueFiles.length - HANDOFF_MAX_FILES_PER_RULE;
     if (remainingFiles > 0) lines.push(`   - +${remainingFiles} more files`);
+    const migrationBucket = migrationScaleBuckets.get(ruleKey);
+    if (migrationBucket) {
+      lines.push(
+        `   Migration-scale (${migrationBucket.fileCount} files): fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before sweeping the rest in one pass.`,
+      );
+    }
   });
 
   lines.push("");

--- a/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
+++ b/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
@@ -63,7 +63,7 @@ export const buildHandoffPayload = (input: HandoffPayloadInput): string => {
     const migrationBucket = migrationScaleBuckets.get(ruleKey);
     if (migrationBucket) {
       lines.push(
-        `   Migration-scale (${migrationBucket.fileCount} files): fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before sweeping the rest in one pass.`,
+        `   Migration-scale (${migrationBucket.fileCount} files): fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before changing the rest in one pass.`,
       );
     }
   });
@@ -98,7 +98,7 @@ export const buildHandoffPayload = (input: HandoffPayloadInput): string => {
       .map((bucket) => `${bucket.title} (${bucket.fileCount} files)`)
       .join(", ");
     lines.push(
-      `Some of the rest are migration-scale (span many files): ${ruleSummaries}. For each, fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before sweeping the rest in one pass.`,
+      `Some of the rest are migration-scale (span dozens of files): ${ruleSummaries}. For each, fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before changing the rest in one pass.`,
       "",
     );
   }

--- a/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
+++ b/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
@@ -84,8 +84,26 @@ export const buildHandoffPayload = (input: HandoffPayloadInput): string => {
     "",
     'Teach me as you go: for every issue you touch, explain it in plain language (no jargon) — what the problem is, why it\'s a problem, and how serious it is in human terms. Describe the real-world impact and severity concretely (e.g. "this crashes the page for users on Safari" vs. "this is a minor cleanup with no user impact") so I understand why it matters, not just what changed.',
     "",
-    "Then work through the rest from the full results above.",
   );
+
+  // Migration-scale rules that fall outside the shown top-N still carry the
+  // sample-first warning, so the agent doesn't blindly sweep them when it works
+  // through "the rest" — the per-rule note above only reaches the shown groups.
+  const shownRuleKeys = new Set(topGroups.map(([ruleKey]) => ruleKey));
+  const deferredMigrationBuckets = [...migrationScaleBuckets.values()].filter(
+    (bucket) => !shownRuleKeys.has(bucket.ruleKey),
+  );
+  if (deferredMigrationBuckets.length > 0) {
+    const ruleSummaries = deferredMigrationBuckets
+      .map((bucket) => `${bucket.title} (${bucket.fileCount} files)`)
+      .join(", ");
+    lines.push(
+      `Some of the rest are migration-scale (span many files): ${ruleSummaries}. For each, fix a representative sample, confirm the recipe holds, and get the code owner's sign-off before sweeping the rest in one pass.`,
+      "",
+    );
+  }
+
+  lines.push("Then work through the rest from the full results above.");
 
   return lines.join("\n");
 };

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -5,6 +5,7 @@ import {
   summarizeDiagnostics,
 } from "@react-doctor/core";
 import type { BlockingLevel, InspectResult, ReactDoctorConfig } from "@react-doctor/core";
+import { buildRuleBlastRadii } from "./diagnostic-grouping.js";
 import { ACTION_INPUT_ENVIRONMENT_VARIABLES, detectRunnerOs } from "./is-ci-environment.js";
 import { summarizeRuleFirings } from "./record-scan-metrics.js";
 import { isValidBlockingLevel } from "./resolve-blocking-level.js";
@@ -139,6 +140,12 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
     }
   }
 
+  // Widest-blast-radius rule: how many files the single most-spread rule
+  // touches (and its site count). Lets a query see how common migration-scale
+  // buckets are and calibrate MIGRATION_SCALE_RULE_FILE_COUNT — the threshold
+  // that fires the "sample before you sweep" advisory — against real scans.
+  const largestRuleBucket = buildRuleBlastRadii(result.diagnostics)[0] ?? null;
+
   let diagnosticsInTestFiles = 0;
   let diagnosticsInStoryFiles = 0;
   // Root-cause grouping rollup: how many distinct fix groups, and how many
@@ -175,6 +182,9 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
     "diag.fixGroups": findingsPerFixGroup.size,
     "diag.fixGroupedFindings": fixGroupedFindings,
     topRule,
+    "migration.largestRuleBucketFiles": largestRuleBucket ? largestRuleBucket.fileCount : null,
+    "migration.largestRuleBucketSites": largestRuleBucket ? largestRuleBucket.siteCount : null,
+    "migration.largestRuleBucketRule": largestRuleBucket ? largestRuleBucket.ruleKey : null,
     scannedFileCount: result.scannedFileCount ?? null,
     elapsedMs: result.elapsedMilliseconds,
     scanPhaseMs: result.scanElapsedMilliseconds ?? null,

--- a/packages/react-doctor/src/cli/utils/diagnostic-grouping.ts
+++ b/packages/react-doctor/src/cli/utils/diagnostic-grouping.ts
@@ -2,6 +2,7 @@ import {
   buildRuleDocsUrl,
   groupBy,
   hasPublishedFixRecipe,
+  MIGRATION_SCALE_RULE_FILE_COUNT,
   MIN_SHARED_FIX_SITE_COUNT,
 } from "@react-doctor/core";
 import type { Diagnostic, ScoreResult } from "@react-doctor/core";
@@ -108,3 +109,36 @@ export const formatLearnMoreLine = (diagnostic: Diagnostic): string | null =>
   hasPublishedFixRecipe(diagnostic)
     ? `Learn more: ${buildRuleDocsUrl(diagnostic.plugin, diagnostic.rule)}`
     : null;
+
+// Per-rule "blast radius": how many sites a `<plugin>/<rule>` group reports and
+// how many distinct files those sites span. Files (not raw sites) measure the
+// review burden of fixing a rule everywhere — 800 sites in 2 files is a small
+// PR; 800 across 300 files is a migration — so this is what the migration-scale
+// advisory and its calibration metric both read. Sorted widest blast radius
+// first; the title falls back to the rule key for adopted third-party rules.
+export interface RuleBlastRadius {
+  readonly ruleKey: string;
+  readonly title: string;
+  readonly siteCount: number;
+  readonly fileCount: number;
+}
+
+export const buildRuleBlastRadii = (diagnostics: ReadonlyArray<Diagnostic>): RuleBlastRadius[] =>
+  buildSortedRuleGroups(diagnostics)
+    .map(([ruleKey, ruleDiagnostics]) => ({
+      ruleKey,
+      title: ruleDiagnostics[0]!.title ?? ruleKey,
+      siteCount: ruleDiagnostics.length,
+      fileCount: new Set(ruleDiagnostics.map((diagnostic) => diagnostic.filePath)).size,
+    }))
+    .toSorted((left, right) => right.fileCount - left.fileCount);
+
+// The rule groups whose fix would touch enough files to be a migration rather
+// than a quick fix — the set that warrants sampling a few sites, confirming the
+// recipe holds, and getting the code owner's sign-off before sweeping the rest.
+export const findMigrationScaleBuckets = (
+  diagnostics: ReadonlyArray<Diagnostic>,
+): RuleBlastRadius[] =>
+  buildRuleBlastRadii(diagnostics).filter(
+    (bucket) => bucket.fileCount >= MIGRATION_SCALE_RULE_FILE_COUNT,
+  );

--- a/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
+++ b/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
@@ -13,6 +13,7 @@ const AGENT_GUIDANCE_LINES = [
   "Run `npx react-doctor@latest --verbose --scope changed` before and after changes, plus relevant tests after each focused batch.",
   "When available, spawn subagents or isolated worktrees for independent rule families, then review and merge only the best safe fixes.",
   "Split unrelated, broad, or behavior-changing work into separate PRs/branches instead of one large cleanup.",
+  "When one rule spans many files (a migration-scale sweep), fix a representative sample first, confirm the recipe holds, and get the code owner's sign-off before sweeping the rest — don't mass-fix a broad pattern in one unreviewed pass.",
   "For confirmed issues that cannot be fixed now, create GitHub issues with the rule, file/line, confidence, impact, and proposed fix.",
   "If a fix needs an API, UX, or architecture decision, stop and ask before editing.",
 ] as const;

--- a/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
+++ b/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
@@ -13,7 +13,7 @@ const AGENT_GUIDANCE_LINES = [
   "Run `npx react-doctor@latest --verbose --scope changed` before and after changes, plus relevant tests after each focused batch.",
   "When available, spawn subagents or isolated worktrees for independent rule families, then review and merge only the best safe fixes.",
   "Split unrelated, broad, or behavior-changing work into separate PRs/branches instead of one large cleanup.",
-  "When one rule spans many files (a migration-scale sweep), fix a representative sample first, confirm the recipe holds, and get the code owner's sign-off before sweeping the rest — don't mass-fix a broad pattern in one unreviewed pass.",
+  "When one rule spans dozens of files (a migration-scale change), fix a representative sample first, confirm the recipe holds, and get the code owner's sign-off before changing the rest. Don't mass-fix a broad pattern in one unreviewed pass.",
   "For confirmed issues that cannot be fixed now, create GitHub issues with the rule, file/line, confidence, impact, and proposed fix.",
   "If a fix needs an API, UX, or architecture decision, stop and ask before editing.",
 ] as const;

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -26,10 +26,12 @@ import {
 } from "./constants.js";
 import {
   buildSortedRuleGroups,
+  findMigrationScaleBuckets,
   formatFixRecipeLine,
   formatLearnMoreLine,
   getSharedFixSiteCount,
 } from "./diagnostic-grouping.js";
+import type { RuleBlastRadius } from "./diagnostic-grouping.js";
 import { indentMultilineText } from "./indent-multiline-text.js";
 import { resolveMeasureWidth } from "./resolve-measure-width.js";
 import { wrapTextToWidth } from "./wrap-indented-text.js";
@@ -507,6 +509,55 @@ const buildOverflowSummaryLine = (
   return `  ${highlighter.dim("Run")} ${command} ${highlighter.dim("to list every error and warning")}`;
 };
 
+// One bucket's headline: the rule's title plus its blast radius. The site
+// count matches the `×N` badge the reader already saw on the rule, and the
+// file span is the part that makes it a migration rather than a quick fix.
+const formatMigrationBucketLine = (bucket: RuleBlastRadius): string =>
+  `${TOP_ERROR_DETAIL_INDENT}${bucket.title} ${highlighter.gray(`×${bucket.siteCount} across ${bucket.fileCount} files`)}`;
+
+// A parting heads-up for migration-scale buckets (a single rule spanning enough
+// files to be a project, not a quick fix). Empty for an ordinary scan, so it
+// only appears when fixing a rule everywhere is genuinely a sweep that needs
+// sampling + owner sign-off. Names the offending rule(s) so the advice is
+// concrete, then gives the why (review risk) and the next step (scope down).
+export const buildMigrationScaleAdvisoryLines = (
+  diagnostics: Diagnostic[],
+): ReadonlyArray<string> => {
+  const buckets = findMigrationScaleBuckets(diagnostics);
+  if (buckets.length === 0) return [];
+
+  const shownBuckets = buckets.slice(0, TOP_ERRORS_DISPLAY_COUNT);
+  const lines: string[] = [
+    `  ${highlighter.warn("⚠")} ${highlighter.bold("Migration-scale change")} ${highlighter.dim("— sample before you sweep")}`,
+    ...shownBuckets.map(formatMigrationBucketLine),
+  ];
+
+  const remainingBuckets = buckets.length - shownBuckets.length;
+  if (remainingBuckets > 0) {
+    lines.push(
+      highlighter.gray(
+        `${TOP_ERROR_DETAIL_INDENT}+${remainingBuckets} more ${remainingBuckets === 1 ? "rule" : "rules"} at this scale`,
+      ),
+    );
+  }
+
+  const guidance =
+    "These are broad, mechanical sweeps. Fix a representative few first, confirm the recipe holds, then get the code owner's sign-off before changing the rest in one pass — a fix this wide is hard to review and easy to get subtly wrong everywhere at once.";
+  for (const guidanceLine of wrapTextToWidth(
+    guidance,
+    resolveMeasureWidth(TOP_ERROR_DETAIL_INDENT.length),
+    { breakLongWords: false },
+  )) {
+    lines.push(highlighter.dim(`${TOP_ERROR_DETAIL_INDENT}${guidanceLine}`));
+  }
+
+  const command = highlighter.info("npx react-doctor@latest <path>");
+  lines.push(
+    `${TOP_ERROR_DETAIL_INDENT}${highlighter.dim("Scope it down one area at a time:")} ${command}`,
+  );
+  return lines;
+};
+
 // The exact rule keys surfaced in the top-errors block — the set the
 // score projection assumes you fix, so "fix the top N" matches what's
 // shown. Pass the same `rulePriority` the renderer uses so the projected
@@ -697,6 +748,7 @@ export const printDiagnostics = (
       buildOverviewHeaderLines(diagnostics),
       categoryLines,
       overflowLine ? [overflowLine] : [],
+      buildMigrationScaleAdvisoryLines(diagnostics),
     );
     // joinSections preserves the argument order, so the 1st start is the
     // detail block and the 4th is the category block (the header sits

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -528,7 +528,7 @@ export const buildMigrationScaleAdvisoryLines = (
 
   const shownBuckets = buckets.slice(0, TOP_ERRORS_DISPLAY_COUNT);
   const lines: string[] = [
-    `  ${highlighter.warn("⚠")} ${highlighter.bold("Migration-scale change")} ${highlighter.dim("— sample before you sweep")}`,
+    `  ${highlighter.warn("⚠")} ${highlighter.bold("Migration-scale change")}${highlighter.dim(": sample before you sweep")}`,
     ...shownBuckets.map(formatMigrationBucketLine),
   ];
 
@@ -542,7 +542,7 @@ export const buildMigrationScaleAdvisoryLines = (
   }
 
   const guidance =
-    "These are broad, mechanical sweeps. Fix a representative few first, confirm the recipe holds, then get the code owner's sign-off before changing the rest in one pass — a fix this wide is hard to review and easy to get subtly wrong everywhere at once.";
+    "Fixing all of them at once is hard to review and prone to subtle mistakes across the whole repo. Fix a representative few first and confirm the recipe holds. Then get the code owner's sign-off before changing the rest.";
   for (const guidanceLine of wrapTextToWidth(
     guidance,
     resolveMeasureWidth(TOP_ERROR_DETAIL_INDENT.length),

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -116,6 +116,35 @@ describe("buildRunEventAttributes", () => {
     expect(attributes.actorAssociation).toBeUndefined();
     expect(attributes.runnerOs).toBeUndefined();
     expect(attributes.versionPin).toBeUndefined();
+    // Nothing fired -> no migration bucket to report (dropped, not "null").
+    expect(attributes["migration.largestRuleBucketFiles"]).toBeUndefined();
+    expect(attributes["migration.largestRuleBucketRule"]).toBeUndefined();
+  });
+
+  it("records the widest-blast-radius rule for migration-scale calibration", () => {
+    const diagnostics: Diagnostic[] = [];
+    for (let fileIndex = 0; fileIndex < 45; fileIndex += 1) {
+      diagnostics.push(
+        buildDiagnostic({
+          rule: "react-compiler-no-manual-memoization",
+          category: "Performance",
+          filePath: `src/components/widget-${fileIndex}.tsx`,
+        }),
+      );
+    }
+    // A noisier-by-sites but narrow rule must NOT win: blast radius is files.
+    diagnostics.push(
+      buildDiagnostic({ rule: "no-array-index-as-key", filePath: "src/list.tsx", line: 1 }),
+      buildDiagnostic({ rule: "no-array-index-as-key", filePath: "src/list.tsx", line: 2 }),
+    );
+
+    const attributes = buildRunEventAttributes(baseInput({ result: buildResult({ diagnostics }) }));
+
+    expect(attributes["migration.largestRuleBucketFiles"]).toBe(45);
+    expect(attributes["migration.largestRuleBucketSites"]).toBe(45);
+    expect(attributes["migration.largestRuleBucketRule"]).toBe(
+      "react-doctor/react-compiler-no-manual-memoization",
+    );
   });
 
   it("rolls up diagnostics by severity, rule, and category", () => {

--- a/packages/react-doctor/tests/handoff/build-handoff-payload.test.ts
+++ b/packages/react-doctor/tests/handoff/build-handoff-payload.test.ts
@@ -100,4 +100,34 @@ describe("buildHandoffPayload", () => {
     const directory = payload.match(/Full results for all \d+ issues[^:]*: (\S+)/)![1]!;
     fs.rmSync(directory, { recursive: true, force: true });
   });
+
+  it("warns about a migration-scale rule that ranks outside the shown top-N", () => {
+    // Three small rules fill the shown top-N; the migration-scale rule lands
+    // outside it (scan order), so it only reaches the closing summary.
+    const diagnostics: Diagnostic[] = [
+      makeDiagnostic({ rule: "rule-a", title: "Rule A", filePath: "src/a.tsx" }),
+      makeDiagnostic({ rule: "rule-b", title: "Rule B", filePath: "src/b.tsx" }),
+      makeDiagnostic({ rule: "rule-c", title: "Rule C", filePath: "src/c.tsx" }),
+    ];
+    for (let fileIndex = 0; fileIndex < 45; fileIndex += 1) {
+      diagnostics.push(
+        makeDiagnostic({
+          rule: "react-compiler-no-manual-memoization",
+          title: "Manual memoization",
+          filePath: `src/widgets/widget-${fileIndex}.tsx`,
+          line: fileIndex + 1,
+        }),
+      );
+    }
+
+    const payload = buildHandoffPayload({ diagnostics, projectName: "demo" });
+
+    expect(payload).toContain("Some of the rest are migration-scale");
+    expect(payload).toContain("Manual memoization (45 files)");
+    // It's not one of the shown groups, so it gets no inline per-rule note.
+    expect(payload).not.toMatch(/^ {3}Migration-scale \(/m);
+
+    const directory = payload.match(/Full results for all \d+ issues[^:]*: (\S+)/)![1]!;
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
 });

--- a/packages/react-doctor/tests/handoff/build-handoff-payload.test.ts
+++ b/packages/react-doctor/tests/handoff/build-handoff-payload.test.ts
@@ -78,4 +78,26 @@ describe("buildHandoffPayload", () => {
     const directoryMatch = payload.match(/Full results for all 4 issues[^:]*: (\S+)/);
     if (directoryMatch) fs.rmSync(directoryMatch[1]!, { recursive: true, force: true });
   });
+
+  it("flags a migration-scale bucket with sample + sign-off guidance", () => {
+    const diagnostics: Diagnostic[] = [];
+    for (let fileIndex = 0; fileIndex < 45; fileIndex += 1) {
+      diagnostics.push(
+        makeDiagnostic({
+          rule: "react-compiler-no-manual-memoization",
+          title: "Manual memoization",
+          filePath: `src/components/widget-${fileIndex}.tsx`,
+          line: fileIndex + 1,
+        }),
+      );
+    }
+
+    const payload = buildHandoffPayload({ diagnostics, projectName: "demo" });
+
+    expect(payload).toContain("Migration-scale (45 files)");
+    expect(payload).toContain("get the code owner's sign-off");
+
+    const directory = payload.match(/Full results for all \d+ issues[^:]*: (\S+)/)![1]!;
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
 });

--- a/packages/react-doctor/tests/render-migration-advisory.test.ts
+++ b/packages/react-doctor/tests/render-migration-advisory.test.ts
@@ -1,0 +1,92 @@
+import * as Effect from "effect/Effect";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { MIGRATION_SCALE_RULE_FILE_COUNT } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
+import {
+  buildMigrationScaleAdvisoryLines,
+  printDiagnostics,
+} from "../src/cli/utils/render-diagnostics.js";
+
+const makeDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: "src/App.tsx",
+  plugin: "react-doctor",
+  rule: "react-compiler-no-manual-memoization",
+  severity: "error",
+  title: "Manual memoization",
+  message: "The compiler already memoizes this.",
+  help: "Remove the manual useMemo/useCallback.",
+  line: 3,
+  column: 1,
+  category: "Performance",
+  ...overrides,
+});
+
+const ANSI = new RegExp(String.raw`\[[0-?]*[ -/]*[@-~]`, "g");
+const stripAnsi = (text: string): string => text.replace(ANSI, "");
+
+// One rule spread across `fileCount` distinct files (one site each), so its
+// blast radius is exactly `fileCount`.
+const spreadAcrossFiles = (fileCount: number): Diagnostic[] =>
+  Array.from({ length: fileCount }, (_unused, fileIndex) =>
+    makeDiagnostic({ filePath: `src/components/widget-${fileIndex}.tsx`, line: fileIndex + 1 }),
+  );
+
+const captureOutput = async (run: () => Promise<void>): Promise<string> => {
+  const writes: string[] = [];
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    writes.push(`${args.join(" ")}\n`);
+  });
+  try {
+    await run();
+  } finally {
+    logSpy.mockRestore();
+  }
+  return stripAnsi(writes.join(""));
+};
+
+describe("migration-scale advisory", () => {
+  it("stays silent below the file threshold", () => {
+    const lines = buildMigrationScaleAdvisoryLines(
+      spreadAcrossFiles(MIGRATION_SCALE_RULE_FILE_COUNT - 1),
+    );
+    expect(lines).toEqual([]);
+  });
+
+  it("names the rule, its blast radius, the why, and the scope-down step", () => {
+    const fileCount = MIGRATION_SCALE_RULE_FILE_COUNT + 5;
+    // The guidance prose wraps to the terminal measure, so collapse whitespace
+    // before asserting on phrases that may straddle a wrap boundary.
+    const text = stripAnsi(
+      buildMigrationScaleAdvisoryLines(spreadAcrossFiles(fileCount)).join("\n"),
+    )
+      .replace(/\s+/g, " ")
+      .trim();
+    expect(text).toContain("Migration-scale change");
+    expect(text).toContain("Manual memoization");
+    expect(text).toContain(`×${fileCount} across ${fileCount} files`);
+    expect(text).toContain("get the code owner's sign-off");
+    expect(text).toContain("npx react-doctor@latest <path>");
+  });
+
+  it("counts files, not raw sites, so a rule hammering few files stays silent", () => {
+    // Far more sites than the threshold, but all in two files -> small PR, no advisory.
+    const sites = Array.from({ length: MIGRATION_SCALE_RULE_FILE_COUNT * 10 }, (_unused, index) =>
+      makeDiagnostic({ filePath: index % 2 === 0 ? "src/a.tsx" : "src/b.tsx", line: index + 1 }),
+    );
+    expect(buildMigrationScaleAdvisoryLines(sites)).toEqual([]);
+  });
+
+  it("surfaces the advisory in the rendered report", async () => {
+    const output = await captureOutput(() =>
+      Effect.runPromise(
+        printDiagnostics(
+          spreadAcrossFiles(MIGRATION_SCALE_RULE_FILE_COUNT + 2),
+          false,
+          "/nonexistent",
+        ),
+      ),
+    );
+    expect(output).toContain("Migration-scale change");
+    expect(output).toContain("sample before you sweep");
+  });
+});


### PR DESCRIPTION
## Why

When a single rule fires across a huge number of files — Lorenzo's example was `manual-memoization` being huge — React Doctor gave no signal that fixing it everywhere is a *migration*, not a quick fix. Worse, the agent guidance nudged toward a blind fix-all (and the runtime playbook still says "many sites" isn't a reason to slow down). A mechanical sweep that wide is hard to review and easy to get subtly wrong everywhere at once, so it should be sampled and owner-approved, not mass-fixed in one unreviewed pass.

Before:

```
✖ Performance: Manual memoization ×847
  (no signal that this is 312 files of mechanical change)
```

After:

```
  ⚠ Migration-scale change — sample before you sweep
    Manual memoization ×847 across 312 files
    These are broad, mechanical sweeps. Fix a representative few first, confirm the
    recipe holds, then get the code owner's sign-off before changing the rest in one
    pass — a fix this wide is hard to review and easy to get subtly wrong everywhere
    at once.
    Scope it down one area at a time: npx react-doctor@latest <path>
```

## What changed

- **New threshold** `MIGRATION_SCALE_RULE_FILE_COUNT` (default 40) in `core/constants.ts`. Gates on distinct **files** a single rule touches (blast radius / review burden), not raw site count — 800 hits in 2 files is a small PR; 800 across 300 files is a migration.
- **Shared helper** `buildRuleBlastRadii` / `findMigrationScaleBuckets` in `diagnostic-grouping.ts`, built on the existing `buildSortedRuleGroups`. One definition feeds all three surfaces below.
- **Terminal advisory** (`render-diagnostics.ts`): a parting "sample before you sweep" block, empty for ordinary scans, that names the rule(s), gives the *why*, and points at a real scope-down command.
- **Agent guidance** (`render-agent-guidance.ts`) + **handoff prompt** (`build-handoff-payload.ts`): a new guidance line and an inline `Migration-scale (N files): …` note so agents sample + get sign-off instead of mass-fixing.
- **Telemetry** (`build-run-event.ts`): `migration.largestRuleBucketFiles` / `…Sites` / `…Rule` on the per-scan wide event so the threshold can be calibrated against real runs.
- No change to the score, exit code, or JSON report. Changeset: `react-doctor` patch.

## Product brief

- **Job:** a dev or their agent runs React Doctor on a real (often legacy) repo; when one rule is migration-scale they need to know to sample + get owner sign-off before a sweep, not blindly fix-all.
- **Reuse:** extended the existing rule-grouping + `×N` badge rather than adding a new surface; reused `TOP_ERRORS_DISPLAY_COUNT` as the list cap.
- **Metric:** `migration.largestRuleBucketFiles` (wide event). Success = we can see how common migration-scale buckets are and calibrate the threshold.
- **Kill:** drop the threshold / remove if <~1–2% of CI scans cross it after 2 releases (it almost never fires).

## Follow-up (out of tree)

The canonical agent playbook at `react.doctor/prompts/react-doctor-agent.md` is served out-of-tree and currently contradicts this (it rejects "many sites" as a deferral reason). It needs a matching edit — not "defer big buckets", but "pilot a sample, confirm, get sign-off, then sweep". Tracked separately.

## Test plan

- `pnpm --filter react-doctor exec vp test` — full react-doctor suite: **1804 passed, 0 failed**
- New `tests/render-migration-advisory.test.ts` (advisory wording, files-not-sites gate, silent below threshold, end-to-end render) + extended `build-run-event` and `build-handoff-payload` tests
- `pnpm --filter react-doctor typecheck` ✓ · `pnpm lint` (exit 0) ✓ · `pnpm format:check` ✓
- Pre-existing `core` failures (2) are the `.env` global-gitignore env-file security tests — environmental, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and agent-copy only; no changes to scoring, CI gating, exit codes, or diagnostic JSON semantics.
> 
> **Overview**
> Adds a **migration-scale** signal when one rule touches **≥40 distinct files** (`MIGRATION_SCALE_RULE_FILE_COUNT`), using file blast radius—not raw site count—so huge hit counts in a few files stay quiet.
> 
> Shared helpers **`buildRuleBlastRadii`** / **`findMigrationScaleBuckets`** drive three surfaces: a terminal **“Migration-scale change: sample before you sweep”** block (rule names, review risk, `npx react-doctor@latest <path>`), an extra **agent guidance** line, and **handoff** notes (inline for top-N rules; a closing summary for migration-scale rules outside top-N).
> 
> Scan telemetry gains **`migration.largestRuleBucketFiles`**, **`…Sites`**, and **`…Rule`** for threshold calibration. **Score, exit code, and JSON report are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b2139bec5e81459e741ceaebb254d4d2096c6b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->