### PR TITLE
fix(deslop): track Expo config plugin package names as used dependencies

### DIFF
--- a/.changeset/expo-plugin-package-names.md
+++ b/.changeset/expo-plugin-package-names.md
@@ -4,12 +4,12 @@
 
 Fix false positives in Expo config plugin detection for package-name plugins and nested expo config
 
-Expo config plugins can be referenced by package name (not just local paths) from app.json / app.config.\*, but the collector only kept plugins that resolved to local file paths. Additionally, the standard Expo config shape nests plugins under an `expo` key, which was never visited.
+Expo config plugins can be referenced by package name (not just local file paths) from `app.json` / `app.config.*`, but the collector dropped any plugin entry that didn't resolve to a local file — so packages referenced only as config plugins were reported as unused. The `app.config.{js,ts}` AST path also only matched a top-level `plugins` property and never descended into the standard `{ expo: { plugins: [...] } }` shape (the JSON `app.json` path already read `expo.plugins`).
 
 Fixed by:
 
-- Tracking package-name plugins (like "expo-build-properties" or "expo-camera") alongside file-path plugins
-- Descending into nested `expo` object in config objects
-- Marking package-name plugins as used dependencies in detectStalePackages
+- Tracking package-name plugins (e.g. `@config-plugins/detox`, `@react-native-firebase/app`) alongside local file-path plugins
+- Descending into the nested `expo` object in the config-object AST collector
+- Marking those package-name plugins as used in `detectStalePackages` (gated on the declared dependency set, so unrelated strings can't suppress real unused deps)
 
 Closes #914

--- a/.changeset/expo-plugin-package-names.md
+++ b/.changeset/expo-plugin-package-names.md
@@ -4,9 +4,10 @@
 
 Fix false positives in Expo config plugin detection for package-name plugins and nested expo config
 
-Expo config plugins can be referenced by package name (not just local paths) from app.json / app.config.*, but the collector only kept plugins that resolved to local file paths. Additionally, the standard Expo config shape nests plugins under an `expo` key, which was never visited.
+Expo config plugins can be referenced by package name (not just local paths) from app.json / app.config.\*, but the collector only kept plugins that resolved to local file paths. Additionally, the standard Expo config shape nests plugins under an `expo` key, which was never visited.
 
 Fixed by:
+
 - Tracking package-name plugins (like "expo-build-properties" or "expo-camera") alongside file-path plugins
 - Descending into nested `expo` object in config objects
 - Marking package-name plugins as used dependencies in detectStalePackages

--- a/.changeset/expo-plugin-package-names.md
+++ b/.changeset/expo-plugin-package-names.md
@@ -1,0 +1,14 @@
+---
+"deslop-js": patch
+---
+
+Fix false positives in Expo config plugin detection for package-name plugins and nested expo config
+
+Expo config plugins can be referenced by package name (not just local paths) from app.json / app.config.*, but the collector only kept plugins that resolved to local file paths. Additionally, the standard Expo config shape nests plugins under an `expo` key, which was never visited.
+
+Fixed by:
+- Tracking package-name plugins (like "expo-build-properties" or "expo-camera") alongside file-path plugins
+- Descending into nested `expo` object in config objects
+- Marking package-name plugins as used dependencies in detectStalePackages
+
+Closes #914

--- a/packages/deslop-js/src/collect/entries.ts
+++ b/packages/deslop-js/src/collect/entries.ts
@@ -247,23 +247,23 @@ export const resolveEntries = async (config: DeslopConfig): Promise<ResolvedEntr
   }
 
   const rootPackageDependencies = readPackageJsonDependencies(join(absoluteRoot, "package.json"));
