### PR TITLE
perf(core): overlap the security scan with lint + cap dead-code worker memory

### DIFF
--- a/.changeset/faster-cold-scans.md
+++ b/.changeset/faster-cold-scans.md
@@ -1,0 +1,8 @@
+---
+"react-doctor": patch
+---
+
+Speed up cold scans and bound dead-code memory on multi-project workspaces.
+
+- Overlap the project security scan with the lint pass instead of running it synchronously beforehand. The content-regex security sweep (shipped artifacts, dotenv, SQL — files lint never parses) was the single heaviest CPU phase on real repos and blocked the event loop the whole time. It now runs on a cooperative background fiber that yields between file chunks, so its cost hides under the subprocess-bound lint pass and stops starving a multi-project scan's concurrent git/network work. Cold scans are measurably faster (~30% on a mid-size project and workspace in local benchmarks); diagnostics are byte-identical.
+- Cap concurrent dead-code (deslop) workers by a memory budget so a multi-project scan can't oversubscribe memory with many simultaneous worker processes on a small CI runner. On a roomy machine the cap exceeds the project count, so nothing serializes and scan time is unchanged.

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -516,7 +516,7 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
   // fakes, not real children, and gating them would only serialize the suite.
   const rawResult =
     options.createWorker === undefined
-      ? await withDeadCodeWorkerSlot(spawnAndRun)
+      ? await withDeadCodeWorkerSlot(spawnAndRun, options.abortSignal)
       : await spawnAndRun();
   const result = parseDeadCodeWorkerResult(rawResult);
   const toRelative = (filePath: string): string => toRelativeFilePath(rootDirectory, filePath);

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -6,6 +6,7 @@ import {
   collectDeadCodeEntryPatterns,
   collectDeadCodeIgnorePatterns,
 } from "./dead-code/collect-dead-code-patterns.js";
+import { withDeadCodeWorkerSlot } from "./dead-code/dead-code-worker-slots.js";
 import {
   DEAD_CODE_WORKER_MAX_OLD_SPACE_MB,
   DEAD_CODE_WORKER_TIMEOUT_MS,
@@ -246,7 +247,9 @@ const parseUnusedFiles = (value: unknown): DeadCodeWorkerUnusedFile[] => {
     if (!isRecord(entry)) {
       throw new Error(`Dead-code worker returned invalid unusedFiles[${index}].`);
     }
-    unusedFiles.push({ path: parseString(entry.path, `unusedFiles[${index}].path`) });
+    unusedFiles.push({
+      path: parseString(entry.path, `unusedFiles[${index}].path`),
+    });
   }
   return unusedFiles;
 };
@@ -367,7 +370,10 @@ const createDeadCodeWorker: DeadCodeWorkerFactory = (input) => {
       env:
         input.parseConcurrency === undefined
           ? process.env
-          : { ...process.env, DESLOP_PARSE_CONCURRENCY: String(input.parseConcurrency) },
+          : {
+              ...process.env,
+              DESLOP_PARSE_CONCURRENCY: String(input.parseConcurrency),
+            },
     },
   );
 
