### PR TITLE
fix(core): survive synchronous git spawn failures (ENOTDIR / ENAMETOOLONG) (#924)

### DIFF
--- a/.changeset/fix-924-git-spawn-defect.md
+++ b/.changeset/fix-924-git-spawn-defect.md
@@ -1,0 +1,6 @@
+---
+"react-doctor": patch
+"@react-doctor/core": patch
+---
+
+Stop a scan from crashing when a git subprocess fails synchronously (fixes REACT-DOCTOR-1E, REACT-DOCTOR-1P, REACT-DOCTOR-20). Unlike a missing binary (`ENOENT`, which arrives on the catchable `'error'` event), `child_process.spawn` **throws synchronously** when the working directory isn't a directory (`ENOTDIR`) or the argument list exceeds the OS command-line limit (`ENAMETOOLONG` — e.g. `--scope lines` on a 1,000+-file diff on Windows). That throw escaped Effect's error channel entirely and took down the whole scan (reported to Sentry as a raw `spawn` error). The git runner now pre-flights both conditions and fails on its normal channel, so the existing fallbacks recover instead: a bad working directory degrades like an unavailable git, and an over-long `--scope lines` diff degrades to file-level scope.

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -9,7 +9,11 @@ import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
-import { DEFAULT_BRANCH_CANDIDATES, GITHUB_VIEWER_PERMISSION_TIMEOUT_MS } from "../constants.js";
+import {
+  DEFAULT_BRANCH_CANDIDATES,
+  GITHUB_VIEWER_PERMISSION_TIMEOUT_MS,
+  SPAWN_ARGS_MAX_LENGTH_CHARS,
+} from "../constants.js";
 import {
   GitBaseBranchInvalid,
   GitBaseBranchMissing,
@@ -17,6 +21,7 @@ import {
   ReactDoctorError,
 } from "../errors.js";
 import { parseChangedLineRanges } from "../parse-changed-line-ranges.js";
+import { isDirectory } from "../project-info/utils/is-directory.js";
 import type { ChangedFileLineRanges } from "../types/index.js";
 
 interface GitInvocationResult {
@@ -310,9 +315,54 @@ export class Git extends Context.Service<
        */
       const runCommand = (
         input: CommandInvocationInput,
-      ): Effect.Effect<GitInvocationResult, ReactDoctorError> =>
-        Effect.scoped(
+      ): Effect.Effect<GitInvocationResult, ReactDoctorError> => {
+        // Shared by the async `PlatformError` path and the synchronous-spawn
+        // defect path so both spawn-failure shapes resolve identically: a
+        // non-`git` command degrades to a non-zero result the caller already
+        // handles; `git` fails with the tagged `GitInvocationFailed` its
+        // degradation paths (currentBranch → null, branchExists → false,
+        // changedLineRanges → null) recover from.
+        const foldSpawnFailure = (
+          cause: unknown,
+        ): Effect.Effect<GitInvocationResult, ReactDoctorError> =>
+          input.command !== "git"
+            ? Effect.succeed({ status: 127, stdout: "", stderr: String(cause) })
+            : Effect.fail(
+                new ReactDoctorError({
+                  reason: new GitInvocationFailed({
+                    args: [...input.args],
+                    directory: input.directory,
+                    cause,
+                  }),
+                }),
+              );
+        return Effect.scoped(
           Effect.gen(function* () {
+            // `child_process.spawn` THROWS synchronously — escaping Effect's
+            // failure channel as an uncatchable runtime exception, because
+            // Effect's `Async` register isn't guarded — when the cwd isn't a
+            // directory (`ENOTDIR`) or the argv exceeds the OS command-line
+            // limit (`ENAMETOOLONG`, e.g. `git diff -- <1k files>` under
+            // `--scope lines` on Windows). The 'error' event (which becomes a
+            // catchable `PlatformError`) never fires. Both conditions are
+            // predictable, so fail them on the typed channel up front; the
+            // degradation paths (currentBranch → null, branchExists → false,
+            // changedLineRanges → null) then recover instead of the whole scan
+            // crashing and reporting to Sentry (REACT-DOCTOR-1E / 1P / 20).
+            if (!isDirectory(input.directory)) {
+              return yield* foldSpawnFailure(
+                `spawn ENOTDIR (cwd is not a directory: ${input.directory})`,
+              );
+            }
+            const argvLengthChars =
+              input.command.length +
+              1 +
+              input.args.reduce((total, arg) => total + arg.length + 1, 0);
+            if (argvLengthChars > SPAWN_ARGS_MAX_LENGTH_CHARS) {
+              return yield* foldSpawnFailure(
+                `spawn ENAMETOOLONG (${argvLengthChars} argv chars exceed ${SPAWN_ARGS_MAX_LENGTH_CHARS})`,
+              );
+            }
             const handle = yield* spawner.spawn(
               // HACK: `extendEnv: true` is required for spawned commands
               // to inherit `process.env.PATH` — without it Effect's
@@ -365,22 +415,7 @@ export class Git extends Context.Service<
             return { status, stdout, stderr } satisfies GitInvocationResult;
           }),
         ).pipe(
-          Effect.catchTag("PlatformError", (cause) => {
-            if (input.command !== "git") {
-              return Effect.succeed({
-                status: 127,
-                stdout: "",
-                stderr: String(cause),
-              } satisfies GitInvocationResult);
-            }
-            return new ReactDoctorError({
-              reason: new GitInvocationFailed({
-                args: [...input.args],
-                directory: input.directory,
-                cause,
-              }),
-            });
-          }),
+          Effect.catchTag("PlatformError", foldSpawnFailure),
           // One span per actual subprocess invocation. The subcommand
           // (`args[0]`) is safe to attribute; full args/paths are omitted so
           // no scanned path leaks into an exported trace.
@@ -391,6 +426,7 @@ export class Git extends Context.Service<
             },
           }),
         );
+      };
 
       const runGit = (
         directory: string,
@@ -774,7 +810,18 @@ export class Git extends Context.Service<
             ]);
             if (result.status !== 0) return null;
             return parseChangedLineRanges(result.stdout);
