### PR TITLE
chore: add AI training restriction to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -16,8 +16,8 @@ The Software, its source code, and any derivative works thereof may not be
 used, in whole or in part, as training data, fine-tuning data, evaluation
 data, or as input to any automated pipeline for the purpose of training or
 improving any machine learning model or AI system, without prior written
-permission from the copyright holder. Academic researchers may request written
-permission at no cost by contacting founders@million.dev before use.
+permission from the copyright holder. To request permission, contact
+founders@million.dev.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+MIT License (with Additional Restrictions)
 
 Copyright (c) 2026 Million Software, Inc.
 
@@ -11,6 +11,13 @@ furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
+
+The Software, its source code, and any derivative works thereof may not be
+used, in whole or in part, as training data, fine-tuning data, evaluation
+data, or as input to any automated pipeline for the purpose of training or
+improving any machine learning model or AI system, without prior written
+permission from the copyright holder. Academic researchers may request written
+permission at no cost by contacting founders@million.dev before use.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.8",
   "private": true,
   "description": "Internal: programmatic diagnose() API for React Doctor — thin Effect.runPromise shell around @react-doctor/core's runInspect orchestrator. Not published.",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -1,4 +1,39 @@
 import * as Effect from "effect/Effect";
+
+// Env vars that signal an active AI/ML training pipeline or agent sandbox.
+// Mirrors the CLI's detect-ai-training-environment.ts — kept inline so the
+// API package has no dependency on the CLI package.
+const AI_TRAINING_ENV_VARS = [
+  "HF_DATASETS_CACHE", "HF_HOME", "HUGGINGFACE_HUB_CACHE",
+  "CUDA_VISIBLE_DEVICES", "NVIDIA_VISIBLE_DEVICES",
+  "WANDB_RUN_ID", "WANDB_SWEEP_ID", "MLFLOW_RUN_ID", "MLFLOW_TRACKING_URI",
+  "COMET_EXPERIMENT_KEY", "NEPTUNE_RUN_ID", "CLEARML_TASK_ID",
+  "RAY_WORKER_PROCESS", "RAY_ADDRESS",
+  "MUJOCO_GL", "MUJOCO_PATH", "GYM_DISABLE_ENV_CHECKER",
+  "SM_TRAINING_ENV", "TRAINING_JOB_ARN", "SAGEMAKER_BASE_DIR",
+  "AZUREML_RUN_ID", "AZURE_ML_MODEL_DIR",
+  "CLOUD_ML_PROJECT_ID", "VERTEX_AI_LOG_LEVEL",
+  "KAGGLE_KERNEL_RUN_TYPE", "COLAB_BACKEND_VERSION", "DATABRICKS_RUNTIME_VERSION",
+  "FLYTE_INTERNAL_EXECUTION_ID", "DET_MASTER", "LIGHTNING_USER_ID",
+  "ARGO_WORKFLOW_NAME", "KFP_POD_NAME", "DVC_STAGE",
+  "DAYTONA_WS_ID", "DAYTONA_WS_NAME", "E2B_SANDBOX_ID",
+  "MODAL_FUNCTION_ID", "MODAL_TASK_ID", "RUNPOD_POD_ID",
+  "SPACE_ID", "REPLICATE_USERNAME", "VAST_CONTAINERLABEL",
+  "TPU_NAME", "ROCR_VISIBLE_DEVICES",
+  "HARBOR_URL", "HARBOR_HOSTNAME",
+  "SWE_BENCH_TASK", "SWEBENCH_TASK", "SWE_AGENT_MODEL",
+] as const;
+
+let didWarnAiTraining = false;
+const warnIfAiTrainingEnvironment = (): void => {
+  if (didWarnAiTraining) return;
+  const detected = AI_TRAINING_ENV_VARS.find((envVar) => process.env[envVar] !== undefined);
+  if (detected === undefined) return;
+  didWarnAiTraining = true;
+  console.warn(
+    "[react-doctor] Use in an AI or ML pipeline requires written permission under the react-doctor license. Contact founders@million.dev to request access.",
+  );
+};
 import * as Layer from "effect/Layer";
 import {
   buildSkippedChecks,
@@ -120,6 +155,7 @@ const diagnoseDirectory = async (
   directory: string,
   options: DiagnoseOptions,
 ): Promise<DiagnoseResult> => {
+  warnIfAiTrainingEnvironment();
   const startTime = globalThis.performance.now();
   const scanTarget = await resolveScanTarget(directory);
   const program = buildInspectProgram(scanTarget, options);
@@ -210,6 +246,7 @@ const diagnoseProject = async (
 const diagnoseProjectBatch = async (
   input: DiagnoseProjectsInput,
 ): Promise<DiagnoseProjectsResult> => {
+  warnIfAiTrainingEnvironment();
   const startTime = globalThis.performance.now();
   const { projects, concurrency, config: batchConfig, ...baseOptions } = input;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.8",
   "private": true,
   "description": "Internal: diagnostic engine for React Doctor (lint runner, scoring, config, suppressions). Not published.",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/packages/deslop-cli/package.json
+++ b/packages/deslop-cli/package.json
@@ -15,7 +15,7 @@
   "bugs": {
     "url": "https://github.com/millionco/react-doctor/issues"
   },
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "author": {
     "name": "Aiden Bai",
     "email": "aiden@million.dev"

--- a/packages/deslop-js/package.json
+++ b/packages/deslop-js/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/millionco/react-doctor/issues"
   },
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "author": {
     "name": "Aiden Bai",
     "email": "aiden@million.dev"

--- a/packages/eslint-plugin-react-doctor/package.json
+++ b/packages/eslint-plugin-react-doctor/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/millionco/react-doctor/issues"
   },
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "author": "Aiden Bai",
   "repository": {
     "type": "git",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.8",
   "private": true,
   "description": "Internal: editor language server for React Doctor — daemonized diagnostics, hovers, and code actions over LSP. Not published directly; bundled into the react-doctor CLI as `react-doctor experimental-lsp`.",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "bin": {
     "react-doctor-language-server": "./bin/react-doctor-language-server.js"
   },

--- a/packages/oxlint-plugin-react-doctor/package.json
+++ b/packages/oxlint-plugin-react-doctor/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/millionco/react-doctor/issues"
   },
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "author": "Aiden Bai",
   "repository": {
     "type": "git",

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/millionco/react-doctor/issues"
   },
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "author": "Million Software, Inc",
   "repository": {
     "type": "git",

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -73,6 +73,7 @@ import { isSpinnerSilent, setSpinnerSilent, spinner } from "../utils/spinner.js"
 import { shouldBlockCi } from "../utils/should-block-ci.js";
 import { shouldSkipPrompts } from "../utils/should-skip-prompts.js";
 import { warnDeprecatedFailOn } from "../utils/warn-deprecated-fail-on.js";
+import { warnIfAiTrainingEnvironment } from "../utils/warn-ai-training-environment.js";
 import { validateModeFlags } from "../utils/validate-mode-flags.js";
 import { VERSION } from "../utils/version.js";
 
@@ -259,6 +260,7 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
     // Emitted on every path (including the early-returning `--staged` branch),
     // so the deprecation nudge fires whenever `--diff` / `diff` is set.
     warnDeprecatedDiff(flags, userConfig);
+    warnIfAiTrainingEnvironment();
     if (scanTarget.didRedirectViaRootDir && !isQuiet) {
       logger.dim(
         `Redirected to ${highlighter.info(toRelativePath(resolvedDirectory, requestedDirectory))} via react-doctor config "rootDir".`,

--- a/packages/react-doctor/src/cli/utils/detect-ai-training-environment.ts
+++ b/packages/react-doctor/src/cli/utils/detect-ai-training-environment.ts
@@ -1,0 +1,53 @@
+// Presence-based env vars that signal an active ML training pipeline, data
+// collection job, RL simulation, or AI-agent sandbox. Auth/config vars (e.g.
+// OPENAI_API_KEY, HF_TOKEN) are excluded — a stored credential doesn't mean
+// the process is inside a training run. Active-run or hardware-binding vars do.
+const AI_TRAINING_ENV_VARS: ReadonlyArray<readonly [string, string]> = [
+  // HuggingFace – dataset/cache paths only (active data pipeline, not just auth)
+  ["HF_DATASETS_CACHE", "huggingface"],
+  ["HF_HOME", "huggingface"],
+  ["HUGGINGFACE_HUB_CACHE", "huggingface"],
+  // GPU compute – hardware binding means an active training or inference job
+  ["CUDA_VISIBLE_DEVICES", "cuda"],
+  ["NVIDIA_VISIBLE_DEVICES", "nvidia"],
+  // Experiment tracking – active run IDs, not just stored API keys
+  ["WANDB_RUN_ID", "wandb"],
+  ["MLFLOW_RUN_ID", "mlflow"],
+  ["MLFLOW_TRACKING_URI", "mlflow"],
+  ["COMET_EXPERIMENT_KEY", "comet"],
+  ["NEPTUNE_RUN_ID", "neptune"],
+  // Ray – distributed ML/RL workers
+  ["RAY_WORKER_PROCESS", "ray"],
+  ["RAY_ADDRESS", "ray"],
+  // RL simulation environments
+  ["MUJOCO_GL", "mujoco"],
+  ["MUJOCO_PATH", "mujoco"],
+  ["GYM_DISABLE_ENV_CHECKER", "gymnasium"],
+  // Cloud ML platforms – job/model dir presence implies a managed training job
+  ["SAGEMAKER_BASE_DIR", "sagemaker"],
+  ["AZURE_ML_MODEL_DIR", "azure-ml"],
+  ["VERTEX_AI_LOG_LEVEL", "vertex-ai"],
+  // Sandboxed code-execution environments used by AI agents
+  ["DAYTONA_WS_ID", "daytona"],
+  ["DAYTONA_WS_NAME", "daytona"],
+  ["E2B_SANDBOX_ID", "e2b"],
+  ["MODAL_FUNCTION_ID", "modal"],
+  ["MODAL_TASK_ID", "modal"],
+  ["RUNPOD_POD_ID", "runpod"],
+  // Container registries for ML artifacts
+  ["HARBOR_URL", "harbor"],
+  ["HARBOR_HOSTNAME", "harbor"],
+  // Coding-agent evaluation harnesses (SWE-bench and derivatives)
+  ["SWE_BENCH_TASK", "swe-bench"],
+  ["SWEBENCH_TASK", "swe-bench"],
+  ["SWE_AGENT_MODEL", "swe-agent"],
+] as const;
+
+export const detectAiTrainingEnvironment = (): string | null => {
+  for (const [envVar, label] of AI_TRAINING_ENV_VARS) {
+    if (process.env[envVar] !== undefined) return label;
+  }
+  return null;
+};
+
+export const isAiTrainingEnvironment = (): boolean => detectAiTrainingEnvironment() !== null;

--- a/packages/react-doctor/src/cli/utils/detect-ai-training-environment.ts
+++ b/packages/react-doctor/src/cli/utils/detect-ai-training-environment.ts
@@ -41,6 +41,29 @@ const AI_TRAINING_ENV_VARS: ReadonlyArray<readonly [string, string]> = [
   ["SWE_BENCH_TASK", "swe-bench"],
   ["SWEBENCH_TASK", "swe-bench"],
   ["SWE_AGENT_MODEL", "swe-agent"],
+  // Notebook environments – active session markers
+  ["KAGGLE_KERNEL_RUN_TYPE", "kaggle"],
+  ["COLAB_BACKEND_VERSION", "google-colab"],
+  ["DATABRICKS_RUNTIME_VERSION", "databricks"],
+  // ML training platforms – active job or run identifiers
+  ["SM_TRAINING_ENV", "sagemaker"],
+  ["TRAINING_JOB_ARN", "sagemaker"],
+  ["AZUREML_RUN_ID", "azure-ml"],
+  ["CLOUD_ML_PROJECT_ID", "vertex-ai"],
+  ["WANDB_SWEEP_ID", "wandb"],
+  ["DVC_STAGE", "dvc"],
+  ["CLEARML_TASK_ID", "clearml"],
+  ["FLYTE_INTERNAL_EXECUTION_ID", "flyte"],
+  ["DET_MASTER", "determined-ai"],
+  ["LIGHTNING_USER_ID", "lightning-ai"],
+  ["ARGO_WORKFLOW_NAME", "argo-workflows"],
+  ["KFP_POD_NAME", "kubeflow-pipelines"],
+  // GPU cloud platforms
+  ["SPACE_ID", "huggingface-spaces"],
+  ["REPLICATE_USERNAME", "replicate"],
+  ["VAST_CONTAINERLABEL", "vast-ai"],
+  ["TPU_NAME", "google-tpu"],
+  ["ROCR_VISIBLE_DEVICES", "rocm"],
 ] as const;
 
 export const detectAiTrainingEnvironment = (): string | null => {

--- a/packages/react-doctor/src/cli/utils/is-ci-environment.ts
+++ b/packages/react-doctor/src/cli/utils/is-ci-environment.ts
@@ -20,6 +20,24 @@ const CI_PROVIDER_BY_ENVIRONMENT_VARIABLE: ReadonlyArray<readonly [string, strin
   ["BITBUCKET_BUILD_NUMBER", "bitbucket"],
   ["TRAVIS", "travis"],
   ["DRONE", "drone"],
+  ["SEMAPHORE", "semaphore"],
+  ["APPVEYOR", "appveyor"],
+  ["HARNESS_BUILD_ID", "harness"],
+  ["BUDDY", "buddy"],
+  ["CF_BUILD_ID", "codefresh"],
+  ["NETLIFY", "netlify"],
+  ["RAILWAY_SERVICE_ID", "railway"],
+  ["VERCEL", "vercel"],
+  ["CM_BUILD_ID", "codemagic"],
+  ["PROW_JOB_ID", "prow"],
+  ["AGOLA_GIT_REF", "agola"],
+  ["CIRRUS_CI", "cirrus-ci"],
+  ["BLACKSMITH_STICKYDISK_TOKEN", "blacksmith"],
+  ["WARPBUILD_RUNNER_VERIFICATION_TOKEN", "warpbuild"],
+  ["NSC_CACHE_PATH", "namespace"],
+  ["UBICLOUD_CACHE_URL", "ubicloud"],
+  ["RENDER", "render"],
+  ["FLY_APP_NAME", "fly-io"],
 ];
 
 // Marker the official react-doctor GitHub Action sets on its scan step so CLI
@@ -54,6 +72,9 @@ const CODING_AGENT_BY_ENVIRONMENT_VARIABLE: ReadonlyArray<readonly [string, stri
   ["OPENCODE", "opencode"],
   ["GOOSE_TERMINAL", "goose"],
   ["AMP_THREAD_ID", "amp"],
+  ["CLINE_ACTIVE", "cline"],
+  ["AUGMENT_AGENT", "augment"],
+  ["TRAE_AI_SHELL_ID", "trae-ai"],
 ];
 
 // Generic "an agent is driving this" markers that signal an agent without

--- a/packages/react-doctor/src/cli/utils/warn-ai-training-environment.ts
+++ b/packages/react-doctor/src/cli/utils/warn-ai-training-environment.ts
@@ -1,0 +1,9 @@
+import { cliLogger as logger } from "./cli-logger.js";
+import { detectAiTrainingEnvironment } from "./detect-ai-training-environment.js";
+
+export const warnIfAiTrainingEnvironment = (): void => {
+  if (detectAiTrainingEnvironment() === null) return;
+  logger.warn(
+    "react-doctor detected use in an AI or ML pipeline. This use requires written permission under the react-doctor license — contact founders@million.dev to request access.",
+  );
+};

--- a/packages/vscode-react-doctor/package.json
+++ b/packages/vscode-react-doctor/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/millionco/react-doctor/issues"
   },
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
     "url": "https://github.com/millionco/react-doctor.git",

--- a/packages/website/src/app/license/page.tsx
+++ b/packages/website/src/app/license/page.tsx
@@ -1,0 +1,129 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "License - React Doctor",
+  description:
+    "React Doctor is free for most uses. AI training and large-scale commercial use require a written license from Million Software, Inc.",
+};
+
+const LICENSE_URL =
+  "https://github.com/millionco/react-doctor/blob/main/LICENSE";
+
+const PERMITTED: readonly { label: string; detail: string }[] = [
+  { label: "Use", detail: "Run react-doctor in any project or pipeline." },
+  { label: "Modify", detail: "Fork and change the source for your needs." },
+  { label: "Distribute", detail: "Ship it as part of your own tooling." },
+  { label: "Sell", detail: "Include it in a commercial product or service." },
+];
+
+const REQUIRES_PERMISSION: readonly { label: string; detail: string }[] = [
+  {
+    label: "AI / ML training",
+    detail:
+      "Using the source code, outputs, or derivative works as training data, fine-tuning data, or evaluation data for any machine learning model.",
+  },
+  {
+    label: "Automated data collection",
+    detail:
+      "Feeding react-doctor into a pipeline whose primary purpose is building or improving an AI system.",
+  },
+];
+
+const Row = ({
+  label,
+  detail,
+  permitted,
+}: {
+  label: string;
+  detail: string;
+  permitted: boolean;
+}) => (
+  <div className="flex gap-4 py-3 border-b border-white/10 last:border-0">
+    <span
+      className={`mt-0.5 text-xs font-mono shrink-0 w-4 ${permitted ? "text-green-400" : "text-red-400"}`}
+    >
+      {permitted ? "✓" : "⊘"}
+    </span>
+    <div className="flex flex-col gap-0.5">
+      <span className="text-sm text-white font-mono">{label}</span>
+      <span className="text-xs text-white/50 leading-relaxed">{detail}</span>
+    </div>
+  </div>
+);
+
+const LicensePage = () => (
+  <main className="min-h-screen bg-[#0a0a0a] text-white font-mono px-6 py-16 flex justify-center">
+    <div className="w-full max-w-xl flex flex-col gap-10">
+
+      <div className="flex flex-col gap-2">
+        <span className="text-xs text-white/40 uppercase tracking-widest">
+          Million Software, Inc.
+        </span>
+        <h1 className="text-2xl text-white">License</h1>
+        <p className="text-sm text-white/50 leading-relaxed">
+          React Doctor is free for most uses under the{" "}
+          <Link
+            href={LICENSE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-white underline underline-offset-4 hover:text-white/70 transition-colors"
+          >
+            react-doctor license
+          </Link>
+          . AI training use requires written permission.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-white/30 uppercase tracking-widest mb-2">
+          Permitted
+        </span>
+        <div className="border border-white/10 rounded px-4">
+          {PERMITTED.map((item) => (
+            <Row key={item.label} {...item} permitted={true} />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-white/30 uppercase tracking-widest mb-2">
+          Requires written permission
+        </span>
+        <div className="border border-white/10 rounded px-4">
+          {REQUIRES_PERMISSION.map((item) => (
+            <Row key={item.label} {...item} permitted={false} />
+          ))}
+        </div>
+      </div>
+
+      <div className="border border-white/10 rounded p-5 flex flex-col gap-3">
+        <p className="text-sm text-white/70 leading-relaxed">
+          If your use case requires a commercial license — or if you&apos;re
+          unsure whether your use qualifies — reach out. We respond quickly.
+        </p>
+        <a
+          href="mailto:founders@million.dev"
+          className="text-sm text-white border border-white/20 rounded px-4 py-2 hover:bg-white hover:text-black transition-colors w-fit"
+        >
+          founders@million.dev
+        </a>
+      </div>
+
+      <div className="text-xs text-white/25 leading-relaxed">
+        Copyright &copy; 2026 Million Software, Inc. &mdash;{" "}
+        <Link
+          href={LICENSE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-white/50 transition-colors underline underline-offset-2"
+        >
+          Full license text
+        </Link>
+      </div>
+
+    </div>
+  </main>
+);
+
+export default LicensePage;


### PR DESCRIPTION
## Summary

- Adds a no-training clause: the source code and derivative works may not be used as training, fine-tuning, or evaluation data for ML/AI models without prior written permission
- Academic researchers can request a no-cost exemption at founders@million.dev — but must ask first
- Updates the title to `MIT License (with Additional Restrictions)` to accurately reflect the terms
- Removes the `outputs` language from the draft — legally overreaching since users own output from their own data, which would invite challenge

## Legal notes

This is source-available, not OSI open source. The no-training restriction is newer case law and largely untested, but the explicit prior-written-permission gate makes infringement unambiguous. Get a lawyer to review before treating this as final.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> License terms change distribution/compliance expectations for all consumers; env-based warnings are heuristic and may false-positive (e.g. GPU or notebook markers) without blocking execution.
> 
> **Overview**
> Adds an **MIT License (with Additional Restrictions)** clause forbidding use of the software, source, or derivatives as ML/AI training, fine-tuning, or evaluation data (or as input to automated pipelines for that purpose) without prior written permission from **founders@million.dev**.
> 
> Published and internal packages now declare **`SEE LICENSE IN LICENSE`** instead of plain MIT. A new **`/license`** site page summarizes permitted vs permission-required uses and links to the full license text.
> 
> **Runtime detection (warn-only):** the CLI **`inspect`** path and the programmatic **`diagnose`** API call a one-time warning when presence-based env vars suggest an active ML training job, agent sandbox, or SWE-bench-style harness (CLI uses `detect-ai-training-environment.ts`; API duplicates the var list inline to avoid a CLI dependency).
> 
> **Telemetry context:** `is-ci-environment.ts` expands CI provider and coding-agent env markers (e.g. Vercel, Cline, Augment) for labeling runs—not enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15b1237f67fe2902cb86d5804dc5895c5aa2756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->