@@ -396,7 +402,9 @@ const createDeadCodeWorker: DeadCodeWorkerFactory = (input) => {
         settle(() =>
           reject(
             new Error(
-              `Dead-code worker exited with code ${exitCode ?? "null"}${stderr ? `: ${stderr}` : ""}.`,
+              `Dead-code worker exited with code ${exitCode ?? "null"}${
+                stderr ? `: ${stderr}` : ""
+              }.`,
             ),
           ),
         );
@@ -481,24 +489,35 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
 
   const entryPatterns = collectDeadCodeEntryPatterns(rootDirectory);
   const ignorePatterns = collectDeadCodeIgnorePatterns(rootDirectory);
-  const workerHandle = (options.createWorker ?? createDeadCodeWorker)({
-    rootDirectory,
-    entryPatterns,
-    tsConfigPath: resolveTsConfigPath(rootDirectory),
-    ignorePatterns,
-    deslopJsModuleSpecifier: options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js"),
-    parseConcurrency: options.parseConcurrency,
-  });
   // `runDeadCodeWorkerWithTimeout` owns the abort wiring: when the surrounding
   // Effect fiber is interrupted (lint failed / dead-code phase timeout / scan
   // cancelled), `Effect.tryPromise` aborts `options.abortSignal`, which its
   // `settle()` path turns into an immediate worker SIGKILL — rather than
   // orphaning the child until the in-worker timer expires.
-  const rawResult = await runDeadCodeWorkerWithTimeout(
-    workerHandle,
-    options.workerTimeoutMs ?? DEAD_CODE_WORKER_TIMEOUT_MS,
-    options.abortSignal,
-  );
+  const spawnAndRun = (): Promise<unknown> => {
+    const workerHandle = (options.createWorker ?? createDeadCodeWorker)({
+      rootDirectory,
+      entryPatterns,
+      tsConfigPath: resolveTsConfigPath(rootDirectory),
+      ignorePatterns,
+      deslopJsModuleSpecifier: options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js"),
+      parseConcurrency: options.parseConcurrency,
+    });
+    return runDeadCodeWorkerWithTimeout(
+      workerHandle,
+      options.workerTimeoutMs ?? DEAD_CODE_WORKER_TIMEOUT_MS,
+      options.abortSignal,
+    );
+  };
+  // A REAL deslop spawn passes through the process-global memory-budgeted
+  // semaphore so a multi-project scan never runs more concurrent 8 GB-ceiling
+  // children than memory allows (on a roomy box the cap exceeds the project
+  // count, so nothing serializes). Injected test workers bypass it — they're
+  // fakes, not real children, and gating them would only serialize the suite.
+  const rawResult =
+    options.createWorker === undefined
+      ? await withDeadCodeWorkerSlot(spawnAndRun)
+      : await spawnAndRun();
   const result = parseDeadCodeWorkerResult(rawResult);
   const toRelative = (filePath: string): string => toRelativeFilePath(rootDirectory, filePath);
   const diagnostics: Diagnostic[] = [];
@@ -559,7 +578,11 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
       plugin: DEAD_CODE_PLUGIN,
       rule: "circular-dependency",
       severity: "warning",
-      message: `Circular import cycle: ${cycle.files.map(toRelative).join(" → ")}. Modules in the cycle can observe partially initialized exports, causing order-dependent bugs.`,
+      message: `Circular import cycle: ${cycle.files
+        .map(toRelative)
+        .join(
+          " → ",
+        )}. Modules in the cycle can observe partially initialized exports, causing order-dependent bugs.`,
       help: "Break the cycle by extracting the shared code into a third module that both files import.",
       line: 0,
       column: 0,

--- a/packages/core/src/check-security-scan.ts
+++ b/packages/core/src/check-security-scan.ts
@@ -3,9 +3,11 @@ import type { FileScan, ScannedFile } from "oxlint-plugin-react-doctor";
 import { buildSecurityScanDiagnostic } from "./checks/security-scan/build-security-scan-diagnostic.js";
 import type { SecurityScanRuleEntry } from "./checks/security-scan/build-security-scan-diagnostic.js";
 import { collectSecurityScanFiles } from "./checks/security-scan/collect-security-scan-files.js";
+import { SECURITY_SCAN_YIELD_FILE_INTERVAL } from "./checks/security-scan/constants.js";
 import { buildCapabilities, shouldEnableRule } from "./runners/oxlint/capabilities.js";
 import type { Diagnostic, ProjectInfo } from "./types/index.js";
 import { isPathGitIgnored } from "./utils/is-path-git-ignored.js";
+import { yieldToEventLoop } from "./utils/yield-to-event-loop.js";
 
 export interface CheckSecurityScanOptions {
   readonly project?: ProjectInfo;
@@ -19,16 +21,20 @@ interface EnabledScanRule {
   readonly committedFilesOnly: boolean;
 }
 
-// Project-level security scan check: registry rules carrying a
-// `scan` are excluded from the generated oxlint config and instead run here
-// over one bounded whole-tree walk (shipped artifacts, dotenv/config files,
-// SQL — paths lint never sees). Selection goes through the same
-// `shouldEnableRule` capability/tag gate as lint rules, so `--ignore-tag
-// security-scan` and `disabledBy` behave identically across both engines.
-export const checkSecurityScan = (
+interface SecurityScanSession {
+  /** Runs every enabled scan rule over one file, accumulating into `diagnostics`. */
+  readonly scanFile: (file: ScannedFile) => void;
+  readonly diagnostics: Diagnostic[];
+}
+
+// Shared setup for both drivers below: resolves the enabled scan rules through
+// the capability/tag gate and returns a `scanFile` closure over the dedupe set
+// + git-ignore cache. `null` when no scan rule is enabled, so callers can
+// short-circuit the whole-tree walk.
+const createSecurityScanSession = (
   rootDirectory: string,
-  options: CheckSecurityScanOptions = {},
-): Diagnostic[] => {
+  options: CheckSecurityScanOptions,
+): SecurityScanSession | null => {
   const capabilities = options.project ? buildCapabilities(options.project) : new Set<string>();
   const ignoredTags = options.ignoredTags ?? new Set<string>();
 
@@ -42,7 +48,7 @@ export const checkSecurityScan = (
     }
     return [{ entry, scan, committedFilesOnly: rule.committedFilesOnly === true }];
   });
-  if (enabledScanRules.length === 0) return [];
+  if (enabledScanRules.length === 0) return null;
 
   const diagnostics: Diagnostic[] = [];
   const seen = new Set<string>();
@@ -56,7 +62,7 @@ export const checkSecurityScan = (
     return status === true;
   };
 
-  for (const file of collectSecurityScanFiles(rootDirectory)) {
+  const scanFile = (file: ScannedFile): void => {
     for (const { entry, scan, committedFilesOnly } of enabledScanRules) {
       for (const finding of scan(file)) {
         // A committed-file rule's finding doesn't apply to a path git ignores
@@ -73,7 +79,47 @@ export const checkSecurityScan = (
         diagnostics.push(diagnostic);
       }
     }
-  }
+  };
 
-  return diagnostics;
+  return { scanFile, diagnostics };
+};
+
+// Project-level security scan check: registry rules carrying a
+// `scan` are excluded from the generated oxlint config and instead run here
+// over one bounded whole-tree walk (shipped artifacts, dotenv/config files,
+// SQL — paths lint never sees). Selection goes through the same
+// `shouldEnableRule` capability/tag gate as lint rules, so `--ignore-tag
+// security-scan` and `disabledBy` behave identically across both engines.
+export const checkSecurityScan = (
+  rootDirectory: string,
+  options: CheckSecurityScanOptions = {},
+): Diagnostic[] => {
+  const session = createSecurityScanSession(rootDirectory, options);
+  if (session === null) return [];
+  for (const file of collectSecurityScanFiles(rootDirectory)) {
+    session.scanFile(file);
+  }
+  return session.diagnostics;
+};
+
+// Cooperative variant: identical output to `checkSecurityScan`, but yields to
+// the event loop every `SECURITY_SCAN_YIELD_FILE_INTERVAL` files so a caller
+// that forks it (the orchestrator) can overlap its CPU with other async work
+// instead of blocking the loop for the whole scan.
+export const checkSecurityScanCooperative = async (
+  rootDirectory: string,
+  options: CheckSecurityScanOptions = {},
+): Promise<Diagnostic[]> => {
+  const session = createSecurityScanSession(rootDirectory, options);
+  if (session === null) return [];
+  let filesSinceYield = 0;
+  for (const file of collectSecurityScanFiles(rootDirectory)) {
+    session.scanFile(file);
+    filesSinceYield += 1;
+    if (filesSinceYield >= SECURITY_SCAN_YIELD_FILE_INTERVAL) {
+      filesSinceYield = 0;
+      await yieldToEventLoop();
+    }
+  }
+  return session.diagnostics;
 };

--- a/packages/core/src/checks/security-scan/constants.ts
+++ b/packages/core/src/checks/security-scan/constants.ts
@@ -3,6 +3,12 @@ export const SECURITY_SCAN_MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
 export const SECURITY_SCAN_MAX_BUNDLE_FILE_SIZE_BYTES = 8 * 1024 * 1024;
 export const SECURITY_SCAN_MAX_DIRECTORY_DEPTH = 8;
 
+// Files the cooperative scan processes between event-loop yields. At ~4ms of
+// regex per file this bounds each synchronous burst to ~60ms, small enough that
+// the overlapping lint subprocesses' I/O callbacks (and sibling project scans)
+// stay responsive while the scan runs.
+export const SECURITY_SCAN_YIELD_FILE_INTERVAL = 16;
+
 export const SKIPPED_DIRECTORY_NAMES = new Set([
   ".git",
   ".turbo",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -341,6 +341,15 @@ export const SCAN_TOTAL_DEADLINE_MS = 900_000;
 // the child's heap so those projects complete instead of crashing.
 export const DEAD_CODE_WORKER_MAX_OLD_SPACE_MB = 8192;
 
+// Memory budgeted per concurrent dead-code worker when sizing the global
+// `withDeadCodeWorkerSlot` semaphore (`resolveDeadCodeConcurrency`). Deliberately
+// well below the worker's `--max-old-space-size` ceiling above (that's a crash
+// guard, not steady-state use): a deslop graph on a few-hundred-file project
+// peaks around 1–1.5 GB, so 2 GB leaves headroom while still collapsing the
+// concurrency toward 1 on a small CI runner — capping how many 8 GB-ceiling
+// children a multi-project scan starts at once.
+export const DEAD_CODE_WORKER_MEM_BUDGET_BYTES = 2 * 1024 * 1024 * 1024;
+
 // Dead-code timeout scales with the work. deslop is CPU-bound and roughly
 // linear in source-file count, so a single fixed timeout is at once too
 // generous for a small repo and too tight for a large one — on a multi-thousand

--- a/packages/core/src/dead-code/dead-code-worker-slots.ts
+++ b/packages/core/src/dead-code/dead-code-worker-slots.ts
@@ -1,0 +1,47 @@
+import { resolveDeadCodeConcurrency } from "../utils/resolve-dead-code-concurrency.js";
+
+// A process-global counting semaphore bounding how many real deslop dead-code
+// child processes run at once, to the memory budget (`resolveDeadCodeConcurrency`).
+//
+// It's process-global on purpose: the CLI scans the projects of a workspace in
+// concurrent `runInspect` fibers within ONE process, and each spawns its own
+// dead-code worker — without a shared cap, N concurrent projects could
+// oversubscribe memory with N simultaneous children on a small runner. This
+// gates only HOW MANY start; each worker still self-terminates via the proven
+// one-shot lifecycle (spawn → analyze → exit), so the semaphore adds no
+// process-lifecycle surface — it's plain in-process bookkeeping.
+//
+// `-1` is the un-initialized sentinel; the first acquirer reads the budget once
+// (after which the cap is fixed for the process).
+let availableSlots = -1;
+const waiters: Array<() => void> = [];
+
+const releaseSlot = (): void => {
+  const nextWaiter = waiters.shift();
+  // Hand the slot straight to the next waiter (no increment); only return it to
+  // the pool when nobody is waiting. Keeps the count balanced either way.
+  if (nextWaiter !== undefined) nextWaiter();
+  else availableSlots += 1;
+};
+
+/**
+ * Runs `task` once a dead-code worker slot is free, releasing the slot when the
+ * task settles (success or failure). With a high cap (roomy machine) every
+ * caller proceeds immediately; with a low cap (constrained runner) callers
+ * queue and run as slots free.
+ */
+export const withDeadCodeWorkerSlot = async <Result>(
+  task: () => Promise<Result>,
+): Promise<Result> => {
+  if (availableSlots < 0) availableSlots = resolveDeadCodeConcurrency();
+  if (availableSlots > 0) {
+    availableSlots -= 1;
+  } else {
+    await new Promise<void>((resolve) => waiters.push(resolve));
+  }
+  try {
+    return await task();
+  } finally {
+    releaseSlot();
+  }
+};

--- a/packages/core/src/dead-code/dead-code-worker-slots.ts
+++ b/packages/core/src/dead-code/dead-code-worker-slots.ts
@@ -29,15 +29,35 @@ const releaseSlot = (): void => {
  * task settles (success or failure). With a high cap (roomy machine) every
  * caller proceeds immediately; with a low cap (constrained runner) callers
  * queue and run as slots free.
+ *
+ * `abortSignal` short-circuits the WAIT: if it's already aborted, or fires while
+ * this caller is queued, the call rejects without acquiring a slot or running
+ * `task` — so a cancelled scan (e.g. lint failed) doesn't sit in the queue and
+ * then spawn a child only to tear it down. A queued caller that aborts removes
+ * its own waiter so a later release never hands a slot to a dead request.
  */
 export const withDeadCodeWorkerSlot = async <Result>(
   task: () => Promise<Result>,
+  abortSignal?: AbortSignal,
 ): Promise<Result> => {
+  if (abortSignal?.aborted) throw new Error("Dead-code worker aborted.");
   if (availableSlots < 0) availableSlots = resolveDeadCodeConcurrency();
   if (availableSlots > 0) {
     availableSlots -= 1;
   } else {
-    await new Promise<void>((resolve) => waiters.push(resolve));
+    await new Promise<void>((resolve, reject) => {
+      const waiter = (): void => {
+        abortSignal?.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      const onAbort = (): void => {
+        const queuedIndex = waiters.indexOf(waiter);
+        if (queuedIndex !== -1) waiters.splice(queuedIndex, 1);
+        reject(new Error("Dead-code worker aborted."));
+      };
+      waiters.push(waiter);
+      abortSignal?.addEventListener("abort", onAbort, { once: true });
+    });
   }
   try {
     return await task();

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -296,7 +296,10 @@ const formatLintFailText = (
  *      diagnostics).
  *   2. beforeLint hook (e.g. CLI renders the project-detection block)
  *   3. environment checks (reduced-motion + pnpm hardening +
- *      expo/react-native + security scan), collected synchronously
+ *      expo/react-native), collected synchronously. The heavier
+ *      content-regex security scan is forked instead (like supply-chain
+ *      below) and joined before the concat, so its CPU overlaps lint
+ *      rather than blocking the event loop before it.
  *   4. The supply-chain check (Socket.dev) is forked onto a background
  *      fiber so its ~100% network-bound time overlaps the ~100%
  *      CPU/subprocess-bound lint pass below, collapsing two serial
@@ -316,7 +319,7 @@ const formatLintFailText = (
  *      order, so terminal output is identical either way; supply-chain
  *      rides alongside without a spinner.
  *   6. Join the supply-chain fiber, then assemble the diagnostics in a
- *      FIXED order (env, supply-chain, lint, dead-code) so the output is
+ *      FIXED order (env, security-scan, supply-chain, lint, dead-code) so the output is
  *      byte-identical regardless of which fiber settled first. The
  *      viewer-permission fiber is joined later, during score-metadata
  *      assembly (it feeds score metadata, not diagnostics). The per-element

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -20,7 +20,7 @@ import { checkPnpmHardening } from "./check-pnpm-hardening.js";
 import { checkReactNativeProject } from "./check-react-native-project.js";
 import { checkReactServerComponentsAdvisory } from "./check-react-server-components-advisory.js";
 import { checkReducedMotion } from "./check-reduced-motion.js";
-import { checkSecurityScan } from "./check-security-scan.js";
+import { checkSecurityScanCooperative } from "./check-security-scan.js";
 import {
   DEAD_CODE_OVERLAP_PARSE_SHARE,
   DEAD_CODE_PHASE_TIMEOUT_MS,
@@ -436,6 +436,8 @@ export const runInspect = <HooksR = never>(
       );
 
     // ── Phase: environment checks ──────────────────────────────────
+    // The project-shape checks below are sub-millisecond; the security scan
+    // (whole-tree content pass) is heavy and forks separately just below.
     const environmentDiagnostics: ReadonlyArray<Diagnostic> = isDiffMode
       ? []
       : [
@@ -444,10 +446,37 @@ export const runInspect = <HooksR = never>(
           ...checkReactServerComponentsAdvisory(scanDirectory, project),
           ...checkExpoProject(scanDirectory, project),
           ...checkReactNativeProject(scanDirectory, project),
-          ...checkSecurityScan(scanDirectory, { project, ignoredTags: input.ignoredTags }),
         ];
     const envCollected = yield* Stream.runCollect(
       applyPerElementPipeline(Stream.fromIterable(environmentDiagnostics)),
+    );
+
+    // ── Phase: security scan (content-regex over the whole tree) ───
+    // Registry rules carrying a `scan` run here, not via oxlint — over shipped
+    // artifacts / dotenv / SQL that lint never parses. It's the heaviest CPU
+    // phase on real repos (~O(rules × files × content)) and previously ran
+    // SYNCHRONOUSLY before lint, blocking the event loop the whole time. Fork it
+    // here (before lint) and join it just before the concat so its main-thread
+    // CPU overlaps the subprocess-bound lint pass; `checkSecurityScanCooperative`
+    // yields to the event loop between file chunks so it can't starve lint's
+    // subprocess I/O or concurrently-scanning sibling projects. Skipped in
+    // diff/staged mode like the env checks. The final stable sort makes the
+    // concat order irrelevant, so output stays byte-identical to the serial path.
+    const securityScanFiber = yield* Effect.forkChild(
+      Stream.runCollect(
+        applyPerElementPipeline(
+          isDiffMode
+            ? (Stream.empty as Stream.Stream<Diagnostic, never>)
+            : Stream.unwrap(
+                Effect.promise(() =>
+                  checkSecurityScanCooperative(scanDirectory, {
+                    project,
+                    ignoredTags: input.ignoredTags,
+                  }),
+                ).pipe(Effect.map((diagnostics) => Stream.fromIterable(diagnostics))),
+              ),
+        ),
+      ).pipe(Effect.withSpan("SecurityScan.run")),
     );
 
     // ── Phase: supply-chain score check (Socket.dev, opt-in) ───────
@@ -488,13 +517,21 @@ export const runInspect = <HooksR = never>(
               }),
             ),
           ).pipe(
-            Effect.map((diagnostics): SupplyChainForkResult => ({ diagnostics, timedOut: false })),
+            Effect.map(
+              (diagnostics): SupplyChainForkResult => ({
+                diagnostics,
+                timedOut: false,
+              }),
+            ),
             Effect.timeout(supplyChainOverlapTimeout),
             Effect.orElseSucceed(
               (): SupplyChainForkResult => ({ diagnostics: [], timedOut: true }),
             ),
           )
-        : Effect.succeed<SupplyChainForkResult>({ diagnostics: [], timedOut: false }),
+        : Effect.succeed<SupplyChainForkResult>({
+            diagnostics: [],
+            timedOut: false,
+          }),
     );
 
     const lintFailure = yield* Ref.make<{
@@ -503,7 +540,10 @@ export const runInspect = <HooksR = never>(
       reasonTag: ReactDoctorErrorReason["_tag"] | null;
       reasonKind: OxlintUnavailable["kind"] | null;
     }>({ didFail: false, reason: null, reasonTag: null, reasonKind: null });
-    const deadCodeFailure = yield* Ref.make<{ didFail: boolean; reason: string | null }>({
+    const deadCodeFailure = yield* Ref.make<{
+      didFail: boolean;
+      reason: string | null;
+    }>({
       didFail: false,
       reason: null,
     });
@@ -587,7 +627,10 @@ export const runInspect = <HooksR = never>(
               Stream.catchTag("ReactDoctorError", (error: ReactDoctorError) =>
                 Stream.unwrap(
                   Effect.gen(function* () {
-                    yield* Ref.set(deadCodeFailure, { didFail: true, reason: error.message });
+                    yield* Ref.set(deadCodeFailure, {
+                      didFail: true,
+                      reason: error.message,
+                    });
                     return Stream.empty as Stream.Stream<Diagnostic, never>;
                   }),
                 ),
@@ -605,7 +648,9 @@ export const runInspect = <HooksR = never>(
             onNone: () =>
               Ref.set(deadCodeFailure, {
                 didFail: true,
-                reason: `Dead-code analysis exceeded ${Math.round(deadCodeTimeout.phaseTimeoutMs / MILLISECONDS_PER_SECOND)}s and was skipped.`,
+                reason: `Dead-code analysis exceeded ${Math.round(
+                  deadCodeTimeout.phaseTimeoutMs / MILLISECONDS_PER_SECOND,
+                )}s and was skipped.`,
               }).pipe(Effect.as<Diagnostic[]>([])),
             onSome: Effect.succeed,
           }),
@@ -699,7 +744,9 @@ export const runInspect = <HooksR = never>(
           onNone: () =>
             Ref.set(lintFailure, {
               didFail: true,
-              reason: `Lint analysis exceeded ${lintPhaseTimeoutMs / MILLISECONDS_PER_SECOND}s and was skipped.`,
+              reason: `Lint analysis exceeded ${
+                lintPhaseTimeoutMs / MILLISECONDS_PER_SECOND
+              }s and was skipped.`,
               reasonTag: "OxlintBatchExceeded",
               reasonKind: null,
             }).pipe(Effect.as<Diagnostic[]>([])),
@@ -787,6 +834,9 @@ export const runInspect = <HooksR = never>(
     // overlap budget fired (the rare hung-socket guard) for telemetry.
     const supplyChainResult = yield* Fiber.join(supplyChainFiber);
     const supplyChainCollected = supplyChainResult.diagnostics;
+    // Join the forked security scan (it overlapped lint). Its diagnostics are
+    // kept regardless of lint outcome, mirroring the other environment checks.
+    const securityScanCollected = yield* Fiber.join(securityScanFiber);
 
     yield* reporterService.finalize;
 
@@ -801,6 +851,7 @@ export const runInspect = <HooksR = never>(
     const finalDiagnostics: ReadonlyArray<Diagnostic> = sortDiagnosticsStable(
       assignFixGroups([
         ...envCollected,
+        ...securityScanCollected,
         ...supplyChainCollected,
         ...lintCollected,
         ...deadCodeCollected,

--- a/packages/core/src/utils/resolve-dead-code-concurrency.ts
+++ b/packages/core/src/utils/resolve-dead-code-concurrency.ts
@@ -1,0 +1,45 @@
+import os from "node:os";
+import { DEAD_CODE_WORKER_MEM_BUDGET_BYTES } from "../constants.js";
+import { readCgroupMemoryLimitBytes } from "./read-cgroup-memory-limit-bytes.js";
+
+export interface DeadCodeConcurrencyFacts {
+  /** `os.availableParallelism()` — cgroup-CPU-aware on the supported Node range. */
+  readonly availableCores: number;
+  /** `os.totalmem()` — host total, floored by `cgroupMemoryLimitBytes`. */
+  readonly totalMemoryBytes: number;
+  /** The cgroup memory limit, or `undefined` on bare metal. */
+  readonly cgroupMemoryLimitBytes: number | undefined;
+}
+
+const readSystemFacts = (): DeadCodeConcurrencyFacts => ({
+  availableCores: os.availableParallelism(),
+  totalMemoryBytes: os.totalmem(),
+  cgroupMemoryLimitBytes: readCgroupMemoryLimitBytes(),
+});
+
+/**
+ * How many real deslop dead-code child processes may run at once, across the
+ * concurrent per-project `runInspect` fibers of one CLI run. The cap is the
+ * smaller of the core count and the number of `DEAD_CODE_WORKER_MEM_BUDGET_BYTES`
+ * workers that fit in available memory, floored at 1.
+ *
+ * On a roomy dev box / CI runner this resolves high enough that every
+ * concurrently-scanned project still spawns its own worker (no serialization vs
+ * the prior uncapped behavior); on a memory-constrained runner it collapses
+ * toward 1, so the `withDeadCodeWorkerSlot` semaphore serializes the spawns
+ * instead of oversubscribing memory with N simultaneous children — the global
+ * cap the per-project spawn path lacked.
+ *
+ * Mirrors `resolveAutoScanConcurrency` (lint), but budgets memory per the
+ * heavier dead-code worker. `facts` is injectable for tests.
+ */
+export const resolveDeadCodeConcurrency = (
+  facts: DeadCodeConcurrencyFacts = readSystemFacts(),
+): number => {
+  const availableMemoryBytes = Math.min(
+    facts.totalMemoryBytes,
+    facts.cgroupMemoryLimitBytes ?? Number.POSITIVE_INFINITY,
+  );
+  const memoryBoundedWorkers = Math.floor(availableMemoryBytes / DEAD_CODE_WORKER_MEM_BUDGET_BYTES);
+  return Math.max(1, Math.min(facts.availableCores, memoryBoundedWorkers));
+};

--- a/packages/core/src/utils/yield-to-event-loop.ts
+++ b/packages/core/src/utils/yield-to-event-loop.ts
@@ -1,0 +1,9 @@
+// Resolves on the next event-loop iteration so pending I/O callbacks can run
+// between synchronous chunks of a long CPU pass — e.g. lint subprocess
+// stdout/close events and concurrently-scanning sibling projects' git/network.
+// `setImmediate` (check phase, after the I/O/poll phase) rather than a
+// microtask, which would drain before any I/O and so wouldn't unblock them.
+export const yieldToEventLoop = (): Promise<void> =>
+  new Promise((resolve) => {
+    setImmediate(resolve);
+  });

--- a/packages/core/tests/dead-code-worker-slots.test.ts
+++ b/packages/core/tests/dead-code-worker-slots.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+import { withDeadCodeWorkerSlot } from "../src/dead-code/dead-code-worker-slots.js";
+import { resolveDeadCodeConcurrency } from "../src/utils/resolve-dead-code-concurrency.js";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("withDeadCodeWorkerSlot", () => {
+  it("never runs more tasks at once than the resolved concurrency", async () => {
+    const cap = resolveDeadCodeConcurrency();
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const task = async (): Promise<string> => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await sleep(5);
+      inFlight -= 1;
+      return "ok";
+    };
+    // Twice the cap → the extra callers must queue, so the peak lands exactly
+    // at the cap (not higher), proving the gate, and every caller still runs.
+    const results = await Promise.all(
+      Array.from({ length: cap * 2 }, () => withDeadCodeWorkerSlot(task)),
+    );
+    expect(results).toHaveLength(cap * 2);
+    expect(results.every((value) => value === "ok")).toBe(true);
+    expect(peakInFlight).toBe(cap);
+  });
+
+  it("releases the slot when a task rejects, so later tasks still run", async () => {
+    await expect(
+      withDeadCodeWorkerSlot(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    // A leaked slot would (on a cap-1 runner) wedge this forever.
+    expect(await withDeadCodeWorkerSlot(async () => "after")).toBe("after");
+  });
+});

--- a/packages/core/tests/dead-code-worker-slots.test.ts
+++ b/packages/core/tests/dead-code-worker-slots.test.ts
@@ -35,4 +35,40 @@ describe("withDeadCodeWorkerSlot", () => {
     // A leaked slot would (on a cap-1 runner) wedge this forever.
     expect(await withDeadCodeWorkerSlot(async () => "after")).toBe("after");
   });
+
+  it("rejects an already-aborted caller without running its task", async () => {
+    let taskRan = false;
+    await expect(
+      withDeadCodeWorkerSlot(async () => {
+        taskRan = true;
+        return "ran";
+      }, AbortSignal.abort()),
+    ).rejects.toThrow(/aborted/i);
+    expect(taskRan).toBe(false);
+  });
+
+  it("rejects a queued caller when its abort fires during the wait, without leaking the slot", async () => {
+    const cap = resolveDeadCodeConcurrency();
+    let releaseHeld!: () => void;
+    const heldGate = new Promise<void>((resolve) => {
+      releaseHeld = resolve;
+    });
+    // Occupy every slot so the next caller has to queue.
+    const held = Array.from({ length: cap }, () => withDeadCodeWorkerSlot(() => heldGate));
+    const controller = new AbortController();
+    let queuedTaskRan = false;
+    const queued = withDeadCodeWorkerSlot(async () => {
+      queuedTaskRan = true;
+      return "ran";
+    }, controller.signal);
+    await sleep(5);
+    controller.abort();
+    await expect(queued).rejects.toThrow(/aborted/i);
+    expect(queuedTaskRan).toBe(false);
+    // Drain the held slots; if the aborted waiter had leaked a slot the
+    // semaphore would now be permanently down one, wedging the call below.
+    releaseHeld();
+    await Promise.all(held);
+    expect(await withDeadCodeWorkerSlot(async () => "after")).toBe("after");
+  });
 });

--- a/packages/core/tests/resolve-dead-code-concurrency.test.ts
+++ b/packages/core/tests/resolve-dead-code-concurrency.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveDeadCodeConcurrency } from "../src/utils/resolve-dead-code-concurrency.js";
+
+const GIB = 1024 * 1024 * 1024;
+
+describe("resolveDeadCodeConcurrency", () => {
+  it("is core-bound when memory is plentiful", () => {
+    // floor(64 GiB / 2 GiB) = 32 workers fit, so the 8 cores bind.
+    expect(
+      resolveDeadCodeConcurrency({
+        availableCores: 8,
+        totalMemoryBytes: 64 * GIB,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(8);
+  });
+
+  it("keeps full project-level parallelism on a roomy dev box (10 cores / 16 GiB)", () => {
+    // floor(16 / 2) = 8 ≥ the 4 projects scanned concurrently, so every project
+    // still spawns its own worker — no serialization vs the prior uncapped path.
+    expect(
+      resolveDeadCodeConcurrency({
+        availableCores: 10,
+        totalMemoryBytes: 16 * GIB,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(8);
+  });
+
+  it("collapses toward serial on a memory-starved runner", () => {
+    // floor(3 GiB / 2 GiB) = 1 — a small CI runner serializes the spawns through
+    // one slot instead of oversubscribing memory with N simultaneous children.
+    expect(
+      resolveDeadCodeConcurrency({
+        availableCores: 8,
+        totalMemoryBytes: 3 * GIB,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(1);
+  });
+
+  it("honors a cgroup memory limit below the host total", () => {
+    // The container sees 200 GiB of HOST memory but its cgroup caps it at 4 GiB
+    // → floor(4 / 2) = 2.
+    expect(
+      resolveDeadCodeConcurrency({
+        availableCores: 64,
+        totalMemoryBytes: 200 * GIB,
+        cgroupMemoryLimitBytes: 4 * GIB,
+      }),
+    ).toBe(2);
+  });
+
+  it("never drops below one worker", () => {
+    expect(
+      resolveDeadCodeConcurrency({
+        availableCores: 8,
+        totalMemoryBytes: 512 * 1024 * 1024,
+        cgroupMemoryLimitBytes: undefined,
+      }),
+    ).toBe(1);
+  });
+
+  it("returns a positive integer on the real system", () => {
+    const resolved = resolveDeadCodeConcurrency();
+    expect(Number.isInteger(resolved)).toBe(true);
+    expect(resolved).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Why

Profiling a cold scan with OTel tracing (`runInspect` span tree, against `excalidraw`) surfaced that the **project security scan** — a content-regex sweep over shipped artifacts / dotenv / SQL that lint never parses — was the single heaviest CPU phase (~3.4s on a 413-file project, *bigger than lint itself*), ran **synchronously before lint**, blocked the event loop the whole time, and wasn't even traced. In a multi-project workspace it also starved sibling projects' concurrent git/network work.

Separately, dead-code (deslop) workers were spawned one-per-project with **no global cap**, so a multi-project scan could oversubscribe memory with many simultaneous worker processes on a small CI runner.

Before:

```
phases (single 413-file project, cold): security-scan 3366ms (sync, pre-lint, untraced)
                                         lint        ~2700ms
                                         dead-code   ~1300ms
multi-project: a sibling's sync security scan blocked the loop → git.exec ballooned 66ms → ~3.3s
```

After:

```
security scan runs on a cooperative background fiber, overlapping the lint pass (SecurityScan.run span)
single 413-file project: ~7.5s → ~4.9s   (~35%)
4-project workspace:     ~7.9s → ~5.4s   (~32%)
multi-project git.exec aggregate: 21s → ~2.6s   (event-loop starvation gone)
diagnostics: byte-identical (556 issues on excalidraw, unchanged)
```

## What changed

- **Security scan overlaps lint.** Fork it onto a child fiber (mirroring the existing supply-chain fork) and run it via `checkSecurityScanCooperative`, which yields to the event loop every N files so it can't starve lint's subprocess I/O or sibling scans. Wrapped in a `SecurityScan.run` span. The shared scan logic is extracted into `createSecurityScanSession`, so the sync `checkSecurityScan` (used by ~130 tests) is unchanged and output stays byte-identical (the final stable sort makes the new concat slot irrelevant).
- **Dead-code worker memory cap.** Gate real deslop spawns behind a process-global counting semaphore (`withDeadCodeWorkerSlot`) sized by `resolveDeadCodeConcurrency = max(1, min(cores, floor(mem_or_cgroup / 2GB)))`. On a roomy box the cap exceeds the project count, so nothing serializes (wall-clock neutral); on a memory-constrained runner it collapses toward 1. The worker stays the proven **self-terminating one-shot child** — no persistent process / IPC / unref lifecycle — so this adds no cross-platform surface, only in-process bookkeeping. (A persistent warm-worker pool was prototyped and rejected: its only benefit was load amortization, which was neutral on capable machines and leaned on platform-sensitive unref + IPC-disconnect semantics.)

## Test plan

- `pnpm --filter @react-doctor/core typecheck` — passes
- `pnpm --filter @react-doctor/core test` — run-inspect 38/38, dead-code 33/33, new `resolve-dead-code-concurrency` 6/6 + `dead-code-worker-slots` 2/2 (asserts the cap binds and slots release on success *and* rejection). Pre-existing env-file failures (`flags a non-gitignored env file`, `flags a committed .env.local`) reproduce on `main` and are a local global-`.env*`-gitignore artifact, not from this change.
- `pnpm build` + `vp fmt --check` — clean
- Manual: `react-doctor ~/projects/personal/excalidraw` → 556 issues, byte-identical to before; cold wall-clock A/B above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inspect phase ordering and global concurrency for memory-heavy child processes; output is intended to stay byte-identical, but timing-sensitive abort/queue behavior and multi-project scans deserve extra scrutiny.
> 
> **Overview**
> Cold scans get faster by **overlapping the whole-tree security scan with lint** instead of running it synchronously on the main thread before lint. `runInspect` forks `checkSecurityScanCooperative` (with a `SecurityScan.run` span); shared logic lives in `createSecurityScanSession`, while the sync `checkSecurityScan` API stays for tests. The cooperative driver yields every 16 files via `setImmediate` so lint subprocess I/O and sibling project work stay responsive.
> 
> **Dead-code (deslop) spawns** are gated by a process-global `withDeadCodeWorkerSlot` semaphore sized by `resolveDeadCodeConcurrency` (cores vs ~2 GiB/worker, cgroup-aware). Real workers wait for a slot; injected test workers skip the gate. On large machines behavior is unchanged; on tight CI memory, concurrent multi-project scans serialize workers instead of stacking many high-heap children.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27ca2120f56b01f12b3a4021e6be8fa5b5a070bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->