### PR TITLE
ci: action version-bump guard + faster CI (turbo remote cache, concurrency)

### DIFF
--- a/.github/workflows/action-version-bump.yml
+++ b/.github/workflows/action-version-bump.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Detect action changes and compute recommended bump
         id: detect
@@ -37,7 +38,6 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           ACTION_COMMIT_SUBJECT: ${{ github.event.pull_request.title }}
         run: |
-          git fetch --tags --quiet || true
           export ACTION_CHANGED_FILES="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
           export ACTION_ALL_TAGS="$(git tag --list 'v*')"
           node scripts/recommend-action-version-bump.mjs "${RUNNER_TEMP}/action-version-comment.md"
@@ -87,24 +87,35 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Detect action changes and compute recommended bump
         id: detect
         env:
+          GH_TOKEN: ${{ github.token }}
           BEFORE_SHA: ${{ github.event.before }}
-          ACTION_COMMIT_SUBJECT: ${{ github.event.head_commit.message }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          git fetch --tags --quiet || true
           base="${BEFORE_SHA}"
           if [ -z "${base}" ] || [ "${base}" = "0000000000000000000000000000000000000000" ]; then
             base="$(git rev-parse HEAD^ 2>/dev/null || git rev-parse HEAD)"
+          fi
+          # Classify from the merged PR's title — the same authoritative signal the
+          # recommend job uses — so a non-conventional merge subject (e.g.
+          # "Merge pull request #N") can't silently downgrade the bump to a patch.
+          # Fall back to the commit subject for a direct push to main.
+          pr_title="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].title // ""' 2>/dev/null || true)"
+          if [ -n "${pr_title}" ]; then
+            export ACTION_COMMIT_SUBJECT="${pr_title}"
+          else
+            export ACTION_COMMIT_SUBJECT="$(printf '%s' "${HEAD_COMMIT_MESSAGE}" | head -n1)"
           fi
           export ACTION_CHANGED_FILES="$(git diff --name-only "${base}" "${GITHUB_SHA}")"
           export ACTION_ALL_TAGS="$(git tag --list 'v*')"
           node scripts/recommend-action-version-bump.mjs
 
       - name: Create and push action release tags
-        if: ${{ steps.detect.outputs.changed == 'true' && steps.detect.outputs.tag-exists != 'true' }}
+        if: ${{ steps.detect.outputs.changed == 'true' && steps.detect.outputs['tag-exists'] != 'true' }}
         env:
           NEXT_TAG: ${{ steps.detect.outputs.next }}
           MAJOR_TAG: ${{ steps.detect.outputs.major }}

--- a/.github/workflows/action-version-bump.yml
+++ b/.github/workflows/action-version-bump.yml
@@ -1,0 +1,121 @@
+name: Action Version Bump
+
+# Guards the GitHub Action's independent release cadence (AGENTS.md → "GitHub
+# Action versioning"). When a change touches the action's release surface
+# (action.yml + the scripts it shells out to), this either recommends a version
+# bump on the PR or — opt-in — performs it on merge to main.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  recommend:
+    name: Recommend bump on PR
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Detect action changes and compute recommended bump
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ACTION_COMMIT_SUBJECT: ${{ github.event.pull_request.title }}
+        run: |
+          git fetch --tags --quiet || true
+          export ACTION_CHANGED_FILES="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
+          export ACTION_ALL_TAGS="$(git tag --list 'v*')"
+          node scripts/recommend-action-version-bump.mjs "${RUNNER_TEMP}/action-version-comment.md"
+
+      - name: Upsert recommendation comment
+        uses: actions/github-script@v7
+        env:
+          ACTION_CHANGED: ${{ steps.detect.outputs.changed }}
+          COMMENT_FILE: ${{ runner.temp }}/action-version-comment.md
+        with:
+          script: |
+            const fs = require("node:fs");
+            const marker = "<!-- react-doctor:action-version -->";
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (process.env.ACTION_CHANGED !== "true") {
+              // The PR no longer touches the action surface — clear a stale recommendation.
+              if (existing) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+              }
+              return;
+            }
+            const body = fs.readFileSync(process.env.COMMENT_FILE, "utf8");
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+            }
+
+  bump:
+    name: Perform bump on merge
+    # Opt-in: set the repo variable AUTO_BUMP_ACTION_TAG=true to auto-tag.
+    # Otherwise this is a no-op and the maintainer cuts the GPG-signed tag by
+    # hand using the commands from the PR recommendation.
+    if: ${{ github.event_name == 'push' && vars.AUTO_BUMP_ACTION_TAG == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect action changes and compute recommended bump
+        id: detect
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          ACTION_COMMIT_SUBJECT: ${{ github.event.head_commit.message }}
+        run: |
+          git fetch --tags --quiet || true
+          base="${BEFORE_SHA}"
+          if [ -z "${base}" ] || [ "${base}" = "0000000000000000000000000000000000000000" ]; then
+            base="$(git rev-parse HEAD^ 2>/dev/null || git rev-parse HEAD)"
+          fi
+          export ACTION_CHANGED_FILES="$(git diff --name-only "${base}" "${GITHUB_SHA}")"
+          export ACTION_ALL_TAGS="$(git tag --list 'v*')"
+          node scripts/recommend-action-version-bump.mjs
+
+      - name: Create and push action release tags
+        if: ${{ steps.detect.outputs.changed == 'true' && steps.detect.outputs.tag-exists != 'true' }}
+        env:
+          NEXT_TAG: ${{ steps.detect.outputs.next }}
+          MAJOR_TAG: ${{ steps.detect.outputs.major }}
+          BUMP_LEVEL: ${{ steps.detect.outputs.level }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # CI has no signing key, so override the repo's tag.gpgsign default and
+          # create an unsigned annotated tag instead of failing on a missing key.
+          git -c tag.gpgsign=false tag -a "${NEXT_TAG}" -m "react-doctor action ${NEXT_TAG} (${BUMP_LEVEL})"
+          git -c tag.gpgsign=false tag -fa "${MAJOR_TAG}" -m "react-doctor action ${MAJOR_TAG} (floating major -> ${NEXT_TAG})"
+          git push origin "${NEXT_TAG}"
+          git push --force origin "${MAJOR_TAG}"
+          echo "Tagged ${NEXT_TAG} and moved ${MAJOR_TAG} to ${GITHUB_SHA}." >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,27 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on a PR (a new push obsoletes the in-flight one); let
+# every push to main finish so per-commit jobs aren't skipped.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Turbo Remote Cache: share build/typecheck/test artifacts across runs, runners,
+# and branches. Both are repo secrets, so they're empty on fork PRs (secrets are
+# withheld there) — turbo just runs cold, it does not fail.
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    # Fold the Node version into turbo's `test` task hash (turbo.json) so a
+    # cached result from one matrix leg is never replayed for another.
+    env:
+      MATRIX_NODE_VERSION: ${{ matrix.node-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -34,16 +52,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --prefer-offline
 
       - run: pnpm test
 
-      - run: pnpm typecheck
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '22.18.0' }}
-
-      - run: pnpm lint
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '22.18.0' }}
-
+      # lint + typecheck run as dedicated jobs in code-quality.yml; don't pay for
+      # them again here.
       - name: Check formatting
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '22.18.0' }}
         shell: bash

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,6 +9,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -30,7 +38,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Lint
         run: pnpm lint
