### PR TITLE
perf(core): memoize large-minified-file stat/sniff across scan walks

### DIFF
--- a/.changeset/memoize-minified-file-stat.md
+++ b/.changeset/memoize-minified-file-stat.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Memoize the large-minified-file stat/sniff so each source path is statted and content-sniffed at most once per process. A full scan enumerates the source tree more than once — `countSourceFiles` during discovery, `listSourceFiles` during the lint pass, and `collectSecurityScanFiles` during the env-check phase — and every `≥20KB` candidate was `statSync`'d (plus a 64KB content read) on each walk. A module-scope path-keyed cache collapses that to a single stat/sniff per file, wired into the existing `clearCaches()` invalidation contract so long-running `diagnose()` consumers still re-read files that change between calls. Behavior is unchanged (identical diagnostics and `sourceFileCount`); this only removes redundant pre-lint syscalls on full scans.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,7 @@ export * from "./utils/dedupe-diagnostics.js";
 export * from "./utils/define-config.js";
 export * from "./utils/group-by.js";
 export * from "./utils/has-published-fix-recipe.js";
+export * from "./utils/is-large-minified-file.js";
 export * from "./utils/list-source-files.js";
 export * from "./utils/map-with-concurrency.js";
 export * from "./utils/match-glob-pattern.js";

--- a/packages/core/src/utils/is-large-minified-file.ts
+++ b/packages/core/src/utils/is-large-minified-file.ts
@@ -2,19 +2,33 @@ import * as fs from "node:fs";
 import { MINIFIED_MIN_SIZE_BYTES } from "../project-info/constants.js";
 import { isMinifiedSource } from "./is-minified-source.js";
 
+const cachedIsLargeMinifiedByPath = new Map<string, boolean>();
+
+// Clears the memoized classifications so a long-running consumer (watch mode,
+// agentic CLI, repeated `diagnose()`) re-sniffs files that changed between
+// calls. Wired into `clearCaches()` alongside the other module-scope caches.
+export const clearMinifiedFileCache = (): void => {
+  cachedIsLargeMinifiedByPath.clear();
+};
+
 // Whether a file is large enough to plausibly be a bundle AND sniffs as
 // minified. The size gate keeps whole-tree discovery from reading every
 // small source file just to check. Both `listSourceFiles` (the scanned set)
 // and `countSourceFiles` (the reported `sourceFileCount`) route through here
-// so the two can never diverge. Returns false on any stat error so an
-// unreadable file is kept / counted as usual.
+// so the two can never diverge. Memoized by absolute path because a full scan
+// walks the tree more than once; returns (and caches) false on any stat error
+// so an unreadable file is kept / counted as usual.
 export const isLargeMinifiedFile = (absolutePath: string): boolean => {
-  let sizeBytes: number;
+  const cached = cachedIsLargeMinifiedByPath.get(absolutePath);
+  if (cached !== undefined) return cached;
+
+  let result: boolean;
   try {
-    sizeBytes = fs.statSync(absolutePath).size;
+    const sizeBytes = fs.statSync(absolutePath).size;
+    result = sizeBytes >= MINIFIED_MIN_SIZE_BYTES && isMinifiedSource(absolutePath);
   } catch {
-    return false;
+    result = false;
   }
-  if (sizeBytes < MINIFIED_MIN_SIZE_BYTES) return false;
-  return isMinifiedSource(absolutePath);
+  cachedIsLargeMinifiedByPath.set(absolutePath, result);
+  return result;
 };

