### PR TITLE
refactor(cli): namespace the Sentry wide-event span attributes

### DIFF
--- a/.changeset/namespace-wide-event-telemetry.md
+++ b/.changeset/namespace-wide-event-telemetry.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Organize the per-scan Sentry "wide event" under dotted namespaces. The root-span attributes had accreted into a flat, half-namespaced set (~50 keys, most bare); each now carries a namespace matching its concept — `scan.*` (config + `scan.fileCount`), `action.*` (CI/action knobs), `outcome.*` (verdict), `diag.*` (findings), `score.*`, `lint.*`, `deadCode.*`, `supplyChain.*`, `timing.*` — alongside the already-namespaced `migration.*`/`baseline.*`. Applied via a single `withNamespace` helper so the prefix lives in one place instead of being hand-spelled per key. Pure rename: value types are preserved (numbers stay numeric so `p75`/`avg` keep working) and the keys stay filter-/group-/aggregate-able in Sentry's Spans dataset. Run/project base tags and all metrics are unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,30 +276,35 @@ for this codebase) for canonical examples.
   `cli/utils/build-run-event.ts` (`recordRunEvent`, plus the pure, testable
   `buildRunEventAttributes`). `inspect.ts` calls it on the success path (after
   `recordScanMetrics`) and, via a `try/catch` around the span body, on the
-  failure path — so the event lands with an `outcome` (`clean`/`ok`/`blocked`/
-  `error`), `exitCode`, and `errorTag` taxonomy even when the scan throws. The
-  run + project base context is already on the span (run tags from
-  `withSentryRunSpan`, project shape from `recordSentryProjectContext`), so the
-  event adds only what those don't: scan config (`mode`, `parallel`,
-  `workerCount`, `rulesConfigured`/`rulesDisabled`, `ignoredTagCount`,
-  `hasCustomConfig`, …), outcome (`totalDiagnostics`, `errorCount`/
-  `warningCount`, `affectedFiles`, `distinctRulesFired`, `topRule`, per-category
-  `diag.category.*`, `score`/`scoreLabel`/`scoreAvailable`, `scanClean`,
-  `skippedCheckCount`, lint/dead-code failure), and the CI/PR specifics
-  (`actorAssociation`, `runnerOs`, the forwarded action knobs `failOn`/
-  `nonBlocking`/`comment`/`annotations`/`versionPin`, and the `wouldBlock` gate).
-  Typing matters for querying: numeric outcomes are numbers (so Sentry can do
-  `p75(score)`), dimensions are strings/bools (so they filter/group); `null` is
-  dropped via `toSpanAttributes` so absent signals never become `"null"`. Query
-  it in Sentry's **Trace Explorer** and build **Dashboard widgets on the Spans
-  dataset** (filter/group by any attribute) instead of pre-aggregating counters.
-  Put new run-level dimensions on `build-run-context.ts` → `build-sentry-scope.ts`
-  (now also the `eventName` + `viaAction` tags) so they ride every event and
-  metric; put per-scan outcome dimensions on the wide event, **not** new
-  counters (we deliberately did not add `ci.*` counters — those dims are wide-
-  event attributes; the `scan.*`/`rule.fired` counters stay as the cheap,
+  failure path — so the event lands with an `outcome.status` (`clean`/`ok`/
+  `blocked`/`error`), `outcome.exitCode`, and `outcome.errorTag` taxonomy even
+  when the scan throws. The run + project base context is already on the span
+  (run tags from `withSentryRunSpan`, project shape from
+  `recordSentryProjectContext`), so the event adds only what those don't — every
+  attribute namespaced by concept via `withNamespace` (`cli/utils/with-namespace.ts`)
+  so the keys tree up in Sentry's attribute browser: scan config (`scan.mode`,
+  `scan.parallel`, `scan.workerCount`, `scan.rulesConfigured`/`scan.rulesDisabled`,
+  `scan.ignoredTagCount`, `scan.hasCustomConfig`, … plus the `scan.fileCount`
+  extent), the verdict (`outcome.wouldBlock`/`outcome.blocking`/`outcome.clean`/
+  `outcome.skippedChecks`), findings (`diag.total`, `diag.errors`/`diag.warnings`,
+  `diag.affectedFiles`, `diag.distinctRules`, `diag.topRule`, per-category
+  `diag.category.*`), `score.value`/`score.label`/`score.available`, the
+  `lint.*`/`deadCode.*`/`supplyChain.*` pass outcomes, `timing.*` durations, and
+  the CI/PR specifics (`action.actorAssociation`, `action.runnerOs`, and the
+  forwarded action knobs `action.comment`/`action.reviewComments`/
+  `action.versionPin`). Typing matters for querying: numeric outcomes are numbers
+  (so Sentry can do `p75(score.value)`), dimensions are strings/bools (so they
+  filter/group); `null` is dropped via `toSpanAttributes` so absent signals never
+  become `"null"`. Query it in Sentry's **Trace Explorer** and build **Dashboard
+  widgets on the Spans dataset** (filter/group by any attribute) instead of
+  pre-aggregating counters. Put new run-level dimensions on `build-run-context.ts`
+  → `build-sentry-scope.ts` (now also the `eventName` + `viaAction` tags) so they
+  ride every event and metric; put per-scan outcome dimensions on the wide event
+  (wrapped in `withNamespace`), **not** new counters (we deliberately did not add
+  `ci.*` counters — those dims are wide-event attributes; the `scan.completed`/
+  `scan.duration`/`rule.fired` metric counters stay as the cheap,
   trace-sampling-independent floor alongside `cli.invoked`/`cli.error`). Score