@@ -55,7 +63,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Typecheck
         run: pnpm typecheck

--- a/.github/workflows/publish-any-commit.yml
+++ b/.github/workflows/publish-any-commit.yml
@@ -4,6 +4,14 @@ on: [push, pull_request]
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,7 +28,7 @@ jobs:
           node-version: 22.18.0
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --prefer-offline
 
       - run: pnpm build
 

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -12,6 +12,14 @@ permissions:
   issues: write
   statuses: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
 jobs:
   react-doctor:
     runs-on: ubuntu-latest
@@ -29,7 +37,7 @@ jobs:
           node-version: 22.18.0
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --prefer-offline
 
       - run: pnpm --filter react-doctor... build
 

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: millionco/react-doctor@v2
+      - uses: ./

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,9 +1,9 @@
 name: React Doctor
 
 on:
-  push:
-    branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
     branches: [main]
 
 permissions:
@@ -13,36 +13,14 @@ permissions:
   statuses: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  group: react-doctor-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   react-doctor:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
           fetch-depth: 0
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22.18.0
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile --prefer-offline
-
-      - run: pnpm --filter react-doctor... build
-
-      - uses: ./
-        with:
-          blocking: none
-          node-version: 22.18.0
-          version: ./packages/react-doctor
+      - uses: millionco/react-doctor@v2

