### PR TITLE
chore: format is-environment-error.test.ts

### DIFF
--- a/packages/react-doctor/tests/is-environment-error.test.ts
+++ b/packages/react-doctor/tests/is-environment-error.test.ts
@@ -29,7 +29,9 @@ describe("isEnvironmentError", () => {
   it("does NOT treat ENAMETOOLONG as an environment error", () => {
     // An argv we built overflowing the OS limit is a batching bug we must fix,
     // not a user environment problem — it has to stay visible in Sentry.
-    expect(isEnvironmentError(systemError("ENAMETOOLONG", { syscall: "spawn oxlint" }))).toBe(false);
+    expect(isEnvironmentError(systemError("ENAMETOOLONG", { syscall: "spawn oxlint" }))).toBe(
+      false,
+    );
   });
 
   it("does NOT treat other speculative codes as environment errors", () => {


### PR DESCRIPTION
A long assertion line in `is-environment-error.test.ts` slipped past `pnpm format:check` when #928 merged (format isn't a CI gate, so it wasn't caught). This re-wraps it to the project's formatter output — no behavior change, restores a clean `format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test file whitespace/formatting only; no runtime or assertion logic changes.
> 
> **Overview**
> Re-wraps a single long `expect(...).toBe(false)` in **`is-environment-error.test.ts`** (the `ENAMETOOLONG` case) to match the project formatter—same assertion, no test or production behavior change.
> 
> This clears a **`pnpm format:check`** failure that slipped in when the line was left on one row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b17799ac41854289cc53d9059162460b4f7983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->