-          }).pipe(Effect.withSpan("Git.changedLineRanges")),
+          }).pipe(
+            // A git invocation failure (binary missing, or a synchronous spawn
+            // throw such as ENAMETOOLONG on a 1k-file `--scope lines` diff) means
+            // "couldn't compute" — degrade to file-level scope per this method's
+            // documented null contract instead of crashing the scan.
+            Effect.catch((error) =>
+              error.reason._tag === "GitInvocationFailed"
+                ? Effect.succeed(null)
+                : Effect.fail(error),
+            ),
+            Effect.withSpan("Git.changedLineRanges"),
+          ),
       });
     }),
   ).pipe(

--- a/packages/core/tests/regressions/issue-924-git-spawn-defect.test.ts
+++ b/packages/core/tests/regressions/issue-924-git-spawn-defect.test.ts
@@ -1,0 +1,84 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as Effect from "effect/Effect";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { Git } from "@react-doctor/core";
+
+/**
+ * Regression for REACT-DOCTOR-1E / 1P / 20: a `child_process.spawn` that fails
+ * synchronously — ENAMETOOLONG (over-long argv on a large `--scope lines`
+ * diff), ENOTDIR (a non-directory cwd), Windows UNKNOWN — throws *before* the
+ * 'error' event, so the failure escapes Effect's typed channel as a defect and
+ * crashed the whole scan (and reported to Sentry) instead of degrading.
+ *
+ * Pointing a Git call's `directory` at a file is a deterministic,
+ * cross-platform way to make `spawn(..., { cwd })` throw `ENOTDIR`
+ * synchronously — the exact 1P shape. After the fix every git path folds the
+ * defect into `GitInvocationFailed` and degrades: no branch, no line ranges,
+ * branch-absent — never a rejection.
+ */
+const runNode = <Value>(program: Effect.Effect<Value, unknown, Git>): Promise<Value> =>
+  Effect.runPromise(program.pipe(Effect.provide(Git.layerNode)));
+
+const fileAsDirectory = (() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "rd-924-"));
+  const filePath = path.join(root, "not-a-directory");
+  fs.writeFileSync(filePath, "i am a file, not a directory");
+  return { root, filePath };
+})();
+
+afterAll(() => fs.rmSync(fileAsDirectory.root, { recursive: true, force: true }));
+
+describe("issue #924: a synchronous git spawn failure degrades instead of crashing", () => {
+  it("currentBranch returns null when the spawn throws ENOTDIR", async () => {
+    const branch = await runNode(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.currentBranch(fileAsDirectory.filePath);
+      }),
+    );
+    expect(branch).toBeNull();
+  });
+
+  it("branchExists returns false when the spawn throws ENOTDIR", async () => {
+    const exists = await runNode(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.branchExists(fileAsDirectory.filePath, "main");
+      }),
+    );
+    expect(exists).toBe(false);
+  });
+
+  it("changedLineRanges returns null (degrade to file scope) when the spawn throws ENOTDIR", async () => {
+    const ranges = await runNode(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.changedLineRanges({
+          directory: fileAsDirectory.filePath,
+          files: ["src/App.tsx"],
+        });
+      }),
+    );
+    expect(ranges).toBeNull();
+  });
+
+  it("changedLineRanges returns null when the file pathspecs would overflow the argv limit", async () => {
+    // ~2000 nested paths blow past the OS command-line limit (the original
+    // `--scope lines` ENAMETOOLONG on a 1k+-file Windows diff); the pre-flight
+    // degrades to file scope instead of letting git's spawn throw. The
+    // directory is real, so only the argv-length guard fires.
+    const manyFiles = Array.from(
+      { length: 2000 },
+      (_, index) => `src/${"deeply/nested/".repeat(4)}file-${index}.tsx`,
+    );
+    const ranges = await runNode(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.changedLineRanges({ directory: fileAsDirectory.root, files: manyFiles });
+      }),
+    );
+    expect(ranges).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #924. Fixes Sentry **REACT-DOCTOR-1E** (21), **REACT-DOCTOR-1P** (18), **REACT-DOCTOR-20**.

