### PR TITLE
fix(git-hook): surface staged diagnostics instead of swallowing them

### DIFF
--- a/.changeset/fix-969-precommit-show-output.md
+++ b/.changeset/fix-969-precommit-show-output.md
@@ -1,0 +1,12 @@
+---
+"react-doctor": patch
+---
+
+Show staged findings in the pre-commit hook instead of swallowing them
+
+The generated pre-commit hook captured react-doctor's output to a temp file and
+deleted it before printing, so a failing scan showed only a generic "found
+staged regressions" notice — never the actual findings (#969). The hook now
+writes the scan output to stderr before cleanup, in both the raw hook and the
+hook-manager command. It stays non-blocking by design (the commit still
+proceeds); the diagnostics are simply visible now so you know what to fix.

--- a/packages/react-doctor/src/cli/utils/git-hook-shared.ts
+++ b/packages/react-doctor/src/cli/utils/git-hook-shared.ts
@@ -18,6 +18,9 @@ export const NON_BLOCKING_REACT_DOCTOR_COMMAND = [
   `if ${REACT_DOCTOR_COMMAND} > "$react_doctor_output" 2>&1; then`,
   'rm -f "$react_doctor_output";',
   "else",
+  // Show the findings before deleting the temp file — non-blocking (the commit
+  // still proceeds), but no longer swallowing what was reported (#969).
+  'cat "$react_doctor_output" >&2;',
   'rm -f "$react_doctor_output";',
   `printf "%s\\n" "React Doctor found staged regressions." "Run ${REACT_DOCTOR_COMMAND} to inspect." "Want them fixed? Ask your agent to run that command and resolve the findings." >&2;`,
   "fi",

--- a/packages/react-doctor/src/cli/utils/install-git-hook-file.ts
+++ b/packages/react-doctor/src/cli/utils/install-git-hook-file.ts
@@ -58,6 +58,10 @@ const buildReactDoctorHookBlock = (): string =>
     'if react_doctor_scan_staged_files > "$react_doctor_output" 2>&1; then',
     '  rm -f "$react_doctor_output"',
     "else",
+    // Surface the scan output before deleting the temp file — the hook stays
+    // non-blocking (the commit still proceeds), but the developer can now see
+    // which findings were reported instead of just a generic notice (#969).
+    '  cat "$react_doctor_output" >&2',
     '  rm -f "$react_doctor_output"',
     `  printf '%s\\n' "React Doctor found staged regressions." "Run ${REACT_DOCTOR_COMMAND} to inspect." "Want them fixed? Ask your agent to run that command and resolve the findings." >&2`,
     "fi",

--- a/packages/react-doctor/tests/install-git-hook.test.ts
+++ b/packages/react-doctor/tests/install-git-hook.test.ts
@@ -717,7 +717,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorGitHook", () =>
     expect(fs.readFileSync(invocationPath, "utf8")).toBe("--staged\n--blocking\nwarning\n");
   });
 
-  it("prints a minimal non-invasive prompt during a real git commit", () => {
+  it("surfaces the diagnostics and still allows the commit (non-blocking)", () => {
     execFileSync("git", ["init"], { cwd: fixture.projectRoot, stdio: "ignore" });
     execFileSync("git", ["config", "user.email", "doctor@example.com"], {
       cwd: fixture.projectRoot,
@@ -768,8 +768,10 @@ describe.skipIf(process.platform === "win32")("installReactDoctorGitHook", () =>
     expect(commitResult.stderr).toContain(
       "Want them fixed? Ask your agent to run that command and resolve the findings.",
     );
-    expect(commitResult.stderr).not.toContain("noisy stdout diagnostic");
-    expect(commitResult.stderr).not.toContain("noisy stderr diagnostic");
+    // The scan output is surfaced (not swallowed) so the developer sees what was
+    // flagged — #969. The commit still succeeds (non-blocking).
+    expect(commitResult.stderr).toContain("noisy stdout diagnostic");
+    expect(commitResult.stderr).toContain("noisy stderr diagnostic");
     expect(commitResult.stderr).not.toContain("Stop commit");
     expect(fs.readFileSync(invocationPath, "utf8")).toBe("--staged\n--blocking\nwarning\n");
     expect(


### PR DESCRIPTION
## Problem

The generated pre-commit hook captured react-doctor's output to a temp file and **deleted it before printing** — so on a failing scan the developer saw only a generic "React Doctor found staged regressions" notice, never *which* findings (#969).

```sh
react_doctor_output=$(mktemp …)
if react_doctor_scan_staged_files > "$react_doctor_output" 2>&1; then
  rm -f "$react_doctor_output"
else
  rm -f "$react_doctor_output"   # ← deletes before showing
  printf '…React Doctor found staged regressions…' >&2
fi
```

## Fix

`cat` the captured output to stderr before cleanup, in both the raw `.git/hooks/pre-commit` (`buildReactDoctorHookBlock`) and the shared hook-manager command (`NON_BLOCKING_REACT_DOCTOR_COMMAND`, used by husky/lefthook/pre-commit/overcommit/simple-git-hooks).

## Scope

The hook is **intentionally non-blocking** (the constant is literally `NON_BLOCKING_REACT_DOCTOR_COMMAND`) — this PR keeps that: the commit still proceeds, the diagnostics are just no longer swallowed. Whether the hook should *gate* commits (the other half of #969) is a separate product decision, so this PR addresses only the swallowed-output bug and doesn't auto-close the issue.

## Test

Updated the real-git-commit test: the fake runner's stdout/stderr diagnostics now appear in the commit output, and the commit still exits 0. Full install-git-hook (29) + install-react-doctor (40) suites green.

Addresses #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell-template change to hook output ordering with no auth or blocking-behavior changes; covered by an updated real-git-commit test.
> 
> **Overview**
> Fixes **#969** where a failing staged `react-doctor` scan in the pre-commit hook only showed a generic “found staged regressions” message because captured output was removed before anything was printed.
> 
> On scan failure, the hook now **`cat`s the temp file to stderr** before cleanup, in both the generated `.git/hooks/pre-commit` block (`buildReactDoctorHookBlock`) and the shared **`NON_BLOCKING_REACT_DOCTOR_COMMAND`** snippet used by Husky, Lefthook, pre-commit, Overcommit, simple-git-hooks, and similar managers. The hook stays **non-blocking**—commits still succeed; developers just see the real diagnostics.
> 
> The integration test was updated so fake scan stdout/stderr appear in commit output while exit status remains 0. A patch **changeset** documents the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f65237933188bbc9ff5ccf16c0627657dd23322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->