--- a/scripts/recommend-action-version-bump.mjs
+++ b/scripts/recommend-action-version-bump.mjs
@@ -1,0 +1,150 @@
+import * as fs from "node:fs";
+
+// The GitHub Action's release surface, per AGENTS.md ("GitHub Action
+// versioning"): a change to any of these files is an action release and must be
+// tagged. Keep this list in sync with that section.
+const ACTION_RELEASE_FILES = [
+  "action.yml",
+  "scripts/ensure-json-report.mjs",
+  "scripts/render-github-action-comment.mjs",
+];
+
+const COMMENT_MARKER = "<!-- react-doctor:action-version -->";
+const STRICT_TAG_PATTERN = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+const BUMP_REASON = {
+  major: "a **major** bump (breaking change to the action's inputs/outputs or runtime contract)",
+  minor: "a **minor** bump (`feat` — a new action capability)",
+  patch: "a **patch** bump (fix / refactor / chore / docs)",
+};
+
+const [commentOutputPath] = process.argv.slice(2);
+
+const changedFiles = (process.env.ACTION_CHANGED_FILES ?? "")
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+const commitSubject = (process.env.ACTION_COMMIT_SUBJECT ?? "").trim();
+const allTags = (process.env.ACTION_ALL_TAGS ?? "")
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const appendOutput = (name, value) => {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  fs.appendFileSync(outputPath, `${name}=${value ?? ""}\n`);
+};
+
+const compareVersions = (left, right) =>
+  left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+
+const formatTag = (version) => `v${version.major}.${version.minor}.${version.patch}`;
+
+// Highest strict `vMAJOR.MINOR.PATCH` tag, ignoring the floating-major aliases
+// (`v1`, `v2`) and any pre-rebuild oddities — those never match the pattern.
+const pickLatestTag = () => {
+  let latest = null;
+  for (const tag of allTags) {
+    const match = STRICT_TAG_PATTERN.exec(tag);
+    if (!match) continue;
+    const version = { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+    if (!latest || compareVersions(version, latest) > 0) latest = version;
+  }
+  return latest ?? { major: 0, minor: 0, patch: 0 };
+};
+
+// Conventional-commit → action bump level (AGENTS.md): a breaking change to the
+// inputs/outputs or runtime contract is a major; a `feat` is a minor; everything
+// else (fix / refactor / chore / revert / docs) is a patch.
+const classifyBumpLevel = (subject) => {
+  if (/^[a-z]+(\([^)]*\))?!:/i.test(subject) || /BREAKING[ -]CHANGE/.test(subject)) {
+    return "major";
+  }
+  if (/^feat(\([^)]*\))?:/i.test(subject)) return "minor";
+  return "patch";
+};
+
+const computeNextVersion = (current, level) => {
+  if (level === "major") return { major: current.major + 1, minor: 0, patch: 0 };
+  if (level === "minor") return { major: current.major, minor: current.minor + 1, patch: 0 };
+  return { major: current.major, minor: current.minor, patch: current.patch + 1 };
+};
+
+const buildCommentBody = ({ changed, currentTag, nextTag, majorTag, level, tagExists }) => {
+  const changedList = changed.map((file) => `- \`${file}\``).join("\n");
+  const reason = BUMP_REASON[level];
+  const lines = [
+    COMMENT_MARKER,
+    "",
+    "### 📦 GitHub Action release recommended",
+    "",
+    "This PR changes the React Doctor GitHub Action's release surface:",
+    "",
+    changedList,
+    "",
+    "The composite action is versioned independently from the npm packages, so it",
+    "needs its own git tag once this merges. Based on the PR title, this looks like",
+    `${reason}: \`${currentTag}\` → **\`${nextTag}\`**.`,
+    "",
+  ];
+  if (tagExists) {
+    lines.push(
+      `> ⚠️ Tag \`${nextTag}\` already exists. Confirm it points at this change before re-tagging, or pick the next free version.`,
+      "",
+    );
+  }
+  lines.push(
+    "After merging, cut the tag from the merge commit on `main` (tags are GPG-signed",
+    "annotated tags, so run this locally where your signing key is configured):",
+    "",
+    "```bash",
+    "git checkout main && git pull --ff-only",
+    "merge_commit=$(git rev-parse HEAD)",
+    `git tag -a ${nextTag} "$merge_commit" -m "react-doctor action ${nextTag}"`,
+    `git tag -fa ${majorTag} "$merge_commit" -m "react-doctor action ${majorTag} (floating major -> ${nextTag})"`,
+    `git push origin ${nextTag}`,
+    `git push --force origin ${majorTag}   # moves only the floating major pointer`,
+    "```",
+    "",
+    "<sub>This bump can also be performed automatically on merge — set the repo",
+    "variable `AUTO_BUMP_ACTION_TAG=true`. Recommendation by the Action Version Bump workflow.</sub>",
+  );
+  return `${lines.join("\n")}\n`;
+};
+
+const latest = pickLatestTag();
+const changedActionFiles = changedFiles.filter((file) => ACTION_RELEASE_FILES.includes(file));
+const changed = changedActionFiles.length > 0;
+const level = classifyBumpLevel(commitSubject);
+const next = computeNextVersion(latest, level);
+const currentTag = formatTag(latest);
+const nextTag = formatTag(next);
+const majorTag = `v${next.major}`;
+const tagExists = allTags.includes(nextTag);
+
+appendOutput("changed", String(changed));
+appendOutput("level", level);
+appendOutput("current", currentTag);
+appendOutput("next", nextTag);
+appendOutput("major", majorTag);
+appendOutput("tag-exists", String(tagExists));
+
+if (changed && commentOutputPath) {
+  fs.writeFileSync(
+    commentOutputPath,
+    buildCommentBody({
+      changed: changedActionFiles,
+      currentTag,
+      nextTag,
+      majorTag,
+      level,
+      tagExists,
+    }),
+  );
+}
+
+const summary = changed
+  ? `Action release surface changed (${changedActionFiles.join(", ")}). Recommend ${level} bump: ${currentTag} -> ${nextTag}.`
+  : "No action release surface changes detected.";
+process.stdout.write(`${summary}\n`);

