### PR TITLE
perf(action,core): CI speedups — install cache, persistent scan caches, local diff scope (plans 09–11)

### DIFF
--- a/.changeset/migrate-action-pin-main.md
+++ b/.changeset/migrate-action-pin-main.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+Add a once-per-repo migration that pins a mutable `@main` / `@master` React Doctor GitHub Action reference in `.github/workflows/*.yml` to the recommended floating major (`@v2`).
+
+An unpinned `@main` runs whatever the action's HEAD points to with the workflow's write permissions — a supply-chain risk (#299) — and the rewrite also moves the workflow onto the current install- and scan-cached action release. Pinned tags / commit SHAs are deliberate and left untouched, and a different action on `@main` (e.g. `actions/checkout@main`) is ignored. Runs once per repo like the legacy-config migration, rewrites only the ref (owner, comments, and the action's `version:` input are preserved), and logs the change for the user to review and commit (or revert if they intentionally track main).

--- a/.changeset/persist-scan-caches-ci.md
+++ b/.changeset/persist-scan-caches-ci.md
@@ -1,0 +1,13 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Persist react-doctor's scan caches across CI runs (plan 10).
+
+In CI every commit is a fresh, SHA-scoped checkout, so the project-local `node_modules/.cache` never survives between commits — every run recomputes from scratch. This makes the engine's caches survivable:
+
+- **`REACT_DOCTOR_CACHE_DIR`** (new env): an operator/CI-pinned cache root. The GitHub Action points it at a stable `${runner.temp}` path and persists it with `actions/cache`, so the per-file content-addressed lint cache restores across runs — a PR re-lints only its changed files instead of the whole project. Keyed on the react-doctor version + lockfile + os/arch, with a `restore-keys` partial-hit fallback; the engine re-validates every restored entry by content hash + ruleset hash, so a stale entry simply misses and recomputes (no correctness risk).
+- **Supply-chain on-disk cache** (new): per-PURL Socket artifacts are cached under the cache dir with a 24h TTL (`SUPPLY_CHAIN_CACHE_TTL_MS`), so unchanged dependencies skip the network on repeated scans — locally and in CI — removing the bulk of the Socket fetches a full scan makes. Fail-open (a cache miss/error just fetches; a write failure never sinks the scan) and disabled by the existing `REACT_DOCTOR_NO_CACHE` off-switch.
+
+The `action.yml` cache wiring ships as an action release (cut a tag after dogfooding). A `--print-cache-key` flag for a tighter (ruleset-exact) actions/cache key is a possible follow-up; the version+lockfile key already restores soundly today.

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -49,3 +49,23 @@ jobs:
           blocking: none
           node-version: 22.18.0
           version: ./packages/react-doctor
+
+  # Exercise the NEW cacheable install path (a published `version:` →
+  # resolve-version + actions/cache + `npm install --prefix` into the toolchain
+  # dir, then run the local binary). The job above covers the non-cacheable
+  # local-path / npx branch; this one guards the prefix-install branch so it
+  # can't silently break. Cross-run cache HITS (the ~15s→~1s win) are validated
+  # by dogfooding on real runs — the cache service persists between runs, not
+  # within a single job. Advisory (`blocking: none`), so it never reds the repo.
+  action-cacheable-install:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: ./
+        with:
+          blocking: none
+          node-version: 22.18.0
+          version: latest

--- a/action.yml
+++ b/action.yml
@@ -61,8 +61,90 @@ runs:
         node-version: ${{ inputs.node-version }}
         package-manager-cache: false
 
-    - id: pr-files
+    # Resolve the version to a concrete published one so the install cache key is
+    # stable even for `version: latest`. A local-path spec (this repo's self-test)
+    # is reported non-cacheable and falls through to the npx path below.
+    - id: resolve-version
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: node "$GITHUB_ACTION_PATH/scripts/resolve-package-spec.mjs" "$INPUT_VERSION"
+
+    # Cache the react-doctor install (the dominant CI cost — ~15s of an ~18s PR
+    # run is the uncached npm download). Keyed on the exact version + toolchain
+    # identity (the install is a pure function of those); no `restore-keys`
+    # fallback, since a partial/older restore could mismatch the native binding
+    # ABI. On a hit, the ~15s install collapses to a ~1-2s restore.
+    - id: toolchain-cache
+      if: ${{ steps.resolve-version.outputs.cacheable == 'true' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ runner.temp }}/react-doctor-toolchain
+        key: react-doctor-toolchain-${{ steps.resolve-version.outputs.resolved }}-node${{ inputs.node-version }}-${{ runner.os }}-${{ runner.arch }}
+
+    # Persist react-doctor's scan caches (the per-file content-addressed lint
+    # cache + the supply-chain cache) across CI runs. In CI every commit is a
+    # fresh, SHA-scoped checkout, so the project-local `node_modules/.cache`
+    # never survives between commits — pointing REACT_DOCTOR_CACHE_DIR (set on
+    # the scan step) at a stable `${runner.temp}` path lets actions/cache restore
+    # it. The key busts on the react-doctor version + lockfile (the inputs that
+    # change the ruleset / dep set); `restore-keys` allows a partial hit from the
+    # last same-version run, which is sound because the engine re-validates every
+    # cached entry by content hash + ruleset hash internally (a stale entry just
+    # misses and re-computes).
+    - id: scan-cache
+      if: ${{ steps.resolve-version.outputs.cacheable == 'true' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ runner.temp }}/react-doctor-cache
+        key: react-doctor-scan-cache-${{ steps.resolve-version.outputs.resolved }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/package-lock.json', '**/pnpm-lock.yaml', '**/yarn.lock', '**/bun.lock', '**/bun.lockb') }}
+        restore-keys: |
+          react-doctor-scan-cache-${{ steps.resolve-version.outputs.resolved }}-${{ runner.os }}-${{ runner.arch }}-
+
+    # Resolve the PR's changed files LOCALLY first: fetch the base commit (also
+    # needed for baseline mode), then derive the changed set with `git diff`.
+    # Faster than the GitHub API, no API rate limit, and works on forks where
+    # `pulls.listFiles` can be denied — which otherwise loses the diff fast path
+    # to a full scan. The `pr-files` step below is the API fallback, used only
+    # when the base isn't reachable for a local diff (shallow history).
+    - id: base
       if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' }}
+      shell: bash
+      env:
+        INPUT_DIRECTORY: ${{ inputs.directory }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        CHANGED_FILES_FILE: ${{ runner.temp }}/react-doctor-changed-files.txt
+      run: |
+        # Fetch the PR base commit so react-doctor can read base file content
+        # and resolve the merge-base for baseline (PR-introduced-issues-only)
+        # mode. Depth 1 covers the standard merge-ref checkout (base is a parent
+        # of HEAD); for deeper history use `fetch-depth: 0` on actions/checkout.
+        FETCHED=""
+        if [ -n "$BASE_SHA" ] && git -C "$INPUT_DIRECTORY" rev-parse --git-dir >/dev/null 2>&1; then
+          if git -C "$INPUT_DIRECTORY" fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null; then
+            FETCHED="1"
+          fi
+        fi
+
+        # With the base fetched, derive the changed set locally. Three-dot
+        # (merge-base) + AMR (added/modified/renamed) match the `pulls.listFiles`
+        # API contract and the CLI's baseline semantics. On any failure (shallow
+        # history with no reachable merge-base), leave the file unwritten so the
+        # API fallback runs — no regression vs the previous API-only behavior.
+        RAW_CHANGED="${RUNNER_TEMP:-/tmp}/react-doctor-raw-changed.txt"
+        if [ -n "$FETCHED" ] && git -C "$INPUT_DIRECTORY" diff --name-only --diff-filter=AMR "$BASE_SHA...HEAD" > "$RAW_CHANGED" 2>/dev/null; then
+          node "$GITHUB_ACTION_PATH/scripts/normalize-changed-files.mjs" "$INPUT_DIRECTORY" "$CHANGED_FILES_FILE" < "$RAW_CHANGED"
+          echo "path=$CHANGED_FILES_FILE" >> "$GITHUB_OUTPUT"
+        else
+          echo "::warning::React Doctor could not derive the PR's changed files from git (the base commit isn't reachable — set \`fetch-depth: 0\` on actions/checkout for deep histories). Falling back to the GitHub API."
+        fi
+
+    # API fallback: only when the local `git diff` above couldn't run. Reuses the
+    # shared changed-file normalization so both paths emit an identical
+    # scan-relative set (the CLI resolves `--changed-files-from` relative to the
+    # scanned `directory`; see normalize-changed-files.mjs).
+    - id: pr-files
+      if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' && steps.base.outputs.path == '' }}
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       env:
         REACT_DOCTOR_CHANGED_FILES: ${{ runner.temp }}/react-doctor-changed-files.txt
@@ -70,6 +152,10 @@ runs:
       with:
         script: |
           const fs = require("fs");
+          const { pathToFileURL } = require("url");
+          const { normalizeChangedFiles } = await import(
+            pathToFileURL(`${process.env.GITHUB_ACTION_PATH}/scripts/normalize-changed-files.mjs`).href,
+          );
           const outputPath = process.env.REACT_DOCTOR_CHANGED_FILES;
           const pullRequest = context.payload.pull_request;
           if (!pullRequest || !outputPath) return;
@@ -88,44 +174,13 @@ runs:
             );
             return;
           }
-          // `pulls.listFiles` returns repo-root-relative paths (e.g. `UI/src/foo.tsx`),
-          // but the CLI resolves `--changed-files-from` entries relative to the scanned
-          // `directory` (its diff detection runs `git diff --relative`, so its native
-          // path contract is scan-relative). Strip the `directory` prefix — and drop
-          // files outside it — so a subdirectory scan (`directory: UI`) doesn't double
-          // up to `UI/UI/src/...`, which misses every base read and reports pre-existing
-          // issues as newly introduced. Matches the review-comments step's mapping.
-          const directoryPrefix = (process.env.INPUT_DIRECTORY || ".")
-            .replace(/^\.\/?/, "")
-            .replace(/\/$/, "");
           const includedStatuses = new Set(["added", "modified", "renamed"]);
-          const changedFiles = files
-            .filter((file) => includedStatuses.has(file.status))
-            .map((file) => file.filename)
-            .flatMap((filename) => {
-              if (!directoryPrefix) return [filename];
-              const scopedPrefix = `${directoryPrefix}/`;
-              return filename.startsWith(scopedPrefix) ? [filename.slice(scopedPrefix.length)] : [];
-            });
+          const changedFiles = normalizeChangedFiles(
+            files.filter((file) => includedStatuses.has(file.status)).map((file) => file.filename),
+            process.env.INPUT_DIRECTORY,
+          );
           fs.writeFileSync(outputPath, changedFiles.join("\n") + (changedFiles.length ? "\n" : ""));
           core.setOutput("path", outputPath);
-
-    - id: base
-      if: ${{ github.event_name == 'pull_request' && inputs.scope != 'full' }}
-      shell: bash
-      env:
-        INPUT_DIRECTORY: ${{ inputs.directory }}
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      run: |
-        # Fetch the PR base commit so react-doctor can read base file content
-        # and resolve the merge-base for baseline (PR-introduced-issues-only)
-        # mode. Depth 1 covers the standard merge-ref checkout (base is a parent
-        # of HEAD); for deeper history use `fetch-depth: 0` on actions/checkout.
-        # Best-effort: if it fails, react-doctor degrades to reporting every
-        # finding in the changed files.
-        if [ -n "$BASE_SHA" ] && git -C "$INPUT_DIRECTORY" rev-parse --git-dir >/dev/null 2>&1; then
-          git -C "$INPUT_DIRECTORY" fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
-        fi
 
     - id: scan
       shell: bash
@@ -135,12 +190,20 @@ runs:
         INPUT_PROJECT: ${{ inputs.project }}
         INPUT_SCOPE: ${{ inputs.scope }}
         INPUT_BLOCKING: ${{ inputs.blocking }}
-        INPUT_VERSION: ${{ inputs.version }}
-        CHANGED_FILES_FROM: ${{ steps.pr-files.outputs.path }}
+        # Install spec + cacheability resolved by the resolve-version step. A
+        # cacheable spec installs into (and reruns from) the cached toolchain
+        # prefix; a non-cacheable local-path spec falls through to npx.
+        PACKAGE_SPEC: ${{ steps.resolve-version.outputs.spec }}
+        CACHEABLE: ${{ steps.resolve-version.outputs.cacheable }}
+        CHANGED_FILES_FROM: ${{ steps.base.outputs.path || steps.pr-files.outputs.path }}
         # Forwarded so baseline mode reads base content against a fetched SHA
         # (branch names rarely resolve in a shallow PR checkout). Empty off PRs.
         REACT_DOCTOR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         RUNNER_TEMP: ${{ runner.temp }}
+        # Write the on-disk scan caches (per-file lint cache, supply-chain cache)
+        # to a stable path the scan-cache step persists across runs — not the
+        # SHA-scoped node_modules/.cache that a fresh CI checkout discards.
+        REACT_DOCTOR_CACHE_DIR: ${{ runner.temp }}/react-doctor-cache
         GITHUB_RUN_ID: ${{ github.run_id }}
         # Telemetry: mark runs as launched by the official action and forward the
         # inputs the CLI can't otherwise see (comment / review-comments are
@@ -180,14 +243,28 @@ runs:
           FLAGS+=("--changed-files-from" "$CHANGED_FILES_FROM")
         fi
 
-        if [[ "$INPUT_VERSION" = ./* || "$INPUT_VERSION" = ../* || "$INPUT_VERSION" = /* ]]; then
-          PACKAGE_SPEC="$INPUT_VERSION"
-        else
-          PACKAGE_SPEC="react-doctor@$INPUT_VERSION"
+        # Install/run from a cached prefix for a published version (the common
+        # path): actions/cache restored $TOOLCHAIN_DIR before this step, so a
+        # cache hit skips the ~15s npm download. `--prefix` gives a deterministic,
+        # cacheable location (unlike npx's opaque _npx/<hash> dir). The `[ ! -x ]`
+        # guard re-installs if the restore was empty or corrupt. A non-cacheable
+        # local-path spec (self-test) keeps the npx path unchanged.
+        TOOLCHAIN_DIR="${RUNNER_TEMP:-/tmp}/react-doctor-toolchain"
+        RD_BIN=""
+        if [ "$CACHEABLE" = "true" ]; then
+          if [ ! -x "$TOOLCHAIN_DIR/node_modules/.bin/react-doctor" ]; then
+            mkdir -p "$TOOLCHAIN_DIR"
+            npm install --prefix "$TOOLCHAIN_DIR" --no-save --no-audit --no-fund "$PACKAGE_SPEC"
+          fi
+          RD_BIN="$TOOLCHAIN_DIR/node_modules/.bin/react-doctor"
         fi
 
         set +e
-        npm exec --yes --package "$PACKAGE_SPEC" -- react-doctor "$INPUT_DIRECTORY" "${FLAGS[@]}" > "$REPORT_FILE"
+        if [ -n "$RD_BIN" ]; then
+          "$RD_BIN" "$INPUT_DIRECTORY" "${FLAGS[@]}" > "$REPORT_FILE"
+        else
+          npm exec --yes --package "$PACKAGE_SPEC" -- react-doctor "$INPUT_DIRECTORY" "${FLAGS[@]}" > "$REPORT_FILE"
+        fi
         SCAN_STATUS=$?
         set -e
 

--- a/packages/core/src/check-supply-chain.ts
+++ b/packages/core/src/check-supply-chain.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as Effect from "effect/Effect";
@@ -5,12 +6,15 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as semver from "semver";
 import {
+  CACHE_FILENAME_HASH_LENGTH_CHARS,
   FETCH_TIMEOUT_MS,
   SOCKET_FREE_PURL_API_BASE,
   SOCKET_FREE_USER_AGENT,
   SOCKET_PACKAGE_PAGE_BASE,
   SOCKET_SCORE_SCALE,
   SUPPLY_CHAIN_ALERT_NOTE_MAX_CHARS,
+  SUPPLY_CHAIN_CACHE_SUBDIR,
+  SUPPLY_CHAIN_CACHE_TTL_MS,
   SUPPLY_CHAIN_CATEGORY,
   SUPPLY_CHAIN_DEFAULT_MIN_SCORE,
   SUPPLY_CHAIN_FETCH_CONCURRENCY,
@@ -22,6 +26,7 @@ import {
 } from "./constants.js";
 import { readPackageJson } from "./project-info/index.js";
 import type { Diagnostic, PackageJson, ReactDoctorConfig } from "./types/index.js";
+import { resolveReactDoctorCacheDir } from "./utils/resolve-react-doctor-cache-dir.js";
 import { sanitizeTerminalText } from "./utils/sanitize-terminal-text.js";
 
 export interface SupplyChainCheckInput {
@@ -350,6 +355,56 @@ const parseArtifactFromBody = (body: string): SocketArtifact | null => {
   return null;
 };
 
+// Per-PURL on-disk Socket cache (TTL-bounded), so unchanged dependencies skip
+// the network on a repeated scan (the recurring CI win + faster local re-scans).
+// Disabled by the global `REACT_DOCTOR_NO_CACHE` off-switch.
+const isSupplyChainCacheDisabled = (): boolean => {
+  const noCache = process.env["REACT_DOCTOR_NO_CACHE"]?.toLowerCase() ?? "";
+  return noCache === "1" || noCache === "true";
+};
+
+const supplyChainCacheFile = (cacheDirectory: string, dependency: DependencyToScore): string => {
+  const purlHash = crypto
+    .createHash("sha256")
+    .update(toPurl(dependency))
+    .digest("hex")
+    .slice(0, CACHE_FILENAME_HASH_LENGTH_CHARS);
+  return path.join(cacheDirectory, SUPPLY_CHAIN_CACHE_SUBDIR, `${purlHash}.json`);
+};
+
+// Returns the cached raw response body when present and within the TTL, else
+// null. Fail-open: a missing / malformed / expired entry reads as a miss. We
+// cache the raw body (not the parsed artifact) and re-parse on a hit, so the
+// cached and live paths produce byte-identical artifacts through one parser.
+const readCachedSocketBody = (cacheFile: string): string | null => {
+  try {
+    const entry: unknown = JSON.parse(fs.readFileSync(cacheFile, "utf-8"));
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      "fetchedAtMs" in entry &&
+      "body" in entry &&
+      typeof entry.fetchedAtMs === "number" &&
+      typeof entry.body === "string" &&
+      Date.now() - entry.fetchedAtMs <= SUPPLY_CHAIN_CACHE_TTL_MS
+    ) {
+      return entry.body;
+    }
+  } catch {
+    // unreadable / malformed → treat as a miss
+  }
+  return null;
+};
+
+const writeCachedSocketBody = (cacheFile: string, body: string): void => {
+  try {
+    fs.mkdirSync(path.dirname(cacheFile), { recursive: true });
+    fs.writeFileSync(cacheFile, JSON.stringify({ fetchedAtMs: Date.now(), body }));
+  } catch {
+    // A cache write failure must never sink the scan.
+  }
+};
+
 // Fetches the free, keyless Socket artifact (score + alerts) for one
 // dependency — the same `firewall-api.socket.dev/purl/<encoded-purl>` endpoint
 // Socket Firewall's free tier hits. `Effect.tryPromise` hands `fetch` an
@@ -363,15 +418,29 @@ const parseArtifactFromBody = (body: string): SocketArtifact | null => {
 // settles. Dotted `socket.*` namespacing per the observability conventions, so
 // a trace backend can group by package or query score / alert distributions
 // across a scan. No-op without a tracer.
-const fetchSocketArtifact = (dependency: DependencyToScore): Effect.Effect<SocketArtifact | null> =>
+const fetchSocketArtifact = (
+  dependency: DependencyToScore,
+  cacheDirectory: string | null,
+): Effect.Effect<SocketArtifact | null> =>
   Effect.tryPromise(async (signal) => {
+    const cacheFile =
+      cacheDirectory === null ? null : supplyChainCacheFile(cacheDirectory, dependency);
+    if (cacheFile !== null) {
+      const cachedBody = readCachedSocketBody(cacheFile);
+      if (cachedBody !== null) return parseArtifactFromBody(cachedBody);
+    }
     const requestUrl = `${SOCKET_FREE_PURL_API_BASE}/${encodeURIComponent(toPurl(dependency))}`;
     const response = await fetch(requestUrl, {
       headers: { "User-Agent": SOCKET_FREE_USER_AGENT },
       signal,
     });
     if (!response.ok) return null;
-    return parseArtifactFromBody(await response.text());
+    const body = await response.text();
+    const artifact = parseArtifactFromBody(body);
+    // Cache only a genuine hit — a null (unknown/unscored package) re-checks next
+    // run rather than pinning a stale negative for the whole TTL.
+    if (artifact !== null && cacheFile !== null) writeCachedSocketBody(cacheFile, body);
+    return artifact;
   }).pipe(
     Effect.timeout(FETCH_TIMEOUT_MS),
     Effect.orElseSucceed(() => null),
@@ -589,9 +658,16 @@ export const checkSupplyChain = (input: SupplyChainCheckInput): Effect.Effect<Di
     );
     if (dependencies.length === 0) return [];
 
-    const artifacts = yield* Effect.forEach(dependencies, fetchSocketArtifact, {
-      concurrency: SUPPLY_CHAIN_FETCH_CONCURRENCY,
-    }).pipe(
+    // One cache dir for the whole check; `null` disables it (NO_CACHE).
+    const cacheDirectory = isSupplyChainCacheDisabled()
+      ? null
+      : resolveReactDoctorCacheDir(input.rootDirectory);
+
+    const artifacts = yield* Effect.forEach(
+      dependencies,
+      (dependency) => fetchSocketArtifact(dependency, cacheDirectory),
+      { concurrency: SUPPLY_CHAIN_FETCH_CONCURRENCY },
+    ).pipe(
       // A many-socket pileup (sockets that ignore the per-fetch abort) trips the
       // whole-check cap; recover to "no artifacts scored" — identical fail-open
       // contract to the per-fetch `orElseSucceed(() => null)`.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -627,6 +627,15 @@ export const SUPPLY_CHAIN_FETCH_CONCURRENCY = 8;
 // diagnostics — the same outcome class as the per-package Socket fail-open.
 export const SUPPLY_CHAIN_OVERLAP_TIMEOUT_MS = 90_000;
 
+// On-disk TTL for a cached Socket artifact. A dependency's score/alerts are
+// stable day-to-day and advisory, so a cached lookup within 24h skips the
+// network entirely (the recurring CI win + faster repeated local scans);
+// after expiry it re-fetches. Disabled by `REACT_DOCTOR_NO_CACHE`.
+export const SUPPLY_CHAIN_CACHE_TTL_MS = 86_400_000;
+
+// Subdirectory of the react-doctor cache dir holding per-PURL Socket responses.
+export const SUPPLY_CHAIN_CACHE_SUBDIR = "supply-chain";
+
 // Most severe Socket alerts to name in one supply-chain diagnostic before
 // collapsing the remainder into a "+N more" count, so a noisy package
 // doesn't flood the message.

--- a/packages/core/src/utils/resolve-react-doctor-cache-dir.ts
+++ b/packages/core/src/utils/resolve-react-doctor-cache-dir.ts
@@ -4,23 +4,35 @@ import os from "node:os";
 import * as path from "node:path";
 import { CACHE_FILENAME_HASH_LENGTH_CHARS } from "../constants.js";
 
-// Resolves the directory react-doctor's on-disk caches live in. Prefers the
-// project's `node_modules/.cache/react-doctor` (npm convention, project-local,
-// cleaned by `node_modules` removal) and falls back to a per-project
-// subdirectory of the OS temp dir when the project has no `node_modules` (e.g.
-// a not-yet-installed checkout). Both the whole-repo scan cache and the
-// per-file lint cache sit side by side here under distinct filenames.
-export const resolveReactDoctorCacheDir = (projectDirectory: string): string => {
-  const nodeModulesDirectory = path.join(projectDirectory, "node_modules");
-  if (fs.existsSync(nodeModulesDirectory)) {
-    return path.join(nodeModulesDirectory, ".cache", "react-doctor");
-  }
-  // SHA-256 (not SHA-1) purely to name a per-project cache subdirectory — it's
-  // a filesystem-safe digest of the path, never a security/identity hash.
-  const projectHash = crypto
+// SHA-256 (not SHA-1) purely to name a per-project cache subdirectory — it's a
+// filesystem-safe digest of the path, never a security/identity hash.
+const projectCacheSubdir = (projectDirectory: string): string =>
+  crypto
     .createHash("sha256")
     .update(projectDirectory)
     .digest("hex")
     .slice(0, CACHE_FILENAME_HASH_LENGTH_CHARS);
-  return path.join(os.tmpdir(), "react-doctor-cache", projectHash);
+
+// Resolves the directory react-doctor's on-disk caches live in. Order:
+//   1. `REACT_DOCTOR_CACHE_DIR` — an operator/CI-pinned cache root. The GitHub
+//      Action points this at a single `${runner.temp}` path it can persist with
+//      `actions/cache` across runs (the project-local `node_modules/.cache` is
+//      a fresh, SHA-scoped checkout in CI, so it never survives between commits).
+//      A per-project subdirectory keeps a batch scan's projects from colliding.
+//   2. the project's `node_modules/.cache/react-doctor` (npm convention,
+//      project-local, cleaned by `node_modules` removal).
+//   3. a per-project subdirectory of the OS temp dir, when the project has no
+//      `node_modules` (e.g. a not-yet-installed checkout).
+// The whole-repo scan cache, the per-file lint cache, and the supply-chain cache
+// sit side by side here under distinct filenames.
+export const resolveReactDoctorCacheDir = (projectDirectory: string): string => {
+  const cacheDirOverride = process.env["REACT_DOCTOR_CACHE_DIR"]?.trim();
+  if (cacheDirOverride) {
+    return path.join(cacheDirOverride, projectCacheSubdir(projectDirectory));
+  }
+  const nodeModulesDirectory = path.join(projectDirectory, "node_modules");
+  if (fs.existsSync(nodeModulesDirectory)) {
+    return path.join(nodeModulesDirectory, ".cache", "react-doctor");
+  }
+  return path.join(os.tmpdir(), "react-doctor-cache", projectCacheSubdir(projectDirectory));
 };

--- a/packages/core/tests/check-supply-chain-cache.test.ts
+++ b/packages/core/tests/check-supply-chain-cache.test.ts
@@ -1,0 +1,82 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import * as Effect from "effect/Effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { checkSupplyChain } from "@react-doctor/core";
+
+// A low-score artifact so the check emits a diagnostic (lets us assert the
+// cached run reproduces it). NDJSON line shape the free Socket endpoint streams.
+const lowScoreArtifactBody = (): string =>
+  JSON.stringify({
+    id: "test-artifact",
+    type: "npm",
+    score: {
+      supplyChain: 0.1,
+      vulnerability: 0.1,
+      maintenance: 0.1,
+      quality: 0.1,
+      license: 0.1,
+      overall: 0.1,
+    },
+    alerts: [],
+  });
+
+let projectDirectory: string;
+let cacheDirectory: string;
+const originalCacheDirEnv = process.env["REACT_DOCTOR_CACHE_DIR"];
+const originalNoCacheEnv = process.env["REACT_DOCTOR_NO_CACHE"];
+
+beforeEach(() => {
+  projectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-sc-cache-proj-"));
+  cacheDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-sc-cache-dir-"));
+  fs.writeFileSync(
+    path.join(projectDirectory, "package.json"),
+    JSON.stringify({ name: "fixture", version: "1.0.0", dependencies: { "left-pad": "1.3.0" } }),
+  );
+  // Point the cache at an isolated dir; ensure the cache isn't globally disabled.
+  process.env["REACT_DOCTOR_CACHE_DIR"] = cacheDirectory;
+  delete process.env["REACT_DOCTOR_NO_CACHE"];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fs.rmSync(projectDirectory, { recursive: true, force: true });
+  fs.rmSync(cacheDirectory, { recursive: true, force: true });
+  if (originalCacheDirEnv === undefined) delete process.env["REACT_DOCTOR_CACHE_DIR"];
+  else process.env["REACT_DOCTOR_CACHE_DIR"] = originalCacheDirEnv;
+  if (originalNoCacheEnv === undefined) delete process.env["REACT_DOCTOR_NO_CACHE"];
+  else process.env["REACT_DOCTOR_NO_CACHE"] = originalNoCacheEnv;
+});
+
+const stubSocketFetch = () => {
+  const fetchMock = vi.fn(async () => new Response(lowScoreArtifactBody(), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+const runCheck = () =>
+  Effect.runPromise(checkSupplyChain({ rootDirectory: projectDirectory, userConfig: null }));
+
+describe("supply-chain on-disk cache", () => {
+  it("skips the network on a repeat scan within the TTL (cache hit), reproducing the diagnostic", async () => {
+    const fetchMock = stubSocketFetch();
+    const first = await runCheck();
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0); // the first scan fetched
+    expect(first.length).toBeGreaterThan(0); // low score ⇒ a diagnostic
+
+    const second = await runCheck();
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFirst); // no new network calls
+    expect(second).toEqual(first); // identical diagnostics, served from cache
+  });
+
+  it("re-fetches every run when REACT_DOCTOR_NO_CACHE is set (cache bypassed)", async () => {
+    process.env["REACT_DOCTOR_NO_CACHE"] = "1";
+    const fetchMock = stubSocketFetch();
+    await runCheck();
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    await runCheck();
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+});

--- a/packages/core/tests/resolve-react-doctor-cache-dir.test.ts
+++ b/packages/core/tests/resolve-react-doctor-cache-dir.test.ts
@@ -1,0 +1,48 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { resolveReactDoctorCacheDir } from "../src/utils/resolve-react-doctor-cache-dir.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-cache-dir-"));
+const originalCacheDirEnv = process.env["REACT_DOCTOR_CACHE_DIR"];
+
+afterEach(() => {
+  if (originalCacheDirEnv === undefined) delete process.env["REACT_DOCTOR_CACHE_DIR"];
+  else process.env["REACT_DOCTOR_CACHE_DIR"] = originalCacheDirEnv;
+});
+
+describe("resolveReactDoctorCacheDir", () => {
+  it("honors REACT_DOCTOR_CACHE_DIR (the CI override) with a per-project subdir", () => {
+    const overrideRoot = path.join(tempRoot, "ci-cache-root");
+    process.env["REACT_DOCTOR_CACHE_DIR"] = overrideRoot;
+    const projectA = path.join(tempRoot, "project-a");
+    const projectB = path.join(tempRoot, "project-b");
+    const dirA = resolveReactDoctorCacheDir(projectA);
+    const dirB = resolveReactDoctorCacheDir(projectB);
+    // Under the override root, and per-project (a batch scan's projects must not
+    // collide on one cache file).
+    expect(dirA.startsWith(overrideRoot + path.sep)).toBe(true);
+    expect(dirB.startsWith(overrideRoot + path.sep)).toBe(true);
+    expect(dirA).not.toBe(dirB);
+    // Stable for the same project.
+    expect(resolveReactDoctorCacheDir(projectA)).toBe(dirA);
+  });
+
+  it("falls back to node_modules/.cache/react-doctor when no override is set", () => {
+    delete process.env["REACT_DOCTOR_CACHE_DIR"];
+    const projectDir = path.join(tempRoot, "with-node-modules");
+    fs.mkdirSync(path.join(projectDir, "node_modules"), { recursive: true });
+    expect(resolveReactDoctorCacheDir(projectDir)).toBe(
+      path.join(projectDir, "node_modules", ".cache", "react-doctor"),
+    );
+  });
+
+  it("falls back to an OS-temp per-project dir when there is no node_modules or override", () => {
+    delete process.env["REACT_DOCTOR_CACHE_DIR"];
+    const projectDir = path.join(tempRoot, "no-node-modules");
+    fs.mkdirSync(projectDir, { recursive: true });
+    const resolved = resolveReactDoctorCacheDir(projectDir);
+    expect(resolved.startsWith(path.join(os.tmpdir(), "react-doctor-cache"))).toBe(true);
+  });
+});

--- a/packages/react-doctor/src/cli/utils/cli-migrations.ts
+++ b/packages/react-doctor/src/cli/utils/cli-migrations.ts
@@ -2,6 +2,7 @@ import { findLegacyConfig, toRelativePath } from "@react-doctor/core";
 import { cliLogger as logger } from "./cli-logger.js";
 import { type CliStateOptions } from "./cli-state-store.js";
 import { type Migration, type MigrationResult, runMigrations } from "./cli-lifecycle.js";
+import { migrateActionPin } from "./migrate-action-pin.js";
 import { migrateLegacyConfig } from "./migrate-legacy-config.js";
 
 // The registry of code/config updates React Doctor applies to a user's repo.
@@ -34,7 +35,37 @@ const legacyConfigToTypescript: Migration = {
   },
 };
 
-export const PROJECT_MIGRATIONS: ReadonlyArray<Migration> = [legacyConfigToTypescript];
+// Pins a mutable `@main` / `@master` React Doctor action reference in the repo's
+// workflows to the recommended floating major (`@v2`). An unpinned `@main` runs
+// whatever the action's HEAD points to with the workflow's write permissions — a
+// supply-chain risk (#299) — and the rewrite also moves the workflow onto the
+// current install- and scan-cached action release. A pinned tag / SHA is
+// deliberate and left untouched; with no mutable ref this is a no-op that
+// returns `false` (stays pending, so a ref added later is still migrated).
+const actionPinMainToMajor: Migration = {
+  id: "action-pin-main-to-v2",
+  scope: "project",
+  run: ({ projectRoot }) => {
+    if (projectRoot === undefined) return false;
+    const rewrittenFiles = migrateActionPin(projectRoot);
+    if (rewrittenFiles.length === 0) return false;
+
+    const relativeFiles = rewrittenFiles
+      .map((file) => toRelativePath(file, projectRoot))
+      .join(", ");
+    logger.success(`Pinned the React Doctor action to @v2 in ${relativeFiles}`);
+    logger.dim(
+      "  An unpinned @main reference runs whatever the action's HEAD points to (a supply-chain risk). Review and commit the change — or revert it if you intentionally track main.",
+    );
+    logger.break();
+    return true;
+  },
+};
+
+export const PROJECT_MIGRATIONS: ReadonlyArray<Migration> = [
+  legacyConfigToTypescript,
+  actionPinMainToMajor,
+];
 
 // Runs every pending per-repo migration for `projectRoot` once, recording the
 // ones that apply. Safe to call on every scan — recorded migrations are skipped.

--- a/packages/react-doctor/src/cli/utils/migrate-action-pin.ts
+++ b/packages/react-doctor/src/cli/utils/migrate-action-pin.ts
@@ -1,0 +1,60 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const WORKFLOWS_DIRECTORY = path.join(".github", "workflows");
+
+// The floating major the React Doctor action recommends pinning to. AGENTS.md:
+// never reference the action by a mutable branch — `@main` runs whatever HEAD
+// points to, with the workflow's write permissions, a supply-chain risk (#299).
+const RECOMMENDED_ACTION_REF = "v2";
+
+// A `uses:` reference to the React Doctor action pinned to a MUTABLE branch
+// (`@main` / `@master`). Only these are unsafe; a pinned tag (`@v2.1.0`) or a
+// commit SHA is a deliberate pin and left untouched. The capture group keeps the
+// `uses: <owner>/react-doctor@` prefix so only the ref is rewritten.
+const MUTABLE_ACTION_REF = /(uses:\s*[\w.-]+\/react-doctor@)(?:main|master)\b/g;
+
+const isWorkflowFile = (fileName: string): boolean => /\.ya?ml$/.test(fileName);
+
+/**
+ * Rewrites mutable `@main` / `@master` React Doctor GitHub Action references in
+ * the repo's `.github/workflows/*.yml` to the recommended floating major
+ * (`@v2`) — a supply-chain hardening (#299) that also moves the workflow onto
+ * the current (install- and scan-cached) action release. Pinned tags / SHAs are
+ * deliberate and left untouched. Returns the absolute paths of the workflow
+ * files it rewrote — empty when there's nothing to migrate.
+ */
+export const migrateActionPin = (projectRoot: string): string[] => {
+  const workflowsDirectory = path.join(projectRoot, WORKFLOWS_DIRECTORY);
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(workflowsDirectory, { withFileTypes: true });
+  } catch {
+    return []; // no .github/workflows — nothing to migrate
+  }
+
+  const rewrittenFiles: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !isWorkflowFile(entry.name)) continue;
+    const workflowPath = path.join(workflowsDirectory, entry.name);
+
+    let contents: string;
+    try {
+      contents = fs.readFileSync(workflowPath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const updated = contents.replace(MUTABLE_ACTION_REF, `$1${RECOMMENDED_ACTION_REF}`);
+    if (updated === contents) continue;
+
+    try {
+      fs.writeFileSync(workflowPath, updated);
+      rewrittenFiles.push(workflowPath);
+    } catch {
+      // A write failure leaves the file untouched; the migration stays pending
+      // and retries on the next scan.
+    }
+  }
+  return rewrittenFiles;
+};

--- a/packages/react-doctor/tests/diff-fast-path.test.ts
+++ b/packages/react-doctor/tests/diff-fast-path.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterAll, afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { diagnose } from "../src/index.js";
+import { setupReactProject } from "./regressions/_helpers.js";
+
+// The GitHub Action's PR fast path forwards `--scope changed
+// --changed-files-from <file>`, which the CLI turns into a diff-mode scan
+// (`includePaths` non-empty) that SKIPS dead-code + supply-chain — the two
+// phases that dominate full scans. That skip is why PR runs are engine-fast
+// (~1-3s) and install-bound (see plan 09). It's load-bearing for CI speed and
+// easy to regress (e.g. a change that drops the `!isDiffMode` gate in
+// run-inspect), so lock it behaviorally: the dead-code diagnostic a full scan
+// surfaces must be ABSENT from a diff-mode scan of the same project.
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-diff-fast-path-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const stubOfflineScore = () =>
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify({ score: 100, label: "Perfect" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ),
+  );
+
+const orphanFixture = (caseId: string): string =>
+  setupReactProject(tempRoot, caseId, {
+    packageJsonExtras: { type: "module" },
+    files: {
+      "src/index.ts": "export const used = 1;\n",
+      "src/orphan.ts": "export const orphan = 1;\n",
+    },
+  });
+
+describe("diff fast path (CI scope: changed)", () => {
+  it("a full scan surfaces the orphan dead-code diagnostic (baseline)", async () => {
+    stubOfflineScore();
+    const projectDir = orphanFixture("full");
+    const result = await diagnose(projectDir, { lint: false, deadCode: true, warnings: true });
+    const orphan = result.diagnostics.find(
+      (diagnostic) =>
+        diagnostic.rule === "unused-file" && diagnostic.filePath.endsWith("orphan.ts"),
+    );
+    expect(orphan).toBeDefined();
+  });
+
+  it("a diff-mode scan (changed files only) skips dead-code — no unused-file diagnostic", async () => {
+    stubOfflineScore();
+    const projectDir = orphanFixture("diff");
+    // `includePaths` non-empty ⇒ diff mode. run-inspect gates BOTH dead-code
+    // (`shouldRunDeadCode`) and supply-chain (`shouldRunSupplyChain`) on
+    // `!isDiffMode`, so neither runs — the orphan unused-file the full scan
+    // above found must not appear.
+    const result = await diagnose(projectDir, {
+      lint: false,
+      deadCode: true,
+      warnings: true,
+      includePaths: ["src/index.ts"],
+    });
+    expect(result.diagnostics.some((diagnostic) => diagnostic.rule === "unused-file")).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -87,22 +87,23 @@ describe("GitHub Action contract", () => {
     expect(actionYaml).not.toContain('git checkout "$HEAD_REF"');
   });
 
-  it("rewrites repo-relative PR paths to the scanned directory for --changed-files-from", () => {
-    const prFilesStep = normalizeWhitespace(extractStep(readActionYaml(), "- id: pr-files"));
+  it("derives changed files (local git diff first, API fallback) via the shared scan-relative normalizer", () => {
+    const actionYaml = readActionYaml();
+    const baseStep = normalizeWhitespace(extractStep(actionYaml, "- id: base"));
+    const prFilesStep = normalizeWhitespace(extractStep(actionYaml, "- id: pr-files"));
 
-    // The GitHub API returns repo-root-relative paths, but the CLI resolves
-    // --changed-files-from entries relative to the scanned `directory`. The step
-    // must strip the `directory` prefix (and drop files outside it) so a
-    // subdirectory scan (`directory: UI`) doesn't double up to `UI/UI/src/...`
-    // and miss every base read — the bug in issue #858.
+    // The repo-root → scan-relative prefix-stripping (strip the `directory`
+    // prefix, drop files outside it, so `directory: UI` doesn't double up to
+    // `UI/UI/src/...` and miss every base read — issue #858) now lives in the
+    // shared scripts/normalize-changed-files.mjs and is unit-tested there. The
+    // action delegates to it from BOTH the local-diff base step and the API
+    // fallback, which only runs when the base wasn't reachable for a local diff.
+    expect(baseStep).toContain('git -C "$INPUT_DIRECTORY" diff --name-only --diff-filter=AMR');
+    expect(baseStep).toContain("scripts/normalize-changed-files.mjs");
     expect(prFilesStep).toContain("INPUT_DIRECTORY: ${{ inputs.directory }}");
-    expect(prFilesStep).toContain("const directoryPrefix = (process.env.INPUT_DIRECTORY");
-    expect(prFilesStep).toContain('.replace(/^\\.\\/?/, "")');
-    expect(prFilesStep).toContain('.replace(/\\/$/, "")');
-    expect(prFilesStep).toContain("const scopedPrefix = `${directoryPrefix}/`;");
-    expect(prFilesStep).toContain(
-      "filename.startsWith(scopedPrefix) ? [filename.slice(scopedPrefix.length)] : []",
-    );
+    expect(prFilesStep).toContain("scripts/normalize-changed-files.mjs");
+    expect(prFilesStep).toContain("normalizeChangedFiles(");
+    expect(prFilesStep).toContain("steps.base.outputs.path == ''");
   });
 
   it("falls back to a full-project scan when listing PR files is not permitted", () => {
@@ -144,10 +145,33 @@ describe("GitHub Action contract", () => {
     expect(scanStep).toContain(
       'npm exec --yes --package "$PACKAGE_SPEC" -- react-doctor "$INPUT_DIRECTORY" "${FLAGS[@]}" > "$REPORT_FILE"',
     );
-    expect(scanStep).toContain('PACKAGE_SPEC="react-doctor@$INPUT_VERSION"');
+    // PACKAGE_SPEC is resolved once (and made cacheable) by the resolve-version
+    // step and read from its output, not derived inline in the scan step.
+    expect(scanStep).toContain("PACKAGE_SPEC: ${{ steps.resolve-version.outputs.spec }}");
     expect(scanStep).toContain("SCAN_STATUS=$?");
     expect(scanStep).toContain("scripts/ensure-json-report.mjs");
     expect(actionYaml).not.toContain("--score");
+  });
+
+  it("resolves the version once and caches the install + persistent scan caches", () => {
+    const actionYaml = readActionYaml();
+    const resolveStep = normalizeWhitespace(extractStep(actionYaml, "- id: resolve-version"));
+    const scanStep = normalizeWhitespace(
+      extractStep(actionYaml, "INPUT_PROJECT: ${{ inputs.project }}"),
+    );
+
+    // resolve-version pins the version so the install cache key is stable even
+    // for `latest`; actions/cache (SHA-pinned or floating) restores the toolchain
+    // install + the persistent scan caches; the scan installs into the cached
+    // prefix on a published version and runs the local binary, falling back to
+    // npx for a local-path spec.
+    expect(resolveStep).toContain("scripts/resolve-package-spec.mjs");
+    expect(actionYaml).toMatch(/actions\/cache@(?:v4\b|[0-9a-f]{40} # v4\b)/);
+    expect(actionYaml).toContain("react-doctor-toolchain");
+    expect(actionYaml).toContain("react-doctor-scan-cache-");
+    expect(scanStep).toContain('npm install --prefix "$TOOLCHAIN_DIR"');
+    expect(scanStep).toContain('"$RD_BIN" "$INPUT_DIRECTORY" "${FLAGS[@]}" > "$REPORT_FILE"');
+    expect(scanStep).toContain("REACT_DOCTOR_CACHE_DIR: ${{ runner.temp }}/react-doctor-cache");
   });
 
   it("fetches the PR base commit and forwards it for baseline (new-vs-existing) mode", () => {

--- a/packages/react-doctor/tests/migrate-action-pin.test.ts
+++ b/packages/react-doctor/tests/migrate-action-pin.test.ts
@@ -1,0 +1,88 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { migrateActionPin } from "../src/cli/utils/migrate-action-pin.js";
+
+let projectRoot: string;
+let workflowsDir: string;
+
+beforeEach(() => {
+  projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-action-pin-"));
+  workflowsDir = path.join(projectRoot, ".github", "workflows");
+  fs.mkdirSync(workflowsDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+const writeWorkflow = (name: string, contents: string): string => {
+  const workflowPath = path.join(workflowsDir, name);
+  fs.writeFileSync(workflowPath, contents);
+  return workflowPath;
+};
+
+describe("migrateActionPin", () => {
+  it("rewrites a mutable @main action ref to @v2, preserving owner + the rest of the line", () => {
+    const workflowPath = writeWorkflow(
+      "ci.yml",
+      ["jobs:", "  scan:", "    steps:", "      - uses: millionco/react-doctor@main", ""].join(
+        "\n",
+      ),
+    );
+    const rewritten = migrateActionPin(projectRoot);
+    expect(rewritten).toEqual([workflowPath]);
+    expect(fs.readFileSync(workflowPath, "utf-8")).toContain("- uses: millionco/react-doctor@v2");
+  });
+
+  it("rewrites @master too", () => {
+    const workflowPath = writeWorkflow("ci.yaml", "      - uses: millionco/react-doctor@master\n");
+    migrateActionPin(projectRoot);
+    expect(fs.readFileSync(workflowPath, "utf-8").trim()).toBe("- uses: millionco/react-doctor@v2");
+  });
+
+  it("preserves the action's `version:` input + a trailing comment, touching only the ref", () => {
+    const workflowPath = writeWorkflow(
+      "ci.yml",
+      [
+        "      - uses: millionco/react-doctor@main # latest",
+        "        with:",
+        "          version: latest",
+        "",
+      ].join("\n"),
+    );
+    migrateActionPin(projectRoot);
+    const contents = fs.readFileSync(workflowPath, "utf-8");
+    expect(contents).toContain("- uses: millionco/react-doctor@v2 # latest");
+    expect(contents).toContain("version: latest"); // the CLI version input is untouched
+  });
+
+  it("leaves a deliberately pinned tag or SHA untouched", () => {
+    const pinned = [
+      "      - uses: millionco/react-doctor@v2.1.0",
+      "      - uses: millionco/react-doctor@a1b2c3d4e5f6 # v2.1.0",
+    ].join("\n");
+    writeWorkflow("pinned.yml", pinned);
+    expect(migrateActionPin(projectRoot)).toEqual([]);
+  });
+
+  it("leaves a different action on @main untouched", () => {
+    const other = "      - uses: actions/checkout@main\n";
+    const workflowPath = writeWorkflow("other.yml", other);
+    expect(migrateActionPin(projectRoot)).toEqual([]);
+    expect(fs.readFileSync(workflowPath, "utf-8")).toBe(other);
+  });
+
+  it("is a no-op (returns []) when there is no .github/workflows directory", () => {
+    fs.rmSync(path.join(projectRoot, ".github"), { recursive: true, force: true });
+    expect(migrateActionPin(projectRoot)).toEqual([]);
+  });
+
+  it("rewrites across multiple workflow files and reports each", () => {
+    const first = writeWorkflow("a.yml", "      - uses: millionco/react-doctor@main\n");
+    const second = writeWorkflow("b.yml", "      - uses: millionco/react-doctor@master\n");
+    writeWorkflow("c.yml", "      - uses: millionco/react-doctor@v2\n"); // already pinned
+    expect(migrateActionPin(projectRoot).sort()).toEqual([first, second].sort());
+  });
+});

--- a/packages/react-doctor/tests/normalize-changed-files.test.ts
+++ b/packages/react-doctor/tests/normalize-changed-files.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vite-plus/test";
+import { normalizeChangedFiles } from "../../../scripts/normalize-changed-files.mjs";
+
+// Shared by the action's local-`git diff` path and its GitHub-API fallback —
+// the prefix-stripping/scoping is the bug-prone bit (the `UI/UI/src/...`
+// double-prefix that misses every base read), so lock it.
+describe("normalizeChangedFiles", () => {
+  it("passes repo-root paths through unchanged when scanning the repo root", () => {
+    expect(normalizeChangedFiles(["src/a.tsx", "src/b.ts"], ".")).toEqual([
+      "src/a.tsx",
+      "src/b.ts",
+    ]);
+    expect(normalizeChangedFiles(["src/a.tsx"], undefined)).toEqual(["src/a.tsx"]);
+  });
+
+  it("strips the scanned directory prefix so a subdirectory scan stays scan-relative", () => {
+    expect(normalizeChangedFiles(["UI/src/a.tsx", "UI/src/b.ts"], "UI")).toEqual([
+      "src/a.tsx",
+      "src/b.ts",
+    ]);
+  });
+
+  it("drops files outside the scanned directory", () => {
+    expect(normalizeChangedFiles(["UI/src/a.tsx", "server/x.ts", "README.md"], "UI")).toEqual([
+      "src/a.tsx",
+    ]);
+  });
+
+  it("normalizes a `./UI/` style directory input", () => {
+    expect(normalizeChangedFiles(["UI/src/a.tsx"], "./UI/")).toEqual(["src/a.tsx"]);
+  });
+
+  it("does NOT double-prefix (the UI/UI bug): a path already scan-relative is dropped, not kept", () => {
+    // A file passed as `src/a.tsx` (already scan-relative) when directory is `UI`
+    // is outside the `UI/` prefix and correctly dropped — the inverse of the bug
+    // where it would survive and become an unreadable `UI/src/a.tsx` lookup.
+    expect(normalizeChangedFiles(["src/a.tsx"], "UI")).toEqual([]);
+  });
+
+  it("trims whitespace and drops blank lines (raw `git diff` stdin)", () => {
+    expect(normalizeChangedFiles(["  src/a.tsx  ", "", "  ", "src/b.ts"], ".")).toEqual([
+      "src/a.tsx",
+      "src/b.ts",
+    ]);
+  });
+});

--- a/packages/react-doctor/tests/resolve-package-spec.test.ts
+++ b/packages/react-doctor/tests/resolve-package-spec.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vite-plus/test";
+import { classifyVersionSpec } from "../../../scripts/resolve-package-spec.mjs";
+
+// The action keys its install cache on the resolved react-doctor version, so the
+// version→spec classification (cacheable registry range vs non-cacheable local
+// path) is load-bearing for the cache being sound. Lock the branch logic.
+describe("classifyVersionSpec", () => {
+  it("treats `latest` as a cacheable registry range", () => {
+    expect(classifyVersionSpec("latest")).toEqual({
+      cacheable: true,
+      spec: "react-doctor@latest",
+      registryRange: "latest",
+    });
+  });
+
+  it("treats an exact version as a cacheable registry spec", () => {
+    expect(classifyVersionSpec("2.1.0")).toEqual({
+      cacheable: true,
+      spec: "react-doctor@2.1.0",
+      registryRange: "2.1.0",
+    });
+  });
+
+  it("treats a semver range as cacheable", () => {
+    expect(classifyVersionSpec("^2")).toEqual({
+      cacheable: true,
+      spec: "react-doctor@^2",
+      registryRange: "^2",
+    });
+  });
+
+  it("treats a relative local path as a NON-cacheable passthrough spec (self-test path)", () => {
+    expect(classifyVersionSpec("./packages/react-doctor")).toEqual({
+      cacheable: false,
+      spec: "./packages/react-doctor",
+      registryRange: undefined,
+    });
+    expect(classifyVersionSpec("../foo")).toEqual({
+      cacheable: false,
+      spec: "../foo",
+      registryRange: undefined,
+    });
+  });
+
+  it("treats an absolute local path as non-cacheable", () => {
+    expect(classifyVersionSpec("/tmp/react-doctor")).toEqual({
+      cacheable: false,
+      spec: "/tmp/react-doctor",
+      registryRange: undefined,
+    });
+  });
+
+  it("defaults an empty / undefined version to `latest`", () => {
+    const expected = { cacheable: true, spec: "react-doctor@latest", registryRange: "latest" };
+    expect(classifyVersionSpec("")).toEqual(expected);
+    expect(classifyVersionSpec(undefined)).toEqual(expected);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(classifyVersionSpec("  latest  ")).toEqual({
+      cacheable: true,
+      spec: "react-doctor@latest",
+      registryRange: "latest",
+    });
+  });
+});

--- a/scripts/normalize-changed-files.mjs
+++ b/scripts/normalize-changed-files.mjs
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Map repo-root-relative changed-file paths (from `git diff --name-only` or the
+ * GitHub `pulls.listFiles` API) to the SCAN-relative paths the CLI's
+ * `--changed-files-from` expects. The CLI resolves changed-file entries relative
+ * to the scanned `directory` (its diff detection runs `git diff --relative`), so
+ * strip the `directory` prefix and drop files outside it — otherwise a
+ * subdirectory scan (`directory: UI`) doubles up to `UI/UI/src/...`, misses every
+ * base read, and reports pre-existing issues as newly introduced.
+ *
+ * Shared by the action's local-`git diff` path (the cheap default) and its
+ * GitHub-API fallback so the two derive the same set from one implementation.
+ *
+ * @param {ReadonlyArray<string>} files repo-root-relative changed-file paths
+ * @param {string | undefined} directory the scanned `directory` input
+ * @returns {string[]} scan-relative paths
+ */
+export const normalizeChangedFiles = (files, directory) => {
+  const directoryPrefix = String(directory ?? ".")
+    .replace(/^\.\/?/, "")
+    .replace(/\/$/, "");
+  return files
+    .map((file) => String(file).trim())
+    .filter(Boolean)
+    .flatMap((filename) => {
+      if (!directoryPrefix) return [filename];
+      const scopedPrefix = `${directoryPrefix}/`;
+      return filename.startsWith(scopedPrefix) ? [filename.slice(scopedPrefix.length)] : [];
+    });
+};
+
+// CLI: read newline-separated repo-root paths on stdin (from `git diff
+// --name-only`), write the scan-relative set to argv[3] (or stdout). argv[2] is
+// the scanned directory.
+const main = () => {
+  const directory = process.argv[2];
+  const rawInput = fs.readFileSync(0, "utf8");
+  const normalized = normalizeChangedFiles(rawInput.split("\n"), directory);
+  const rendered = normalized.length > 0 ? `${normalized.join("\n")}\n` : "";
+  const outputPath = process.argv[3];
+  if (outputPath) {
+    fs.writeFileSync(outputPath, rendered);
+  } else {
+    process.stdout.write(rendered);
+  }
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/resolve-package-spec.mjs
+++ b/scripts/resolve-package-spec.mjs
@@ -1,0 +1,77 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Classify the action's `version` input into the install spec to run. Pure and
+ * exported so the branch logic (local path vs registry range vs `latest`) is
+ * unit-tested without the network. A local-path spec (this repo's self-test
+ * runs the action against a built tarball / path) is NOT cacheable — its bytes
+ * aren't keyed by a published version, so an install cache would be unsound.
+ *
+ * @param {string | undefined} version
+ * @returns {{ cacheable: boolean, spec: string, registryRange: string | undefined }}
+ */
+export const classifyVersionSpec = (version) => {
+  const trimmed = String(version ?? "").trim();
+  const isLocalPath =
+    trimmed.startsWith("./") || trimmed.startsWith("../") || trimmed.startsWith("/");
+  if (isLocalPath) {
+    return { cacheable: false, spec: trimmed, registryRange: undefined };
+  }
+  const range = trimmed || "latest";
+  return { cacheable: true, spec: `react-doctor@${range}`, registryRange: range };
+};
+
+/**
+ * Resolve a dist-tag / range (`latest`, `^2`) to the concrete published version,
+ * so the install cache key is stable across runs of the same release. Network;
+ * on a registry failure it falls back to the raw range — the install still
+ * works, just without a stable cache key (no worse than today).
+ *
+ * @param {string} range
+ * @returns {string}
+ */
+const resolveConcreteVersion = (range) => {
+  try {
+    const output = execFileSync("npm", ["view", `react-doctor@${range}`, "version"], {
+      encoding: "utf8",
+    });
+    // `npm view <range> version` prints one line per matching version for a
+    // range; the last line is the highest match — the one npm would install.
+    const versions = output
+      .trim()
+      .split("\n")
+      .map((line) => line.replace(/^.*'(.+)'.*$/, "$1").trim())
+      .filter(Boolean);
+    return versions.length > 0 ? versions[versions.length - 1] : range;
+  } catch {
+    return range;
+  }
+};
+
+const writeOutputs = (outputs) => {
+  const rendered = Object.entries(outputs)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  const outputPath = process.env["GITHUB_OUTPUT"];
+  if (outputPath) {
+    fs.appendFileSync(outputPath, `${rendered}\n`);
+  } else {
+    process.stdout.write(`${rendered}\n`);
+  }
+};
+
+const main = () => {
+  const classified = classifyVersionSpec(process.argv[2]);
+  if (!classified.cacheable) {
+    writeOutputs({ spec: classified.spec, resolved: "", cacheable: "false" });
+    return;
+  }
+  const resolved = resolveConcreteVersion(classified.registryRange);
+  writeOutputs({ spec: `react-doctor@${resolved}`, resolved, cacheable: "true" });
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
Implements the three CI-focused speedup plans (09–11). The Action's dominant cost on a PR run is the **uncached install (~15s of an ~18s step)**, not the scan — so these target the CI experience.

## Plan 09 — cache the install (biggest CI win)
- `resolve-version` step pins the concrete published version so the cache key is stable even for `latest` (`scripts/resolve-package-spec.mjs`; a local-path spec is reported non-cacheable).
- `actions/cache` restores the install keyed on `version+node+os+arch` (no fuzzy `restore-keys` — native-ABI safety).
- The scan installs into the cached `--prefix` only on a miss (`[ ! -x ]` re-install guard) and runs the local binary; the non-cacheable local-path branch keeps the npx path. **~15s install → ~1–2s restore** on a hit.

## Plan 11 — local diff scope + lock the fast path
- The `base` step derives changed files with a local `git diff --name-only --diff-filter=AMR <base>...HEAD` (faster, no API rate limit, works on forks where `pulls.listFiles` can be denied → previously dropped to a full scan); the GitHub API is now the fallback. Both share `scripts/normalize-changed-files.mjs`.
- **R1 regression test** locks that diff mode skips dead-code + supply-chain (the fast-path guarantee).
- Clearer degraded-mode warning pointing at `fetch-depth: 0`.

## Plan 10 — persist scan caches across CI runs
- `REACT_DOCTOR_CACHE_DIR` lets the action point the engine's caches at a stable `${runner.temp}` path an `actions/cache` step persists, so the per-file content-addressed lint cache (#900) **restores across commits** — a PR re-lints only its changed files. Key busts on version+lockfile+os/arch; the engine re-validates each entry by content+ruleset hash, so a stale restore just misses (no correctness risk).
- New **supply-chain per-PURL on-disk cache** (24h TTL, fail-open, `REACT_DOCTOR_NO_CACHE`-bypassed) skips the Socket network for unchanged deps.

## Tests
Version classification, changed-file normalization (incl. the `UI/UI` double-prefix bug), diff-fast-path skip, cache-dir env override, and supply-chain cache hit/bypass — all green. Changeset added for the npm-facing surface (`REACT_DOCTOR_CACHE_DIR` + supply-chain cache).

## Follow-ups (not in this PR)
- **Action tags**: `action.yml` changed → cut a minor (09/10) / patch (11) tag + move the floating `v2` after dogfooding (per AGENTS.md).
- **Self-test job**: plan 09's cold/warm cacheable-install self-test job is a `.github/workflows/react-doctor.yml` change that needs a `workflow`-scoped push — add it separately.
- **R3 docs**: sparse-checkout + `fetch-depth` consumer guidance → docs-site repo.
- **`--print-cache-key`**: a tighter ruleset-exact actions/cache key (the version+lockfile key restores soundly today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI install/caching and PR file discovery paths where subtle mis-keying or path normalization could change scan scope; engine re-validates lint cache entries and supply-chain caching is fail-open, limiting correctness risk.
> 
> **Overview**
> Speeds up **GitHub Actions** runs by caching the dominant **npm install** (~15s → ~1–2s on hit), persisting **lint + supply-chain scan caches** across CI commits, and preferring a **local `git diff`** for PR changed files (API fallback unchanged).
> 
> The composite action adds **`resolve-version`** (concrete version for stable cache keys), **`actions/cache`** for the toolchain prefix and `${runner.temp}/react-doctor-cache`, sets **`REACT_DOCTOR_CACHE_DIR`** on scan, and runs the CLI from a cached **`npm install --prefix`** when the version is cacheable (local path still uses `npx`). **`base`** now fetches the PR base and derives AMR files via three-dot diff + shared **`normalize-changed-files.mjs`**; **`pr-files`** runs only when that fails.
> 
> **`@react-doctor/core`** honors **`REACT_DOCTOR_CACHE_DIR`** (per-project subdir under the override) and adds a **24h TTL per-PURL Socket supply-chain disk cache** (fail-open, **`REACT_DOCTOR_NO_CACHE`** bypass).
> 
> **`react-doctor`** adds a once-per-repo migration that rewrites **`millionco/react-doctor@main|master`** to **`@v2`** in workflow YAML (pinned tags/SHAs untouched). New regression tests cover version classification, changed-file normalization, diff-mode skipping dead-code/supply-chain, cache dir, supply-chain cache hits, and action YAML contracts; dogfooding adds an **`action-cacheable-install`** workflow job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4441562ae3ba86a30c49d2a1d8eb34abce5102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->