### PR TITLE
perf(core): memory-budget the lint worker cap above 16

### DIFF
--- a/.changeset/memory-budgeted-worker-cap.md
+++ b/.changeset/memory-budgeted-worker-cap.md
@@ -1,0 +1,14 @@
+---
+"react-doctor": patch
+"@react-doctor/core": patch
+---
+
+Replace the fixed 16-worker lint ceiling with a memory-and-core-budgeted auto count (up to 32). The auto path now picks `min(cores, floor(availableMemory / 1 GiB))` clamped to `[1, 32]`, where `availableMemory` is `os.totalmem()` floored by the container's cgroup memory limit (read directly, since Node's memory APIs report the host total inside a container). `os.freemem()` is deliberately not used — it excludes reclaimable page cache and reads near-zero on macOS / cache-heavy Linux, which would have collapsed the default scan to a single worker.
+
+The 1 GiB/worker budget matches the per-worker footprint the old fixed-16 ceiling already tolerated (16 workers on a typical 16 GiB CI box), so machines with at least ~1 GiB per core stay core-bound and unchanged. A 32/64-core runner with enough memory now uses up to 32 workers instead of idling cores behind the old 16; a high-core but memory-starved box or container uses fewer workers so the oxlint native binding doesn't OOM (the existing `EAGAIN`/`ENOMEM` serial replay remains the runtime backstop). Past ~10 workers parallel efficiency already flattens, so this is headroom and OOM-safety, not a proportional speedup.
+
+The cgroup v2 limit is read from the mount-root `memory.max`, which is the container's limit under the standard cgroup-namespace setup CI runners use; a non-namespaced nested cgroup falls back to the host total (with the serial replay as the backstop).
+
+Note for `diagnose({ projects })` batch scans: each project's lint pass is budgeted independently against the whole machine, so a batch (default 4 concurrent projects) can now spawn up to `4 × 32` concurrent oxlint processes on a large runner (was `4 × 16`). The per-project `EAGAIN`/`ENOMEM` serial replay still backstops any over-subscription; dividing the per-project memory budget by the batch concurrency is a possible follow-up.
+
+Explicit `REACT_DOCTOR_PARALLEL=N` and `inspect({ concurrency: N })` pins are now clamped to 32 (was 16). The `[~N workers]` scan suffix can show more than 16 on large runners, and the `oxlint.workers` telemetry distribution (plus the wide-event `workerCount` / `parallel`) now reports the real resolved worker count on the default auto path instead of only when a count was pinned.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -131,16 +131,36 @@ export const SPAWN_ARGS_MAX_LENGTH_CHARS = 24_000;
 // vs the hard-cap perf cliffs they prevent.
 export const OXLINT_MAX_FILES_PER_BATCH = 100;
 
-// Bounds for the lint worker count (the `OxlintConcurrency` Reference, seeded
-// by the `REACT_DOCTOR_PARALLEL` env var; the CLI's `--no-parallel` flag forces
-// the MIN end). React Doctor's rules are oxlint JS plugins — single-threaded
-// per process — so
-// running the file batches across N concurrent oxlint subprocesses scales the
-// scan nearly linearly with N. MAX bounds peak memory (each worker holds its
-// batch's ASTs); the resolved count is clamped to [MIN, MAX].
+// Bounds for the lint worker count (the `OxlintConcurrency` Reference, seeded by
+// the `REACT_DOCTOR_PARALLEL` env var; the CLI's `--no-parallel` flag forces the
+// MIN end). React Doctor's rules are oxlint JS plugins — single-threaded per
+// process — so running the file batches across N concurrent oxlint subprocesses
+// scales the scan nearly linearly with N up to the straggler / per-spawn-overhead
+// knee (~10 workers). `resolveAutoScanConcurrency` chooses N for the auto path;
+// every requested count is clamped to [MIN, HARD_MAX].
 export const MIN_SCAN_CONCURRENCY = 1;
 
-export const MAX_SCAN_CONCURRENCY = 16;
+// Absolute upper bound on lint workers, and the clamp applied to every requested
+// count (auto-detected, `REACT_DOCTOR_PARALLEL=N`, or `inspect({ concurrency })`).
+// Past ~10 workers parallel efficiency already collapses (stragglers + per-spawn
+// overhead), so 32 is headroom that stops a 32/64-core CI runner from idling
+// cores behind the old fixed 16 — not a promise of proportionally more speed.
+export const HARD_MAX_SCAN_CONCURRENCY = 32;
+
+// Memory one oxlint subprocess is budgeted at the OXLINT_MAX_FILES_PER_BATCH=100
+// batch size (the native binding's parser arena + the batch's ASTs + the
+// JS-plugin heap). The auto path takes `floor(availableMemory / this)` as a
+// second ceiling alongside the core count, so a high-core / memory-starved box
+// (or a memory-limited container) doesn't spawn enough workers to trip the
+// native-binding SIGABRT that OXLINT_MAX_FILES_PER_BATCH and the EAGAIN/ENOMEM
+// serial replay already guard. 1 GiB matches the per-worker footprint the old
+// fixed-16 ceiling implicitly tolerated (16 workers on a typical 16 GiB CI box),
+// so any machine with >= ~1 GiB/core stays core-bound and the memory term only
+// binds on genuinely memory-constrained hosts — exactly where over-subscription
+// would OOM. `availableMemory` is `os.totalmem()` floored by the cgroup memory
+// limit, NOT `os.freemem()`, which excludes reclaimable page cache and reads
+// near-zero on macOS / cache-heavy Linux, collapsing the auto path to one worker.
+export const PER_WORKER_MEM_BUDGET_BYTES = 1024 * 1024 * 1024;
 
 // Default worker count for a `diagnose({ projects })` batch. Each project
 // scan already fans out its own oxlint workers (bounded by the constants

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,7 @@ export * from "./utils/match-glob-pattern.js";
 export * from "./utils/message-from-unknown.js";
 export * from "./utils/merge-react-doctor-configs.js";
 export * from "./utils/redact-sensitive-text.js";
