### PR TITLE
fix: validate string array config fields (projects, textComponents, etc.)

### DIFF
--- a/.changeset/fix-921-validate-projects-config.md
+++ b/.changeset/fix-921-validate-projects-config.md
@@ -1,0 +1,10 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+fix: validate string array config fields (projects, textComponents, etc.)
+
+Non-string entries in `config.projects` caused `selectProjects` to crash with `requestedName.trim is not a function`. The validator now filters non-string entries from `projects`, `textComponents`, `rawTextWrapperComponents`, and `serverAuthFunctionNames` with warnings instead of crashing.
+
+Fixes #921 (Sentry REACT-DOCTOR-1R)

--- a/packages/core/src/validate-config-types.ts
+++ b/packages/core/src/validate-config-types.ts
@@ -50,6 +50,13 @@ const BOOLEAN_FIELD_NAMES = [
 
 const STRING_FIELD_NAMES = ["rootDir"] as const satisfies ReadonlyArray<keyof ReactDoctorConfig>;
 
+const STRING_ARRAY_FIELD_NAMES = [
+  "projects",
+  "textComponents",
+  "rawTextWrapperComponents",
+  "serverAuthFunctionNames",
+] as const satisfies ReadonlyArray<keyof ReactDoctorConfig>;
+
 const SURFACE_CONTROL_FIELD_NAMES = [
   "includeTags",
   "excludeTags",
@@ -231,6 +238,11 @@ export const validateConfigTypes = (config: ReactDoctorConfig): ReactDoctorConfi
   }
   for (const fieldName of STRING_FIELD_NAMES) {
     applyFieldValidator(config, validated, fieldName, (value) => validateString(fieldName, value));
+  }
+  for (const fieldName of STRING_ARRAY_FIELD_NAMES) {
+    applyFieldValidator(config, validated, fieldName, (value) =>
+      validateStringArrayField(fieldName, value),
+    );
   }
   applyFieldValidator(config, validated, "surfaces", validateSurfacesField);
   for (const fieldName of SEVERITY_FIELD_NAMES) {

--- a/packages/core/tests/validate-config-types.test.ts
+++ b/packages/core/tests/validate-config-types.test.ts
@@ -174,4 +174,64 @@ describe("validateConfigTypes", () => {
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`config field "categories"`));
     });
   });
+
+  describe("string array fields (projects, textComponents, etc.)", () => {
+    it("passes through valid string arrays untouched", () => {
+      const input: ReactDoctorConfig = {
+        projects: ["app", "packages/core"],
+        textComponents: ["MyText", "Label"],
+        rawTextWrapperComponents: ["Button"],
+        serverAuthFunctionNames: ["requireAuth", "checkPermissions"],
+      };
+      expect(validateConfigTypes(input)).toEqual(input);
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it("filters out non-string entries from projects array with warnings", () => {
+      const result = validateConfigTypes({
+        projects: [42, "valid-project", null, { name: "obj" }] as unknown as string[],
+      });
+      expect(result.projects).toEqual(["valid-project"]);
+      expect(stderrSpy).toHaveBeenCalledTimes(3);
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('config field "projects"'));
+    });
+
+    it("filters out non-string entries from textComponents", () => {
+      const result = validateConfigTypes({
+        textComponents: ["Text", 123, "Label", false] as unknown as string[],
+      });
+      expect(result.textComponents).toEqual(["Text", "Label"]);
+      expect(stderrSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("drops the entire field when it isn't an array", () => {
+      const result = validateConfigTypes({
+        projects: "app" as unknown as string[],
+        textComponents: 42 as unknown as string[],
+      });
+      expect(result.projects).toBeUndefined();
+      expect(result.textComponents).toBeUndefined();
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('config field "projects"'));
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('config field "textComponents"'),
+      );
+    });
+
+    it("handles empty arrays", () => {
+      const input: ReactDoctorConfig = {
+        projects: [],
+        serverAuthFunctionNames: [],
+      };
+      expect(validateConfigTypes(input)).toEqual(input);
+      expect(stderrSpy).not.toHaveBeenCalled();
+    });
+
+    it("handles arrays with all invalid entries", () => {
+      const result = validateConfigTypes({
+        projects: [null, 42, {}] as unknown as string[],
+      });
+      expect(result.projects).toEqual([]);
+      expect(stderrSpy).toHaveBeenCalledTimes(3);
+    });
+  });
 });

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -45,7 +45,7 @@ import {
   getStagedSourceFiles,
   materializeStagedFiles,
 } from "../../src/cli/utils/get-staged-files.js";
