### PR TITLE
fix(dead-code): don't flag react-doctor's own toolchain as unused

### DIFF
--- a/.changeset/fix-961-self-toolchain.md
+++ b/.changeset/fix-961-self-toolchain.md
@@ -1,0 +1,16 @@
+---
+"@react-doctor/core": patch
+---
+
+Stop react-doctor from flagging its own toolchain as an unused dependency
+
+After `react-doctor install` — especially via `bunx`, where react-doctor is
+declared in `package.json` but never materialized in `node_modules` — a scan
+reported `react-doctor` itself as an unused devDependency. It's used via the CLI,
+git hooks, CI, and the agent skill (never imported in source), so the dead-code
+import graph can't see it, and deslop's "ships a binary → used" heuristic can't
+read its `bin` when it isn't installed. The dead-code pass now never reports
+react-doctor's own CLI / plugin packages (`react-doctor`,
+`eslint-plugin-react-doctor`, `oxlint-plugin-react-doctor`) as unused.
+
+Closes #961

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -24,6 +24,17 @@ import { toRelativePath } from "./utils/to-relative-path.js";
 export const DEAD_CODE_PLUGIN = "deslop";
 export const DEAD_CODE_CATEGORY = "Maintainability";
 
+// react-doctor's own toolchain is used via the CLI, git hooks, CI, and the agent
+// skill — never imported in source — so deslop's import-graph scan can't see the
+// usage and flags it as unused after `react-doctor install` (especially via
+// `bunx`, where the package is declared but not in node_modules, so deslop can't
+// read its `bin` either). react-doctor never reports its own tooling as unused.
+const REACT_DOCTOR_TOOLCHAIN_PACKAGES: ReadonlySet<string> = new Set([
+  "react-doctor",
+  "eslint-plugin-react-doctor",
+  "oxlint-plugin-react-doctor",
+]);
+
 interface CheckDeadCodeOptions {
   readonly rootDirectory: string;
   /** Loaded react-doctor config — `ignore.files` is forwarded to deslop. */
@@ -553,6 +564,7 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
   }
 
   for (const unusedDependency of result.unusedDependencies) {
+    if (REACT_DOCTOR_TOOLCHAIN_PACKAGES.has(unusedDependency.name)) continue;
     const label = unusedDependency.isDevDependency ? "devDependency" : "dependency";
     // Every unused dependency reports at `package.json` with no line, so the
     // renderer lists all of them under one location. Keep the per-item message

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -258,6 +258,36 @@ describe("checkDeadCode", () => {
     ).toBe("Unused devDependency: `vitest`");
   });
 
+  it("does not report react-doctor's own toolchain as unused (#961)", async () => {
+    const directory = setupProject("react-doctor-self-toolchain", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+
+    const diagnostics = await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: () => ({
+        result: Promise.resolve({
+          unusedFiles: [],
+          unusedExports: [],
+          unusedDependencies: [
+            { name: "react-doctor", isDevDependency: true },
+            { name: "eslint-plugin-react-doctor", isDevDependency: true },
+            { name: "oxlint-plugin-react-doctor", isDevDependency: true },
+            { name: "genuinely-unused", isDevDependency: true },
+          ],
+          circularDependencies: [],
+        }),
+      }),
+    });
+
+    const flaggedDevDeps = diagnostics
+      .filter((diagnostic) => diagnostic.rule === "unused-dev-dependency")
+      .map((diagnostic) => diagnostic.message);
+    // The react-doctor toolchain is used via the CLI/hooks/CI, never imported —
+    // it must not be self-flagged; an unrelated unused dep still is.
+    expect(flaggedDevDeps).toEqual(["Unused devDependency: `genuinely-unused`"]);
+  });
+
   it("rejects malformed worker results instead of silently dropping diagnostics", async () => {
     const directory = setupProject("malformed-worker-result", {
       "src/index.ts": "export const used = 1;\n",


### PR DESCRIPTION
## Problem

After `react-doctor install`, a scan reported **react-doctor itself** as an unused devDependency (#961):

> Maintainability: deslop/unused-dev-dependency — Unused devDependency: `react-doctor`

## Root cause

react-doctor is used via the CLI, git hooks, CI, and the agent skill — it's never `import`ed in source — so deslop's import-graph scan can't see the usage. deslop has a "ships a CLI binary → used" heuristic for exactly this (tools run from hooks/CI/npx), **but it reads the package's `bin` field from `node_modules`**. In the reporter's `bunx react-doctor@latest install` flow, react-doctor is added to `package.json` but never materialized in `node_modules`, so deslop can't read its `bin` and falls through to flagging it.

Verified both states locally: with `node_modules/react-doctor` present → not flagged; without it → flagged.

## Fix

The dead-code pass now skips react-doctor's own CLI / plugin packages (`react-doctor`, `eslint-plugin-react-doctor`, `oxlint-plugin-react-doctor`) when emitting unused-dependency diagnostics — a tool shouldn't report its own toolchain as unused. Standalone deslop-js behavior is unchanged.

## Test

A `createWorker`-injected `checkDeadCode` test: the three toolchain packages are filtered out while an unrelated `genuinely-unused` devDep is still flagged. Full core check-dead-code suite green.

Fixes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist filter on unused-dependency diagnostics only; no changes to deslop or other dead-code rules.
> 
> **Overview**
> Fixes **#961**, where scans after `react-doctor install` could warn that **`react-doctor`** (and related packages) are unused devDependencies—common when install via **`bunx`** leaves the package in `package.json` but not in `node_modules`, so deslop can't treat CLI `bin` usage as in-use.
> 
> The dead-code pass in **`check-dead-code.ts`** now **skips** unused-dependency diagnostics for **`react-doctor`**, **`eslint-plugin-react-doctor`**, and **`oxlint-plugin-react-doctor`**. Other unused deps are unchanged.
> 
> Adds a **`createWorker`** test proving those three are filtered while a real unused devDep still reports. Patch changeset for **`@react-doctor/core`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c13b38f6fd14360e79aac3a20f15317ded018d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->