### PR TITLE
feat(cli): remember the post-scan handoff choice

### DIFF
--- a/.changeset/remember-handoff-target.md
+++ b/.changeset/remember-handoff-target.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Remember the post-scan "What would you like to do next?" pick. The interactive handoff prompt now pre-selects whatever the user chose last (an agent, "copy to clipboard", or "skip"), so the common "always hand off to the same agent" path is a single Enter. The choice is remembered per user in the existing CLI state file via a new `Preference` lifecycle primitive; a remembered agent that's since been uninstalled falls back to highlighting the first option, and pressing Esc leaves the prior preference untouched.

--- a/packages/react-doctor/src/cli/utils/cli-lifecycle.ts
+++ b/packages/react-doctor/src/cli/utils/cli-lifecycle.ts
@@ -13,13 +13,16 @@ import {
 import { hashProjectRoot } from "./hash-project-root.js";
 import { nowIso } from "./now-iso.js";
 
-// The CLI growth/lifecycle framework. Three primitives, all backed by the one
+// The CLI growth/lifecycle framework. Four primitives, all backed by the one
 // per-user state file and all idempotent + fail-safe:
 //
 //   • Gate      — fire something ONCE per scope (onboarding, a CTA, a one-time
 //                 prompt). Carries an outcome and a version.
 //   • Migration — run a code/config change ONCE per scope, tracked so it never
 //                 re-runs (action + config updates).
+//   • Preference — remember a free-form value the user picks every run (e.g. the
+//                 post-scan handoff target), read back as the next run's default.
+//                 Unlike a gate it has no version/outcome and is rewritten freely.
 //   • Invalidate — bump a gate's or migration's `version` and it re-fires /
 //                 re-runs, so a reworded CTA or a new migration shows again.
 //
@@ -62,6 +65,16 @@ export interface Migration extends Scoped {
   // safe. Returns whether it actually applied — a `false` (nothing to do, or
   // failed) is NOT recorded, so it stays pending and retries next time.
   readonly run: (context: MigrationRunContext) => boolean | Promise<boolean>;
+}
+
+export interface Preference extends Scoped {
+  // Stable storage key for this preference's remembered value.
+  readonly id: string;
+}
+
+export interface PreferenceTarget {
+  // Required for `scope: "project"` preferences; ignored for global ones.
+  readonly projectRoot?: string;
 }
 
 export interface MigrationRunContext {
@@ -194,6 +207,40 @@ export const clearGate = (
       updateScope(state, gate, target.projectRoot, (scope) => ({
         ...scope,
         events: omitKey(scope.events, gate.id),
+      })),
+    options,
+  );
+
+// === Preferences ===
+
+// The value last written for this preference, or null when never written (or
+// the store is unreadable) — callers treat null as "no remembered default".
+export const readPreference = (
+  preference: Preference,
+  target: PreferenceTarget = {},
+  options: CliStateOptions = {},
+): string | null =>
+  readCliState(
+    (state) =>
+      selectScope(state, preference, target.projectRoot)?.preferences?.[preference.id] ?? null,
+    null,
+    options,
+  );
+
+// Remembers `value` as this preference's latest pick (overwriting any prior).
+// Returns whether it persisted; a read-only store just means the next run won't
+// pre-fill the default. A project preference with no `projectRoot` is a no-op.
+export const writePreference = (
+  preference: Preference,
+  value: string,
+  target: PreferenceTarget = {},
+  options: CliStateOptions = {},
+): boolean =>
+  updateCliState(
+    (state) =>
+      updateScope(state, preference, target.projectRoot, (scope) => ({
+        ...scope,
+        preferences: { ...scope.preferences, [preference.id]: value },
       })),
     options,
   );

--- a/packages/react-doctor/src/cli/utils/cli-state-store.ts
+++ b/packages/react-doctor/src/cli/utils/cli-state-store.ts
@@ -46,6 +46,16 @@ export const CI_PITCH_EVENT = "ci-pitch";
 export const ACTION_UPGRADE_EVENT = "action-upgrade-v2";
 export const SETUP_HINT_EVENT = "setup-hint";
 
+// Well-known preference ids (stable storage keys). Unlike gates, a preference
+// is a free-form remembered value the user can change every run, read back as a
+// default rather than fired once. Kept here so the whole persisted-key surface
+// stays greppable in one place.
+//
+//   surface                       scope    id                  wired in
+//   ────────────────────────────  ───────  ──────────────────  ──────────────────────────────
+//   post-scan handoff target      global   handoff-target      handoff-target-preference.ts
+export const HANDOFF_TARGET_PREFERENCE_ID = "handoff-target";
+
 export type EventOutcome = "seen" | "accepted" | "declined";
 
 // One firing of a gate (an onboarding reveal, a CTA, a once-per-repo prompt).
@@ -66,6 +76,10 @@ export interface MigrationRecord {
 export interface ScopeState {
   readonly events?: Record<string, EventRecord>;
   readonly migrations?: Record<string, MigrationRecord>;
+  // Free-form remembered values, keyed by a well-known preference id. Additive
+  // and optional: pre-existing state files simply lack it (no migration needed),
+  // and an absent key reads back as "no preference yet".
+  readonly preferences?: Record<string, string>;
 }
 
 // Per-repo scope, keyed by hashed root under `projects`. Carries the resolved

--- a/packages/react-doctor/src/cli/utils/handoff-target-preference.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-target-preference.ts
@@ -1,0 +1,21 @@
+import { type CliStateOptions, HANDOFF_TARGET_PREFERENCE_ID } from "./cli-state-store.js";
+import { type Preference, readPreference, writePreference } from "./cli-lifecycle.js";
+
+// The post-scan "What would you like to do next?" pick (an agent id, "copy to
+// clipboard", or "skip"). Remembered globally — the preferred handoff is a
+// personal habit, not a per-repo setting — so every scan defaults to whatever
+// the user chose last, anywhere. A new value just overwrites the old one.
+export const HANDOFF_TARGET_PREFERENCE: Preference = {
+  id: HANDOFF_TARGET_PREFERENCE_ID,
+  scope: "global",
+};
+
+// The handoff target the user picked last, or null if they never have (or the
+// store is unreadable) — callers fall back to highlighting the first option.
+export const readHandoffTarget = (options: CliStateOptions = {}): string | null =>
+  readPreference(HANDOFF_TARGET_PREFERENCE, {}, options);
+
+// Remembers the user's latest pick so the next scan defaults to it. Returns
+// whether it persisted.
+export const rememberHandoffTarget = (target: string, options: CliStateOptions = {}): boolean =>
+  writePreference(HANDOFF_TARGET_PREFERENCE, target, {}, options);

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -15,6 +15,7 @@ import {
 } from "./install-github-workflow.js";
 import { hasHandledActionUpgrade, recordActionUpgradeDecision } from "./action-upgrade-prompt.js";
 import { hasHandledCiPrompt, recordCiPromptDecision } from "./ci-prompt-decision.js";
+import { readHandoffTarget, rememberHandoffTarget } from "./handoff-target-preference.js";
 import { askAddToGitHubActions } from "./ask-add-to-github-actions.js";
 import { askUpgradeActionVersion } from "./ask-upgrade-action-version.js";
 import { setUpGitHubActions } from "./set-up-github-actions.js";
@@ -223,28 +224,42 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
   }
 
   const launchableAgents = await detectLaunchableAgents();
+  const choices = [
+    ...launchableAgents.map((agentId) => ({
+      title: getSkillAgentConfig(agentId).displayName,
+      description: `Open ${CLI_AGENT_BINARIES[agentId]} here with the top issues as a prompt`,
+      value: agentId,
+    })),
+    {
+      title: "Copy prompt to clipboard",
+      description: "Paste into any agent or chat",
+      value: CLIPBOARD_CHOICE,
+    },
+    { title: "Skip", description: "Don't hand off", value: SKIP_CHOICE },
+  ];
+
+  // Pre-select the user's last pick when it's still an available choice, so the
+  // common "always hand off to the same agent" path is a single Enter. A
+  // remembered agent that's no longer launchable (uninstalled since) won't match
+  // any choice, so we fall back to highlighting the first option.
+  const rememberedTarget = readHandoffTarget();
+  const rememberedChoiceIndex = choices.findIndex((choice) => choice.value === rememberedTarget);
+  const initial = rememberedChoiceIndex >= 0 ? rememberedChoiceIndex : 0;
+
   const { handoffTarget } = await prompts<"handoffTarget">(
     {
       type: "select",
       name: "handoffTarget",
       message: "What would you like to do next?",
-      choices: [
-        ...launchableAgents.map((agentId) => ({
-          title: getSkillAgentConfig(agentId).displayName,
-          description: `Open ${CLI_AGENT_BINARIES[agentId]} here with the top issues as a prompt`,
-          value: agentId,
-        })),
-        {
-          title: "Copy prompt to clipboard",
-          description: "Paste into any agent or chat",
-          value: CLIPBOARD_CHOICE,
-        },
-        { title: "Skip", description: "Don't hand off", value: SKIP_CHOICE },
-      ],
-      initial: 0,
+      choices,
+      initial,
     },
     { onCancel: () => true },
   );
+
+  // Remember the pick so the next scan defaults to it; a cancel (Esc) leaves the
+  // prior preference untouched.
+  if (handoffTarget !== undefined) rememberHandoffTarget(handoffTarget);
 
   // Count the agent-handoff outcome (the second activation moment). The CI
   // outcome was counted separately above, since it's now its own question.
@@ -258,6 +273,13 @@ export const handoffToAgent = async (input: HandoffToAgentInput): Promise<void> 
     outcome: handoffOutcome,
     agent: handoffOutcome === "launch" ? handoffTarget : undefined,
     diagnosticsCount: input.diagnostics.length,
+    // Kill metric for the remembered default: did a remembered pick pre-fill the
+    // prompt, and did the user keep what was highlighted? If `keptDefault` among
+    // `defaultRemembered` runs is no better than the first-option baseline, the
+    // remembering isn't earning its place. (A cancel makes `handoffTarget`
+    // undefined, which never equals a choice value, so it reads as not-kept.)
+    defaultRemembered: rememberedChoiceIndex >= 0,
+    keptDefault: handoffTarget === choices[initial].value,
   });
 
   if (handoffTarget === undefined || handoffTarget === SKIP_CHOICE) return;

