### PR TITLE
docs(action): clarify the node-version input description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: 'Publish a commit status with the score and error / warning counts, linking to the run. Surfaces the result on pushes to the default branch (where the PR comment is skipped). Reads "Skipped" when the pull request changes no React-eligible files. Requires `statuses: write` (skipped with a warning otherwise).'
     default: "true"
   node-version:
-    description: "Node.js version to use"
+    description: "Node.js version used to run react-doctor (defaults to 24)."
     default: "24"
   version:
     description: "react-doctor npm version or package spec to run"


### PR DESCRIPTION
## Why

**Test PR** — verifies the `action-version-bump` workflow detects a change to the action's release surface (`action.yml`) and posts its bump-recommendation comment.

## What changed

- `action.yml`: clarified the `node-version` input description (notes the default).

## Expected

The **Action Version Bump → Recommend bump on PR** job should post a sticky comment recommending a **patch** bump (`docs` → patch per AGENTS.md), e.g. `v2.2.0 → v2.2.1`, with the signed-tag commands.

Safe to close without merging once the comment is confirmed (or merge — the doc tweak is legit).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an input description; no workflow or runtime behavior changes.
> 
> **Overview**
> Updates the **`node-version`** input description in `action.yml` so it states that the value is the Node.js version used to run react-doctor and that it **defaults to 24** (the default was already `24`; only the help text changed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecb64a7836cb3fa3b98a7ebcc1713ddcb634c45a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->