### Root cause

`child_process.spawn` reports failure two ways. A missing binary (`ENOENT`) and
permission errors arrive **asynchronously** on the `'error'` event — Effect's
`ChildProcessSpawner` turns those into a `PlatformError`, which `runCommand`
already folds into the tagged `GitInvocationFailed`. But for a **non-directory
cwd** (`ENOTDIR`) or an **over-long argv** (`ENAMETOOLONG` — e.g. `--scope
lines` passing a 1,000+-file pathspec list to `git diff` on Windows, whose
command line caps at 32 KiB), Node throws **synchronously** from `spawn()`.

Effect's `Async` register isn't wrapped in a try/catch, so that synchronous
throw escapes the fiber's run-loop as a raw runtime exception — `catchTag` and
even `catchDefect` never see it. It propagated to the top-level `runPromise` and
crashed the whole scan, surfacing in Sentry as a raw `Error: spawn ENAMETOOLONG`
/ `spawn ENOTDIR` (note: **not** a tagged `ReactDoctorError`, which is what made
these distinct from the git-unavailable crashes fixed in #930).

This is **not** the oxlint path — that spawn is already arg-batched
(`batchIncludePaths`, since #140) and non-fatal. The shared stack frame and
Effect-fiber frames in the Sentry events point at the git runner, the only
`ChildProcessSpawner`-based spawn.

### Fix

Both throw conditions are predictable, so `runCommand` pre-flights them and
fails on its normal channel (shared with the async `PlatformError` path via the
new `foldSpawnFailure`):

- **cwd isn't a directory** → fail like an unavailable git, so `currentBranch →
  null` / `branchExists → false` degrade (auto-detect falls back to a full scan).
- **argv exceeds `SPAWN_ARGS_MAX_LENGTH_CHARS`** → fail, and `changedLineRanges`
  now degrades to `null` on `GitInvocationFailed` (its documented "couldn't
  compute → file-level scope" contract).

Net effect: the exact crashes become the graceful fallbacks that already exist
for these scopes, and nothing reaches Sentry.

I deliberately **degrade** an over-long `--scope lines` diff to file-level scope
rather than batching the git pathspecs into multiple `git diff` calls — file
scope is the documented fallback and is far less code. Batching to preserve
line-level scope on enormous diffs is a possible future enhancement.

### Tests

`packages/core/tests/regressions/issue-924-git-spawn-defect.test.ts` reproduces
the real synchronous throws through `Git.layerNode` (no mocks):

- a **file** as the `directory` → real `spawn ENOTDIR` → `currentBranch`/
  `branchExists`/`changedLineRanges` degrade (null/false/null) instead of
  rejecting (the deterministic, cross-platform 1P shape);
- ~2,000 nested pathspecs → argv overflow → `changedLineRanges` degrades to
  `null` (the 1E shape).

Verified the happy path is unchanged (`diff-commit-range`, `diff-detached-head`
e2e suites green); `pnpm typecheck` + targeted `pnpm test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/millionco/react-doctor/pull/940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted git runner hardening with existing fallback semantics; regression tests cover the failure modes.
> 
> **Overview**
> Prevents full-scan crashes when `child_process.spawn` throws **synchronously** (`ENOTDIR` for a non-directory cwd, `ENAMETOOLONG` for huge `git diff` path lists under `--scope lines` on Windows). Those throws bypass Effect’s error channel; the git runner now **pre-checks** cwd and argv length and routes failures through the same **`GitInvocationFailed`** path as async spawn errors via **`foldSpawnFailure`**.
> 
> **`changedLineRanges`** now treats **`GitInvocationFailed`** as “couldn’t compute” and returns **`null`** (file-level scope) instead of failing the scan. Existing degradations (`currentBranch` → null, `branchExists` → false) apply for bad cwd. Adds regression tests for ENOTDIR and argv overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a65cebd9340c589a4a8894b6521d56e3f2ab0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->