--- a/packages/react-doctor/tests/cli-lifecycle.test.ts
+++ b/packages/react-doctor/tests/cli-lifecycle.test.ts
@@ -5,12 +5,15 @@ import * as fs from "node:fs";
 import {
   type Gate,
   type Migration,
+  type Preference,
   clearGate,
   isGatePending,
   isMigrationPending,
   readGateOutcome,
+  readPreference,
   recordGate,
   runMigrations,
+  writePreference,
 } from "../src/cli/utils/cli-lifecycle.js";
 
 describe("cli-lifecycle", () => {
@@ -158,6 +161,45 @@ describe("cli-lifecycle", () => {
       expect(isMigrationPending(v2, {}, options)).toBe(true);
       await runMigrations([v2], {}, options);
       expect(calls).toEqual(["v1", "v2"]);
+    });
+  });
+
+  describe("preferences", () => {
+    it("reads null before anything is written (global scope)", () => {
+      const preference: Preference = { id: "handoff-target", scope: "global" };
+      expect(readPreference(preference, {}, options)).toBe(null);
+    });
+
+    it("remembers the last written value and overwrites on re-write (global scope)", () => {
+      const preference: Preference = { id: "handoff-target", scope: "global" };
+      expect(writePreference(preference, "claude", {}, options)).toBe(true);
+      expect(readPreference(preference, {}, options)).toBe("claude");
+      expect(writePreference(preference, "skip", {}, options)).toBe(true);
+      expect(readPreference(preference, {}, options)).toBe("skip");
+    });
+
+    it("scopes preferences per repo independently (project scope)", () => {
+      const preference: Preference = { id: "handoff-target", scope: "project" };
+      writePreference(preference, "cursor", { projectRoot: "/repo/a" }, options);
+      expect(readPreference(preference, { projectRoot: "/repo/a" }, options)).toBe("cursor");
+      expect(readPreference(preference, { projectRoot: "/repo/b" }, options)).toBe(null);
+    });
+
+    it("is a no-op for a project preference with no projectRoot", () => {
+      const preference: Preference = { id: "handoff-target", scope: "project" };
+      writePreference(preference, "claude", {}, options);
+      expect(readPreference(preference, {}, options)).toBe(null);
+    });
+
+    it("keeps gate outcomes and preferences in separate namespaces", () => {
+      const gate: Gate = { id: "handoff-target", scope: "global" };
+      const preference: Preference = { id: "handoff-target", scope: "global" };
+      recordGate(gate, { outcome: "accepted" }, options);
+      writePreference(preference, "skip", {}, options);
+      // Same id, different stores: the gate outcome is "accepted", the
+      // preference value is "skip" — neither clobbers the other.
+      expect(readGateOutcome(gate, {}, options)).toBe("accepted");
+      expect(readPreference(preference, {}, options)).toBe("skip");
     });
   });
 });

