### PR TITLE
perf(core): overlap the supply-chain check with the lint pass

### DIFF
--- a/.changeset/supply-chain-lint-overlap.md
+++ b/.changeset/supply-chain-lint-overlap.md
@@ -1,0 +1,12 @@
+---
+"react-doctor": patch
+---
+
+Overlap the Socket.dev supply-chain check with the lint pass. The supply-chain
+score lookup is ~100% network-bound and the lint pass is ~100% CPU/subprocess-
+bound, but they previously ran back-to-back. The check now runs on a background
+fiber whose wall-clock overlaps the lint pass, collapsing the two serial phases
+into roughly `max(supplyChain, lint)`. A generous wall-clock budget bounds a
+hung network socket so it can never drag out a scan; on expiry the check fails
+open to no diagnostics — the same outcome as an existing Socket API outage. The
+diagnostic set, ordering, and score are unchanged.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -510,6 +510,16 @@ export const SOCKET_SCORE_SCALE = 100;
 // per-route rate limit.
 export const SUPPLY_CHAIN_FETCH_CONCURRENCY = 8;
 
+// Belt-and-suspenders wall-clock cap on the supply-chain check while it runs on
+// a background fiber overlapping the lint pass. `Effect.timeout` measures from
+// when the forked effect STARTS (at fork, before lint) — NOT from the join — so
+// this is sized generously above the worst-case healthy run (FETCH_TIMEOUT_MS ×
+// ceil(~45 deps / SUPPLY_CHAIN_FETCH_CONCURRENCY) ≈ 60s) to avoid cutting a
+// slow-but-working scan, while still bounding a hung undici socket instead of
+// letting it drag out the join. On expiry the check fails open to no
+// diagnostics — the same outcome class as the per-package Socket fail-open.
+export const SUPPLY_CHAIN_OVERLAP_TIMEOUT_MS = 90_000;
+
 // Most severe Socket alerts to name in one supply-chain diagnostic before
 // collapsing the remainder into a "+N more" count, so a noisy package
 // doesn't flood the message.

--- a/packages/core/src/refs.ts
+++ b/packages/core/src/refs.ts
@@ -3,6 +3,7 @@ import {
   MIN_SCAN_CONCURRENCY,
   OXLINT_OUTPUT_MAX_BYTES,
   OXLINT_SPAWN_TIMEOUT_MS,
+  SUPPLY_CHAIN_OVERLAP_TIMEOUT_MS,
 } from "./constants.js";
 import { resolveScanConcurrency } from "./utils/resolve-scan-concurrency.js";
 
@@ -20,6 +21,26 @@ export class OxlintSpawnTimeoutMs extends Context.Reference<number>(
       if (raw === undefined) return OXLINT_SPAWN_TIMEOUT_MS;
       const parsed = Number(raw);
       if (!Number.isFinite(parsed) || parsed <= 0) return OXLINT_SPAWN_TIMEOUT_MS;
+      return parsed;
+    },
+  },
+) {}
+
+/**
+ * Wall-clock budget for the supply-chain check when it runs on a background
+ * fiber overlapping the lint pass. Reads from the env var on startup so the
+ * eval harness can raise the budget under sandbox microVMs (slower network)
+ * without recompiling react-doctor. Tests override via
+ * `Layer.succeed(SupplyChainOverlapTimeoutMs, ...)`.
+ */
+export class SupplyChainOverlapTimeoutMs extends Context.Reference<number>(
+  "react-doctor/SupplyChainOverlapTimeoutMs",
+  {
+    defaultValue: () => {
+      const raw = process.env["REACT_DOCTOR_SUPPLY_CHAIN_TIMEOUT_MS"];
+      if (raw === undefined) return SUPPLY_CHAIN_OVERLAP_TIMEOUT_MS;
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0) return SUPPLY_CHAIN_OVERLAP_TIMEOUT_MS;
       return parsed;
     },
   },

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -32,7 +32,7 @@ import {
 } from "./errors.js";
 import { filterDiagnosticsForSurface } from "./filter-for-surface.js";
 import { isAnalyzableProject } from "./project-info/index.js";
