### PR TITLE
fix(cli): align install agent selection with the Vercel skills CLI

### DIFF
--- a/.changeset/install-recommended-agents-only.md
+++ b/.changeset/install-recommended-agents-only.md
@@ -1,0 +1,13 @@
+---
+"react-doctor": patch
+---
+
+Align `react-doctor install`'s agent selection with the Vercel `skills` CLI so it stops scattering skill directories across your project. The prompt previously detected every agent with a config dir anywhere in `$HOME` (`~/.codebuddy`, `~/.crush`, `~/.goose`, `~/.kilocode`, …) and **pre-selected all of them**, so a single Enter copied `.codebuddy/`, `.crush/`, `.goose/`, … into the project root.
+
+Now, following that CLI's heuristic, the default selection is:
+
+- your **remembered** last pick (persisted globally, like `skills`' `lastSelectedAgents` lock), else
+- a small curated set of popular agents (`claude-code`, `cursor`, `codex`, `opencode`), else
+- a lone detected agent when that's the only one — and otherwise nothing, so you make a deliberate choice.
+
+Every detected agent is still shown so the rest are one keystroke away; they're just no longer pre-checked. A non-interactive run (`--yes` / CI) still installs to all detected agents, matching `skills`' `--yes`.

--- a/packages/react-doctor/src/cli/utils/cli-state-store.ts
+++ b/packages/react-doctor/src/cli/utils/cli-state-store.ts
@@ -54,7 +54,13 @@ export const SETUP_HINT_EVENT = "setup-hint";
 //   surface                       scope    id                  wired in
 //   ────────────────────────────  ───────  ──────────────────  ──────────────────────────────
 //   post-scan handoff target      global   handoff-target      handoff-target-preference.ts
+//   install agent selection       global   install-agents      install-agents-preference.ts
 export const HANDOFF_TARGET_PREFERENCE_ID = "handoff-target";
+
+// The comma-encoded agent list the user picked at their last `install` (see the
+// Vercel `skills` CLI's `lastSelectedAgents` lock). Read back as the next
+// install's pre-selected default.
+export const INSTALL_AGENTS_PREFERENCE_ID = "install-agents";
 
 export type EventOutcome = "seen" | "accepted" | "declined";
 

--- a/packages/react-doctor/src/cli/utils/detect-agents.ts
+++ b/packages/react-doctor/src/cli/utils/detect-agents.ts
@@ -41,3 +41,36 @@ export const detectAvailableAgents = async (): Promise<SkillAgentType[]> => {
   ]);
   return getSkillAgentTypes().filter((agent) => agent !== "universal" && detected.has(agent));
 };
+
+// The popular coding agents `install` pre-selects by default when the user has
+// no remembered selection yet — mirroring the Vercel `skills` CLI's curated
+// default (`claude-code`, `opencode`, `codex`). Cursor is added because that CLI
+// installs it unconditionally as an always-on universal agent, whereas React
+// Doctor doesn't lock universal agents on, so it belongs in the default set
+// here. Niche tools the user merely has installed somewhere in $HOME stay
+// shown-but-unselected, so a machine full of AI tools doesn't get the skill
+// copied into a dozen project-local directories just by pressing Enter.
+export const DEFAULT_INSTALL_AGENTS: readonly SkillAgentType[] = [
+  "claude-code",
+  "cursor",
+  "codex",
+  "opencode",
+];
+
+// The agents `install` selects by default, following the Vercel `skills` CLI
+// heuristic: prefer the user's remembered last selection; else the curated
+// popular defaults; else (neither applies) a lone detected agent is the obvious
+// pick and anything longer defaults to nothing, so the user makes a deliberate
+// choice. Every candidate is intersected with the detected agents so we never
+// pre-select something that isn't installed.
+export const computeDefaultSelectedAgents = (
+  detectedAgents: readonly SkillAgentType[],
+  rememberedAgents: readonly SkillAgentType[],
+): SkillAgentType[] => {
+  const detected = new Set(detectedAgents);
+  const remembered = rememberedAgents.filter((agent) => detected.has(agent));
+  if (remembered.length > 0) return remembered;
+  const defaults = DEFAULT_INSTALL_AGENTS.filter((agent) => detected.has(agent));
+  if (defaults.length > 0) return defaults;
+  return detectedAgents.length === 1 ? [...detectedAgents] : [];
+};

