### PR TITLE
fix(ci): address post-merge Bugbot findings (cancel scope, self-test CLI, root-commit diff)

### DIFF
--- a/.github/workflows/action-version-bump.yml
+++ b/.github/workflows/action-version-bump.yml
@@ -98,7 +98,10 @@ jobs:
         run: |
           base="${BEFORE_SHA}"
           if [ -z "${base}" ] || [ "${base}" = "0000000000000000000000000000000000000000" ]; then
-            base="$(git rev-parse HEAD^ 2>/dev/null || git rev-parse HEAD)"
+            # New branch / first push: diff against HEAD's parent, or the empty
+            # tree for a root commit with no parent (so its files still count as
+            # changed instead of diffing HEAD against itself).
+            base="$(git rev-parse HEAD^ 2>/dev/null || git hash-object -t tree /dev/null)"
           fi
           # Classify from the merged PR's title — the same authoritative signal the
           # recommend job uses — so a non-conventional merge subject (e.g.

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -14,13 +14,38 @@ permissions:
 
 concurrency:
   group: react-doctor-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 jobs:
   react-doctor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22.18.0
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --prefer-offline
+
+      # Build the workspace CLI and point the local action at it (version:
+      # ./packages/react-doctor) so this job dogfoods the PR's own action AND
+      # CLI, not the published npm release.
+      - run: pnpm --filter react-doctor... build
+
       - uses: ./
+        with:
+          blocking: none
+          node-version: 22.18.0
+          version: ./packages/react-doctor


### PR DESCRIPTION
## Why

Follow-up to #885. Cursor Bugbot posted three findings after that PR merged; this addresses all three.

## What changed

**`react-doctor.yml`**
- **Cancel scope (#1, was Medium).** `cancel-in-progress` is now gated to `pull_request` only — `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — matching `ci.yml` / `code-quality.yml` / `publish-any-commit.yml`. Rapid merges to `main` no longer cancel each other, so every `main` commit still posts its React Doctor commit status.
- **Self-test dogfoods the local CLI (#2, was Medium).** Restored the workspace build + `version: ./packages/react-doctor`, so the job runs the PR's **own** action *and* CLI instead of `react-doctor@latest` from npm. Kept the slim triggers/concurrency from #885.

**`action-version-bump.yml`**
- **Root-commit diff (#3, was Low).** On an all-zero `before` SHA, the bump job now falls back to the git **empty tree** (`git hash-object -t tree /dev/null`) when `HEAD` has no parent, instead of `HEAD`. Previously a root commit diffed `HEAD` against itself (empty) and missed its action-surface changes. Edge case (only with `AUTO_BUMP_ACTION_TAG` on, on a repo's first commit), but now correct.

Before (root commit, all-zero before-SHA):

```
base = HEAD  ->  git diff HEAD HEAD  ->  (empty)  ->  no changes detected
```

After:

```
base = <empty tree>  ->  git diff <empty-tree> HEAD  ->  all files added  ->  changes detected
```

## Test plan

- `git diff <empty-tree> HEAD` verified locally to list the commit's files as added.
- `pnpm exec vp fmt --check` passes on both workflows.
- The `react-doctor` job (CI on this PR) exercises the restored `uses: ./` + local build path end to end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no runtime product impact; low blast radius aside from slightly longer React Doctor runs on main.
> 
> **Overview**
> Follow-up CI fixes for **React Doctor** and **action version bump** workflows.
> 
> **`react-doctor.yml`** now only cancels in-progress runs on pull requests (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`), aligned with `ci.yml` and peers, so rapid merges to `main` no longer drop commit statuses. The job again installs the workspace, builds `react-doctor`, and runs the local action with `version: ./packages/react-doctor` and `blocking: none`, plus Turbo env, timeout, and checkout hardening.
> 
> **`action-version-bump.yml`** fixes base-SHA selection when `before` is missing or all zeros: if `HEAD` has no parent, the diff base is the git **empty tree** instead of `HEAD`, so a root commit’s action-surface files are detected instead of an empty self-diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba66b99b08c95a6fed249983cbd32cadd04df6cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->