-  reachability is derivable (`!scoreAvailable && !didLintFail && !noScore`) and
+  reachability is derivable (`!score.available && !lint.failed && !scan.noScore`) and
   score latency is the `Score.compute` child span's duration, so neither needs a
   dedicated field. CI detection + the official-action marker and forwarded
   inputs live in `cli/utils/is-ci-environment.ts`; `action.yml` sets the

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -216,7 +216,7 @@ export interface InspectOutput {
    * Per-file lint cache outcome for the lint pass: files served from cache and
    * total files considered. Both `null` when the cache was disabled or bypassed
    * (audit mode, adopted `extends`, user plugins) so the run never split. Fed
-   * to the Sentry wide event as `lintCacheHitRatio`.
+   * to the Sentry wide event as `lint.cacheHitRatio`.
    */
   readonly lintCacheHitFileCount: number | null;
   readonly lintCacheTotalFileCount: number | null;

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -44,7 +44,7 @@ export interface InspectResult {
    * Per-file lint cache outcome: files served from cache, and total files
    * considered. Both absent when the cache was off or bypassed (audit mode,
    * adopted `extends`, user plugins). The CLI projects these onto the Sentry
-   * wide event as `lintCacheHitRatio`.
+   * wide event as `lint.cacheHitRatio`.
    */
   lintCacheHitFileCount?: number | null;
   lintCacheTotalFileCount?: number | null;

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -59,7 +59,7 @@ export interface RunEventInput {
   // `true` when the background supply-chain check hit its overlap budget and
   // failed open to no diagnostics. The kill metric for the lint/supply-chain
   // overlap watches the rate of this per supply-chain-eligible scan (filter to
-  // `mode == "full"`, since a skipped check also reports `false`). Known on the
+  // `scan.mode == "full"`, since a skipped check also reports `false`). Known on the
   // success path and replayed from the cached payload on a cache hit — but a
   // timed-out run is never cached (`shouldStoreScanPayload`), so a cache hit
   // always reports `false`. Omitted only on the failure path (the scan threw
@@ -127,7 +127,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   // Mirror the CLI's real blocking gate (cli/commands/inspect.ts → finalizeScans):
   // it tests the threshold against diagnostics filtered for the `ciFailure`
   // surface (weak-signal `design`-tagged rules are dropped by default), so the
-  // wide event's wouldBlock/outcome/exitCode can't disagree with the actual
+  // wide event's `outcome.wouldBlock`/`outcome.status`/`outcome.exitCode` can't disagree with the actual
   // process exit. The descriptive totals below still reflect the full findings.
   const gateDiagnostics = filterDiagnosticsForSurface(
     result.diagnostics,
@@ -136,7 +136,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   );
   // `scoreOnly` runs never raise a non-zero exit (finalizeScans guards the gate
   // on `!isScoreOnly`), and a degraded baseline run (`gateExempt`) skips the
-  // gate too — keep wouldBlock/outcome/exitCode consistent with the real exit.
+  // gate too — keep `outcome.wouldBlock`/`outcome.status`/`outcome.exitCode` consistent with the real exit.
   const wouldBlock =
     !input.scoreOnly && !input.gateExempt && shouldBlockCi(gateDiagnostics, blockingLevel);
   const hasSkippedChecks = result.skippedChecks.length > 0;

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -12,6 +12,7 @@ import { isValidBlockingLevel } from "./resolve-blocking-level.js";
 import { shouldBlockCi } from "./should-block-ci.js";
 import { toCategoryKey } from "./to-category-key.js";
 import { toSpanAttributes } from "./to-span-attributes.js";
+import { withNamespace } from "./with-namespace.js";
 import type { SentryRootSpan } from "./with-sentry-run-span.js";
 
 // A tag-like map: `null` denotes an absent signal and is dropped by
@@ -112,12 +113,12 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   if (input.result === undefined) {
     const error = input.error;
     const known = isReactDoctorError(error);
-    return {
-      outcome: "error",
+    return withNamespace("outcome", {
+      status: "error",
       exitCode: 1,
       knownError: known,
       errorTag: known ? error.reason._tag : error instanceof Error ? error.name : null,
-    };
+    });
   }
 
   const result = input.result;
@@ -187,88 +188,113 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   let fixGroupedFindings = 0;
   for (const count of findingsPerFixGroup.values()) fixGroupedFindings += count;
 
-  const attributes: RunEventAttributes = {
-    outcome,
-    exitCode: wouldBlock ? 1 : 0,
-    wouldBlock,
-    blocking: blockingLevel,
-    scanClean: isClean,
-    totalDiagnostics: summary.totalDiagnosticCount,
-    errorCount: summary.errorCount,
-    warningCount: summary.warningCount,
-    affectedFiles: summary.affectedFileCount,
-    diagnosticsInTestFiles,
-    diagnosticsInStoryFiles,
-    distinctRulesFired: countByRule.size,
-    "diag.fixGroups": findingsPerFixGroup.size,
-    "diag.fixGroupedFindings": fixGroupedFindings,
-    topRule,
-    "migration.largestRuleBucketFiles": largestRuleBucket ? largestRuleBucket.fileCount : null,
-    "migration.largestRuleBucketSites": largestRuleBucket ? largestRuleBucket.siteCount : null,
-    "migration.largestRuleBucketRule": largestRuleBucket ? largestRuleBucket.ruleKey : null,
-    scannedFileCount: result.scannedFileCount ?? null,
-    // Per-file lint cache outcome. Numeric so Sentry can `p75(lintCacheHitRatio)`;
-    // all `null` when the cache was off/bypassed so "no cache" reads distinctly
-    // from a 0% hit rate (`toSpanAttributes` drops the nulls).
-    lintCacheHitFiles: result.lintCacheHitFileCount ?? null,
-    lintCacheTotalFiles: result.lintCacheTotalFileCount ?? null,
-    lintCacheHitRatio:
-      result.lintCacheTotalFileCount != null && result.lintCacheTotalFileCount > 0
-        ? (result.lintCacheHitFileCount ?? 0) / result.lintCacheTotalFileCount
-        : null,
-    elapsedMs: result.elapsedMilliseconds,
-    scanPhaseMs: result.scanElapsedMilliseconds ?? null,
-    score: result.score ? result.score.score : null,
-    scoreLabel: result.score ? result.score.label : null,
-    scoreAvailable: result.score !== null,
-    skippedCheckCount: result.skippedChecks.length,
-    didLintFail: input.didLintFail ?? null,
-    lintFailureReasonKind: input.lintFailureReasonKind ?? null,
-    lintPartialFailureCount: input.lintPartialFailureCount ?? null,
-    lintDroppedFileCount: input.lintDroppedFileCount ?? null,
-    didDeadCodeFail: input.didDeadCodeFail ?? null,
-    supplyChainOverlapTimedOut: input.supplyChainOverlapTimedOut ?? null,
-    deadCodeOverlapped: input.deadCodeOverlapped ?? null,
-  };
+  // Per-category diagnostic counts, keyed so the `diag` namespace yields
+  // `diag.category.<key>` once prefixed.
+  const categoryRollup: RunEventAttributes = {};
   for (const [category, count] of countByCategory) {
-    attributes[`diag.category.${toCategoryKey(category)}`] = count;
+    categoryRollup[`category.${toCategoryKey(category)}`] = count;
   }
+
+  const attributes: RunEventAttributes = {
+    ...withNamespace("outcome", {
+      status: outcome,
+      exitCode: wouldBlock ? 1 : 0,
+      wouldBlock,
+      blocking: blockingLevel,
+      clean: isClean,
+      skippedChecks: result.skippedChecks.length,
+    }),
+    ...withNamespace("diag", {
+      total: summary.totalDiagnosticCount,
+      errors: summary.errorCount,
+      warnings: summary.warningCount,
+      affectedFiles: summary.affectedFileCount,
+      inTestFiles: diagnosticsInTestFiles,
+      inStoryFiles: diagnosticsInStoryFiles,
+      distinctRules: countByRule.size,
+      topRule,
+      fixGroups: findingsPerFixGroup.size,
+      fixGroupedFindings,
+      ...categoryRollup,
+    }),
+    ...withNamespace("score", {
+      value: result.score ? result.score.score : null,
+      label: result.score ? result.score.label : null,
+      available: result.score !== null,
+    }),
+    ...withNamespace("lint", {
+      failed: input.didLintFail ?? null,
+      failureReasonKind: input.lintFailureReasonKind ?? null,
+      partialFailureCount: input.lintPartialFailureCount ?? null,
+      droppedFileCount: input.lintDroppedFileCount ?? null,
+      // Per-file lint cache outcome. Numeric so Sentry can `p75(lint.cacheHitRatio)`;
+      // all `null` when the cache was off/bypassed so "no cache" reads distinctly
+      // from a 0% hit rate (`toSpanAttributes` drops the nulls).
+      cacheHitFiles: result.lintCacheHitFileCount ?? null,
+      cacheTotalFiles: result.lintCacheTotalFileCount ?? null,
+      cacheHitRatio:
+        result.lintCacheTotalFileCount != null && result.lintCacheTotalFileCount > 0
+          ? (result.lintCacheHitFileCount ?? 0) / result.lintCacheTotalFileCount
+          : null,
+    }),
+    ...withNamespace("deadCode", {
+      failed: input.didDeadCodeFail ?? null,
+      overlapped: input.deadCodeOverlapped ?? null,
+    }),
+    ...withNamespace("supplyChain", {
+      overlapTimedOut: input.supplyChainOverlapTimedOut ?? null,
+    }),
+    ...withNamespace("timing", {
+      elapsedMs: result.elapsedMilliseconds,
+      scanMs: result.scanElapsedMilliseconds ?? null,
+    }),
+    ...withNamespace("migration", {
+      largestRuleBucketFiles: largestRuleBucket ? largestRuleBucket.fileCount : null,
+      largestRuleBucketSites: largestRuleBucket ? largestRuleBucket.siteCount : null,
+      largestRuleBucketRule: largestRuleBucket ? largestRuleBucket.ruleKey : null,
+    }),
+  };
   // Baseline (PR-introduced-issues-only) signal. Emitted only for baseline runs
   // so non-baseline scans stay clean: a computed run carries the delta (`new` is
-  // the introduced count == totalDiagnostics, plus `fixed` and base `baseTotal`)
-  // and `degraded: false`; a degraded run (base ref unfetchable or lint failed,
+  // the introduced count == diag.total, plus `fixed` and base `baseTotal`) and
+  // `degraded: false`; a degraded run (base ref unfetchable or lint failed,
   // surfaced via `gateExempt`) carries only `degraded: true`. The pair lets a
   // query compute the degradation rate over all baseline runs.
   if (result.baselineDelta) {
-    attributes["baseline.new"] = summary.totalDiagnosticCount;
-    attributes["baseline.fixed"] = result.baselineDelta.fixedCount;
-    attributes["baseline.baseTotal"] = result.baselineDelta.baseTotalCount;
-    attributes["baseline.degraded"] = false;
+    Object.assign(
+      attributes,
+      withNamespace("baseline", {
+        new: summary.totalDiagnosticCount,
+        fixed: result.baselineDelta.fixedCount,
+        baseTotal: result.baselineDelta.baseTotalCount,
+        degraded: false,
+      }),
+    );
   } else if (input.gateExempt) {
     attributes["baseline.degraded"] = true;
   }
   return attributes;
 };
 
-const buildCiAttributes = (): RunEventAttributes => {
+const buildActionAttributes = (): RunEventAttributes => {
   const { githubActorAssociation } = resolveGithubActionsScoreMetadata();
-  return {
+  return withNamespace("action", {
     actorAssociation: githubActorAssociation ?? null,
     runnerOs: detectRunnerOs(),
     // Action knobs: present only when the official action forwarded them, so
-    // they're `null` (dropped) for any non-action run. The action's
-    // `blocking` is already captured as `blocking`
-    // (resolveTelemetryBlocking prefers it).
+    // they're `null` (dropped) for any non-action run. The action's `blocking`
+    // is already captured as `outcome.blocking` (resolveTelemetryBlocking
+    // prefers it).
     comment: readEnvBoolean(ACTION_INPUT_ENVIRONMENT_VARIABLES.comment),
     reviewComments: readEnvBoolean(ACTION_INPUT_ENVIRONMENT_VARIABLES.reviewComments),
     versionPin: resolveVersionPin(process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.version]),
-  };
+  });
 };
 
-const buildConfigAttributes = (input: RunEventInput): RunEventAttributes => {
+const buildScanAttributes = (input: RunEventInput): RunEventAttributes => {
   const ruleOverrides = input.userConfig?.rules ?? {};
   const ruleKeys = Object.keys(ruleOverrides);
-  return {
+  return withNamespace("scan", {
     mode: input.mode,
     scope: input.scope,
     parallel: input.parallel,
@@ -284,12 +310,20 @@ const buildConfigAttributes = (input: RunEventInput): RunEventAttributes => {
     hasCustomConfig: input.hasCustomConfig,
     rulesConfigured: ruleKeys.length,
     rulesDisabled: ruleKeys.filter((key) => ruleOverrides[key] === "off").length,
-  };
+    // Scan extent — how many files this run covered (the denominator for
+    // `diag.affectedFiles`). Known only on the success path.
+    fileCount: input.result?.scannedFileCount ?? null,
+  });
 };
 
 /**
- * Projects a scan into the flat attribute set for its root span — the canonical
- * per-scan "wide event". Pure and exported so the projection (outcome
+ * Projects a scan into the namespaced attribute set for its root span — the
+ * canonical per-scan "wide event". Every attribute carries a dotted namespace
+ * that groups it by concept (`scan.*` config, `action.*` CI knobs, `outcome.*`
+ * verdict, `diag.*` findings, `score.*`, `lint.*`, `deadCode.*`,
+ * `supplyChain.*`, `timing.*`, `migration.*`, `baseline.*`) so the attributes
+ * tree up in Sentry's attribute browser and stay filter-/group-/aggregate-able
+ * in the Spans dataset. Pure and exported so the projection (outcome
  * precedence, rule/category rollups, CI knobs, config shape) is unit-testable
  * without a live Sentry client. `null` values are dropped so absent signals
  * never become misleading `"null"` attributes. The run + project base context
@@ -301,8 +335,8 @@ export const buildRunEventAttributes = (
   input: RunEventInput,
 ): Record<string, string | number | boolean> =>
   toSpanAttributes({
-    ...buildConfigAttributes(input),
-    ...buildCiAttributes(),
+    ...buildScanAttributes(input),
+    ...buildActionAttributes(),
     ...buildOutcomeAttributes(input),
   });
 

--- a/packages/react-doctor/src/cli/utils/count-dropped-lint-files.ts
+++ b/packages/react-doctor/src/cli/utils/count-dropped-lint-files.ts
@@ -6,7 +6,7 @@
 // and contribute 0. The count is more sensitive than the message count
 // (`lintPartialFailureCount`) for the LPT kill metric — a batch that strands
 // the timeout-tripping bucket can drop many files in a single message — so it
-// rides the wide event as `lintDroppedFileCount`. Parsing the anchored prefix
+// rides the wide event as `lint.droppedFileCount`. Parsing the anchored prefix
 // keeps the signal contained to one CLI util instead of plumbing a structured
 // count through the Linter → run-inspect → cache-payload chain.
 const DROPPED_FILES_MESSAGE_PATTERN = /^(\d+) file\(s\) failed to lint and were skipped/;

--- a/packages/react-doctor/src/cli/utils/with-namespace.ts
+++ b/packages/react-doctor/src/cli/utils/with-namespace.ts
@@ -1,0 +1,22 @@
+/**
+ * Prefixes every key in a flat attribute group with `namespace.`, so a logical
+ * group (scan config, diagnostics rollup, score, …) carries one dotted
+ * namespace applied in a single place rather than hand-spelled into each key —
+ * which is how the wide event drifted into a flat, half-namespaced soup. The
+ * dotted prefix is what makes the attributes tree up in Sentry's attribute
+ * browser and stay group-/filter-/aggregate-able in the Spans dataset.
+ *
+ * Value types are preserved verbatim (numbers stay numbers so Sentry infers a
+ * numeric attribute and `p75(...)`/`avg(...)` work; `null` is kept so
+ * `toSpanAttributes` can drop absent signals rather than coerce them).
+ */
+export const withNamespace = (
+  namespace: string,
+  attributes: Record<string, string | number | boolean | null>,
+): Record<string, string | number | boolean | null> => {
+  const namespaced: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    namespaced[`${namespace}.${key}`] = value;
+  }
+  return namespaced;
+};

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -108,32 +108,34 @@ describe("buildRunEventAttributes", () => {
 
   it("records whether the dead-code pass overlapped lint, and drops it on the failure path", () => {
     expect(
-      buildRunEventAttributes(baseInput({ result: buildResult(), deadCodeOverlapped: true }))
-        .deadCodeOverlapped,
+      buildRunEventAttributes(baseInput({ result: buildResult(), deadCodeOverlapped: true }))[
+        "deadCode.overlapped"
+      ],
     ).toBe(true);
     // A false dimension is still emitted (toSpanAttributes only drops null), so
     // overlap-adoption rate is queryable across all scans.
     expect(
-      buildRunEventAttributes(baseInput({ result: buildResult(), deadCodeOverlapped: false }))
-        .deadCodeOverlapped,
+      buildRunEventAttributes(baseInput({ result: buildResult(), deadCodeOverlapped: false }))[
+        "deadCode.overlapped"
+      ],
     ).toBe(false);
     // Failure path (no result) carries no outcome dimensions, so it's dropped.
     expect(
-      buildRunEventAttributes(baseInput({ error: new Error("boom") })).deadCodeOverlapped,
+      buildRunEventAttributes(baseInput({ error: new Error("boom") }))["deadCode.overlapped"],
     ).toBeUndefined();
   });
 
   it("marks a finding-free run clean and drops absent CI signals", () => {
     const attributes = buildRunEventAttributes(baseInput({ result: buildResult() }));
-    expect(attributes.outcome).toBe("clean");
-    expect(attributes.scanClean).toBe(true);
-    expect(attributes.totalDiagnostics).toBe(0);
-    expect(attributes.exitCode).toBe(0);
-    expect(attributes.wouldBlock).toBe(false);
+    expect(attributes["outcome.status"]).toBe("clean");
+    expect(attributes["outcome.clean"]).toBe(true);
+    expect(attributes["diag.total"]).toBe(0);
+    expect(attributes["outcome.exitCode"]).toBe(0);
+    expect(attributes["outcome.wouldBlock"]).toBe(false);
     // No GitHub signals in the cleared env -> these are dropped, not "null".
-    expect(attributes.actorAssociation).toBeUndefined();
-    expect(attributes.runnerOs).toBeUndefined();
-    expect(attributes.versionPin).toBeUndefined();
+    expect(attributes["action.actorAssociation"]).toBeUndefined();
+    expect(attributes["action.runnerOs"]).toBeUndefined();
+    expect(attributes["action.versionPin"]).toBeUndefined();
     // Nothing fired -> no migration bucket to report (dropped, not "null").
     expect(attributes["migration.largestRuleBucketFiles"]).toBeUndefined();
     expect(attributes["migration.largestRuleBucketRule"]).toBeUndefined();
@@ -184,28 +186,28 @@ describe("buildRunEventAttributes", () => {
       score: { score: 73, label: "Fair" },
     });
     const attributes = buildRunEventAttributes(baseInput({ result }));
-    expect(attributes.outcome).toBe("ok");
-    expect(attributes.totalDiagnostics).toBe(3);
-    expect(attributes.errorCount).toBe(1);
-    expect(attributes.warningCount).toBe(2);
-    expect(attributes.affectedFiles).toBe(2);
-    expect(attributes.distinctRulesFired).toBe(2);
-    expect(attributes.topRule).toBe("react-doctor/no-foo");
+    expect(attributes["outcome.status"]).toBe("ok");
+    expect(attributes["diag.total"]).toBe(3);
+    expect(attributes["diag.errors"]).toBe(1);
+    expect(attributes["diag.warnings"]).toBe(2);
+    expect(attributes["diag.affectedFiles"]).toBe(2);
+    expect(attributes["diag.distinctRules"]).toBe(2);
+    expect(attributes["diag.topRule"]).toBe("react-doctor/no-foo");
     expect(attributes["diag.category.performance"]).toBe(2);
     expect(attributes["diag.category.correctness"]).toBe(1);
-    expect(attributes.score).toBe(73);
-    expect(attributes.scoreLabel).toBe("Fair");
-    expect(attributes.scoreAvailable).toBe(true);
+    expect(attributes["score.value"]).toBe(73);
+    expect(attributes["score.label"]).toBe("Fair");
+    expect(attributes["score.available"]).toBe(true);
   });
 
   it("flags a blocking run when the action blocking gate would trip", () => {
     process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.blocking] = "error";
     const result = buildResult({ diagnostics: [buildDiagnostic({ severity: "error" })] });
     const attributes = buildRunEventAttributes(baseInput({ result }));
-    expect(attributes.blocking).toBe("error");
-    expect(attributes.wouldBlock).toBe(true);
-    expect(attributes.outcome).toBe("blocked");
-    expect(attributes.exitCode).toBe(1);
+    expect(attributes["outcome.blocking"]).toBe("error");
+    expect(attributes["outcome.wouldBlock"]).toBe(true);
+    expect(attributes["outcome.status"]).toBe("blocked");
+    expect(attributes["outcome.exitCode"]).toBe(1);
   });
 
   it("derives wouldBlock from the CI-failure surface, not the full diagnostic list", () => {
@@ -214,7 +216,7 @@ describe("buildRunEventAttributes", () => {
       diagnostics: [buildDiagnostic({ severity: "error", rule: "no-foo" })],
     });
     // No surface exclusion: the error trips the gate.
-    expect(buildRunEventAttributes(baseInput({ result })).wouldBlock).toBe(true);
+    expect(buildRunEventAttributes(baseInput({ result }))["outcome.wouldBlock"]).toBe(true);
     // Excluding the rule from the `ciFailure` surface (what the real CLI gate
     // does for weak-signal `design`-tagged rules) -> the wide event must agree
     // the run doesn't block, instead of disagreeing with the actual exit code.
@@ -224,34 +226,34 @@ describe("buildRunEventAttributes", () => {
         userConfig: { surfaces: { ciFailure: { excludeRules: ["react-doctor/no-foo"] } } },
       }),
     );
-    expect(excluded.wouldBlock).toBe(false);
-    expect(excluded.outcome).toBe("ok");
-    expect(excluded.exitCode).toBe(0);
+    expect(excluded["outcome.wouldBlock"]).toBe(false);
+    expect(excluded["outcome.status"]).toBe("ok");
+    expect(excluded["outcome.exitCode"]).toBe(0);
   });
 
   it("never reports a blocked run in score-only mode (matches the CLI exit guard)", () => {
     process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.blocking] = "error";
     const result = buildResult({ diagnostics: [buildDiagnostic({ severity: "error" })] });
     // A normal run with these findings blocks...
-    expect(buildRunEventAttributes(baseInput({ result })).wouldBlock).toBe(true);
+    expect(buildRunEventAttributes(baseInput({ result }))["outcome.wouldBlock"]).toBe(true);
     // ...but `scoreOnly` runs never raise a non-zero exit, so the wide event
     // must not claim blocked/exitCode 1 when the process actually exits 0.
     const scoreOnly = buildRunEventAttributes(baseInput({ result, scoreOnly: true }));
-    expect(scoreOnly.wouldBlock).toBe(false);
-    expect(scoreOnly.outcome).toBe("ok");
-    expect(scoreOnly.exitCode).toBe(0);
+    expect(scoreOnly["outcome.wouldBlock"]).toBe(false);
+    expect(scoreOnly["outcome.status"]).toBe("ok");
+    expect(scoreOnly["outcome.exitCode"]).toBe(0);
   });
 
   it("records the error taxonomy on the failure path", () => {
     const attributes = buildRunEventAttributes(
       baseInput({ result: undefined, error: new TypeError("boom") }),
     );
-    expect(attributes.outcome).toBe("error");
-    expect(attributes.knownError).toBe(false);
-    expect(attributes.errorTag).toBe("TypeError");
-    expect(attributes.exitCode).toBe(1);
+    expect(attributes["outcome.status"]).toBe("error");
+    expect(attributes["outcome.knownError"]).toBe(false);
+    expect(attributes["outcome.errorTag"]).toBe("TypeError");
+    expect(attributes["outcome.exitCode"]).toBe(1);
     // No result -> no outcome rollups.
-    expect(attributes.totalDiagnostics).toBeUndefined();
+    expect(attributes["diag.total"]).toBeUndefined();
   });
 
   it("records the supply-chain overlap timeout outcome and drops it when absent", () => {
@@ -261,15 +263,15 @@ describe("buildRunEventAttributes", () => {
     expect(
       buildRunEventAttributes(
         baseInput({ result: buildResult(), supplyChainOverlapTimedOut: true }),
-      ).supplyChainOverlapTimedOut,
+      )["supplyChain.overlapTimedOut"],
     ).toBe(true);
     expect(
       buildRunEventAttributes(
         baseInput({ result: buildResult(), supplyChainOverlapTimedOut: false }),
-      ).supplyChainOverlapTimedOut,
+      )["supplyChain.overlapTimedOut"],
     ).toBe(false);
     expect(
-      buildRunEventAttributes(baseInput({ result: buildResult() })).supplyChainOverlapTimedOut,
+      buildRunEventAttributes(baseInput({ result: buildResult() }))["supplyChain.overlapTimedOut"],
     ).toBeUndefined();
   });
 
@@ -294,33 +296,37 @@ describe("buildRunEventAttributes", () => {
     expect(attributes["baseline.new"]).toBeUndefined();
     expect(attributes["baseline.fixed"]).toBeUndefined();
     // Gate-exempt: the degraded run never blocks even with an error finding.
-    expect(attributes.wouldBlock).toBe(false);
+    expect(attributes["outcome.wouldBlock"]).toBe(false);
   });
 
   it("captures forwarded action knobs and classifies the version pin", () => {
     process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.reviewComments] = "false";
     process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.version] = "latest";
     const attributes = buildRunEventAttributes(baseInput({ result: buildResult() }));
-    expect(attributes.reviewComments).toBe(false);
-    expect(attributes.versionPin).toBe("latest");
+    expect(attributes["action.reviewComments"]).toBe(false);
+    expect(attributes["action.versionPin"]).toBe("latest");
     // `comment` env not set -> dropped, never coerced to a value.
-    expect(attributes.comment).toBeUndefined();
+    expect(attributes["action.comment"]).toBeUndefined();
 
     process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.version] = "1.2.3";
-    expect(buildRunEventAttributes(baseInput({ result: buildResult() })).versionPin).toBe("pinned");
+    expect(buildRunEventAttributes(baseInput({ result: buildResult() }))["action.versionPin"]).toBe(
+      "pinned",
+    );
     process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.version] = "./local/pkg";