--- a/turbo.json
+++ b/turbo.json
@@ -19,7 +19,8 @@
       "persistent": true
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "env": ["MATRIX_NODE_VERSION"]
     },
     "typecheck": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Why

The composite GitHub Action (`action.yml` + the scripts it shells out to —
`scripts/ensure-json-report.mjs`, `scripts/render-github-action-comment.mjs`) is
versioned via git tags (`vX.Y.Z` + a floating `vN`), **independently** from the
npm packages — see AGENTS.md → "GitHub Action versioning". Today a change to that
release surface can merge with no matching tag, so consumers on `@vN` silently
miss the fix until someone remembers to tag by hand.

This adds a CI guard that watches the action's release surface and either
**recommends** a version bump on the PR or **performs** it on merge.

Before:

```
# A PR edits action.yml, merges to main.
# Nothing tags it. @v2 keeps pointing at the old commit. Easy to forget.
```

After:

```
# PR that touches the action surface gets a sticky comment:
#   📦 GitHub Action release recommended — v2.2.0 → v2.3.0 (minor, `feat`)
#   + the exact GPG-signed-tag commands to run after merge.
# Optionally (AUTO_BUMP_ACTION_TAG=true) the merge auto-tags v2.3.0
# and moves the floating v2.
```

## What changed

- **`.github/workflows/action-version-bump.yml`** — two jobs:
  - `recommend` (on `pull_request`, `pull-requests: write`): if the PR changes the action's release surface, upserts one sticky comment recommending the bump with copy-paste signed-tag commands; removes it if the change is reverted. Re-runs on `edited` so a title change re-evaluates the level.
  - `bump` (on `push` to `main`, `contents: write`): **opt-in** via repo variable `AUTO_BUMP_ACTION_TAG=true` — tags the new `vX.Y.Z` at the merge commit and force-moves the floating `vN`. No-op by default (safe).