--- a/packages/react-doctor/src/cli/utils/install-agents-preference.ts
+++ b/packages/react-doctor/src/cli/utils/install-agents-preference.ts
@@ -1,0 +1,36 @@
+import { isSkillAgentType, type SkillAgentType } from "agent-install";
+import { type CliStateOptions, INSTALL_AGENTS_PREFERENCE_ID } from "./cli-state-store.js";
+import { type Preference, readPreference, writePreference } from "./cli-lifecycle.js";
+
+// The agents the user selected at their last `install`, remembered globally —
+// which coding agents you wire React Doctor into is a personal habit, not a
+// per-repo setting — so the next install pre-selects the same picks anywhere.
+// Mirrors the Vercel `skills` CLI's `lastSelectedAgents` lock. The Preference
+// primitive stores one string, so the list is comma-encoded.
+export const INSTALL_AGENTS_PREFERENCE: Preference = {
+  id: INSTALL_AGENTS_PREFERENCE_ID,
+  scope: "global",
+};
+
+const PREFERENCE_SEPARATOR = ",";
+
+// The agents the user picked last, filtered to ones agent-install still
+// recognizes (a stale id from an older release just drops out). Empty when the
+// user has never picked or the store is unreadable — callers fall back to the
+// curated defaults.
+export const readInstallAgents = (options: CliStateOptions = {}): SkillAgentType[] => {
+  const stored = readPreference(INSTALL_AGENTS_PREFERENCE, {}, options);
+  if (stored === null) return [];
+  return stored
+    .split(PREFERENCE_SEPARATOR)
+    .map((entry) => entry.trim())
+    .filter((entry) => isSkillAgentType(entry));
+};
+
+// Remembers the user's latest selection so the next install defaults to it.
+// Returns whether it persisted.
+export const rememberInstallAgents = (
+  agents: readonly SkillAgentType[],
+  options: CliStateOptions = {},
+): boolean =>
+  writePreference(INSTALL_AGENTS_PREFERENCE, agents.join(PREFERENCE_SEPARATOR), {}, options);

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -11,7 +11,8 @@ import {
 } from "agent-install";
 import { highlighter, SKILL_NAME } from "@react-doctor/core";
 import { cliLogger as logger } from "./cli-logger.js";