+export * from "./utils/resolve-auto-scan-concurrency.js";
 export * from "./utils/resolve-github-actions-score-metadata.js";
 export * from "./utils/resolve-scan-concurrency.js";
 export * from "./utils/to-relative-path.js";

--- a/packages/core/src/refs.ts
+++ b/packages/core/src/refs.ts
@@ -4,6 +4,7 @@ import {
   OXLINT_OUTPUT_MAX_BYTES,
   OXLINT_SPAWN_TIMEOUT_MS,
 } from "./constants.js";
+import { resolveAutoScanConcurrency } from "./utils/resolve-auto-scan-concurrency.js";
 import { resolveScanConcurrency } from "./utils/resolve-scan-concurrency.js";
 
 /**
@@ -39,27 +40,28 @@ export class OxlintOutputMaxBytes extends Context.Reference<number>(
 ) {}
 
 /**
- * Number of oxlint subprocesses the lint pass runs in parallel. Defaults
- * to auto-detected CPU cores (parallel) so large repos scan fast out of
- * the box; `spawnLintBatches` transparently falls back to a single worker
- * if a parallel run exhausts system resources. The CLI's `--no-parallel`
- * flag forces serial via `Layer.succeed`; the `REACT_DOCTOR_PARALLEL` env
- * var seeds the default for programmatic / CI callers that never touch the
- * flag — parallelism is opt-OUT, so only the explicit serial values pin
- * one worker:
+ * Number of oxlint subprocesses the lint pass runs in parallel. Defaults to a
+ * memory-and-core-budgeted auto count (`resolveAutoScanConcurrency`) so large
+ * repos scan fast out of the box without OOMing the native binding on a
+ * high-core / low-memory box; `spawnLintBatches` transparently falls back to a
+ * single worker if a parallel run still exhausts system resources. The CLI's
+ * `--no-parallel` flag forces serial via `Layer.succeed`; the
+ * `REACT_DOCTOR_PARALLEL` env var seeds the default for programmatic / CI
+ * callers that never touch the flag — parallelism is opt-OUT, so only the
+ * explicit serial values pin one worker:
  *
- *   - unset / `auto` / `true` / `on`  → available CPU cores (clamped)
+ *   - unset / `auto` / `true` / `on`  → memory-and-core-budgeted auto count
  *   - `0` / `false` / `off`           → `1` (serial)
  *   - a positive integer              → that many workers (clamped)
- *   - any other value                 → available CPU cores (clamped)
+ *   - any other value                 → memory-and-core-budgeted auto count
  *
  * The resolved value is always within
- * `[MIN_SCAN_CONCURRENCY, MAX_SCAN_CONCURRENCY]`.
+ * `[MIN_SCAN_CONCURRENCY, HARD_MAX_SCAN_CONCURRENCY]`.
  */
 export class OxlintConcurrency extends Context.Reference<number>("react-doctor/OxlintConcurrency", {
   defaultValue: () => {
     const raw = process.env["REACT_DOCTOR_PARALLEL"];
-    if (raw === undefined) return resolveScanConcurrency("auto");
+    if (raw === undefined) return resolveAutoScanConcurrency();
     const normalized = raw.trim().toLowerCase();
     if (normalized === "0" || normalized === "false" || normalized === "off") {
       return MIN_SCAN_CONCURRENCY;
@@ -68,6 +70,6 @@ export class OxlintConcurrency extends Context.Reference<number>("react-doctor/O
     // A positive integer pins the worker count; everything else (empty,
     // `auto`/`true`/`on`, or unparseable) takes the parallel default.
     if (Number.isInteger(parsed) && parsed > 0) return resolveScanConcurrency(parsed);
-    return resolveScanConcurrency("auto");
+    return resolveAutoScanConcurrency();
   },
 }) {}

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -46,6 +46,7 @@ import { Score } from "./services/score.js";
 import { SupplyChain } from "./services/supply-chain.js";
 import type { ScoreRequestMetadata } from "./calculate-score.js";
 import { resolveGithubActionsScoreMetadata } from "./utils/resolve-github-actions-score-metadata.js";
+import { resolveScanConcurrency } from "./utils/resolve-scan-concurrency.js";
 
 export interface InspectInput {
   readonly directory: string;
@@ -161,6 +162,13 @@ export interface InspectOutput {
   readonly scannedFilePaths: ReadonlyArray<string>;
   /** Wall-clock duration of the scan phase, in milliseconds. */
   readonly scanElapsedMilliseconds: number;
+  /**
+   * Resolved lint worker count the linter actually fanned out to (the
+   * `OxlintConcurrency` Reference read through the spawn-boundary clamp).
+   * Surfaced so CLI telemetry reports the real worker count on the auto
+   * path, where the caller's `concurrency` option is `undefined`.
+   */
+  readonly scanConcurrency: number;
 }
 
 /**
@@ -389,10 +397,12 @@ export const runInspect = <HooksR = never>(
       reason: null,
     });
 
-    // Read only for the spinner suffix below (the Linter reads the same
-    // Reference to actually fan out the lint pass); defaults to parallel
-    // (auto-detected cores).
-    const scanConcurrency = yield* OxlintConcurrency;
+    // The actual worker count: clamp the Reference through the same
+    // spawn-boundary clamp the Linter applies, so the spinner suffix and the
+    // `scanConcurrency` we surface for telemetry both reflect the real fan-out
+    // (a programmatic `inspect({ concurrency })` override reaches the Reference
+    // unclamped). Defaults to the memory-and-core-budgeted auto count.
+    const scanConcurrency = resolveScanConcurrency(yield* OxlintConcurrency);
     const workerCountSuffix =
       scanConcurrency > 1 ? ` ${highlighter.dim(`[~${scanConcurrency} workers]`)}` : "";
 
@@ -569,6 +579,7 @@ export const runInspect = <HooksR = never>(
       scannedFileCount: totalFileCount,
       scannedFilePaths,
       scanElapsedMilliseconds,
+      scanConcurrency,
     };
   }).pipe(
     Effect.withSpan("runInspect", {

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -93,7 +93,7 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
   } = input;
   // Clamp at the spawn boundary so any caller — including programmatic
   // `inspect({ concurrency })` that skips the CLI's resolver — is bounded by
-  // the [MIN, MAX] worker ceiling and can't oversubscribe oxlint processes.
+  // the [MIN, HARD_MAX] worker ceiling and can't oversubscribe oxlint processes.
   const requestedConcurrency = resolveScanConcurrency(input.concurrency ?? MIN_SCAN_CONCURRENCY);
   const totalFileCount = fileBatches.reduce((sum, batch) => sum + batch.length, 0);
 

--- a/packages/core/src/utils/read-cgroup-memory-limit-bytes.ts
+++ b/packages/core/src/utils/read-cgroup-memory-limit-bytes.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+
+// cgroup v2 writes the limit (or the literal "max" when unlimited) here; v1
+// exposes it as a byte count (and a near-2^63 value when unlimited). Probed in
+// that order so a v2 host wins before the v1 fallback path is consulted.
+const CGROUP_V2_MEMORY_MAX_PATH = "/sys/fs/cgroup/memory.max";
+const CGROUP_V1_MEMORY_LIMIT_PATH = "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+
+// "Unlimited" sentinel: v2 writes the literal "max" (handled below) while v1
+// writes a near-2^63 value when no limit is set. Anything at or above this is
+// treated as "no limit" so an unconstrained container doesn't read as a tiny
+// budget. `Number.MAX_SAFE_INTEGER` is a safe floor — real container limits
+// (gigabytes) sit far below it, and v1's unlimited value sits far above.
+const CGROUP_UNLIMITED_SENTINEL_BYTES = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Parses one raw cgroup memory-limit file value into a positive byte count, or
+ * `undefined` when it represents "no limit" (the v2 `"max"` literal, an empty
+ * read, a non-positive / non-finite value, or v1's near-2^63 unlimited
+ * sentinel). Pure and exported so the classification is unit-testable without
+ * touching the filesystem.
+ */
+export const parseCgroupMemoryLimitBytes = (raw: string | undefined): number | undefined => {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "max") return undefined;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed >= CGROUP_UNLIMITED_SENTINEL_BYTES) {
+    return undefined;
+  }
+  return parsed;
+};
+
+const CGROUP_MEMORY_LIMIT_PATHS: ReadonlyArray<string> = [
+  CGROUP_V2_MEMORY_MAX_PATH,
+  CGROUP_V1_MEMORY_LIMIT_PATH,
+];
+
+/**
+ * Reads this process's cgroup memory limit in bytes from the first candidate
+ * path that yields a real limit, or `undefined` when none does — no cgroup, no
+ * limit, or the files are unreadable (e.g. macOS / Windows dev machines).
+ * `os.totalmem()` reports the HOST total and ignores cgroup memory limits, so a
+ * memory-constrained container over-reports total memory; `resolveAutoScan-
+ * Concurrency` takes `min(totalmem, this)` to honor the limit.
+ *
+ * The cgroup v2 read is the mount-root `memory.max`, which IS the container's
+ * limit under the standard cgroup-namespace setup CI runners use (the
+ * container's own cgroup is the root of its namespaced view). A process in a
+ * non-namespaced nested/delegated cgroup whose root reads `"max"` is not
+ * detected here and falls back to the host total; the EAGAIN/ENOMEM serial
+ * replay in `spawnLintBatches` remains the runtime backstop for that case.
+ *
+ * `candidatePaths` is injectable so tests exercise the v2-wins-over-v1
+ * precedence, the skip-unreadable fallback, and the all-missing case without a
+ * real `/sys/fs/cgroup`.
+ */
+export const readCgroupMemoryLimitBytes = (
+  candidatePaths: ReadonlyArray<string> = CGROUP_MEMORY_LIMIT_PATHS,
+): number | undefined => {
+  for (const limitPath of candidatePaths) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(limitPath, "utf8");
+    } catch {
+      continue;
+    }
+    const limitBytes = parseCgroupMemoryLimitBytes(raw);
+    if (limitBytes !== undefined) return limitBytes;
+  }
+  return undefined;
+};