- **`scripts/recommend-action-version-bump.mjs`** — pure, testable helper: picks the latest strict `vMAJOR.MINOR.PATCH` tag, classifies the bump from the conventional-commit subject (`feat`→minor, `!`/`BREAKING CHANGE`→major, else→patch, per AGENTS.md), computes the next tag, and emits the step outputs + comment markdown.

### Notes / design choices

- **Auto-bump is off by default.** Tags are GPG-signed annotated tags and CI has no signing key, so the default path only *recommends* (the comment hands you the signed-tag commands to run locally). When `AUTO_BUMP_ACTION_TAG=true`, CI creates an *unsigned* annotated tag via `git -c tag.gpgsign=false`.
- **Fork PRs** get a read-only token, so the comment step won't post on external forks — same limitation the existing `react-doctor.yml` already lives with.
- This PR itself touches **neither** `action.yml` nor the two release-surface scripts, so the new workflow does not flag it (no self-trigger).
- No changeset: CI tooling + a standalone script, no published-package behavior change.

## Test plan

- Helper verified locally against the live tag line (`v2.2.0`):
  - `fix(action): …` → patch → `v2.2.1`
  - `feat(action): …` → minor → `v2.3.0`
  - `feat(action)!: …` → major → `v3.0.0`
  - non-action change → "No action release surface changes detected."
- `pnpm exec vp check` (lint) + `pnpm format:check` pass on both files.
- Workflow YAML validated by `vp fmt`. Full action-trigger run will exercise on this PR (action surface untouched ⇒ expect no comment).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in auto-bump can push release tags and force-move floating major pointers; turbo cache mis-keying could theoretically mask cross-Node test issues, though `MATRIX_NODE_VERSION` is meant to prevent that.
> 
> **Overview**
> Adds **CI guardrails** so changes to the composite action release surface (`action.yml` and its shell scripts) don’t merge without a matching git tag. A new workflow posts or updates a sticky PR comment with the recommended semver bump (from conventional-commit semantics) and copy-paste GPG tag commands, and can **opt-in** auto-tag on merge via `AUTO_BUMP_ACTION_TAG=true` (unsigned tags in CI). Logic lives in `scripts/recommend-action-version-bump.mjs`.
> 
> **CI performance:** wires **Turbo Remote Cache** (`TURBO_TOKEN` / `TURBO_TEAM`) across main workflows, adds **PR concurrency** cancellation, drops duplicate **lint/typecheck** from `ci.yml` (kept in `code-quality.yml`), folds **Node version into the `test` task cache key** in `turbo.json`, and uses `--prefer-offline` installs plus job timeouts. **`react-doctor.yml`** is slimmed to checkout + run the local action (no separate pnpm build/install in that job).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c7486b5aaecc30b2463f48bb34b3bb963b8faf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Added: CI performance (no coverage dropped)

A second concern landed in this PR — making CI faster:

- **Turbo Remote Cache** wired into `ci`, `code-quality`, `react-doctor`, and `publish-any-commit` (via the `TURBO_TOKEN`/`TURBO_TEAM` secrets) so `build`/`typecheck`/`test` artifacts replay across runs, runners, and branches.
- **`test` task made Node-version-aware** (`turbo.json` `env: ["MATRIX_NODE_VERSION"]`, fed `${{ matrix.node-version }}` in CI) so a shared remote-cache hit is **never** replayed across the Node matrix — every matrix leg still runs its own tests. Verified: per-version `test` hashes differ while `build` stays shared.
- **Concurrency groups** that cancel superseded **PR** runs (pushes to `main` still run to completion).
- **Removed the duplicated lint + typecheck** from `ci.yml` (`code-quality.yml` owns them; `typecheck` `dependsOn ^build`, so it was paid twice).
- `timeout-minutes` + `pnpm --prefer-offline`.

The full Node/OS matrix and the Windows packed-CLI install smoke test are **kept** (coverage preserved by request).