### PR TITLE
fix(jsx-no-undef): honor /* global */ comments for runtime-injected identifiers

### DIFF
--- a/.changeset/jsx-no-undef-global-comments.md
+++ b/.changeset/jsx-no-undef-global-comments.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `jsx-no-undef` false positives for identifiers provided via runtime-injected scope (e.g., react-live, Storybook). The rule now honors ESLint-style `/* global X, Y */` or `// global X` comments, allowing files that use JSX identifiers from an injected scope to declare them without triggering the diagnostic.
+
+Fixes #959.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-undef.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-undef.regressions.test.ts
@@ -67,4 +67,81 @@ describe("react-builtins/jsx-no-undef regressions", () => {
     // the second usage at the function level should be flagged.
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("does not flag JSX elements declared via /* global */ comments", () => {
+    const code = `
+/* global DatePicker, CalendarContainer */
+const App = () => (
+  <DatePicker>
+    <CalendarContainer />
+  </DatePicker>
+);
+`;
+    const result = runRule(jsxNoUndef, code, {
+      settings: { "jsx-no-undef-source-text": code },
+    });
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag JSX elements declared via single-identifier global comments", () => {
+    const code = `
+/* global MyComponent */
+const App = () => <MyComponent />;
+`;
+    const result = runRule(jsxNoUndef, code, {
+      settings: { "jsx-no-undef-source-text": code },
+    });
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags JSX elements not in global comments", () => {
+    const code = `
+/* global DatePicker */
+const App = () => (
+  <>
+    <DatePicker />
+    <CalendarContainer />
+  </>
+);
+`;
+    const result = runRule(jsxNoUndef, code, {
+      settings: { "jsx-no-undef-source-text": code },
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain("CalendarContainer");
+  });
+
+  it("handles line comments for globals", () => {
+    const code = `
+// global MyComponent
+const App = () => <MyComponent />;
+`;
+    const result = runRule(jsxNoUndef, code, {
+      settings: { "jsx-no-undef-source-text": code },
+    });
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("handles multiple global comments", () => {
+    const code = `
+/* global Foo */
+/* global Bar, Baz */
+const App = () => (
+  <>
+    <Foo />
+    <Bar />
+    <Baz />
+  </>
+);
+`;
+    const result = runRule(jsxNoUndef, code, {
+      settings: { "jsx-no-undef-source-text": code },
+    });
+
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-undef.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-undef.ts
@@ -43,7 +43,7 @@ const parseGlobalComments = (sourceText: string): Set<string> => {
   const globals = new Set<string>();
   const blockCommentPattern = /\/\*\s*global\s+([^*]+)\*\//g;
   const lineCommentPattern = /\/\/\s*global\s+(.+)$/gm;
-  
+
   let match: RegExpExecArray | null;
   while ((match = blockCommentPattern.exec(sourceText)) !== null) {
     const identifiers = match[1].split(",");
@@ -52,7 +52,7 @@ const parseGlobalComments = (sourceText: string): Set<string> => {
       if (trimmed) globals.add(trimmed);
     }
   }
-  
+
   while ((match = lineCommentPattern.exec(sourceText)) !== null) {
     const identifiers = match[1].split(",");
     for (const identifier of identifiers) {
@@ -60,7 +60,7 @@ const parseGlobalComments = (sourceText: string): Set<string> => {
       if (trimmed) globals.add(trimmed);
     }
   }
-  
+
   return globals;
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-undef.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-undef.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -38,6 +39,31 @@ const getRootIdentifier = (elementName: EsTreeNode): string | null => {
   return null;
 };
 
+const parseGlobalComments = (sourceText: string): Set<string> => {
+  const globals = new Set<string>();
+  const blockCommentPattern = /\/\*\s*global\s+([^*]+)\*\//g;
+  const lineCommentPattern = /\/\/\s*global\s+(.+)$/gm;
+  
+  let match: RegExpExecArray | null;
+  while ((match = blockCommentPattern.exec(sourceText)) !== null) {
+    const identifiers = match[1].split(",");
+    for (const identifier of identifiers) {
+      const trimmed = identifier.trim();
+      if (trimmed) globals.add(trimmed);
+    }
+  }
+  
+  while ((match = lineCommentPattern.exec(sourceText)) !== null) {
+    const identifiers = match[1].split(",");
+    for (const identifier of identifiers) {
+      const trimmed = identifier.trim();
+      if (trimmed) globals.add(trimmed);
+    }
+  }
+  
+  return globals;
+};
+
 // Port of `oxc_linter::rules::react::jsx_no_undef`. Reports JSX usages
 // of an identifier (or root of a member expression) that has no
 // binding visible from the JSX site.
@@ -54,24 +80,52 @@ const getRootIdentifier = (elementName: EsTreeNode): string | null => {
 //     diagnostic. `interface` and `type` alias declarations do NOT
 //     — those are erased at runtime and JSX usage of them is an
 //     error we want to surface.
+const sourceTextCache = new Map<string, string>();
+const getSourceText = (filename: string | undefined): string | null => {
+  if (!filename) return null;
+  if (sourceTextCache.has(filename)) {
+    return sourceTextCache.get(filename)!;
+  }
+  try {
+    const text = fs.readFileSync(filename, "utf8");
+    sourceTextCache.set(filename, text);
+    return text;
+  } catch {
+    sourceTextCache.set(filename, "");
+    return null;
+  }
+};
+
 export const jsxNoUndef = defineRule({
   id: "jsx-no-undef",
   title: "Undefined JSX component",
   severity: "error",
   recommendation:
     "Import the component or fix the typo so React can resolve the JSX identifier at runtime.",
-  create: (context) => ({
-    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      const rootIdentifier = getRootIdentifier(node.name as EsTreeNode);
-      if (!rootIdentifier) return;
-      if (KNOWN_GLOBALS.has(rootIdentifier)) return;
-      const programRoot = findProgramRoot(node);
-      if (!programRoot) return;
-      // Scope-aware lookup first — finds bindings whose scope owner is
-      // an ancestor of the JSX site (respects let/const block scoping
-      // AND TS declarations like enum / type / interface / module).
-      if (findVariableInitializer(node, rootIdentifier)) return;
-      context.report({ node: node.name, message: buildMessage(rootIdentifier) });
-    },
-  }),
+  create: (context) => {
+    let commentGlobals: Set<string> | null = null;
+    const getCommentGlobals = (): Set<string> => {
+      if (commentGlobals) return commentGlobals;
+      const settingsSourceText = context.settings?.["jsx-no-undef-source-text"];
+      const sourceText =
+        typeof settingsSourceText === "string"
+          ? settingsSourceText
+          : getSourceText(context.filename);
+      commentGlobals = sourceText ? parseGlobalComments(sourceText) : new Set();
+      return commentGlobals;
+    };
+    return {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        const rootIdentifier = getRootIdentifier(node.name as EsTreeNode);
+        if (!rootIdentifier) return;
+        if (KNOWN_GLOBALS.has(rootIdentifier)) return;
+        const programRoot = findProgramRoot(node);
+        if (!programRoot) return;
+        const globals = getCommentGlobals();
+        if (globals.has(rootIdentifier)) return;
+        if (findVariableInitializer(node, rootIdentifier)) return;
+        context.report({ node: node.name, message: buildMessage(rootIdentifier) });
+      },
+    };
+  },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #959 — `jsx-no-undef` false positives for JSX identifiers provided via runtime-injected scope (e.g., react-live `<LiveProvider scope={...}>`, Storybook globals, or MDX live code blocks).

## Root Cause

The rule flags identifiers that don't have a local binding or import, even when they're legitimately provided at runtime by:
- **react-live**'s `<LiveProvider scope={...}>` injecting components into playground snippets
- **Ambient type declarations** in separate `.d.ts` files (e.g., `declare global { const X: any; }`)
- Other runtime-scope mechanisms (Storybook, MDX, custom render harnesses)

The AST-only rule can't see cross-file type declarations or runtime scope injection, so every unimported identifier is flagged.

## Solution

The rule now honors ESLint-style `/* global X, Y, Z */` or `// global X` comments, providing an opt-in escape hatch for files that use injected globals.

### Why This Approach?

1. **Standard pattern** — ESLint's `react/jsx-no-undef` and many other linters use the same comment syntax
2. **Self-documenting** — the comment explains why identifiers aren't imported
3. **No infrastructure changes** — works within the existing AST-only rule architecture
4. **Practical workaround** — users can fix the false positives immediately by adding one comment to affected files

### Example

**Before** (112 false positives in react-datepicker):
```tsx
// docs-site/src/examples/ts/calendarContainer.tsx
const CustomCalendarContainer = () => {
  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
  
  return (
    <DatePicker selected={selectedDate} onChange={setSelectedDate}>
      <CalendarContainer />  {/* ✖ "CalendarContainer crashes at runtime" */}
    </DatePicker>
  );
};
```

**After** (no errors):
```tsx
/* global DatePicker, CalendarContainer, useState */

const CustomCalendarContainer = () => {
  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
  
  return (
    <DatePicker selected={selectedDate} onChange={setSelectedDate}>
      <CalendarContainer />  {/* ✓ recognized as a declared global */}
    </DatePicker>
  );
};
```

## Scope

The fix is **narrowly scoped**:
- Only affects files that explicitly add `/* global */` comments (opt-in)
- No behavioral change for files without the comments
- Doesn't weaken the rule's ability to catch real undefined identifiers

## Testing

- ✅ Added 5 new regression tests covering block comments, line comments, multiple globals, and partial coverage
- ✅ All existing tests pass
- ✅ Manually verified fix works on react-datepicker example files
- ✅ CI: All checks now passing (formatting issue resolved)

## RDE Parity

Per the triage playbook, `rde parity` should be run during review to validate no regressions across the OSS corpus. The fix is narrowly scoped (opt-in via comments only) and expected to have zero impact on repos without `/* global */` comments.

## Changeset

Included a patch-level changeset for `oxlint-plugin-react-doctor`.

Closes #959

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-403a35d8-3245-466e-a85e-795c282221d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-403a35d8-3245-466e-a85e-795c282221d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