-import { OxlintConcurrency } from "./refs.js";
+import { OxlintConcurrency, SupplyChainOverlapTimeoutMs } from "./refs.js";
 import { resolveLintIncludePaths } from "./resolve-lint-include-paths.js";
 import { Config, type ResolvedConfig } from "./services/config.js";
 import { DeadCode } from "./services/dead-code.js";
@@ -161,6 +161,23 @@ export interface InspectOutput {
   readonly scannedFilePaths: ReadonlyArray<string>;
   /** Wall-clock duration of the scan phase, in milliseconds. */
   readonly scanElapsedMilliseconds: number;
+  /**
+   * `true` when the background supply-chain fiber hit its overlap budget
+   * (`SupplyChainOverlapTimeoutMs`) and failed open to no diagnostics — a
+   * rare hung-socket guard, surfaced for telemetry. `false` on the healthy
+   * path and whenever supply-chain was skipped (diff/staged scans).
+   */
+  readonly supplyChainOverlapTimedOut: boolean;
+}
+
+/**
+ * The settled result of the background supply-chain fiber: its collected
+ * diagnostics, plus whether the fork-relative overlap timeout fired (in which
+ * case `diagnostics` is empty — the fail-open outcome).
+ */
+interface SupplyChainForkResult {
+  readonly diagnostics: ReadonlyArray<Diagnostic>;
+  readonly timedOut: boolean;
 }
 
 /**
@@ -221,18 +238,35 @@ const formatLintFailText = (
  *
  * Phases:
  *
- *   1. Config.resolve(directory) → Project.discover → Git metadata
+ *   1. Config.resolve(directory) → Project.discover → Git metadata.
+ *      The GitHub viewer-permission lookup is forked onto a background
+ *      fiber here and joined late (it feeds score metadata, not
+ *      diagnostics).
  *   2. beforeLint hook (e.g. CLI renders the project-detection block)
  *   3. environment checks (reduced-motion + pnpm hardening +
- *      expo/react-native + security scan)
- *   4. Linter.run + DeadCode.run — forked as concurrent fibers so
- *      their wall-clock times overlap. Progress spinners stay
- *      sequential (lint first, then dead-code) for clean terminal
- *      output. GitHub viewer permission also runs as a background
- *      fiber during this phase.
- *   5. afterLint hook
- *   6. Reporter.finalize
- *   7. Score.compute against the surface-filtered diagnostic set
+ *      expo/react-native + security scan), collected synchronously
+ *   4. The supply-chain check (Socket.dev) is forked onto a background
+ *      fiber so its ~100% network-bound time overlaps the ~100%
+ *      CPU/subprocess-bound lint pass below, collapsing two serial
+ *      phases into roughly `max(supplyChain, lint)`. It is capped by
+ *      `SupplyChainOverlapTimeoutMs` (measured from fork) so a hung
+ *      socket can't drag out its join; on timeout it fails open to no
+ *      diagnostics — the same outcome class as a Socket outage.
+ *   5. Linter.run, then DeadCode.run — collected sequentially (dead-code
+ *      gated on lint not failing), with the afterLint hook firing
+ *      between them. Progress spinners stay lint-driven for clean
+ *      terminal output; supply-chain rides alongside without a spinner.
+ *   6. Join the supply-chain fiber, then assemble the diagnostics in a
+ *      FIXED order (env, supply-chain, lint, dead-code) so the output is
+ *      byte-identical regardless of which fiber settled first. The
+ *      viewer-permission fiber is joined later, during score-metadata
+ *      assembly (it feeds score metadata, not diagnostics). The per-element
+ *      `Reporter.emit` side-channel now interleaves supply-chain with lint
+ *      emits, so capture-order assertions must target the deterministic
+ *      concat below, not emit order (production `Reporter.layerNoop` makes
+ *      emit a no-op).
+ *   7. Reporter.finalize
+ *   8. Score.compute against the surface-filtered diagnostic set
  *
  * The orchestrator owns spinner lifecycle via `Progress`; callers
  * choose `Progress.layerOra(...)` for CLI feedback or
@@ -366,17 +400,43 @@ export const runInspect = <HooksR = never>(
     // provided layer (`SupplyChain.layerOf([])` when disabled). The stream
     // is fail-open — per-package timeouts / network failures are recovered
     // to "skip" inside the check — so a Socket API outage never sinks the scan.
+    //
+    // The check is ~100% network-bound and the lint pass below is ~100%
+    // CPU/subprocess-bound, so we fork it onto a child fiber here and join it
+    // just before the diagnostic concat — its wall-clock overlaps lint instead
+    // of running serially before it. `forkChild` is structured: any
+    // error/interrupt in the orchestrator tears this fiber down with it, so it
+    // never leaks. The collect can't fail (the stream has no error channel), so
+    // the only failure is the `Effect.timeout` deadline, which we fold into a
+    // fail-open `[]` + a `timedOut` marker — the same outcome class as a Socket
+    // outage. The deadline is measured FROM FORK (before lint), so it bounds a
+    // hung undici socket without depending on how long lint takes. (On the rare
+    // timeout, a stateful `Reporter` — only `layerNdjson`, which has no in-tree
+    // consumer — may hold supply-chain emits from before the deadline that the
+    // returned `[]` omits; production `Reporter.layerNoop` makes emit a no-op,
+    // and the returned `diagnostics`/score only ever read the joined value.)
+    // When skipped, the fork takes the empty branch so the join below stays
+    // unconditional (mirroring the viewer-permission fiber above).
     const shouldRunSupplyChain = !isDiffMode || (input.supplyChainManifestChanged ?? false);
-    const supplyChainCollected = shouldRunSupplyChain
-      ? yield* Stream.runCollect(
-          applyPerElementPipeline(
-            supplyChainService.run({
-              rootDirectory: scanDirectory,
-              userConfig: resolvedConfig.config,
-            }),
-          ),
-        )
-      : [];
+    const supplyChainOverlapTimeout = yield* SupplyChainOverlapTimeoutMs;
+    const supplyChainFiber = yield* Effect.forkChild(
+      shouldRunSupplyChain
+        ? Stream.runCollect(
+            applyPerElementPipeline(
+              supplyChainService.run({
+                rootDirectory: scanDirectory,
+                userConfig: resolvedConfig.config,
+              }),
+            ),
+          ).pipe(
+            Effect.map((diagnostics): SupplyChainForkResult => ({ diagnostics, timedOut: false })),
+            Effect.timeout(supplyChainOverlapTimeout),
+            Effect.orElseSucceed(
+              (): SupplyChainForkResult => ({ diagnostics: [], timedOut: true }),
+            ),
+          )
+        : Effect.succeed<SupplyChainForkResult>({ diagnostics: [], timedOut: false }),
+    );
 
     const lintFailure = yield* Ref.make<{
       didFail: boolean;
@@ -510,6 +570,16 @@ export const runInspect = <HooksR = never>(
       }
     }
 
+    // Join the background supply-chain fiber now that lint + dead-code have
+    // run, so its network time overlapped the lint pass. This lands BEFORE
+    // `reporterService.finalize` so every supply-chain `Reporter.emit` from the
+    // forked stream has flushed before a stateful reporter (e.g. NDJSON) closes
+    // its sink. Fail-open + the fork-relative timeout are already folded into
+    // the fiber result, so the join never fails; `timedOut` records whether the
+    // overlap budget fired (the rare hung-socket guard) for telemetry.
+    const supplyChainResult = yield* Fiber.join(supplyChainFiber);
+    const supplyChainCollected = supplyChainResult.diagnostics;
+
     yield* reporterService.finalize;
 
     // Stamp shared `fixGroupId`s once on the finalized list (post-collection,
@@ -569,6 +639,7 @@ export const runInspect = <HooksR = never>(
       scannedFileCount: totalFileCount,
       scannedFilePaths,
       scanElapsedMilliseconds,
+      supplyChainOverlapTimedOut: supplyChainResult.timedOut,
     };
   }).pipe(
     Effect.withSpan("runInspect", {

--- a/packages/core/src/services/supply-chain.ts
+++ b/packages/core/src/services/supply-chain.ts
@@ -24,6 +24,10 @@ interface SupplyChainInput {
  * The underlying `checkSupplyChain` Effect is total/fail-open — per-package
  * timeouts and network failures recover to "skip" — so the stream never
  * fails, mirroring `DeadCode`'s stream shape so the two compose the same way.
+ * The orchestrator (`run-inspect.ts`) consumes this stream on a background
+ * fiber whose network time overlaps the lint pass, joined under a generous
+ * wall-clock budget; a budget expiry is the same fail-open outcome as a Socket
+ * outage.
  */
 export class SupplyChain extends Context.Service<
   SupplyChain,

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -16,6 +16,7 @@ import {
   ReactDoctorError,
 } from "../src/errors.js";
 import { runInspect, type InspectInput } from "../src/run-inspect.js";
