### PR TITLE
fix: handle malformed JSON and filesystem conflicts in install command

### DIFF
--- a/.changeset/install-error-handling.md
+++ b/.changeset/install-error-handling.md
@@ -1,0 +1,11 @@
+---
+"react-doctor": patch
+---
+
+Fix `react-doctor install` crashes on pre-existing malformed/conflicting agent config. The install command now handles three user-environment failure modes gracefully with clear error messages instead of unhandled exceptions:
+
+1. Malformed JSON in `~/.claude/settings.json` or `~/.cursor/hooks.json` (REACT-DOCTOR-25)
+2. Directory path blocked by an existing file at `~/.claude/skills` or parent paths (REACT-DOCTOR-17)
+3. Permission denied when target directories aren't writable (REACT-DOCTOR-1A)
+
+These errors are now treated as expected user-environment conditions (not react-doctor bugs) and surface actionable messages without Sentry reports.

--- a/packages/react-doctor/src/cli/commands/install.ts
+++ b/packages/react-doctor/src/cli/commands/install.ts
@@ -1,10 +1,11 @@
 import * as Effect from "effect/Effect";
 import { METRIC } from "../utils/constants.js";
-import { handleError } from "../utils/handle-error.js";
+import { handleError, handleUserError } from "../utils/handle-error.js";
 import { runInstallReactDoctor } from "../utils/install-react-doctor.js";
 import { printBrandedHeader } from "../utils/print-branded-header.js";
 import { recordCount } from "../utils/record-metric.js";
 import { reportErrorToSentry } from "../utils/report-error.js";
+import { isExpectedUserError } from "../utils/is-expected-user-error.js";
 
 interface InstallCommandOptions {
   yes?: boolean;
@@ -39,6 +40,10 @@ export const installAction = async (
       projectRoot: options.cwd ?? process.cwd(),
     });
   } catch (error) {
+    if (isExpectedUserError(error)) {
+      handleUserError(error);
+      return;
+    }
     const sentryEventId = await reportErrorToSentry(error);
     handleError(error, { sentryEventId });
   }

--- a/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
+++ b/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
@@ -73,6 +73,11 @@ const ensureDirectoryExists = (directoryPath: string): void => {
     fs.mkdirSync(directoryPath, { recursive: true });
   } catch (error) {
     const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "EACCES" || nodeError.code === "EPERM") {
+      throw new CliInputError(
+        `Could not create directory ${directoryPath}: permission denied. Ensure you have write permissions for this location and re-run the install command.`,
+      );
+    }
     if (nodeError.code === "ENOTDIR" || nodeError.code === "EEXIST") {
       const stat = fs.existsSync(directoryPath) ? fs.statSync(directoryPath) : null;
       if (stat && !stat.isDirectory()) {
@@ -80,11 +85,6 @@ const ensureDirectoryExists = (directoryPath: string): void => {
           `Could not create directory ${directoryPath}: a file exists at this path or one of its parent paths. Remove the conflicting file and re-run the install command.`,
         );
       }
-    }
-    if (nodeError.code === "EACCES" || nodeError.code === "EPERM") {
-      throw new CliInputError(
-        `Could not create directory ${directoryPath}: permission denied. Ensure you have write permissions for this location and re-run the install command.`,
-      );
     }
     throw error;
   }

--- a/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
+++ b/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import type { SkillAgentType } from "agent-install";
 import { AGENT_HOOK_TIMEOUT_SECONDS, GIT_HOOK_EXECUTABLE_MODE } from "./constants.js";
 import * as fs from "node:fs";
