### PR TITLE
fix(staged): log warning when git errors occur in getStagedSourceFiles

### DIFF
--- a/.changeset/fix-staged-error-logging.md
+++ b/.changeset/fix-staged-error-logging.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+fix(staged): log warning when getStagedSourceFiles encounters git errors
+
+When git commands fail (missing git binary, corrupted repo, permission errors), `getStagedSourceFiles` now logs a warning message showing the error instead of silently returning an empty array. This makes `--staged` failures much easier to debug while still gracefully degrading.

--- a/packages/react-doctor/src/cli/utils/get-staged-files.ts
+++ b/packages/react-doctor/src/cli/utils/get-staged-files.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Git, StagedFiles, type StagedSnapshot } from "@react-doctor/core";
+import { cliLogger } from "./cli-logger.js";
 
 const stagedFilesLayer = StagedFiles.layerNode.pipe(Layer.provide(Git.layerNode));
 
@@ -13,7 +14,10 @@ export const getStagedSourceFiles = async (directory: string): Promise<string[]>
       }).pipe(Effect.provide(stagedFilesLayer)),
     );
     return [...files];
-  } catch {
+  } catch (error) {
+    cliLogger.warn(
+      `Failed to discover staged files: ${error instanceof Error ? error.message : String(error)}`,
+    );
     return [];
   }
 };

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -327,6 +327,25 @@ describe("issue #115: --staged uses git INDEX content, not working tree", () => 
   });
 });
 
+describe("issue #937: getStagedSourceFiles logs warnings on git errors", () => {
+  it("getStagedSourceFiles returns [] and logs a warning when git command fails", async () => {
+    const nonExistentDir = path.join(tempRoot, "issue-937-nonexistent");
+    const warnSpy: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message: string) => {
+      warnSpy.push(message);
+    };
+    try {
+      const result = await getStagedSourceFiles(nonExistentDir);
+      expect(result).toEqual([]);
+      expect(warnSpy.length).toBeGreaterThan(0);
+      expect(warnSpy[0]).toContain("Failed to discover staged files");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
 describe("issue #141: oxlint config must not reference unloaded plugins", () => {
   // HACK: the bug only fires when eslint-plugin-react-hooks is missing
   // AND React Compiler is detected — so REACT_COMPILER_RULES (under the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

`getStagedSourceFiles` in `packages/react-doctor/src/cli/utils/get-staged-files.ts` catches all errors from the underlying Effect-based `StagedFiles.discoverSourceFiles` and silently returns an empty array. When git commands fail (missing git binary, corrupted repo, permission errors), users see "No staged source files found" with no indication that an error occurred, making `--staged` failures very difficult to debug.

## Fix

Added error logging via `cliLogger.warn()` to display the error message before returning `[]`. The function still gracefully degrades (returns empty array), but now users can see what went wrong:

```
Failed to discover staged files: <error message>
```

## Scope Decision

This fix is narrowly scoped to `getStagedSourceFiles`. Other similar catch blocks in the codebase have valid reasons for silent failures:
- Sentry scrubbing (must not send unscrubbed data)
- Cache operations (non-critical graceful degradation)
- Error reporting itself (can't recursively report)

This is the only place where a user-facing diagnostic operation silently swallows errors that users need to see for debugging.

## Testing

- Added regression test in `scan-resilience.test.ts` that verifies the warning is logged when git command fails
- All existing tests pass
- Lint and typecheck pass

## Parity

This change **only adds logging** - it doesn't change any diagnostic behavior:
- On success: returns the same files as before
- On failure: returns `[]` (same as before), but now also logs a warning

Since the return value is unchanged in all cases, there should be **zero diagnostic changes** across the corpus. The diagnostic pipeline depends on the return value, not on console output.

Closes #937
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6e3e1ca-7fb5-4f37-8a5b-82d55a184ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6e3e1ca-7fb5-4f37-8a5b-82d55a184ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

