### PR TITLE
feat(cli): add `ci` command for managing CI

### DIFF
--- a/.changeset/ci-management-command.md
+++ b/.changeset/ci-management-command.md
@@ -1,0 +1,11 @@
+---
+"react-doctor": minor
+---
+
+Add `react-doctor ci <install|upgrade|config>`, a dedicated command for managing React Doctor in CI.
+
+- `ci install` adds a workflow that scans every pull request. It auto-detects the provider (GitHub Actions or GitLab CI), bakes a gate from `--blocking`/`--scope`/`--comment`/`--review-comments`/`--commit-status`, and can open a pull request with `--pr`.
+- `ci config` walks you through the gate, scan scope, and pull-request reporting interactively (with a plain-language recap of what each setting does), or applies the same flags non-interactively. It only edits a workflow React Doctor generated; a hand-customized file gets a paste snippet instead of an overwrite.
+- `ci upgrade` bumps the GitHub Action to its current floating major.
+
+GitHub Actions is fully supported; GitLab CI gets a gate-only scaffold. The `install` command's CI setup is unchanged; `ci` is the focused home for managing CI on its own.

--- a/.changeset/ci-management-command.md
+++ b/.changeset/ci-management-command.md
@@ -5,7 +5,7 @@
 Add `react-doctor ci <install|upgrade|config>`, a dedicated command for managing React Doctor in CI.
 
 - `ci install` adds a workflow that scans every pull request. It auto-detects the provider (GitHub Actions or GitLab CI), bakes a gate from `--blocking`/`--scope`/`--comment`/`--review-comments`/`--commit-status`, and can open a pull request with `--pr`.
-- `ci config` walks you through the gate, scan scope, and pull-request reporting interactively (with a plain-language recap of what each setting does), or applies the same flags non-interactively. It only edits a workflow React Doctor generated; a hand-customized file gets a paste snippet instead of an overwrite.
+- `ci config` walks you through the gate, scan scope, and pull-request reporting interactively (with a plain-language recap of what each setting does), or applies the same flags non-interactively. It edits any workflow that contains the React Doctor action step in place — preserving your other steps, jobs, inputs, and comments — and only prints a paste snippet when the file has no React Doctor step.
 - `ci upgrade` bumps the GitHub Action to its current floating major.
 
 GitHub Actions is fully supported; GitLab CI gets a gate-only scaffold. The `install` command's CI setup is unchanged; `ci` is the focused home for managing CI on its own.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -39,9 +39,15 @@ Works with Claude Code, Cursor, Codex, OpenCode, and many more.
 
 ### 3. Run in CI
 
-React Doctor CI (GitHub Actions) reviews every pull request automatically and reports only the issues your change introduced, not your existing backlog.
+React Doctor reviews every pull request and reports only the issues your change introduced, not your existing backlog. Set it up with one command:
 