--- a/packages/core/tests/is-large-minified-file.test.ts
+++ b/packages/core/tests/is-large-minified-file.test.ts
@@ -1,0 +1,100 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { MINIFIED_MAX_LINE_LENGTH_CHARS, MINIFIED_MIN_SIZE_BYTES } from "../src/constants.js";
+import { countSourceFiles } from "../src/project-info/count-source-files.js";
+import {
+  clearMinifiedFileCache,
+  isLargeMinifiedFile,
+} from "../src/utils/is-large-minified-file.js";
+import { listSourceFiles } from "../src/utils/list-source-files.js";
+
+// A single enormous line that clears both gates: total bytes past
+// MINIFIED_MIN_SIZE_BYTES and one line far longer than the sniff threshold.
+const minifiedBundleContents = (): string =>
+  `var bundle=${JSON.stringify("a".repeat(MINIFIED_MIN_SIZE_BYTES + MINIFIED_MAX_LINE_LENGTH_CHARS))};`;
+
+// Large enough to clear the size gate but plainly not minified — many short
+// lines keep the average line length far below the sniff threshold.
+const largeRealSourceContents = (): string =>
+  Array.from({ length: 2_000 }, (_, index) => `const value${index} = ${index};`).join("\n");
+
+// Plainly-not-minified content that is also under the size gate, so an
+// un-memoized re-sniff would short-circuit to false on the size check alone.
+const tinySourceContents = "export const x = 1;\n";
+
+describe("isLargeMinifiedFile", () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    clearMinifiedFileCache();
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "large-minified-"));
+  });
+
+  afterEach(() => {
+    clearMinifiedFileCache();
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  const writeFile = (name: string, contents: string): string => {
+    const filePath = path.join(temporaryDirectory, name);
+    fs.writeFileSync(filePath, contents);
+    return filePath;
+  };
+
+  it("flags a large single-line bundle and clears a large real source file", () => {
+    expect(isLargeMinifiedFile(writeFile("bundle.js", minifiedBundleContents()))).toBe(true);
+    expect(isLargeMinifiedFile(writeFile("App.tsx", largeRealSourceContents()))).toBe(false);
+  });
+
+  it("memoizes the result so a later walk never re-sniffs the same path", () => {
+    const bundlePath = writeFile("bundle.js", minifiedBundleContents());
+    expect(isLargeMinifiedFile(bundlePath)).toBe(true);
+
+    // Shrink on disk: an un-memoized call would now fail the size gate and
+    // return false. The cached `true` proves the second call never re-statted.
+    fs.writeFileSync(bundlePath, tinySourceContents);
+    expect(isLargeMinifiedFile(bundlePath)).toBe(true);
+  });
+
+  it("caches the sub-threshold false so small files are not re-statted", () => {
+    const smallPath = writeFile("small.tsx", tinySourceContents);
+    expect(isLargeMinifiedFile(smallPath)).toBe(false);
+
+    // Grow past the size gate with minified content: a re-stat would now
+    // return true. The cached `false` proves the small result was memoized.
+    fs.writeFileSync(smallPath, minifiedBundleContents());
+    expect(isLargeMinifiedFile(smallPath)).toBe(false);
+  });
+
+  it("re-sniffs after clearMinifiedFileCache invalidates the memo", () => {
+    const filePath = writeFile("widget.js", tinySourceContents);
+    expect(isLargeMinifiedFile(filePath)).toBe(false);
+
+    fs.writeFileSync(filePath, minifiedBundleContents());
+    expect(isLargeMinifiedFile(filePath)).toBe(false);
+
+    clearMinifiedFileCache();
+    expect(isLargeMinifiedFile(filePath)).toBe(true);
+  });
+
+  it("shares one result across the discovery and lint walks", () => {
+    writeFile("bundle.js", minifiedBundleContents());
+    writeFile("App.tsx", tinySourceContents);
+    fs.mkdirSync(path.join(temporaryDirectory, "dist"));
+    writeFile(path.join("dist", "vendor.js"), minifiedBundleContents());
+
+    // Walk #1 (discovery) caches bundle.js -> true, App.tsx -> false; the
+    // ignored dist/ tree is skipped, so only App.tsx counts.
+    expect(countSourceFiles(temporaryDirectory)).toBe(1);
+
+    // Shrink the bundle on disk. Walk #2 (lint) must still drop it from the
+    // scanned set off the shared memo rather than re-sniff the now-small file.
+    fs.writeFileSync(path.join(temporaryDirectory, "bundle.js"), tinySourceContents);
+
+    const sourceFiles = listSourceFiles(temporaryDirectory);
+    expect(sourceFiles).toContain("App.tsx");
+    expect(sourceFiles).not.toContain("bundle.js");
+  });
+});