+import { CliInputError } from "./cli-input-error.js";
 
 interface InstallAgentHooksOptions {
   readonly projectRoot: string;
@@ -58,16 +59,44 @@ const readJsonFile = <Value>(filePath: string, fallback: Value): Value => {
   if (!fs.existsSync(filePath)) return fallback;
   const content = fs.readFileSync(filePath, "utf8").trim();
   if (content.length === 0) return fallback;
-  return JSON.parse(content);
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    throw new CliInputError(
+      `Could not parse ${filePath}: the file contains invalid JSON. Fix the syntax errors in this file and re-run the install command.`,
+    );
+  }
+};
+
+const ensureDirectoryExists = (directoryPath: string): void => {
+  try {
+    fs.mkdirSync(directoryPath, { recursive: true });
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOTDIR" || nodeError.code === "EEXIST") {
+      const stat = fs.existsSync(directoryPath) ? fs.statSync(directoryPath) : null;
+      if (stat && !stat.isDirectory()) {
+        throw new CliInputError(
+          `Could not create directory ${directoryPath}: a file exists at this path or one of its parent paths. Remove the conflicting file and re-run the install command.`,
+        );
+      }
+    }
+    if (nodeError.code === "EACCES" || nodeError.code === "EPERM") {
+      throw new CliInputError(
+        `Could not create directory ${directoryPath}: permission denied. Ensure you have write permissions for this location and re-run the install command.`,
+      );
+    }
+    throw error;
+  }
 };
 
 const writeJsonFile = (filePath: string, value: unknown): void => {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  ensureDirectoryExists(path.dirname(filePath));
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, JSON_INDENT_SPACES)}\n`);
 };
 
 const writeHookScript = (filePath: string): void => {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  ensureDirectoryExists(path.dirname(filePath));
   fs.writeFileSync(filePath, buildAgentHookScript());
   fs.chmodSync(filePath, GIT_HOOK_EXECUTABLE_MODE);
 };

--- a/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
+++ b/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
@@ -76,26 +76,21 @@ const ensureDirectoryExists = (directoryPath: string): void => {
   try {
     fs.mkdirSync(directoryPath, { recursive: true });
   } catch (error) {
-    const nodeError = error as NodeJS.ErrnoException;
-    if (nodeError.code === "EACCES" || nodeError.code === "EPERM") {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EACCES" || code === "EPERM") {
       throw new CliInputError(
         `Could not create directory ${directoryPath}: permission denied. Ensure you have write permissions for this location and re-run the install command.`,
       );
     }
-    if (nodeError.code === "ENOTDIR" || nodeError.code === "EEXIST") {
-      try {
-        const stat = fs.statSync(directoryPath);
-        if (!stat.isDirectory()) {
-          throw new CliInputError(
-            `Could not create directory ${directoryPath}: a file exists at this path or one of its parent paths. Remove the conflicting file and re-run the install command.`,
-          );
-        }
-      } catch (statError) {
-        const statErrnoException = statError as NodeJS.ErrnoException;
-        if (statErrnoException.code !== "ENOENT") {
-          throw statError;
-        }
-      }
+    // A recursive `mkdir` reports a conflicting file two ways: `EEXIST` when the
+    // target itself is a file, `ENOTDIR` when a parent segment is. The code
+    // already settles it — don't `statSync` to confirm, because on the
+    // `ENOTDIR` (parent-is-a-file) case the stat throws `ENOTDIR` too and the
+    // actionable message would be lost (the original REACT-DOCTOR-17 path).
+    if (code === "ENOTDIR" || code === "EEXIST") {
+      throw new CliInputError(
+        `Could not create directory ${directoryPath}: a file exists at this path or one of its parent paths. Remove the conflicting file and re-run the install command.`,
+      );
     }
     throw error;
   }

--- a/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
+++ b/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
@@ -3,6 +3,7 @@ import type { SkillAgentType } from "agent-install";
 import { AGENT_HOOK_TIMEOUT_SECONDS, GIT_HOOK_EXECUTABLE_MODE } from "./constants.js";
 import * as fs from "node:fs";
 import { CliInputError } from "./cli-input-error.js";
+import { writeJsonFile } from "./git-hook-shared.js";
 
 interface InstallAgentHooksOptions {
   readonly projectRoot: string;
@@ -62,9 +63,12 @@ const readJsonFile = <Value>(filePath: string, fallback: Value): Value => {
   try {
     return JSON.parse(content);
   } catch (error) {
-    throw new CliInputError(
-      `Could not parse ${filePath}: the file contains invalid JSON. Fix the syntax errors in this file and re-run the install command.`,
-    );
+    if (error instanceof SyntaxError) {
+      throw new CliInputError(
+        `Could not parse ${filePath}: the file contains invalid JSON. Fix the syntax errors in this file and re-run the install command.`,
+      );
+    }
+    throw error;
   }
 };
 
@@ -79,20 +83,27 @@ const ensureDirectoryExists = (directoryPath: string): void => {
       );
     }
     if (nodeError.code === "ENOTDIR" || nodeError.code === "EEXIST") {
-      const stat = fs.existsSync(directoryPath) ? fs.statSync(directoryPath) : null;
-      if (stat && !stat.isDirectory()) {
-        throw new CliInputError(
-          `Could not create directory ${directoryPath}: a file exists at this path or one of its parent paths. Remove the conflicting file and re-run the install command.`,
-        );
+      try {
+        const stat = fs.statSync(directoryPath);
+        if (!stat.isDirectory()) {
+          throw new CliInputError(
+            `Could not create directory ${directoryPath}: a file exists at this path or one of its parent paths. Remove the conflicting file and re-run the install command.`,
+          );
+        }
+      } catch (statError) {
+        const statErrnoException = statError as NodeJS.ErrnoException;
+        if (statErrnoException.code !== "ENOENT") {
+          throw statError;
+        }
       }
     }
     throw error;
   }
 };
 
-const writeJsonFile = (filePath: string, value: unknown): void => {
+const writeJsonFileWithDirectoryCheck = (filePath: string, value: unknown): void => {
   ensureDirectoryExists(path.dirname(filePath));
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, JSON_INDENT_SPACES)}\n`);
+  writeJsonFile(filePath, value);
 };
 
 const writeHookScript = (filePath: string): void => {
@@ -123,7 +134,7 @@ const installClaudeHook = (projectRoot: string): readonly string[] => {
   }
 
   hooks.PostToolBatch = postToolBatchHooks;
-  writeJsonFile(settingsPath, { ...settings, hooks });
+  writeJsonFileWithDirectoryCheck(settingsPath, { ...settings, hooks });
   writeHookScript(hookPath);
 
   return [settingsPath, hookPath];
@@ -148,7 +159,7 @@ const installCursorHook = (projectRoot: string): readonly string[] => {
   }
 
   hooks.postToolUse = postToolUseHooks;
-  writeJsonFile(configPath, {
+  writeJsonFileWithDirectoryCheck(configPath, {
     ...config,
     version: config.version ?? CURSOR_HOOKS_SCHEMA_VERSION,
     hooks,

--- a/packages/react-doctor/tests/install-agent-hooks.test.ts
+++ b/packages/react-doctor/tests/install-agent-hooks.test.ts
@@ -419,4 +419,73 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     expect(fs.existsSync(path.join(fixture.projectRoot, ".cursor/hooks.json"))).toBe(false);
     expect(fs.existsSync(path.join(fixture.projectRoot, ".claude/settings.json"))).toBe(false);
   });
+
+  it("throws CliInputError when settings file contains malformed JSON", () => {
+    const settingsPath = path.join(fixture.projectRoot, ".claude/settings.json");
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, '{ "permissions": { "allow": ["Bash(git status)"] }');
+
+    expect(() => {
+      installReactDoctorAgentHooks({
+        projectRoot: fixture.projectRoot,
+        agents: ["claude-code"],
+      });
+    }).toThrow(/Could not parse.*invalid JSON/);
+  });
+
+  it("throws CliInputError when config file contains malformed JSON", () => {
+    const configPath = path.join(fixture.projectRoot, ".cursor/hooks.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, '{ "version": 1, "hooks": {');
+
+    expect(() => {
+      installReactDoctorAgentHooks({
+        projectRoot: fixture.projectRoot,
+        agents: ["cursor"],
+      });
+    }).toThrow(/Could not parse.*invalid JSON/);
+  });
+
+  it("throws CliInputError when .claude directory exists as a file", () => {
+    const claudePath = path.join(fixture.projectRoot, ".claude");
+    fs.writeFileSync(claudePath, "i am a file not a directory");
+
+    expect(() => {
+      installReactDoctorAgentHooks({
+        projectRoot: fixture.projectRoot,
+        agents: ["claude-code"],
+      });
+    }).toThrow(/Could not create directory.*file exists at this path/);
+  });
+
+  it("throws CliInputError when .cursor/hooks exists as a file", () => {
+    const hooksPath = path.join(fixture.projectRoot, ".cursor/hooks");
+    fs.mkdirSync(path.dirname(hooksPath), { recursive: true });
+    fs.writeFileSync(hooksPath, "i am a file not a directory");
+
+    expect(() => {
+      installReactDoctorAgentHooks({
+        projectRoot: fixture.projectRoot,
+        agents: ["cursor"],
+      });
+    }).toThrow(/Could not create directory.*file exists at this path/);
+  });
+
+  it("throws CliInputError when target directory is not writable", () => {
+    if (process.getuid?.() === 0) {
+      return;
+    }
+
+    const readOnlyRoot = path.join(fixture.projectRoot, "readonly");
+    fs.mkdirSync(readOnlyRoot, { mode: 0o555 });
+
+    expect(() => {
+      installReactDoctorAgentHooks({
+        projectRoot: readOnlyRoot,
+        agents: ["cursor"],
+      });
+    }).toThrow(/Could not create directory.*permission denied/);
+
+    fs.chmodSync(readOnlyRoot, 0o755);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The `react-doctor install` command crashes with unhandled errors when it meets pre-existing filesystem state it should tolerate. Three distinct failure modes are landing in Sentry:

1. **REACT-DOCTOR-25**: `SyntaxError` in `JSON.parse` when the user's existing `~/.claude/settings.json` or `~/.cursor/hooks.json` contains invalid JSON
2. **REACT-DOCTOR-17**: `ENOTDIR` or `EEXIST` error when `~/.claude/skills` (or a parent) exists as a **file**, not a directory
3. **REACT-DOCTOR-1A**: `EACCES` permission denied when the target dir isn't writable

The root cause is that `install-agent-hooks.ts` reads existing agent config with a raw `JSON.parse` (no try/catch) and writes hook/skill files with bare `mkdirSync` — both throw on unexpected state.

## Fix

Make `install` defensive about state it didn't create:

- Wrap `JSON.parse` in `readJsonFile`; on a parse error throw a `CliInputError` that names the file and tells the user it isn't valid JSON
- Catch `ENOTDIR` / `EEXIST` / `EACCES` around the skill/hook `mkdirSync` via a new `ensureDirectoryExists` helper and emit actionable one-liners
- These are user-environment conditions, not react-doctor defects — they throw `CliInputError` (not generic `Error`) so `isExpectedUserError` routes them through `handleUserError` (clean message, no Sentry report)

## Scope Decision

The fix is scoped to exactly the three reported failure modes in the `install` command. No other commands are affected. The defensive handling applies only to pre-existing config files and filesystem state the install command needs to read or create — the fix doesn't change any diagnostic behavior, rule logic, or scanning.

## Tests

Added unit tests for all three failure modes in `install-agent-hooks.test.ts`:

- Malformed JSON in settings file
- Directory path blocked by an existing file
- Permission denied on target directory

Closes #922
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8573a746-3e10-430c-a2b2-b54d730e22e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8573a746-3e10-430c-a2b2-b54d730e22e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

