### PR TITLE
feat(config): add `runtimeGlobals` to silence jsx-no-undef for runtime-injected identifiers

### DIFF
--- a/.changeset/feat-959-runtime-globals.md
+++ b/.changeset/feat-959-runtime-globals.md
@@ -1,0 +1,14 @@
+---
+"@react-doctor/core": patch
+---
+
+Add `runtimeGlobals` config to silence jsx-no-undef false positives for runtime-injected identifiers
+
+`jsx-no-undef` is a single-file rule, so it flags capitalized JSX identifiers
+that are provided at runtime rather than imported in the file — react-live's
+`<LiveProvider scope={...}>`, Storybook globals, MDX live blocks, or an ambient
+`declare global` in a separate `.d.ts`. List those names in the new
+`runtimeGlobals` config array and `jsx-no-undef` treats them as known. Opt-in —
+an empty/absent list leaves behavior unchanged.
+
+Closes #959

--- a/packages/core/src/build-diagnostic-pipeline.ts
+++ b/packages/core/src/build-diagnostic-pipeline.ts
@@ -50,6 +50,11 @@ const collectStringSet = (values: unknown): ReadonlySet<string> => {
   return new Set(values.filter((value): value is string => typeof value === "string"));
 };
 
+// `jsx-no-undef` reports the flagged root identifier as the first backticked
+// token of its message (`` `Foo` crashes at runtime… ``), so the configured
+// `runtimeGlobals` allowlist matches against that token.
+const JSX_NO_UNDEF_IDENTIFIER_PATTERN = /^`([^`]+)`/;
+
 /**
  * Pre-compiles every stateful filter and returns a single
  * `apply(diagnostic)` closure that runs (in order):
@@ -91,8 +96,10 @@ export const buildDiagnosticPipeline = (
   const compiledOverrides = compileIgnoreOverrides(userConfig);
   const textComponentNames = collectStringSet(userConfig?.textComponents);
   const rawTextWrapperComponentNames = collectStringSet(userConfig?.rawTextWrapperComponents);
+  const runtimeGlobalNames = collectStringSet(userConfig?.runtimeGlobals);
   const hasTextComponents = textComponentNames.size > 0;
   const hasRawTextWrappers = rawTextWrapperComponentNames.size > 0;
+  const hasRuntimeGlobals = runtimeGlobalNames.size > 0;
   const fileLinesCache = new Map<string, string[] | null>();
   const fileContextCache = new Map<string, DiagnosticFileContext>();
   const libraryFileCache = new Map<string, boolean>();
@@ -177,6 +184,17 @@ export const buildDiagnosticPipeline = (
     return false;
   };
 
+  // `runtimeGlobals` declares identifiers that exist at runtime but aren't
+  // imported in-file — react-live `<LiveProvider scope>`, Storybook globals,
+  // ambient `declare global` — which the single-file `jsx-no-undef` rule can't
+  // see and would flag as undefined (#959).
+  const isJsxNoUndefSuppressedByConfig = (diagnostic: Diagnostic): boolean => {
+    if (!hasRuntimeGlobals) return false;
+    if (diagnostic.rule !== "jsx-no-undef") return false;
+    const identifierMatch = JSX_NO_UNDEF_IDENTIFIER_PATTERN.exec(diagnostic.message);
+    return identifierMatch !== null && runtimeGlobalNames.has(identifierMatch[1]);
+  };
+
   return {
     apply: (diagnostic) => {
       if (shouldAutoSuppress(diagnostic)) return null;
@@ -227,6 +245,7 @@ export const buildDiagnosticPipeline = (
         }
         if (isDiagnosticIgnoredByOverrides(current, rootDirectory, compiledOverrides)) return null;
         if (isRnRawTextSuppressedByConfig(current)) return null;
+        if (isJsxNoUndefSuppressedByConfig(current)) return null;
       }
 
       if (respectInlineDisables && current.line > 0) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -313,6 +313,15 @@ export interface ReactDoctorConfig {
    */
   rawTextWrapperComponents?: string[];
   /**
+   * Capitalized identifiers that exist at runtime but aren't imported in
+   * the file that uses them — react-live's `<LiveProvider scope={...}>`,
+   * Storybook globals, MDX live blocks, or an ambient `declare global` in a
+   * separate `.d.ts`. The single-file `jsx-no-undef` rule can't see those
+   * bindings and would report `<DatePicker />` as an undefined JSX component.
+   * List the injected names here and `jsx-no-undef` treats them as known.
+   */
+  runtimeGlobals?: string[];
+  /**
    * Project-level allowlist of function names that the
    * `server-auth-actions` rule treats as an auth check at the top of
    * a server action. Names are accepted whether called as a bare

--- a/packages/core/src/validate-config-types.ts
+++ b/packages/core/src/validate-config-types.ts
@@ -54,6 +54,7 @@ const STRING_ARRAY_FIELD_NAMES = [
   "projects",
   "textComponents",
   "rawTextWrapperComponents",
+  "runtimeGlobals",
   "serverAuthFunctionNames",
 ] as const satisfies ReadonlyArray<keyof ReactDoctorConfig>;
 

--- a/packages/core/tests/filter-diagnostics.test.ts
+++ b/packages/core/tests/filter-diagnostics.test.ts
@@ -432,3 +432,37 @@ describe("mergeAndFilterDiagnostics — file-context stamping", () => {
     expect(filtered[0].fileContext).toBeUndefined();
   });
 });
+
+describe("mergeAndFilterDiagnostics — runtimeGlobals (issue #959)", () => {
+  const jsxNoUndef = (identifier: string): Diagnostic =>
+    createDiagnostic({
+      plugin: "react-doctor",
+      rule: "jsx-no-undef",
+      severity: "error",
+      message: `\`${identifier}\` crashes at runtime because it isn't defined here.`,
+    });
+
+  it("suppresses jsx-no-undef for an identifier listed in runtimeGlobals", () => {
+    const filtered = filterIgnoredDiagnostics(
+      [jsxNoUndef("DatePicker"), jsxNoUndef("Mystery")],
+      { runtimeGlobals: ["DatePicker"] },
+      TEST_ROOT_DIRECTORY,
+      testReadFileLines,
+    );
+    // `DatePicker` is declared runtime-injected → suppressed; an identifier not
+    // in the list still reports, so the filter isn't blanket-silencing the rule.
+    expect(filtered.map((diagnostic) => diagnostic.message)).toEqual([
+      "`Mystery` crashes at runtime because it isn't defined here.",
+    ]);
+  });
+
+  it("leaves jsx-no-undef untouched when runtimeGlobals is unset", () => {
+    const filtered = filterIgnoredDiagnostics(
+      [jsxNoUndef("DatePicker")],
+      {},
+      TEST_ROOT_DIRECTORY,
+      testReadFileLines,
+    );
+    expect(filtered).toHaveLength(1);
+  });
+});

