### PR TITLE
fix: pre-commit hook now blocks commits when diagnostics are found

### DIFF
--- a/.changeset/fix-hook-blocking.md
+++ b/.changeset/fix-hook-blocking.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix pre-commit hook to actually block commits when diagnostics are found. The hook previously captured output but never exited with non-zero status, allowing commits to proceed despite blocking diagnostics. The hook now displays react-doctor output and exits with status 1 to properly block commits.

--- a/packages/react-doctor/src/cli/utils/git-hook-shared.ts
+++ b/packages/react-doctor/src/cli/utils/git-hook-shared.ts
@@ -15,12 +15,13 @@ export const OVERCOMMIT_CONFIG_FILE = ".overcommit.yml";
 export const REACT_DOCTOR_COMMAND = "react-doctor --staged --blocking warning";
 export const NON_BLOCKING_REACT_DOCTOR_COMMAND = [
   'react_doctor_output=$(mktemp "${TMPDIR:-/tmp}/react-doctor-hook.XXXXXX");',
-  `if ${REACT_DOCTOR_COMMAND} > "$react_doctor_output" 2>&1; then`,
+  `if ! ${REACT_DOCTOR_COMMAND} > "$react_doctor_output" 2>&1; then`,
+  'cat "$react_doctor_output" >&2;',
   'rm -f "$react_doctor_output";',
-  "else",
-  'rm -f "$react_doctor_output";',
-  `printf "%s\\n" "React Doctor found staged regressions." "Run ${REACT_DOCTOR_COMMAND} to inspect." "Want them fixed? Ask your agent to run that command and resolve the findings." >&2;`,
-  "fi",
+  `printf "%s\\n" "React Doctor found staged regressions." >&2;`,
+  "exit 1;",
+  "fi;",
+  'rm -f "$react_doctor_output"',
 ].join(" ");
 const PACKAGE_JSON_FILE_NAME = "package.json";
 

--- a/packages/react-doctor/src/cli/utils/install-git-hook-file.ts
+++ b/packages/react-doctor/src/cli/utils/install-git-hook-file.ts
@@ -55,12 +55,13 @@ const buildReactDoctorHookBlock = (): string =>
     "}",
     "",
     'react_doctor_output=$(mktemp "${TMPDIR:-/tmp}/react-doctor-hook.XXXXXX")',
-    'if react_doctor_scan_staged_files > "$react_doctor_output" 2>&1; then',
+    'if ! react_doctor_scan_staged_files > "$react_doctor_output" 2>&1; then',
+    '  cat "$react_doctor_output" >&2',
     '  rm -f "$react_doctor_output"',
-    "else",
-    '  rm -f "$react_doctor_output"',
-    `  printf '%s\\n' "React Doctor found staged regressions." "Run ${REACT_DOCTOR_COMMAND} to inspect." "Want them fixed? Ask your agent to run that command and resolve the findings." >&2`,
+    `  printf '%s\\n' "React Doctor found staged regressions." >&2`,
+    "  exit 1",
     "fi",
+    'rm -f "$react_doctor_output"',
     REACT_DOCTOR_BLOCK_END,
   ].join("\n");
 

--- a/packages/react-doctor/tests/install-git-hook.test.ts
+++ b/packages/react-doctor/tests/install-git-hook.test.ts
@@ -43,7 +43,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorGitHook", () =>
     fixture.cleanup();
   });
 