-import { buildTestProject, initGitRepo, writeFile, writeJson } from "./_helpers.js";
+import { buildTestProject, initGitRepo, setupReactProject, writeFile, writeJson } from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-scan-resilience-"));
 
@@ -723,5 +723,46 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
       expect(pluginModule.RECOMMENDED_RULES).not.toHaveProperty(key);
       expect(pluginModule.ALL_REACT_DOCTOR_RULES).not.toHaveProperty(key);
     }
+  });
+});
+
+describe("issue #921: non-string `projects` config entry crashes selectProjects", () => {
+  it("validates projects config at load time and filters non-string entries", async () => {
+    const { loadConfigWithSource, clearConfigCache } = await import("@react-doctor/core");
+    const projectDir = setupReactProject(tempRoot, "issue-921", {
+      files: {
+        "doctor.config.ts": `export default { projects: [42, "valid", null, { name: "obj" }] };`,
+        "src/App.tsx": "export const App = () => <div />;",
+      },
+    });
+    clearConfigCache();
+    const loaded = await loadConfigWithSource(projectDir);
+    expect(loaded?.config.projects).toEqual(["valid"]);
+  });
+
+  it("does not crash when projects contains only invalid entries", async () => {
+    const { loadConfigWithSource, clearConfigCache } = await import("@react-doctor/core");
+    const projectDir = setupReactProject(tempRoot, "issue-921-all-invalid", {
+      files: {
+        "doctor.config.ts": `export default { projects: [42, null, {}] };`,
+        "src/App.tsx": "export const App = () => <div />;",
+      },
+    });
+    clearConfigCache();
+    const loaded = await loadConfigWithSource(projectDir);
+    expect(loaded?.config.projects).toEqual([]);
+  });
+
+  it("does not crash when projects is not an array", async () => {
+    const { loadConfigWithSource, clearConfigCache } = await import("@react-doctor/core");
+    const projectDir = setupReactProject(tempRoot, "issue-921-not-array", {
+      files: {
+        "doctor.config.ts": `export default { projects: "single-project" };`,
+        "src/App.tsx": "export const App = () => <div />;",
+      },
+    });
+    clearConfigCache();
+    const loaded = await loadConfigWithSource(projectDir);
+    expect(loaded?.config.projects).toBeUndefined();
   });
 });

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -45,7 +45,13 @@ import {
   getStagedSourceFiles,
   materializeStagedFiles,
 } from "../../src/cli/utils/get-staged-files.js";
-import { buildTestProject, initGitRepo, setupReactProject, writeFile, writeJson } from "./_helpers.js";
+import {
+  buildTestProject,
+  initGitRepo,
+  setupReactProject,
+  writeFile,
+  writeJson,
+} from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-scan-resilience-"));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #921 (Sentry [REACT-DOCTOR-1R](https://millionco.sentry.io/issues/REACT-DOCTOR-1R))

Non-string entries in `config.projects` caused `selectProjects` to crash with `requestedName.trim is not a function` because the `projects` field was not validated at config load time.

## Root Cause

The config validator (`validateConfigTypes`) already filtered non-string entries from other string-array fields (`plugins`, `surfaces.*Tags`, etc.) but `projects`, `textComponents`, `rawTextWrapperComponents`, and `serverAuthFunctionNames` were missing from the validation.

When a user wrote:
```ts
// doctor.config.ts
export default { projects: [42] };
```

The config would pass TypeScript's type checking (since it's authored JS/TS at runtime) but crash when `selectProjects` called `.trim()` on the number `42`.

## Scope

**Fixed**: All four string-array fields (`projects`, `textComponents`, `rawTextWrapperComponents`, `serverAuthFunctionNames`) now validate at config-load time:
- Non-string entries are filtered out with warnings
- Non-array values drop the entire field
- The scan continues instead of crashing

**Not changed**: No rule logic, no lint behavior. This is a config validation fix only.

## Test Coverage

- Unit tests in `validate-config-types.test.ts` for all validation paths (valid arrays, mixed valid/invalid entries, non-arrays, empty arrays)
- Regression tests in `scan-resilience.test.ts` for the crash scenario (all three edge cases: mixed entries, all-invalid, non-array)

## Parity

This fix prevents crashes in the config loading phase (before any scanning occurs). It does not change any rule logic or diagnostic output. **Expected parity result: zero diagnostic changes** — only invalid configs that would have crashed now emit warnings and continue.

The baseline scan for parity is not available in this environment, but given the nature of this fix (config validation only, no rule changes), there should be no diagnostic differences across the corpus.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07d1466d-8435-436f-961d-4aa2e852a84f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07d1466d-8435-436f-961d-4aa2e852a84f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

