### PR TITLE
fix(security): skip test-like files in no-eval and auth-token-in-web-storage

### DIFF
--- a/.changeset/fix-security-rules-skip-test-files.md
+++ b/.changeset/fix-security-rules-skip-test-files.md
@@ -1,0 +1,13 @@
+---
+"react-doctor": patch
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Stop `no-eval` and `auth-token-in-web-storage` from firing in non-production files
+
+`eval` / `new Function` / a stringy `setTimeout`, and a token written to web
+storage, are only vulnerabilities in code that ships to users. Both rules now
+skip test, spec, fixture, story, and script files (`isTestlikeFilename`), so a
+`new Function(...)` inside a `*.test.ts` or a throwaway token in `__tests__/` is
+no longer reported. The rules stay fully enabled in production code.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.test.ts
@@ -57,4 +57,18 @@ describe("auth-token-in-web-storage", () => {
     const result = runRule(authTokenInWebStorage, `const t = localStorage.token;`);
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("does not flag a token write in a `.test.ts` file (throwaway test token)", () => {
+    const result = runRule(authTokenInWebStorage, `localStorage.setItem("authToken", token);`, {
+      filename: "src/auth.test.ts",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a token write inside a `__tests__` directory", () => {
+    const result = runRule(authTokenInWebStorage, `localStorage.setItem("jwt", x);`, {
+      filename: "src/__tests__/auth.ts",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.ts
@@ -1,9 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
-import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { skipNonProductionFiles } from "../../utils/skip-non-production-files.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import type { RuleVisitors } from "../../utils/rule-visitors.js";
 
 const MESSAGE =
   "Storing an auth token in `localStorage`/`sessionStorage` exposes it to any XSS on the page: JavaScript can read web storage and exfiltrate the token. Keep tokens in an `HttpOnly`, `Secure`, `SameSite` cookie instead.";
@@ -53,39 +52,33 @@ export const authTokenInWebStorage = defineRule({
   severity: "warn",
   recommendation:
     "Don't persist auth tokens (JWTs, access/refresh tokens, secrets) in `localStorage`/`sessionStorage`; they're readable by any XSS. Use an `HttpOnly` cookie set by the server.",
-  create: (context): RuleVisitors => {
-    // A token persisted to web storage only leaks to XSS in code that runs
-    // in a real browser. Test, fixture, story, and script files use throwaway
-    // tokens and never ship, so the finding is unactionable there — skip them.
-    if (isTestlikeFilename(context.filename)) return {};
-    return {
-      // `localStorage.setItem("authToken", t)`
-      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        const callee = node.callee;
-        if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
-        if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "setItem")
-          return;
-        if (!isWebStorageObject(callee.object)) return;
-        const keyArgument = node.arguments?.[0];
-        if (
-          !keyArgument ||
-          !isNodeOfType(keyArgument, "Literal") ||
-          typeof keyArgument.value !== "string"
-        ) {
-          return;
-        }
-        if (!SENSITIVE_KEY_PATTERN.test(keyArgument.value)) return;
-        context.report({ node, message: MESSAGE });
-      },
-      // `localStorage.authToken = t` / `localStorage["jwt"] = t`
-      AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
-        const target = node.left;
-        if (!isNodeOfType(target, "MemberExpression")) return;
-        if (!isWebStorageObject(target.object)) return;
-        const propertyName = staticMemberName(target);
-        if (!propertyName || !SENSITIVE_KEY_PATTERN.test(propertyName)) return;
-        context.report({ node: target, message: MESSAGE });
-      },
-    };
-  },
+  create: skipNonProductionFiles((context) => ({
+    // `localStorage.setItem("authToken", t)`
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const callee = node.callee;
+      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+      if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "setItem")
+        return;
+      if (!isWebStorageObject(callee.object)) return;
+      const keyArgument = node.arguments?.[0];
+      if (
+        !keyArgument ||
+        !isNodeOfType(keyArgument, "Literal") ||
+        typeof keyArgument.value !== "string"
+      ) {
+        return;
+      }
+      if (!SENSITIVE_KEY_PATTERN.test(keyArgument.value)) return;
+      context.report({ node, message: MESSAGE });
+    },
+    // `localStorage.authToken = t` / `localStorage["jwt"] = t`
+    AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
+      const target = node.left;
+      if (!isNodeOfType(target, "MemberExpression")) return;
+      if (!isWebStorageObject(target.object)) return;
+      const propertyName = staticMemberName(target);
+      if (!propertyName || !SENSITIVE_KEY_PATTERN.test(propertyName)) return;
+      context.report({ node: target, message: MESSAGE });
+    },
+  })),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.ts
@@ -1,7 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 
 const MESSAGE =
   "Storing an auth token in `localStorage`/`sessionStorage` exposes it to any XSS on the page: JavaScript can read web storage and exfiltrate the token. Keep tokens in an `HttpOnly`, `Secure`, `SameSite` cookie instead.";
@@ -51,33 +53,39 @@ export const authTokenInWebStorage = defineRule({
   severity: "warn",
   recommendation:
     "Don't persist auth tokens (JWTs, access/refresh tokens, secrets) in `localStorage`/`sessionStorage`; they're readable by any XSS. Use an `HttpOnly` cookie set by the server.",
-  create: (context) => ({
-    // `localStorage.setItem("authToken", t)`
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      const callee = node.callee;
-      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
-      if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "setItem")
-        return;
-      if (!isWebStorageObject(callee.object)) return;
-      const keyArgument = node.arguments?.[0];
-      if (
-        !keyArgument ||
-        !isNodeOfType(keyArgument, "Literal") ||
-        typeof keyArgument.value !== "string"
-      ) {
-        return;
-      }
-      if (!SENSITIVE_KEY_PATTERN.test(keyArgument.value)) return;
-      context.report({ node, message: MESSAGE });
-    },
-    // `localStorage.authToken = t` / `localStorage["jwt"] = t`
-    AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
-      const target = node.left;
-      if (!isNodeOfType(target, "MemberExpression")) return;
-      if (!isWebStorageObject(target.object)) return;
-      const propertyName = staticMemberName(target);
-      if (!propertyName || !SENSITIVE_KEY_PATTERN.test(propertyName)) return;
-      context.report({ node: target, message: MESSAGE });
-    },
-  }),
+  create: (context): RuleVisitors => {
+    // A token persisted to web storage only leaks to XSS in code that runs
+    // in a real browser. Test, fixture, story, and script files use throwaway
+    // tokens and never ship, so the finding is unactionable there — skip them.
+    if (isTestlikeFilename(context.filename)) return {};
+    return {
+      // `localStorage.setItem("authToken", t)`
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        const callee = node.callee;
+        if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+        if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "setItem")
+          return;
+        if (!isWebStorageObject(callee.object)) return;
+        const keyArgument = node.arguments?.[0];
+        if (
+          !keyArgument ||
+          !isNodeOfType(keyArgument, "Literal") ||
+          typeof keyArgument.value !== "string"
+        ) {
+          return;
+        }
+        if (!SENSITIVE_KEY_PATTERN.test(keyArgument.value)) return;
+        context.report({ node, message: MESSAGE });
+      },
+      // `localStorage.authToken = t` / `localStorage["jwt"] = t`
+      AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
+        const target = node.left;
+        if (!isNodeOfType(target, "MemberExpression")) return;
+        if (!isWebStorageObject(target.object)) return;
+        const propertyName = staticMemberName(target);
+        if (!propertyName || !SENSITIVE_KEY_PATTERN.test(propertyName)) return;
+        context.report({ node: target, message: MESSAGE });
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noEval } from "./no-eval.js";
+
+describe("no-eval", () => {
+  it("flags eval() in production code", () => {
+    const result = runRule(noEval, `eval(userInput);`, { filename: "src/run.ts" });
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("eval()");
+  });
+
+  it("flags `new Function(...)` in production code", () => {
+    const result = runRule(noEval, `const fn = new Function("return 1");`, {
+      filename: "src/run.ts",
+    });
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new Function()");
+  });
+
+  it("flags a stringy setTimeout in production code", () => {
+    const result = runRule(noEval, `setTimeout("doThing()", 100);`, { filename: "src/run.ts" });
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag `new Function(...)` in a `.test.ts` file", () => {
+    const result = runRule(noEval, `const fn = new Function("return 1");`, {
+      filename: "lib/pages/document/_applyThemeForDocument.test.ts",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag eval() inside a `__tests__` directory", () => {
+    const result = runRule(noEval, `eval(userInput);`, {
+      filename: "src/__tests__/run.ts",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.ts
@@ -1,5 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -9,36 +11,44 @@ export const noEval = defineRule({
   severity: "error",
   recommendation:
     "Use `JSON.parse` for data, or rewrite the code so it doesn't build and run code from strings.",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "eval") {
-        context.report({
-          node,
-          message: "eval() is a code-injection vulnerability: it runs any string as code.",
-        });
-        return;
-      }
+  create: (context: RuleContext): RuleVisitors => {
+    // `eval` / `new Function` / a stringy `setTimeout` is only a
+    // code-injection vulnerability in code that ships to users. Test,
+    // fixture, story, and script files never reach production, so this
+    // critical-severity finding is unactionable there — skip them rather
+    // than make people litter scaffolding with disable directives.
+    if (isTestlikeFilename(context.filename)) return {};
+    return {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "eval") {
+          context.report({
+            node,
+            message: "eval() is a code-injection vulnerability: it runs any string as code.",
+          });
+          return;
+        }
 
-      if (
-        isNodeOfType(node.callee, "Identifier") &&
-        (node.callee.name === "setTimeout" || node.callee.name === "setInterval") &&
-        isNodeOfType(node.arguments?.[0], "Literal") &&
-        typeof node.arguments[0].value === "string"
-      ) {
-        context.report({
-          node,
-          message: `Passing a string to ${node.callee.name}() is a code-injection vulnerability, since it runs that string as code.`,
-        });
-      }
-    },
-    NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
-      if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "Function") {
-        context.report({
-          node,
-          message:
-            "new Function() is a code-injection vulnerability: it builds & runs code from a string.",
-        });
-      }
-    },
-  }),
+        if (
+          isNodeOfType(node.callee, "Identifier") &&
+          (node.callee.name === "setTimeout" || node.callee.name === "setInterval") &&
+          isNodeOfType(node.arguments?.[0], "Literal") &&
+          typeof node.arguments[0].value === "string"
+        ) {
+          context.report({
+            node,
+            message: `Passing a string to ${node.callee.name}() is a code-injection vulnerability, since it runs that string as code.`,
+          });
+        }
+      },
+      NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
+        if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "Function") {
+          context.report({
+            node,
+            message:
+              "new Function() is a code-injection vulnerability: it builds & runs code from a string.",
+          });
+        }
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.ts
@@ -1,7 +1,6 @@
 import { defineRule } from "../../utils/define-rule.js";
-import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { skipNonProductionFiles } from "../../utils/skip-non-production-files.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -11,44 +10,36 @@ export const noEval = defineRule({
   severity: "error",
   recommendation:
     "Use `JSON.parse` for data, or rewrite the code so it doesn't build and run code from strings.",
-  create: (context: RuleContext): RuleVisitors => {
-    // `eval` / `new Function` / a stringy `setTimeout` is only a
-    // code-injection vulnerability in code that ships to users. Test,
-    // fixture, story, and script files never reach production, so this
-    // critical-severity finding is unactionable there — skip them rather
-    // than make people litter scaffolding with disable directives.
-    if (isTestlikeFilename(context.filename)) return {};
-    return {
-      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "eval") {
-          context.report({
-            node,
-            message: "eval() is a code-injection vulnerability: it runs any string as code.",
-          });
-          return;
-        }
+  create: skipNonProductionFiles((context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "eval") {
+        context.report({
+          node,
+          message: "eval() is a code-injection vulnerability: it runs any string as code.",
+        });
+        return;
+      }
 
-        if (
-          isNodeOfType(node.callee, "Identifier") &&
-          (node.callee.name === "setTimeout" || node.callee.name === "setInterval") &&
-          isNodeOfType(node.arguments?.[0], "Literal") &&
-          typeof node.arguments[0].value === "string"
-        ) {
-          context.report({
-            node,
-            message: `Passing a string to ${node.callee.name}() is a code-injection vulnerability, since it runs that string as code.`,
-          });
-        }
-      },
-      NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
-        if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "Function") {
-          context.report({
-            node,
-            message:
-              "new Function() is a code-injection vulnerability: it builds & runs code from a string.",
-          });
-        }
-      },
-    };
-  },
+      if (
+        isNodeOfType(node.callee, "Identifier") &&
+        (node.callee.name === "setTimeout" || node.callee.name === "setInterval") &&
+        isNodeOfType(node.arguments?.[0], "Literal") &&
+        typeof node.arguments[0].value === "string"
+      ) {
+        context.report({
+          node,
+          message: `Passing a string to ${node.callee.name}() is a code-injection vulnerability, since it runs that string as code.`,
+        });
+      }
+    },
+    NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
+      if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "Function") {
+        context.report({
+          node,
+          message:
+            "new Function() is a code-injection vulnerability: it builds & runs code from a string.",
+        });
+      }
+    },
+  })),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.ts
@@ -1,9 +1,9 @@
 import type { FileScan } from "./file-scan.js";
