### PR TITLE
perf(core): propagate V8 compile cache to oxlint batch subprocesses

### DIFF
--- a/.changeset/propagate-compile-cache-oxlint-children.md
+++ b/.changeset/propagate-compile-cache-oxlint-children.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Propagate the V8 compile cache (`NODE_COMPILE_CACHE`) to oxlint batch subprocesses so later batches reuse warm bytecode. Measured ~2% of the lint phase on large multi-batch scans; no benefit for single-batch (`--diff`/`--staged`) scans. The dominant per-child cost is plugin eval/registration, which the compile cache does not address — this is a small internal speedup, not a headline. Opt out with `NODE_DISABLE_COMPILE_CACHE=1`.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -268,6 +268,11 @@ export const OXLINT_OUTPUT_MAX_BYTES = 50 * 1024 * 1024;
 // binding is markedly slower than on a developer laptop.
 export const OXLINT_SPAWN_TIMEOUT_MS = 60_000;
 
+// Directory name appended to os.tmpdir() to form the shared base for the V8
+// compile cache. Matches the base Node's own module.enableCompileCache() uses,
+// so the bin (parent) and the spawned oxlint batches (children) share one tree.
+export const NODE_COMPILE_CACHE_DIR_NAME = "node-compile-cache";
+
 export const DEAD_CODE_WORKER_TIMEOUT_MS = 120_000;
 
 // deslop's semantic pass builds a full TypeScript program and walks

--- a/packages/core/src/runners/oxlint/spawn-oxlint.ts
+++ b/packages/core/src/runners/oxlint/spawn-oxlint.ts
@@ -5,21 +5,9 @@ import {
   OXLINT_SPAWN_TIMEOUT_MS as DEFAULT_OXLINT_SPAWN_TIMEOUT_MS,
 } from "../../constants.js";
 import { OxlintBatchExceeded, OxlintSpawnFailed, ReactDoctorError } from "../../errors.js";
+import { buildOxlintChildEnv } from "../../utils/build-oxlint-child-env.js";
 