--- a/packages/core/src/utils/resolve-auto-scan-concurrency.ts
+++ b/packages/core/src/utils/resolve-auto-scan-concurrency.ts
@@ -1,0 +1,46 @@
+import os from "node:os";
+import { PER_WORKER_MEM_BUDGET_BYTES } from "../constants.js";
+import { readCgroupMemoryLimitBytes } from "./read-cgroup-memory-limit-bytes.js";
+import { resolveScanConcurrency } from "./resolve-scan-concurrency.js";
+
+export interface AutoScanConcurrencyFacts {
+  /** `os.availableParallelism()` — already cgroup-CPU-aware on the supported Node range. */
+  readonly availableCores: number;
+  /** `os.totalmem()` — the HOST total; floored by `cgroupMemoryLimitBytes` below. */
+  readonly totalMemoryBytes: number;
+  /** The cgroup memory limit, or `undefined` when there is none (bare metal / dev machines). */
+  readonly cgroupMemoryLimitBytes: number | undefined;
+}
+
+const readSystemFacts = (): AutoScanConcurrencyFacts => ({
+  availableCores: os.availableParallelism(),
+  totalMemoryBytes: os.totalmem(),
+  cgroupMemoryLimitBytes: readCgroupMemoryLimitBytes(),
+});
+
+/**
+ * Auto lint-worker count: the smaller of the (cgroup-CPU-aware) core count and
+ * the number of `PER_WORKER_MEM_BUDGET_BYTES` workers that fit in available
+ * memory, then clamped to `[MIN, HARD_MAX]` by `resolveScanConcurrency`.
+ *
+ * `os.availableParallelism()` already respects cgroup CPU quotas, so the core
+ * term needs no help. Available memory is `os.totalmem()` floored by the cgroup
+ * memory limit — `os.freemem()` is deliberately NOT used: it excludes
+ * reclaimable page cache and reads near-zero on macOS / cache-heavy Linux, which
+ * would collapse the auto path to a single worker. `os.totalmem()` reports the
+ * host total even inside a container, so the cgroup limit (read directly,
+ * because Node doesn't fold it into `totalmem()`) is the real ceiling there.
+ *
+ * `facts` is injectable so tests exercise core-bound, memory-bound, cgroup-
+ * limited, and ceiling cases without mocking `os` or the filesystem.
+ */
+export const resolveAutoScanConcurrency = (
+  facts: AutoScanConcurrencyFacts = readSystemFacts(),
+): number => {
+  const availableMemoryBytes = Math.min(
+    facts.totalMemoryBytes,
+    facts.cgroupMemoryLimitBytes ?? Number.POSITIVE_INFINITY,
+  );
+  const memoryBoundedWorkers = Math.floor(availableMemoryBytes / PER_WORKER_MEM_BUDGET_BYTES);
+  return resolveScanConcurrency(Math.min(facts.availableCores, memoryBoundedWorkers));
+};