-import { isTestlikeFilename } from "./is-testlike-filename.js";
 import {
   fileImportsNonReactJsxDialect,
   jsxAttributeIsNonReactDialectMarker,
 } from "./non-react-jsx-dialect.js";
+import { skipNonProductionFiles } from "./skip-non-production-files.js";
 import type { Rule } from "./rule.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 
@@ -14,21 +14,6 @@ import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 // inert visitor factory injected for host compatibility. Metadata,
 // registration, tags, and severity flow identically either way.
 export type RuleDefinition = Rule | (Omit<Rule, "create"> & { scan: FileScan });
-
-// Rules tagged `"test-noise"` are by-design noisy in tests / stories /
-// playgrounds — design-system style preferences, deprecated-API hints,
-// auto-parallelizable awaits, etc. None of these apply to files that
-// don't ship to users. We wrap `create()` once here so every such rule
-// auto-skips testlike files without each one re-implementing the check.
-const wrapCreateForTestNoise = <
-  CreateFn extends (context: { filename?: string }) => Record<string, unknown>,
->(
-  create: CreateFn,
-): CreateFn =>
-  ((context) => {
-    if (isTestlikeFilename(context.filename)) return {};
-    return create(context);
-  }) as CreateFn;
 
 // Rules tagged `"react-jsx-only"` apply React-flavoured semantics
 // (a11y semantics tuned for React's synthetic-event listener naming,