-// HACK: Sanitize child env so a developer's NODE_OPTIONS=--inspect (or
-// --max-old-space-size=128, etc.) doesn't leak into oxlint and either spawn a
-// debugger port or starve it of memory. We also drop npm_config_* lifecycle
-// vars to keep oxlint from picking up package-manager state. PATH, HOME,
-// NODE_ENV, NODE_PATH, etc. pass through unchanged.
-const SANITIZED_ENV: NodeJS.ProcessEnv = (() => {
-  const sanitized: NodeJS.ProcessEnv = {};
-  for (const [name, value] of Object.entries(process.env)) {
-    if (name === "NODE_OPTIONS" || name === "NODE_DEBUG") continue;
-    if (name.startsWith("npm_config_")) continue;
-    sanitized[name] = value;
-  }
-  return sanitized;
-})();
+const SANITIZED_ENV: NodeJS.ProcessEnv = buildOxlintChildEnv(process.env);
 
 /**
  * Spawn one oxlint subprocess with hard ceilings on wall time and

--- a/packages/core/src/utils/build-oxlint-child-env.ts
+++ b/packages/core/src/utils/build-oxlint-child-env.ts
@@ -1,0 +1,34 @@
+import os from "node:os";
+import * as path from "node:path";
+import { NODE_COMPILE_CACHE_DIR_NAME } from "../constants.js";
+
+// Sanitize the child env so a developer's NODE_OPTIONS=--inspect (or
+// --max-old-space-size=128, etc.) doesn't leak into oxlint and either spawn a
+// debugger port or starve it of memory; drop npm_config_* lifecycle vars so
+// oxlint can't pick up package-manager state. PATH, HOME, NODE_ENV, NODE_PATH
+// pass through unchanged.
+//
+// oxlint batches are fresh `node` children that re-parse oxlint + plugin JS
+// per spawn. The bin enables the V8 compile cache for the parent only, so
+// propagate NODE_COMPILE_CACHE to the children that do the repeated work.
+// Set the shared BASE dir (not the parent's version-specific getCompileCacheDir),
+// because the child may run a different node (the nvm fallback in
+// resolveNodeForOxlint): Node nests each node version under its own subdir of
+// the base, so there is no cross-version cache poisoning, and a same-version
+// child transparently reads what the parent warmed.
+export const buildOxlintChildEnv = (sourceEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
+  const childEnv: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(sourceEnv)) {
+    if (name === "NODE_OPTIONS" || name === "NODE_DEBUG") continue;
+    if (name.startsWith("npm_config_")) continue;
+    childEnv[name] = value;
+  }
+
+  const isCompileCacheDisabled = Boolean(sourceEnv.NODE_DISABLE_COMPILE_CACHE);
+  const isCompileCacheAlreadySet = childEnv.NODE_COMPILE_CACHE !== undefined;
+  if (!isCompileCacheDisabled && !isCompileCacheAlreadySet) {
+    childEnv.NODE_COMPILE_CACHE = path.join(os.tmpdir(), NODE_COMPILE_CACHE_DIR_NAME);
+  }
+
+  return childEnv;
+};

--- a/packages/core/tests/build-oxlint-child-env.test.ts
+++ b/packages/core/tests/build-oxlint-child-env.test.ts
@@ -1,0 +1,51 @@
+import os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { NODE_COMPILE_CACHE_DIR_NAME } from "../src/constants.js";
+import { buildOxlintChildEnv } from "../src/utils/build-oxlint-child-env.js";
+
+const SHARED_COMPILE_CACHE_BASE = path.join(os.tmpdir(), NODE_COMPILE_CACHE_DIR_NAME);
+
+describe("buildOxlintChildEnv", () => {
+  it("sets NODE_COMPILE_CACHE to the shared tmp base dir by default", () => {
+    const childEnv = buildOxlintChildEnv({ PATH: "/usr/bin" });
+    expect(childEnv.NODE_COMPILE_CACHE).toBe(SHARED_COMPILE_CACHE_BASE);
+  });
+
+  it("respects NODE_DISABLE_COMPILE_CACHE and leaves NODE_COMPILE_CACHE unset", () => {
+    const childEnv = buildOxlintChildEnv({ PATH: "/usr/bin", NODE_DISABLE_COMPILE_CACHE: "1" });
+    expect(childEnv.NODE_COMPILE_CACHE).toBeUndefined();
+  });
+
+  it("does not clobber an inherited NODE_COMPILE_CACHE value", () => {
+    const childEnv = buildOxlintChildEnv({ PATH: "/usr/bin", NODE_COMPILE_CACHE: "/custom/dir" });
+    expect(childEnv.NODE_COMPILE_CACHE).toBe("/custom/dir");
+  });
+
+  it("preserves an inherited empty-string NODE_COMPILE_CACHE (the guard is !== undefined)", () => {
+    const childEnv = buildOxlintChildEnv({ PATH: "/usr/bin", NODE_COMPILE_CACHE: "" });
+    expect(childEnv.NODE_COMPILE_CACHE).toBe("");
+  });
+
+  it("treats the disable and inherited guards independently", () => {
+    const childEnv = buildOxlintChildEnv({
+      PATH: "/usr/bin",
+      NODE_DISABLE_COMPILE_CACHE: "1",
+      NODE_COMPILE_CACHE: "/custom/dir",
+    });
+    expect(childEnv.NODE_COMPILE_CACHE).toBe("/custom/dir");
+  });
+
+  it("still strips NODE_OPTIONS, NODE_DEBUG, and npm_config_* while passing PATH through", () => {
+    const childEnv = buildOxlintChildEnv({
+      PATH: "/usr/bin",
+      NODE_OPTIONS: "--inspect",
+      NODE_DEBUG: "module",
+      npm_config_foo: "bar",
+    });
+    expect(childEnv.NODE_OPTIONS).toBeUndefined();
+    expect(childEnv.NODE_DEBUG).toBeUndefined();
+    expect(childEnv.npm_config_foo).toBeUndefined();
+    expect(childEnv.PATH).toBe("/usr/bin");
+  });
+});

--- a/packages/core/tests/spawn-oxlint-compile-cache.test.ts
+++ b/packages/core/tests/spawn-oxlint-compile-cache.test.ts
@@ -1,0 +1,29 @@
+import os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { NODE_COMPILE_CACHE_DIR_NAME } from "../src/constants.js";
+import { spawnOxlint } from "../src/runners/oxlint/spawn-oxlint.js";
+
+// spawn-oxlint.ts captures SANITIZED_ENV from the live process.env at module
+// load, so this default-case assertion only holds when the test process itself
+// has neither opted out (NODE_DISABLE_COMPILE_CACHE) nor pre-set
+// NODE_COMPILE_CACHE — the same two guards buildOxlintChildEnv honors. Skip
+// rather than fail spuriously for a developer running with the documented
+// opt-out exported; that path is covered by the pure-helper unit test.
+const isCompileCacheEnvOverridden =
+  Boolean(process.env.NODE_DISABLE_COMPILE_CACHE) || process.env.NODE_COMPILE_CACHE !== undefined;
+
+describe("spawnOxlint propagates the V8 compile cache to children", () => {
+  it.skipIf(isCompileCacheEnvOverridden)(
+    "child sees NODE_COMPILE_CACHE set to the shared tmp base dir",
+    async () => {
+      const stdout = await spawnOxlint(
+        ["-e", "process.stdout.write(process.env.NODE_COMPILE_CACHE ?? 'unset')"],
+        process.cwd(),
+        process.execPath,
+        5_000,
+      );
+      expect(stdout).toBe(path.join(os.tmpdir(), NODE_COMPILE_CACHE_DIR_NAME));
+    },
+  );
+});


### PR DESCRIPTION
## Why

Each oxlint batch is a fresh `node` subprocess that cold-parses oxlint's CLI JS plus the react-doctor plugin JS on every spawn. The published bins enable Node's V8 compile cache for the **parent** only, so the children doing the repeated parsing got no warm bytecode. Pointing them at the same shared cache lets the second-and-later batches reuse compiled bytecode.

This is a small, honest internal speedup — **~2% of the lint phase** on large multi-batch scans — not a headline. Single-batch `--diff`/`--staged` scans see no benefit (only one batch, nothing to warm), and it does **not** address the dominant per-child cost (plugin eval/registration).

Before:

```
spawn(node, [oxlintBin, ...], { env: SANITIZED_ENV })   // env never set NODE_COMPILE_CACHE
# every batch cold-parses oxlint + plugin JS
```

After:

```
env now carries NODE_COMPILE_CACHE = <os.tmpdir()>/node-compile-cache
# batch 1 warms the cache; batches 2..N read compiled bytecode
```

## What changed

- New `packages/core/src/utils/build-oxlint-child-env.ts` — `buildOxlintChildEnv()` ports the existing env sanitization (strip `NODE_OPTIONS` / `NODE_DEBUG` / `npm_config_*`) and adds `NODE_COMPILE_CACHE` propagation behind two guards: skip when `NODE_DISABLE_COMPILE_CACHE` is set, and never clobber an inherited value.
- It sets the shared **base** dir (`os.tmpdir()/node-compile-cache`), never the parent's version-specific `getCompileCacheDir()` — Node namespaces each node version under its own subdir, so an nvm-fallback child running a different node can't poison the parent's cache, and a same-version child transparently reads what the parent warmed.
- `spawn-oxlint.ts` now calls the helper instead of the inline IIFE; the spawn call is otherwise unchanged.
- `constants.ts` gains `NODE_COMPILE_CACHE_DIR_NAME`.
- Tests: 6 unit cases for the guards + 1 end-to-end spawn test (skips under a polluted env so the documented `NODE_DISABLE_COMPILE_CACHE=1` opt-out can't cause a spurious failure).
- `patch` changeset for `@react-doctor/core` (it's in the changeset `fixed` group, so the published `react-doctor` CLI bumps in lockstep).

No public-surface change: no CLI flag, config field, JSON-report field, package API, Action input, score, or terminal output. Opt out with the existing `NODE_DISABLE_COMPILE_CACHE=1`. The experimental LSP benefits for free (same `spawnOxlint` path).

## Test plan

- `pnpm typecheck` — ✓ 11/11
- `pnpm lint` — ✓ exit 0 (only pre-existing fixture warnings)
- `pnpm format:check` — ✓ all files correct
- New tests — ✓ 7/7 in a clean env; under `NODE_DISABLE_COMPILE_CACHE=1` the spawn test skips (6 pass, 1 skip)
- Full `@react-doctor/core` suite — 891 pass; the 2 failures in `check-security-scan.test.ts` are a **pre-existing** local global-`.env*`-gitignore trap, reproduced on the unmodified baseline (unrelated to this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal spawn env change only; no public API or config surface, with documented opt-out via `NODE_DISABLE_COMPILE_CACHE=1`.
> 
> **Overview**
> Oxlint batch subprocesses now receive **`NODE_COMPILE_CACHE`** pointing at the same shared tmp base (`os.tmpdir()/node-compile-cache`) the parent CLI uses, so later batches can reuse warmed V8 bytecode instead of cold-parsing oxlint and plugin JS every spawn. Expected gain is modest (~2% of lint on large multi-batch scans); single-batch `--diff` / `--staged` runs see little benefit.
> 
> The inline env sanitizer in **`spawn-oxlint.ts`** is replaced by **`buildOxlintChildEnv()`**, which keeps stripping `NODE_OPTIONS`, `NODE_DEBUG`, and `npm_config_*` and adds compile-cache propagation only when `NODE_DISABLE_COMPILE_CACHE` is unset and `NODE_COMPILE_CACHE` is not already defined. **`NODE_COMPILE_CACHE_DIR_NAME`** is added to **`constants.ts`**. Unit and spawn integration tests cover the guards and opt-out behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0cca71b53a24ce8e559fd3358e2bfee8bf6ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->