### PR TITLE
fix(deslop): track JSX namespace member access (`<S.Custom/>`)

### DIFF
--- a/.changeset/fix-875-jsx-namespace-member.md
+++ b/.changeset/fix-875-jsx-namespace-member.md
@@ -1,0 +1,12 @@
+---
+"deslop-js": patch
+---
+
+Fix `deslop/unused-export` false positive for namespace-imported components used in JSX
+
+A component referenced only through a namespace import in JSX —
+`import * as S from "./style"` then `<S.Custom />` — was reported as an unused
+export. The usage walker recorded namespace member access in regular expressions
+(`MemberExpression`, e.g. `S.helper()`) but not in JSX (`JSXMemberExpression`),
+so a member used solely as `<S.x />` was missed whenever the namespace had any
+other accessed member. Closes #875.

--- a/packages/deslop-js/src/collect/parse.ts
+++ b/packages/deslop-js/src/collect/parse.ts
@@ -942,6 +942,27 @@ const collectMemberAccesses = (
       }
     }
 
+    // `<S.Custom />` — a JSX element whose name is a member of a namespace
+    // import. The name node is a `JSXMemberExpression`, not a `MemberExpression`,
+    // so it would otherwise be missed and the export reported unused (#875).
+    if (node.type === "JSXMemberExpression") {
+      const jsxMember = node as unknown as {
+        object: { type: string; name?: string };
+        property: { name?: string };
+      };
+      if (
+        jsxMember.object.type === "JSXIdentifier" &&
+        jsxMember.object.name !== undefined &&
+        namespaceLocalNames.has(jsxMember.object.name) &&
+        jsxMember.property.name !== undefined
+      ) {
+        memberAccesses.push({
+          objectName: jsxMember.object.name,
+          memberName: jsxMember.property.name,
+        });
+      }
+    }
+
     if (node.type === "SpreadElement") {
       const spreadArgument = (node as unknown as { argument: WalkableNode }).argument;
       if (

--- a/packages/deslop-js/tests/analyze.test.ts
+++ b/packages/deslop-js/tests/analyze.test.ts
@@ -5072,3 +5072,16 @@ describe("typescript-smells", () => {
     );
   });
 });
+
+describe("jsx-namespace-member (issue #875)", () => {
+  it("treats a namespace member used only in JSX (<S.Custom/>) as used", async () => {
+    const result = await scanFixture("jsx-namespace-member");
+    const dead = deadExportNames(result);
+    assert.ok(
+      !dead.includes("Custom"),
+      `Custom is used via <S.Custom/> and must not be flagged unused, got: ${dead}`,
+    );
+    // `Plain` is genuinely unused — proves the scan ran and isn't passing vacuously.
+    assert.ok(dead.includes("Plain"), `Plain is unused and should still be flagged, got: ${dead}`);
+  });
+});

--- a/packages/deslop-js/tests/fixtures/jsx-namespace-member/package.json
+++ b/packages/deslop-js/tests/fixtures/jsx-namespace-member/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "jsx-namespace-member",
+  "main": "src/index.tsx",
+  "dependencies": {
+    "react": "^18.0.0",
+    "styled-components": "^6.0.0"
+  }
+}

--- a/packages/deslop-js/tests/fixtures/jsx-namespace-member/src/index.tsx
+++ b/packages/deslop-js/tests/fixtures/jsx-namespace-member/src/index.tsx
@@ -1,0 +1,10 @@
+import * as S from "./style";
+
+export const App = () => {
+  const label = S.helper();
+  return (
+    <div title={label}>
+      <S.Custom />
+    </div>
+  );
+};

--- a/packages/deslop-js/tests/fixtures/jsx-namespace-member/src/style.ts
+++ b/packages/deslop-js/tests/fixtures/jsx-namespace-member/src/style.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const Custom = styled.div``;
+export const Plain = styled.span``;
+export const helper = (): string => "x";


### PR DESCRIPTION
## Problem

`deslop/unused-export` reported a component as unused when it was referenced only through a namespace import in JSX:

```tsx
// style.ts
export const Custom = styled.div``;

// Component.tsx
import * as S from "./style";
const App = () => <S.Custom />;   // ← Custom flagged "unused export" (#875)
```

## Root cause

The usage walker (`collectMemberAccesses` in `collect/parse.ts`) recorded namespace member access for regular `MemberExpression` nodes (`S.helper()`) but **not** for `JSXMemberExpression` (`<S.Custom />`). When the namespace had any *other* accessed member, the JSX-only member fell outside the accessed set and was reported unused. (Pure-JSX-only usage happened to be safe via the "no members accessed → mark all used" fallback, which is why it surfaced intermittently.)

## Fix

Record `JSXMemberExpression` namespace access in the walker — one node-type case, mirroring the existing `MemberExpression` handling.

## Test

New `jsx-namespace-member` fixture + a discriminating test: a member used only via `<S.Custom/>` (alongside a regular `S.helper()` access) is no longer flagged, while a genuinely-unused `Plain` export still is. Full deslop-js suite green (489 tests).

Fixes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow AST-walker change in static analysis only; no runtime app behavior, with regression coverage for the reported scenario.
> 
> **Overview**
> Fixes a **`deslop/unused-export` false positive** when a namespace import member appears only in JSX (e.g. `import * as S from "./style"` and `<S.Custom />`).
> 
> **`collectMemberAccesses`** in `parse.ts` now records **`JSXMemberExpression`** nodes the same way it already did for **`MemberExpression`**, so `S.Custom` in JSX is treated as a used export. That closes the gap where JSX-only members were missed once *any other* member on the same namespace was accessed (e.g. `S.helper()`), which incorrectly flagged exports like `Custom` as unused (#875).
> 
> Adds a **`jsx-namespace-member`** fixture and regression test (used `Custom` not dead; unused `Plain` still flagged), plus a patch **changeset** for `deslop-js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba26cee1a9a9caf7e2b2aa0184758b4e276f8aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->