### PR TITLE
fix(core): support TypeScript 5 alongside 6

### DIFF
--- a/.changeset/core-typescript-5-range.md
+++ b/.changeset/core-typescript-5-range.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Loosen the `typescript` dependency range to `>=5.0.4 <7` so consumers on TypeScript 5 can vendor `@react-doctor/core` without a forced TS 6 install. Every TypeScript compiler API the engine uses (`createSourceFile`, `forEachChild`, `parseConfigFileTextToJson`, and the AST type guards — the newest being `isTypeAssertionExpression`, TS 5.0) exists in TS 5.x, and this matches the range already declared by the published `react-doctor` CLI that bundles core.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "oxlint-plugin-react-doctor": "workspace:*",
     "picomatch": "^4.0.4",
     "semver": "^7.7.4",
-    "typescript": "^6.0.3"
+    "typescript": ">=5.0.4 <7"
   },
   "devDependencies": {
     "@effect/vitest": "4.0.0-beta.70",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         specifier: ^7.7.4
         version: 7.7.4
       typescript:
-        specifier: ^6.0.3
+        specifier: '>=5.0.4 <7'
         version: 6.0.3
     devDependencies:
       '@effect/vitest':


### PR DESCRIPTION
## Why

`@react-doctor/core` declared `typescript: "^6.0.3"` as a **runtime** dependency, forcing every consumer who vendors the private core package onto TypeScript 6 — even though the engine only uses TS compiler APIs that have existed since TS 5.0. This blocks server-side / programmatic use of the engine in codebases pinned to TypeScript 5 (the scenario in #886).

The published `react-doctor` CLI — which bundles this exact core code — already declares `">=5.0.4 <7"`, so core's stricter floor was just dev-version leakage.

Before:

```jsonc
// packages/core/package.json
"typescript": "^6.0.3"   // excludes every TS 5 consumer
```

After:

```jsonc
"typescript": ">=5.0.4 <7"   // matches the published react-doctor CLI
```

## What changed

- Widen core's `typescript` runtime range from `^6.0.3` to `>=5.0.4 <7`.
- Lockfile updated — the **resolved** version is unchanged (still `6.0.3`), so the monorepo dev toolchain is untouched; only the declared range moves.
- Added a patch changeset (core is in the `fixed` release group).

## Notes

- Every `ts.*` API core uses exists in TS 5.x; the newest is `isTypeAssertionExpression` (TS 5.0).
- `@react-doctor/core` is **private** and `react-doctor` declares its own TS range, so no published manifest changes besides the version bump.
- Follow-up (out of scope, per #886): consider moving `typescript` to a `peerDependency` to avoid loading two TS copies when a host already ships one.

## Test plan

- `pnpm --filter @react-doctor/core typecheck` — passes (TS 6.0.3, resolution unchanged)
- `pnpm --filter @react-doctor/api --filter react-doctor typecheck` — all 11 tasks pass
- `pnpm build` — passes
- `pnpm --filter @react-doctor/core test` — 880/882 pass; the 2 failures are the pre-existing local `.env*` global-gitignore trap (`check-expo-project`, `check-security-scan`), confirmed to fail identically on the un-changed baseline and unrelated to this change (they pass in CI)
- `pnpm format:check` + `pnpm install --frozen-lockfile` — pass

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only semver range change with no engine code changes; monorepo still resolves TypeScript 6.0.3.
> 
> **Overview**
> **Widens `@react-doctor/core`'s runtime `typescript` dependency** from `^6.0.3` to `>=5.0.4 <7`, so projects on TypeScript 5 can depend on the private core package without npm/pnpm forcing a TypeScript 6 install (fixes #886).
> 
> The declared range now matches the published **`react-doctor`** CLI. The lockfile **specifier** is updated; **resolved** TypeScript for core in the monorepo stays **6.0.3**, so local dev tooling is unchanged. A **patch changeset** records the `@react-doctor/core` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84636b5b53b829d6c9fd5cee3c8c6812cb81c2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->