-[Add GitHub Action →](https://react.doctor/docs/ci-and-prs/github-actions-setup)
+```bash
+npx react-doctor@latest ci install
+```
+
+This adds the workflow, scans every pull request, and posts a summary comment. Change the gate, scan scope, and comments anytime with `react-doctor ci config`, and bump the action with `react-doctor ci upgrade`. GitHub Actions is fully supported; GitLab CI gets a gate-only scaffold.
+
+[CI docs →](https://react.doctor/ci)
 
 ### 4. Configure rules
 
@@ -57,7 +63,7 @@ We collect:
 
 - Environment: CLI version, platform, Node version
 - Invocation: which command, package manager, and run context (whether it's local vs. CI vs. coding agent)
-- Project shape: framework, React version, TypeScript, project size NO file contents)
+- Project shape: framework, React version, TypeScript, project size (NO file contents)
 - Rules fired: rule names and counts only (e.g. `react-doctor/no-array-index-as-key`) (NO code or specific findings)
 - De-minified React Doctor CLI stack traces
 

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -71,7 +71,8 @@
     "typescript": ">=5.0.4 <7",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",
-    "vscode-uri": "^3.1.0"
+    "vscode-uri": "^3.1.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@react-doctor/api": "workspace:*",

--- a/packages/react-doctor/src/cli/commands/ci.ts
+++ b/packages/react-doctor/src/cli/commands/ci.ts
@@ -1,0 +1,45 @@
+import * as Effect from "effect/Effect";
+import { METRIC } from "../utils/constants.js";
+import {
+  runCiConfig,
+  runCiInstall,
+  runCiUpgrade,
+  type CiCommandOptions,
+} from "../utils/ci/manage-ci.js";
+import { handleError, handleUserError } from "../utils/handle-error.js";
+import { isExpectedUserError } from "../utils/is-expected-user-error.js";
+import { printBrandedHeader } from "../utils/print-branded-header.js";
+import { recordCount } from "../utils/record-metric.js";
+import { reportErrorToSentry } from "../utils/report-error.js";
+
+// Shared shell for the three `ci` subcommands: it stamps the invocation metric,
+// prints the branded header, and funnels failures through the same crash
+// reporting the other commands use, so each subcommand body stays focused on
+// its own work.
+const runCiCommand = async (
+  subcommand: string,
+  run: (options: CiCommandOptions) => Promise<void>,
+  options: CiCommandOptions,
+): Promise<void> => {
+  recordCount(METRIC.cliInvoked, 1, { command: `ci ${subcommand}` });
+  Effect.runSync(printBrandedHeader);
+  try {
+    await run({ ...options, cwd: options.cwd ?? process.cwd() });
+  } catch (error) {
+    if (isExpectedUserError(error)) {
+      handleUserError(error);
+      return;
+    }
+    const sentryEventId = await reportErrorToSentry(error);
+    handleError(error, { sentryEventId });
+  }
+};
+
+export const ciInstallAction = (options: CiCommandOptions): Promise<void> =>
+  runCiCommand("install", runCiInstall, options);
+
+export const ciUpgradeAction = (options: CiCommandOptions): Promise<void> =>
+  runCiCommand("upgrade", runCiUpgrade, options);
+
+export const ciConfigAction = (options: CiCommandOptions): Promise<void> =>
+  runCiCommand("config", runCiConfig, options);

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from "commander";
-import { CANONICAL_GITHUB_URL, highlighter } from "@react-doctor/core";
+import { CANONICAL_GITHUB_URL, CI_URL, highlighter } from "@react-doctor/core";
 import { flushSentry, initializeSentry } from "../instrument.js";
+import { ciConfigAction, ciInstallAction, ciUpgradeAction } from "./commands/ci.js";
 import { inspectAction } from "./commands/inspect.js";
 import { installAction } from "./commands/install.js";
 import {
@@ -76,6 +77,7 @@ ${formatExampleLines([
   ["react-doctor --blocking warning", "fail CI on warnings too (default: error)"],
   ["react-doctor --json > report.json", "write a machine-readable report"],
   ["react-doctor why src/App.tsx:42", "explain why a rule fired there"],
+  ["react-doctor ci install", "scan every pull request in CI"],
   ["react-doctor install", "set up the agent skill and git hook"],
 ])}
 
@@ -99,8 +101,30 @@ ${formatExampleLines([
   ["react-doctor install --agent-hooks", "also install native agent hooks"],
 ])}
 
+${highlighter.dim("Managing CI:")}
+  ${highlighter.info("react-doctor ci install")} sets up, upgrades, and configures CI on its own.
+
 ${highlighter.dim("Learn more:")}
   ${highlighter.info(CANONICAL_GITHUB_URL)}
+`;
+
+const renderCiHelpEpilog = (): string => `
+${highlighter.dim("Examples:")}
+${formatExampleLines([
+  ["react-doctor ci install", "add a workflow that scans every pull request"],
+  ["react-doctor ci install --blocking error", "add it and fail the check on new errors"],
+  ["react-doctor ci install --pr", "open a pull request with the workflow"],
+  ["react-doctor ci config", "change the gate, scope, and reporting settings"],
+  ["react-doctor ci config --scope full", "scan the whole project on every pull request"],
+  ["react-doctor ci upgrade", "bump the action to its current major"],
+])}
+
+${highlighter.dim("Providers:")}
+  GitHub Actions is auto-detected and fully supported. GitLab CI is a gate-only
+  scaffold. Pass ${highlighter.info("--provider gitlab-ci")} to choose it explicitly.
+
+${highlighter.dim("Learn more:")}
+  ${highlighter.info(CI_URL)}
 `;
 
 const collectCategoryOption = (value: string, previousValues: string[] | undefined): string[] => [
@@ -219,6 +243,73 @@ program
   .option("--no-color", "disable colored output (also honors NO_COLOR)")
   .addHelpText("after", renderInstallHelpEpilog)
   .action(installAction);
+
+const providerOption: [string, string] = [
+  "--provider <name>",
+  "ci provider: github-actions or gitlab-ci (auto-detected by default)",
+];
+const prOption: [string, string] = [
+  "--pr",
+  "open a pull request with the change instead of writing it to the working tree",
+];
+
+// HACK: `--blocking`, `--scope`, `--yes`, and `--color` are also declared on
+// the root program (for the default inspect command), so Commander stashes a
+// colliding flag on the parent rather than the `ci` subcommand. Route every
+// action through `optsWithGlobals()` so the merged option set (subcommand +
+// inherited globals) is what the action sees — mirroring the `rules` group.
+const ci = program
+  .command("ci")
+  .description("Set up, upgrade, and configure React Doctor in your CI");
+
+ci.command("install")
+  .description("Add a CI workflow that scans every pull request")
+  .option(...providerOption)
+  .option(...prOption)
+  .option("--blocking <level>", "gate level: none (advisory, default), warning, or error")
+  .option(
+    "--scope <value>",
+    "what a pull-request scan reports: changed (default), files, lines, full",
+  )
+  .option("--comment", "post a summary comment on each pull request")
+  .option("--no-comment", "don't post a summary comment")
+  .option("--review-comments", "add inline review comments on changed lines")
+  .option("--no-review-comments", "don't add inline review comments")
+  .option("--commit-status", "report a commit status with the health score")
+  .option("--no-commit-status", "don't report a commit status")
+  .option("-y, --yes", "skip prompts; use the defaults")
+  .option("-c, --cwd <cwd>", "working directory", process.cwd())
+  .option("--color", "force colored output")
+  .option("--no-color", "disable colored output (also honors NO_COLOR)")
+  .addHelpText("after", renderCiHelpEpilog)
+  .action((_options, command) => ciInstallAction(command.optsWithGlobals()));
+
+ci.command("config")
+  .description("Change the gate, scan scope, and pull-request reporting")
+  .option(...providerOption)
+  .option("--blocking <level>", "gate level: none (advisory), warning, or error")
+  .option("--scope <value>", "what a pull-request scan reports: changed, files, lines, or full")
+  .option("--comment", "post a summary comment on each pull request")
+  .option("--no-comment", "don't post a summary comment")
+  .option("--review-comments", "add inline review comments on changed lines")
+  .option("--no-review-comments", "don't add inline review comments")
+  .option("--commit-status", "report a commit status with the health score")
+  .option("--no-commit-status", "don't report a commit status")
+  .option("-y, --yes", "skip prompts; print the current settings")
+  .option("-c, --cwd <cwd>", "working directory", process.cwd())
+  .option("--color", "force colored output")
+  .option("--no-color", "disable colored output (also honors NO_COLOR)")
+  .action((_options, command) => ciConfigAction(command.optsWithGlobals()));
+
+ci.command("upgrade")
+  .description("Upgrade the CI workflow to the action's current major")
+  .option(...providerOption)
+  .option(...prOption)
+  .option("-y, --yes", "skip prompts")
+  .option("-c, --cwd <cwd>", "working directory", process.cwd())
+  .option("--color", "force colored output")
+  .option("--no-color", "disable colored output (also honors NO_COLOR)")
+  .action((_options, command) => ciUpgradeAction(command.optsWithGlobals()));
 
 program
   .command("version")

--- a/packages/react-doctor/src/cli/utils/ci/ci-provider-registry.ts
+++ b/packages/react-doctor/src/cli/utils/ci/ci-provider-registry.ts
@@ -1,0 +1,17 @@
+import type { CiProvider, CiProviderId } from "./ci-provider.js";
+import { githubActionsProvider } from "./github-actions-provider.js";
+import { gitlabCiProvider } from "./gitlab-ci-provider.js";
+
+// GitHub Actions leads because it's the fully supported backend (and the one
+// the overwhelming majority of repos use); GitLab is the gate-only fallback.
+export const CI_PROVIDERS: ReadonlyArray<CiProvider> = [githubActionsProvider, gitlabCiProvider];
+
+export const isCiProviderId = (value: string): value is CiProviderId =>
+  CI_PROVIDERS.some((provider) => provider.id === value);
+
+export const getCiProvider = (id: CiProviderId): CiProvider => {
+  const provider = CI_PROVIDERS.find((candidate) => candidate.id === id);
+  // Unreachable for a validated id; the throw makes the non-null return honest.
+  if (!provider) throw new Error(`Unknown CI provider: ${id}`);
+  return provider;
+};

--- a/packages/react-doctor/src/cli/utils/ci/ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/ci-provider.ts
@@ -166,6 +166,10 @@ export interface CiProvider {
   readonly workflowPath: (projectRoot: string) => string;
   // Reads the provider's file, or null when it's absent or unreadable.
   readonly readWorkflow: (projectRoot: string) => CiWorkflowFile | null;
+  // Whether `content` actually wires up React Doctor (a GitHub step, a GitLab
+  // scan job) — distinct from the file merely existing, since a `.gitlab-ci.yml`
+  // can be a full pipeline with no React Doctor job at all.
+  readonly containsReactDoctor: (content: string) => boolean;
   // Writes a fresh file from the gate. Returns "exists" without overwriting.
   readonly scaffold: (projectRoot: string, defaultBranch: string, gate: CiGate) => CiScaffoldResult;
   // The gate currently in effect in `content` (advisory defaults when nothing

--- a/packages/react-doctor/src/cli/utils/ci/ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/ci-provider.ts
@@ -1,0 +1,207 @@
+import type { BlockingLevel, ScopeValue } from "@react-doctor/core";
+
+// One CI backend React Doctor can scaffold and manage. GitHub Actions is the
+// fully supported provider; GitLab CI is a gate-only scaffold (no PR-opening,
+// no comment/status reporter yet), so the interface lets each provider declare
+// exactly what it supports instead of forcing every backend to implement the
+// full surface.
+export type CiProviderId = "github-actions" | "gitlab-ci";
+
+// The pull-request gate: how React Doctor behaves on each scan. The values map
+// 1:1 to the GitHub Action inputs (action.yml), so a gate round-trips between
+// the workflow file and the `ci config` command without translation.
+export type CiGateKey = "blocking" | "scope" | "comment" | "reviewComments" | "commitStatus";
+
+export interface CiGate {
+  // Whether a finding fails the check: "none" reports only, "warning" fails on
+  // any finding, "error" fails on error-level findings.
+  readonly blocking: BlockingLevel;
+  // Which issues a pull-request scan reports (see SCOPE_CHOICES for the copy).
+  readonly scope: ScopeValue;
+  // Post a summary comment on each pull request.
+  readonly comment: boolean;
+  // Add inline review comments on changed lines.
+  readonly reviewComments: boolean;
+  // Report a commit status carrying the health score.
+  readonly commitStatus: boolean;
+}
+
+// The advisory default every fresh scaffold starts from: report on every pull
+// request, never fail the check. Mirrors the GitHub Action's own input
+// defaults so an advisory gate produces the canonical commented template.
+export const ADVISORY_GATE: CiGate = {
+  blocking: "none",
+  scope: "changed",
+  comment: true,
+  reviewComments: true,
+  commitStatus: true,
+};
+
+// A workflow file read from disk, ready to parse or edit.
+export interface CiWorkflowFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface CiScaffoldResult {
+  readonly status: "created" | "exists" | "failed";
+  readonly path: string;
+}
+
+export interface CiEditResult {
+  readonly content: string;
+  readonly changed: boolean;
+}
+
+// A choice the `ci config` prompt offers for an enum gate field, paired with
+// the plain-language line shown after the change so the question and the recap
+// never drift.
+export interface CiGateChoice<Value extends string> {
+  readonly value: Value;
+  readonly title: string;
+  readonly description: string;
+}
+
+export const BLOCKING_CHOICES: ReadonlyArray<CiGateChoice<BlockingLevel>> = [
+  {
+    value: "none",
+    title: "Advisory",
+    description: "Report findings, never fail the check",
+  },
+  {
+    value: "error",
+    title: "Block on errors",
+    description: "Fail the check on new error-level findings",
+  },
+  {
+    value: "warning",
+    title: "Block on warnings",
+    description: "Fail the check on any new finding",
+  },
+];
+
+export const SCOPE_CHOICES: ReadonlyArray<CiGateChoice<ScopeValue>> = [
+  {
+    value: "changed",
+    title: "New issues",
+    description: "Only the issues a change introduces",
+  },
+  {
+    value: "files",
+    title: "Changed files",
+    description: "Every issue in the files a change touches",
+  },
+  {
+    value: "lines",
+    title: "Changed lines",
+    description: "Issues on the exact lines a change edits",
+  },
+  {
+    value: "full",
+    title: "Whole project",
+    description: "Every issue in the project, on every run",
+  },
+];
+
+// One toggle gate field. `description` is the prompt label and doubles as the
+// "on" recap line; `whenOff` is the recap line when it's disabled.
+export interface CiGateToggleInfo {
+  readonly key: Extract<CiGateKey, "comment" | "reviewComments" | "commitStatus">;
+  readonly title: string;
+  readonly description: string;
+  readonly whenOff: string;
+}
+
+export const TOGGLE_INFO: ReadonlyArray<CiGateToggleInfo> = [
+  {
+    key: "comment",
+    title: "Summary comment",
+    description: "Post a summary comment on each pull request",
+    whenOff: "Skip the summary comment",
+  },
+  {
+    key: "reviewComments",
+    title: "Inline review comments",
+    description: "Add inline review comments on changed lines",
+    whenOff: "Skip inline review comments",
+  },
+  {
+    key: "commitStatus",
+    title: "Commit status",
+    description: "Report a commit status with the health score",
+    whenOff: "Skip the commit status",
+  },
+];
+
+// Recap copy for the two enum fields, keyed by value so there's no nested
+// ternary. Phrased as actions ("Fail the check…") to read under "will now:".
+const BLOCKING_SUMMARY: Record<BlockingLevel, string> = {
+  none: "Report findings without failing the check",
+  warning: "Fail the check on any new finding",
+  error: "Fail the check on new error-level findings",
+};
+
+const SCOPE_SUMMARY: Record<ScopeValue, string> = {
+  full: "Scan the whole project on every run",
+  files: "Report every issue in changed files",
+  lines: "Report issues on changed lines",
+  changed: "Report only the issues a change introduces",
+};
+
+// The interface every CI backend implements. A provider owns its file format
+// (workflow YAML, `.gitlab-ci.yml`), so the command layer stays format-blind:
+// it detects a provider, reads the gate, edits it, and reports the result.
+export interface CiProvider {
+  readonly id: CiProviderId;
+  // Human name for prompts and messages ("GitHub Actions").
+  readonly displayName: string;
+  // Project-relative path of the file this provider owns, for messages.
+  readonly fileLabel: string;
+  // Gate fields this provider can act on. GitLab supports only blocking + scope
+  // (it has no PR comment or commit-status reporter yet), so `ci config` hides
+  // the toggles it can't honor instead of writing settings that do nothing.
+  readonly supportedGateKeys: ReadonlyArray<CiGateKey>;
+  // Whether `ci install --pr` / `ci upgrade --pr` can open a pull request.
+  readonly supportsPullRequest: boolean;
+  readonly workflowPath: (projectRoot: string) => string;
+  // Reads the provider's file, or null when it's absent or unreadable.
+  readonly readWorkflow: (projectRoot: string) => CiWorkflowFile | null;
+  // Writes a fresh file from the gate. Returns "exists" without overwriting.
+  readonly scaffold: (projectRoot: string, defaultBranch: string, gate: CiGate) => CiScaffoldResult;
+  // The gate currently in effect in `content` (advisory defaults when nothing
+  // is configured explicitly).
+  readonly parseGate: (content: string) => CiGate;
+  // Rewrites `content` to the new gate, or null when the file diverged from
+  // what React Doctor generates and editing it could clobber the user's work
+  // (the caller then prints `renderSnippet` for the user to paste).
+  readonly applyGate: (content: string, gate: CiGate) => CiEditResult | null;
+  // The block a user pastes by hand when `applyGate` declines to edit.
+  readonly renderSnippet: (gate: CiGate) => string;
+  // Bumps a pinned floating major to the current one (GitHub only).
+  readonly upgradeMajor?: (content: string) => CiEditResult;
+}
+
+// True when two gates request the same behavior on every field.
+export const gatesEqual = (left: CiGate, right: CiGate): boolean =>
+  left.blocking === right.blocking &&
+  left.scope === right.scope &&
+  left.comment === right.comment &&
+  left.reviewComments === right.reviewComments &&
+  left.commitStatus === right.commitStatus;
+
+// Plain-language recap of what a gate does, one line per supported field, for
+// the message printed after `ci config` writes the change. Keeps users from
+// having to read YAML to know what they just turned on.
+export const summarizeGate = (
+  gate: CiGate,
+  supportedGateKeys: ReadonlyArray<CiGateKey>,
+): ReadonlyArray<string> => {
+  const lines: string[] = [];
+  if (supportedGateKeys.includes("blocking")) lines.push(BLOCKING_SUMMARY[gate.blocking]);
+  if (supportedGateKeys.includes("scope")) lines.push(SCOPE_SUMMARY[gate.scope]);
+  for (const toggle of TOGGLE_INFO) {
+    if (!supportedGateKeys.includes(toggle.key)) continue;
+    lines.push(gate[toggle.key] ? toggle.description : toggle.whenOff);
+  }
+  return lines;
+};

--- a/packages/react-doctor/src/cli/utils/ci/detect-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/detect-ci-provider.ts
@@ -5,23 +5,29 @@ import type { CiProviderId } from "./ci-provider.js";
 import { githubActionsProvider } from "./github-actions-provider.js";
 import { gitlabCiProvider } from "./gitlab-ci-provider.js";
 
-// Picks the CI backend a repo already uses. A config file that's already on
-// disk is the strongest signal (it beats whatever the remote host implies),
-// then the presence of a `.github/workflows` directory, then the git remote
-// host. Returns null when nothing is conclusive, so the caller can ask rather
-// than guess.
+// Picks the CI backend a repo already uses, strongest signal first:
+//
+// 1. React Doctor's own workflow file already on disk — it's React-Doctor-specific.
+// 2. The git remote host — the authoritative platform signal. It's checked
+//    before the generic on-disk files so a GitHub repo carrying a stray or
+//    legacy `.gitlab-ci.yml` (e.g. from a mirror) isn't misread as GitLab.
+// 3. A generic CI file/dir on disk — the fallback when the remote is missing
+//    or a host we don't recognize (self-hosted).
+//
+// Returns null when nothing is conclusive, so the caller can ask rather than guess.
 export const detectCiProvider = async (
   projectRoot: string,
   run: CommandRunner = runCommand,
 ): Promise<CiProviderId | null> => {
   if (githubActionsProvider.readWorkflow(projectRoot)) return "github-actions";
-  if (gitlabCiProvider.readWorkflow(projectRoot)) return "gitlab-ci";
-  if (fs.existsSync(path.join(projectRoot, ".github", "workflows"))) return "github-actions";
 
   const remote = await run("git", ["remote", "get-url", "origin"], projectRoot);
   if (remote.success) {
     if (/github\.com[:/]/i.test(remote.stdout)) return "github-actions";
     if (/gitlab/i.test(remote.stdout)) return "gitlab-ci";
   }
+
+  if (fs.existsSync(path.join(projectRoot, ".github", "workflows"))) return "github-actions";
+  if (gitlabCiProvider.readWorkflow(projectRoot)) return "gitlab-ci";
   return null;
 };

--- a/packages/react-doctor/src/cli/utils/ci/detect-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/detect-ci-provider.ts
@@ -1,0 +1,27 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { runCommand, type CommandRunner } from "../run-command.js";
+import type { CiProviderId } from "./ci-provider.js";
+import { githubActionsProvider } from "./github-actions-provider.js";
+import { gitlabCiProvider } from "./gitlab-ci-provider.js";
+
+// Picks the CI backend a repo already uses. A config file that's already on
+// disk is the strongest signal (it beats whatever the remote host implies),
+// then the presence of a `.github/workflows` directory, then the git remote
+// host. Returns null when nothing is conclusive, so the caller can ask rather
+// than guess.
+export const detectCiProvider = async (
+  projectRoot: string,
+  run: CommandRunner = runCommand,
+): Promise<CiProviderId | null> => {
+  if (githubActionsProvider.readWorkflow(projectRoot)) return "github-actions";
+  if (gitlabCiProvider.readWorkflow(projectRoot)) return "gitlab-ci";
+  if (fs.existsSync(path.join(projectRoot, ".github", "workflows"))) return "github-actions";
+
+  const remote = await run("git", ["remote", "get-url", "origin"], projectRoot);
+  if (remote.success) {
+    if (/github\.com[:/]/i.test(remote.stdout)) return "github-actions";
+    if (/gitlab/i.test(remote.stdout)) return "gitlab-ci";
+  }
+  return null;
+};

--- a/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
@@ -263,7 +263,49 @@ const renderSnippet = (gate: CiGate): string => {
   return [`${WITH_INDENT}with:`, ...gateLines].join("\n");
 };
 
+const containsReactDoctor = (content: string): boolean => {
+  try {
+    return findReactDoctorStep(YAML.parseDocument(content)) !== null;
+  } catch {
+    return false;
+  }
+};
+
+// Scans `.github/workflows/*.{yml,yaml}` for the first file that wires up the
+// React Doctor action step — a user may have added the step to their existing
+// CI workflow instead of a dedicated `react-doctor.yml`.
+const findActionWorkflowFile = (projectRoot: string): CiWorkflowFile | null => {
+  const workflowsDir = path.join(projectRoot, ".github", "workflows");
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(workflowsDir).sort();
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!/\.ya?ml$/.test(entry)) continue;
+    try {
+      const content = fs.readFileSync(path.join(workflowsDir, entry), "utf8");
+      if (containsReactDoctor(content)) return { path: path.join(workflowsDir, entry), content };
+    } catch {}
+  }
+  return null;
+};
+
+// The canonical `react-doctor.yml` when present (it's ours, so edit it), else
+// the first other workflow that wires up the action — so `ci config` /
+// `ci upgrade` manage the step wherever the user put it.
+const readWorkflow = (projectRoot: string): CiWorkflowFile | null => {
+  const canonical = readReactDoctorWorkflow(projectRoot);
+  if (canonical) return { path: canonical.workflowPath, content: canonical.content };
+  return findActionWorkflowFile(projectRoot);
+};
+
+// Reports "exists" when the action is already wired up anywhere (or our
+// canonical file is present), so `ci install` never adds a second workflow.
 const scaffold = (projectRoot: string, defaultBranch: string, gate: CiGate): CiScaffoldResult => {
+  const existing = readWorkflow(projectRoot);
+  if (existing) return { status: "exists", path: existing.path };
   const workflowPath = getReactDoctorWorkflowPath(projectRoot);
   if (fs.existsSync(workflowPath)) return { status: "exists", path: workflowPath };
   try {
@@ -272,19 +314,6 @@ const scaffold = (projectRoot: string, defaultBranch: string, gate: CiGate): CiS
     return { status: "created", path: workflowPath };
   } catch {
     return { status: "failed", path: workflowPath };
-  }
-};
-
-const readWorkflow = (projectRoot: string): CiWorkflowFile | null => {
-  const workflow = readReactDoctorWorkflow(projectRoot);
-  return workflow ? { path: workflow.workflowPath, content: workflow.content } : null;
-};
-
-const containsReactDoctor = (content: string): boolean => {
-  try {
-    return findReactDoctorStep(YAML.parseDocument(content)) !== null;
-  } catch {
-    return false;
   }
 };
 

--- a/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
@@ -280,6 +280,14 @@ const readWorkflow = (projectRoot: string): CiWorkflowFile | null => {
   return workflow ? { path: workflow.workflowPath, content: workflow.content } : null;
 };
 
+const containsReactDoctor = (content: string): boolean => {
+  try {
+    return findReactDoctorStep(YAML.parseDocument(content)) !== null;
+  } catch {
+    return false;
+  }
+};
+
 export const githubActionsProvider: CiProvider = {
   id: "github-actions",
   displayName: "GitHub Actions",
@@ -288,6 +296,7 @@ export const githubActionsProvider: CiProvider = {
   supportsPullRequest: true,
   workflowPath: getReactDoctorWorkflowPath,
   readWorkflow,
+  containsReactDoctor,
   scaffold,
   parseGate,
   applyGate,

--- a/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
@@ -1,0 +1,237 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+import {
+  buildWorkflowContent,
+  getReactDoctorWorkflowPath,
+  readReactDoctorWorkflow,
+  upgradeWorkflowActionToV2,
+} from "../install-github-workflow.js";
+import { isValidBlockingLevel } from "../resolve-blocking-level.js";
+import { isScopeValue } from "../resolve-scope.js";
+import { normalizeWorkflowContent } from "./normalize-workflow-content.js";
+import {
+  ADVISORY_GATE,
+  gatesEqual,
+  type CiEditResult,
+  type CiGate,
+  type CiProvider,
+  type CiScaffoldResult,
+  type CiWorkflowFile,
+} from "./ci-provider.js";
+
+// Indentation inside the generated workflow's job step. `- uses:` sits at six
+// spaces, so its sibling `with:` aligns at eight and the gate keys nest at ten.
+const WITH_INDENT = "        ";
+const GATE_KEY_INDENT = "          ";
+
+// Maps each gate field to the GitHub Action input name (action.yml). Booleans
+// default to true and `scope`/`blocking` to "changed"/"none", so a fresh
+// `with:` block only spells out the fields that deviate from those defaults.
+const ACTION_INPUT_NAME = {
+  blocking: "blocking",
+  scope: "scope",
+  comment: "comment",
+  reviewComments: "review-comments",
+  commitStatus: "commit-status",
+} as const;
+
+const buildGateLines = (gate: CiGate): ReadonlyArray<string> => {
+  const lines: string[] = [];
+  if (gate.blocking !== ADVISORY_GATE.blocking) {
+    lines.push(`${GATE_KEY_INDENT}${ACTION_INPUT_NAME.blocking}: ${gate.blocking}`);
+  }
+  if (gate.scope !== ADVISORY_GATE.scope) {
+    lines.push(`${GATE_KEY_INDENT}${ACTION_INPUT_NAME.scope}: ${gate.scope}`);
+  }
+  if (gate.comment !== ADVISORY_GATE.comment) {
+    lines.push(`${GATE_KEY_INDENT}${ACTION_INPUT_NAME.comment}: ${gate.comment}`);
+  }
+  if (gate.reviewComments !== ADVISORY_GATE.reviewComments) {
+    lines.push(`${GATE_KEY_INDENT}${ACTION_INPUT_NAME.reviewComments}: ${gate.reviewComments}`);
+  }
+  if (gate.commitStatus !== ADVISORY_GATE.commitStatus) {
+    lines.push(`${GATE_KEY_INDENT}${ACTION_INPUT_NAME.commitStatus}: ${gate.commitStatus}`);
+  }
+  return lines;
+};
+
+// The active-gate workflow: a concrete `with:` block holding every setting that
+// deviates from the advisory defaults. Used whenever the gate isn't advisory;
+// an advisory gate produces the canonical commented template instead, so the
+// two forms round-trip cleanly through `parseGate`.
+const buildActiveWorkflow = (defaultBranch: string, gate: CiGate, actionRef: string): string =>
+  `# React Doctor: security, performance, correctness, accessibility, bundle-size,
+# and architecture checks for React.
+#
+# These settings were written by \`react-doctor ci config\`. Run it again to change them.
+# Docs: https://www.react.doctor/ci
+
+name: React Doctor
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: ["${defaultBranch}"]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+concurrency:
+  group: react-doctor-\${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: millionco/react-doctor@${actionRef}
+${WITH_INDENT}with:
+${buildGateLines(gate).join("\n")}
+`;
+
+const buildGithubWorkflow = (defaultBranch: string, gate: CiGate, actionRef: string): string =>
+  gatesEqual(gate, ADVISORY_GATE)
+    ? buildWorkflowContent(defaultBranch, actionRef)
+    : buildActiveWorkflow(defaultBranch, gate, actionRef);
+
+// The push-trigger branch (`branches: ["main"]`) the workflow already scans, so
+// a `ci config` rewrite preserves it instead of reverting to a guessed default.
+const extractDefaultBranch = (content: string): string | null => {
+  const match = content.match(/branches:\s*\[\s*"([^"]+)"\s*\]/);
+  return match ? match[1] : null;
+};
+
+// The action ref the `uses:` line carries (`v2`, `v1`, a tag, or a SHA), so a
+// gate edit re-pins the same version rather than bumping the major.
+const extractActionRef = (content: string): string | null => {
+  const match = content.match(/millionco\/react-doctor@([\w.-]+)/);
+  return match ? match[1] : null;
+};
+
+const parseBoolean = (raw: string, fallback: boolean): boolean => {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return fallback;
+};
+
+// Strips an inline `# comment` and any matching surrounding quotes, so a
+// hand-written `blocking: "error"` reads the same as the bare `blocking: error`
+// React Doctor generates.
+const parseScalar = (raw: string): string =>
+  raw
+    .replace(/\s*#.*$/, "")
+    .trim()
+    .replace(/^(["'])(.*)\1$/, "$2");
+
+// Reads the `with:` mapping React Doctor's own step currently applies. The
+// search is anchored to the `millionco/react-doctor@…` line so a preceding
+// step's `with:` block (e.g. actions/setup-node) is never mistaken for the
+// gate. A step with no active `with:` reports the action's own defaults, so the
+// gate the user sees in `ci config` matches what a scan actually does.
+const parseGate = (content: string): CiGate => {
+  const lines = content.split(/\r?\n/);
+  const stepIndex = lines.findIndex((line) => /millionco\/react-doctor@/.test(line));
+  if (stepIndex === -1) return ADVISORY_GATE;
+
+  // The active `with:` for this step (a leading `#` rules out the commented
+  // example the advisory template ships); stop at the next step.
+  let withLineIndex = -1;
+  for (let lineIndex = stepIndex + 1; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    if (line.trim() === "") continue;
+    if (/^\s*-\s/.test(line)) break;
+    if (/^\s*with:\s*$/.test(line)) {
+      withLineIndex = lineIndex;
+      break;
+    }
+  }
+  if (withLineIndex === -1) return ADVISORY_GATE;
+
+  const entries = new Map<string, string>();
+  for (const line of lines.slice(withLineIndex + 1)) {
+    if (line.trim() === "") continue;
+    const keyValue = line.match(/^\s+([\w-]+):\s*(.+?)\s*$/);
+    if (!keyValue) break;
+    entries.set(keyValue[1], parseScalar(keyValue[2]));
+  }
+
+  const blockingRaw = entries.get(ACTION_INPUT_NAME.blocking);
+  const scopeRaw = entries.get(ACTION_INPUT_NAME.scope);
+  return {
+    blocking:
+      blockingRaw && isValidBlockingLevel(blockingRaw) ? blockingRaw : ADVISORY_GATE.blocking,
+    scope: scopeRaw && isScopeValue(scopeRaw) ? scopeRaw : ADVISORY_GATE.scope,
+    comment: parseBoolean(entries.get(ACTION_INPUT_NAME.comment) ?? "", ADVISORY_GATE.comment),
+    reviewComments: parseBoolean(
+      entries.get(ACTION_INPUT_NAME.reviewComments) ?? "",
+      ADVISORY_GATE.reviewComments,
+    ),
+    commitStatus: parseBoolean(
+      entries.get(ACTION_INPUT_NAME.commitStatus) ?? "",
+      ADVISORY_GATE.commitStatus,
+    ),
+  };
+};
+
+// Rewrites the gate only when the file on disk is still exactly what React
+// Doctor generates for its current gate (reconstructed from the parsed gate +
+// the file's own branch and ref). That guarantees a hand-customized workflow is
+// never silently overwritten: the caller falls back to printing the snippet.
+const applyGate = (content: string, gate: CiGate): CiEditResult | null => {
+  const defaultBranch = extractDefaultBranch(content) ?? "main";
+  const actionRef = extractActionRef(content) ?? "v2";
+  const currentGate = parseGate(content);
+  const canonical = buildGithubWorkflow(defaultBranch, currentGate, actionRef);
+  if (normalizeWorkflowContent(canonical) !== normalizeWorkflowContent(content)) return null;
+  const next = buildGithubWorkflow(defaultBranch, gate, actionRef);
+  return {
+    content: next,
+    changed: normalizeWorkflowContent(next) !== normalizeWorkflowContent(content),
+  };
+};
+
+const renderSnippet = (gate: CiGate): string => {
+  const gateLines = buildGateLines(gate);
+  if (gateLines.length === 0) {
+    return `${WITH_INDENT}# No \`with:\` block needed. The defaults are advisory (report, never fail).`;
+  }
+  return [`${WITH_INDENT}with:`, ...gateLines].join("\n");
+};
+
+const scaffold = (projectRoot: string, defaultBranch: string, gate: CiGate): CiScaffoldResult => {
+  const workflowPath = getReactDoctorWorkflowPath(projectRoot);
+  if (fs.existsSync(workflowPath)) return { status: "exists", path: workflowPath };
+  try {
+    fs.mkdirSync(path.dirname(workflowPath), { recursive: true });
+    fs.writeFileSync(workflowPath, buildGithubWorkflow(defaultBranch, gate, "v2"));
+    return { status: "created", path: workflowPath };
+  } catch {
+    return { status: "failed", path: workflowPath };
+  }
+};
+
+const readWorkflow = (projectRoot: string): CiWorkflowFile | null => {
+  const workflow = readReactDoctorWorkflow(projectRoot);
+  return workflow ? { path: workflow.workflowPath, content: workflow.content } : null;
+};
+
+export const githubActionsProvider: CiProvider = {
+  id: "github-actions",
+  displayName: "GitHub Actions",
+  fileLabel: ".github/workflows/react-doctor.yml",
+  supportedGateKeys: ["blocking", "scope", "comment", "reviewComments", "commitStatus"],
+  supportsPullRequest: true,
+  workflowPath: getReactDoctorWorkflowPath,
+  readWorkflow,
+  scaffold,
+  parseGate,
+  applyGate,
+  renderSnippet,
+  upgradeMajor: upgradeWorkflowActionToV2,
+};

--- a/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
@@ -130,13 +130,17 @@ const parseScalar = (raw: string): string =>
     .replace(/^(["'])(.*)\1$/, "$2");
 
 // Reads the `with:` mapping React Doctor's own step currently applies. The
-// search is anchored to the `millionco/react-doctor@…` line so a preceding
-// step's `with:` block (e.g. actions/setup-node) is never mistaken for the
-// gate. A step with no active `with:` reports the action's own defaults, so the
-// gate the user sees in `ci config` matches what a scan actually does.
+// search is anchored to the step's `- uses: millionco/react-doctor@…` line —
+// requiring the `- uses:` prefix, not just the ref, so a comment mentioning the
+// action (or a preceding step's `with:` block, e.g. actions/setup-node) is
+// never mistaken for the gate. A step with no active `with:` reports the
+// action's own defaults, so the gate the user sees in `ci config` matches what
+// a scan actually does.
 const parseGate = (content: string): CiGate => {
   const lines = content.split(/\r?\n/);
-  const stepIndex = lines.findIndex((line) => /millionco\/react-doctor@/.test(line));
+  const stepIndex = lines.findIndex((line) =>
+    /^\s*-\s*uses:\s*millionco\/react-doctor@/.test(line),
+  );
   if (stepIndex === -1) return ADVISORY_GATE;
 
   // The active `with:` for this step (a leading `#` rules out the commented

--- a/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/github-actions-provider.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
+import * as YAML from "yaml";
 import {
   buildWorkflowContent,
   getReactDoctorWorkflowPath,
@@ -34,6 +35,50 @@ const ACTION_INPUT_NAME = {
   reviewComments: "review-comments",
   commitStatus: "commit-status",
 } as const;
+
+// The five gate fields paired with their action-input names, for iterating when
+// reading or writing the `with:` mapping.
+const MANAGED_INPUTS = Object.entries(ACTION_INPUT_NAME) as ReadonlyArray<
+  [keyof typeof ACTION_INPUT_NAME, string]
+>;
+
+const ACTION_REF_PREFIX = "millionco/react-doctor@";
+
+// Locates React Doctor's own step in a parsed workflow and its active `with:`
+// mapping (null when the step has none). Anchored to the step's `uses` scalar
+// (any ref, including a SHA pin), so a comment mentioning the action or a
+// sibling step's `with:` block is never mistaken for the gate.
+const findReactDoctorStep = (
+  doc: YAML.Document.Parsed,
+): { step: YAML.YAMLMap; withMap: YAML.YAMLMap | null } | null => {
+  const jobs = doc.get("jobs");
+  if (!YAML.isMap(jobs)) return null;
+  for (const jobPair of jobs.items) {
+    const job = jobPair.value;
+    if (!YAML.isMap(job)) continue;
+    const steps = job.get("steps");
+    if (!YAML.isSeq(steps)) continue;
+    for (const step of steps.items) {
+      if (!YAML.isMap(step)) continue;
+      const uses = step.get("uses");
+      if (typeof uses === "string" && uses.startsWith(ACTION_REF_PREFIX)) {
+        const withNode = step.get("with");
+        return { step, withMap: YAML.isMap(withNode) ? withNode : null };
+      }
+    }
+  }
+  return null;
+};
+
+// Per-level indentation the file uses, so a `yaml` re-stringify matches a
+// consistently-indented workflow instead of forcing the 2-space default.
+const detectIndent = (content: string): number => {
+  for (const line of content.split(/\r?\n/)) {
+    const match = line.match(/^( +)\S/);
+    if (match) return Math.max(2, match[1].length);
+  }
+  return 2;
+};
 
 const buildGateLines = (gate: CiGate): ReadonlyArray<string> => {
   const lines: string[] = [];
@@ -120,84 +165,94 @@ const parseBoolean = (raw: string, fallback: boolean): boolean => {
   return fallback;
 };
 
-// Strips an inline `# comment` and any matching surrounding quotes, so a
-// hand-written `blocking: "error"` reads the same as the bare `blocking: error`
-// React Doctor generates.
-const parseScalar = (raw: string): string =>
-  raw
-    .replace(/\s*#.*$/, "")
-    .trim()
-    .replace(/^(["'])(.*)\1$/, "$2");
-
-// Reads the `with:` mapping React Doctor's own step currently applies. The
-// search is anchored to the step's `- uses: millionco/react-doctor@…` line —
-// requiring the `- uses:` prefix, not just the ref, so a comment mentioning the
-// action (or a preceding step's `with:` block, e.g. actions/setup-node) is
-// never mistaken for the gate. A step with no active `with:` reports the
+// Reads the `with:` mapping React Doctor's own step currently applies, via the
+// YAML AST so comments, a preceding step's `with:`, and quoted scalars can't
+// fool it. A step with no active `with:` (or an unparseable file) reports the
 // action's own defaults, so the gate the user sees in `ci config` matches what
 // a scan actually does.
 const parseGate = (content: string): CiGate => {
-  const lines = content.split(/\r?\n/);
-  const stepIndex = lines.findIndex((line) =>
-    /^\s*-\s*uses:\s*millionco\/react-doctor@/.test(line),
-  );
-  if (stepIndex === -1) return ADVISORY_GATE;
-
-  // The active `with:` for this step (a leading `#` rules out the commented
-  // example the advisory template ships); stop at the next step.
-  let withLineIndex = -1;
-  for (let lineIndex = stepIndex + 1; lineIndex < lines.length; lineIndex += 1) {
-    const line = lines[lineIndex];
-    if (line.trim() === "") continue;
-    if (/^\s*-\s/.test(line)) break;
-    if (/^\s*with:\s*$/.test(line)) {
-      withLineIndex = lineIndex;
-      break;
-    }
+  let withMap: YAML.YAMLMap | null;
+  try {
+    withMap = findReactDoctorStep(YAML.parseDocument(content))?.withMap ?? null;
+  } catch {
+    return ADVISORY_GATE;
   }
-  if (withLineIndex === -1) return ADVISORY_GATE;
+  if (withMap === null) return ADVISORY_GATE;
 
-  const entries = new Map<string, string>();
-  for (const line of lines.slice(withLineIndex + 1)) {
-    if (line.trim() === "") continue;
-    const keyValue = line.match(/^\s+([\w-]+):\s*(.+?)\s*$/);
-    if (!keyValue) break;
-    entries.set(keyValue[1], parseScalar(keyValue[2]));
-  }
-
-  const blockingRaw = entries.get(ACTION_INPUT_NAME.blocking);
-  const scopeRaw = entries.get(ACTION_INPUT_NAME.scope);
+  const readInput = (input: string): string | undefined => {
+    const value = withMap.get(input);
+    return value === undefined || value === null ? undefined : String(value);
+  };
+  const blockingRaw = readInput(ACTION_INPUT_NAME.blocking);
+  const scopeRaw = readInput(ACTION_INPUT_NAME.scope);
   return {
     blocking:
       blockingRaw && isValidBlockingLevel(blockingRaw) ? blockingRaw : ADVISORY_GATE.blocking,
     scope: scopeRaw && isScopeValue(scopeRaw) ? scopeRaw : ADVISORY_GATE.scope,
-    comment: parseBoolean(entries.get(ACTION_INPUT_NAME.comment) ?? "", ADVISORY_GATE.comment),
+    comment: parseBoolean(readInput(ACTION_INPUT_NAME.comment) ?? "", ADVISORY_GATE.comment),
     reviewComments: parseBoolean(
-      entries.get(ACTION_INPUT_NAME.reviewComments) ?? "",
+      readInput(ACTION_INPUT_NAME.reviewComments) ?? "",
       ADVISORY_GATE.reviewComments,
     ),
     commitStatus: parseBoolean(
-      entries.get(ACTION_INPUT_NAME.commitStatus) ?? "",
+      readInput(ACTION_INPUT_NAME.commitStatus) ?? "",
       ADVISORY_GATE.commitStatus,
     ),
   };
 };
 
-// Rewrites the gate only when the file on disk is still exactly what React
-// Doctor generates for its current gate (reconstructed from the parsed gate +
-// the file's own branch and ref). That guarantees a hand-customized workflow is
-// never silently overwritten: the caller falls back to printing the snippet.
+// Surgically edits React Doctor's step `with:` mapping in place, setting the
+// keys that deviate from the advisory defaults and deleting those that return
+// to a default (so the block stays minimal and round-trips). Comments, the
+// action ref, and the step's other inputs (directory / project / node-version /
+// version) are preserved by the YAML AST. An empty `with:` is removed entirely.
+// Returns null when the file doesn't parse or has no React Doctor step.
+const surgicalApplyGate = (content: string, gate: CiGate): CiEditResult | null => {
+  let doc: YAML.Document.Parsed;
+  try {
+    doc = YAML.parseDocument(content);
+  } catch {
+    return null;
+  }
+  const located = findReactDoctorStep(doc);
+  if (located === null) return null;
+
+  let withMap = located.withMap;
+  if (withMap === null) {
+    withMap = new YAML.YAMLMap();
+    located.step.set("with", withMap);
+  }
+  for (const [field, input] of MANAGED_INPUTS) {
+    if (gate[field] === ADVISORY_GATE[field]) {
+      withMap.delete(input);
+    } else {
+      withMap.set(input, gate[field]);
+    }
+  }
+  if (withMap.items.length === 0) located.step.delete("with");
+
+  const next = doc.toString({ flowCollectionPadding: false, indent: detectIndent(content) });
+  return { content: next, changed: next !== content };
+};
+
+// Two paths: a pristine scaffold is rebuilt from the template (the cleanest
+// diff, and it restores the commented advisory block when graduating back to
+// advisory); any other workflow that contains the React Doctor step is edited
+// surgically in place. Only a file with no React Doctor step (or unparseable
+// YAML) is refused — the caller then prints the snippet.
 const applyGate = (content: string, gate: CiGate): CiEditResult | null => {
   const defaultBranch = extractDefaultBranch(content) ?? "main";
   const actionRef = extractActionRef(content) ?? "v2";
   const currentGate = parseGate(content);
   const canonical = buildGithubWorkflow(defaultBranch, currentGate, actionRef);
-  if (normalizeWorkflowContent(canonical) !== normalizeWorkflowContent(content)) return null;
-  const next = buildGithubWorkflow(defaultBranch, gate, actionRef);
-  return {
-    content: next,
-    changed: normalizeWorkflowContent(next) !== normalizeWorkflowContent(content),
-  };
+  if (normalizeWorkflowContent(canonical) === normalizeWorkflowContent(content)) {
+    const next = buildGithubWorkflow(defaultBranch, gate, actionRef);
+    return {
+      content: next,
+      changed: normalizeWorkflowContent(next) !== normalizeWorkflowContent(content),
+    };
+  }
+  return surgicalApplyGate(content, gate);
 };
 
 const renderSnippet = (gate: CiGate): string => {

--- a/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
@@ -10,7 +10,6 @@ import {
   type CiScaffoldResult,
   type CiWorkflowFile,
 } from "./ci-provider.js";
-import { normalizeWorkflowContent } from "./normalize-workflow-content.js";
 
 const GITLAB_CONFIG_FILENAME = ".gitlab-ci.yml";
 
@@ -75,17 +74,38 @@ const parseGate = (content: string): CiGate => {
   };
 };
 
-// Edits the gate only when the file is still exactly the React Doctor scaffold
-// (reconstructed from its own parsed gate). A user who folded the job into a
-// larger pipeline gets the paste snippet instead of an overwrite.
+const BASE_FLAG = ' --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"';
+
+// Splices the gate flags on React Doctor's own scan line in place — preserving
+// every other line and job, so a scan job folded into a larger pipeline edits
+// cleanly. Only `--blocking` / `--scope` values change; the canonical `--base`
+// is dropped/re-added per scope (a user's custom `--base` is left alone), and a
+// trailing comment is kept. Returns null when there's no scan line to edit.
 const applyGate = (content: string, gate: CiGate): CiEditResult | null => {
-  const canonical = buildGitlabConfig(parseGate(content));
-  if (normalizeWorkflowContent(canonical) !== normalizeWorkflowContent(content)) return null;
-  const next = buildGitlabConfig(gate);
-  return {
-    content: next,
-    changed: normalizeWorkflowContent(next) !== normalizeWorkflowContent(content),
-  };
+  const newline = content.includes("\r\n") ? "\r\n" : "\n";
+  const lines = content.split(/\r?\n/);
+  const index = lines.findIndex(
+    (line) =>
+      /^\s*-\s/.test(line) && /react-doctor/.test(line) && /--(blocking|scope)\b/.test(line),
+  );
+  if (index === -1) return null;
+
+  // Edit only the command, re-attaching any trailing `# comment` verbatim.
+  const commentMatch = lines[index].match(/\s+#.*$/);
+  const comment = commentMatch ? commentMatch[0] : "";
+  let command = comment
+    ? lines[index].slice(0, lines[index].length - comment.length)
+    : lines[index];
+
+  command = command
+    .replace(/--blocking[ =]\S+/, `--blocking ${gate.blocking}`)
+    .replace(/--scope[ =]\S+/, `--scope ${gate.scope}`)
+    .replace(/\s*--base[ =]"\$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"/, "");
+  if (gate.scope !== "full" && !/--base\b/.test(command)) command = `${command}${BASE_FLAG}`;
+
+  lines[index] = `${command}${comment}`;
+  const next = lines.join(newline);
+  return { content: next, changed: next !== content };
 };
 
 // Never overwrites an existing `.gitlab-ci.yml`: most repos already have one

--- a/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
@@ -1,0 +1,115 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { isValidBlockingLevel } from "../resolve-blocking-level.js";
+import { isScopeValue } from "../resolve-scope.js";
+import {
+  ADVISORY_GATE,
+  type CiEditResult,
+  type CiGate,
+  type CiProvider,
+  type CiScaffoldResult,
+  type CiWorkflowFile,
+} from "./ci-provider.js";
+import { normalizeWorkflowContent } from "./normalize-workflow-content.js";
+
+const GITLAB_CONFIG_FILENAME = ".gitlab-ci.yml";
+
+const getGitlabConfigPath = (projectRoot: string): string =>
+  path.join(projectRoot, GITLAB_CONFIG_FILENAME);
+
+// A diff-based scope needs a base to compare against; on a merge-request
+// pipeline GitLab exposes the target branch as `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME`.
+// A whole-project scan ("full") ignores the base, so it's left off.
+const buildScanCommand = (gate: CiGate): string => {
+  const baseFlag = gate.scope === "full" ? "" : ' --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"';
+  return `npx react-doctor@latest --blocking ${gate.blocking} --scope ${gate.scope}${baseFlag}`;
+};
+
+// A single GitLab CI job that scans every merge request. GitLab has no React
+// Doctor comment or commit-status reporter yet, so the scaffold is gate-only:
+// it sets the pass/fail behavior and reports findings in the job log. Push
+// pipelines on the default branch are left out because a diff scope has no
+// merge-request target to compare against there.
+const buildGitlabConfig = (
+  gate: CiGate,
+): string => `# React Doctor: security, performance, correctness, accessibility, bundle-size,
+# and architecture checks for React.
+#
+# These settings were written by \`react-doctor ci config\`. Run it again to change them.
+# Docs: https://www.react.doctor/ci
+
+react-doctor:
+  image: node:lts
+  script:
+    - ${buildScanCommand(gate)}
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+`;
+
+// GitLab keeps its gate in the scan command's flags rather than a mapping, so
+// the parser reads `--blocking` / `--scope` straight off the `npx` line. The
+// `['"]?` tolerates a hand-quoted value (`--blocking "error"`).
+const parseGate = (content: string): CiGate => {
+  const blockingMatch = content.match(/--blocking[ =]['"]?([\w-]+)/);
+  const scopeMatch = content.match(/--scope[ =]['"]?([\w-]+)/);
+  const blocking =
+    blockingMatch && isValidBlockingLevel(blockingMatch[1]) ? blockingMatch[1] : null;
+  const scope = scopeMatch && isScopeValue(scopeMatch[1]) ? scopeMatch[1] : null;
+  return {
+    ...ADVISORY_GATE,
+    blocking: blocking ?? ADVISORY_GATE.blocking,
+    scope: scope ?? ADVISORY_GATE.scope,
+  };
+};
+
+// Edits the gate only when the file is still exactly the React Doctor scaffold
+// (reconstructed from its own parsed gate). A user who folded the job into a
+// larger pipeline gets the paste snippet instead of an overwrite.
+const applyGate = (content: string, gate: CiGate): CiEditResult | null => {
+  const canonical = buildGitlabConfig(parseGate(content));
+  if (normalizeWorkflowContent(canonical) !== normalizeWorkflowContent(content)) return null;
+  const next = buildGitlabConfig(gate);
+  return {
+    content: next,
+    changed: normalizeWorkflowContent(next) !== normalizeWorkflowContent(content),
+  };
+};
+
+// Never overwrites an existing `.gitlab-ci.yml`: most repos already have one
+// with unrelated jobs, so an existing file reports "exists" and the caller
+// prints the job to paste in.
+const scaffold = (projectRoot: string, _defaultBranch: string, gate: CiGate): CiScaffoldResult => {
+  const configPath = getGitlabConfigPath(projectRoot);
+  if (fs.existsSync(configPath)) return { status: "exists", path: configPath };
+  try {
+    fs.writeFileSync(configPath, buildGitlabConfig(gate));
+    return { status: "created", path: configPath };
+  } catch {
+    return { status: "failed", path: configPath };
+  }
+};
+
+const readWorkflow = (projectRoot: string): CiWorkflowFile | null => {
+  const configPath = getGitlabConfigPath(projectRoot);
+  try {
+    return { path: configPath, content: fs.readFileSync(configPath, "utf8") };
+  } catch {
+    return null;
+  }
+};
+
+const renderSnippet = (gate: CiGate): string => buildGitlabConfig(gate).trimEnd();
+
+export const gitlabCiProvider: CiProvider = {
+  id: "gitlab-ci",
+  displayName: "GitLab CI/CD",
+  fileLabel: GITLAB_CONFIG_FILENAME,
+  supportedGateKeys: ["blocking", "scope"],
+  supportsPullRequest: false,
+  workflowPath: getGitlabConfigPath,
+  readWorkflow,
+  scaffold,
+  parseGate,
+  applyGate,
+  renderSnippet,
+};

--- a/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
@@ -21,14 +21,20 @@ const getGitlabConfigPath = (projectRoot: string): string =>
 // scan ("full") ignores the base, so it's left off.
 const BASE_FLAG = ' --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"';
 
-// React Doctor's scan command RUNS the tool, as a YAML sequence item: via a
-// runner (`npx` / `pnpm dlx` / `yarn dlx` / `bunx`) or a bare `react-doctor`
-// command. Matching the run (not a mere `react-doctor@` mention) keeps an
-// `- npm install react-doctor@latest` step, a comment, or another job's command
-// from being mistaken for the scan line.
-const isScanLine = (line: string): boolean =>
-  /^\s*-\s/.test(line) &&
-  (/(?:npx|dlx|bunx)\s+react-doctor\b/.test(line) || /^\s*-\s+react-doctor\b/.test(line));
+// True when `line` RUNS React Doctor — via a runner (`npx` / `pnpm dlx` /
+// `yarn dlx` / `bunx`) or a bare `react-doctor` command. The leading `- `
+// sequence marker is optional, so a command inside a multiline `script: - |`
+// block scalar is matched too; a leading `#` (comment) and an
+// `npm install react-doctor` step are excluded because the run must be the
+// first token.
+const isScanLine = (line: string): boolean => {
+  const command = line.replace(/^\s*-?\s*/, "");
+  if (command.startsWith("#")) return false;
+  // `react-doctor` followed by `@`, whitespace, or end — the run. The trailing
+  // class excludes the YAML job key `react-doctor:` and names like
+  // `react-doctor-setup`.
+  return /^(?:(?:npx|bunx|dlx|(?:pnpm|yarn)\s+dlx)\s+)?react-doctor(?:@|\s|$)/.test(command);
+};
 
 const stripTrailingComment = (line: string): string => line.replace(/\s+#.*$/, "");
 

--- a/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
@@ -52,10 +52,17 @@ react-doctor:
 // `--scope` can't be mistaken for the gate. The `['"]?` tolerates a hand-quoted
 // value (`--blocking "error"`).
 const parseGate = (content: string): CiGate => {
-  const scanLine =
+  // The scan command is a YAML sequence item (`- npx react-doctor@latest …`);
+  // requiring the `- ` prefix and stripping any trailing `# comment` keeps a
+  // comment line (or an inline note) from being read as the gate.
+  const scanLine = (
     content
       .split(/\r?\n/)
-      .find((line) => /react-doctor/.test(line) && /--(blocking|scope)\b/.test(line)) ?? "";
+      .find(
+        (line) =>
+          /^\s*-\s/.test(line) && /react-doctor/.test(line) && /--(blocking|scope)\b/.test(line),
+      ) ?? ""
+  ).replace(/#.*$/, "");
   const blockingMatch = scanLine.match(/--blocking[ =]['"]?([\w-]+)/);
   const scopeMatch = scanLine.match(/--scope[ =]['"]?([\w-]+)/);
   const blocking =

--- a/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
@@ -46,12 +46,18 @@ react-doctor:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 `;
 
-// GitLab keeps its gate in the scan command's flags rather than a mapping, so
-// the parser reads `--blocking` / `--scope` straight off the `npx` line. The
-// `['"]?` tolerates a hand-quoted value (`--blocking "error"`).
+// GitLab keeps its gate in the scan command's flags rather than a mapping. The
+// flags are read off React Doctor's own scan line, not file-wide, so a merged
+// pipeline that runs other jobs (or tools) with their own `--blocking` /
+// `--scope` can't be mistaken for the gate. The `['"]?` tolerates a hand-quoted
+// value (`--blocking "error"`).
 const parseGate = (content: string): CiGate => {
-  const blockingMatch = content.match(/--blocking[ =]['"]?([\w-]+)/);
-  const scopeMatch = content.match(/--scope[ =]['"]?([\w-]+)/);
+  const scanLine =
+    content
+      .split(/\r?\n/)
+      .find((line) => /react-doctor/.test(line) && /--(blocking|scope)\b/.test(line)) ?? "";
+  const blockingMatch = scanLine.match(/--blocking[ =]['"]?([\w-]+)/);
+  const scopeMatch = scanLine.match(/--scope[ =]['"]?([\w-]+)/);
   const blocking =
     blockingMatch && isValidBlockingLevel(blockingMatch[1]) ? blockingMatch[1] : null;
   const scope = scopeMatch && isScopeValue(scopeMatch[1]) ? scopeMatch[1] : null;

--- a/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
@@ -17,12 +17,20 @@ const getGitlabConfigPath = (projectRoot: string): string =>
   path.join(projectRoot, GITLAB_CONFIG_FILENAME);
 
 // A diff-based scope needs a base to compare against; on a merge-request
-// pipeline GitLab exposes the target branch as `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME`.
-// A whole-project scan ("full") ignores the base, so it's left off.
-const buildScanCommand = (gate: CiGate): string => {
-  const baseFlag = gate.scope === "full" ? "" : ' --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"';
-  return `npx react-doctor@latest --blocking ${gate.blocking} --scope ${gate.scope}${baseFlag}`;
-};
+// pipeline GitLab exposes the target branch as this variable. A whole-project
+// scan ("full") ignores the base, so it's left off.
+const BASE_FLAG = ' --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"';
+
+// React Doctor's scan command is a YAML sequence item that invokes the npx
+// package spec (`- npx react-doctor@latest …`). The `react-doctor@` anchor
+// matches it with or without gate flags, and the `- ` prefix excludes comment
+// lines and other jobs' commands.
+const isScanLine = (line: string): boolean => /^\s*-\s/.test(line) && /react-doctor@/.test(line);
+
+const stripTrailingComment = (line: string): string => line.replace(/\s+#.*$/, "");
+
+const buildScanCommand = (gate: CiGate): string =>
+  `npx react-doctor@latest --blocking ${gate.blocking} --scope ${gate.scope}${gate.scope === "full" ? "" : BASE_FLAG}`;
 
 // A single GitLab CI job that scans every merge request. GitLab has no React
 // Doctor comment or commit-status reporter yet, so the scaffold is gate-only:
@@ -46,24 +54,13 @@ react-doctor:
 `;
 
 // GitLab keeps its gate in the scan command's flags rather than a mapping. The
-// flags are read off React Doctor's own scan line, not file-wide, so a merged
-// pipeline that runs other jobs (or tools) with their own `--blocking` /
-// `--scope` can't be mistaken for the gate. The `['"]?` tolerates a hand-quoted
-// value (`--blocking "error"`).
+// flags are read off React Doctor's own scan line (with any trailing comment
+// stripped), so a comment or another job can't be mistaken for the gate. The
+// `['"]?` tolerates a hand-quoted value (`--blocking "error"`).
 const parseGate = (content: string): CiGate => {
-  // The scan command is a YAML sequence item (`- npx react-doctor@latest …`);
-  // requiring the `- ` prefix and stripping any trailing `# comment` keeps a
-  // comment line (or an inline note) from being read as the gate.
-  const scanLine = (
-    content
-      .split(/\r?\n/)
-      .find(
-        (line) =>
-          /^\s*-\s/.test(line) && /react-doctor/.test(line) && /--(blocking|scope)\b/.test(line),
-      ) ?? ""
-  ).replace(/#.*$/, "");
-  const blockingMatch = scanLine.match(/--blocking[ =]['"]?([\w-]+)/);
-  const scopeMatch = scanLine.match(/--scope[ =]['"]?([\w-]+)/);
+  const command = stripTrailingComment(content.split(/\r?\n/).find(isScanLine) ?? "");
+  const blockingMatch = command.match(/--blocking[ =]['"]?([\w-]+)/);
+  const scopeMatch = command.match(/--scope[ =]['"]?([\w-]+)/);
   const blocking =
     blockingMatch && isValidBlockingLevel(blockingMatch[1]) ? blockingMatch[1] : null;
   const scope = scopeMatch && isScopeValue(scopeMatch[1]) ? scopeMatch[1] : null;
@@ -74,33 +71,38 @@ const parseGate = (content: string): CiGate => {
   };
 };
 
-const BASE_FLAG = ' --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"';
+const containsReactDoctor = (content: string): boolean => content.split(/\r?\n/).some(isScanLine);
+
+// Replaces a flag's value in place, or appends the flag when it isn't present,
+// so a requested change always lands even if the user had removed the flag.
+const upsertFlag = (command: string, flag: string, value: string): string => {
+  const pattern = new RegExp(`(--${flag})[ =]\\S+`);
+  return pattern.test(command)
+    ? command.replace(pattern, `$1 ${value}`)
+    : `${command} --${flag} ${value}`;
+};
 
 // Splices the gate flags on React Doctor's own scan line in place — preserving
 // every other line and job, so a scan job folded into a larger pipeline edits
-// cleanly. Only `--blocking` / `--scope` values change; the canonical `--base`
-// is dropped/re-added per scope (a user's custom `--base` is left alone), and a
-// trailing comment is kept. Returns null when there's no scan line to edit.
+// cleanly. `--blocking` / `--scope` are set (added if missing); the canonical
+// `--base` is dropped/re-added per scope (a user's custom `--base` is left
+// alone), and a trailing comment is kept. Returns null when there's no scan
+// line to edit (the caller then prints the snippet).
 const applyGate = (content: string, gate: CiGate): CiEditResult | null => {
   const newline = content.includes("\r\n") ? "\r\n" : "\n";
   const lines = content.split(/\r?\n/);
-  const index = lines.findIndex(
-    (line) =>
-      /^\s*-\s/.test(line) && /react-doctor/.test(line) && /--(blocking|scope)\b/.test(line),
-  );
+  const index = lines.findIndex(isScanLine);
   if (index === -1) return null;
 
-  // Edit only the command, re-attaching any trailing `# comment` verbatim.
   const commentMatch = lines[index].match(/\s+#.*$/);
   const comment = commentMatch ? commentMatch[0] : "";
   let command = comment
     ? lines[index].slice(0, lines[index].length - comment.length)
     : lines[index];
 
-  command = command
-    .replace(/--blocking[ =]\S+/, `--blocking ${gate.blocking}`)
-    .replace(/--scope[ =]\S+/, `--scope ${gate.scope}`)
-    .replace(/\s*--base[ =]"\$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"/, "");
+  command = upsertFlag(command, "blocking", gate.blocking);
+  command = upsertFlag(command, "scope", gate.scope);
+  command = command.replace(/\s*--base[ =]"\$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"/, "");
   if (gate.scope !== "full" && !/--base\b/.test(command)) command = `${command}${BASE_FLAG}`;
 
   lines[index] = `${command}${comment}`;
@@ -141,6 +143,7 @@ export const gitlabCiProvider: CiProvider = {
   supportsPullRequest: false,
   workflowPath: getGitlabConfigPath,
   readWorkflow,
+  containsReactDoctor,
   scaffold,
   parseGate,
   applyGate,

--- a/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/gitlab-ci-provider.ts
@@ -21,11 +21,14 @@ const getGitlabConfigPath = (projectRoot: string): string =>
 // scan ("full") ignores the base, so it's left off.
 const BASE_FLAG = ' --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"';
 
-// React Doctor's scan command is a YAML sequence item that invokes the npx
-// package spec (`- npx react-doctor@latest …`). The `react-doctor@` anchor
-// matches it with or without gate flags, and the `- ` prefix excludes comment
-// lines and other jobs' commands.
-const isScanLine = (line: string): boolean => /^\s*-\s/.test(line) && /react-doctor@/.test(line);
+// React Doctor's scan command RUNS the tool, as a YAML sequence item: via a
+// runner (`npx` / `pnpm dlx` / `yarn dlx` / `bunx`) or a bare `react-doctor`
+// command. Matching the run (not a mere `react-doctor@` mention) keeps an
+// `- npm install react-doctor@latest` step, a comment, or another job's command
+// from being mistaken for the scan line.
+const isScanLine = (line: string): boolean =>
+  /^\s*-\s/.test(line) &&
+  (/(?:npx|dlx|bunx)\s+react-doctor\b/.test(line) || /^\s*-\s+react-doctor\b/.test(line));
 
 const stripTrailingComment = (line: string): string => line.replace(/\s+#.*$/, "");
 

--- a/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
+++ b/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
@@ -299,7 +299,9 @@ export const runCiInstall = async (options: CiCommandOptions = {}): Promise<void
   }
 
   if (result.status === "exists") {
-    scaffoldSpinner.succeed(`${provider.fileLabel} already exists.`);
+    scaffoldSpinner.succeed(
+      `${path.relative(projectRoot, result.path)} already configured React Doctor.`,
+    );
     if (provider.id === "github-actions") {
       // The file is left untouched, so any gate flags weren't applied — say so
       // and point at the command that does edit an existing workflow.

--- a/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
+++ b/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
@@ -366,7 +366,12 @@ export const runCiUpgrade = async (options: CiCommandOptions = {}): Promise<void
 
   const edit = provider.upgradeMajor(workflow.content);
   if (!edit.changed) {
-    logger.success(`Your workflow already uses the current major (${highlighter.info("@v2")}).`);
+    // Nothing was rewritten: the workflow either already uses the current
+    // floating major or pins a specific version/SHA we shouldn't bump. Don't
+    // claim it's on `@v2` when it might be deliberately pinned elsewhere.
+    logger.success(
+      `Nothing to upgrade: your workflow doesn't use the floating ${highlighter.info("@v1")} ref.`,
+    );
     return;
   }
 

--- a/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
+++ b/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
@@ -426,6 +426,16 @@ export const runCiConfig = async (options: CiCommandOptions = {}): Promise<void>
     return;
   }
 
+  // The file can exist without wiring up React Doctor (a `.gitlab-ci.yml` is
+  // often a full pipeline with no scan job); say so plainly instead of treating
+  // its absent gate as advisory and offering an edit that can't land.
+  if (!provider.containsReactDoctor(workflow.content)) {
+    logger.error(`${path.relative(projectRoot, workflow.path)} has no React Doctor job.`);
+    logger.dim(`  Run ${highlighter.info("react-doctor ci install")} to add one first.`);
+    process.exitCode = 1;
+    return;
+  }
+
   warnUnsupportedGateFlags(provider, options);
   const currentGate = provider.parseGate(workflow.content);
 

--- a/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
+++ b/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
@@ -1,0 +1,492 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { CI_URL, GITHUB_ACTIONS_SETUP_URL, highlighter } from "@react-doctor/core";
+import { cliLogger as logger } from "../cli-logger.js";
+import { METRIC } from "../constants.js";
+import { detectDefaultBranch } from "../detect-default-branch.js";
+import { findNearestPackageDirectory } from "../install-doctor-script.js";
+import {
+  openWorkflowPullRequest,
+  stageWorkflowFile,
+  type OpenWorkflowPullRequestResult,
+} from "../open-workflow-pull-request.js";
+import { prompts } from "../prompts.js";
+import { recordCount } from "../record-metric.js";
+import { runCommand, type CommandRunner } from "../run-command.js";
+import { shouldSkipPrompts } from "../should-skip-prompts.js";
+import { spinner } from "../spinner.js";
+import {
+  ADVISORY_GATE,
+  BLOCKING_CHOICES,
+  SCOPE_CHOICES,
+  TOGGLE_INFO,
+  gatesEqual,
+  summarizeGate,
+  type CiGate,
+  type CiProvider,
+} from "./ci-provider.js";
+import { CI_PROVIDERS, getCiProvider, isCiProviderId } from "./ci-provider-registry.js";
+import { detectCiProvider } from "./detect-ci-provider.js";
+import { githubActionsProvider } from "./github-actions-provider.js";
+import { applyGateFlags, hasAnyGateFlag } from "./resolve-ci-gate.js";
+import type { MetricAttributes } from "../record-metric.js";
+
+// Shared shape for `ci install` / `ci upgrade` / `ci config`. The gate flags
+// are optional on every command: `ci install` bakes them into a fresh file,
+// `ci config` edits an existing one, and `ci upgrade` ignores them.
+export interface CiCommandOptions {
+  cwd?: string;
+  yes?: boolean;
+  provider?: string;
+  pr?: boolean;
+  blocking?: string;
+  scope?: string;
+  comment?: boolean;
+  reviewComments?: boolean;
+  commitStatus?: boolean;
+  // Injectable for tests; production callers leave these unset.
+  prompt?: typeof prompts;
+  run?: CommandRunner;
+}
+
+const resolveProjectRoot = (options: CiCommandOptions): string => {
+  const requestedDirectory = path.resolve(options.cwd ?? process.cwd());
+  return findNearestPackageDirectory(requestedDirectory) ?? requestedDirectory;
+};
+
+const setupDocsUrl = (provider: CiProvider): string =>
+  provider.id === "github-actions" ? GITHUB_ACTIONS_SETUP_URL : CI_URL;
+
+// Resolves the CI backend: an explicit `--provider`, else autodetection, else a
+// prompt (or GitHub Actions when prompts are off). Returns null when the user
+// passed an unknown id (after reporting it) so the caller stops cleanly.
+const resolveProvider = async (
+  options: CiCommandOptions,
+  projectRoot: string,
+  prompt: typeof prompts,
+  skipPrompts: boolean,
+  run: CommandRunner,
+): Promise<CiProvider | null> => {
+  if (options.provider !== undefined) {
+    if (!isCiProviderId(options.provider)) {
+      logger.error(
+        `Unknown --provider "${options.provider}". Expected one of: ${CI_PROVIDERS.map((provider) => provider.id).join(", ")}.`,
+      );
+      process.exitCode = 1;
+      return null;
+    }
+    return getCiProvider(options.provider);
+  }
+
+  const detected = await detectCiProvider(projectRoot, run);
+  if (detected !== null) return getCiProvider(detected);
+
+  if (skipPrompts) {
+    logger.dim("No CI provider detected; using GitHub Actions. Pass --provider to choose.");
+    return githubActionsProvider;
+  }
+
+  const { providerId } = await prompt<"providerId">({
+    type: "select",
+    name: "providerId",
+    message: "Which CI provider does this repository use?",
+    hint: " ",
+    choices: CI_PROVIDERS.map((provider) => ({
+      title: provider.displayName,
+      value: provider.id,
+      description:
+        provider.id === "github-actions"
+          ? "Pass or fail the check, comment on pull requests, post the score"
+          : "Pass or fail the check on findings",
+    })),
+    initial: 0,
+  });
+  if (providerId === undefined || !isCiProviderId(providerId)) return null;
+  return getCiProvider(providerId);
+};
+
+// Flags a provider can't honor (e.g. `--comment` on GitLab) so the user isn't
+// left thinking a setting took effect when it was dropped.
+const warnUnsupportedGateFlags = (provider: CiProvider, options: CiCommandOptions): void => {
+  const unsupported: string[] = [];
+  if (options.comment !== undefined && !provider.supportedGateKeys.includes("comment")) {
+    unsupported.push("--comment");
+  }
+  if (
+    options.reviewComments !== undefined &&
+    !provider.supportedGateKeys.includes("reviewComments")
+  ) {
+    unsupported.push("--review-comments");
+  }
+  if (options.commitStatus !== undefined && !provider.supportedGateKeys.includes("commitStatus")) {
+    unsupported.push("--commit-status");
+  }
+  if (unsupported.length > 0) {
+    logger.warn(`${provider.displayName} doesn't support ${unsupported.join(", ")}; ignoring.`);
+  }
+};
+
+const printIndentedBlock = (block: string): void => {
+  for (const line of block.split("\n")) logger.dim(`    ${line}`);
+};
+
+// The plain-language recap printed after a scaffold or edit, so a user knows
+// what they just turned on without reading the YAML.
+const printGateSummary = (provider: CiProvider, gate: CiGate): void => {
+  logger.break();
+  logger.log("  React Doctor will now:");
+  for (const line of summarizeGate(gate, provider.supportedGateKeys)) {
+    logger.dim(`    • ${line}`);
+  }
+};
+
+const gateMetricAttributes = (provider: CiProvider, gate: CiGate): MetricAttributes => ({
+  blocking: gate.blocking,
+  scope: gate.scope,
+  comment: provider.supportedGateKeys.includes("comment") ? gate.comment : null,
+  reviewComments: provider.supportedGateKeys.includes("reviewComments")
+    ? gate.reviewComments
+    : null,
+  commitStatus: provider.supportedGateKeys.includes("commitStatus") ? gate.commitStatus : null,
+});
+
+const choiceIndex = <Value extends string>(
+  choices: ReadonlyArray<{ readonly value: Value }>,
+  value: Value,
+): number =>
+  Math.max(
+    0,
+    choices.findIndex((choice) => choice.value === value),
+  );
+
+// The interactive gate editor: one select for the gate level, one for scope,
+// and a multiselect for the reporting toggles the provider supports. Pre-fills
+// every field with the current value so a user changes only what they mean to.
+const promptForGate = async (
+  provider: CiProvider,
+  currentGate: CiGate,
+  prompt: typeof prompts,
+): Promise<CiGate | null> => {
+  const supported = provider.supportedGateKeys;
+  const supportedToggles = TOGGLE_INFO.filter((toggle) => supported.includes(toggle.key));
+
+  const answers = await prompt<"blocking" | "scope" | "toggles">([
+    {
+      type: "select",
+      name: "blocking",
+      message: "When a scan finds a new issue, what should happen?",
+      hint: " ",
+      choices: BLOCKING_CHOICES.map((choice) => ({
+        title: choice.title,
+        value: choice.value,
+        description: choice.description,
+      })),
+      initial: choiceIndex(BLOCKING_CHOICES, currentGate.blocking),
+    },
+    {
+      type: "select",
+      name: "scope",
+      message: "Which issues should a pull-request scan report?",
+      hint: " ",
+      choices: SCOPE_CHOICES.map((choice) => ({
+        title: choice.title,
+        value: choice.value,
+        description: choice.description,
+      })),
+      initial: choiceIndex(SCOPE_CHOICES, currentGate.scope),
+    },
+    ...(supportedToggles.length > 0
+      ? [
+          {
+            type: "multiselect" as const,
+            name: "toggles" as const,
+            message: "Pull request reporting (space to toggle, enter to confirm):",
+            instructions: false,
+            choices: supportedToggles.map((toggle) => ({
+              title: toggle.title,
+              value: toggle.key,
+              description: toggle.description,
+              selected: currentGate[toggle.key],
+            })),
+          },
+        ]
+      : []),
+  ]);
+
+  // A cancelled select yields `undefined`; bail without writing anything.
+  if (answers.blocking === undefined || answers.scope === undefined) return null;
+
+  const enabledToggles: ReadonlyArray<string> = answers.toggles ?? [];
+  const toggleValue = (key: (typeof TOGGLE_INFO)[number]["key"]): boolean =>
+    supported.includes(key) ? enabledToggles.includes(key) : currentGate[key];
+
+  return {
+    blocking: answers.blocking,
+    scope: answers.scope,
+    comment: toggleValue("comment"),
+    reviewComments: toggleValue("reviewComments"),
+    commitStatus: toggleValue("commitStatus"),
+  };
+};
+
+// Opens a pull request for an already-written file and reports the outcome on a
+// spinner, falling back to staging the file when a PR can't be opened (no `gh`,
+// not authenticated, dirty tree, …). Returns the mode for telemetry.
+const openCiPullRequest = async (params: {
+  workflowPath: string;
+  baseBranch: string;
+  commitMessage?: string;
+  prTitle?: string;
+  prBody?: string;
+}): Promise<"pr" | "tree"> => {
+  const pullRequestSpinner = spinner("Opening a pull request for review...").start();
+  const result: OpenWorkflowPullRequestResult = await openWorkflowPullRequest(params);
+  if (result.status === "pr-opened") {
+    pullRequestSpinner.succeed(`Opened pull request for review: ${highlighter.info(result.url)}`);
+    return "pr";
+  }
+  if (result.status === "pr-exists") {
+    pullRequestSpinner.succeed(
+      `A React Doctor pull request is already open: ${highlighter.info(result.url)}`,
+    );
+    return "pr";
+  }
+  if (result.status === "branch-pushed") {
+    pullRequestSpinner.warn(
+      `Pushed ${highlighter.bold(result.branch)} but couldn't open a PR. Open one with: gh pr create --head ${result.branch}`,
+    );
+    return "pr";
+  }
+  pullRequestSpinner.stop();
+  const didStage = await stageWorkflowFile({ workflowPath: params.workflowPath });
+  logger.dim(
+    didStage
+      ? "  Staged the change. Commit it to apply."
+      : "  Review and commit the change to apply it.",
+  );
+  return "tree";
+};
+
+export const runCiInstall = async (options: CiCommandOptions = {}): Promise<void> => {
+  const projectRoot = resolveProjectRoot(options);
+  const prompt = options.prompt ?? prompts;
+  const run = options.run ?? runCommand;
+  const skipPrompts = shouldSkipPrompts({ yes: options.yes });
+
+  const provider = await resolveProvider(options, projectRoot, prompt, skipPrompts, run);
+  if (provider === null) return;
+
+  warnUnsupportedGateFlags(provider, options);
+  const { gate, error } = applyGateFlags(ADVISORY_GATE, options);
+  if (error !== null) {
+    logger.error(error);
+    process.exitCode = 1;
+    return;
+  }
+
+  const defaultBranch =
+    provider.id === "github-actions"
+      ? ((await detectDefaultBranch(projectRoot, run)) ?? "main")
+      : "main";
+
+  const scaffoldSpinner = spinner(`Adding ${provider.displayName} workflow...`).start();
+  const result = provider.scaffold(projectRoot, defaultBranch, gate);
+
+  if (result.status === "failed") {
+    scaffoldSpinner.fail(`Couldn't write ${provider.fileLabel}.`);
+    logger.dim(`  Set it up by hand: ${highlighter.info(setupDocsUrl(provider))}`);
+    return;
+  }
+
+  if (result.status === "exists") {
+    scaffoldSpinner.succeed(`${provider.fileLabel} already exists.`);
+    if (provider.supportedGateKeys.includes("comment")) {
+      logger.dim(`  Change its settings with ${highlighter.info("react-doctor ci config")}.`);
+    } else {
+      logger.break();
+      logger.log("  Add this job to your existing config:");
+      printIndentedBlock(provider.renderSnippet(gate));
+    }
+    recordCount(METRIC.ciScaffolded, 1, {
+      provider: provider.id,
+      mode: "exists",
+      ...gateMetricAttributes(provider, gate),
+    });
+    return;
+  }
+
+  scaffoldSpinner.succeed(`Added ${provider.fileLabel}.`);
+
+  let mode: "pr" | "tree" = "tree";
+  if (provider.supportsPullRequest && options.pr) {
+    mode = await openCiPullRequest({ workflowPath: result.path, baseBranch: defaultBranch });
+  } else {
+    logger.dim("  Review and commit it to start scanning every pull request.");
+  }
+
+  printGateSummary(provider, gate);
+  logger.log(`  Learn more: ${highlighter.info(setupDocsUrl(provider))}`);
+
+  recordCount(METRIC.ciScaffolded, 1, {
+    provider: provider.id,
+    mode,
+    ...gateMetricAttributes(provider, gate),
+  });
+};
+
+export const runCiUpgrade = async (options: CiCommandOptions = {}): Promise<void> => {
+  const projectRoot = resolveProjectRoot(options);
+  const prompt = options.prompt ?? prompts;
+  const run = options.run ?? runCommand;
+  const skipPrompts = shouldSkipPrompts({ yes: options.yes });
+
+  const provider = await resolveProvider(options, projectRoot, prompt, skipPrompts, run);
+  if (provider === null) return;
+
+  const workflow = provider.readWorkflow(projectRoot);
+  if (workflow === null) {
+    logger.error(`No ${provider.displayName} workflow found.`);
+    logger.dim(`  Run ${highlighter.info("react-doctor ci install")} to add one first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (provider.upgradeMajor === undefined) {
+    logger.log(
+      `${provider.displayName} runs ${highlighter.info("npx react-doctor@latest")}, so it always uses the current release. Nothing to upgrade.`,
+    );
+    return;
+  }
+
+  const edit = provider.upgradeMajor(workflow.content);
+  if (!edit.changed) {
+    logger.success(`Your workflow already uses the current major (${highlighter.info("@v2")}).`);
+    return;
+  }
+
+  let mode: "pr" | "tree" = "tree";
+  const upgradeCopy = {
+    commitMessage: "ci: upgrade React Doctor action to v2",
+    prTitle: "Upgrade React Doctor action to v2",
+    prBody:
+      "Bumps the React Doctor GitHub Action to its current major (`@v2`).\n\nDocs: https://www.react.doctor/ci",
+  };
+
+  if (provider.supportsPullRequest && options.pr) {
+    try {
+      fs.writeFileSync(workflow.path, edit.content);
+    } catch {
+      logger.error(`Couldn't update ${path.relative(projectRoot, workflow.path)}.`);
+      process.exitCode = 1;
+      return;
+    }
+    mode = await openCiPullRequest({
+      workflowPath: workflow.path,
+      baseBranch: (await detectDefaultBranch(projectRoot, run)) ?? "main",
+      ...upgradeCopy,
+    });
+  } else {
+    const upgradeSpinner = spinner("Upgrading workflow to @v2...").start();
+    try {
+      fs.writeFileSync(workflow.path, edit.content);
+      upgradeSpinner.succeed(
+        `Upgraded to ${highlighter.info("@v2")} at ${path.relative(projectRoot, workflow.path)}.`,
+      );
+    } catch {
+      upgradeSpinner.fail(`Couldn't update ${path.relative(projectRoot, workflow.path)}.`);
+      process.exitCode = 1;
+      return;
+    }
+    logger.dim("  Review and commit the change.");
+  }
+
+  recordCount(METRIC.ciUpgraded, 1, { provider: provider.id, mode });
+};
+
+export const runCiConfig = async (options: CiCommandOptions = {}): Promise<void> => {
+  const projectRoot = resolveProjectRoot(options);
+  const prompt = options.prompt ?? prompts;
+  const run = options.run ?? runCommand;
+  const skipPrompts = shouldSkipPrompts({ yes: options.yes });
+
+  const provider = await resolveProvider(options, projectRoot, prompt, skipPrompts, run);
+  if (provider === null) return;
+
+  const workflow = provider.readWorkflow(projectRoot);
+  if (workflow === null) {
+    logger.error(`No ${provider.displayName} workflow found.`);
+    logger.dim(`  Run ${highlighter.info("react-doctor ci install")} to add one first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  warnUnsupportedGateFlags(provider, options);
+  const currentGate = provider.parseGate(workflow.content);
+
+  // Flags (or a non-interactive shell) apply exactly what was passed; otherwise
+  // the prompts walk the user through each setting, pre-filled with the current
+  // value.
+  let nextGate: CiGate;
+  if (hasAnyGateFlag(options)) {
+    const { gate, error } = applyGateFlags(currentGate, options);
+    if (error !== null) {
+      logger.error(error);
+      process.exitCode = 1;
+      return;
+    }
+    nextGate = gate;
+  } else if (skipPrompts) {
+    logger.log(`Current ${provider.displayName} settings:`);
+    for (const line of summarizeGate(currentGate, provider.supportedGateKeys)) {
+      logger.dim(`  • ${line}`);
+    }
+    logger.dim("  Pass --blocking, --scope, or a reporting flag to change them.");
+    return;
+  } else {
+    const promptedGate = await promptForGate(provider, currentGate, prompt);
+    if (promptedGate === null) return;
+    nextGate = promptedGate;
+  }
+
+  if (gatesEqual(nextGate, currentGate)) {
+    logger.log("No changes. Your settings already match.");
+    recordCount(METRIC.ciConfigured, 1, {
+      provider: provider.id,
+      applied: false,
+      ...gateMetricAttributes(provider, nextGate),
+    });
+    return;
+  }
+
+  const edit = provider.applyGate(workflow.content, nextGate);
+  if (edit === null) {
+    logger.warn(
+      `Couldn't edit ${path.relative(projectRoot, workflow.path)} automatically: it's been customized.`,
+    );
+    logger.dim("  Apply these settings by hand:");
+    printIndentedBlock(provider.renderSnippet(nextGate));
+    recordCount(METRIC.ciConfigured, 1, {
+      provider: provider.id,
+      applied: false,
+      ...gateMetricAttributes(provider, nextGate),
+    });
+    return;
+  }
+
+  const configSpinner = spinner(`Updating ${provider.fileLabel}...`).start();
+  try {
+    fs.writeFileSync(workflow.path, edit.content);
+    configSpinner.succeed(`Updated ${path.relative(projectRoot, workflow.path)}.`);
+  } catch {
+    configSpinner.fail(`Couldn't write ${path.relative(projectRoot, workflow.path)}.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  printGateSummary(provider, nextGate);
+  recordCount(METRIC.ciConfigured, 1, {
+    provider: provider.id,
+    applied: true,
+    ...gateMetricAttributes(provider, nextGate),
+  });
+};

--- a/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
+++ b/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
@@ -300,8 +300,14 @@ export const runCiInstall = async (options: CiCommandOptions = {}): Promise<void
 
   if (result.status === "exists") {
     scaffoldSpinner.succeed(`${provider.fileLabel} already exists.`);
-    if (provider.supportedGateKeys.includes("comment")) {
-      logger.dim(`  Change its settings with ${highlighter.info("react-doctor ci config")}.`);
+    if (provider.id === "github-actions") {
+      // The file is left untouched, so any gate flags weren't applied — say so
+      // and point at the command that does edit an existing workflow.
+      logger.dim(
+        hasAnyGateFlag(options)
+          ? `  Left unchanged, so those settings weren't applied. Set them with ${highlighter.info("react-doctor ci config")}.`
+          : `  Change its settings with ${highlighter.info("react-doctor ci config")}.`,
+      );
     } else {
       logger.break();
       logger.log("  Add this job to your existing config:");

--- a/packages/react-doctor/src/cli/utils/ci/normalize-workflow-content.ts
+++ b/packages/react-doctor/src/cli/utils/ci/normalize-workflow-content.ts
@@ -1,0 +1,9 @@
+// Trailing whitespace and a final newline don't change a workflow's meaning, so
+// the round-trip safety check (does the file still match what React Doctor
+// generates?) ignores them. Shared by both CI providers so the overwrite-safety
+// contract can't drift between GitHub Actions and GitLab CI.
+export const normalizeWorkflowContent = (content: string): string =>
+  content
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+$/gm, "")
+    .replace(/\n+$/, "");

--- a/packages/react-doctor/src/cli/utils/ci/resolve-ci-gate.ts
+++ b/packages/react-doctor/src/cli/utils/ci/resolve-ci-gate.ts
@@ -1,0 +1,66 @@
+import { isValidBlockingLevel } from "../resolve-blocking-level.js";
+import { isScopeValue } from "../resolve-scope.js";
+import { BLOCKING_CHOICES, SCOPE_CHOICES, type CiGate } from "./ci-provider.js";
+
+// The gate fields a command can set non-interactively. Commander leaves an
+// absent flag `undefined` and resolves `--comment` / `--no-comment` to a single
+// boolean, so an unset field means "leave the current value alone".
+export interface CiGateFlagInput {
+  readonly blocking?: string;
+  readonly scope?: string;
+  readonly comment?: boolean;
+  readonly reviewComments?: boolean;
+  readonly commitStatus?: boolean;
+}
+
+export interface CiGateFlagResult {
+  readonly gate: CiGate;
+  // A human-readable message when a flag carried an invalid value; the gate is
+  // unchanged in that case so the caller can report and stop.
+  readonly error: string | null;
+}
+
+const expectedValues = (choices: ReadonlyArray<{ readonly value: string }>): string =>
+  choices.map((choice) => choice.value).join(", ");
+
+// Layers the flags a user passed onto a base gate (the advisory default for
+// `ci install`, or the current on-disk gate for `ci config`), validating the
+// two enum fields against the same guards the scanner uses.
+export const applyGateFlags = (base: CiGate, flags: CiGateFlagInput): CiGateFlagResult => {
+  let next = base;
+
+  if (flags.blocking !== undefined) {
+    if (!isValidBlockingLevel(flags.blocking)) {
+      return {
+        gate: base,
+        error: `Invalid --blocking "${flags.blocking}". Expected one of: ${expectedValues(BLOCKING_CHOICES)}.`,
+      };
+    }
+    next = { ...next, blocking: flags.blocking };
+  }
+
+  if (flags.scope !== undefined) {
+    if (!isScopeValue(flags.scope)) {
+      return {
+        gate: base,
+        error: `Invalid --scope "${flags.scope}". Expected one of: ${expectedValues(SCOPE_CHOICES)}.`,
+      };
+    }
+    next = { ...next, scope: flags.scope };
+  }
+
+  if (flags.comment !== undefined) next = { ...next, comment: flags.comment };
+  if (flags.reviewComments !== undefined) next = { ...next, reviewComments: flags.reviewComments };
+  if (flags.commitStatus !== undefined) next = { ...next, commitStatus: flags.commitStatus };
+
+  return { gate: next, error: null };
+};
+
+// True when at least one gate flag was supplied, which puts `ci config` into
+// non-interactive mode (apply exactly what was passed, ask nothing).
+export const hasAnyGateFlag = (flags: CiGateFlagInput): boolean =>
+  flags.blocking !== undefined ||
+  flags.scope !== undefined ||
+  flags.comment !== undefined ||
+  flags.reviewComments !== undefined ||
+  flags.commitStatus !== undefined;

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -180,6 +180,13 @@ export const METRIC = {
   installWorkflow: "install.workflow",
   installAgentHooks: "install.agent_hooks",
   installDependency: "install.dependency",
+  // `react-doctor ci` management. `ci.scaffolded` counts a fresh workflow
+  // (mode: tree | pr | exists), `ci.upgraded` an action-major bump, and
+  // `ci.configured` a gate edit (applied: true|false). High-cardinality detail
+  // — provider, gate level, scope — rides the attributes, never the name.
+  ciScaffolded: "ci.scaffolded",
+  ciUpgraded: "ci.upgraded",
+  ciConfigured: "ci.configured",
   rulesChanged: "rules.changed",
   rulesQueried: "rules.queried",
   // Editor language server (`react-doctor experimental-lsp`). Each workspace

--- a/packages/react-doctor/src/cli/utils/install-github-workflow.ts
+++ b/packages/react-doctor/src/cli/utils/install-github-workflow.ts
@@ -17,8 +17,13 @@ export interface InstallGitHubWorkflowResult {
 // pinned to the floating major `@v2` (never `@main`, per the supply-chain
 // guidance in AGENTS.md): `@main` would run whatever HEAD points to with
 // `pull-requests: write` granted.
-const buildWorkflowContent = (
+// `actionRef` is the floating-major (or pin) the `uses:` line carries. It
+// defaults to the current major so fresh installs always pin `@v2`; the
+// `ci config` round-trip passes the ref it read back so editing a workflow's
+// gate never silently bumps its version across a major boundary.
+export const buildWorkflowContent = (
   defaultBranch: string,
+  actionRef: string = "v2",
 ): string => `# React Doctor — finds security, performance, correctness, accessibility,
 # bundle-size, and architecture issues in React codebases.
 #
@@ -52,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: millionco/react-doctor@v2
+      - uses: millionco/react-doctor@${actionRef}
         # Advisory by default: React Doctor reports findings on every PR — a
         # sticky summary comment, inline review comments, and a commit status
         # with the health score — but never fails the check, so it won't red-X

--- a/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
+++ b/packages/react-doctor/src/cli/utils/strip-unknown-cli-flags.ts
@@ -89,6 +89,30 @@ const RULES_FLAG_SPEC: CliFlagSpec = {
   shortOptionsWithRequiredValues: new Set(["-c"]),
 };
 
+// Union of every flag across the `ci` subcommands (install / config / upgrade).
+// The subcommand name is a non-flag token that passes through untouched; only
+// the options here need to survive the pre-parse strip so Commander can route
+// them to the right subcommand.
+const CI_FLAG_SPEC: CliFlagSpec = {
+  longOptionsWithoutValues: new Set([
+    "--color",
+    "--comment",
+    "--commit-status",
+    "--help",
+    "--no-color",
+    "--no-comment",
+    "--no-commit-status",
+    "--no-review-comments",
+    "--pr",
+    "--review-comments",
+    "--yes",
+  ]),
+  longOptionsWithRequiredValues: new Set(["--blocking", "--cwd", "--provider", "--scope"]),
+  longOptionsWithOptionalValues: new Set(),
+  shortOptionsWithoutValues: new Set(["-h", "-y"]),
+  shortOptionsWithRequiredValues: new Set(["-c"]),
+};
+
 // `why <file:line>` takes a positional location (passed through untouched) plus
 // the working-directory / project / color options.
 const WHY_FLAG_SPEC: CliFlagSpec = {
@@ -104,6 +128,7 @@ const COMMAND_FLAG_SPECS = new Map<string, CliFlagSpec>([
   ["setup", INSTALL_FLAG_SPEC],
   ["version", VERSION_FLAG_SPEC],
   ["rules", RULES_FLAG_SPEC],
+  ["ci", CI_FLAG_SPEC],
   ["why", WHY_FLAG_SPEC],
 ]);
 

--- a/packages/react-doctor/tests/ci-providers.test.ts
+++ b/packages/react-doctor/tests/ci-providers.test.ts
@@ -230,6 +230,30 @@ describe("githubActionsProvider scaffold", () => {
     githubActionsProvider.scaffold(project.root, "main", ADVISORY_GATE);
     expect(githubActionsProvider.scaffold(project.root, "main", ERROR_GATE).status).toBe("exists");
   });
+
+  it("finds and manages the action in a non-canonical workflow file", () => {
+    const workflowsDir = path.join(project.root, ".github", "workflows");
+    fs.mkdirSync(workflowsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workflowsDir, "ci.yml"),
+      [
+        "jobs:",
+        "  build:",
+        "    steps:",
+        "      - uses: millionco/react-doctor@v2",
+        "        with:",
+        "          blocking: error",
+        "",
+      ].join("\n"),
+    );
+    const found = githubActionsProvider.readWorkflow(project.root);
+    expect(found?.path.endsWith("ci.yml")).toBe(true);
+    expect(githubActionsProvider.parseGate(found?.content ?? "").blocking).toBe("error");
+    // `ci install` must not add a duplicate react-doctor.yml.
+    expect(githubActionsProvider.scaffold(project.root, "main", ADVISORY_GATE).status).toBe(
+      "exists",
+    );
+  });
 });
 
 describe("gitlabCiProvider", () => {
@@ -310,6 +334,21 @@ describe("gitlabCiProvider", () => {
     expect(edited?.content).toContain("- npm install react-doctor@latest");
     expect(edited?.content).toContain("--blocking error");
     expect(edited?.content).not.toContain("install react-doctor@latest --blocking");
+  });
+
+  it("handles a multiline block-scalar script", () => {
+    const block = [
+      "react-doctor:",
+      "  script:",
+      "    - |",
+      "      npx react-doctor@latest --blocking error --scope changed",
+      "",
+    ].join("\n");
+    expect(gitlabCiProvider.containsReactDoctor(block)).toBe(true);
+    expect(gitlabCiProvider.parseGate(block).blocking).toBe("error");
+    const edited = gitlabCiProvider.applyGate(block, { ...ADVISORY_GATE, blocking: "warning" });
+    expect(edited?.content).toContain("--blocking warning");
+    expect(edited?.content).toContain("- |");
   });
 
   it("reports whether a file wires up a React Doctor job", () => {

--- a/packages/react-doctor/tests/ci-providers.test.ts
+++ b/packages/react-doctor/tests/ci-providers.test.ts
@@ -297,6 +297,21 @@ describe("gitlabCiProvider", () => {
     expect(edited?.content).toContain("--scope full");
   });
 
+  it("ignores an install step and edits the real scan line", () => {
+    const withInstall = [
+      "react-doctor:",
+      "  script:",
+      "    - npm install react-doctor@latest",
+      "    - npx react-doctor@latest --blocking none --scope changed",
+      "",
+    ].join("\n");
+    expect(gitlabCiProvider.parseGate(withInstall)).toEqual(ADVISORY_GATE);
+    const edited = gitlabCiProvider.applyGate(withInstall, { ...ADVISORY_GATE, blocking: "error" });
+    expect(edited?.content).toContain("- npm install react-doctor@latest");
+    expect(edited?.content).toContain("--blocking error");
+    expect(edited?.content).not.toContain("install react-doctor@latest --blocking");
+  });
+
   it("reports whether a file wires up a React Doctor job", () => {
     const config = fs.readFileSync(
       gitlabCiProvider.scaffold(project.root, "main", ADVISORY_GATE).path,

--- a/packages/react-doctor/tests/ci-providers.test.ts
+++ b/packages/react-doctor/tests/ci-providers.test.ts
@@ -60,6 +60,22 @@ describe("githubActionsProvider gate parsing", () => {
     expect(githubActionsProvider.parseGate(workflow)).toEqual(ERROR_GATE);
   });
 
+  it("ignores a comment mentioning the action above the real step", () => {
+    const workflow = [
+      "jobs:",
+      "  ci:",
+      "    steps:",
+      "      # we run millionco/react-doctor@v2 on every PR",
+      "      - uses: actions/checkout@v5",
+      "      - uses: millionco/react-doctor@v2",
+      "        with:",
+      "          blocking: error",
+      "          scope: full",
+      "",
+    ].join("\n");
+    expect(githubActionsProvider.parseGate(workflow)).toEqual(ERROR_GATE);
+  });
+
   it("reads quoted scalar values like the bare forms", () => {
     const workflow = [
       "      - uses: millionco/react-doctor@v2",
@@ -180,6 +196,19 @@ describe("gitlabCiProvider", () => {
       "",
     ].join("\n");
     const gate = gitlabCiProvider.parseGate(merged);
+    expect(gate.blocking).toBe("error");
+    expect(gate.scope).toBe("changed");
+  });
+
+  it("ignores a comment line that mentions react-doctor and gate flags", () => {
+    const config = [
+      "# legacy: react-doctor --blocking warning --scope full",
+      "react-doctor:",
+      "  script:",
+      "    - npx react-doctor@latest --blocking error --scope changed",
+      "",
+    ].join("\n");
+    const gate = gitlabCiProvider.parseGate(config);
     expect(gate.blocking).toBe("error");
     expect(gate.scope).toBe("changed");
   });

--- a/packages/react-doctor/tests/ci-providers.test.ts
+++ b/packages/react-doctor/tests/ci-providers.test.ts
@@ -78,6 +78,9 @@ describe("githubActionsProvider gate parsing", () => {
 
   it("reads quoted scalar values like the bare forms", () => {
     const workflow = [
+      "jobs:",
+      "  ci:",
+      "    steps:",
       "      - uses: millionco/react-doctor@v2",
       "        with:",
       '          blocking: "error"',
@@ -105,9 +108,85 @@ describe("githubActionsProvider gate parsing", () => {
     expect(edited?.content).toContain("blocking: error");
   });
 
-  it("declines to edit a hand-customized workflow so it's never clobbered", () => {
-    const customized = `${buildWorkflowContent("main")}\n# a teammate added this line\n`;
-    expect(githubActionsProvider.applyGate(customized, ERROR_GATE)).toBeNull();
+  it("surgically edits a customized workflow, preserving everything else", () => {
+    const customized = [
+      "name: React Doctor",
+      "on:",
+      "  pull_request:",
+      "jobs:",
+      "  react-doctor:",
+      "    runs-on: ubuntu-latest",
+      "    steps:",
+      "      - uses: actions/checkout@v5",
+      "      - uses: millionco/react-doctor@v2 # pinned",
+      "        with:",
+      "          directory: apps/web",
+      "          node-version: 24",
+      "          blocking: none",
+      "",
+    ].join("\n");
+    const edited = githubActionsProvider.applyGate(customized, ERROR_GATE);
+    expect(edited).not.toBeNull();
+    expect(githubActionsProvider.parseGate(edited?.content ?? "")).toEqual(ERROR_GATE);
+    // The other step, the action ref + its comment, and the unmanaged inputs survive.
+    expect(edited?.content).toContain("actions/checkout@v5");
+    expect(edited?.content).toContain("millionco/react-doctor@v2 # pinned");
+    expect(edited?.content).toContain("directory: apps/web");
+    expect(edited?.content).toContain("node-version: 24");
+  });
+
+  it("creates a with: block when the React Doctor step has none", () => {
+    const customized = [
+      "jobs:",
+      "  react-doctor:",
+      "    steps:",
+      "      - run: echo hi",
+      "      - uses: millionco/react-doctor@v2",
+      "",
+    ].join("\n");
+    const edited = githubActionsProvider.applyGate(customized, ERROR_GATE);
+    expect(githubActionsProvider.parseGate(edited?.content ?? "")).toEqual(ERROR_GATE);
+    expect(edited?.content).toContain("- run: echo hi");
+  });
+
+  it("removes a managed key when it returns to the action default", () => {
+    const active = githubActionsProvider.applyGate(
+      [
+        "jobs:",
+        "  react-doctor:",
+        "    steps:",
+        "      - uses: millionco/react-doctor@v2",
+        "        with:",
+        "          blocking: error",
+        "          directory: apps/web",
+        "",
+      ].join("\n"),
+      ADVISORY_GATE,
+    );
+    expect(active?.content).not.toContain("blocking:");
+    expect(active?.content).toContain("directory: apps/web");
+    expect(githubActionsProvider.parseGate(active?.content ?? "")).toEqual(ADVISORY_GATE);
+  });
+
+  it("edits a flow-style with: mapping", () => {
+    const flow = [
+      "jobs:",
+      "  react-doctor:",
+      "    steps:",
+      "      - uses: millionco/react-doctor@v2",
+      "        with: { blocking: none, directory: apps/web }",
+      "",
+    ].join("\n");
+    const edited = githubActionsProvider.applyGate(flow, ERROR_GATE);
+    expect(githubActionsProvider.parseGate(edited?.content ?? "").blocking).toBe("error");
+    expect(edited?.content).toContain("apps/web");
+  });
+
+  it("refuses (null) when there is no React Doctor step", () => {
+    const other = ["jobs:", "  ci:", "    steps:", "      - uses: actions/checkout@v5", ""].join(
+      "\n",
+    );
+    expect(githubActionsProvider.applyGate(other, ERROR_GATE)).toBeNull();
   });
 
   it("upgrades a floating @v1 ref to @v2", () => {
@@ -170,14 +249,33 @@ describe("gitlabCiProvider", () => {
     expect(content).not.toContain("--base");
   });
 
-  it("parses and edits its own gate, declining hand-edited files", () => {
+  it("edits the scan line in place, even folded into a larger pipeline", () => {
     const advisory = gitlabCiProvider.scaffold(project.root, "main", ADVISORY_GATE);
     const content = fs.readFileSync(advisory.path, "utf8");
     expect(gitlabCiProvider.parseGate(content)).toEqual(ADVISORY_GATE);
     expect(gitlabCiProvider.applyGate(content, ERROR_GATE)?.content).toContain("--blocking error");
-    expect(
-      gitlabCiProvider.applyGate(`${content}\nrubocop:\n  script: true\n`, ERROR_GATE),
-    ).toBeNull();
+
+    const merged = `${content}\nrubocop:\n  script: true\n`;
+    const edited = gitlabCiProvider.applyGate(merged, ERROR_GATE);
+    expect(edited?.content).toContain("--blocking error");
+    expect(edited?.content).toContain("rubocop:");
+  });
+
+  it("adds --base on a diff scope and removes it on full", () => {
+    const full = fs.readFileSync(
+      gitlabCiProvider.scaffold(project.root, "main", ERROR_GATE).path,
+      "utf8",
+    );
+    expect(full).not.toContain("--base");
+    const toDiff = gitlabCiProvider.applyGate(full, { ...ERROR_GATE, scope: "changed" });
+    expect(toDiff?.content).toContain('--base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"');
+    expect(gitlabCiProvider.applyGate(toDiff?.content ?? "", ERROR_GATE)?.content).not.toContain(
+      "--base",
+    );
+  });
+
+  it("refuses (null) when there is no scan line", () => {
+    expect(gitlabCiProvider.applyGate("stages: [test]\n", ERROR_GATE)).toBeNull();
   });
 
   it("never overwrites an existing .gitlab-ci.yml", () => {

--- a/packages/react-doctor/tests/ci-providers.test.ts
+++ b/packages/react-doctor/tests/ci-providers.test.ts
@@ -1,0 +1,248 @@
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { buildWorkflowContent } from "../src/cli/utils/install-github-workflow.js";
+import type { CommandRunner, RunCommandResult } from "../src/cli/utils/run-command.js";
+import { ADVISORY_GATE, summarizeGate, type CiGate } from "../src/cli/utils/ci/ci-provider.js";
+import { githubActionsProvider } from "../src/cli/utils/ci/github-actions-provider.js";
+import { gitlabCiProvider } from "../src/cli/utils/ci/gitlab-ci-provider.js";
+import { detectCiProvider } from "../src/cli/utils/ci/detect-ci-provider.js";
+import { applyGateFlags, hasAnyGateFlag } from "../src/cli/utils/ci/resolve-ci-gate.js";
+
+const ERROR_GATE: CiGate = { ...ADVISORY_GATE, blocking: "error", scope: "full" };
+
+const succeed = (stdout = ""): RunCommandResult => ({ success: true, stdout, stderr: "" });
+const fail = (): RunCommandResult => ({ success: false, stdout: "", stderr: "" });
+const runner =
+  (result: RunCommandResult): CommandRunner =>
+  () =>
+    Promise.resolve(result);
+
+interface TempProject {
+  readonly root: string;
+  readonly cleanup: () => void;
+}
+
+const makeTempProject = (): TempProject => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), "react-doctor-ci-provider-"));
+  return { root, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+};
+
+describe("githubActionsProvider gate parsing", () => {
+  it("reports the advisory defaults for the canonical commented template", () => {
+    expect(githubActionsProvider.parseGate(buildWorkflowContent("main"))).toEqual(ADVISORY_GATE);
+  });
+
+  it("reads an active with: block back into a gate", () => {
+    const edited = githubActionsProvider.applyGate(buildWorkflowContent("main"), ERROR_GATE);
+    expect(edited).not.toBeNull();
+    expect(edited?.content).toContain("blocking: error");
+    expect(edited?.content).toContain("scope: full");
+    expect(edited?.content).not.toContain("# with:");
+    expect(githubActionsProvider.parseGate(edited?.content ?? "")).toEqual(ERROR_GATE);
+  });
+
+  it("reads React Doctor's own gate, not a preceding step's with: block", () => {
+    const workflow = [
+      "jobs:",
+      "  ci:",
+      "    steps:",
+      "      - uses: actions/setup-node@v4",
+      "        with:",
+      "          node-version: 20",
+      "      - uses: millionco/react-doctor@v2",
+      "        with:",
+      "          blocking: error",
+      "          scope: full",
+      "",
+    ].join("\n");
+    expect(githubActionsProvider.parseGate(workflow)).toEqual(ERROR_GATE);
+  });
+
+  it("reads quoted scalar values like the bare forms", () => {
+    const workflow = [
+      "      - uses: millionco/react-doctor@v2",
+      "        with:",
+      '          blocking: "error"',
+      "          scope: 'full'",
+      "",
+    ].join("\n");
+    expect(githubActionsProvider.parseGate(workflow)).toEqual(ERROR_GATE);
+  });
+
+  it("round-trips an active gate back to the advisory template", () => {
+    const active = githubActionsProvider.applyGate(buildWorkflowContent("main"), ERROR_GATE);
+    const reverted = githubActionsProvider.applyGate(active?.content ?? "", ADVISORY_GATE);
+    expect(reverted).not.toBeNull();
+    expect(reverted?.content).toContain("# with:");
+    expect(githubActionsProvider.parseGate(reverted?.content ?? "")).toEqual(ADVISORY_GATE);
+  });
+
+  it("preserves the push branch and the pinned action ref when editing", () => {
+    const edited = githubActionsProvider.applyGate(
+      buildWorkflowContent("develop", "v1"),
+      ERROR_GATE,
+    );
+    expect(edited?.content).toContain('branches: ["develop"]');
+    expect(edited?.content).toContain("millionco/react-doctor@v1");
+    expect(edited?.content).toContain("blocking: error");
+  });
+
+  it("declines to edit a hand-customized workflow so it's never clobbered", () => {
+    const customized = `${buildWorkflowContent("main")}\n# a teammate added this line\n`;
+    expect(githubActionsProvider.applyGate(customized, ERROR_GATE)).toBeNull();
+  });
+
+  it("upgrades a floating @v1 ref to @v2", () => {
+    const v1 = buildWorkflowContent("main", "v1");
+    const upgraded = githubActionsProvider.upgradeMajor?.(v1);
+    expect(upgraded?.changed).toBe(true);
+    expect(upgraded?.content).toContain("millionco/react-doctor@v2");
+    expect(githubActionsProvider.upgradeMajor?.(buildWorkflowContent("main", "v2")).changed).toBe(
+      false,
+    );
+  });
+});
+
+describe("githubActionsProvider scaffold", () => {
+  let project: TempProject;
+  beforeEach(() => {
+    project = makeTempProject();
+  });
+  afterEach(() => project.cleanup());
+
+  it("writes the advisory template for a fresh project", () => {
+    const result = githubActionsProvider.scaffold(project.root, "main", ADVISORY_GATE);
+    expect(result.status).toBe("created");
+    expect(fs.readFileSync(result.path, "utf8")).toContain("# with:");
+  });
+
+  it("bakes the gate into the with: block when it isn't advisory", () => {
+    const result = githubActionsProvider.scaffold(project.root, "main", ERROR_GATE);
+    expect(fs.readFileSync(result.path, "utf8")).toContain("blocking: error");
+  });
+
+  it("never overwrites an existing workflow", () => {
+    githubActionsProvider.scaffold(project.root, "main", ADVISORY_GATE);
+    expect(githubActionsProvider.scaffold(project.root, "main", ERROR_GATE).status).toBe("exists");
+  });
+});
+
+describe("gitlabCiProvider", () => {
+  let project: TempProject;
+  beforeEach(() => {
+    project = makeTempProject();
+  });
+  afterEach(() => project.cleanup());
+
+  it("scaffolds an advisory merge-request job", () => {
+    const result = gitlabCiProvider.scaffold(project.root, "main", ADVISORY_GATE);
+    const content = fs.readFileSync(result.path, "utf8");
+    expect(result.path.endsWith(".gitlab-ci.yml")).toBe(true);
+    expect(content).toContain("--blocking none --scope changed");
+    expect(content).toContain('--base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"');
+    expect(content).toContain('if: $CI_PIPELINE_SOURCE == "merge_request_event"');
+  });
+
+  it("drops the base flag for a whole-project scope", () => {
+    const content = fs.readFileSync(
+      gitlabCiProvider.scaffold(project.root, "main", ERROR_GATE).path,
+      "utf8",
+    );
+    expect(content).toContain("--blocking error --scope full");
+    expect(content).not.toContain("--base");
+  });
+
+  it("parses and edits its own gate, declining hand-edited files", () => {
+    const advisory = gitlabCiProvider.scaffold(project.root, "main", ADVISORY_GATE);
+    const content = fs.readFileSync(advisory.path, "utf8");
+    expect(gitlabCiProvider.parseGate(content)).toEqual(ADVISORY_GATE);
+    expect(gitlabCiProvider.applyGate(content, ERROR_GATE)?.content).toContain("--blocking error");
+    expect(
+      gitlabCiProvider.applyGate(`${content}\nrubocop:\n  script: true\n`, ERROR_GATE),
+    ).toBeNull();
+  });
+
+  it("never overwrites an existing .gitlab-ci.yml", () => {
+    fs.writeFileSync(path.join(project.root, ".gitlab-ci.yml"), "stages: [test]\n");
+    expect(gitlabCiProvider.scaffold(project.root, "main", ADVISORY_GATE).status).toBe("exists");
+  });
+});
+
+describe("detectCiProvider", () => {
+  let project: TempProject;
+  beforeEach(() => {
+    project = makeTempProject();
+  });
+  afterEach(() => project.cleanup());
+
+  it("prefers an existing GitHub workflow on disk", async () => {
+    fs.mkdirSync(path.join(project.root, ".github", "workflows"), { recursive: true });
+    fs.writeFileSync(
+      path.join(project.root, ".github", "workflows", "react-doctor.yml"),
+      "name: React Doctor\n",
+    );
+    expect(await detectCiProvider(project.root, runner(succeed("git@gitlab.com:o/r.git")))).toBe(
+      "github-actions",
+    );
+  });
+
+  it("detects an existing .gitlab-ci.yml", async () => {
+    fs.writeFileSync(path.join(project.root, ".gitlab-ci.yml"), "stages: [test]\n");
+    expect(await detectCiProvider(project.root, runner(fail()))).toBe("gitlab-ci");
+  });
+
+  it("falls back to the git remote host", async () => {
+    expect(
+      await detectCiProvider(project.root, runner(succeed("https://github.com/o/r.git"))),
+    ).toBe("github-actions");
+    expect(
+      await detectCiProvider(project.root, runner(succeed("git@gitlab.example.com:o/r.git"))),
+    ).toBe("gitlab-ci");
+  });
+
+  it("returns null when nothing is conclusive", async () => {
+    expect(await detectCiProvider(project.root, runner(fail()))).toBeNull();
+  });
+});
+
+describe("applyGateFlags", () => {
+  it("layers valid flags onto the base gate", () => {
+    const result = applyGateFlags(ADVISORY_GATE, { blocking: "error", comment: false });
+    expect(result.error).toBeNull();
+    expect(result.gate.blocking).toBe("error");
+    expect(result.gate.comment).toBe(false);
+  });
+
+  it("rejects an invalid gate level without changing anything", () => {
+    const result = applyGateFlags(ADVISORY_GATE, { blocking: "loud" });
+    expect(result.error).toContain("Invalid --blocking");
+    expect(result.gate).toEqual(ADVISORY_GATE);
+  });
+
+  it("rejects an invalid scope", () => {
+    expect(applyGateFlags(ADVISORY_GATE, { scope: "everything" }).error).toContain(
+      "Invalid --scope",
+    );
+  });
+
+  it("reports no flags when none are passed", () => {
+    expect(hasAnyGateFlag({})).toBe(false);
+    expect(hasAnyGateFlag({ scope: "full" })).toBe(true);
+  });
+});
+
+describe("summarizeGate", () => {
+  it("renders one plain line per supported field", () => {
+    const lines = summarizeGate(ERROR_GATE, githubActionsProvider.supportedGateKeys);
+    expect(lines).toContain("Fail the check on new error-level findings");
+    expect(lines).toContain("Scan the whole project on every run");
+  });
+
+  it("omits fields a provider can't honor", () => {
+    const lines = summarizeGate(ERROR_GATE, gitlabCiProvider.supportedGateKeys);
+    expect(lines).toHaveLength(2);
+    expect(lines.some((line) => line.includes("comment"))).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/ci-providers.test.ts
+++ b/packages/react-doctor/tests/ci-providers.test.ts
@@ -168,6 +168,21 @@ describe("gitlabCiProvider", () => {
     fs.writeFileSync(path.join(project.root, ".gitlab-ci.yml"), "stages: [test]\n");
     expect(gitlabCiProvider.scaffold(project.root, "main", ADVISORY_GATE).status).toBe("exists");
   });
+
+  it("reads the gate off React Doctor's own job, not another job's flags", () => {
+    const merged = [
+      "other-tool:",
+      "  script:",
+      "    - some-tool --blocking warning --scope full",
+      "react-doctor:",
+      "  script:",
+      '    - npx react-doctor@latest --blocking error --scope changed --base "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"',
+      "",
+    ].join("\n");
+    const gate = gitlabCiProvider.parseGate(merged);
+    expect(gate.blocking).toBe("error");
+    expect(gate.scope).toBe("changed");
+  });
 });
 
 describe("detectCiProvider", () => {
@@ -200,6 +215,13 @@ describe("detectCiProvider", () => {
     expect(
       await detectCiProvider(project.root, runner(succeed("git@gitlab.example.com:o/r.git"))),
     ).toBe("gitlab-ci");
+  });
+
+  it("prefers the GitHub remote over a stray .gitlab-ci.yml", async () => {
+    fs.writeFileSync(path.join(project.root, ".gitlab-ci.yml"), "stages: [test]\n");
+    expect(
+      await detectCiProvider(project.root, runner(succeed("https://github.com/o/r.git"))),
+    ).toBe("github-actions");
   });
 
   it("returns null when nothing is conclusive", async () => {

--- a/packages/react-doctor/tests/ci-providers.test.ts
+++ b/packages/react-doctor/tests/ci-providers.test.ts
@@ -189,6 +189,14 @@ describe("githubActionsProvider gate parsing", () => {
     expect(githubActionsProvider.applyGate(other, ERROR_GATE)).toBeNull();
   });
 
+  it("reports whether a workflow wires up React Doctor", () => {
+    expect(githubActionsProvider.containsReactDoctor(buildWorkflowContent("main"))).toBe(true);
+    const noStep = ["jobs:", "  ci:", "    steps:", "      - uses: actions/checkout@v5", ""].join(
+      "\n",
+    );
+    expect(githubActionsProvider.containsReactDoctor(noStep)).toBe(false);
+  });
+
   it("upgrades a floating @v1 ref to @v2", () => {
     const v1 = buildWorkflowContent("main", "v1");
     const upgraded = githubActionsProvider.upgradeMajor?.(v1);
@@ -276,6 +284,28 @@ describe("gitlabCiProvider", () => {
 
   it("refuses (null) when there is no scan line", () => {
     expect(gitlabCiProvider.applyGate("stages: [test]\n", ERROR_GATE)).toBeNull();
+  });
+
+  it("adds a missing flag instead of skipping the change", () => {
+    const onlyBlocking = [
+      "react-doctor:",
+      "  script:",
+      "    - npx react-doctor@latest --blocking none",
+      "",
+    ].join("\n");
+    const edited = gitlabCiProvider.applyGate(onlyBlocking, { ...ADVISORY_GATE, scope: "full" });
+    expect(edited?.content).toContain("--scope full");
+  });
+
+  it("reports whether a file wires up a React Doctor job", () => {
+    const config = fs.readFileSync(
+      gitlabCiProvider.scaffold(project.root, "main", ADVISORY_GATE).path,
+      "utf8",
+    );
+    expect(gitlabCiProvider.containsReactDoctor(config)).toBe(true);
+    expect(gitlabCiProvider.containsReactDoctor("stages: [test]\nrubocop:\n  script: true\n")).toBe(
+      false,
+    );
   });
 
   it("never overwrites an existing .gitlab-ci.yml", () => {

--- a/packages/react-doctor/tests/manage-ci.test.ts
+++ b/packages/react-doctor/tests/manage-ci.test.ts
@@ -99,14 +99,16 @@ describe("runCiConfig", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("leaves a hand-customized workflow untouched", async () => {
+  it("surgically edits a customized workflow in place", async () => {
     const customized = `${buildWorkflowContent("main")}\n# teammate edit\n`;
     fs.mkdirSync(path.dirname(githubActionsProvider.workflowPath(project.root)), {
       recursive: true,
     });
     fs.writeFileSync(githubActionsProvider.workflowPath(project.root), customized);
     await runCiConfig(baseOptions({ provider: "github-actions", blocking: "error" }));
-    expect(githubContent(project.root)).toBe(customized);
+    const updated = githubContent(project.root);
+    expect(githubActionsProvider.parseGate(updated).blocking).toBe("error");
+    expect(updated).toContain("# teammate edit");
   });
 
   it("walks an interactive session and writes the chosen gate", async () => {

--- a/packages/react-doctor/tests/manage-ci.test.ts
+++ b/packages/react-doctor/tests/manage-ci.test.ts
@@ -1,0 +1,187 @@
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import type { Answers, PromptObject } from "prompts";
+import { buildWorkflowContent } from "../src/cli/utils/install-github-workflow.js";
+import {
+  runCiConfig,
+  runCiInstall,
+  runCiUpgrade,
+  type CiCommandOptions,
+} from "../src/cli/utils/ci/manage-ci.js";
+import { githubActionsProvider } from "../src/cli/utils/ci/github-actions-provider.js";
+import { gitlabCiProvider } from "../src/cli/utils/ci/gitlab-ci-provider.js";
+import { NON_INTERACTIVE_ENVIRONMENT_VARIABLES } from "../src/cli/utils/is-non-interactive-environment.js";
+import {
+  CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+  CODING_AGENT_ENVIRONMENT_VARIABLES,
+} from "../src/cli/utils/is-ci-environment.js";
+import type { CommandRunner } from "../src/cli/utils/run-command.js";
+
+// Everything fails, so `detectDefaultBranch` falls through to "main" and no
+// real git/gh process is ever spawned.
+const failingRun: CommandRunner = () => Promise.resolve({ success: false, stdout: "", stderr: "" });
+
+interface TempProject {
+  readonly root: string;
+  readonly cleanup: () => void;
+}
+
+const makeTempProject = (): TempProject => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), "react-doctor-manage-ci-"));
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "fixture" }));
+  return { root, cleanup: () => fs.rmSync(root, { recursive: true, force: true }) };
+};
+
+const githubContent = (root: string): string =>
+  githubActionsProvider.readWorkflow(root)?.content ?? "";
+
+let project: TempProject;
+let originalExitCode: number | string | null | undefined;
+
+beforeEach(() => {
+  project = makeTempProject();
+  originalExitCode = process.exitCode;
+});
+
+afterEach(() => {
+  project.cleanup();
+  process.exitCode = originalExitCode;
+});
+
+const baseOptions = (overrides: CiCommandOptions): CiCommandOptions => ({
+  cwd: project.root,
+  yes: true,
+  run: failingRun,
+  ...overrides,
+});
+
+describe("runCiInstall", () => {
+  it("scaffolds the advisory GitHub workflow", async () => {
+    await runCiInstall(baseOptions({ provider: "github-actions" }));
+    expect(githubContent(project.root)).toContain("# with:");
+    expect(githubContent(project.root)).toContain("millionco/react-doctor@v2");
+  });
+
+  it("bakes a non-advisory gate into the workflow", async () => {
+    await runCiInstall(
+      baseOptions({ provider: "github-actions", blocking: "error", scope: "full" }),
+    );
+    expect(githubContent(project.root)).toContain("blocking: error");
+    expect(githubContent(project.root)).toContain("scope: full");
+  });
+
+  it("rejects an invalid gate level", async () => {
+    await runCiInstall(baseOptions({ provider: "github-actions", blocking: "loud" }));
+    expect(process.exitCode).toBe(1);
+    expect(githubActionsProvider.readWorkflow(project.root)).toBeNull();
+  });
+
+  it("scaffolds a GitLab merge-request job", async () => {
+    await runCiInstall(baseOptions({ provider: "gitlab-ci" }));
+    const content = fs.readFileSync(path.join(project.root, ".gitlab-ci.yml"), "utf8");
+    expect(content).toContain("npx react-doctor@latest --blocking none");
+  });
+});
+
+describe("runCiConfig", () => {
+  it("applies gate flags non-interactively and round-trips", async () => {
+    await runCiInstall(baseOptions({ provider: "github-actions" }));
+    await runCiConfig(baseOptions({ provider: "github-actions", scope: "full", comment: false }));
+    const gate = githubActionsProvider.parseGate(githubContent(project.root));
+    expect(gate.scope).toBe("full");
+    expect(gate.comment).toBe(false);
+  });
+
+  it("errors when there's no workflow to configure", async () => {
+    await runCiConfig(baseOptions({ provider: "github-actions", scope: "full" }));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("leaves a hand-customized workflow untouched", async () => {
+    const customized = `${buildWorkflowContent("main")}\n# teammate edit\n`;
+    fs.mkdirSync(path.dirname(githubActionsProvider.workflowPath(project.root)), {
+      recursive: true,
+    });
+    fs.writeFileSync(githubActionsProvider.workflowPath(project.root), customized);
+    await runCiConfig(baseOptions({ provider: "github-actions", blocking: "error" }));
+    expect(githubContent(project.root)).toBe(customized);
+  });
+
+  it("walks an interactive session and writes the chosen gate", async () => {
+    await runCiInstall(baseOptions({ provider: "github-actions" }));
+
+    const prompt = (<PromptName extends string>(
+      _questions: PromptObject<PromptName> | PromptObject<PromptName>[],
+    ): Promise<Answers<PromptName>> => {
+      const answers = Object.create(null) as Record<string, unknown>;
+      answers.blocking = "error";
+      answers.scope = "changed";
+      // comment left off; the two it keeps stay on.
+      answers.toggles = ["reviewComments", "commitStatus"];
+      return Promise.resolve(answers as Answers<PromptName>);
+    }) as CiCommandOptions["prompt"];
+
+    await withForcedInteractive(() => runCiConfig({ cwd: project.root, run: failingRun, prompt }));
+
+    const gate = githubActionsProvider.parseGate(githubContent(project.root));
+    expect(gate.blocking).toBe("error");
+    expect(gate.comment).toBe(false);
+    expect(gate.reviewComments).toBe(true);
+  });
+});
+
+describe("runCiUpgrade", () => {
+  it("bumps a floating @v1 workflow to @v2", async () => {
+    fs.mkdirSync(path.dirname(githubActionsProvider.workflowPath(project.root)), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      githubActionsProvider.workflowPath(project.root),
+      buildWorkflowContent("main", "v1"),
+    );
+    await runCiUpgrade(baseOptions({ provider: "github-actions" }));
+    expect(githubContent(project.root)).toContain("millionco/react-doctor@v2");
+  });
+
+  it("reports nothing to upgrade for GitLab without throwing", async () => {
+    gitlabCiProvider.scaffold(project.root, "main", {
+      blocking: "none",
+      scope: "changed",
+      comment: true,
+      reviewComments: true,
+      commitStatus: true,
+    });
+    const before = fs.readFileSync(path.join(project.root, ".gitlab-ci.yml"), "utf8");
+    await runCiUpgrade(baseOptions({ provider: "gitlab-ci" }));
+    expect(fs.readFileSync(path.join(project.root, ".gitlab-ci.yml"), "utf8")).toBe(before);
+  });
+});
+
+// Forces the interactive code path by clearing the CI / agent signals and
+// flagging stdin as a TTY, then restoring everything — mirroring the install
+// command's own interactive tests.
+const withForcedInteractive = async (run: () => Promise<void>): Promise<void> => {
+  const originalIsTty = process.stdin.isTTY;
+  const variables = [
+    ...NON_INTERACTIVE_ENVIRONMENT_VARIABLES,
+    ...CODING_AGENT_ENVIRONMENT_VARIABLES,
+    ...CODING_AGENT_ENVIRONMENT_VALUE_VARIABLES,
+  ];
+  const saved = new Map<string, string | undefined>();
+  for (const variable of variables) {
+    saved.set(variable, process.env[variable]);
+    delete process.env[variable];
+  }
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+  try {
+    await run();
+  } finally {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalIsTty });
+    for (const [variable, value] of saved) {
+      if (value === undefined) delete process.env[variable];
+      else process.env[variable] = value;
+    }
+  }
+};

--- a/packages/react-doctor/tests/manage-ci.test.ts
+++ b/packages/react-doctor/tests/manage-ci.test.ts
@@ -99,6 +99,15 @@ describe("runCiConfig", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("errors when the file has no React Doctor job", async () => {
+    fs.writeFileSync(
+      path.join(project.root, ".gitlab-ci.yml"),
+      "stages: [test]\nrubocop:\n  script: true\n",
+    );
+    await runCiConfig(baseOptions({ provider: "gitlab-ci", blocking: "error" }));
+    expect(process.exitCode).toBe(1);
+  });
+
   it("surgically edits a customized workflow in place", async () => {
     const customized = `${buildWorkflowContent("main")}\n# teammate edit\n`;
     fs.mkdirSync(path.dirname(githubActionsProvider.workflowPath(project.root)), {

--- a/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
+++ b/packages/react-doctor/tests/strip-unknown-cli-flags.test.ts
@@ -143,4 +143,36 @@ describe("stripUnknownCliFlags", () => {
       "--color",
     ]);
   });
+
+  it("keeps ci subcommand options (including the gate toggles) and drops unknown ones", () => {
+    expect(
+      stripUserArguments([
+        "ci",
+        "config",
+        "--blocking",
+        "error",
+        "--scope",
+        "full",
+        "--no-comment",
+        "--review-comments",
+        "--offline",
+      ]),
+    ).toEqual([
+      "ci",
+      "config",
+      "--blocking",
+      "error",
+      "--scope",
+      "full",
+      "--no-comment",
+      "--review-comments",
+    ]);
+    expect(stripUserArguments(["ci", "install", "--provider", "gitlab-ci", "--pr"])).toEqual([
+      "ci",
+      "install",
+      "--provider",
+      "gitlab-ci",
+      "--pr",
+    ]);
+  });
 });

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -71,7 +71,9 @@ export default defineConfig({
         // (its jsonc-parser/yaml/toml transitives ship as UMD that
         // doesn't bundle cleanly), and the typescript compiler all
         // stay external.
-        alwaysBundle: ["commander", "ora"],
+        // `yaml` (pure JS, no native deps) backs the `ci config` in-place
+        // workflow editor; inline it so end users get no extra install.
+        alwaysBundle: ["commander", "ora", "yaml"],
         neverBundle: [
           // Sentry bundles its own OpenTelemetry instrumentation chain
           // and resolves native/optional deps via require() at runtime;
@@ -145,7 +147,7 @@ export default defineConfig({
     {
       entry: { index: "./src/index.ts" },
       deps: {
-        alwaysBundle: ["commander", "ora"],
+        alwaysBundle: ["commander", "ora", "yaml"],
         neverBundle: [
           "@sentry/node",
           "agent-install",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       vscode-uri:
         specifier: ^3.1.0
         version: 3.1.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@react-doctor/api':
         specifier: workspace:*
@@ -4033,11 +4036,6 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -5698,7 +5696,7 @@ snapshots:
       jsonc-parser: 3.3.1
       picocolors: 1.1.1
       prompts: 2.4.2
-      yaml: 2.8.3
+      yaml: 2.9.0
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -7165,8 +7163,6 @@ snapshots:
   ws@8.20.0: {}
 
   yallist@3.1.1: {}
-
-  yaml@2.8.3: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Why

`react-doctor install` bundles CI setup together with skills, hooks, and the package script, so there was no focused way to set up, tune, or upgrade React Doctor in CI on its own. This adds `react-doctor ci <install|upgrade|config>` as the dedicated home for CI, while leaving `install` unchanged.

`ci config` edits **any** workflow that contains the React Doctor action — surgically, in place, preserving your other steps, jobs, inputs, and comments — rather than only a pristine scaffold.

## Usage

**Set up CI in one command** — auto-detects the provider (GitHub Actions or GitLab CI), scaffolds an advisory workflow that scans every PR:

```bash
npx react-doctor@latest ci install
```

```
✔ Added .github/workflows/react-doctor.yml.
  Review and commit it to start scanning every pull request.

  React Doctor will now:
    • Report findings without failing the check
    • Report only the issues a change introduces
    • Post a summary comment on each pull request
    • Add inline review comments on changed lines
    • Report a commit status with the health score
```

**Tune the gate later** — interactively, or with flags for scripts/CI:

```bash
react-doctor ci config --blocking error --scope full --no-comment
```

```
✔ Updated .github/workflows/react-doctor.yml.

  React Doctor will now:
    • Fail the check on new error-level findings
    • Scan the whole project on every run
    • Skip the summary comment
    • Add inline review comments on changed lines
    • Report a commit status with the health score
```

It edits your real workflow in place. Given a hand-customized file:

```yaml
# our team's custom CI
jobs:
  react-doctor:
    steps:
      - uses: actions/checkout@v5
      - uses: millionco/react-doctor@v2 # pinned by us
        with:
          node-version: 24
          directory: apps/web
          blocking: none
```

`ci config --blocking error --scope full --no-comment` touches only the gate, preserving the rest:

```yaml
# our team's custom CI
jobs:
  react-doctor:
    steps:
      - uses: actions/checkout@v5
      - uses: millionco/react-doctor@v2 # pinned by us
        with:
          node-version: 24
          directory: apps/web
          blocking: error      # changed
          scope: full          # added
          comment: false        # added
```

**Bake the gate at install time, or open a PR with the change:**

```bash
react-doctor ci install --blocking error          # advisory off from day one
react-doctor ci install --pr                       # open a PR instead of writing to the tree
react-doctor ci install --provider gitlab-ci       # GitLab gate-only scaffold
react-doctor ci upgrade                            # bump the action to its current major
```

## What changed

- **New `ci` command group** (`commands/ci.ts`, wired in `cli/index.ts`) with `install`, `config`, `upgrade`, a help epilog, and flag-strip routing.
- **Provider abstraction** (`cli/utils/ci/`): `githubActionsProvider` (full support) + `gitlabCiProvider` (gate-only scaffold), auto-detected from the git remote host then on-disk CI files, `--provider` to override.
- **`ci config` edits in place.** GitHub uses the `yaml` AST to set only the managed gate keys (`blocking`/`scope`/`comment`/`review-comments`/`commit-status`) on the React Doctor step's `with:` map — preserving comments, the action ref (incl. SHA pins), and other inputs (`directory`/`project`/`node-version`/`version`); keys that return to the action default are removed. A pristine scaffold still gets the clean template rebuild; only a file with no React Doctor step is refused. GitLab splices the gate flags on its scan line. `yaml` is added and inlined into the bundle (no extra user install).
- **Telemetry**: `ci.scaffolded` / `ci.configured` / `ci.upgraded` (anonymized: provider id, mode, gate enums, booleans).
- `install` unchanged; its help points to `ci`. No `action.yml` / JSON-report / `schemaVersion` change. Minor changeset.

## Test plan

- `pnpm --filter react-doctor run typecheck` · `pnpm lint` · `pnpm format:check` — clean
- `pnpm --filter react-doctor exec vp test run tests/ci-providers.test.ts tests/manage-ci.test.ts tests/strip-unknown-cli-flags.test.ts tests/install-github-workflow.test.ts tests/install-react-doctor.test.ts tests/open-workflow-pull-request.test.ts` — **113 passing**, incl. surgical edit preserving extra steps/inputs/comments, no-`with:` insertion, remove-on-default, flow-style `with: {…}`, no-step → snippet, GitLab splice in a larger pipeline, `--base` add/remove, provider detection, flag routing
- Full `react-doctor` suite green in isolation (the only workspace failures are pre-existing: the `.env*`-gitignore-trap tests in `core`, a `deslop-js` fixture, and flaky e2e `cli-and-output` under parallel load)
- Built the CLI, confirmed `yaml` is bundled into `dist/cli.js`, and smoke-tested the built bin end to end (`ci install`, `ci config` on a customized workflow, GitLab scaffold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The CLI writes and rewrites real CI config files (workflows and `.gitlab-ci.yml`); mistakes in YAML editing could break pipelines, though surgical edits and broad tests reduce that risk.
> 
> **Overview**
> Adds **`react-doctor ci`** with **`install`**, **`config`**, and **`upgrade`** as the dedicated way to set up and tune React Doctor in CI (the bundled **`install`** flow is unchanged).
> 
> **`ci install`** auto-detects GitHub Actions or GitLab CI, scaffolds an advisory PR-scan workflow, accepts gate flags (`--blocking`, `--scope`, PR reporting toggles), and optional **`--pr`** to open a setup PR. **GitHub** gets full workflow + action inputs; **GitLab** is a merge-request job scaffold only (blocking/scope on the CLI).
> 
> **`ci config`** reads the current gate from disk, applies flags or interactive prompts, then **edits workflows in place**—GitHub via **`yaml`** AST on the React Doctor step’s `with:` map (preserving other steps, pins, and custom inputs); GitLab by splicing flags on the scan line. Customized files get surgical edits; missing React Doctor wiring falls back to a paste snippet.
> 
> **`ci upgrade`** bumps a floating **`@v1`** GitHub Action ref to **`@v2`**. Provider resolution uses existing workflow, `origin` remote, then on-disk CI files. README CI steps now point at **`ci install`**; **`yaml`** is bundled; telemetry adds **`ci.scaffolded`** / **`ci.configured`** / **`ci.upgraded`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58e01fb97435c66b0be9b5f3441c9bfbefc1f16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->