--- a/packages/language-server/src/core/project-graph.ts
+++ b/packages/language-server/src/core/project-graph.ts
@@ -3,6 +3,7 @@ import {
   clearAutoSuppressionCaches,
   clearConfigCache,
   clearIgnorePatternsCache,
+  clearMinifiedFileCache,
   clearPackageJsonCache,
   clearProjectCache,
   discoverReactSubprojects,
@@ -80,6 +81,7 @@ export const createProjectGraph = (options: ProjectGraphOptions): ProjectGraph =
       clearPackageJsonCache();
       clearIgnorePatternsCache();
       clearAutoSuppressionCaches();
+      clearMinifiedFileCache();
       projects = null;
     },
   };

--- a/packages/language-server/tests/unit/project-graph-invalidate.test.ts
+++ b/packages/language-server/tests/unit/project-graph-invalidate.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  clearMinifiedFileCache,
+  isLargeMinifiedFile,
+  MINIFIED_MAX_LINE_LENGTH_CHARS,
+  MINIFIED_MIN_SIZE_BYTES,
+} from "@react-doctor/core";
+import { createProjectGraph } from "../../src/core/project-graph.js";
+
+const minifiedBundleContents = (): string =>
+  `var bundle=${JSON.stringify("a".repeat(MINIFIED_MIN_SIZE_BYTES + MINIFIED_MAX_LINE_LENGTH_CHARS))};`;
+
+describe("createProjectGraph invalidate", () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    clearMinifiedFileCache();
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-project-graph-test-"));
+  });
+
+  afterEach(() => {
+    clearMinifiedFileCache();
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("clears the minified-file memo so a changed bundle is re-sniffed on the next scan", () => {
+    const graph = createProjectGraph({ roots: [workspaceRoot] });
+    const bundlePath = path.join(workspaceRoot, "bundle.js");
+    fs.writeFileSync(bundlePath, minifiedBundleContents());
+    expect(isLargeMinifiedFile(bundlePath)).toBe(true);
+
+    // The editor caches listSourceFiles' minified classification at module
+    // scope; without invalidate() clearing it, a shrunk bundle stays excluded
+    // from scans for the life of the language-server process.
+    fs.writeFileSync(bundlePath, "export const x = 1;\n");
+    expect(isLargeMinifiedFile(bundlePath)).toBe(true);
+
+    graph.invalidate();
+    expect(isLargeMinifiedFile(bundlePath)).toBe(false);
+  });
+});

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -4,6 +4,7 @@ import {
   clearAutoSuppressionCaches,
   clearConfigCache,
   clearIgnorePatternsCache,
+  clearMinifiedFileCache,
   clearPackageJsonCache,
   clearPackageRoleCache,
   clearProjectCache,
@@ -89,6 +90,7 @@ export const clearCaches = (): void => {
   clearIgnorePatternsCache();
   clearPackageRoleCache();
   clearAutoSuppressionCaches();
+  clearMinifiedFileCache();
 };
 
 interface ToJsonReportOptions {

--- a/packages/react-doctor/tests/clear-caches.test.ts
+++ b/packages/react-doctor/tests/clear-caches.test.ts
@@ -1,0 +1,43 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  clearMinifiedFileCache,
+  isLargeMinifiedFile,
+  MINIFIED_MAX_LINE_LENGTH_CHARS,
+  MINIFIED_MIN_SIZE_BYTES,
+} from "@react-doctor/core";
+import { clearCaches } from "../src/index.js";
+
+const minifiedBundleContents = (): string =>
+  `var bundle=${JSON.stringify("a".repeat(MINIFIED_MIN_SIZE_BYTES + MINIFIED_MAX_LINE_LENGTH_CHARS))};`;
+
+describe("clearCaches", () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    clearMinifiedFileCache();
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "clear-caches-"));
+  });
+
+  afterEach(() => {
+    clearMinifiedFileCache();
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it("clears the memoized minified-file results", () => {
+    const bundlePath = path.join(temporaryDirectory, "bundle.js");
+    fs.writeFileSync(bundlePath, minifiedBundleContents());
+    expect(isLargeMinifiedFile(bundlePath)).toBe(true);
+
+    // Shrink on disk: the cached `true` survives until something clears it.
+    fs.writeFileSync(bundlePath, "export const x = 1;\n");
+    expect(isLargeMinifiedFile(bundlePath)).toBe(true);
+
+    clearCaches();
+    // The aggregate clear must invalidate the minified memo so the predicate
+    // re-sniffs the now-small file. A surviving `true` means it was not wired.
+    expect(isLargeMinifiedFile(bundlePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

A full scan enumerates the source tree more than once — `countSourceFiles` in discovery, `listSourceFiles` in the lint pass, and `collectSecurityScanFiles` in the env-check phase — and `isLargeMinifiedFile` `statSync`'d (plus a content sniff for `≥20KB` files) every candidate on **each** walk, repeating identical per-file work 2–4×. This memoizes the predicate by absolute path so each file is statted/sniffed at most once per process. Pure pre-lint dead-work removal; no behavior change.

Before:

```
# per full scan, for every >=20KB candidate file:
walk 1 (discovery):      statSync + up-to-64KB sniff
walk 2 (lint):           statSync + up-to-64KB sniff   <- same file, again
walk 3 (security-scan):  statSync + up-to-64KB sniff   <- same file, again
```

After:

```
# per full scan, for every file:
first walk:   statSync + sniff  ->  cached by absolute path
later walks:  served from the memo (no syscalls)
# identical booleans -> identical diagnostics and sourceFileCount
```

## What changed

- **`packages/core/src/utils/is-large-minified-file.ts`** — module-scope `Map<absolutePath, boolean>` backing `isLargeMinifiedFile`, plus an exported `clearMinifiedFileCache()`. Mirrors the existing `cachedProjectInfos`/`clearProjectCache` and `cachedRoleByPackageDirectory`/`clearPackageRoleCache` memo precedents (compute inlined, single rationale comment on the clearer).
- **`packages/core/src/index.ts`** — export the util from the core barrel (it was exported nowhere before).
- **Invalidation contract** — `clearMinifiedFileCache()` wired into the CLI's `clearCaches()` (`packages/react-doctor/src/index.ts`) **and** the language-server's project-graph `invalidate()` (`packages/language-server/src/core/project-graph.ts`), which already flushed the sibling project/config caches but would otherwise have left a stale bundle classification across editor reloads (it reaches the memo via `listSourceFiles` and `discoverReactSubprojects → countSourceFiles`).
- **Tests** — core memo behavior incl. cross-walk dedup, sub-threshold caching, and invalidation (5); the `clearCaches()` wiring (1); the language-server `invalidate()` wiring (1).
- `patch` changeset on `react-doctor` (the published CLI; the fixed-version group bumps the rest).

The separate per-call `minifiedFileCache` in `parse-output.ts` (which uses the *ungated* `isMinifiedSource`) is deliberately left untouched — different predicate, must not share the map.

## Test plan

- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm format:check` ✅ · `pnpm smoke:json-report` ✅
- Tests green across **core (892), react-doctor (1838), api (15), language-server (61), oxlint-plugin (7277)**, including all 7 new cases.
- One unrelated failure locally — `check-security-scan.test.ts > flags a non-gitignored env file checked into the repository` — is **pre-existing and environment-specific** (fails identically with this branch's changes stashed; depends on a local global `.env` gitignore / uncommitted-file git behavior). CI is the source of truth for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change with explicit cache invalidation; classification logic and scan outputs are intended to be unchanged.
> 
> **Overview**
> Adds a **module-scope path cache** to `isLargeMinifiedFile` so each absolute path is `statSync`'d and content-sniffed at most once per process. Full scans walk the tree multiple times (`countSourceFiles`, `listSourceFiles`, security-scan collection); large candidates no longer repeat the same syscalls on every walk.
> 
> Exports **`clearMinifiedFileCache`** from core and hooks it into existing invalidation: CLI **`clearCaches()`** and language-server **`project-graph.invalidate()`**, so watch mode and repeated `diagnose()` calls still see file changes after a clear.
> 
> Diagnostics and `sourceFileCount` stay the same; this is redundant I/O removal only. New tests cover memo behavior, cross-walk sharing, and invalidation wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eff4c9ec474a65e9c3dcc88f9344ecc63157e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->