--- a/packages/website/public/schema/config.json
+++ b/packages/website/public/schema/config.json
@@ -119,6 +119,13 @@
           },
           "description": "Names of components that safely route string-only children through a React Native `<Text>` internally (e.g. `heroui-native`'s `Button`, which stringifies its children and renders them through a `ButtonLabel` → `Text`). For listed components, `rn-no-raw-text` is suppressed ONLY when the wrapper's children are entirely stringifiable (no nested JSX elements). A wrapper with mixed children — e.g. `<Button>Save<Icon /></Button>` — still reports, because the wrapper can't safely route raw text alongside a sibling JSX element.\n\nUse this instead of `textComponents` when the component is not itself a text element but is known to wrap its string children in one. `textComponents` is the broader escape hatch and suppresses regardless of sibling content."
         },
+        "runtimeGlobals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Capitalized identifiers that exist at runtime but aren't imported in the file that uses them — react-live's `<LiveProvider scope={...}>`, Storybook globals, MDX live blocks, or an ambient `declare global` in a separate `.d.ts`. The single-file `jsx-no-undef` rule can't see those bindings and would report `<DatePicker />` as an undefined JSX component. List the injected names here and `jsx-no-undef` treats them as known."
+        },
         "serverAuthFunctionNames": {
           "type": "array",
           "items": {


### PR DESCRIPTION
## Problem

`jsx-no-undef` is a single-file AST rule, so it flags capitalized JSX identifiers that exist at **runtime** but aren't imported in the file (#959):

- react-live's `<LiveProvider scope={{ DatePicker }}>` injecting components into playground snippets
- Storybook globals / MDX live code blocks
- an ambient `declare global { const X }` in a separate `.d.ts`

The reporter's repro (react-datepicker docs-site) had **112 occurrences across 107 `?raw`-imported snippet files** — all false positives the rule structurally can't resolve.

## Approach

A config allowlist (the standard ESLint-style escape hatch), named **`runtimeGlobals`** per maintainer decision. It's applied in `build-diagnostic-pipeline.ts` — the same place `textComponents` suppresses `rn-no-raw-text` — so no oxlint host plumbing is needed:

```jsonc
// doctor.config.json
{ "runtimeGlobals": ["DatePicker", "Calendar"] }
```

The pipeline matches the flagged root identifier (the first backticked token of jsx-no-undef's message) against the list and suppresses it. Opt-in: an empty/absent list is exactly today's behavior.

The earlier triage PR (#960, closed) added an opt-in `/* global */` comment hatch, but the repro files have no such comments and the identifiers are injected cross-file — so a per-file comment couldn't fix the 107-file repro, and reading comments would need oxlint host changes. A project-level config declares the injected names once.

## Changes

- `runtimeGlobals?: string[]` on the config type + `validate-config-types` + the config JSON schema (editor autocomplete/docs).
- Suppression in `build-diagnostic-pipeline.ts`.
- Discriminating test: a listed identifier is suppressed, an unlisted one still reports, and an unset config leaves jsx-no-undef untouched. Core typecheck + filter-diagnostics/validate-config-types suites green.

Fixes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Post-lint, opt-in filtering only; default behavior is unchanged unless names are explicitly allowlisted.
> 
> **Overview**
> Adds an opt-in **`runtimeGlobals`** string array on doctor config so projects can declare JSX identifiers that are injected at runtime (react-live scopes, Storybook/MDX playgrounds, ambient globals) without imports in each snippet file.
> 
> **`build-diagnostic-pipeline`** drops `jsx-no-undef` findings when the first backticked identifier in the rule message is on that list; omitted or empty config keeps current behavior. Types, config validation, public JSON schema, and filter tests cover listed vs unlisted identifiers and unset config.
> 
> Closes #959.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844963c973a8c02424fd066a78affd152e8c6a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->