--- a/packages/core/src/utils/resolve-scan-concurrency.ts
+++ b/packages/core/src/utils/resolve-scan-concurrency.ts
@@ -1,14 +1,13 @@
-import os from "node:os";
-import { MAX_SCAN_CONCURRENCY, MIN_SCAN_CONCURRENCY } from "../constants.js";
+import { HARD_MAX_SCAN_CONCURRENCY, MIN_SCAN_CONCURRENCY } from "../constants.js";
 
 /**
- * Resolves a requested lint worker count to a clamped integer within
- * `[MIN_SCAN_CONCURRENCY, MAX_SCAN_CONCURRENCY]`. `"auto"` uses the
- * machine's CPU cores; out-of-range or non-finite requests degrade to
+ * Clamps a requested lint worker count to `[MIN_SCAN_CONCURRENCY,
+ * HARD_MAX_SCAN_CONCURRENCY]` as a finite integer. This is the explicit-pin and
+ * spawn-boundary clamp — the memory-and-core-budgeted auto count comes from
+ * `resolveAutoScanConcurrency`. Out-of-range or non-finite requests degrade to
  * `MIN_SCAN_CONCURRENCY` rather than oversubscribing or running zero workers.
  */
-export const resolveScanConcurrency = (requested: number | "auto"): number => {
-  const desired = requested === "auto" ? os.availableParallelism() : requested;
-  if (!Number.isFinite(desired) || desired < MIN_SCAN_CONCURRENCY) return MIN_SCAN_CONCURRENCY;
-  return Math.max(MIN_SCAN_CONCURRENCY, Math.min(Math.floor(desired), MAX_SCAN_CONCURRENCY));
+export const resolveScanConcurrency = (requested: number): number => {
+  if (!Number.isFinite(requested) || requested < MIN_SCAN_CONCURRENCY) return MIN_SCAN_CONCURRENCY;
+  return Math.min(Math.floor(requested), HARD_MAX_SCAN_CONCURRENCY);
 };

--- a/packages/core/tests/oxlint-concurrency-default.test.ts
+++ b/packages/core/tests/oxlint-concurrency-default.test.ts
@@ -1,7 +1,7 @@
 /**
  * Guards the "parallel by default" contract: with no `REACT_DOCTOR_PARALLEL`
- * override, the `OxlintConcurrency` Reference resolves to auto-detected CPU
- * cores (parallel), not `1` (serial).
+ * override, the `OxlintConcurrency` Reference resolves to the memory-and-core-
+ * budgeted auto count (parallel), not `1` (serial).
  *
  * The Reference caches its `defaultValue` on first access, so this asserts a
  * single read with the env var cleared beforehand — enough to catch a
@@ -10,11 +10,11 @@
 
 import * as Effect from "effect/Effect";
 import { describe, expect, it } from "vite-plus/test";
-import { OxlintConcurrency, resolveScanConcurrency } from "@react-doctor/core";
+import { OxlintConcurrency, resolveAutoScanConcurrency } from "@react-doctor/core";
 
 describe("OxlintConcurrency default", () => {
-  it("defaults to auto-detected cores (parallel) when REACT_DOCTOR_PARALLEL is unset", () => {
+  it("defaults to the auto-budgeted worker count (parallel) when REACT_DOCTOR_PARALLEL is unset", () => {
     delete process.env.REACT_DOCTOR_PARALLEL;
-    expect(Effect.runSync(OxlintConcurrency)).toBe(resolveScanConcurrency("auto"));
+    expect(Effect.runSync(OxlintConcurrency)).toBe(resolveAutoScanConcurrency());
   });
 });

--- a/packages/core/tests/read-cgroup-memory-limit-bytes.test.ts
+++ b/packages/core/tests/read-cgroup-memory-limit-bytes.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  parseCgroupMemoryLimitBytes,
+  readCgroupMemoryLimitBytes,
+} from "../src/utils/read-cgroup-memory-limit-bytes.js";
+
+describe("parseCgroupMemoryLimitBytes", () => {
+  it("parses a numeric cgroup v2 / v1 byte value", () => {
+    expect(parseCgroupMemoryLimitBytes("4294967296")).toBe(4294967296);
+    expect(parseCgroupMemoryLimitBytes(" 4294967296\n")).toBe(4294967296);
+  });
+
+  it("treats the cgroup v2 'max' literal as no limit", () => {
+    expect(parseCgroupMemoryLimitBytes("max")).toBe(undefined);
+    expect(parseCgroupMemoryLimitBytes(" max \n")).toBe(undefined);
+  });
+
+  it("treats an empty / undefined read as no limit", () => {
+    expect(parseCgroupMemoryLimitBytes("")).toBe(undefined);
+    expect(parseCgroupMemoryLimitBytes("   ")).toBe(undefined);
+    expect(parseCgroupMemoryLimitBytes(undefined)).toBe(undefined);
+  });
+
+  it("treats the cgroup v1 near-2^63 unlimited sentinel as no limit", () => {
+    // The canonical v1 "unlimited" value on a 64-bit host.
+    expect(parseCgroupMemoryLimitBytes("9223372036854771712")).toBe(undefined);
+  });
+
+  it("treats non-positive or non-numeric values as no limit", () => {
+    expect(parseCgroupMemoryLimitBytes("0")).toBe(undefined);
+    expect(parseCgroupMemoryLimitBytes("-1")).toBe(undefined);
+    expect(parseCgroupMemoryLimitBytes("not-a-number")).toBe(undefined);
+  });
+});
+
+describe("readCgroupMemoryLimitBytes", () => {
+  let temporaryDirectory: string;
+  const missingPath = "/nonexistent/react-doctor-cgroup-test/memory.max";
+
+  const writeLimitFile = (fileName: string, contents: string): string => {
+    const filePath = path.join(temporaryDirectory, fileName);
+    fs.writeFileSync(filePath, contents);
+    return filePath;
+  };
+
+  beforeEach(() => {
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-cgroup-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it("prefers the first (v2) path when both yield a limit", () => {
+    const v2Path = writeLimitFile("v2-memory.max", "2147483648");
+    const v1Path = writeLimitFile("v1-limit_in_bytes", "4294967296");
+    expect(readCgroupMemoryLimitBytes([v2Path, v1Path])).toBe(2147483648);
+  });
+
+  it("falls through to the next path when the first is unreadable", () => {
+    const v1Path = writeLimitFile("v1-limit_in_bytes", "4294967296");
+    expect(readCgroupMemoryLimitBytes([missingPath, v1Path])).toBe(4294967296);
+  });
+
+  it("falls through when the first path reports 'max' (no limit there)", () => {
+    const v2Path = writeLimitFile("v2-memory.max", "max");
+    const v1Path = writeLimitFile("v1-limit_in_bytes", "4294967296");
+    expect(readCgroupMemoryLimitBytes([v2Path, v1Path])).toBe(4294967296);
+  });
+
+  it("returns undefined when no path yields a real limit", () => {
+    const unlimitedV2Path = writeLimitFile("v2-memory.max", "max");
+    expect(readCgroupMemoryLimitBytes([missingPath, unlimitedV2Path])).toBe(undefined);
+  });
+
+  it("returns a positive byte count or undefined on the real system (no throw)", () => {
+    // Dev Macs / Windows have no /sys/fs/cgroup → undefined; a Linux container
+    // returns its limit. Either way it must never throw or be non-positive.
+    const limit = readCgroupMemoryLimitBytes();
+    expect(limit === undefined || (typeof limit === "number" && limit > 0)).toBe(true);
+  });
+});

--- a/packages/core/tests/resolve-auto-scan-concurrency.test.ts
+++ b/packages/core/tests/resolve-auto-scan-concurrency.test.ts
@@ -1,0 +1,99 @@
+import os from "node:os";
+import { describe, expect, it } from "vite-plus/test";
+import { HARD_MAX_SCAN_CONCURRENCY, MIN_SCAN_CONCURRENCY } from "../src/constants.js";
+import { readCgroupMemoryLimitBytes } from "../src/utils/read-cgroup-memory-limit-bytes.js";
+import { resolveAutoScanConcurrency } from "../src/utils/resolve-auto-scan-concurrency.js";
+
+const GIB = 1024 * 1024 * 1024;
+const MIB = 1024 * 1024;
+
+describe("resolveAutoScanConcurrency", () => {
+  it("is core-bound when memory is plentiful", () => {
+    // floor(64 GiB / 1 GiB) = 64 workers fit, so the 8 cores bind.
+    expect(
+      resolveAutoScanConcurrency({
+        availableCores: 8,
+        totalMemoryBytes: 64 * GIB,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(8);
+  });
+
+  it("does not regress a 16-core / 16 GiB machine below the old fixed ceiling", () => {
+    // 1 GiB/worker is calibrated so the common 1 GiB/core shape stays core-bound:
+    // floor(16 / 1) = 16, so a 16-core box still runs 16 workers (not fewer).
+    expect(
+      resolveAutoScanConcurrency({
+        availableCores: 16,
+        totalMemoryBytes: 16 * GIB,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(16);
+  });
+
+  it("is memory-bound on a high-core / memory-starved box", () => {
+    // floor(6 GiB / 1 GiB) = 6 — a 64-core box with little RAM does NOT spawn
+    // 32 workers (the native-binding SIGABRT trap this budget exists to avoid).
+    expect(
+      resolveAutoScanConcurrency({
+        availableCores: 64,
+        totalMemoryBytes: 6 * GIB,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(6);
+  });
+
+  it("honors a cgroup memory limit below the host total", () => {
+    // The container sees 200 GiB of HOST memory via os.totalmem(), but its
+    // cgroup caps it at 4 GiB → floor(4 / 1) = 4. This is the case Node's
+    // totalmem()/freemem() both get wrong without the direct cgroup read.
+    expect(
+      resolveAutoScanConcurrency({
+        availableCores: 64,
+        totalMemoryBytes: 200 * GIB,
+        cgroupMemoryLimitBytes: 4 * GIB,
+      }),
+    ).toBe(4);
+  });
+
+  it("never exceeds HARD_MAX_SCAN_CONCURRENCY", () => {
+    expect(
+      resolveAutoScanConcurrency({
+        availableCores: 128,
+        totalMemoryBytes: 256 * GIB,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(HARD_MAX_SCAN_CONCURRENCY);
+  });
+
+  it("floors to MIN when not even one worker's budget fits", () => {
+    expect(
+      resolveAutoScanConcurrency({
+        availableCores: 64,
+        totalMemoryBytes: 256 * MIB,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(MIN_SCAN_CONCURRENCY);
+  });
+
+  it("returns an integer within [MIN, HARD_MAX] on the real system", () => {
+    const resolved = resolveAutoScanConcurrency();
+    expect(Number.isInteger(resolved)).toBe(true);
+    expect(resolved).toBeGreaterThanOrEqual(MIN_SCAN_CONCURRENCY);
+    expect(resolved).toBeLessThanOrEqual(HARD_MAX_SCAN_CONCURRENCY);
+  });
+
+  it("sources total (not free) memory on the real system", () => {
+    // Pins that the default facts use os.totalmem() + os.availableParallelism()
+    // + the cgroup limit. If `readSystemFacts` ever regressed to os.freemem()
+    // (which reads ~0 of a large total on macOS / cache-heavy Linux, collapsing
+    // the scan to one worker), the no-arg call would diverge from this
+    // total-memory recomputation and this assertion would fail.
+    const fromTotalMemory = resolveAutoScanConcurrency({
+      availableCores: os.availableParallelism(),
+      totalMemoryBytes: os.totalmem(),
+      cgroupMemoryLimitBytes: readCgroupMemoryLimitBytes(),
+    });
+    expect(resolveAutoScanConcurrency()).toBe(fromTotalMemory);
+  });
+});

--- a/packages/core/tests/resolve-scan-concurrency.test.ts
+++ b/packages/core/tests/resolve-scan-concurrency.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vite-plus/test";
-import { MAX_SCAN_CONCURRENCY, MIN_SCAN_CONCURRENCY } from "../src/constants.js";
+import { HARD_MAX_SCAN_CONCURRENCY, MIN_SCAN_CONCURRENCY } from "../src/constants.js";
 import { resolveScanConcurrency } from "../src/utils/resolve-scan-concurrency.js";
 
 describe("resolveScanConcurrency", () => {
   it("passes through in-range integers unchanged", () => {
     expect(resolveScanConcurrency(4)).toBe(4);
     expect(resolveScanConcurrency(MIN_SCAN_CONCURRENCY)).toBe(MIN_SCAN_CONCURRENCY);
-    expect(resolveScanConcurrency(MAX_SCAN_CONCURRENCY)).toBe(MAX_SCAN_CONCURRENCY);
+    expect(resolveScanConcurrency(HARD_MAX_SCAN_CONCURRENCY)).toBe(HARD_MAX_SCAN_CONCURRENCY);
   });
 
-  it("clamps to MAX above the ceiling", () => {
-    expect(resolveScanConcurrency(MAX_SCAN_CONCURRENCY + 100)).toBe(MAX_SCAN_CONCURRENCY);
+  it("clamps to HARD_MAX above the ceiling", () => {
+    expect(resolveScanConcurrency(HARD_MAX_SCAN_CONCURRENCY + 100)).toBe(HARD_MAX_SCAN_CONCURRENCY);
   });
 
   it("clamps to MIN at or below the floor", () => {
@@ -24,12 +24,6 @@ describe("resolveScanConcurrency", () => {
 
   it("falls back to MIN for non-finite requests", () => {
     expect(resolveScanConcurrency(Number.NaN)).toBe(MIN_SCAN_CONCURRENCY);
-  });
-
-  it("resolves 'auto' to an integer within [MIN, MAX]", () => {
-    const resolved = resolveScanConcurrency("auto");
-    expect(Number.isInteger(resolved)).toBe(true);
-    expect(resolved).toBeGreaterThanOrEqual(MIN_SCAN_CONCURRENCY);
-    expect(resolved).toBeLessThanOrEqual(MAX_SCAN_CONCURRENCY);
+    expect(resolveScanConcurrency(Number.POSITIVE_INFINITY)).toBe(MIN_SCAN_CONCURRENCY);
   });
 });

--- a/packages/react-doctor/src/cli/utils/record-scan-metrics.ts
+++ b/packages/react-doctor/src/cli/utils/record-scan-metrics.ts
@@ -47,8 +47,14 @@ export interface ScanMetricsInput {
   readonly result: InspectResult;
   /** `"diff"` (changed/staged files) or `"full"` (whole project). */
   readonly mode: string;
+  /** Whether the lint pass fanned out to more than one worker (`workerCount > 1`). */
   readonly parallel: boolean;
-  /** Resolved oxlint worker count when `--experimental-parallel` is active. */
+  /**
+   * Resolved lint worker count the scan actually used — the auto-detected
+   * count on the default parallel path, or the caller's `REACT_DOCTOR_PARALLEL`
+   * / `inspect({ concurrency })` pin. `undefined` only when a pre-field cache
+   * hit can't recover it.
+   */
   readonly workerCount: number | undefined;
   readonly lint: boolean;
   readonly deadCode: boolean;

--- a/packages/react-doctor/src/cli/utils/resolve-worker-telemetry.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-worker-telemetry.ts
@@ -1,0 +1,24 @@
+export interface WorkerTelemetry {
+  /** The lint worker count to report, or `undefined` when neither source knows it. */
+  readonly workerCount: number | undefined;
+  /** Whether the lint pass fanned out to more than one worker. */
+  readonly parallel: boolean;
+}
+
+/**
+ * Projects the resolved lint worker count into the `(workerCount, parallel)`
+ * telemetry pair. `resolvedWorkerCount` is the count the scan actually fanned
+ * out to (`InspectOutput.scanConcurrency`); `pinnedConcurrency` is the caller's
+ * `inspect({ concurrency })` pin, used as the fallback when no scan resolved a
+ * count (the pre-scan failure path, or a cache entry persisted before the
+ * resolved count was tracked). `parallel` is derived from the count — NOT from
+ * whether a count was pinned — so the common auto path (no pin) still reports
+ * parallelism correctly instead of always reading `false`.
+ */
+export const resolveWorkerTelemetry = (
+  resolvedWorkerCount: number | undefined,
+  pinnedConcurrency: number | undefined,
+): WorkerTelemetry => {
+  const workerCount = resolvedWorkerCount ?? pinnedConcurrency;
+  return { workerCount, parallel: workerCount !== undefined && workerCount > 1 };
+};

--- a/packages/react-doctor/src/cli/utils/scan-result-cache.ts
+++ b/packages/react-doctor/src/cli/utils/scan-result-cache.ts
@@ -39,6 +39,12 @@ export interface CachedScanPayload {
   readonly scanElapsedMilliseconds: number;
   readonly baselineDelta: InspectResult["baselineDelta"];
   readonly lintFailureReasonKind: InspectOutput["lintFailureReasonKind"];
+  /**
+   * Resolved lint worker count (`InspectOutput["scanConcurrency"]`), surfaced
+   * for telemetry. Optional so cache entries persisted before this field
+   * existed still load — a stale hit falls back to the caller's `concurrency`.
+   */
+  readonly scanConcurrency?: number;
 }
 
 interface PersistedScanResultCacheEntry {

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -27,6 +27,7 @@ import { BASELINE_FILES_TEMP_DIR_PREFIX, METRIC } from "./cli/utils/constants.js
 import { recordCount } from "./cli/utils/record-metric.js";
 import { recordScanMetrics } from "./cli/utils/record-scan-metrics.js";
 import { recordRunEvent } from "./cli/utils/build-run-event.js";
+import { resolveWorkerTelemetry } from "./cli/utils/resolve-worker-telemetry.js";
 import type {
   ChangedFileLineRanges,
   Diagnostic,
@@ -234,21 +235,32 @@ const buildRunEventConfig = (
   options: ResolvedInspectOptions,
   userConfig: ReactDoctorConfig | null,
   hasCustomConfig: boolean,
-) => ({
-  scope: deriveScope(options),
-  parallel: options.concurrency !== undefined,
-  workerCount: options.concurrency,
-  lint: options.lint,
-  deadCode: options.deadCode,
-  scoreOnly: options.scoreOnly,
-  noScore: options.noScore,
-  respectInlineDisables: options.respectInlineDisables,
-  showWarnings: options.warnings,
-  usedOutputDir: options.outputDirectory !== null,
-  ignoredTagCount: options.ignoredTags.size,
-  hasCustomConfig,
-  userConfig,
-});
+  // The worker count the scan actually resolved to (`output.scanConcurrency`),
+  // which is the real value on the auto path where `options.concurrency` is
+  // `undefined`. Omitted on the pre-scan failure path (no scan ran), where it
+  // falls back to the caller's pin.
+  resolvedWorkerCount?: number,
+) => {
+  const { workerCount, parallel } = resolveWorkerTelemetry(
+    resolvedWorkerCount,
+    options.concurrency,
+  );
+  return {
+    scope: deriveScope(options),
+    parallel,
+    workerCount,
+    lint: options.lint,
+    deadCode: options.deadCode,
+    scoreOnly: options.scoreOnly,
+    noScore: options.noScore,
+    respectInlineDisables: options.respectInlineDisables,
+    showWarnings: options.warnings,
+    usedOutputDir: options.outputDirectory !== null,
+    ignoredTagCount: options.ignoredTags.size,
+    hasCustomConfig,
+    userConfig,
+  };
+};
 
 export const inspect = async (
   directory: string,
@@ -688,6 +700,7 @@ const runInspectWithRuntime = async (
     scannedFileCount: output.scannedFileCount,
     scannedFilePaths: output.scannedFilePaths,
     scanElapsedMilliseconds: output.scanElapsedMilliseconds,
+    scanConcurrency: output.scanConcurrency,
     baselineDelta,
     lintFailureReasonKind: lintBindingMissing
       ? "native-binding-missing"
@@ -793,12 +806,19 @@ const renderAndRecordScan = async (input: RenderAndRecordScanInput): Promise<Ins
   const result = await Effect.runPromise(
     runMaybeSilent(finalizeAndRender(finalizeInput), input.options.silent),
   );
+  // The real worker count the scan fanned out to (resolved auto count on the
+  // common parallel path, where the caller pinned no `concurrency`). A stale
+  // cache hit predating the field falls back to the caller's pin.
+  const { workerCount: resolvedWorkerCount, parallel } = resolveWorkerTelemetry(
+    input.payload.scanConcurrency,
+    input.options.concurrency,
+  );
   recordScanMetrics({
     result,
     mode: input.scanMode,
     baselineDegraded: input.baselineDegraded,
-    parallel: input.options.concurrency !== undefined,
-    workerCount: input.options.concurrency,
+    parallel,
+    workerCount: resolvedWorkerCount,
     lint: input.options.lint,
     deadCode: input.options.deadCode,
     scoreOnly: input.options.scoreOnly,
@@ -808,7 +828,12 @@ const renderAndRecordScan = async (input: RenderAndRecordScanInput): Promise<Ins
     didDeadCodeFail: input.payload.didDeadCodeFail,
   });
   recordRunEvent(input.rootSentrySpan, {
-    ...buildRunEventConfig(input.options, input.userConfig, input.hasCustomConfig),
+    ...buildRunEventConfig(
+      input.options,
+      input.userConfig,
+      input.hasCustomConfig,
+      resolvedWorkerCount,
+    ),
     result,
     mode: input.scanMode,
     gateExempt: input.baselineDegraded,

--- a/packages/react-doctor/tests/resolve-worker-telemetry.test.ts
+++ b/packages/react-doctor/tests/resolve-worker-telemetry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveWorkerTelemetry } from "../src/cli/utils/resolve-worker-telemetry.js";
+
+describe("resolveWorkerTelemetry", () => {
+  it("reports the resolved auto count and parallel=true when no count was pinned", () => {
+    // The headline case: auto path, caller pinned nothing — telemetry must still
+    // see the real worker count and read parallel, not fall back to false.
+    expect(resolveWorkerTelemetry(8, undefined)).toEqual({ workerCount: 8, parallel: true });
+  });
+
+  it("reports parallel=false for a single-worker (serial) run", () => {
+    expect(resolveWorkerTelemetry(1, undefined)).toEqual({ workerCount: 1, parallel: false });
+    // A pinned serial run (`inspect({ concurrency: 1 })`) is NOT parallel, even
+    // though a count was pinned — the old `concurrency !== undefined` proxy got
+    // this wrong.
+    expect(resolveWorkerTelemetry(1, 1)).toEqual({ workerCount: 1, parallel: false });
+  });
+
+  it("prefers the resolved count over the pin", () => {
+    expect(resolveWorkerTelemetry(12, 4)).toEqual({ workerCount: 12, parallel: true });
+  });
+
+  it("falls back to the pin when no resolved count is available (stale cache / failure path)", () => {
+    expect(resolveWorkerTelemetry(undefined, 4)).toEqual({ workerCount: 4, parallel: true });
+    expect(resolveWorkerTelemetry(undefined, 1)).toEqual({ workerCount: 1, parallel: false });
+  });
+
+  it("reports an undefined count and parallel=false when neither source knows it", () => {
+    expect(resolveWorkerTelemetry(undefined, undefined)).toEqual({
+      workerCount: undefined,
+      parallel: false,
+    });
+  });
+});


### PR DESCRIPTION
## Why

The auto lint concurrency hard-clamps to **16** oxlint workers (`resolveScanConcurrency`), so a 32/64-core CI runner idles cores behind an arbitrary ceiling. The 16 existed purely to bound peak memory (each worker holds its batch's ASTs; the oxlint native binding SIGABRTs under memory pressure). The right control variable is memory + cores, not a fixed number.

Before:

```
auto workers = min(cores, 16)        // 32-core runner → 16 workers, 16 cores idle
```

After:

```
auto workers = clamp(min(cores, floor(availableMemory / 1 GiB)), 1, 32)
  availableMemory = min(os.totalmem(), cgroupMemoryLimit)
// 32-core/64GB runner → 32 workers; 64-core/8GB container → 8 (OOM-safe);
// 16-core/16GB laptop → 16 (unchanged)
```

Impact is **headroom + OOM-safety, not a 2x** — measured parallel efficiency already flattens past ~10 workers (39% at 10w on a 21.7k-file repo), and lint is the minority phase of a full scan. This removes the arbitrary 16 ceiling and adds a proactive memory guard the code previously only handled reactively (the EAGAIN/ENOMEM serial replay).

## What changed

- **`resolve-scan-concurrency.ts`** is now a pure `[MIN, HARD_MAX=32]` integer clamp (explicit-pin + spawn-boundary clamp). The `"auto"` branch moved to a new **`resolve-auto-scan-concurrency.ts`** (`min(cores, floor(availableMemory / PER_WORKER_MEM_BUDGET_BYTES))`, injectable facts for tests).
- New **`read-cgroup-memory-limit-bytes.ts`** reads the container's cgroup v2/v1 memory limit (Node's `os.totalmem()`/`freemem()` report the *host* total inside a container).
- **Budget by `os.totalmem()`, not `os.freemem()`** — `freemem()` excludes reclaimable page cache and reads ~0 on macOS / cache-heavy Linux, which would have collapsed the default scan to a single worker. `PER_WORKER_MEM_BUDGET_BYTES = 1 GiB` keeps machines with ≥1 GiB/core core-bound (unchanged from today); only memory-starved hosts/containers are reduced.
- `MAX_SCAN_CONCURRENCY` (the old fixed 16) is **removed** from core (the `language-server` package keeps its own independent copy). Explicit `REACT_DOCTOR_PARALLEL=N` / `inspect({ concurrency: N })` pins now clamp to 32.
- **Telemetry**: the resolved worker count is threaded `InspectOutput → CachedScanPayload → recordScanMetrics/recordRunEvent`, so `oxlint.workers` (and the wide-event `workerCount`/`parallel`) report the real auto count, not just explicit pins. `parallel` now derives from `workerCount > 1` (was `concurrency !== undefined`, wrong in both directions).
- The EAGAIN/ENOMEM serial replay backstop is untouched. Patch changeset for `react-doctor` + `@react-doctor/core`.

## Test plan

- `pnpm typecheck` — 11/11 ✅
- `pnpm lint` / `pnpm format:check` — clean ✅
- `pnpm test` (core / react-doctor / api) — green ✅. New: `resolve-auto-scan-concurrency.test.ts` (core-bound, memory-bound, cgroup-override, HARD_MAX ceiling, floor-to-MIN, no-regression-at-16c/16GB, totalmem-source pin), `read-cgroup-memory-limit-bytes.test.ts` (parser + v2-over-v1 precedence / skip-unreadable / fallback), `resolve-worker-telemetry.test.ts`.
- `pnpm smoke:json-report` — `schemaVersion=1`, unchanged ✅
- Note: 2 pre-existing local failures (`check-expo-project` / `check-security-scan`) are the global `.env*` gitignore trap, unrelated to this change — they pass when the global ignore is neutralized.

## Rollout notes

- No-op on machines with ≥1 GiB/core (most laptops/CI); observable only on ≥17-core runners with memory. Reversible per-user today via `REACT_DOCTOR_PARALLEL≤16`, or globally via a one-line `HARD_MAX_SCAN_CONCURRENCY` 32→16.
- Prove-it (Sentry Spans): `p50/p95/max(oxlint.workers)` by `runnerOs` + core bucket. Kill metric: roll back if `lint.failed{reasonKind: oom|killed}` or the serial-replay rate rises.
- `diagnose({ projects })` batches can now spawn up to `4 × 32` concurrent oxlint processes on a large runner (was `4 × 16`); the per-project serial replay backstops over-subscription (a follow-up could divide the per-project budget by the batch concurrency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default subprocess fan-out and peak memory on large CI runners and batched `diagnose` scans; cgroup mis-detection is mitigated by serial replay but could still cause transient OOM pressure.
> 
> **Overview**
> **Auto oxlint parallelism** no longer hard-caps at 16 workers. The default path uses `min(cores, floor(availableMemory / 1 GiB))` clamped to `[1, 32]`, where available memory is `os.totalmem()` capped by a **cgroup v2/v1** read (not `freemem()`). Explicit pins (`REACT_DOCTOR_PARALLEL`, `inspect({ concurrency })`) clamp to **32** instead of 16; `resolveScanConcurrency` is now only the integer clamp, with **`resolveAutoScanConcurrency`** owning the auto logic.
> 
> **Inspect / CLI** surfaces the resolved fan-out as `scanConcurrency` (spinner `[~N workers]`, scan cache, metrics). **`resolveWorkerTelemetry`** sets `parallel` from `workerCount > 1` so auto runs report real parallelism and `oxlint.workers` distributions, not “pinned only” behavior.
> 
> Typical ≥1 GiB/core machines stay **unchanged** at 16 workers; large CI runners can use more workers; memory-tight hosts/containers spawn fewer. Multi-project `diagnose` batches can multiply concurrent oxlint processes further (noted in the changeset); existing **EAGAIN/ENOMEM** serial replay remains the backstop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ee5feb1a43365b687b87b6cc55926067ad9df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->