--- a/packages/react-doctor/tests/handoff-target-preference.test.ts
+++ b/packages/react-doctor/tests/handoff-target-preference.test.ts
@@ -1,0 +1,45 @@
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  readHandoffTarget,
+  rememberHandoffTarget,
+} from "../src/cli/utils/handoff-target-preference.js";
+import { getCliStatePath } from "../src/cli/utils/cli-state-store.js";
+
+describe("handoff target preference", () => {
+  let configRoot: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const root = fs.mkdtempSync(path.join(tmpdir(), "react-doctor-handoff-pref-"));
+    configRoot = root;
+    cleanup = () => fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reads null before the user has ever picked", () => {
+    expect(readHandoffTarget({ cwd: configRoot })).toBe(null);
+  });
+
+  it("remembers the last pick and reads it back", () => {
+    expect(rememberHandoffTarget("claude", { cwd: configRoot })).toBe(true);
+    expect(readHandoffTarget({ cwd: configRoot })).toBe("claude");
+  });
+
+  it("overwrites the remembered pick on each new choice (last wins)", () => {
+    rememberHandoffTarget("claude", { cwd: configRoot });
+    rememberHandoffTarget("skip", { cwd: configRoot });
+    expect(readHandoffTarget({ cwd: configRoot })).toBe("skip");
+  });
+
+  it("stores the pick as a global handoff-target preference in the shared config file", () => {
+    rememberHandoffTarget("cursor", { cwd: configRoot });
+    const stored = JSON.parse(fs.readFileSync(getCliStatePath({ cwd: configRoot }), "utf8"));
+    expect(stored.global.preferences["handoff-target"]).toBe("cursor");
+  });
+});


