### PR TITLE
docs(changeset): correct #920 fix description to match implementation

### DIFF
--- a/.changeset/fix-object-prototype-keys.md
+++ b/.changeset/fix-object-prototype-keys.md
@@ -6,4 +6,4 @@ Fix crash when disable comments contain Object.prototype keys (constructor, toSt
 
 Resolves REACT-DOCTOR-1Y and fixes #920.
 
-The suppression near-miss detector would crash with `TypeError: bareRuleKey.includes is not a function` when an eslint-disable or oxlint-disable comment contained a token matching an Object.prototype member name. The LEGACY_RULE_KEY_TO_NATIVE_RULE_KEY lookup map now uses Object.create(null) to be immune to inherited keys, with an additional typeof guard for defense-in-depth.
+The suppression near-miss detector would crash with `TypeError: bareRuleKey.includes is not a function` when an eslint-disable or oxlint-disable comment contained a token matching an Object.prototype member name. Indexing the LEGACY_RULE_KEY_TO_NATIVE_RULE_KEY lookup map with such a token returned an inherited method (which the `??` fallback let through), so `canonicalizeRuleKey` now guards the lookup with a `typeof` check and only treats the result as an alias when it is a string.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The `bareRuleKey.includes is not a function` crash (#920, REACT-DOCTOR-1Y) was already fixed on `main` in #927 (`c2ce2989`). This PR only corrects the **changeset text**, which still describes a discarded approach.

## Why

The changeset claimed the fix made the `LEGACY_RULE_KEY_TO_NATIVE_RULE_KEY` lookup map "use `Object.create(null)`", but the final commit in #927 explicitly **reverted** that `Object.create(null)` churn and kept only the `typeof` guard in `canonicalizeRuleKey`:

```9:9:packages/core/src/rule-key-aliases.ts
const canonicalizeRuleKey = (ruleKey: string): string => {
  const nativeRuleKey = LEGACY_RULE_KEY_TO_NATIVE_RULE_KEY[ruleKey];
  return typeof nativeRuleKey === "string" ? nativeRuleKey : ruleKey;
};
```

Left as-is, the published changelog entry would describe an implementation that does not exist. This updates the description to match the actual fix.

## Verification

The existing regression + unit tests for the fix continue to pass:

```
Test Files  2 passed (2)
     Tests  71 passed (71)
```

(`tests/regressions/issue-920-object-prototype-keys.test.ts` + `tests/rule-key-aliases.test.ts`)

## Note on the underlying crash

For anyone hitting this on a released version: the actual code fix is already merged on `main` but **not yet published to npm** (the changeset is still pending release). Once a release ships, upgrading `react-doctor` resolves the crash. No source changes are needed here — the fix is sound and fully covered by tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be28b0b2-560c-44f8-a45e-a835196453d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be28b0b2-560c-44f8-a45e-a835196453d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

