### PR TITLE
chore: install formatting pre-commit hook on dependency install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "type": "module",
   "scripts": {
+    "prepare": "vp config",
     "dev": "turbo run dev --filter=react-doctor",
     "build": "turbo run build",
     "test": "turbo run test --filter=react-doctor --filter=@react-doctor/core --filter=@react-doctor/api --filter=@react-doctor/language-server --filter=oxlint-plugin-react-doctor",


### PR DESCRIPTION
## Why

The vite-plus pre-commit hook (`.vite-hooks/pre-commit`) is committed to the repo and already formats staged files via `vp staged` (`vp fmt` for JSON/MD/YAML/etc., `vp check --fix` for JS/TS). But nothing **activated** it on a fresh clone — `core.hooksPath` was never set and there was no lifecycle script to generate vite-plus's gitignored `.vite-hooks/_` dispatchers. So formatting silently never ran on commit for anyone who hadn't manually run `vp config`.

Before:

```
$ git config --get core.hooksPath
$            # unset → git ignores .vite-hooks/pre-commit → no formatting on commit
```

After:

```
$ pnpm install        # runs `prepare` → `vp config`
$ git config --get core.hooksPath
.vite-hooks/_         # dispatchers generated, committed hook now fires
$ git commit ...      # vp staged formats staged files before the commit lands
```

## What changed

- Added a `"prepare": "vp config"` script to the root `package.json`. On every `pnpm install`, vite-plus regenerates the gitignored `.vite-hooks/_` dispatchers and points `core.hooksPath` at them, so the already-committed `.vite-hooks/pre-commit` runs for all contributors. Opt out with `VITE_GIT_HOOKS=0`.

No changeset: tooling-only change to the `private` root package; no published-package behavior changes.

## Test plan

- Simulated a fresh clone (`git config --unset core.hooksPath` + `rm -rf .vite-hooks/_`) → `pnpm prepare` restored both. ✓
- Real commit of a mis-formatted JSON file → hook reformatted it before committing (`{"z":1,"a":  2}` → `{ "z": 1, "a": 2 }`); react-doctor staged scan ran non-blocking. ✓
- This PR's own commit exercised the now-active hook (`vp staged` ran on commit). ✓
- `vp fmt --check package.json` → clean. ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only lifecycle script on the private root package; no runtime or published-package behavior changes.
> 
> **Overview**
> Adds a root **`prepare`** script that runs **`vp config`** on every **`pnpm install`**, so fresh clones automatically set **`core.hooksPath`** and regenerate vite-plus’s gitignored hook dispatchers.
> 
> That wires up the existing **`.vite-hooks/pre-commit`** hook (formatting via **`vp staged`**) for all contributors without a manual **`vp config`** step. Contributors can still opt out with **`VITE_GIT_HOOKS=0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 740c7825efbfda5a4505839f7d5255926e6ebb90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->