### PR DESCRIPTION
## Why

The interactive post-scan **"What would you like to do next?"** prompt always started highlighted on the first option. Users who hand off to the same agent on every scan had to re-navigate the list each time. Remembering their last pick makes the common path a single Enter.

Before:

```
? What would you like to do next? › - Use arrow-keys. Return to submit.
❯   Claude Code          ← always highlighted first, every scan
    Cursor
    Copy prompt to clipboard
    Skip
```

After:

```
? What would you like to do next? › - Use arrow-keys. Return to submit.
    Claude Code
❯   Cursor               ← whatever you picked last scan, pre-selected
    Copy prompt to clipboard
    Skip
```

## What changed

- **New `Preference` lifecycle primitive** (`cli-lifecycle.ts`): a free-form remembered value scoped global/project, sibling to the existing `Gate` and `Migration`. Backed by the same single per-user state file (`readPreference` / `writePreference`).
- **`ScopeState.preferences`** (`cli-state-store.ts`): an optional `Record<string, string>`. Purely additive — pre-existing state files just lack it, so **no schema bump / migration needed**.
- **`handoff-target-preference.ts`** (new): thin `readHandoffTarget` / `rememberHandoffTarget` wrappers, **global scope** (a preferred handoff is a personal habit, not a per-repo setting), mirroring `ci-prompt-decision.ts`.
- **`handoff-to-agent.ts`**: pre-selects the remembered pick when it's still an available choice; persists every non-cancel pick. A remembered agent that's since been **uninstalled** won't match a choice → falls back to the first option. **Esc** (cancel) leaves the prior preference untouched.
- **Telemetry**: the existing `agent.handoff` metric gains `defaultRemembered` / `keptDefault` dims — the kill metric. If `keptDefault` among `defaultRemembered` runs is no better than the first-option baseline, the remembering isn't earning its place.
- Changeset (`react-doctor` patch).

## Test plan

- `turbo run typecheck --filter=react-doctor` — passes.
- `vp lint` + `vp fmt --check` on touched files — clean.
- New tests pass: a `preferences` block in `cli-lifecycle.test.ts` (incl. a same-id gate-vs-preference namespace isolation check) + new `handoff-target-preference.test.ts`; related suites (state-store, ci-prompt, migrations, onboarding) green.
- Full `react-doctor` suite green except pre-existing local git-`commit` timeouts caused by a global `commit.gpgsign=true` (no TTY for the GPG agent), proven unrelated by re-running each failing file with `GIT_CONFIG_GLOBAL=/dev/null` → all pass. CI doesn't set gpgsign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and additive local state only; no auth, network, or scan logic changes.
> 
> **Overview**
> Adds a **`Preference`** lifecycle primitive alongside gates and migrations: **`readPreference` / `writePreference`** persist free-form strings in the existing per-user CLI state via an optional **`ScopeState.preferences`** map (no schema bump).
> 
> The post-scan **"What would you like to do next?"** select now **pre-highlights the last choice** (agent, clipboard, or skip) when it is still in the list; unavailable remembered agents fall back to the first option. Each confirmed pick is saved globally through **`handoff-target-preference`**; **Esc** does not overwrite the stored value.
> 
> **`agent.handoff`** metrics gain **`defaultRemembered`** and **`keptDefault`** to measure whether remembering the default actually helps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9791623fea6ac62c8c63236ec3867f2ed954763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->