### PR TITLE
fix(action,core): address Cursor Bugbot findings on the CI-speedup PR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,24 +115,26 @@ runs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         CHANGED_FILES_FILE: ${{ runner.temp }}/react-doctor-changed-files.txt
       run: |
-        # Fetch the PR base commit so react-doctor can read base file content
-        # and resolve the merge-base for baseline (PR-introduced-issues-only)
-        # mode. Depth 1 covers the standard merge-ref checkout (base is a parent
-        # of HEAD); for deeper history use `fetch-depth: 0` on actions/checkout.
-        FETCHED=""
+        # Best-effort fetch of the PR base commit so react-doctor can read base
+        # file content and resolve the merge-base for baseline (PR-introduced-
+        # issues-only) mode. Depth 1 covers the standard merge-ref checkout (base
+        # is a parent of HEAD); for deeper history use `fetch-depth: 0` on
+        # actions/checkout. The base may ALREADY be present (e.g. `fetch-depth: 0`
+        # or a prior fetch), so don't gate the diff on this succeeding — `|| true`
+        # keeps a redundant/failed fetch from blocking the local diff below.
         if [ -n "$BASE_SHA" ] && git -C "$INPUT_DIRECTORY" rev-parse --git-dir >/dev/null 2>&1; then
-          if git -C "$INPUT_DIRECTORY" fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null; then
-            FETCHED="1"
-          fi
+          git -C "$INPUT_DIRECTORY" fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
         fi
 
-        # With the base fetched, derive the changed set locally. Three-dot
-        # (merge-base) + AMR (added/modified/renamed) match the `pulls.listFiles`
-        # API contract and the CLI's baseline semantics. On any failure (shallow
-        # history with no reachable merge-base), leave the file unwritten so the
-        # API fallback runs — no regression vs the previous API-only behavior.
+        # Derive the changed set locally. Three-dot (merge-base) + AMR
+        # (added/modified/renamed) match the `pulls.listFiles` API contract and
+        # the CLI's baseline semantics. Attempt it whenever a base SHA is known —
+        # the base may be reachable in history even when the fetch above was a
+        # no-op or failed. On any failure (shallow history with no reachable
+        # merge-base), leave the file unwritten so the API fallback runs — no
+        # regression vs the previous API-only behavior.
         RAW_CHANGED="${RUNNER_TEMP:-/tmp}/react-doctor-raw-changed.txt"
-        if [ -n "$FETCHED" ] && git -C "$INPUT_DIRECTORY" diff --name-only --diff-filter=AMR "$BASE_SHA...HEAD" > "$RAW_CHANGED" 2>/dev/null; then
+        if [ -n "$BASE_SHA" ] && git -C "$INPUT_DIRECTORY" diff --name-only --diff-filter=AMR "$BASE_SHA...HEAD" > "$RAW_CHANGED" 2>/dev/null; then
           node "$GITHUB_ACTION_PATH/scripts/normalize-changed-files.mjs" "$INPUT_DIRECTORY" "$CHANGED_FILES_FILE" < "$RAW_CHANGED"
           echo "path=$CHANGED_FILES_FILE" >> "$GITHUB_OUTPUT"
         else
@@ -149,12 +151,17 @@ runs:
       env:
         REACT_DOCTOR_CHANGED_FILES: ${{ runner.temp }}/react-doctor-changed-files.txt
         INPUT_DIRECTORY: ${{ inputs.directory }}
+        # `github.action_path` is THIS composite action's directory. Inside a
+        # nested `actions/github-script` step, the ambient GITHUB_ACTION_PATH env
+        # points at github-script's own dir, not ours — so the shared script
+        # would be unresolvable. Pass the composite path explicitly.
+        COMPOSITE_ACTION_PATH: ${{ github.action_path }}
       with:
         script: |
           const fs = require("fs");
           const { pathToFileURL } = require("url");
           const { normalizeChangedFiles } = await import(
-            pathToFileURL(`${process.env.GITHUB_ACTION_PATH}/scripts/normalize-changed-files.mjs`).href,
+            pathToFileURL(`${process.env.COMPOSITE_ACTION_PATH}/scripts/normalize-changed-files.mjs`).href,
           );
           const outputPath = process.env.REACT_DOCTOR_CHANGED_FILES;
           const pullRequest = context.payload.pull_request;
@@ -252,11 +259,20 @@ runs:
         TOOLCHAIN_DIR="${RUNNER_TEMP:-/tmp}/react-doctor-toolchain"
         RD_BIN=""
         if [ "$CACHEABLE" = "true" ]; then
