### PR TITLE
fix: make GitHub Actions setup flow idempotent and stop bundling local changes

### DIFF
--- a/.changeset/fix-setup-flow-idempotent-pr.md
+++ b/.changeset/fix-setup-flow-idempotent-pr.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix the GitHub Actions setup flow opening duplicate PRs and bundling unrelated local changes (#904). Before creating a branch, `openWorkflowPullRequest` now checks for an already-open React Doctor setup PR and surfaces it instead of minting a second timestamped branch, and it bails when the working tree has tracked changes other than the workflow file (which `git checkout -b` + the whole-index `git commit` would otherwise sweep into the PR), falling back to staging the workflow file.

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -34,6 +34,11 @@ export const AGENT_HOOK_TIMEOUT_SECONDS = 120;
 // git fallbacks behind it are correct for almost every repo — so fail fast.
 export const GH_DEFAULT_BRANCH_PROBE_TIMEOUT_MS = 5000;
 
+// Cap on open PRs scanned when checking for an already-open React Doctor
+// setup PR (the idempotency guard). Far above any realistic count of open
+// PRs whose head sits under the setup-branch prefix.
+export const GH_PR_LIST_MAX = 100;
+
 // Cap on files listed per rule in the agent-handoff prompt so it stays a
 // compact, passable CLI argument.
 export const HANDOFF_MAX_FILES_PER_RULE = 3;

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -89,6 +89,10 @@ const upgradeGitHubActionsWorkflow = async (
     upgradeSpinner.succeed(
       `Opened pull request for review: ${highlighter.info(pullRequestResult.url)}`,
     );
+  } else if (pullRequestResult.status === "pr-exists") {
+    upgradeSpinner.succeed(
+      `A React Doctor pull request is already open: ${highlighter.info(pullRequestResult.url)}`,
+    );
   } else if (pullRequestResult.status === "branch-pushed") {
     upgradeSpinner.warn(
       `Pushed branch ${highlighter.bold(

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -90,6 +90,14 @@ const upgradeGitHubActionsWorkflow = async (
       `Opened pull request for review: ${highlighter.info(pullRequestResult.url)}`,
     );
   } else if (pullRequestResult.status === "pr-exists") {
+    // `pr-exists` returns without touching git state, so the @v2 edit we wrote
+    // above still sits uncommitted in the working tree. Restore the original
+    // @v1 content — the bump lives on the already-open PR's branch — matching
+    // the pr-opened path's "the bump lives only on the PR branch" contract so
+    // the user can't accidentally commit a stray edit to their working branch.
+    try {
+      fs.writeFileSync(workflow.workflowPath, workflow.content);
+    } catch {}
     upgradeSpinner.succeed(
       `A React Doctor pull request is already open: ${highlighter.info(pullRequestResult.url)}`,
     );

--- a/packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts
+++ b/packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts
@@ -63,14 +63,17 @@ const findUniqueBranchName = async (cwd: string, run: CommandRunner): Promise<st
   return `${NEW_BRANCH_PREFIX}-${stamp}`;
 };
 
-// Returns the URL of an already-open React Doctor setup PR, or null when
-// none is open. Matches any head branch under the setup prefix so it catches
-// both the canonical branch and earlier timestamped variants. Best-effort:
-// a failed or unparsable `gh` call returns null so setup still proceeds.
+// Returns the already-open React Doctor setup PR, or null when none is open.
+// Matches any head branch under the setup prefix so it catches both the
+// canonical branch and earlier timestamped variants. Returns the matched PR
+// itself (not just its URL) so the caller short-circuits on the PR's
+// *existence* — never opening a duplicate even if `gh` omits the URL field.
+// Best-effort: a failed or unparsable `gh` call returns null so setup still
+// proceeds.
 const findExistingSetupPullRequest = async (
   cwd: string,
   run: CommandRunner,
-): Promise<string | null> => {
+): Promise<OpenPullRequestSummary | null> => {
   const prList = await run(
     "gh",
     [
@@ -88,10 +91,11 @@ const findExistingSetupPullRequest = async (
   if (!prList.success) return null;
   try {
     const openPullRequests: OpenPullRequestSummary[] = JSON.parse(prList.stdout);
-    const setupPullRequest = openPullRequests.find((pullRequest) =>
-      (pullRequest.headRefName ?? "").startsWith(NEW_BRANCH_PREFIX),
+    return (
+      openPullRequests.find((pullRequest) =>
+        (pullRequest.headRefName ?? "").startsWith(NEW_BRANCH_PREFIX),
+      ) ?? null
     );
-    return setupPullRequest?.url ?? null;
   } catch {
     return null;
   }
@@ -188,8 +192,10 @@ export const openWorkflowPullRequest = async (params: {
   // so without this guard `findUniqueBranchName` would mint a timestamped
   // branch and `gh pr create` would open a second PR for the same change
   // (issue #904).
-  const existingPullRequestUrl = await findExistingSetupPullRequest(cwd, run);
-  if (existingPullRequestUrl) return { status: "pr-exists", url: existingPullRequestUrl };
+  const existingSetupPullRequest = await findExistingSetupPullRequest(cwd, run);
+  if (existingSetupPullRequest) {
+    return { status: "pr-exists", url: existingSetupPullRequest.url ?? "" };
+  }
 
   // Bail before touching any git state if the working tree carries unrelated
   // tracked changes: the checkout + whole-index commit below would otherwise

--- a/packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts
+++ b/packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts
@@ -1,9 +1,16 @@
 import * as path from "node:path";
 import { detectDefaultBranch } from "./detect-default-branch.js";
 import { isCommandAvailable } from "./is-command-available.js";
-import { runCommand as run } from "./run-command.js";
+import { runCommand, type CommandRunner } from "./run-command.js";
 
 const NEW_BRANCH_PREFIX = "react-doctor/add-github-actions";
+
+// One open PR returned by `gh pr list --json headRefName,url`. Only the two
+// fields the idempotency check reads are modeled; `gh` emits more.
+interface OpenPullRequestSummary {
+  readonly headRefName?: string;
+  readonly url?: string;
+}
 
 const DEFAULT_COMMIT_MESSAGE = "ci: add React Doctor GitHub Actions workflow";
 
@@ -18,6 +25,9 @@ Docs: https://www.react.doctor/ci`;
 
 export type OpenWorkflowPullRequestResult =
   | { readonly status: "pr-opened"; readonly url: string }
+  // A React Doctor setup PR is already open — we surface it instead of
+  // opening a duplicate (issue #904). Caller reports the existing URL.
+  | { readonly status: "pr-exists"; readonly url: string }
   // Commit + push succeeded but \`gh pr create\` failed — the branch is on
   // the remote so the user can still open a PR manually.
   | { readonly status: "branch-pushed"; readonly branch: string }
@@ -31,6 +41,10 @@ export type NotAttemptedReason =
   | "not-a-git-repo"
   | "no-default-branch"
   | "detached-head"
+  // The working tree has tracked (staged or unstaged) modifications, which
+  // `git checkout -b` would carry onto the PR branch and the whole-index
+  // `git commit` would sweep in alongside the workflow file (issue #904).
+  | "working-tree-dirty"
   | "checkout-failed"
   | "git-add-failed"
   | "git-commit-failed"
@@ -39,7 +53,7 @@ export type NotAttemptedReason =
 // Tries `react-doctor/add-github-actions` first and appends a compact
 // timestamp suffix if a local branch already exists with that name (avoids
 // clobbering a previous attempt's branch).
-const findUniqueBranchName = async (cwd: string): Promise<string> => {
+const findUniqueBranchName = async (cwd: string, run: CommandRunner): Promise<string> => {
   if (!(await run("git", ["rev-parse", "--verify", NEW_BRANCH_PREFIX], cwd)).success) {
     return NEW_BRANCH_PREFIX;
   }
@@ -47,12 +61,64 @@ const findUniqueBranchName = async (cwd: string): Promise<string> => {
   return `${NEW_BRANCH_PREFIX}-${stamp}`;
 };
 
+// Returns the URL of an already-open React Doctor setup PR, or null when
+// none is open. Matches any head branch under the setup prefix so it catches
+// both the canonical branch and earlier timestamped variants. Best-effort:
+// a failed or unparsable `gh` call returns null so setup still proceeds.
+const findExistingSetupPullRequest = async (
+  cwd: string,
+  run: CommandRunner,
+): Promise<string | null> => {
+  const prList = await run(
+    "gh",
+    ["pr", "list", "--state", "open", "--json", "headRefName,url", "--limit", "100"],
+    cwd,
+  );
+  if (!prList.success) return null;
+  try {
+    const openPullRequests: OpenPullRequestSummary[] = JSON.parse(prList.stdout);
+    const setupPullRequest = openPullRequests.find((pullRequest) =>
+      (pullRequest.headRefName ?? "").startsWith(NEW_BRANCH_PREFIX),
+    );
+    return setupPullRequest?.url ?? null;
+  } catch {
+    return null;
+  }
+};
+
+// True when the working tree has tracked changes (staged or unstaged) to
+// files OTHER than the workflow itself. `git checkout -b` carries those onto
+// the fresh branch and the whole-index `git commit` would then sweep them
+// into the PR (issue #904). The workflow file is excluded because it's the
+// one change we *do* mean to commit — newly written (fresh install) or
+// modified in place (the v1→v2 upgrade). Untracked entries (`??`) are
+// ignored since the path-less commit never stages them. A failed probe is
+// treated as dirty so we never risk bundling a user's work.
+const hasUnrelatedTrackedChanges = async (
+  cwd: string,
+  workflowRelative: string,
+  run: CommandRunner,
+): Promise<boolean> => {
+  const statusProbe = await run(
+    "git",
+    ["status", "--porcelain", "--", ".", `:!${workflowRelative}`],
+    cwd,
+  );
+  if (!statusProbe.success) return true;
+  return statusProbe.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .some((statusLine) => !statusLine.startsWith("??"));
+};
+
 // Best-effort: commits the just-written workflow file onto a fresh branch
 // based on the default-branch tip, pushes it, and opens a pull request via
-// `gh pr create`. Returns `"not-attempted"` (without modifying git state)
-// when `gh` is missing, the working tree isn't a git repo, the user isn't
-// authenticated, we can't find the default branch, or the checkout to the
-// new branch would conflict with local working-tree modifications. Returns
+// `gh pr create`. Returns `"pr-exists"` (without modifying git state) when a
+// React Doctor setup PR is already open, so a re-run never opens a duplicate.
+// Returns `"not-attempted"` (without modifying git state) when `gh` is
+// missing, the working tree isn't a git repo, the user isn't authenticated,
+// the working tree has tracked modifications (which would otherwise be
+// bundled into the PR), or we can't find the default branch. Returns
 // `"branch-pushed"` when the commit + push succeeded but `gh pr create`
 // failed (so the user can still open the PR manually). Restores the
 // original branch on success and on any mid-flight failure.
@@ -74,11 +140,17 @@ export const openWorkflowPullRequest = async (params: {
   // branch (to keep the installed workflow consistent with the PR base) pass
   // it here; when omitted it's detected from the repo.
   baseBranch?: string;
+  // Injectable runner / `gh`-availability probe so tests drive the flow
+  // without spawning real `git` / `gh`. Production passes neither.
+  run?: CommandRunner;
+  checkCommandAvailable?: (command: string) => boolean;
 }): Promise<OpenWorkflowPullRequestResult> => {
   const workflowPath = path.resolve(params.workflowPath);
   const commitMessage = params.commitMessage ?? DEFAULT_COMMIT_MESSAGE;
   const prTitle = params.prTitle ?? DEFAULT_PR_TITLE;
   const prBody = params.prBody ?? DEFAULT_PR_BODY;
+  const run = params.run ?? runCommand;
+  const checkCommandAvailable = params.checkCommandAvailable ?? isCommandAvailable;
 
   // Probe from the workflow file's directory so we resolve the repo root
   // even when the CLI was invoked from a sub-package in a monorepo.
@@ -89,13 +161,31 @@ export const openWorkflowPullRequest = async (params: {
   );
   if (!repoRootProbe.success) return { status: "not-attempted", reason: "not-a-git-repo" };
   const cwd = repoRootProbe.stdout;
+  const workflowRelative = path.relative(cwd, workflowPath);
 
-  if (!isCommandAvailable("gh")) return { status: "not-attempted", reason: "gh-not-installed" };
+  if (!checkCommandAvailable("gh")) return { status: "not-attempted", reason: "gh-not-installed" };
   if (!(await run("gh", ["auth", "status"], cwd)).success) {
     return { status: "not-attempted", reason: "gh-not-authenticated" };
   }
 
-  const defaultBranch = params.baseBranch ?? (await detectDefaultBranch(cwd));
+  // Idempotency: if a React Doctor setup PR is already open, surface it
+  // rather than opening a duplicate. A re-run re-writes the workflow file
+  // (it lives only on the prior PR's branch, not the user's working branch),
+  // so without this guard `findUniqueBranchName` would mint a timestamped
+  // branch and `gh pr create` would open a second PR for the same change
+  // (issue #904).
+  const existingPullRequestUrl = await findExistingSetupPullRequest(cwd, run);
+  if (existingPullRequestUrl) return { status: "pr-exists", url: existingPullRequestUrl };
+
+  // Bail before touching any git state if the working tree carries unrelated
+  // tracked changes: the checkout + whole-index commit below would otherwise
+  // bundle the user's work into the PR. The caller falls back to staging the
+  // workflow file so it still lands in their next commit.
+  if (await hasUnrelatedTrackedChanges(cwd, workflowRelative, run)) {
+    return { status: "not-attempted", reason: "working-tree-dirty" };
+  }
+
+  const defaultBranch = params.baseBranch ?? (await detectDefaultBranch(cwd, run));
   if (!defaultBranch) return { status: "not-attempted", reason: "no-default-branch" };
 
   const previousBranchProbe = await run("git", ["rev-parse", "--abbrev-ref", "HEAD"], cwd);
@@ -109,12 +199,11 @@ export const openWorkflowPullRequest = async (params: {
   // ref genuinely isn't available.
   await run("git", ["fetch", "origin", defaultBranch], cwd);
 
-  const newBranch = await findUniqueBranchName(cwd);
+  const newBranch = await findUniqueBranchName(cwd, run);
 
-  // `git checkout -b <new> origin/<default>` carries untracked files (the
-  // just-written workflow) and refuses with a non-zero status if tracked
-  // working-tree modifications would conflict with the destination — in
-  // which case we bail out without touching anything else.
+  // `git checkout -b <new> origin/<default>` carries the untracked workflow
+  // file onto the new branch. The dirty-tree guard above guarantees nothing
+  // else rides along, so the commit below only ever contains the workflow.
   if (!(await run("git", ["checkout", "-b", newBranch, `origin/${defaultBranch}`], cwd)).success) {
     return { status: "not-attempted", reason: "checkout-failed" };
   }
@@ -127,8 +216,6 @@ export const openWorkflowPullRequest = async (params: {
     await run("git", ["checkout", previousBranch], cwd);
     if (deleteNewBranch) await run("git", ["branch", "-D", newBranch], cwd);
   };
-
-  const workflowRelative = path.relative(cwd, workflowPath);
 
   if (!(await run("git", ["add", "--", workflowRelative], cwd)).success) {
     await restoreToPreviousBranch(true);
@@ -176,8 +263,12 @@ export const openWorkflowPullRequest = async (params: {
 // `"not-attempted"` and the file should still land in their next commit
 // instead of sitting as an orphan untracked path. Returns whether the stage
 // actually happened.
-export const stageWorkflowFile = async (params: { workflowPath: string }): Promise<boolean> => {
+export const stageWorkflowFile = async (params: {
+  workflowPath: string;
+  run?: CommandRunner;
+}): Promise<boolean> => {
   const workflowPath = path.resolve(params.workflowPath);
+  const run = params.run ?? runCommand;
   const repoRootProbe = await run(
     "git",
     ["rev-parse", "--show-toplevel"],

--- a/packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts
+++ b/packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts
@@ -1,6 +1,8 @@
 import * as path from "node:path";
+import { GH_PR_LIST_MAX } from "./constants.js";
 import { detectDefaultBranch } from "./detect-default-branch.js";
 import { isCommandAvailable } from "./is-command-available.js";
+import { toForwardSlashes } from "./path-format.js";
 import { runCommand, type CommandRunner } from "./run-command.js";
 
 const NEW_BRANCH_PREFIX = "react-doctor/add-github-actions";
@@ -71,7 +73,16 @@ const findExistingSetupPullRequest = async (
 ): Promise<string | null> => {
   const prList = await run(
     "gh",
-    ["pr", "list", "--state", "open", "--json", "headRefName,url", "--limit", "100"],
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--json",
+      "headRefName,url",
+      "--limit",
+      String(GH_PR_LIST_MAX),
+    ],
     cwd,
   );
   if (!prList.success) return null;
@@ -161,7 +172,10 @@ export const openWorkflowPullRequest = async (params: {
   );
   if (!repoRootProbe.success) return { status: "not-attempted", reason: "not-a-git-repo" };
   const cwd = repoRootProbe.stdout;
-  const workflowRelative = path.relative(cwd, workflowPath);
+  // Forward slashes so the `:!` exclude pathspec and `git add` match git's
+  // forward-slash-normalized repo paths on Windows (where `path.relative`
+  // yields backslashes, which git's magic pathspec won't treat as separators).
+  const workflowRelative = toForwardSlashes(path.relative(cwd, workflowPath));
 
   if (!checkCommandAvailable("gh")) return { status: "not-attempted", reason: "gh-not-installed" };
   if (!(await run("gh", ["auth", "status"], cwd)).success) {
@@ -275,6 +289,6 @@ export const stageWorkflowFile = async (params: {
     path.dirname(workflowPath),
   );
   if (!repoRootProbe.success) return false;
-  const workflowRelative = path.relative(repoRootProbe.stdout, workflowPath);
+  const workflowRelative = toForwardSlashes(path.relative(repoRootProbe.stdout, workflowPath));
   return (await run("git", ["add", "--", workflowRelative], repoRootProbe.stdout)).success;
 };

--- a/packages/react-doctor/src/cli/utils/set-up-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/set-up-github-actions.ts
@@ -70,6 +70,10 @@ export const setUpGitHubActions = async (options: SetUpGitHubActionsOptions): Pr
       pullRequestSpinner.succeed(
         `Opened pull request for review: ${highlighter.info(pullRequestResult.url)}`,
       );
+    } else if (pullRequestResult.status === "pr-exists") {
+      pullRequestSpinner.succeed(
+        `A React Doctor setup pull request is already open: ${highlighter.info(pullRequestResult.url)}`,
+      );
     } else if (pullRequestResult.status === "branch-pushed") {
       pullRequestSpinner.warn(
         `Pushed branch ${highlighter.bold(pullRequestResult.branch)} but couldn't open a PR. Open one with: gh pr create --head ${pullRequestResult.branch}`,

--- a/packages/react-doctor/tests/open-workflow-pull-request.test.ts
+++ b/packages/react-doctor/tests/open-workflow-pull-request.test.ts
@@ -99,6 +99,18 @@ describe("openWorkflowPullRequest", () => {
     expect(invocations.some((invocation) => invocation.startsWith("git commit"))).toBe(false);
   });
 
+  // The duplicate guard must short-circuit on the matching PR's existence, not
+  // on gh having reported a URL — otherwise a missing url would let a duplicate
+  // through (the exact bug the guard exists to prevent).
+  it("short-circuits on a matching setup PR even when gh omits the url", async () => {
+    const { result, invocations } = invoke({
+      ...cleanRepoResponses(),
+      [GH_PR_LIST]: succeed(JSON.stringify([{ headRefName: "react-doctor/add-github-actions" }])),
+    });
+    expect(await result).toEqual({ status: "pr-exists", url: "" });
+    expect(invocations.some((invocation) => invocation.startsWith("git checkout"))).toBe(false);
+  });
+
   it("matches timestamped setup branches from earlier attempts", async () => {
     const { result } = invoke({
       ...cleanRepoResponses(),

--- a/packages/react-doctor/tests/open-workflow-pull-request.test.ts
+++ b/packages/react-doctor/tests/open-workflow-pull-request.test.ts
@@ -64,11 +64,23 @@ const invoke = (responses: Record<string, RunCommandResult>) => {
 
 describe("openWorkflowPullRequest", () => {
   it("opens a PR and returns its URL on the happy path", async () => {
-    const { result } = invoke(cleanRepoResponses());
+    const { result, invocations } = invoke(cleanRepoResponses());
     expect(await result).toEqual({
       status: "pr-opened",
       url: "https://github.com/o/r/pull/42",
     });
+    // Issue #904, half 2: staging is path-scoped to the workflow file — never a
+    // broad `git add -A`/`.`/`--all` that would sweep unrelated changes into the
+    // commit. This is the line that stopped the deleted lockfile riding along.
+    expect(invocations).toContain(`git add -- ${WORKFLOW_RELATIVE}`);
+    expect(
+      invocations.some(
+        (invocation) =>
+          invocation === "git add -A" ||
+          invocation === "git add ." ||
+          invocation.startsWith("git add --all"),
+      ),
+    ).toBe(false);
   });
 
   // Issue #904, half 1: a re-run must not open a duplicate. When a setup PR is
@@ -119,7 +131,11 @@ describe("openWorkflowPullRequest", () => {
       [GIT_STATUS]: succeed(" M src/app.tsx\nD  pnpm-lock.yaml"),
     });
     expect(await result).toEqual({ status: "not-attempted", reason: "working-tree-dirty" });
-    expect(invocations.some((invocation) => invocation.startsWith("git checkout"))).toBe(false);
+    // The whole #904-half-2 guarantee is that a dirty tree touches no git write
+    // state — assert the harmful operations were all skipped, not just checkout.
+    for (const writeCommand of ["git checkout", "git add", "git commit", "git push"]) {
+      expect(invocations.some((invocation) => invocation.startsWith(writeCommand))).toBe(false);
+    }
   });
 
   it("allows untracked files (they're never committed) and opens the PR", async () => {
@@ -158,11 +174,15 @@ describe("openWorkflowPullRequest", () => {
   });
 
   it("reports branch-pushed when the push lands but gh pr create fails", async () => {
-    const { result } = invoke({ ...cleanRepoResponses(), [GH_PR_CREATE]: fail() });
+    const { result, invocations } = invoke({ ...cleanRepoResponses(), [GH_PR_CREATE]: fail() });
     expect(await result).toEqual({
       status: "branch-pushed",
       branch: "react-doctor/add-github-actions",
     });
+    // branch-pushed promises the branch survives on the remote for a manual PR —
+    // the pushed branch must NOT be deleted, and the original branch is restored.
+    expect(invocations.some((invocation) => invocation.startsWith("git branch -D"))).toBe(false);
+    expect(invocations).toContain("git checkout feature");
   });
 
   it("reports gh-not-installed before probing for an existing PR", async () => {

--- a/packages/react-doctor/tests/open-workflow-pull-request.test.ts
+++ b/packages/react-doctor/tests/open-workflow-pull-request.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vite-plus/test";
+import { openWorkflowPullRequest } from "../src/cli/utils/open-workflow-pull-request.js";
+import type { CommandRunner, RunCommandResult } from "../src/cli/utils/run-command.js";
+
+const succeed = (stdout = ""): RunCommandResult => ({ success: true, stdout, stderr: "" });
+const fail = (): RunCommandResult => ({ success: false, stdout: "", stderr: "" });
+
+const REPO_ROOT = "/repo";
+const WORKFLOW_PATH = "/repo/.github/workflows/react-doctor.yml";
+const WORKFLOW_RELATIVE = ".github/workflows/react-doctor.yml";
+
+// Records every invocation so tests can assert which git/gh commands ran (and,
+// crucially for issue #904, which ones did NOT). Keyed on "command arg1 arg2 …";
+// anything unlisted resolves to `defaultResult` so happy-path tests only spell
+// out the probes whose stdout matters.
+const recordingRunner = (
+  responses: Record<string, RunCommandResult>,
+  defaultResult: RunCommandResult = succeed(),
+): { run: CommandRunner; invocations: string[] } => {
+  const invocations: string[] = [];
+  const run: CommandRunner = (command, args) => {
+    const invocation = [command, ...args].join(" ");
+    invocations.push(invocation);
+    return Promise.resolve(responses[invocation] ?? defaultResult);
+  };
+  return { run, invocations };
+};
+
+const TOPLEVEL = "git rev-parse --show-toplevel";
+const GH_AUTH = "gh auth status";
+const GH_PR_LIST = "gh pr list --state open --json headRefName,url --limit 100";
+const GIT_STATUS = `git status --porcelain -- . :!${WORKFLOW_RELATIVE}`;
+const HEAD_BRANCH = "git rev-parse --abbrev-ref HEAD";
+const VERIFY_LOCAL_BRANCH = "git rev-parse --verify react-doctor/add-github-actions";
+const CHECKOUT_NEW = "git checkout -b react-doctor/add-github-actions origin/main";
+const GH_PR_CREATE =
+  "gh pr create --title title --body body --base main --head react-doctor/add-github-actions";
+
+// A clean tree on branch `feature` with no local setup branch and no open PR —
+// the baseline every happy-path test starts from before overriding one probe.
+const cleanRepoResponses = (): Record<string, RunCommandResult> => ({
+  [TOPLEVEL]: succeed(REPO_ROOT),
+  [GH_AUTH]: succeed(),
+  [GH_PR_LIST]: succeed("[]"),
+  [GIT_STATUS]: succeed(""),
+  [HEAD_BRANCH]: succeed("feature"),
+  [VERIFY_LOCAL_BRANCH]: fail(),
+  [GH_PR_CREATE]: succeed("https://github.com/o/r/pull/42"),
+});
+
+const invoke = (responses: Record<string, RunCommandResult>) => {
+  const { run, invocations } = recordingRunner(responses);
+  const result = openWorkflowPullRequest({
+    workflowPath: WORKFLOW_PATH,
+    baseBranch: "main",
+    commitMessage: "commit",
+    prTitle: "title",
+    prBody: "body",
+    run,
+    checkCommandAvailable: () => true,
+  });
+  return { result, invocations };
+};
+
+describe("openWorkflowPullRequest", () => {
+  it("opens a PR and returns its URL on the happy path", async () => {
+    const { result } = invoke(cleanRepoResponses());
+    expect(await result).toEqual({
+      status: "pr-opened",
+      url: "https://github.com/o/r/pull/42",
+    });
+  });
+
+  // Issue #904, half 1: a re-run must not open a duplicate. When a setup PR is
+  // already open, surface it without minting a new (timestamped) branch.
+  it("returns the existing PR instead of opening a duplicate", async () => {
+    const { result, invocations } = invoke({
+      ...cleanRepoResponses(),
+      [GH_PR_LIST]: succeed(
+        JSON.stringify([
+          { headRefName: "react-doctor/add-github-actions", url: "https://github.com/o/r/pull/7" },
+        ]),
+      ),
+    });
+    expect(await result).toEqual({ status: "pr-exists", url: "https://github.com/o/r/pull/7" });
+    expect(invocations.some((invocation) => invocation.startsWith("git checkout"))).toBe(false);
+    expect(invocations.some((invocation) => invocation.startsWith("git commit"))).toBe(false);
+  });
+
+  it("matches timestamped setup branches from earlier attempts", async () => {
+    const { result } = invoke({
+      ...cleanRepoResponses(),
+      [GH_PR_LIST]: succeed(
+        JSON.stringify([
+          {
+            headRefName: "react-doctor/add-github-actions-202606191729",
+            url: "https://github.com/o/r/pull/19",
+          },
+        ]),
+      ),
+    });
+    expect(await result).toEqual({ status: "pr-exists", url: "https://github.com/o/r/pull/19" });
+  });
+
+  it("ignores open PRs whose head branch isn't a setup branch", async () => {
+    const { result } = invoke({
+      ...cleanRepoResponses(),
+      [GH_PR_LIST]: succeed(
+        JSON.stringify([{ headRefName: "feature/login", url: "https://github.com/o/r/pull/3" }]),
+      ),
+    });
+    expect((await result).status).toBe("pr-opened");
+  });
+
+  // Issue #904, half 2: a dirty tree must not be swept into the PR.
+  it("bails when the working tree has unrelated tracked changes", async () => {
+    const { result, invocations } = invoke({
+      ...cleanRepoResponses(),
+      [GIT_STATUS]: succeed(" M src/app.tsx\nD  pnpm-lock.yaml"),
+    });
+    expect(await result).toEqual({ status: "not-attempted", reason: "working-tree-dirty" });
+    expect(invocations.some((invocation) => invocation.startsWith("git checkout"))).toBe(false);
+  });
+
+  it("allows untracked files (they're never committed) and opens the PR", async () => {
+    const { result } = invoke({
+      ...cleanRepoResponses(),
+      [GIT_STATUS]: succeed("?? notes.txt\n?? scratch/"),
+    });
+    expect((await result).status).toBe("pr-opened");
+  });
+
+  it("scopes the dirty check so the workflow file's own change is allowed", async () => {
+    // The status probe excludes the workflow path, so the upgrade flow (which
+    // modifies the tracked workflow in place) is never flagged as dirty.
+    const { result, invocations } = invoke(cleanRepoResponses());
+    expect((await result).status).toBe("pr-opened");
+    expect(invocations).toContain(GIT_STATUS);
+  });
+
+  it("checks for an existing PR before checking the working tree", async () => {
+    // An open setup PR wins even when the tree is dirty — the more useful signal.
+    const { result } = invoke({
+      ...cleanRepoResponses(),
+      [GIT_STATUS]: succeed(" M src/app.tsx"),
+      [GH_PR_LIST]: succeed(
+        JSON.stringify([
+          { headRefName: "react-doctor/add-github-actions", url: "https://github.com/o/r/pull/7" },
+        ]),
+      ),
+    });
+    expect(await result).toEqual({ status: "pr-exists", url: "https://github.com/o/r/pull/7" });
+  });
+
+  it("proceeds when gh pr list fails or returns unparsable output", async () => {
+    const { result } = invoke({ ...cleanRepoResponses(), [GH_PR_LIST]: succeed("not json") });
+    expect((await result).status).toBe("pr-opened");
+  });
+
+  it("reports branch-pushed when the push lands but gh pr create fails", async () => {
+    const { result } = invoke({ ...cleanRepoResponses(), [GH_PR_CREATE]: fail() });
+    expect(await result).toEqual({
+      status: "branch-pushed",
+      branch: "react-doctor/add-github-actions",
+    });
+  });
+
+  it("reports gh-not-installed before probing for an existing PR", async () => {
+    const { run, invocations } = recordingRunner(cleanRepoResponses());
+    const result = await openWorkflowPullRequest({
+      workflowPath: WORKFLOW_PATH,
+      baseBranch: "main",
+      run,
+      checkCommandAvailable: () => false,
+    });
+    expect(result).toEqual({ status: "not-attempted", reason: "gh-not-installed" });
+    expect(invocations).not.toContain(GH_PR_LIST);
+  });
+});


### PR DESCRIPTION
## Root cause

Closes #904. The GitHub Actions setup flow opened two PRs for the same integration and swept unrelated local changes (modified app files, a deleted `pnpm-lock.yaml`) into the generated branches. Two independent bugs in `packages/react-doctor/src/cli/utils/open-workflow-pull-request.ts`:

### Bug 1 — duplicate PRs (idempotency)
The flow never checked for an already-open setup PR. `findUniqueBranchName` only avoided a *local* branch collision by appending a timestamp (`react-doctor/add-github-actions-202606191729` — the exact suffix format seen in the issue). Because the workflow file lives only on the prior PR's branch (not the user's working branch), a re-run re-writes it and opens a *second* PR.

### Bug 2 — bundled local changes
`git checkout -b <new> origin/<default>` carries the index onto the new branch, and the path-less `git commit` then commits the **whole index** — so anything the user had staged rode along into the PR. The inline comment assumed git refuses on conflict, but git only errors on *conflicts*; non-conflicting staged changes pass through silently.

## The fix

- **Idempotency:** before creating anything, `gh pr list` for an open PR whose head branch is under the `react-doctor/add-github-actions` prefix (covers timestamped variants too). If one exists, return the new `pr-exists` status and surface its URL instead of opening a duplicate.
- **Dirty-tree guard:** bail with `not-attempted` / `working-tree-dirty` when the tree has tracked changes **other than the workflow file**, falling back to staging the workflow file. The workflow path is excluded via a `:!` pathspec so the v1→v2 **upgrade** flow (which modifies the tracked workflow in place) still opens its PR.
- The existing-PR check runs before the dirty check (the open PR is the more useful signal). Both `setUpGitHubActions` and the upgrade flow in `handoff-to-agent` handle `pr-exists`.
- The command runner and `gh`-availability probe are now injectable for hermetic unit tests.

## Why this over #905

#905 (closed) added the dirty-tree guard only — a sound fix for Bug 2, but it leaves Bug 1 open: re-running on a *clean* tree still opens a second duplicate PR. This PR guards both, and scopes the dirty check so it doesn't break the upgrade flow.

## Testing

- New `tests/open-workflow-pull-request.test.ts` (11 cases): happy path, existing-PR short-circuit (canonical + timestamped + non-matching heads), dirty-tree bail, untracked-files allowed, workflow-path exclusion, ordering (PR check before dirty check), unparsable `gh` output, `branch-pushed`, and `gh-not-installed` short-circuit.
- `pnpm --filter react-doctor typecheck`, `pnpm lint`, `pnpm format:check` all green.

> The one flaky `install-react-doctor` persisted-decision test fails identically on `main` (it's `conf`-store state pollution from `vp` running each file under two vite configs) — unrelated to this change.

No new CLI flags, config, or JSON-report changes — only two new internal result variants and their messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git/gh automation that creates branches and PRs; mistakes could skip setup or still pollute PRs, but behavior is guarded with fallbacks to staging and covered by new tests.
> 
> **Overview**
> Fixes **#904** by hardening `openWorkflowPullRequest` so re-running the GitHub Actions setup does not open a second PR and does not sweep unrelated local git changes into the automation branch.
> 
> **Idempotency:** Before any branch/checkout work, the CLI scans open PRs (`gh pr list`, capped via `GH_PR_LIST_MAX`) for a head branch under `react-doctor/add-github-actions` (including timestamped variants). If one exists, it returns **`pr-exists`** with that URL and skips all git writes. Fresh install (`setUpGitHubActions`) and the v1→v2 upgrade (`handoff-to-agent`) surface that message; the upgrade path also **reverts** the in-memory `@v2` edit so the working tree stays on `@v1` when the bump already lives on the open PR branch.
> 
> **Dirty-tree guard:** If tracked changes exist outside the workflow file (workflow path excluded via `:!` pathspec so in-place upgrades still work), the flow returns **`not-attempted` / `working-tree-dirty`** and callers fall back to **staging only the workflow file**. Untracked files are ignored; a failed status probe is treated as dirty. The existing-PR check runs before the dirty check.
> 
> **Other:** Injectable `run` / `gh` availability for tests; workflow-relative paths normalized with `toForwardSlashes` on Windows. New unit tests cover happy path, duplicate PR short-circuit, dirty tree, ordering, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b80b31f11d066b69fa33098717cc8105ba2940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->