-  const expoConfigPluginEntries = extractExpoConfigPluginEntries(
+  const expoConfigPluginCollection = extractExpoConfigPluginEntries(
     absoluteRoot,
     rootPackageDependencies,
     absoluteRoot,
     false,
   );
+  const expoConfigPluginEntries = [...expoConfigPluginCollection.filePaths];
   for (const workspacePackage of entryEligiblePackages) {
     const workspacePackageDependencies = readPackageJsonDependencies(
       join(workspacePackage.directory, "package.json"),
     );
-    expoConfigPluginEntries.push(
-      ...extractExpoConfigPluginEntries(
-        workspacePackage.directory,
-        workspacePackageDependencies,
-        absoluteRoot,
-      ),
+    const workspaceExpoCollection = extractExpoConfigPluginEntries(
+      workspacePackage.directory,
+      workspacePackageDependencies,
+      absoluteRoot,
     );
+    expoConfigPluginEntries.push(...workspaceExpoCollection.filePaths);
   }
 
   const sectionsModuleEntries = extractSectionsModuleEntries(absoluteRoot);

--- a/packages/deslop-js/src/collect/expo-config-plugin-entries.ts
+++ b/packages/deslop-js/src/collect/expo-config-plugin-entries.ts
@@ -112,7 +112,13 @@ const collectExpoPluginPathsFromArray = (
         pluginName &&
         (ts.isStringLiteral(pluginName) || ts.isNoSubstitutionTemplateLiteral(pluginName))
       ) {
-        addExpoPluginEntry(entries, packageNamePlugins, rootDirectory, configDirectory, pluginName.text);
+        addExpoPluginEntry(
+          entries,
+          packageNamePlugins,
+          rootDirectory,
+          configDirectory,
+          pluginName.text,
+        );
       }
     }
   }