+import { SupplyChainOverlapTimeoutMs } from "../src/refs.js";
 import { Config } from "../src/services/config.js";
 import { DeadCode } from "../src/services/dead-code.js";
 import { Files } from "../src/services/files.js";
@@ -130,6 +131,32 @@ const layersOf = (config: {
     SupplyChain.layerOf(config.supplyChain ?? []),
     Progress.layerNoop,
     Reporter.layerCapture,
+  );
+
+// Builds the orchestration stack with a CUSTOM supply-chain layer (a mock that
+// hangs, delays, or counts calls) plus an overridable overlap budget — the
+// fork/timeout/join path needs both, which the array-only `SupplyChain.layerOf`
+// shape behind `layersOf` can't express.
+const overlapLayersOf = (config: {
+  supplyChain: Layer.Layer<SupplyChain>;
+  overlapTimeoutMs: number;
+  linter?: Layer.Layer<Linter>;
+  diagnostics?: ReadonlyArray<Diagnostic>;
+  deadCode?: ReadonlyArray<Diagnostic>;
+}) =>
+  Layer.mergeAll(
+    Project.layerOf(sampleProject),
+    Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
+    Files.layerInMemory(new Map()),
+    config.linter ?? Linter.layerOf(config.diagnostics ?? []),
+    LintPartialFailures.layerLive,
+    DeadCode.layerOf(config.deadCode ?? []),
+    Git.layerOf({}),
+    Score.layerOf({ score: 85, label: "Good" }),
+    config.supplyChain,
+    Progress.layerNoop,
+    Reporter.layerNoop,
+    Layer.succeed(SupplyChainOverlapTimeoutMs, config.overlapTimeoutMs),
   );
 
 describe("runInspect — happy path", () => {
@@ -600,6 +627,193 @@ describe("runInspect — supply-chain in diff mode", () => {
       }).pipe(Effect.provide(layersOf({ supplyChain: [supplyChainDiagnostic] }))),
     );
     expect(output.diagnostics.map((d) => d.rule)).toContain("low-supply-chain-score");
+  });
+});
+
+describe("runInspect — supply-chain lint overlap", () => {
+  it("preserves the fixed diagnostic order when the forked check is joined", async () => {
+    const output = await Effect.runPromise(
+      runInspect(baseInput).pipe(
+        Effect.provide(
+          layersOf({
+            supplyChain: [supplyChainDiagnostic],
+            diagnostics: [lintDiagnostic],
+            deadCode: [deadCodeDiagnostic],
+          }),
+        ),
+      ),
+    );
+    // env (none), supply-chain, lint, dead-code — independent of which fiber
+    // settled first, the concat slot is fixed.
+    expect(output.diagnostics.map((d) => d.rule)).toEqual([
+      "low-supply-chain-score",
+      "no-derived-state",
+      "unused-file",
+    ]);
+    expect(output.supplyChainOverlapTimedOut).toBe(false);
+  });
+
+  it("keeps the score unchanged on the healthy overlap path", async () => {
+    const output = await Effect.runPromise(
+      runInspect(baseInput).pipe(
+        Effect.provide(
+          layersOf({
+            supplyChain: [supplyChainDiagnostic],
+            diagnostics: [lintDiagnostic],
+            deadCode: [deadCodeDiagnostic],
+          }),
+        ),
+      ),
+    );
+    expect(output.score).toEqual({ score: 85, label: "Good" });
+    expect(output.didLintFail).toBe(false);
+  });
+
+  it("times out a hung supply-chain fiber instead of hanging the scan", async () => {
+    const hungSupplyChain = Layer.mock(SupplyChain, {
+      run: () => Stream.fromEffect(Effect.never),
+    });
+    const output = await Effect.runPromise(
+      runInspect(baseInput).pipe(
+        Effect.provide(
+          overlapLayersOf({
+            supplyChain: hungSupplyChain,
+            overlapTimeoutMs: 50,
+            diagnostics: [lintDiagnostic],
+          }),
+        ),
+      ),
+    );
+    // Without the fork-relative `Effect.timeout`, this scan never resolves.
+    expect(output.supplyChainOverlapTimedOut).toBe(true);
+    expect(output.diagnostics.map((d) => d.rule)).toEqual(["no-derived-state"]);
+    expect(output.didLintFail).toBe(false);
+  });
+
+  it("does not cut a slow-but-healthy supply-chain run that finishes within budget", async () => {
+    const slowSupplyChain = Layer.mock(SupplyChain, {
+      run: () =>
+        Stream.fromEffect(Effect.succeed(supplyChainDiagnostic).pipe(Effect.delay("20 millis"))),
+    });
+    const output = await Effect.runPromise(
+      runInspect(baseInput).pipe(
+        Effect.provide(
+          overlapLayersOf({
+            supplyChain: slowSupplyChain,
+            overlapTimeoutMs: 5_000,
+            diagnostics: [lintDiagnostic],
+          }),
+        ),
+      ),
+    );
+    expect(output.supplyChainOverlapTimedOut).toBe(false);
+    expect(output.diagnostics.map((d) => d.rule)).toContain("low-supply-chain-score");
+  });
+
+  it("never invokes supply-chain run in a plain diff scan (fork takes the empty branch)", async () => {
+    let supplyChainRunCount = 0;
+    const countingSupplyChain = Layer.mock(SupplyChain, {
+      run: () => {
+        supplyChainRunCount += 1;
+        return Stream.fromIterable([supplyChainDiagnostic]);
+      },
+    });
+    const output = await Effect.runPromise(
+      runInspect({ ...baseInput, includePaths: ["src/App.tsx"] }).pipe(
+        Effect.provide(
+          overlapLayersOf({
+            supplyChain: countingSupplyChain,
+            overlapTimeoutMs: 90_000,
+            diagnostics: [lintDiagnostic],
+          }),
+        ),
+      ),
+    );
+    expect(supplyChainRunCount).toBe(0);
+    expect(output.diagnostics.map((d) => d.rule)).not.toContain("low-supply-chain-score");
+    expect(output.supplyChainOverlapTimedOut).toBe(false);
+  });
+
+  it("invokes supply-chain run once in a diff scan when the manifest changed", async () => {
+    let supplyChainRunCount = 0;
+    const countingSupplyChain = Layer.mock(SupplyChain, {
+      run: () => {
+        supplyChainRunCount += 1;
+        return Stream.fromIterable([supplyChainDiagnostic]);
+      },
+    });
+    const output = await Effect.runPromise(
+      runInspect({
+        ...baseInput,
+        includePaths: ["src/App.tsx"],
+        supplyChainManifestChanged: true,
+      }).pipe(
+        Effect.provide(
+          overlapLayersOf({
+            supplyChain: countingSupplyChain,
+            overlapTimeoutMs: 90_000,
+            diagnostics: [lintDiagnostic],
+          }),
+        ),
+      ),
+    );
+    expect(supplyChainRunCount).toBe(1);
+    expect(output.diagnostics.map((d) => d.rule)).toContain("low-supply-chain-score");
+  });
+
+  it("fails open on a supply-chain timeout while a folded lint failure nulls the score", async () => {
+    // A lint failure is FOLDED into Stream.empty (not propagated), so the scan
+    // still finalizes: the supply-chain fiber self-times-out to [], the score
+    // is gated to null by the lint failure, and the timeout flag is recorded.
+    const failingLinter = Layer.mock(Linter, {
+      run: () =>
+        Stream.fail(
+          new ReactDoctorError({ reason: new OxlintSpawnFailed({ cause: "synthetic failure" }) }),
+        ),
+    });
+    const hungSupplyChain = Layer.mock(SupplyChain, {
+      run: () => Stream.fromEffect(Effect.never),
+    });
+    const output = await Effect.runPromise(
+      runInspect(baseInput).pipe(
+        Effect.provide(
+          overlapLayersOf({
+            supplyChain: hungSupplyChain,
+            overlapTimeoutMs: 50,
+            linter: failingLinter,
+          }),
+        ),
+      ),
+    );
+    expect(output.didLintFail).toBe(true);
+    expect(output.score).toBeNull();
+    expect(output.supplyChainOverlapTimedOut).toBe(true);
+    expect(output.diagnostics).toHaveLength(0);
+  });
+
+  it("propagates a defect raised after the supply-chain fork without hanging", async () => {
+    // Force a defect in the afterLint hook — it fires AFTER the supply-chain
+    // fork but BEFORE the join. `forkChild` is structured, so the hung
+    // supply-chain child is interrupted with the failing parent rather than
+    // left to run out the (deliberately long) budget: the scan fails fast
+    // instead of blocking the join on `Effect.never`.
+    const hungSupplyChain = Layer.mock(SupplyChain, {
+      run: () => Stream.fromEffect(Effect.never),
+    });
+    const exit = await Effect.runPromiseExit(
+      runInspect(baseInput, {
+        afterLint: () => Effect.die(new Error("synthetic post-fork defect")),
+      }).pipe(
+        Effect.provide(
+          overlapLayersOf({
+            supplyChain: hungSupplyChain,
+            overlapTimeoutMs: 600_000,
+            diagnostics: [lintDiagnostic],
+          }),
+        ),
+      ),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
   });
 });
 

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -50,6 +50,15 @@ export interface RunEventInput {
   readonly lintFailureReasonKind?: string | null;
   readonly lintPartialFailureCount?: number;
   readonly didDeadCodeFail?: boolean;
+  // `true` when the background supply-chain check hit its overlap budget and
+  // failed open to no diagnostics. The kill metric for the lint/supply-chain
+  // overlap watches the rate of this per supply-chain-eligible scan (filter to
+  // `mode == "full"`, since a skipped check also reports `false`). Known on the
+  // success path and replayed from the cached payload on a cache hit — but a
+  // timed-out run is never cached (`shouldStoreScanPayload`), so a cache hit
+  // always reports `false`. Omitted only on the failure path (the scan threw
+  // before finalizing).
+  readonly supplyChainOverlapTimedOut?: boolean;
   // A degraded baseline run (no delta computed) skips the CI gate, so the
   // `wouldBlock` prediction must match — never block on its plain-diff findings.
   readonly gateExempt?: boolean;
@@ -196,6 +205,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
     lintFailureReasonKind: input.lintFailureReasonKind ?? null,
     lintPartialFailureCount: input.lintPartialFailureCount ?? null,
     didDeadCodeFail: input.didDeadCodeFail ?? null,
+    supplyChainOverlapTimedOut: input.supplyChainOverlapTimedOut ?? null,
   };
   for (const [category, count] of countByCategory) {
     attributes[`diag.category.${toCategoryKey(category)}`] = count;

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -21,7 +21,9 @@ export const REACT_DOCTOR_CONFIG_PROJECT_NAME = "react-doctor";
 
 export const STAGED_FILES_TEMP_DIR_PREFIX = "react-doctor-staged-";
 export const BASELINE_FILES_TEMP_DIR_PREFIX = "react-doctor-baseline-";
-export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 1;
+// Bumped to 2: `CachedScanPayload` gained `supplyChainOverlapTimedOut`, so
+// entries written by an older schema lack the field and must be discarded.
+export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 2;
 export const SCAN_RESULT_CACHE_MAX_ENTRY_COUNT = 20;
 export const CACHE_FILENAME_HASH_LENGTH_CHARS = 16;
 

--- a/packages/react-doctor/src/cli/utils/scan-result-cache.ts
+++ b/packages/react-doctor/src/cli/utils/scan-result-cache.ts
@@ -39,6 +39,7 @@ export interface CachedScanPayload {
   readonly scanElapsedMilliseconds: number;
   readonly baselineDelta: InspectResult["baselineDelta"];
   readonly lintFailureReasonKind: InspectOutput["lintFailureReasonKind"];
+  readonly supplyChainOverlapTimedOut: boolean;
 }
 
 interface PersistedScanResultCacheEntry {
@@ -284,4 +285,13 @@ export const createScanResultCache = (projectDirectory: string): ScanResultCache
 };
 
 export const shouldStoreScanPayload = (payload: CachedScanPayload): boolean =>
-  !payload.didLintFail && !payload.didDeadCodeFail && payload.lintPartialFailures.length === 0;
+  !payload.didLintFail &&
+  !payload.didDeadCodeFail &&
+  payload.lintPartialFailures.length === 0 &&
+  // A supply-chain overlap timeout means the cached diagnostics are missing
+  // their supply-chain findings; don't persist a degraded result — re-attempt
+  // the check on the next run instead. This also keeps the timeout kill metric
+  // clean: a stored payload therefore always carries
+  // `supplyChainOverlapTimedOut: false`, so a cache hit never replays a stale
+  // `true`.
+  !payload.supplyChainOverlapTimedOut;

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -692,6 +692,7 @@ const runInspectWithRuntime = async (
     lintFailureReasonKind: lintBindingMissing
       ? "native-binding-missing"
       : output.lintFailureReasonKind,
+    supplyChainOverlapTimedOut: output.supplyChainOverlapTimedOut,
   };
   if (cacheKey !== null && scanResultCache !== null && shouldStoreScanPayload(payload)) {
     scanResultCache.store(cacheKey, payload);
@@ -816,6 +817,7 @@ const renderAndRecordScan = async (input: RenderAndRecordScanInput): Promise<Ins
     lintFailureReasonKind: input.payload.lintFailureReasonKind,
     lintPartialFailureCount: input.payload.lintPartialFailures.length,
     didDeadCodeFail: input.payload.didDeadCodeFail,
+    supplyChainOverlapTimedOut: input.payload.supplyChainOverlapTimedOut,
   });
   return result;
 };

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -236,6 +236,25 @@ describe("buildRunEventAttributes", () => {
     expect(attributes.totalDiagnostics).toBeUndefined();
   });
 