-  it("creates a dependency-free non-blocking pre-commit hook without a managed runner", () => {
+  it("creates a dependency-free pre-commit hook without a managed runner", () => {
     const result = installReactDoctorGitHook({
       hookPath: fixture.hookPath,
       projectRoot: fixture.projectRoot,
@@ -56,8 +56,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorGitHook", () =>
     expect(hookContent).toContain("react-doctor --staged --blocking warning");
     expect(hookContent).toContain("pnpm dlx react-doctor@latest --staged --blocking warning");
     expect(hookContent).toContain("npx --yes react-doctor@latest --staged --blocking warning");
-    expect(hookContent).toContain("Want them fixed?");
-    expect(hookContent).not.toContain("Stop commit");
+    expect(hookContent).toContain("exit 1");
     expect(hookContent).not.toContain(".react-doctor/hooks/pre-commit");
     expect(hookContent).not.toContain("husky");
     expect(fs.existsSync(fixture.hookPath)).toBe(true);
@@ -717,7 +716,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorGitHook", () =>
     expect(fs.readFileSync(invocationPath, "utf8")).toBe("--staged\n--blocking\nwarning\n");
   });
 
-  it("prints a minimal non-invasive prompt during a real git commit", () => {
+  it("blocks commit when react-doctor finds regressions", () => {
     execFileSync("git", ["init"], { cwd: fixture.projectRoot, stdio: "ignore" });
     execFileSync("git", ["config", "user.email", "doctor@example.com"], {
       cwd: fixture.projectRoot,
@@ -760,24 +759,11 @@ describe.skipIf(process.platform === "win32")("installReactDoctorGitHook", () =>
       encoding: "utf8",
     });
 
-    expect(commitResult.status).toBe(0);
+    expect(commitResult.status).toBe(1);
+    expect(commitResult.stderr).toContain("noisy stdout diagnostic");
+    expect(commitResult.stderr).toContain("noisy stderr diagnostic");
     expect(commitResult.stderr).toContain("React Doctor found staged regressions.");
-    expect(commitResult.stderr).toContain(
-      "Run react-doctor --staged --blocking warning to inspect.",
-    );
-    expect(commitResult.stderr).toContain(
-      "Want them fixed? Ask your agent to run that command and resolve the findings.",
-    );
-    expect(commitResult.stderr).not.toContain("noisy stdout diagnostic");
-    expect(commitResult.stderr).not.toContain("noisy stderr diagnostic");
-    expect(commitResult.stderr).not.toContain("Stop commit");
     expect(fs.readFileSync(invocationPath, "utf8")).toBe("--staged\n--blocking\nwarning\n");
-    expect(
-      execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
-        cwd: fixture.projectRoot,
-        encoding: "utf8",
-      }).trim(),
-    ).toHaveLength(40);
   });
 
   it("preserves and executes existing hook content during a real git commit", () => {

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -626,7 +626,7 @@ describe("runInstallReactDoctor", () => {
     ).toBe(true);
   });
 
-  it("--yes installs a non-blocking pre-commit hook when a git hook target is detected", async () => {
+  it("--yes installs a pre-commit hook when a git hook target is detected", async () => {
     writeValidSkill(fixture.sourceDir);
     const hookPath = path.join(fixture.projectRoot, ".git/hooks/pre-commit");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The generated pre-commit hook captured react-doctor output to a temp file but never exited with non-zero status when diagnostics were found. This allowed commits to proceed even when blocking diagnostics were present, completely defeating the purpose of the hook.

The bug existed in two places:
1. `buildReactDoctorHookBlock()` in `install-git-hook-file.ts` 
2. `NON_BLOCKING_REACT_DOCTOR_COMMAND` in `git-hook-shared.ts`

Both implementations had the same flaw:
- Captured output to a temp file
- Deleted the file in both success and failure branches
- Never called `exit 1` in the failure branch
- Printed a generic message but allowed the commit to proceed

## Fix

The hook now:
1. Displays the full react-doctor output to stderr (so users see which rules failed)
2. Exits with status 1 when diagnostics are found (blocking the commit)
3. Cleans up the temp file after displaying output

## Testing

- Updated existing integration test that was expecting non-blocking behavior
- Test now verifies the commit is blocked (exit code 1) when react-doctor fails
- Test verifies react-doctor output is displayed to the user
- All existing tests pass

Closes #969
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f510353-a7fc-4f95-b57e-601b9fd56a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f510353-a7fc-4f95-b57e-601b9fd56a2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