@@ -161,7 +167,13 @@ const collectReturnedExpoConfigPluginPaths = (
   if (!ts.isBlock(body)) {
     const expression = unwrapExpression(body);
     if (ts.isObjectLiteralExpression(expression)) {
-      collectExpoPluginPathsFromConfigObject(expression, entries, packageNamePlugins, rootDirectory, configDirectory);
+      collectExpoPluginPathsFromConfigObject(
+        expression,
+        entries,
+        packageNamePlugins,
+        rootDirectory,
+        configDirectory,
+      );
     }
     return;
   }
@@ -173,7 +185,13 @@ const collectReturnedExpoConfigPluginPaths = (
     if (ts.isReturnStatement(node) && node.expression) {
       const expression = unwrapExpression(node.expression);
       if (ts.isObjectLiteralExpression(expression)) {
-        collectExpoPluginPathsFromConfigObject(expression, entries, packageNamePlugins, rootDirectory, configDirectory);
+        collectExpoPluginPathsFromConfigObject(
+          expression,
+          entries,
+          packageNamePlugins,
+          rootDirectory,
+          configDirectory,
+        );
       }
       return;
     }
@@ -325,7 +343,13 @@ const collectExpoPluginPathsFromAppConfig = (
     }
 
     if (ts.isFunctionDeclaration(node) && hasDefaultExportModifier(node) && node.body) {
-      collectReturnedExpoConfigPluginPaths(node.body, entries, packageNamePlugins, rootDirectory, configDirectory);
+      collectReturnedExpoConfigPluginPaths(
+        node.body,
+        entries,
+        packageNamePlugins,
+        rootDirectory,
+        configDirectory,
+      );
       return;
     }
 

--- a/packages/deslop-js/src/collect/expo-config-plugin-entries.ts
+++ b/packages/deslop-js/src/collect/expo-config-plugin-entries.ts
@@ -60,11 +60,15 @@ const resolveExpoPluginPath = (configDirectory: string, pluginPath: string): str
 
 const addExpoPluginEntry = (
   entries: Set<string>,
+  packageNamePlugins: Set<string>,
   rootDirectory: string,
   configDirectory: string,
   pluginPath: string,
 ): void => {
-  if (!isLocalExpoPluginPath(pluginPath)) return;
+  if (!isLocalExpoPluginPath(pluginPath)) {
+    packageNamePlugins.add(pluginPath);
+    return;
+  }
 
   const resolvedPath = resolveExpoPluginPath(configDirectory, pluginPath);
   if (!resolvedPath) return;
@@ -92,12 +96,13 @@ const unwrapExpression = (expression: ts.Expression): ts.Expression => {
 const collectExpoPluginPathsFromArray = (
   array: ts.ArrayLiteralExpression,
   entries: Set<string>,
+  packageNamePlugins: Set<string>,
   rootDirectory: string,
   configDirectory: string,
 ): void => {
   for (const element of array.elements) {
     if (ts.isStringLiteral(element) || ts.isNoSubstitutionTemplateLiteral(element)) {
-      addExpoPluginEntry(entries, rootDirectory, configDirectory, element.text);
+      addExpoPluginEntry(entries, packageNamePlugins, rootDirectory, configDirectory, element.text);
       continue;
     }
 
@@ -107,7 +112,7 @@ const collectExpoPluginPathsFromArray = (
         pluginName &&
         (ts.isStringLiteral(pluginName) || ts.isNoSubstitutionTemplateLiteral(pluginName))
       ) {
-        addExpoPluginEntry(entries, rootDirectory, configDirectory, pluginName.text);
+        addExpoPluginEntry(entries, packageNamePlugins, rootDirectory, configDirectory, pluginName.text);
       }
     }
   }
@@ -116,18 +121,29 @@ const collectExpoPluginPathsFromArray = (
 const collectExpoPluginPathsFromConfigObject = (
   objectLiteral: ts.ObjectLiteralExpression,
   entries: Set<string>,
+  packageNamePlugins: Set<string>,
   rootDirectory: string,
   configDirectory: string,
 ): void => {
   for (const property of objectLiteral.properties) {
-    if (
-      ts.isPropertyAssignment(property) &&
-      getPropertyName(property.name) === "plugins" &&
-      ts.isArrayLiteralExpression(property.initializer)
-    ) {
+    if (!ts.isPropertyAssignment(property)) continue;
+
+    const propertyName = getPropertyName(property.name);
+    if (propertyName === "plugins" && ts.isArrayLiteralExpression(property.initializer)) {
       collectExpoPluginPathsFromArray(
         property.initializer,
         entries,
+        packageNamePlugins,
+        rootDirectory,
+        configDirectory,
+      );
+    }
+
+    if (propertyName === "expo" && ts.isObjectLiteralExpression(property.initializer)) {
+      collectExpoPluginPathsFromConfigObject(
+        property.initializer,
+        entries,
+        packageNamePlugins,
         rootDirectory,
         configDirectory,
       );
@@ -138,13 +154,14 @@ const collectExpoPluginPathsFromConfigObject = (
 const collectReturnedExpoConfigPluginPaths = (
   body: ts.ConciseBody,
   entries: Set<string>,
+  packageNamePlugins: Set<string>,
   rootDirectory: string,
   configDirectory: string,
 ): void => {
   if (!ts.isBlock(body)) {
     const expression = unwrapExpression(body);
     if (ts.isObjectLiteralExpression(expression)) {
-      collectExpoPluginPathsFromConfigObject(expression, entries, rootDirectory, configDirectory);
+      collectExpoPluginPathsFromConfigObject(expression, entries, packageNamePlugins, rootDirectory, configDirectory);
     }
     return;
   }
@@ -156,7 +173,7 @@ const collectReturnedExpoConfigPluginPaths = (
     if (ts.isReturnStatement(node) && node.expression) {
       const expression = unwrapExpression(node.expression);
       if (ts.isObjectLiteralExpression(expression)) {
-        collectExpoPluginPathsFromConfigObject(expression, entries, rootDirectory, configDirectory);
+        collectExpoPluginPathsFromConfigObject(expression, entries, packageNamePlugins, rootDirectory, configDirectory);
       }
       return;
     }
@@ -170,6 +187,7 @@ const collectReturnedExpoConfigPluginPaths = (
 const collectExpoPluginPathsFromConfigExpression = (
   expression: ts.Expression,
   entries: Set<string>,
+  packageNamePlugins: Set<string>,
   rootDirectory: string,
   configDirectory: string,
   bindings: StaticConfigBindings,
@@ -180,6 +198,7 @@ const collectExpoPluginPathsFromConfigExpression = (
     collectExpoPluginPathsFromConfigObject(
       configExpression,
       entries,
+      packageNamePlugins,
       rootDirectory,
       configDirectory,
     );
@@ -195,6 +214,7 @@ const collectExpoPluginPathsFromConfigExpression = (
       collectExpoPluginPathsFromConfigExpression(
         boundExpression,
         entries,
+        packageNamePlugins,
         rootDirectory,
         configDirectory,
         bindings,
@@ -208,6 +228,7 @@ const collectExpoPluginPathsFromConfigExpression = (
       collectReturnedExpoConfigPluginPaths(
         boundFunction.body,
         entries,
+        packageNamePlugins,
         rootDirectory,
         configDirectory,
       );
@@ -219,6 +240,7 @@ const collectExpoPluginPathsFromConfigExpression = (
     collectReturnedExpoConfigPluginPaths(
       configExpression.body,
       entries,
+      packageNamePlugins,
       rootDirectory,
       configDirectory,
     );
@@ -229,6 +251,7 @@ const collectExpoPluginPathsFromConfigExpression = (
     collectReturnedExpoConfigPluginPaths(
       configExpression.body,
       entries,
+      packageNamePlugins,
       rootDirectory,
       configDirectory,
     );
@@ -272,6 +295,7 @@ const collectStaticConfigBindings = (sourceFile: ts.SourceFile): StaticConfigBin
 const collectExpoPluginPathsFromAppConfig = (
   configPath: string,
   entries: Set<string>,
+  packageNamePlugins: Set<string>,
   rootDirectory: string,
 ): void => {
   const extension = extname(configPath);
@@ -292,6 +316,7 @@ const collectExpoPluginPathsFromAppConfig = (
       collectExpoPluginPathsFromConfigExpression(
         node.expression,
         entries,
+        packageNamePlugins,
         rootDirectory,
         configDirectory,
         bindings,
@@ -300,7 +325,7 @@ const collectExpoPluginPathsFromAppConfig = (
     }
 
     if (ts.isFunctionDeclaration(node) && hasDefaultExportModifier(node) && node.body) {
-      collectReturnedExpoConfigPluginPaths(node.body, entries, rootDirectory, configDirectory);
+      collectReturnedExpoConfigPluginPaths(node.body, entries, packageNamePlugins, rootDirectory, configDirectory);
       return;
     }
 
@@ -312,6 +337,7 @@ const collectExpoPluginPathsFromAppConfig = (
       collectExpoPluginPathsFromConfigExpression(
         node.right,
         entries,
+        packageNamePlugins,
         rootDirectory,
         configDirectory,
         bindings,
@@ -344,6 +370,7 @@ const collectPluginPathsFromJsonValue = (value: unknown): string[] => {
 const collectExpoPluginPathsFromAppJson = (
   configPath: string,
   entries: Set<string>,
+  packageNamePlugins: Set<string>,
   rootDirectory: string,
 ): void => {
   const parsedJson: unknown = JSON.parse(readFileSync(configPath, "utf8"));
@@ -359,34 +386,41 @@ const collectExpoPluginPathsFromAppJson = (
     ...expoPluginPaths,
     ...collectPluginPathsFromJsonValue(parsedJson.plugins),
   ]) {
-    addExpoPluginEntry(entries, rootDirectory, configDirectory, pluginPath);
+    addExpoPluginEntry(entries, packageNamePlugins, rootDirectory, configDirectory, pluginPath);
   }
 };
 
 const collectExpoPluginPathsFromConfig = (
   configPath: string,
   entries: Set<string>,
+  packageNamePlugins: Set<string>,
   rootDirectory: string,
 ): void => {
   try {
     if (basename(configPath) === "app.json") {
-      collectExpoPluginPathsFromAppJson(configPath, entries, rootDirectory);
+      collectExpoPluginPathsFromAppJson(configPath, entries, packageNamePlugins, rootDirectory);
       return;
     }
 
-    collectExpoPluginPathsFromAppConfig(configPath, entries, rootDirectory);
+    collectExpoPluginPathsFromAppConfig(configPath, entries, packageNamePlugins, rootDirectory);
   } catch {}
 };
+
+interface ExpoConfigPluginCollection {
+  readonly filePaths: string[];
+  readonly packageNames: string[];
+}
 
 export const extractExpoConfigPluginEntries = (
   directory: string,
   dependencies: Record<string, string>,
   rootDirectory = directory,
   includeNestedConfigs = true,
-): string[] => {
-  if (!isExpoOrReactNativeWorkspace(dependencies)) return [];
+): ExpoConfigPluginCollection => {
+  if (!isExpoOrReactNativeWorkspace(dependencies)) return { filePaths: [], packageNames: [] };
 
   const entries = new Set<string>();
+  const packageNamePlugins = new Set<string>();
   const configPaths = fg.sync(
     includeNestedConfigs ? NESTED_EXPO_CONFIG_FILE_GLOBS : EXPO_CONFIG_FILE_GLOBS,
     {
@@ -399,8 +433,31 @@ export const extractExpoConfigPluginEntries = (
   );
 
   for (const configPath of configPaths) {
-    collectExpoPluginPathsFromConfig(configPath, entries, rootDirectory);
+    collectExpoPluginPathsFromConfig(configPath, entries, packageNamePlugins, rootDirectory);
   }
 
-  return [...entries];
+  return { filePaths: [...entries], packageNames: [...packageNamePlugins] };
+};
+
+export const extractExpoConfigPluginPackageNames = (
+  directory: string,
+  dependencies: Record<string, string>,
+): string[] => {
+  if (!isExpoOrReactNativeWorkspace(dependencies)) return [];
+
+  const packageNamePlugins = new Set<string>();
+  const entries = new Set<string>();
+  const configPaths = fg.sync(NESTED_EXPO_CONFIG_FILE_GLOBS, {
+    cwd: directory,
+    absolute: true,
+    onlyFiles: true,
+    ignore: ["**/node_modules/**", "**/dist/**", "**/build/**"],
+    deep: EXPO_CONFIG_SCAN_MAX_DEPTH,
+  });
+
+  for (const configPath of configPaths) {
+    collectExpoPluginPathsFromConfig(configPath, entries, packageNamePlugins, directory);
+  }
+
+  return [...packageNamePlugins];
 };

--- a/packages/deslop-js/src/collect/expo-config-plugin-entries.ts
+++ b/packages/deslop-js/src/collect/expo-config-plugin-entries.ts
@@ -462,26 +462,3 @@ export const extractExpoConfigPluginEntries = (
 
   return { filePaths: [...entries], packageNames: [...packageNamePlugins] };
 };
-
-export const extractExpoConfigPluginPackageNames = (
-  directory: string,
-  dependencies: Record<string, string>,
-): string[] => {
-  if (!isExpoOrReactNativeWorkspace(dependencies)) return [];
-
-  const packageNamePlugins = new Set<string>();
-  const entries = new Set<string>();
-  const configPaths = fg.sync(NESTED_EXPO_CONFIG_FILE_GLOBS, {
-    cwd: directory,
-    absolute: true,
-    onlyFiles: true,
-    ignore: ["**/node_modules/**", "**/dist/**", "**/build/**"],
-    deep: EXPO_CONFIG_SCAN_MAX_DEPTH,
-  });
-
-  for (const configPath of configPaths) {
-    collectExpoPluginPathsFromConfig(configPath, entries, packageNamePlugins, directory);
-  }
-
-  return [...packageNamePlugins];
-};

--- a/packages/deslop-js/src/report/packages.ts
+++ b/packages/deslop-js/src/report/packages.ts
@@ -9,7 +9,7 @@ import { collectPnpmWorkspaceOverrideMappings } from "../utils/parse-pnpm-worksp
 import { matchesPackageImportReference } from "../utils/matches-package-import-reference.js";
 import { matchesPackageTokenReference } from "../utils/matches-package-token-reference.js";
 import { findMonorepoRoot } from "../utils/find-monorepo-root.js";
-import { extractExpoConfigPluginPackageNames } from "../collect/expo-config-plugin-entries.js";
+import { extractExpoConfigPluginEntries } from "../collect/expo-config-plugin-entries.js";
 
 interface OverrideMapping {
   fromPackage: string;
@@ -119,10 +119,10 @@ export const detectStalePackages = (
     const tsconfigReferenced = collectTsconfigReferencedPackages(configSearchRoot);
     for (const packageName of tsconfigReferenced) usedPackageNames.add(packageName);
 
-    const expoPluginPackageNames = extractExpoConfigPluginPackageNames(configSearchRoot, {
-      ...dependencies,
-      ...devDependencies,
-    });
+    const { packageNames: expoPluginPackageNames } = extractExpoConfigPluginEntries(
+      configSearchRoot,
+      { ...dependencies, ...devDependencies },
+    );
     for (const packageName of expoPluginPackageNames) {
       if (declaredNames.has(packageName)) {
         usedPackageNames.add(packageName);

--- a/packages/deslop-js/src/report/packages.ts
+++ b/packages/deslop-js/src/report/packages.ts
@@ -119,10 +119,10 @@ export const detectStalePackages = (
     const tsconfigReferenced = collectTsconfigReferencedPackages(configSearchRoot);
     for (const packageName of tsconfigReferenced) usedPackageNames.add(packageName);
 
-    const expoPluginPackageNames = extractExpoConfigPluginPackageNames(
-      configSearchRoot,
-      { ...dependencies, ...devDependencies },
-    );
+    const expoPluginPackageNames = extractExpoConfigPluginPackageNames(configSearchRoot, {
+      ...dependencies,
+      ...devDependencies,
+    });
     for (const packageName of expoPluginPackageNames) {
       if (declaredNames.has(packageName)) {
         usedPackageNames.add(packageName);

--- a/packages/deslop-js/src/report/packages.ts
+++ b/packages/deslop-js/src/report/packages.ts
@@ -9,6 +9,7 @@ import { collectPnpmWorkspaceOverrideMappings } from "../utils/parse-pnpm-worksp
 import { matchesPackageImportReference } from "../utils/matches-package-import-reference.js";
 import { matchesPackageTokenReference } from "../utils/matches-package-token-reference.js";
 import { findMonorepoRoot } from "../utils/find-monorepo-root.js";
+import { extractExpoConfigPluginPackageNames } from "../collect/expo-config-plugin-entries.js";
 
 interface OverrideMapping {
   fromPackage: string;
@@ -117,6 +118,16 @@ export const detectStalePackages = (
 
     const tsconfigReferenced = collectTsconfigReferencedPackages(configSearchRoot);
     for (const packageName of tsconfigReferenced) usedPackageNames.add(packageName);
+
+    const expoPluginPackageNames = extractExpoConfigPluginPackageNames(
+      configSearchRoot,
+      { ...dependencies, ...devDependencies },
+    );
+    for (const packageName of expoPluginPackageNames) {
+      if (declaredNames.has(packageName)) {
+        usedPackageNames.add(packageName);
+      }
+    }
   }
 
   if (hasJsxFiles(graph)) {

--- a/packages/deslop-js/tests/analyze.test.ts
+++ b/packages/deslop-js/tests/analyze.test.ts
@@ -449,6 +449,22 @@ describe("expo-config-plugins", () => {
   });
 });
 
+describe("expo-plugin-packages-false-positive", () => {
+  it("should not flag Expo config plugin packages (referenced by package name) as unused", async () => {
+    const result = await scanFixture("expo-plugin-packages-false-positive");
+    const deps = staleDependencyNames(result);
+
+    assert.ok(
+      !deps.includes("expo-build-properties"),
+      `expo-build-properties is used as a config plugin in app.json and must not be flagged as unused, got: ${deps}`,
+    );
+    assert.ok(
+      !deps.includes("expo-camera"),
+      `expo-camera is used as a config plugin in app.config.js (nested under expo key) and must not be flagged as unused, got: ${deps}`,
+    );
+  });
+});
+
 describe("nested-dist-non-workspace", () => {
   it("should exclude `dist/` directories at ANY depth, not just at workspace roots", async () => {
     const result = await scanFixture("nested-dist-non-workspace");

--- a/packages/deslop-js/tests/analyze.test.ts
+++ b/packages/deslop-js/tests/analyze.test.ts
@@ -454,13 +454,25 @@ describe("expo-plugin-packages-false-positive", () => {
     const result = await scanFixture("expo-plugin-packages-false-positive");
     const deps = staleDependencyNames(result);
 
+    // Both plugin packages are deliberately NOT covered by the always-used
+    // prefix allowlist (unlike `expo-*` / `react-native-*`), and neither is
+    // imported in source — so without the config-plugin detection they WOULD
+    // be flagged. This makes the test fail on unfixed code.
     assert.ok(
-      !deps.includes("expo-build-properties"),
-      `expo-build-properties is used as a config plugin in app.json and must not be flagged as unused, got: ${deps}`,
+      !deps.includes("@config-plugins/detox"),
+      `@config-plugins/detox is a config plugin (tuple form) in app.json and must not be flagged as unused, got: ${deps}`,
     );
     assert.ok(
-      !deps.includes("expo-camera"),
-      `expo-camera is used as a config plugin in app.config.js (nested under expo key) and must not be flagged as unused, got: ${deps}`,
+      !deps.includes("@react-native-firebase/app"),
+      `@react-native-firebase/app is a config plugin nested under the \`expo\` key in app.config.js and must not be flagged as unused, got: ${deps}`,
+    );
+
+    // Negative control: a declared dependency that is neither a plugin nor
+    // imported must STILL be reported, proving the scan runs and the plugin
+    // assertions above aren't passing vacuously.
+    assert.ok(
+      deps.includes("left-pad"),
+      `left-pad is genuinely unused and must still be flagged, got: ${deps}`,
     );
   });
 });

--- a/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/app.config.js
+++ b/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/app.config.js
@@ -1,0 +1,8 @@
+export default () => ({
+  expo: {
+    name: "TestApp",
+    plugins: [
+      "expo-camera"
+    ]
+  }
+});

--- a/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/app.config.js
+++ b/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/app.config.js
@@ -2,7 +2,7 @@ export default () => ({
   expo: {
     name: "TestApp",
     plugins: [
-      "expo-camera"
+      "@react-native-firebase/app"
     ]
   }
 });

--- a/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/app.json
+++ b/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "TestApp",
     "plugins": [
-      ["expo-build-properties", { "ios": { "deploymentTarget": "15.1" } }]
+      ["@config-plugins/detox", { "skipProguardConfig": false }]
     ]
   }
 }

--- a/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/app.json
+++ b/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "TestApp",
+    "plugins": [
+      ["expo-build-properties", { "ios": { "deploymentTarget": "15.1" } }]
+    ]
+  }
+}

--- a/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/package.json
+++ b/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "expo-plugin-packages-false-positive",
+  "type": "module",
+  "dependencies": {
+    "expo": "^56.0.0",
+    "react": "^19.0.0",
+    "expo-build-properties": "^1.0.0",
+    "expo-camera": "^16.0.0"
+  }
+}

--- a/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/package.json
+++ b/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "expo": "^56.0.0",
     "react": "^19.0.0",
-    "expo-build-properties": "^1.0.0",
-    "expo-camera": "^16.0.0"
+    "@config-plugins/detox": "^9.0.0",
+    "@react-native-firebase/app": "^21.0.0",
+    "left-pad": "^1.3.0"
   }
 }

--- a/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/src/index.js
+++ b/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/src/index.js
@@ -1,5 +1,6 @@
-import { StatusBar } from 'expo-status-bar';
+import { registerRootComponent } from "expo";
+import { createElement } from "react";
 
-export default function App() {
-  return null;
-}
+const App = () => createElement("div", null, "Hello");
+
+registerRootComponent(App);

--- a/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/src/index.js
+++ b/packages/deslop-js/tests/fixtures/expo-plugin-packages-false-positive/src/index.js
@@ -1,0 +1,5 @@
+import { StatusBar } from 'expo-status-bar';
+
+export default function App() {
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #914 - False positives in deslop-js unused-dependency detection for Expo config plugins referenced by package name and plugins nested under an `expo` key.

## Root Cause

Two related gaps in `expo-config-plugin-entries.ts`:

### 1. Package-name plugins were dropped

`addExpoPluginEntry` returned early for anything that wasn't a local path:

```typescript
if (!isLocalExpoPluginPath(pluginPath)) return;  // ← package names exit here
```

This meant plugins like `"expo-build-properties"` or `"expo-camera"` were never tracked as "used" even though they're legitimate Expo config plugin packages.

### 2. Nested `expo` key was never visited

`collectExpoPluginPathsFromConfigObject` only looked for a top-level `plugins` property. In both `app.json` and `app.config.js`, the standard Expo shape is `{ expo: { plugins: [...] } }`, but the collector never descended into that `expo` wrapper.

## Fix

- Thread `packageNamePlugins` Set through all collector functions to track package-name plugins alongside file-path plugins
- Descend into nested `expo` object in `collectExpoPluginPathsFromConfigObject`
- Export `extractExpoConfigPluginPackageNames` to be called from `detectStalePackages`  
- Union plugin package names into `usedPackageNames` in `detectStalePackages`

## Tests

- Added `expo-plugin-packages-false-positive` fixture with package-name plugins in both `app.json` (`expo-build-properties`) and `app.config.js` (`expo-camera` nested under `expo` key)
- Both are now correctly marked as used
- All existing tests continue to pass

## Parity

⚠️ **Parity validation pending**: The fix is well-scoped and includes regression tests, but full corpus parity hasn't been run yet due to the large corpus size (8423 repos). This should be validated via CI or manual parity run before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-350b040b-3ce0-45aa-9258-fdecafc71041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-350b040b-3ce0-45aa-9258-fdecafc71041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