-    expect(buildRunEventAttributes(baseInput({ result: buildResult() })).versionPin).toBe("local");
+    expect(buildRunEventAttributes(baseInput({ result: buildResult() }))["action.versionPin"]).toBe(
+      "local",
+    );
   });
 
-  it("records lintDroppedFileCount when present and drops it when absent", () => {
+  it("records lint.droppedFileCount when present and drops it when absent", () => {
     const withDrops = buildRunEventAttributes(
       baseInput({ result: buildResult(), lintDroppedFileCount: 4 }),
     );
-    expect(withDrops.lintDroppedFileCount).toBe(4);
+    expect(withDrops["lint.droppedFileCount"]).toBe(4);
 
     // Not passed -> null -> dropped, never coerced to a misleading "null".
     const withoutDrops = buildRunEventAttributes(baseInput({ result: buildResult() }));
-    expect(withoutDrops.lintDroppedFileCount).toBeUndefined();
+    expect(withoutDrops["lint.droppedFileCount"]).toBeUndefined();
   });
 
   it("captures config shape and drops null/undefined-valued attributes", () => {
@@ -333,13 +339,13 @@ describe("buildRunEventAttributes", () => {
         userConfig: { rules: { "react-doctor/no-foo": "off", "react-doctor/no-bar": "error" } },
       }),
     );
-    expect(attributes.mode).toBe("full");
-    expect(attributes.rulesConfigured).toBe(2);
-    expect(attributes.rulesDisabled).toBe(1);
-    expect(attributes.ignoredTagCount).toBe(2);
-    expect(attributes.hasCustomConfig).toBe(true);
-    expect(attributes.workerCount).toBeUndefined();
-    expect(attributes.scannedFileCount).toBeUndefined();
-    expect(attributes.scanPhaseMs).toBeUndefined();
+    expect(attributes["scan.mode"]).toBe("full");
+    expect(attributes["scan.rulesConfigured"]).toBe(2);
+    expect(attributes["scan.rulesDisabled"]).toBe(1);
+    expect(attributes["scan.ignoredTagCount"]).toBe(2);
+    expect(attributes["scan.hasCustomConfig"]).toBe(true);
+    expect(attributes["scan.workerCount"]).toBeUndefined();
+    expect(attributes["scan.fileCount"]).toBeUndefined();
+    expect(attributes["timing.scanMs"]).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

The per-scan Sentry **"wide event"** (the attributes stamped onto each run's root `cli.inspect` span) had accreted into a flat, half-namespaced set of ~50 keys — most bare (`outcome`, `mode`, `score`, `totalDiagnostics`, `wouldBlock`, …), a handful prefixed (`diag.*`, `migration.*`, `baseline.*`). It didn't tree up in Sentry's attribute browser.

This groups **every** attribute under a dotted namespace matching its concept:

| namespace | contents |
|---|---|
| `scan.*` | config (mode, scope, parallel, workers, passes, rules…) + `scan.fileCount` |
| `action.*` | `actorAssociation`, `runnerOs`, `comment`, `reviewComments`, `versionPin` |
| `outcome.*` | `status` (was bare `outcome`), `exitCode`, `wouldBlock`, `blocking`, `clean`, `knownError`, `errorTag`, `skippedChecks` |
| `diag.*` | `total`/`errors`/`warnings`/`affectedFiles`/`distinctRules`/`topRule`/… + `diag.category.*` |
| `score.*` | `value`, `label`, `available` |
| `lint.*` / `deadCode.*` / `supplyChain.*` | per-pass outcomes + cache stats |
| `timing.*` | `elapsedMs`, `scanMs` |
| `migration.*` / `baseline.*` | unchanged (already namespaced) |

The prefix is applied once per logical group via a new `withNamespace` helper (`cli/utils/with-namespace.ts`) rather than hand-spelled into each key — which is how the set drifted in the first place.

## Scope

- **Pure rename.** Value types are preserved (numbers stay numeric so `p75`/`avg` keep working; strings/bools stay dimensions), and `null` is still dropped by `toSpanAttributes` so absent signals don't become `"null"`.
- The run/project **base tags** (`origin`, `command`, `ci`, `project.*`, …) and **all metrics** (`record-scan-metrics.ts`) are **untouched** — those are stable and feed issue filters / counters far more widely.
- No in-repo consumer hardcodes the old key strings; the Sentry scrubber is fully generic (no allowlist).

## Verified

- `pnpm test` (build-run-event 14/14), `typecheck`, `lint`, `format:check` all green.
- **Propagation checked on live Sentry data** (org `millionco`, project `react-doctor`): dotted keys are first-class for filter/group/aggregate in the Spans dataset (`project.framework:nextjs` filters; `avg(diag.fixGroups)` → `tags[diag.fixGroups,number]`), over ~1.5M `cli.inspect` spans/30d.

## ⚠️ Follow-up — dashboards (do AFTER this version ships & propagates)

The renamed attributes only flow once a new CLI version is published, so editing widgets earlier blanks them. **8 widgets** across 2 dashboards reference renamed attrs:

- `outcome` → `outcome.status`: **Quality & Outcomes** (6605961) #2/#3/#4/#8/#9; **Activation Funnel & CI** (6605960) #15
- `actorAssociation` → `action.actorAssociation`: Activation Funnel & CI #12
- `runnerOs` → `action.runnerOs`: Activation Funnel & CI #13

Everything else is safe: all `tracemetrics` widgets use **metrics** (untouched), the score visuals use the `scan.score` **metric** (not the renamed span attr), and **Growth & Adoption** (6605903) has 0 affected widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Telemetry-only but breaks existing Sentry span filters and dashboards until widgets are migrated to the new attribute names; no scan, exit-code, or product API behavior changes.
> 
> **Overview**
> Reorganizes the per-scan Sentry **wide event** on the CLI root span so ~50 flat or half-prefixed keys become **dotted namespaces** (`scan.*`, `action.*`, `outcome.*`, `diag.*`, `score.*`, `lint.*`, `deadCode.*`, `supplyChain.*`, `timing.*`, plus existing `migration.*` / `baseline.*`). Verdict fields move under `outcome.*` (e.g. bare `outcome` → `outcome.status`, `scanClean` → `outcome.clean`); findings rollups use `diag.*`; CI/action env knobs use `action.*`; scan config and extent use `scan.*` including **`scan.fileCount`** (was `scannedFileCount` on the span). Prefixing is centralized in a new **`withNamespace`** helper in `build-run-event.ts` instead of spelling keys by hand.
> 
> **Behavior is unchanged** aside from attribute names: value types and `null` dropping via `toSpanAttributes` stay the same; run/project tags and **metrics** are untouched. Comments in `AGENTS.md` and core types reflect the new query names (e.g. `lint.cacheHitRatio`). Unit tests assert the new keys.
> 
> **Operational note:** Sentry dashboards/widgets that still reference old span attribute names need updating after a release ships the new CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d68f236edf74c81ac4e728e221ed0189857f94d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->