+          # Run the install under `set +e` so a transient npm failure on a cache
+          # miss doesn't abort the whole step under the composite shell's errexit.
+          # Adopt the cached binary only if it's actually executable afterward —
+          # a failed/partial install leaves RD_BIN empty and falls through to the
+          # npx path below instead of failing the action with a raw npm error.
+          set +e
           if [ ! -x "$TOOLCHAIN_DIR/node_modules/.bin/react-doctor" ]; then
             mkdir -p "$TOOLCHAIN_DIR"
             npm install --prefix "$TOOLCHAIN_DIR" --no-save --no-audit --no-fund "$PACKAGE_SPEC"
           fi
-          RD_BIN="$TOOLCHAIN_DIR/node_modules/.bin/react-doctor"
+          set -e
+          if [ -x "$TOOLCHAIN_DIR/node_modules/.bin/react-doctor" ]; then
+            RD_BIN="$TOOLCHAIN_DIR/node_modules/.bin/react-doctor"
+          fi
         fi
 
         set +e

--- a/packages/core/src/check-supply-chain.ts
+++ b/packages/core/src/check-supply-chain.ts
@@ -427,7 +427,13 @@ const fetchSocketArtifact = (
       cacheDirectory === null ? null : supplyChainCacheFile(cacheDirectory, dependency);
     if (cacheFile !== null) {
       const cachedBody = readCachedSocketBody(cacheFile);
-      if (cachedBody !== null) return parseArtifactFromBody(cachedBody);
+      if (cachedBody !== null) {
+        const cachedArtifact = parseArtifactFromBody(cachedBody);
+        // An unparseable cached body (Socket schema drift / a corrupted restore)
+        // is a MISS, not a null result — fall through to the network rather than
+        // silently skipping the advisory until the TTL expires.
+        if (cachedArtifact !== null) return cachedArtifact;
+      }
     }
     const requestUrl = `${SOCKET_FREE_PURL_API_BASE}/${encodeURIComponent(toPurl(dependency))}`;
     const response = await fetch(requestUrl, {

--- a/packages/core/tests/check-supply-chain-cache.test.ts
+++ b/packages/core/tests/check-supply-chain-cache.test.ts
@@ -22,6 +22,15 @@ const lowScoreArtifactBody = (): string =>
     alerts: [],
   });
 
+// The on-disk cache nests under a per-project hash subdir (and a `supply-chain`
+// subdir), so collect every cache `.json` by walking rather than guessing.
+const walkCacheFiles = (directory: string): string[] =>
+  fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return walkCacheFiles(entryPath);
+    return entry.name.endsWith(".json") ? [entryPath] : [];
+  });
+
 let projectDirectory: string;
 let cacheDirectory: string;
 const originalCacheDirEnv = process.env["REACT_DOCTOR_CACHE_DIR"];