-import { detectAvailableAgents } from "./detect-agents.js";
+import { computeDefaultSelectedAgents, detectAvailableAgents } from "./detect-agents.js";
+import { readInstallAgents, rememberInstallAgents } from "./install-agents-preference.js";
 import { METRIC } from "./constants.js";
 import { recordCount } from "./record-metric.js";
 import {
@@ -336,6 +337,7 @@ interface InstallReactDoctorOptions {
   sourceDir?: string;
   projectRoot?: string;
   detectedAgents?: SkillAgentType[];
+  lastSelectedAgents?: SkillAgentType[];
   gitHookPath?: string | null;
   onPromptCancel?: () => void;
   installDependencyRunner?: (
@@ -582,6 +584,17 @@ export const runInstallReactDoctor = async (
   }
 
   // Step 2 — the agent skill + package setup (the core of `install`).
+  // Default agent selection follows the Vercel `skills` CLI: pre-select the
+  // user's remembered last pick, else a small curated set of popular agents.
+  // The rest of the detected agents — tools merely installed somewhere in $HOME
+  // — stay shown-but-unselected, so a machine full of AI tools doesn't get the
+  // skill copied into a dozen project-local directories just by pressing Enter.
+  // A non-interactive run can't ask, so (matching that CLI's `--yes`) it installs
+  // every detected agent.
+  const rememberedAgents = options.lastSelectedAgents ?? readInstallAgents();
+  const defaultSelectedAgents = computeDefaultSelectedAgents(detectedAgents, rememberedAgents);
+  const usedRememberedAgents = rememberedAgents.some((agent) => detectedAgents.includes(agent));
+
   const selectedAgents: SkillAgentType[] = skipPrompts
     ? detectedAgents
     : ((
@@ -593,7 +606,7 @@ export const runInstallReactDoctor = async (
             choices: detectedAgents.map((agent) => ({
               title: getSkillAgentConfig(agent).displayName,
               value: agent,
-              selected: true,
+              selected: defaultSelectedAgents.includes(agent),
             })),
             instructions: false,
             min: 1,
@@ -603,6 +616,12 @@ export const runInstallReactDoctor = async (
       ).agents ?? []);
 
   if (selectedAgents.length === 0) return;
+
+  // Remember the interactive pick so the next install defaults to it. A
+  // non-interactive run installs everything detected rather than making a
+  // deliberate choice, and a dry run previews without writing, so neither
+  // overwrites the remembered set.
+  if (!skipPrompts && !options.dryRun) rememberInstallAgents(selectedAgents);
 
   let dependencyResult: InstallReactDoctorDependencyResult | undefined;
   if (!options.dryRun) {
@@ -740,6 +759,13 @@ export const runInstallReactDoctor = async (
   // the agent set down so per-agent adoption is queryable.
   recordCount(METRIC.installCompleted, 1, {
     agentsCount: selectedAgents.length,
+    // Kill metric for the narrower default: how many agents we detected vs. how
+    // many actually got installed, and whether a remembered selection pre-filled
+    // the prompt. A large `agentsDetected` with a small `agentsCount` is the
+    // anti-pollution default working; if interactive users routinely select well
+    // beyond the curated defaults, the default set should be widened.
+    agentsDetected: detectedAgents.length,
+    usedRememberedAgents,
     gitHook: shouldInstallGitHook,
     agentHooks: shouldInstallAgentHooks,
     workflow: didInstallWorkflow,

--- a/packages/react-doctor/tests/detect-agents.test.ts
+++ b/packages/react-doctor/tests/detect-agents.test.ts
@@ -1,7 +1,10 @@
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
-import { detectAvailableAgents } from "../src/cli/utils/detect-agents.js";
+import {
+  computeDefaultSelectedAgents,
+  detectAvailableAgents,
+} from "../src/cli/utils/detect-agents.js";
 import * as fs from "node:fs";
 
 const writeExecutable = (binDir: string, binaryName: string): void => {
@@ -89,5 +92,40 @@ describe.skipIf(process.platform === "win32")("detectAvailableAgents (PATH detec
     const result = await detectAvailableAgents();
     if (result.includes("claude-code")) return;
     expect(result).not.toContain("claude-code");
+  });
+});
+
+describe("computeDefaultSelectedAgents", () => {
+  it("pre-selects the remembered agents (intersected with what's detected)", () => {
+    expect(
+      computeDefaultSelectedAgents(["claude-code", "cursor", "goose"], ["goose", "crush"]),
+    ).toEqual(["goose"]);
+  });
+
+  it("prefers the remembered selection over the curated defaults", () => {
+    expect(computeDefaultSelectedAgents(["claude-code", "cursor", "goose"], ["goose"])).toEqual([
+      "goose",
+    ]);
+  });
+
+  it("falls back to the curated popular defaults when nothing is remembered", () => {
+    expect(computeDefaultSelectedAgents(["claude-code", "cursor", "goose", "crush"], [])).toEqual([
+      "claude-code",
+      "cursor",
+    ]);
+  });
+
+  it("falls back to a lone detected agent when neither remembered nor a default matches", () => {
+    expect(computeDefaultSelectedAgents(["goose"], [])).toEqual(["goose"]);
+  });
+
+  it("selects nothing when several agents are detected but none is remembered or a default", () => {
+    expect(computeDefaultSelectedAgents(["goose", "crush", "kilo"], [])).toEqual([]);
+  });
+
+  it("never pre-selects a remembered or default agent that isn't detected", () => {
+    // `codex` is a curated default but isn't installed here; `claude-code` is
+    // remembered but also not detected — neither should leak into the result.
+    expect(computeDefaultSelectedAgents(["goose", "crush"], ["claude-code"])).toEqual([]);
   });
 });

--- a/packages/react-doctor/tests/install-agents-preference.test.ts
+++ b/packages/react-doctor/tests/install-agents-preference.test.ts
@@ -1,0 +1,56 @@
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  readInstallAgents,
+  rememberInstallAgents,
+} from "../src/cli/utils/install-agents-preference.js";
+import { getCliStatePath } from "../src/cli/utils/cli-state-store.js";
+
+describe("install agents preference", () => {
+  let configRoot: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    const root = fs.mkdtempSync(path.join(tmpdir(), "react-doctor-install-agents-pref-"));
+    configRoot = root;
+    cleanup = () => fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reads an empty list before the user has ever picked", () => {
+    expect(readInstallAgents({ cwd: configRoot })).toEqual([]);
+  });
+
+  it("remembers the last selection and reads it back in order", () => {
+    expect(rememberInstallAgents(["claude-code", "cursor"], { cwd: configRoot })).toBe(true);
+    expect(readInstallAgents({ cwd: configRoot })).toEqual(["claude-code", "cursor"]);
+  });
+
+  it("overwrites the remembered selection on each new pick (last wins)", () => {
+    rememberInstallAgents(["claude-code", "cursor"], { cwd: configRoot });
+    rememberInstallAgents(["goose"], { cwd: configRoot });
+    expect(readInstallAgents({ cwd: configRoot })).toEqual(["goose"]);
+  });
+
+  it("drops stored ids that agent-install no longer recognizes", () => {
+    // Start from a valid persisted state (so the schema-version migration leaves
+    // it untouched), then corrupt the encoded value with one valid + one bogus id.
+    rememberInstallAgents(["claude-code"], { cwd: configRoot });
+    const statePath = getCliStatePath({ cwd: configRoot });
+    const stored = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    stored.global.preferences["install-agents"] = "claude-code,not-an-agent";
+    fs.writeFileSync(statePath, JSON.stringify(stored));
+    expect(readInstallAgents({ cwd: configRoot })).toEqual(["claude-code"]);
+  });
+
+  it("stores the pick as a comma-encoded global install-agents preference", () => {
+    rememberInstallAgents(["claude-code", "codex"], { cwd: configRoot });
+    const stored = JSON.parse(fs.readFileSync(getCliStatePath({ cwd: configRoot }), "utf8"));
+    expect(stored.global.preferences["install-agents"]).toBe("claude-code,codex");
+  });
+});

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
+import type { SkillAgentType } from "agent-install";
 import type { Answers, PromptObject } from "prompts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import * as fs from "node:fs";
@@ -22,6 +23,7 @@ import type { InstallReactDoctorDependencyRunnerInput } from "../src/cli/utils/i
 import { recordActionUpgradeDecision } from "../src/cli/utils/action-upgrade-prompt.js";
 import { CONFIG_DIR_ENV_VAR } from "../src/cli/utils/cli-state-store.js";
 import { hasHandledCiPrompt, recordCiPromptDecision } from "../src/cli/utils/ci-prompt-decision.js";
+import { readInstallAgents } from "../src/cli/utils/install-agents-preference.js";
 import { setSpinnerSilent } from "../src/cli/utils/spinner.js";
 import { silenceConsoleForTest } from "./helpers/silence-console.js";
 
@@ -113,6 +115,8 @@ interface RunInteractiveInstallReactDoctorForTestOptions {
   readonly gitHookPath: string;
   readonly setupOptions: readonly string[];
   readonly promptQuestions?: unknown[];
+  readonly detectedAgents?: readonly SkillAgentType[];
+  readonly lastSelectedAgents?: readonly SkillAgentType[];
 }
 
 const runInteractiveInstallReactDoctorForTest = async (
@@ -162,7 +166,9 @@ const runInteractiveInstallReactDoctorForTest = async (
     await runInstallReactDoctorForTest({
       sourceDir: options.sourceDir,
       projectRoot: options.projectRoot,
-      detectedAgents: ["cursor"],
+      detectedAgents: [...(options.detectedAgents ?? ["cursor"])],
+      lastSelectedAgents:
+        options.lastSelectedAgents === undefined ? undefined : [...options.lastSelectedAgents],
       gitHookPath: options.gitHookPath,
       prompt,
     });
@@ -718,6 +724,85 @@ describe("runInstallReactDoctor", () => {
     expect(workflowContent).not.toContain("\n        with:\n");
     expect(workflowContent).not.toContain("github-token");
     expect(workflowContent).not.toContain("diff: main");
+  });
+
+  const findAgentChoiceSelection = (promptQuestions: unknown[]): Map<string, boolean> => {
+    const agentQuestion = promptQuestions.find(
+      (question): question is { choices: Array<{ value: string; selected?: boolean }> } =>
+        typeof question === "object" &&
+        question !== null &&
+        "name" in question &&
+        (question as { name?: unknown }).name === "agents",
+    );
+    expect(agentQuestion).toBeDefined();
+    return new Map(
+      agentQuestion!.choices.map((choice) => [choice.value, Boolean(choice.selected)]),
+    );
+  };
+
+  it("pre-selects only the curated default agents, leaving merely-installed ones opt-in", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const promptQuestions: unknown[] = [];
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: path.join(fixture.projectRoot, ".git/hooks/pre-commit"),
+      setupOptions: [],
+      promptQuestions,
+      // A machine with four AI tools installed, no remembered selection yet.
+      detectedAgents: ["claude-code", "cursor", "goose", "crush"],
+    });
+
+    const selectionByAgent = findAgentChoiceSelection(promptQuestions);
+    // Popular agents in the curated default set → pre-checked.
+    expect(selectionByAgent.get("claude-code")).toBe(true);
+    expect(selectionByAgent.get("cursor")).toBe(true);
+    // Merely installed somewhere in $HOME → shown, but not pre-checked, so a
+    // single Enter never copies the skill into their project-local dirs.
+    expect(selectionByAgent.get("goose")).toBe(false);
+    expect(selectionByAgent.get("crush")).toBe(false);
+  });
+
+  it("pre-selects the user's remembered selection over the curated defaults", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    const promptQuestions: unknown[] = [];
+
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: path.join(fixture.projectRoot, ".git/hooks/pre-commit"),
+      setupOptions: [],
+      promptQuestions,
+      detectedAgents: ["claude-code", "cursor", "goose"],
+      // Last time the user deliberately picked Goose; that wins over defaults.
+      lastSelectedAgents: ["goose"],
+    });
+
+    const selectionByAgent = findAgentChoiceSelection(promptQuestions);
+    expect(selectionByAgent.get("goose")).toBe(true);
+    expect(selectionByAgent.get("claude-code")).toBe(false);
+    expect(selectionByAgent.get("cursor")).toBe(false);
+  });
+
+  it("remembers the interactive selection so the next install defaults to it", async () => {
+    writeValidSkill(fixture.sourceDir);
+    writePackageJson(fixture.projectRoot, { scripts: {} });
+    expect(readInstallAgents()).toEqual([]);
+
+    // The interactive harness's prompt mock answers the agent question with
+    // ["cursor"], so that pick should be persisted globally for next time.
+    await runInteractiveInstallReactDoctorForTest({
+      sourceDir: fixture.sourceDir,
+      projectRoot: fixture.projectRoot,
+      gitHookPath: path.join(fixture.projectRoot, ".git/hooks/pre-commit"),
+      setupOptions: [],
+      detectedAgents: ["claude-code", "cursor"],
+    });
+
+    expect(readInstallAgents()).toEqual(["cursor"]);
   });
 
   it("skips optional setup when only the skip option is selected", async () => {


### PR DESCRIPTION
## Why

`npx react-doctor install` detected every coding agent with a config dir anywhere in `$HOME` and **pre-selected all of them**, so a single Enter copied the `/react-doctor` skill into a project-local directory for every tool the user had ever opened ([reported here](https://x.com/mohtashamdotdev) — a project root littered with `.codebuddy/`, `.crush/`, `.goose/`, `.kilocode/`, …). This realigns the default selection with the [Vercel `skills` CLI](https://github.com/vercel-labs/skills) heuristic (the same engine `agent-install` is built on), which never pre-selects "everything detected."

Before:

```
# `npx react-doctor install`, machine with ~20 AI tools → one Enter writes:
.codebuddy/  .continue/  .crush/  .factory/  .goose/  .kilocode/
.openhands/  .qoder/  .qwen/  .roo/  .trae/  .windsurf/  .zencoder/  …
```

After:

```
# one Enter writes only the agents you actually use:
.claude/skills/react-doctor/   .agents/skills/react-doctor/   # cursor/codex/opencode share this
# every other detected agent is shown in the prompt, just un-checked
```

## What changed

- **Default selection follows the Vercel `skills` CLI heuristic** (`computeDefaultSelectedAgents`): remembered last pick → a curated set of popular agents (`claude-code`, `cursor`, `codex`, `opencode`) → a lone detected agent → otherwise nothing. Each candidate is intersected with the detected agents.
- **Remembers the interactive pick** globally and pre-selects it next time (`install-agents-preference.ts`, mirroring `skills`' `lastSelectedAgents` lock and the existing `handoff-target` preference). A dry run / non-interactive run never overwrites it.
- **Non-interactive (`--yes` / CI) still installs all detected agents** — matching `skills`' `--yes`.
- Telemetry on `install.completed`: `agentsDetected` + `usedRememberedAgents` (kill metric — large detected / small installed means the anti-pollution default is working).

Deliberately **not** ported: symlink install mode (we copy because the skill is committed with the project), and `ensureUniversalAgents` (broadens installs against the anti-pollution goal; `cursor`/`codex`/`opencode` are already universal here and share `.agents/skills`).

## Test plan

- `pnpm --filter react-doctor test` — full suite **1938 passed / 0 failed** (new `computeDefaultSelectedAgents` cases, an `install-agents-preference` suite, and install tests for curated-default pre-selection, remembered-selection override, and persistence).
- `pnpm typecheck` (14/14), `pnpm lint`, `pnpm format:check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only install UX and global preference persistence; no auth, security, or scan logic changes. Non-interactive behavior is unchanged.
> 
> **Overview**
> **`react-doctor install` no longer pre-checks every detected coding agent**, which had been copying the skill into many project-local dirs (`.goose/`, `.crush/`, etc.) on a single Enter.
> 
> Interactive installs now default via **`computeDefaultSelectedAgents`**: global **remembered** last pick → curated **`claude-code` / `cursor` / `codex` / `opencode`** (intersected with what’s detected) → sole detected agent → otherwise **none** pre-selected. **`install-agents-preference`** persists the choice after interactive runs; **`--yes` / CI** still installs **all** detected agents.
> 
> **`install.completed`** telemetry adds **`agentsDetected`** and **`usedRememberedAgents`** to track the narrower default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8015a6dfe58ec0197af942d041cfa00222b5a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->