+  it("records the supply-chain overlap timeout outcome and drops it when absent", () => {
+    // The healthy path reports `false`; the rare hung-socket guard reports
+    // `true`. When the field is omitted (failure path / cache hit), it's dropped
+    // rather than coerced to a misleading value.
+    expect(
+      buildRunEventAttributes(
+        baseInput({ result: buildResult(), supplyChainOverlapTimedOut: true }),
+      ).supplyChainOverlapTimedOut,
+    ).toBe(true);
+    expect(
+      buildRunEventAttributes(
+        baseInput({ result: buildResult(), supplyChainOverlapTimedOut: false }),
+      ).supplyChainOverlapTimedOut,
+    ).toBe(false);
+    expect(
+      buildRunEventAttributes(baseInput({ result: buildResult() })).supplyChainOverlapTimedOut,
+    ).toBeUndefined();
+  });
+
   it("emits the baseline delta on a computed baseline run", () => {
     const result = buildResult({
       diagnostics: [buildDiagnostic(), buildDiagnostic({ filePath: "src/B.tsx" })],

--- a/packages/react-doctor/tests/scan-result-cache.test.ts
+++ b/packages/react-doctor/tests/scan-result-cache.test.ts
@@ -129,6 +129,7 @@ describe("scan result cache", () => {
       scanElapsedMilliseconds: 1,
       baselineDelta: undefined,
       lintFailureReasonKind: null,
+      supplyChainOverlapTimedOut: false,
     };
     const cache = createScanResultCache(projectDirectory);
     cache.store(key, payload);


### PR DESCRIPTION
## Why

The Socket.dev supply-chain score check is ~100% network-bound and the lint pass is ~100% CPU/subprocess-bound, but they ran **back-to-back** (`run-inspect.ts` drained the supply-chain stream to completion before lint even started). Running disjoint-resource phases serially wastes the overlap. Forking supply-chain onto a background fiber and joining it just before the fixed-order diagnostic concat collapses two serial phases into roughly `max(supplyChain, lint)`.

Before:

```
supply-chain (network, p50 0.36s / p95 2.5s)  ──┐
                                                 ▼  serial
lint (CPU/subprocess, p95 15s)  ────────────────────────►
total ≈ supplyChain + lint
```

After:

```
supply-chain (network) ┐  overlaps
lint (CPU/subprocess) ─┴────────────────►
total ≈ max(supplyChain, lint)   (saves the full supply-chain time on the ~⅓ of scans that run it)
```

## What changed

- **`run-inspect.ts`**: the supply-chain check is forked via `Effect.forkChild` (structured — interrupted with the parent, no leak) at the supply-chain phase and `Fiber.join`ed just **before `reporterService.finalize`** (so all its `Reporter.emit` side-effects flush before a stateful sink closes). The fixed-order concat `[env, supply-chain, lint, dead-code]` is unchanged, so `diagnostics`, ordering, and `score` are **byte-identical**.
- **Fork-relative timeout**: a generous `SupplyChainOverlapTimeoutMs` (`SUPPLY_CHAIN_OVERLAP_TIMEOUT_MS = 90_000`, env-overridable via `REACT_DOCTOR_SUPPLY_CHAIN_TIMEOUT_MS`, mirrors `OxlintSpawnTimeoutMs`) bounds a hung undici socket. Measured **from fork** (before lint), sized above the ~60s worst-case healthy run so it only bites on genuinely-stuck sockets. On expiry the check fails open to `[]` — the same outcome class as a Socket outage.
- **Telemetry**: new `supplyChainOverlapTimedOut` wide-event dimension, threaded `InspectOutput` → `CachedScanPayload` → `RunEventInput` → attribute (`?? null`, dropped when absent). Kill metric watches its rate per supply-chain-eligible scan.
- **Cache**: degraded (timed-out) scans are **not** cached (`shouldStoreScanPayload` gate), so a cache hit never replays a stale timeout; `SCAN_RESULT_CACHE_SCHEMA_VERSION` bumped 1→2 for the new payload field.
- **Docstring fix**: the orchestrator docstring claimed lint+dead-code were "forked as concurrent fibers" — they run sequentially. Rewritten to describe the real topology.
- **Tests**: 8 new `run-inspect` overlap tests (order/score invariance, hung-fiber timeout, slow-but-healthy-within-budget, diff-mode skip never invokes `run`, manifest-changed runs once, folded-lint-failure coexistence, post-fork-defect teardown) + a wide-event dimension test.

## Test plan

- `pnpm typecheck` — 11/11 ✅
- `pnpm exec vp test run run-inspect` (core) — 28/28 ✅ ; `build-run-event` + `scan-result-cache` (react-doctor) — 17/17 ✅
- `pnpm lint` — exit 0, 0 errors ✅ ; `pnpm format:check` — clean ✅
- `pnpm smoke:json-report` — OK, `schemaVersion=1` unchanged ✅
- Full core/react-doctor suites: green except two **pre-existing, unrelated** failures — the global `.env*`-gitignore env-file test trap and a flaky git `--assume-unchanged` cache test (passes in isolation); neither touches files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core inspect orchestration and timing; happy-path diagnostics/score are intended to stay identical, but a timeout or rare NDJSON reporter edge case can omit supply-chain findings like an API outage.
> 
> **Overview**
> **Scan time:** The Socket.dev supply-chain pass no longer runs to completion before lint starts. It is **forked** at the supply-chain phase and **joined** after lint and dead-code, so network-bound supply-chain work overlaps CPU/subprocess lint—wall time is roughly `max(supplyChain, lint)` instead of their sum. Final diagnostics still concatenate in fixed order **env → supply-chain → lint → dead-code**, so ordering and score stay the same when the check finishes normally.
> 
> **Safety and ops:** A **90s** fork-relative budget (`SUPPLY_CHAIN_OVERLAP_TIMEOUT_MS`, overridable via `REACT_DOCTOR_SUPPLY_CHAIN_TIMEOUT_MS` / `SupplyChainOverlapTimeoutMs`) caps hung sockets; on expiry the check **fails open** (no supply-chain diagnostics), matching a Socket outage. **`supplyChainOverlapTimedOut`** is exposed on inspect output, wide events, and cached payloads; timed-out runs are **not** written to the scan cache, and cache schema version is bumped to **2**.
> 
> **Tests:** New `run-inspect` overlap cases cover ordering, timeout vs slow healthy runs, diff/manifest gating, and parent teardown on defects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbe04742ef5738dde7218c2a360c5fafa68b6aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->