@@ -69,6 +78,31 @@ describe("supply-chain on-disk cache", () => {
     const second = await runCheck();
     expect(fetchMock.mock.calls.length).toBe(callsAfterFirst); // no new network calls
     expect(second).toEqual(first); // identical diagnostics, served from cache
+  });
+
+  it("treats an unparseable cached body as a miss and re-fetches (corruption / schema drift)", async () => {
+    const fetchMock = stubSocketFetch();
+    const first = await runCheck();
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    expect(first.length).toBeGreaterThan(0);
+
+    // Corrupt the cached body in place while keeping a fresh, in-TTL envelope —
+    // the read still returns a string, but it no longer parses to an artifact.
+    // This is the corrupted-restore / Socket-schema-drift case: it must fall
+    // through to the network, not silently skip the advisory for the whole TTL.
+    // The cache nests under a per-project subdir, so walk for the `.json` files.
+    const cacheFiles = walkCacheFiles(cacheDirectory);
+    expect(cacheFiles.length).toBeGreaterThan(0); // the first scan populated it
+    for (const cacheFile of cacheFiles) {
+      fs.writeFileSync(
+        cacheFile,
+        JSON.stringify({ fetchedAtMs: Date.now(), body: "not-valid-json\n{partial" }),
+      );
+    }
+
+    const second = await runCheck();
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterFirst); // re-fetched
+    expect(second).toEqual(first); // advisory still produced from the fresh fetch
   });
 
   it("re-fetches every run when REACT_DOCTOR_NO_CACHE is set (cache bypassed)", async () => {

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -104,6 +104,12 @@ describe("GitHub Action contract", () => {
     expect(prFilesStep).toContain("scripts/normalize-changed-files.mjs");
     expect(prFilesStep).toContain("normalizeChangedFiles(");
     expect(prFilesStep).toContain("steps.base.outputs.path == ''");
+    // Inside the nested github-script step, `GITHUB_ACTION_PATH` resolves to
+    // github-script's own dir — the composite path is forwarded explicitly so
+    // the shared script import resolves. Lock that it reads the forwarded var.
+    expect(prFilesStep).toContain("COMPOSITE_ACTION_PATH: ${{ github.action_path }}");
+    expect(prFilesStep).toContain("process.env.COMPOSITE_ACTION_PATH");
+    expect(prFilesStep).not.toContain("process.env.GITHUB_ACTION_PATH");
   });
 
   it("falls back to a full-project scan when listing PR files is not permitted", () => {
@@ -172,6 +178,12 @@ describe("GitHub Action contract", () => {
     expect(scanStep).toContain('npm install --prefix "$TOOLCHAIN_DIR"');
     expect(scanStep).toContain('"$RD_BIN" "$INPUT_DIRECTORY" "${FLAGS[@]}" > "$REPORT_FILE"');
     expect(scanStep).toContain("REACT_DOCTOR_CACHE_DIR: ${{ runner.temp }}/react-doctor-cache");
+    // A cache-miss install runs under `set +e` and the cached binary is adopted
+    // only when it's executable afterward — a transient npm failure leaves
+    // RD_BIN empty and falls through to the npx path instead of aborting the
+    // whole step under the composite shell's errexit.
+    expect(scanStep).toContain('if [ -x "$TOOLCHAIN_DIR/node_modules/.bin/react-doctor" ]; then');
+    expect(scanStep).toContain('RD_BIN="$TOOLCHAIN_DIR/node_modules/.bin/react-doctor"');
   });
 
   it("fetches the PR base commit and forwards it for baseline (new-vs-existing) mode", () => {
@@ -189,6 +201,12 @@ describe("GitHub Action contract", () => {
     expect(baseStep).toContain(
       'git -C "$INPUT_DIRECTORY" fetch --no-tags --depth=1 origin "$BASE_SHA"',
     );
+    // The fetch is best-effort (`|| true`) and the local diff is gated only on
+    // the base SHA, NOT on a fetch-succeeded flag — the base may already be in
+    // history (e.g. `fetch-depth: 0`), where the old FETCHED gate wrongly fell
+    // through to the API. The diff itself stays guarded against shallow misses.
+    expect(baseStep).toContain('origin "$BASE_SHA" 2>/dev/null || true');
+    expect(baseStep).not.toContain("FETCHED");
     expect(scanStep).toContain("REACT_DOCTOR_BASE_SHA: ${{ github.event.pull_request.base.sha }}");
   });
 

--- a/scripts/resolve-package-spec.mjs
+++ b/scripts/resolve-package-spec.mjs
@@ -26,11 +26,12 @@ export const classifyVersionSpec = (version) => {
 /**
  * Resolve a dist-tag / range (`latest`, `^2`) to the concrete published version,
  * so the install cache key is stable across runs of the same release. Network;
- * on a registry failure it falls back to the raw range — the install still
- * works, just without a stable cache key (no worse than today).
+ * returns `null` on a registry failure / unresolvable range so the caller falls
+ * back to a fresh, non-cached install rather than keying the cache on a coarse,
+ * non-concrete range (which could keep restoring a stale toolchain).
  *
  * @param {string} range
- * @returns {string}
+ * @returns {string | null}
  */
 const resolveConcreteVersion = (range) => {
   try {
@@ -44,9 +45,9 @@ const resolveConcreteVersion = (range) => {
       .split("\n")
       .map((line) => line.replace(/^.*'(.+)'.*$/, "$1").trim())
       .filter(Boolean);
-    return versions.length > 0 ? versions[versions.length - 1] : range;
+    return versions.length > 0 ? versions[versions.length - 1] : null;
   } catch {
-    return range;
+    return null;
   }
 };
 
@@ -69,6 +70,13 @@ const main = () => {
     return;
   }
   const resolved = resolveConcreteVersion(classified.registryRange);
+  if (resolved === null) {
+    // Registry unreachable / range unresolvable — don't cache under a coarse,
+    // non-concrete key (which could keep restoring a STALE toolchain across
+    // failures, even after a newer release). Install the range fresh via npx.
+    writeOutputs({ spec: classified.spec, resolved: "", cacheable: "false" });
+    return;
+  }
   writeOutputs({ spec: `react-doctor@${resolved}`, resolved, cacheable: "true" });
 };
 


### PR DESCRIPTION
Fixes the five Cursor Bugbot findings flagged on #908 (plans 09–11 CI speedup). All five are real bugs introduced by that PR.

## The fixes

1. **Supply-chain cache silently skips advisories on corruption** (`check-supply-chain.ts`). An unparseable cached body (Socket schema drift / a corrupted `actions/cache` restore) returned a `null` artifact, which reads as "unscored" — so the advisory was silently dropped for the full 24h TTL. Now an unparseable cached body is treated as a **miss** and falls through to the network. A parseable body always yields a hit (only genuine hits are ever written), so the normal cache-hit path is unaffected; only true corruption refetches.

2. **Nested github-script can't resolve the shared normalizer** (`action.yml` `pr-files`). The API-fallback step imported `scripts/normalize-changed-files.mjs` via `$GITHUB_ACTION_PATH`, but inside an `actions/github-script` step that env var points at **github-script's** own dir, not the composite action's — so the import was unresolvable and the API fallback crashed. Now the composite path is forwarded explicitly as `COMPOSITE_ACTION_PATH: ${{ github.action_path }}`.

3. **Local diff wrongly skipped when the base is already present** (`action.yml` `base`). The local `git diff` was gated on a `FETCHED` flag, so on a `fetch-depth: 0` checkout (base already in history, fetch a redundant no-op) it fell through to the slower GitHub API. The fetch is now best-effort (`|| true`) and the diff is gated only on the base SHA being known.

4. **Stale toolchain cached after a registry lookup fails** (`resolve-package-spec.mjs`). A failed `npm view` fell back to the raw range yet still emitted `cacheable=true`, so the install cache could be keyed on a coarse, non-concrete range and keep restoring a stale toolchain across failures — even after a newer release. Now returns `null` → installs fresh via npx (`cacheable=false`).

5. **Transient install failure aborts the whole scan step** (`action.yml` `scan`). `npm install --prefix` ran outside `set +e`, so a flaky install tripped the composite shell's errexit and failed the action with a raw npm error instead of recovering. It now runs under `set +e`, and the cached binary is adopted only when it's executable afterward — a failed install leaves `RD_BIN` empty and falls through to the existing npx path.

## Tests
- New `check-supply-chain-cache.test.ts` case: a corrupted in-TTL cache entry refetches and still produces the advisory.
- Updated `github-action.test.ts` contract assertions for all three `action.yml` changes (composite path forwarding, ungated diff, recoverable install).

## Verification
`typecheck` clean · `lint` exit 0 · `format:check` clean on all changed files · full `react-doctor` + `core` suites pass except the known local-only flakes (`scan-result-cache` cleanup race, `check-expo-project` / `check-security-scan` global-`.env*` gitignore trap), all green in CI and untouched here.

> [!NOTE]
> `action.yml` changed, so this is an action release. After merge: cut signed `v2.2.2` at the merge commit and force-move the floating `v2` (which currently points at the buggy #908 code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI action behavior and supply-chain advisory correctness; changes are defensive fallbacks with contract tests, but they affect how PR scans and advisories run in production workflows.
> 
> **Overview**
> Fixes five regressions from the CI speedup work: **supply-chain** cache, **GitHub Action** PR/changed-files and install paths, and **version resolution** for the toolchain cache.
> 
> **Core:** Unparseable Socket cache bodies (corruption or schema drift) are treated as a **cache miss** and re-fetched instead of being read as “unscored” and dropping advisories for the TTL.
> 
> **Action:** The PR `base` step runs a local `git diff` whenever a base SHA exists (not only after a successful fetch), with best-effort fetch (`|| true`). The `pr-files` API fallback imports the shared normalizer via **`COMPOSITE_ACTION_PATH`** because nested `github-script` does not see the composite’s `GITHUB_ACTION_PATH`. The **scan** step wraps prefix `npm install` in `set +e` and only sets `RD_BIN` when the binary is executable, falling back to `npx` on flaky installs.
> 
> **Scripts:** When `npm view` fails or the range is unresolvable, **`resolve-package-spec.mjs`** marks the install **non-cacheable** instead of caching under a coarse range that could restore a stale toolchain.
> 
> Tests lock the action contracts and add a supply-chain cache corruption case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47bd87489d114bbb850cef395c64e5dfe2e302e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->