@@ -101,13 +86,15 @@ export const defineRule = (rule: RuleDefinition): Rule => {
   }
   const tags = rule.tags;
   let wrappedCreate = rule.create;
-  // `migration-hint` wins over `test-noise` — deprecated API usage in
-  // test code is the very surface that needs migration (`react-dom/test-utils`
-  // imports, legacy lifecycle methods in test class fixtures, etc.).
-  // Skip the test-noise wrapper when the rule has both tags.
+  // Rules tagged `"test-noise"` are by-design noisy in non-production files
+  // (design-system style preferences, deprecated-API hints, auto-parallelizable
+  // awaits, …), so we auto-skip testlike files for them. `migration-hint` wins:
+  // deprecated API usage in test code is the very surface that needs migration
+  // (`react-dom/test-utils` imports, legacy lifecycle methods in test fixtures),
+  // so a rule carrying both tags keeps firing there.
   const honorsTestNoise = tags?.includes("test-noise") && !tags?.includes("migration-hint");
   if (honorsTestNoise) {
-    wrappedCreate = wrapCreateForTestNoise(wrappedCreate as never) as never;
+    wrappedCreate = skipNonProductionFiles(wrappedCreate);
   }
   if (tags?.includes("react-jsx-only")) {
     wrappedCreate = wrapCreateForReactJsxOnly(wrappedCreate as never) as never;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/skip-non-production-files.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/skip-non-production-files.ts
@@ -1,0 +1,14 @@
+import { isTestlikeFilename } from "./is-testlike-filename.js";
+import type { RuleContext } from "./rule-context.js";
+import type { RuleVisitors } from "./rule-visitors.js";
+
+// Wrap a rule's `create` so it produces no visitors in non-production files
+// (tests, specs, fixtures, stories, scripts, …). Used by `defineRule` for the
+// `test-noise` tag and directly by rules whose finding is only actionable in
+// code that ships to users — e.g. the security rules, where `eval` /
+// `new Function` / a token in web storage is not a real vulnerability in test
+// scaffolding that never reaches a browser.
+export const skipNonProductionFiles =
+  (create: (context: RuleContext) => RuleVisitors) =>
+  (context: RuleContext): RuleVisitors =>
+    isTestlikeFilename(context.filename) ? {} : create(context);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

`no-eval` fired on `new Function(...)` inside a `*.test.ts` file. `eval` / `new Function` / a stringy `setTimeout`, and a token written to web storage, are only vulnerabilities in code that **ships to users** — test scaffolding never reaches production, so the finding is unactionable there.

- `no-eval` and `auth-token-in-web-storage` now skip non-production files (`.test.*`/`.spec.*`, `__tests__/`, fixtures, stories, scripts, …). (`no-secrets-in-client-code` already has its own file-context classification, so it's left as-is.)
- These rules stay `test-noise`-free, so they remain fully enabled in production and aren't disabled by `ignore.tags: ["test-noise"]`.

### Implementation note

Rather than duplicate an inline `if (isTestlikeFilename(...)) return {}` guard in each rule, the skip is a single shared combinator `skipNonProductionFiles(create)` (`utils/skip-non-production-files.ts`). `defineRule` now uses it for the existing `test-noise` tag too, replacing its bespoke generic `wrapCreateForTestNoise` (and its `as never` casts) — one canonical implementation, used both declaratively (via the tag) and explicitly (the security rules).

> Note: the `revalidateTeamDataCache` server-action false positive that was originally part of this PR is now fixed on `main` by #983 (general non-privileged cache/navigation action detection), so that work was dropped on rebase.

## Tests

- `no-eval.test.ts` (new): flags in production, skips in `*.test.ts` / `__tests__/`.
- `auth-token-in-web-storage.test.ts`: added test-file skip cases.
- Full `oxlint-plugin-react-doctor` suite (7300 tests) green — confirms the `defineRule` refactor preserves `test-noise` behavior. `typecheck`, `lint`, `format` pass.

The ESLint mirror re-exports these rules from the oxlint plugin and forwards `context.filename`, so the fix propagates automatically.

## Related context (not in this PR)

The viewport `maximum-scale=1.0` finding from `no-disabled-zoom` is a **true positive**, not a false positive: it fails WCAG 1.4.4 on Android browsers (iOS Safari has ignored `maximum-scale` since iOS 10). Remediation is to remove `maximum-scale` (or set it `>= 2`). No rule change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cab7bf09-8416-45f3-a946-fff8ebf59720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cab7bf09-8416-45f3-a946-fff8ebf59720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

