### PR TITLE
FP-FIX(architecture): eliminate false positives across architecture/correctness/design rules

### DIFF
--- a/.changeset/fp-fix-architecture-correctness-design.md
+++ b/.changeset/fp-fix-architecture-correctness-design.md
@@ -1,0 +1,33 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(architecture): eliminate false positives across architecture, correctness, and design rules
+
+Hardens ~15 rules so they stop firing on valid code, without weakening the real smell each targets.
+
+Architecture:
+
+- `no-many-boolean-props` requires actual render output before treating a parameter as component props (so non-component factories like `CreateValidator(options)` are skipped), and no longer counts props that are invoked or wired as event handlers (`onClick={showMenu}`) as boolean flags.
+- `no-nested-component-definition` only flags a nested definition that is actually rendered as JSX (`<Inner/>`), not a capitalized helper that is merely called (`Inner()`).
+- `no-render-in-render` exempts render-prop invocations (`props.renderX()`, `this.props.renderX()`, and render props destructured from params) and stable class-method calls (`this.renderX()`).
+- `no-render-prop-children` ignores `render*Props` config bags and literal `render*` mode/flag values, which are not render slots.
+- `prefer-module-scope-static-value` no longer hoists initializers that call impure globals (`Date.now()`, `Math.random()`, `crypto.randomUUID()`, `nanoid()`, …), which are meant to recompute per render.
+- `react-compiler-destructure-method` drops `useSearchParams` (its methods are unbound and throw when destructured).
+- `react-compiler-no-manual-memoization` leaves `memo(Component, areEqual)` with a custom comparator alone.
+
+Correctness:
+
+- `html-no-invalid-paragraph-child` and `html-no-nested-interactive` stop at JSX attribute boundaries, so an element passed as a prop is no longer treated as a DOM child / nested element.
+- `no-polymorphic-children` only flags `typeof children` when `children` resolves to the component's props, not a local variable or field that happens to be named `children`.
+- `no-prevent-default` skips `<form action=…>` (which has a native no-JS submit path) and anchors whose handler also navigates or side-effects after `preventDefault()`.
+- `no-uncontrolled-input` treats `onInput` as controlling, like `onChange`.
+- `rendering-svg-precision` requires at least two distinct over-precise coordinates before reporting.
+
+Design:
+
+- `no-gray-on-colored-background` only fires when the gray text and colored background share the same Tailwind variant scope, and tightens the palette/shade patterns.
+- `no-layout-transition-inline` uses word boundaries so it no longer matches property substrings.
+- `no-long-transition-duration` exempts infinite / looping animations.
+- `no-outline-none` allows `outline: none` alongside a focus-ring class or on elements removed from the tab order (negative `tabIndex`).
+- `no-side-tab-border` runs arbitrary hex/rgb/hsl border colors through the same achromatic check as named palette colors.

--- a/.changeset/fp-fix-architecture-correctness-design.md
+++ b/.changeset/fp-fix-architecture-correctness-design.md
@@ -9,8 +9,8 @@ Hardens ~15 rules so they stop firing on valid code, without weakening the real 
 Architecture:
 
 - `no-many-boolean-props` requires actual render output before treating a parameter as component props (so non-component factories like `CreateValidator(options)` are skipped), and no longer counts props that are invoked or wired as event handlers (`onClick={showMenu}`) as boolean flags.
-- `no-nested-component-definition` only flags a nested definition that is actually rendered as JSX (`<Inner/>`), not a capitalized helper that is merely called (`Inner()`).
-- `no-render-in-render` exempts render-prop invocations (`props.renderX()`, `this.props.renderX()`, and render props destructured from params) and stable class-method calls (`this.renderX()`).
+- `no-nested-component-definition` only flags a nested definition that is actually rendered as JSX (`<Inner/>`) inside its own enclosing component, not a capitalized helper that is merely called (`Inner()`) — and no longer leaks a sibling component's `<Inner/>` onto a same-named call-only helper.
+- `no-render-in-render` exempts render-prop invocations (`props.renderX()`, `this.props.renderX()`, `props.slots.renderX()` on a nested prop bag, and render props destructured from props or a component parameter) and stable class-method calls (`this.renderX()`), while still flagging a `render*` parameter of an ordinary nested helper.
 - `no-render-prop-children` ignores `render*Props` config bags and literal `render*` mode/flag values, which are not render slots.
 - `prefer-module-scope-static-value` no longer hoists initializers that call impure globals (`Date.now()`, `Math.random()`, `crypto.randomUUID()`, `nanoid()`, …), which are meant to recompute per render.
 - `react-compiler-destructure-method` drops `useSearchParams` (its methods are unbound and throw when destructured).

--- a/.changeset/fp-fix-architecture-correctness-design.md
+++ b/.changeset/fp-fix-architecture-correctness-design.md
@@ -8,26 +8,26 @@ Hardens ~15 rules so they stop firing on valid code, without weakening the real 
 
 Architecture:
 
-- `no-many-boolean-props` requires actual render output before treating a parameter as component props (so non-component factories like `CreateValidator(options)` are skipped), and no longer counts props that are invoked or wired as event handlers (`onClick={showMenu}`) as boolean flags.
-- `no-nested-component-definition` only flags a nested definition that is actually rendered as JSX (`<Inner/>`) inside its own enclosing component, not a capitalized helper that is merely called (`Inner()`) — and no longer leaks a sibling component's `<Inner/>` onto a same-named call-only helper.
-- `no-render-in-render` exempts render-prop invocations (`props.renderX()`, `this.props.renderX()`, `props.slots.renderX()` on a nested prop bag, and render props destructured from props or a component parameter) and stable class-method calls (`this.renderX()`), while still flagging a `render*` parameter of an ordinary nested helper.
+- `no-many-boolean-props` requires actual render output before treating a parameter as component props (so non-component factories like `CreateValidator(options)` are skipped; JSX inside `.map`/`useMemo` callbacks still counts), and no longer counts props that are invoked, wired as event handlers (`onClick={showMenu}`), or passed as imperative-prefixed call arguments (`setTimeout(props.showMenu, 100)`) as boolean flags — resolving each name to the component's own props binding, including renamed destructurings.
+- `no-nested-component-definition` only flags a nested definition that is actually rendered — as JSX (`<Inner/>`) or by reference through a component prop (`component={Inner}`) — inside its own enclosing component, not a capitalized helper that is merely called (`Inner()`), and no longer leaks a sibling component's `<Inner/>` onto a same-named call-only helper.
+- `no-render-in-render` exempts render-prop invocations (`props.renderX()`, `this.props.renderX()`, `props.slots.renderX()` on a nested prop bag, and render props destructured or aliased from props or a component parameter — including defaulted/conditional aliases like `props.renderItem ?? defaultRender`), while still flagging local `render*` helpers, `this.renderX()` class-field calls, and a `render*` parameter of an ordinary nested helper.
 - `no-render-prop-children` ignores `render*Props` config bags and literal `render*` mode/flag values, which are not render slots.
-- `prefer-module-scope-static-value` no longer hoists initializers that call impure globals (`Date.now()`, `Math.random()`, `crypto.randomUUID()`, `nanoid()`, …), which are meant to recompute per render.
+- `prefer-module-scope-static-value` no longer hoists initializers that call impure globals (`Date.now()`, `Math.random()`, `crypto.randomUUID()`, `nanoid()`, …) — local helpers that merely share one of those names stay hoistable — and abstains when every reference is a read-only scalar lookup (`KEYS.includes(k)`), where referential identity can't matter.
 - `react-compiler-destructure-method` drops `useSearchParams` (its methods are unbound and throw when destructured).
-- `react-compiler-no-manual-memoization` leaves `memo(Component, areEqual)` with a custom comparator alone.
+- `react-compiler-no-manual-memoization` leaves `memo(Component, areEqual)` with a custom comparator alone (a nullish second argument still counts as redundant).
 
 Correctness:
 
-- `html-no-invalid-paragraph-child` and `html-no-nested-interactive` stop at JSX attribute boundaries, so an element passed as a prop is no longer treated as a DOM child / nested element.
+- `html-no-invalid-paragraph-child` and `html-no-nested-interactive` stop at JSX attribute boundaries, so an element passed as a prop is no longer treated as a DOM child / nested element — except the explicit `children` prop, which React renders as a real DOM child.
 - `no-polymorphic-children` only flags `typeof children` when `children` resolves to the component's props, not a local variable or field that happens to be named `children`.
-- `no-prevent-default` skips `<form action=…>` (which has a native no-JS submit path) and anchors whose handler also navigates or side-effects after `preventDefault()`.
-- `no-uncontrolled-input` treats `onInput` as controlling like `onChange`, and no longer flags `disabled` inputs (React suppresses its missing-`onChange` warning for `disabled` fields, just like `readOnly`).
-- `rendering-svg-precision` requires at least two distinct over-precise coordinates before reporting.
+- `no-prevent-default` skips `<form action=…>` (which has a native no-JS submit path) and anchors whose handler carries positive navigation evidence after `preventDefault()` (`router.push`, `navigate(...)`, `window.open`, delegation to a prop handler) — analytics-only handlers stay flagged as dead links — and stays quiet in test/demo files.
+- `no-uncontrolled-input` treats `onInput` as controlling like `onChange`, no longer flags `disabled` inputs (React suppresses its missing-`onChange` warning for `disabled` fields, just like `readOnly`) unless `disabled={false}` is literal, and stays quiet in test/demo files.
+- `rendering-svg-precision` requires at least two over-precise token occurrences before reporting, and stays quiet in test/demo/docs-site files.
 
 Design:
 
-- `no-gray-on-colored-background` only fires when the gray text and colored background share the same Tailwind variant scope, and tightens the palette/shade patterns.
-- `no-layout-transition-inline` uses word boundaries so it no longer matches property substrings.
-- `no-long-transition-duration` exempts infinite / looping animations.
-- `no-outline-none` allows `outline: none` alongside a focus-ring class or on elements removed from the tab order (negative `tabIndex`).
-- `no-side-tab-border` runs arbitrary hex/rgb/hsl border colors through the same achromatic check as named palette colors.
+- `no-gray-on-colored-background` pairs gray text and colored backgrounds by Tailwind variant scope (order-insensitive, `!important`-aware), including the additive case where a base utility applies under a variant with no same-property override, and tightens the palette/shade patterns.
+- `no-layout-transition-inline` matches an exact set of layout property tokens (now also `border-*-width`, `line-height`, `column-width`) so lookalikes such as `stroke-width` no longer match.
+- `no-long-transition-duration` exempts infinite / looping animation segments (an animation NAME containing "infinite" still counts) and decorative `aria-hidden` elements.
+- `no-outline-none` allows `outline: none` alongside a class that ADDS a visible ring on the element's OWN focus (removal utilities like `focus:ring-0` / `focus:outline-hidden` and `group-focus:`/`peer-focus:` variants don't count) or on elements removed from the tab order (negative `tabIndex`, including conditionals where both branches are negative).
+- `no-side-tab-border` runs arbitrary hex/rgb/hsl border colors through the same achromatic check as named palette colors, preferring the color scoped to the flagged side (`border-l-[#e5e7eb]`) over the base border color.

--- a/.changeset/fp-fix-architecture-correctness-design.md
+++ b/.changeset/fp-fix-architecture-correctness-design.md
@@ -21,7 +21,7 @@ Correctness:
 - `html-no-invalid-paragraph-child` and `html-no-nested-interactive` stop at JSX attribute boundaries, so an element passed as a prop is no longer treated as a DOM child / nested element.
 - `no-polymorphic-children` only flags `typeof children` when `children` resolves to the component's props, not a local variable or field that happens to be named `children`.
 - `no-prevent-default` skips `<form action=…>` (which has a native no-JS submit path) and anchors whose handler also navigates or side-effects after `preventDefault()`.
-- `no-uncontrolled-input` treats `onInput` as controlling, like `onChange`.
+- `no-uncontrolled-input` treats `onInput` as controlling like `onChange`, and no longer flags `disabled` inputs (React suppresses its missing-`onChange` warning for `disabled` fields, just like `readOnly`).
 - `rendering-svg-precision` requires at least two distinct over-precise coordinates before reporting.
 
 Design:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
@@ -20,6 +20,14 @@ export const GET_HANDLER_BINDING_RESOLUTION_DEPTH = 3;
 // ceremony at this scale.
 export const SMALL_LITERAL_ARRAY_MAX_ELEMENTS = 8;
 
+// Materiality gate for `rendering-svg-precision`: a single over-precise
+// coordinate (even repeated) in a one-off hand-written glyph saves only a
+// handful of bytes once — not a download cost worth a diagnostic. Real
+// machine-exported / wasteful paths carry many DISTINCT over-precise
+// coordinates. Require at least this many distinct over-precise tokens
+// before reporting.
+export const MIN_DISTINCT_OVERPRECISE_SVG_TOKENS = 2;
+
 // Cross-file resolution bounds for the reducer / cross-file rules.
 // `CROSS_FILE_PARSE_MAX_BYTES` skips parsing generated / vendored files
 // large enough to slow a lint run; `CROSS_FILE_BARREL_FOLLOW_DEPTH`

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
@@ -20,13 +20,14 @@ export const GET_HANDLER_BINDING_RESOLUTION_DEPTH = 3;
 // ceremony at this scale.
 export const SMALL_LITERAL_ARRAY_MAX_ELEMENTS = 8;
 
-// Materiality gate for `rendering-svg-precision`: a single over-precise
-// coordinate (even repeated) in a one-off hand-written glyph saves only a
+// Materiality gate for `rendering-svg-precision`: a single stray
+// over-precise coordinate in a one-off hand-written glyph saves only a
 // handful of bytes once — not a download cost worth a diagnostic. Real
-// machine-exported / wasteful paths carry many DISTINCT over-precise
-// coordinates. Require at least this many distinct over-precise tokens
-// before reporting.
-export const MIN_DISTINCT_OVERPRECISE_SVG_TOKENS = 2;
+// machine-exported / wasteful attributes carry the over-precise tokens
+// repeatedly (Inkscape's uniform-scale matrix repeats ONE factor twice;
+// exported paths carry many). Require at least this many over-precise
+// token occurrences before reporting.
+export const MIN_OVERPRECISE_SVG_TOKEN_OCCURRENCES = 2;
 
 // Cross-file resolution bounds for the reducer / cross-file rules.
 // `CROSS_FILE_PARSE_MAX_BYTES` skips parsing generated / vendored files

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.regressions.test.ts
@@ -41,4 +41,98 @@ describe("architecture/no-many-boolean-props — regressions", () => {
     );
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
+
+  // fp-review PR 996: the render-output gate treated nested arrow callbacks
+  // as boundaries, skipping components whose JSX lives only inside
+  // `.map`/`useMemo` callbacks.
+  it("flags a component that renders only via a .map callback", () => {
+    const result = run(
+      `function List({ showHeader, showFooter, isCompact, hasBorder, items }){
+        return items.map((item) => <li key={item}>{item}</li>);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a component that returns JSX from a useMemo callback", () => {
+    const result = run(
+      `import { useMemo } from "react";
+      function Panel({ isOpen, isLoading, hasIcon, canEdit }){
+        return useMemo(() => <div data-open={isOpen} data-loading={isLoading} data-icon={hasIcon} data-edit={canEdit} />, [isOpen, isLoading, hasIcon, canEdit]);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a props-object component that renders only via a .map callback", () => {
+    const result = run(
+      `function List(props){
+        return props.items.map((item) => <li data-a={props.showHeader} data-b={props.showFooter} data-c={props.isCompact} data-d={props.hasBorder} key={item}>{item}</li>);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on a non-component factory with zero JSX anywhere", () => {
+    const result = run(
+      `function CreateValidator(options){
+        const check = () => options.isStrict && options.hasSchema;
+        return { check, isEnabled: options.isEnabled, showErrors: options.showErrors };
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  // fp-review PR 996: renamed destructured callbacks (`{ showMenu: openMenu }`)
+  // must match the exclusion via the VALUE binding name.
+  it("does not count renamed destructured callback props", () => {
+    const result = run(
+      `function Toolbar({ showMenu: openMenu, hideMenu: closeMenu, enableSave: turnOn, disableSave: turnOff }){
+        return <div onClick={openMenu}>{closeMenu()}{turnOn()}{turnOff()}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  // fp-review PR 996: imperative-prefixed props passed as call ARGUMENTS
+  // (setTimeout/debounce/subscription wiring) are callbacks too.
+  it("does not count `props.show*` passed as a callback argument", () => {
+    const result = run(
+      `function Toolbar(props){
+        return <div onClick={() => { setTimeout(props.showMenu, 100); setTimeout(props.hideMenu, 100); register(props.enableSave); register(props.disableSave); }} />;
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not count destructured imperative names passed as callback arguments", () => {
+    const result = run(
+      `function Toolbar({ showMenu, hideMenu, enableSave, disableSave }){
+        return <div onClick={() => { setTimeout(showMenu, 100); setTimeout(hideMenu, 100); register(enableSave); register(disableSave); }} />;
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still counts non-imperative boolean props passed as call arguments (classNames)", () => {
+    const result = run(
+      `function Badge(props){
+        return <div className={classNames(props.isActive, props.isPrimary, props.hasIcon, props.isCompact)} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  // fp-review PR 996: the callback exclusion must resolve to the component's
+  // own props binding — a shadowed inner parameter sharing a prop's name
+  // must not drop the genuine boolean prop from the count.
+  it("still flags when a nested shadowed function parameter shares a prop's name", () => {
+    const result = run(
+      `function Panel({ isOpen, isLoading, hasIcon, canEdit }){
+        const helper = (canEdit) => canEdit();
+        return <div data-open={isOpen} data-loading={isLoading} data-icon={hasIcon} data-edit={canEdit} onClick={() => helper(() => true)} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.regressions.test.ts
@@ -28,6 +28,13 @@ describe("architecture/no-many-boolean-props — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not count `props.show*` wired as JSX event handlers", () => {
+    const result = run(
+      `function Toolbar(props){ return <div onClick={props.showMenu} onMouseDown={props.hideMenu} onKeyDown={props.enableSave} onFocus={props.disableSave} />; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags four genuine boolean props read off the props object", () => {
     const result = run(
       `function C(props){ return <div data-a={props.isPrimary} data-b={props.hasIcon} data-c={props.showHeader} data-d={props.canEdit} />; }`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.regressions.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noManyBooleanProps } from "./no-many-boolean-props.js";
+
+const run = (code: string) => runRule(noManyBooleanProps, code, { filename: "fixture.tsx" });
+
+describe("architecture/no-many-boolean-props — regressions", () => {
+  it("does not count boolean-prefixed props that are imperative callbacks", () => {
+    const result = run(
+      `function Toolbar({ showMenu, hideMenu, enableSave, disableSave }){ return <div onClick={showMenu}>{hideMenu()}{enableSave()}{disableSave()}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags four genuine on/off boolean props", () => {
+    const result = run(
+      `function C({ isPrimary, hasIcon, showHeader, canEdit }){ return <div />; }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  // Bugbot wave 4: the callback exclusion must also apply to the `props` object
+  // shape — `props.showMenu()` is an invoked callback, not a boolean prop.
+  it("does not count `props.show*()` callback invocations on the props object", () => {
+    const result = run(
+      `function Toolbar(props){ return <div onClick={props.showMenu}>{props.hideMenu()}{props.enableSave()}{props.disableSave()}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags four genuine boolean props read off the props object", () => {
+    const result = run(
+      `function C(props){ return <div data-a={props.isPrimary} data-b={props.hasIcon} data-c={props.showHeader} data-d={props.canEdit} />; }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noManyBooleanProps } from "./no-many-boolean-props.js";
+
+describe("no-many-boolean-props", () => {
+  it("flags a component with many destructured boolean props", () => {
+    const result = runRule(
+      noManyBooleanProps,
+      `const Toggle = ({ isOpen, isLoading, hasIcon, canEdit }) => <div />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a component that reads many boolean props off its param", () => {
+    const result = runRule(
+      noManyBooleanProps,
+      `function Panel(props) {
+        return <div>{props.isOpen && props.isLoading && props.hasIcon && props.canEdit ? "a" : "b"}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  // A factory that happens to take an options object with on/off flags is
+  // not a component — it never returns render output.
+  it("does not flag a non-component factory with boolean-prefixed options", () => {
+    const result = runRule(
+      noManyBooleanProps,
+      `function CreateValidator(options) {
+        return { run: () => options.isStrict && options.hasSchema && options.canCoerce && options.shouldThrow };
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -4,6 +4,7 @@ import { functionContainsReactRenderOutput } from "../../utils/function-contains
 import { isBooleanPrefixedPropName } from "../../utils/is-boolean-prefixed-prop-name.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
+import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -15,8 +16,6 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 // event handler (`onClick={showMenu}`) are imperative callbacks, not
 // on/off flags — the boolean-prefix heuristic misreads `show`/`hide`/
 // `enable`/`disable` callbacks as booleans, so drop them from the count.
-const EVENT_HANDLER_ATTRIBUTE_PATTERN = /^on[A-Z]/;
-
 const collectCallbackUsedNames = (componentBody: EsTreeNode | undefined): Set<string> => {
   const callbackNames = new Set<string>();
   if (!componentBody) return callbackNames;
@@ -26,9 +25,7 @@ const collectCallbackUsedNames = (componentBody: EsTreeNode | undefined): Set<st
       return;
     }
     if (
-      isNodeOfType(child, "JSXAttribute") &&
-      isNodeOfType(child.name, "JSXIdentifier") &&
-      EVENT_HANDLER_ATTRIBUTE_PATTERN.test(child.name.name) &&
+      isEventHandlerAttribute(child) &&
       isNodeOfType(child.value, "JSXExpressionContainer") &&
       isNodeOfType(child.value.expression, "Identifier")
     ) {
@@ -56,15 +53,8 @@ const collectBooleanLikePropsFromBody = (
     // destructured-param callback exclusion for the `props` object shape.
     const parent = child.parent;
     if (isNodeOfType(parent, "CallExpression") && parent.callee === child) return;
-    if (isNodeOfType(parent, "JSXExpressionContainer")) {
-      const attribute = parent.parent;
-      if (
-        isNodeOfType(attribute, "JSXAttribute") &&
-        isNodeOfType(attribute.name, "JSXIdentifier") &&
-        EVENT_HANDLER_ATTRIBUTE_PATTERN.test(attribute.name.name)
-      ) {
-        return;
-      }
+    if (isNodeOfType(parent, "JSXExpressionContainer") && isEventHandlerAttribute(parent.parent)) {
+      return;
     }
     found.add(child.property.name);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -1,5 +1,6 @@
 import { BOOLEAN_PROP_THRESHOLD } from "../../constants/thresholds.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { isBooleanPrefixedPropName } from "../../utils/is-boolean-prefixed-prop-name.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
@@ -9,6 +10,33 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// Prop names whose value is invoked (`showMenu()`) or wired up as an
+// event handler (`onClick={showMenu}`) are imperative callbacks, not
+// on/off flags — the boolean-prefix heuristic misreads `show`/`hide`/
+// `enable`/`disable` callbacks as booleans, so drop them from the count.
+const EVENT_HANDLER_ATTRIBUTE_PATTERN = /^on[A-Z]/;
+
+const collectCallbackUsedNames = (componentBody: EsTreeNode | undefined): Set<string> => {
+  const callbackNames = new Set<string>();
+  if (!componentBody) return callbackNames;
+  walkAst(componentBody, (child: EsTreeNode) => {
+    if (isNodeOfType(child, "CallExpression") && isNodeOfType(child.callee, "Identifier")) {
+      callbackNames.add(child.callee.name);
+      return;
+    }
+    if (
+      isNodeOfType(child, "JSXAttribute") &&
+      isNodeOfType(child.name, "JSXIdentifier") &&
+      EVENT_HANDLER_ATTRIBUTE_PATTERN.test(child.name.name) &&
+      isNodeOfType(child.value, "JSXExpressionContainer") &&
+      isNodeOfType(child.value.expression, "Identifier")
+    ) {
+      callbackNames.add(child.value.expression.name);
+    }
+  });
+  return callbackNames;
+};
 
 const collectBooleanLikePropsFromBody = (
   componentBody: EsTreeNode | undefined,
@@ -23,6 +51,10 @@ const collectBooleanLikePropsFromBody = (
     if (child.object.name !== propsParamName) return;
     if (!isNodeOfType(child.property, "Identifier")) return;
     if (!isBooleanPrefixedPropName(child.property.name)) return;
+    // `props.showMenu()` is a callback invocation, not a boolean prop — mirror
+    // the destructured-param callback exclusion for the `props` object shape.
+    const parent = child.parent;
+    if (isNodeOfType(parent, "CallExpression") && parent.callee === child) return;
     found.add(child.property.name);
   });
   return found;
@@ -58,18 +90,26 @@ export const noManyBooleanProps = defineRule({
     };
 
     const checkComponent = (
+      functionNode: EsTreeNode,
       param: EsTreeNode | undefined,
       body: EsTreeNode | undefined,
       componentName: string,
       reportNode: EsTreeNode,
     ): void => {
       if (!param) return;
+      // The component gates (uppercase name) also match non-component
+      // factories like `function CreateValidator(options) { … }`, whose
+      // `options.isStrict` accesses look like boolean props. Require
+      // actual render output before treating the param as component props.
+      if (!functionContainsReactRenderOutput(functionNode, context.scopes)) return;
       if (isNodeOfType(param, "ObjectPattern")) {
+        const callbackUsedNames = collectCallbackUsedNames(body);
         const booleanLikePropNames: string[] = [];
         for (const property of param.properties ?? []) {
           if (!isNodeOfType(property, "Property")) continue;
           const keyName = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
           if (!keyName) continue;
+          if (callbackUsedNames.has(keyName)) continue;
           if (isBooleanPrefixedPropName(keyName)) {
             booleanLikePropNames.push(keyName);
           }
@@ -86,13 +126,13 @@ export const noManyBooleanProps = defineRule({
     return {
       FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!isComponentDeclaration(node) || !node.id) return;
-        checkComponent(node.params?.[0], node.body, node.id.name, node.id);
+        checkComponent(node, node.params?.[0], node.body, node.id.name, node.id);
       },
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
         if (!isNodeOfType(node.id, "Identifier")) return;
         if (!isInlineFunctionExpression(node.init)) return;
-        checkComponent(node.init.params?.[0], node.init.body, node.id.name, node.id);
+        checkComponent(node.init, node.init.params?.[0], node.init.body, node.id.name, node.id);
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -51,10 +51,21 @@ const collectBooleanLikePropsFromBody = (
     if (child.object.name !== propsParamName) return;
     if (!isNodeOfType(child.property, "Identifier")) return;
     if (!isBooleanPrefixedPropName(child.property.name)) return;
-    // `props.showMenu()` is a callback invocation, not a boolean prop — mirror
-    // the destructured-param callback exclusion for the `props` object shape.
+    // `props.showMenu()` (invoked) and `onClick={props.showMenu}` (wired as an
+    // event handler) are imperative callbacks, not boolean props — mirror the
+    // destructured-param callback exclusion for the `props` object shape.
     const parent = child.parent;
     if (isNodeOfType(parent, "CallExpression") && parent.callee === child) return;
+    if (isNodeOfType(parent, "JSXExpressionContainer")) {
+      const attribute = parent.parent;
+      if (
+        isNodeOfType(attribute, "JSXAttribute") &&
+        isNodeOfType(attribute.name, "JSXIdentifier") &&
+        EVENT_HANDLER_ATTRIBUTE_PATTERN.test(attribute.name.name)
+      ) {
+        return;
+      }
+    }
     found.add(child.property.name);
   });
   return found;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -11,17 +11,46 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 
-// Prop names whose value is invoked (`showMenu()`) or wired up as an
-// event handler (`onClick={showMenu}`) are imperative callbacks, not
+// `show`/`hide`/`enable`/`disable` names read as commands, so passing one
+// as a call argument (`setTimeout(props.showMenu, 100)`) marks it as a
+// callback. `is`/`has`/`can`/… names passed as arguments stay boolean data
+// (`classNames(props.isActive)`).
+const IMPERATIVE_CALLBACK_PREFIX_PATTERN = /^(?:show|hide|enable|disable)[A-Z]/;
+
+// Prop names whose value is invoked (`showMenu()`), wired up as an event
+// handler (`onClick={showMenu}`), or handed to another call as an
+// imperative-prefixed argument (`register(enableSave)`) are callbacks, not
 // on/off flags — the boolean-prefix heuristic misreads `show`/`hide`/
 // `enable`/`disable` callbacks as booleans, so drop them from the count.
-const collectCallbackUsedNames = (componentBody: EsTreeNode | undefined): Set<string> => {
+// Only identifiers that resolve to the component's own props parameter
+// count; a shadowed inner binding sharing a prop's name must not exclude it.
+const collectCallbackUsedNames = (
+  componentBody: EsTreeNode | undefined,
+  propsParam: EsTreeNode,
+  scopes: ScopeAnalysis,
+): Set<string> => {
   const callbackNames = new Set<string>();
   if (!componentBody) return callbackNames;
+  const addWhenPropsBinding = (identifier: EsTreeNodeOfType<"Identifier">): void => {
+    const symbol = scopes.symbolFor(identifier);
+    if (!symbol || symbol.declarationNode !== propsParam) return;
+    callbackNames.add(symbol.name);
+  };
   walkAst(componentBody, (child: EsTreeNode) => {
-    if (isNodeOfType(child, "CallExpression") && isNodeOfType(child.callee, "Identifier")) {
-      callbackNames.add(child.callee.name);
+    if (isNodeOfType(child, "CallExpression")) {
+      if (isNodeOfType(child.callee, "Identifier")) {
+        addWhenPropsBinding(child.callee);
+      }
+      for (const argumentNode of child.arguments) {
+        if (
+          isNodeOfType(argumentNode, "Identifier") &&
+          IMPERATIVE_CALLBACK_PREFIX_PATTERN.test(argumentNode.name)
+        ) {
+          addWhenPropsBinding(argumentNode);
+        }
+      }
       return;
     }
     if (
@@ -29,10 +58,21 @@ const collectCallbackUsedNames = (componentBody: EsTreeNode | undefined): Set<st
       isNodeOfType(child.value, "JSXExpressionContainer") &&
       isNodeOfType(child.value.expression, "Identifier")
     ) {
-      callbackNames.add(child.value.expression.name);
+      addWhenPropsBinding(child.value.expression);
     }
   });
   return callbackNames;
+};
+
+const getDestructuredBindingName = (propertyValue: EsTreeNode | undefined): string | null => {
+  if (isNodeOfType(propertyValue, "Identifier")) return propertyValue.name;
+  if (
+    isNodeOfType(propertyValue, "AssignmentPattern") &&
+    isNodeOfType(propertyValue.left, "Identifier")
+  ) {
+    return propertyValue.left.name;
+  }
+  return null;
 };
 
 const collectBooleanLikePropsFromBody = (
@@ -48,11 +88,20 @@ const collectBooleanLikePropsFromBody = (
     if (child.object.name !== propsParamName) return;
     if (!isNodeOfType(child.property, "Identifier")) return;
     if (!isBooleanPrefixedPropName(child.property.name)) return;
-    // `props.showMenu()` (invoked) and `onClick={props.showMenu}` (wired as an
-    // event handler) are imperative callbacks, not boolean props — mirror the
-    // destructured-param callback exclusion for the `props` object shape.
+    // `props.showMenu()` (invoked), `onClick={props.showMenu}` (wired as an
+    // event handler), and `setTimeout(props.showMenu, 100)` (imperative name
+    // passed as a call argument) are callbacks, not boolean props — mirror
+    // the destructured-param callback exclusion for the `props` object shape.
     const parent = child.parent;
-    if (isNodeOfType(parent, "CallExpression") && parent.callee === child) return;
+    if (isNodeOfType(parent, "CallExpression")) {
+      if (parent.callee === child) return;
+      if (
+        IMPERATIVE_CALLBACK_PREFIX_PATTERN.test(child.property.name) &&
+        parent.arguments.some((argumentNode) => argumentNode === child)
+      ) {
+        return;
+      }
+    }
     if (isNodeOfType(parent, "JSXExpressionContainer") && isEventHandlerAttribute(parent.parent)) {
       return;
     }
@@ -104,13 +153,17 @@ export const noManyBooleanProps = defineRule({
       // actual render output before treating the param as component props.
       if (!functionContainsReactRenderOutput(functionNode, context.scopes)) return;
       if (isNodeOfType(param, "ObjectPattern")) {
-        const callbackUsedNames = collectCallbackUsedNames(body);
+        const callbackUsedNames = collectCallbackUsedNames(body, param, context.scopes);
         const booleanLikePropNames: string[] = [];
         for (const property of param.properties ?? []) {
           if (!isNodeOfType(property, "Property")) continue;
           const keyName = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
           if (!keyName) continue;
-          if (callbackUsedNames.has(keyName)) continue;
+          // `{ showMenu: openMenu }` binds `openMenu`, so the callback
+          // exclusion matches the VALUE binding name; reported prop names
+          // stay the KEY names.
+          const bindingName = getDestructuredBindingName(property.value);
+          if (bindingName && callbackUsedNames.has(bindingName)) continue;
           if (isBooleanPrefixedPropName(keyName)) {
             booleanLikePropNames.push(keyName);
           }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.regressions.test.ts
@@ -5,6 +5,9 @@ import { noNestedComponentDefinition } from "./no-nested-component-definition.js
 const run = (code: string) =>
   runRule(noNestedComponentDefinition, code, { filename: "fixture.tsx" });
 
+const messagesOf = (result: { diagnostics: Array<{ message: string }> }) =>
+  result.diagnostics.map((diagnostic) => diagnostic.message);
+
 describe("architecture/no-nested-component-definition — regressions", () => {
   it("flags a nested component that is rendered as JSX", () => {
     const result = run(`
@@ -43,5 +46,72 @@ describe("architecture/no-nested-component-definition — regressions", () => {
     // Only Parent2's rendered Inner is a genuine nested component; Parent1's
     // is inlined via a plain call and must stay quiet.
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  // fp-review PR 996: nested components rendered only by reference through a
+  // component prop (`component={Inner}`, `ItemComponent={Row}`) still create
+  // a fresh element type on every render and must be flagged.
+  it("flags a nested arrow component passed by reference as component={Inner}", () => {
+    const result = run(`
+      const Parent = () => {
+        const Inner = () => <span/>;
+        return <Route path="/x" component={Inner} />;
+      };
+    `);
+    expect(messagesOf(result)).toEqual([
+      'Your users lose all state in "Inner" on every render because it\'s defined inside "Parent", so move it out to the top of the file.',
+    ]);
+  });
+
+  it("flags a nested function-declaration component passed as ItemComponent={Row}", () => {
+    const result = run(`
+      const Parent = ({ items }) => {
+        function Row() { return <li/>; }
+        return <List items={items} ItemComponent={Row} />;
+      };
+    `);
+    expect(messagesOf(result)).toEqual([
+      'Your users lose all state in "Row" on every render because it\'s defined inside "Parent", so move it out to the top of the file.',
+    ]);
+  });
+
+  // fp-review PR 996: the harness dispatches `<NodeType>:exit` like production
+  // oxlint, so the componentStack pops between sibling declarations and every
+  // rendered sibling records the correct enclosing component.
+  it("flags both rendered nested siblings independently", () => {
+    const result = run(`
+      const Parent = () => {
+        const Icon = () => <i/>;
+        const Row = () => <li/>;
+        return <div><Icon/><Row/></div>;
+      };
+    `);
+    expect(messagesOf(result)).toEqual([
+      'Your users lose all state in "Icon" on every render because it\'s defined inside "Parent", so move it out to the top of the file.',
+      'Your users lose all state in "Row" on every render because it\'s defined inside "Parent", so move it out to the top of the file.',
+    ]);
+  });
+
+  it("flags only the rendered sibling when a call-only helper precedes it", () => {
+    const result = run(`
+      const Parent = () => {
+        const RenderIcon = () => <i/>;
+        const Row = () => <li/>;
+        return <div>{RenderIcon()}<Row/></div>;
+      };
+    `);
+    expect(messagesOf(result)).toEqual([
+      'Your users lose all state in "Row" on every render because it\'s defined inside "Parent", so move it out to the top of the file.',
+    ]);
+  });
+
+  it("stays silent on a capitalized call-only helper never rendered or referenced", () => {
+    const result = run(`
+      const Screen = () => {
+        const RenderIcon = () => <i/>;
+        return <div>{RenderIcon()}</div>;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.regressions.test.ts
@@ -25,4 +25,23 @@ describe("architecture/no-nested-component-definition — regressions", () => {
     `);
     expect(result.diagnostics).toEqual([]);
   });
+
+  // Devin: rendered-JSX membership must be scoped to the candidate's own
+  // enclosing component. A sibling rendering `<Inner/>` must not make a
+  // same-named call-only helper in another parent a false positive.
+  it("does not leak a sibling's <Inner/> onto a same-named call-only helper", () => {
+    const result = run(`
+      const Parent1 = () => {
+        const Inner = () => <span>call-only</span>;
+        return <div>{Inner()}</div>;
+      };
+      const Parent2 = () => {
+        const Inner = () => <span>rendered</span>;
+        return <Inner />;
+      };
+    `);
+    // Only Parent2's rendered Inner is a genuine nested component; Parent1's
+    // is inlined via a plain call and must stay quiet.
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.regressions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noNestedComponentDefinition } from "./no-nested-component-definition.js";
+
+const run = (code: string) =>
+  runRule(noNestedComponentDefinition, code, { filename: "fixture.tsx" });
+
+describe("architecture/no-nested-component-definition — regressions", () => {
+  it("flags a nested component that is rendered as JSX", () => {
+    const result = run(`
+      const Parent = () => {
+        const NestedChild = () => <span>nested</span>;
+        return <NestedChild />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a nested PascalCase render helper only called inline", () => {
+    const result = run(`
+      const Settings = () => {
+        const GeneralSection = () => <div>general</div>;
+        return <div>{GeneralSection()}</div>;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
@@ -1,4 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -11,6 +12,17 @@ interface NestedComponentCandidate {
   reportNode: EsTreeNode;
   name: string;
   enclosingName: string;
+  enclosingNode: EsTreeNode;
+}
+
+interface RenderedJsxElement {
+  name: string;
+  node: EsTreeNode;
+}
+
+interface EnclosingComponent {
+  name: string;
+  node: EsTreeNode;
 }
 
 export const noNestedComponentDefinition = defineRule({
@@ -22,32 +34,41 @@ export const noNestedComponentDefinition = defineRule({
   recommendation:
     "Move it to module scope or a separate file so React does not recreate the component and erase its state on every parent render.",
   create: (context: RuleContext) => {
-    const componentStack: string[] = [];
+    const componentStack: EnclosingComponent[] = [];
     const candidates: NestedComponentCandidate[] = [];
     // Only a PascalCase binding that is actually RENDERED as a JSX
     // element (`<Name/>`) creates a child fiber that React remounts.
     // A capitalized helper that is exclusively invoked as `Name()` is
     // inlined into the parent's render (no separate fiber, no state to
     // lose), so requiring JSX-render membership before reporting drops
-    // the inline-render-helper false positives.
-    const renderedJsxNames = new Set<string>();
+    // the inline-render-helper false positives. Each rendered element is
+    // kept with its node so the membership test can be scoped to the
+    // candidate's own enclosing component: a `<Inner/>` rendered in a
+    // SIBLING component refers to that sibling's binding, not this one.
+    const renderedJsxElements: RenderedJsxElement[] = [];
+
+    const pushCandidate = (reportNode: EsTreeNode, name: string, enclosingNode: EsTreeNode) => {
+      if (componentStack.length > 0) {
+        const enclosing = componentStack[componentStack.length - 1];
+        candidates.push({
+          reportNode,
+          name,
+          enclosingName: enclosing.name,
+          enclosingNode: enclosing.node,
+        });
+      }
+      componentStack.push({ name, node: enclosingNode });
+    };
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (isNodeOfType(node.name, "JSXIdentifier") && isUppercaseName(node.name.name)) {
-          renderedJsxNames.add(node.name.name);
+          renderedJsxElements.push({ name: node.name.name, node });
         }
       },
       FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!isComponentDeclaration(node) || !node.id) return;
-        if (componentStack.length > 0) {
-          candidates.push({
-            reportNode: node.id,
-            name: node.id.name,
-            enclosingName: componentStack[componentStack.length - 1],
-          });
-        }
-        componentStack.push(node.id.name);
+        pushCandidate(node.id, node.id.name, node);
       },
       "FunctionDeclaration:exit"(node: EsTreeNode) {
         if (isComponentDeclaration(node)) componentStack.pop();
@@ -55,21 +76,19 @@ export const noNestedComponentDefinition = defineRule({
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isComponentAssignment(node)) return;
         if (!isNodeOfType(node.id, "Identifier")) return;
-        if (componentStack.length > 0) {
-          candidates.push({
-            reportNode: node.id,
-            name: node.id.name,
-            enclosingName: componentStack[componentStack.length - 1],
-          });
-        }
-        componentStack.push(node.id.name);
+        pushCandidate(node.id, node.id.name, node);
       },
       "VariableDeclarator:exit"(node: EsTreeNode) {
         if (isComponentAssignment(node)) componentStack.pop();
       },
       "Program:exit"() {
         for (const candidate of candidates) {
-          if (!renderedJsxNames.has(candidate.name)) continue;
+          const isRenderedInEnclosingComponent = renderedJsxElements.some(
+            (element) =>
+              element.name === candidate.name &&
+              isAstDescendant(element.node, candidate.enclosingNode),
+          );
+          if (!isRenderedInEnclosingComponent) continue;
           context.report({
             node: candidate.reportNode,
             message: `Your users lose all state in "${candidate.name}" on every render because it's defined inside "${candidate.enclosingName}", so move it out to the top of the file.`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
@@ -2,9 +2,16 @@ import { defineRule } from "../../utils/define-rule.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+interface NestedComponentCandidate {
+  reportNode: EsTreeNode;
+  name: string;
+  enclosingName: string;
+}
 
 export const noNestedComponentDefinition = defineRule({
   id: "no-nested-component-definition",
@@ -16,14 +23,28 @@ export const noNestedComponentDefinition = defineRule({
     "Move it to module scope or a separate file so React does not recreate the component and erase its state on every parent render.",
   create: (context: RuleContext) => {
     const componentStack: string[] = [];
+    const candidates: NestedComponentCandidate[] = [];
+    // Only a PascalCase binding that is actually RENDERED as a JSX
+    // element (`<Name/>`) creates a child fiber that React remounts.
+    // A capitalized helper that is exclusively invoked as `Name()` is
+    // inlined into the parent's render (no separate fiber, no state to
+    // lose), so requiring JSX-render membership before reporting drops
+    // the inline-render-helper false positives.
+    const renderedJsxNames = new Set<string>();
 
     return {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (isNodeOfType(node.name, "JSXIdentifier") && isUppercaseName(node.name.name)) {
+          renderedJsxNames.add(node.name.name);
+        }
+      },
       FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
         if (!isComponentDeclaration(node) || !node.id) return;
         if (componentStack.length > 0) {
-          context.report({
-            node: node.id,
-            message: `Your users lose all state in "${node.id.name}" on every render because it's defined inside "${componentStack[componentStack.length - 1]}", so move it out to the top of the file.`,
+          candidates.push({
+            reportNode: node.id,
+            name: node.id.name,
+            enclosingName: componentStack[componentStack.length - 1],
           });
         }
         componentStack.push(node.id.name);
@@ -35,15 +56,25 @@ export const noNestedComponentDefinition = defineRule({
         if (!isComponentAssignment(node)) return;
         if (!isNodeOfType(node.id, "Identifier")) return;
         if (componentStack.length > 0) {
-          context.report({
-            node: node.id,
-            message: `Your users lose all state in "${node.id.name}" on every render because it's defined inside "${componentStack[componentStack.length - 1]}", so move it out to the top of the file.`,
+          candidates.push({
+            reportNode: node.id,
+            name: node.id.name,
+            enclosingName: componentStack[componentStack.length - 1],
           });
         }
         componentStack.push(node.id.name);
       },
       "VariableDeclarator:exit"(node: EsTreeNode) {
         if (isComponentAssignment(node)) componentStack.pop();
+      },
+      "Program:exit"() {
+        for (const candidate of candidates) {
+          if (!renderedJsxNames.has(candidate.name)) continue;
+          context.report({
+            node: candidate.reportNode,
+            message: `Your users lose all state in "${candidate.name}" on every render because it's defined inside "${candidate.enclosingName}", so move it out to the top of the file.`,
+          });
+        }
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
@@ -36,12 +36,13 @@ export const noNestedComponentDefinition = defineRule({
   create: (context: RuleContext) => {
     const componentStack: EnclosingComponent[] = [];
     const candidates: NestedComponentCandidate[] = [];
-    // Only a PascalCase binding that is actually RENDERED as a JSX
-    // element (`<Name/>`) creates a child fiber that React remounts.
-    // A capitalized helper that is exclusively invoked as `Name()` is
-    // inlined into the parent's render (no separate fiber, no state to
-    // lose), so requiring JSX-render membership before reporting drops
-    // the inline-render-helper false positives. Each rendered element is
+    // Only a PascalCase binding that is actually RENDERED — as a JSX
+    // element (`<Name/>`) or passed by reference through a component prop
+    // (`<Route component={Name}/>`) — creates a child fiber that React
+    // remounts. A capitalized helper that is exclusively invoked as
+    // `Name()` is inlined into the parent's render (no separate fiber, no
+    // state to lose), so requiring render-site membership before reporting
+    // drops the inline-render-helper false positives. Each render site is
     // kept with its node so the membership test can be scoped to the
     // candidate's own enclosing component: a `<Inner/>` rendered in a
     // SIBLING component refers to that sibling's binding, not this one.
@@ -64,6 +65,16 @@ export const noNestedComponentDefinition = defineRule({
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (isNodeOfType(node.name, "JSXIdentifier") && isUppercaseName(node.name.name)) {
           renderedJsxElements.push({ name: node.name.name, node });
+        }
+      },
+      JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
+        if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
+        const attributeExpression = node.value.expression;
+        if (
+          isNodeOfType(attributeExpression, "Identifier") &&
+          isUppercaseName(attributeExpression.name)
+        ) {
+          renderedJsxElements.push({ name: attributeExpression.name, node });
         }
       },
       FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -83,14 +83,84 @@ describe("architecture/no-render-in-render — regressions", () => {
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
-  it("does not flag a this.render* class-component helper method call", () => {
+  // fp-review PR 996: an earlier isStableMethodReceiver carve-out exempted
+  // every this.renderX() call, voiding the react-datepicker calendar
+  // must-detect oracle. Class fields (`renderX = () => …`) are per-instance,
+  // so `this.` is not a stability signal — these must fire.
+  it("flags a this.render* class-component helper method call", () => {
     const result = run(
       `class Chart extends React.Component {
         renderLine(props) { return <g>{props.x}</g>; }
         render() { return <g>{this.renderLine(this.props)}</g>; }
       }`,
     );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("flags inline this.renderX() class-field calls (calendar.tsx planted shape)", () => {
+    const result = run(
+      `class Calendar extends Component {
+        renderCurrentMonth = (date = this.state.date) => (
+          <h2 className="react-datepicker__current-month">{date.toString()}</h2>
+        );
+        renderDefaultHeader = ({ monthDate }) => (
+          <div className="react-datepicker__header">
+            {this.renderCurrentMonth(monthDate)}
+          </div>
+        );
+        render() {
+          return <div>{this.renderAriaLiveRegion()}</div>;
+        }
+      }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a local const render* helper called inline", () => {
+    const result = run(
+      `const UploadFileItem = (props) => {
+        const renderIcon = () => <div className="icon" />;
+        return <div>{renderIcon()}</div>;
+      };`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  // fp-review PR 996: the plain-alias spelling of a render prop is
+  // semantically identical to the destructured one and must stay silent.
+  it("does not flag a plain alias of a render prop (const renderItem = props.renderItem)", () => {
+    const result = run(
+      `function List(props){ const renderItem = props.renderItem; return <div>{renderItem(1)}</div>; }`,
+    );
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a defaulted render-prop alias (props.renderItem ?? defaultRender)", () => {
+    const result = run(
+      `function List(props){ const renderItem = props.renderItem ?? defaultRender; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a conditional render-prop alias", () => {
+    const result = run(
+      `function List(props){ const renderItem = props.compact ? props.renderCompactItem : props.renderItem; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an alias of a parameter-destructured render prop", () => {
+    const result = run(
+      `function List({ renderItem }){ const renderRow = renderItem; return <div>{renderRow(1)}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags an alias of a local render* helper", () => {
+    const result = run(
+      `function List(){ const renderIcon = () => <i />; const renderItem = renderIcon; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
   // Bugbot: the render-prop exemption is only for `props` / `this.props`. An

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -65,4 +65,14 @@ describe("architecture/no-render-in-render — regressions", () => {
     );
     expect(result.diagnostics).toEqual([]);
   });
+
+  // Bugbot: the render-prop exemption is only for `props` / `this.props`. An
+  // unrelated object that happens to have a `.props` field must not hide a real
+  // inline `render*` call.
+  it("still flags an inline render* call on an arbitrary object's .props field", () => {
+    const result = run(
+      `function List(){ const renderRow = (x) => <li>{x}</li>; const cfg = { props: { renderRow } }; return <ul>{cfg.props.renderRow(1)}</ul>; }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -32,6 +32,23 @@ describe("architecture/no-render-in-render — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  // Bugbot: the parameter carve-out is for COMPONENT props. A render* param
+  // of an ordinary nested helper is a plain local, so an inline call still
+  // remounts and must stay flagged.
+  it("still flags a render* param of a nested non-component helper", () => {
+    const result = run(
+      `const Foo = () => { const runRow = (renderRow) => <li>{renderRow()}</li>; return <ul>{runRow((x) => x)}</ul>; };`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  // Bugbot: a render prop invoked directly on a nested prop bag roots in the
+  // parent-owned props, so it's exempt — matching its destructured form.
+  it("does not flag a render prop invoked on a nested prop bag (props.slots.renderItem())", () => {
+    const result = run(`const Foo = (props) => <div>{props.slots.renderItem(1)}</div>;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // Bugbot wave 4: a render prop destructured from a nested prop bag
   // (`props.slots`) still roots in the parent-owned props, so it's exempt —
   // the comment documented this but the code only matched `this.props`.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noRenderInRender } from "./no-render-in-render.js";
+
+const run = (code: string) => runRule(noRenderInRender, code, { filename: "fixture.tsx" });
+
+describe("architecture/no-render-in-render — regressions", () => {
+  it("flags a locally-declared render* helper called inline", () => {
+    const result = run(`const Foo = () => <div>{renderRow()}</div>;`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag a props.render* render-prop invocation", () => {
+    const result = run(`const Foo = (props) => <div>{props.renderProject(project)}</div>;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a this.props.render* render-prop invocation", () => {
+    const result = run(`const Foo = () => <div>{this.props.renderPanel()}</div>;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a render prop destructured from props", () => {
+    const result = run(
+      `function List(props){ const { renderItem } = props; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a render prop destructured directly in the parameter list", () => {
+    const result = run(`function List({ renderItem }){ return <div>{renderItem(1)}</div>; }`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  // Bugbot wave 4: a render prop destructured from a nested prop bag
+  // (`props.slots`) still roots in the parent-owned props, so it's exempt —
+  // the comment documented this but the code only matched `this.props`.
+  it("does not flag a render prop destructured from a nested prop bag", () => {
+    const result = run(
+      `function List(props){ const { renderItem } = props.slots; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a render prop destructured from this.props.slots", () => {
+    const result = run(
+      `function List(){ const { renderItem } = this.props.slots; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a render prop destructured from a non-prop object", () => {
+    const result = run(
+      `function List(){ const { renderItem } = config.slots; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag a this.render* class-component helper method call", () => {
+    const result = run(
+      `class Chart extends React.Component {
+        renderLine(props) { return <g>{props.x}</g>; }
+        render() { return <g>{this.renderLine(this.props)}</g>; }
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -49,6 +49,16 @@ describe("architecture/no-render-in-render — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  // Bugbot: the `props` carve-out must be scope-aware. A LOCAL object named
+  // `props` is not the component's props bag, so an inline render* call on it
+  // still remounts and stays flagged.
+  it("still flags a render* call on a local object named props", () => {
+    const result = run(
+      `const Foo = () => { const props = { renderRow: (x) => <li>{x}</li> }; return <ul>{props.renderRow(1)}</ul>; };`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
   // Bugbot wave 4: a render prop destructured from a nested prop bag
   // (`props.slots`) still roots in the parent-owned props, so it's exempt —
   // the comment documented this but the code only matched `this.props`.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -7,45 +7,44 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 
-// `this.renderX(...)` is a class-component render-helper method. It has a
-// stable identity (declared on the class, not rebuilt in render) and
-// returns JSX that React inlines in place, so it remounts nothing — the
-// canonical "split render() into methods" pattern the recommendation is
-// itself nudging toward. Only locally-declared inline helpers carry the
-// smell this rule targets, never `this.method` calls.
-const isStableMethodReceiver = (object: EsTreeNode): boolean =>
-  isNodeOfType(object, "ThisExpression");
-
-// `({ renderItem }) => …` / `(props) => { const { renderItem } = props }`:
-// the callee resolves to a COMPONENT parameter or a name destructured FROM
-// one (a render prop owned by the parent). Its identity is the parent's,
-// so calling it inline remounts nothing — the same render-prop carve-out
-// as the `props.renderX()` shape, just for the destructured spelling.
-// A locally-declared `renderRow` helper, or a parameter of an ordinary
-// nested helper, still carries the smell and stays flagged.
+// `({ renderItem }) => …` / `const { renderItem } = props` /
+// `const renderItem = props.renderItem`: the callee resolves to a COMPONENT
+// parameter or a name whose declaration roots in one (a render prop owned by
+// the parent). Its identity is the parent's, so calling it inline remounts
+// nothing — the same render-prop carve-out as the `props.renderX()` shape,
+// for the destructured and plain-alias spellings. A locally-declared
+// `renderRow` helper, or a parameter of an ordinary nested helper, still
+// carries the smell and stays flagged.
 const tracesToPropOrParameter = (
   symbol: SymbolDescriptor | null,
   scopes: ScopeAnalysis,
 ): boolean => {
   if (!symbol) return false;
   if (isComponentParameterSymbol(symbol)) return true;
-  const declaration = symbol.declarationNode;
-  if (
-    !isNodeOfType(declaration, "VariableDeclarator") ||
-    (!isNodeOfType(declaration.id, "ObjectPattern") &&
-      !isNodeOfType(declaration.id, "ArrayPattern"))
-  ) {
-    return false;
-  }
+  if (!isNodeOfType(symbol.declarationNode, "VariableDeclarator")) return false;
   const source = symbol.initializer;
   if (!source) return false;
-  if (isNodeOfType(source, "Identifier")) {
-    return isComponentParameterSymbol(scopes.symbolFor(source));
+  return initializerRootsInProps(source, scopes);
+};
+
+// The initializer of a destructuring (`const { renderItem } = props.slots`)
+// or plain alias (`const renderItem = props.renderItem`) is parent-owned
+// when it roots in `props` / `this.props`, including the defaulted spellings
+// `props.renderItem ?? defaultRender` and
+// `cond ? props.renderItem : renderFallback` where an operand roots there.
+const initializerRootsInProps = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (isNodeOfType(node, "LogicalExpression")) {
+    return (
+      initializerRootsInProps(node.left, scopes) || initializerRootsInProps(node.right, scopes)
+    );
   }
-  // `const { renderItem } = this.props` / `const { renderItem } = props.slots`
-  // (a nested prop bag): the source still roots in the parent-owned `props`
-  // (or `this.props`), so the destructured render prop is parent-owned too.
-  return rootsInProps(source, scopes);
+  if (isNodeOfType(node, "ConditionalExpression")) {
+    return (
+      initializerRootsInProps(node.consequent, scopes) ||
+      initializerRootsInProps(node.alternate, scopes)
+    );
+  }
+  return rootsInProps(node, scopes);
 };
 
 // True when a member-expression chain bottoms out in a COMPONENT parameter
@@ -96,7 +95,6 @@ export const noRenderInRender = defineRule({
         isNodeOfType(expression.callee.property, "Identifier")
       ) {
         if (rootsInProps(expression.callee.object, context.scopes)) return;
-        if (isStableMethodReceiver(expression.callee.object)) return;
         calleeName = expression.callee.property.name;
       }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -1,22 +1,11 @@
 import { RENDER_FUNCTION_PATTERN } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
-import { isComponentFunction } from "../../utils/is-component-function.js";
+import { isComponentParameterSymbol } from "../../utils/is-component-parameter-symbol.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
-
-// A render prop is a parameter of a COMPONENT — the props object, or a
-// render callback destructured from it. Its identity is the parent's, so
-// calling it inline remounts nothing. A parameter of an ordinary nested
-// helper (`function runRow(renderRow) { … }`) is just a local: its identity
-// is rebuilt on each call, so an inline `renderRow()` still carries the
-// smell and stays flagged.
-const isComponentParameterSymbol = (symbol: SymbolDescriptor | null): boolean => {
-  if (!symbol || symbol.kind !== "parameter") return false;
-  return isComponentFunction(symbol.scope.node);
-};
 
 // `this.renderX(...)` is a class-component render-helper method. It has a
 // stable identity (declared on the class, not rebuilt in render) and
@@ -51,7 +40,6 @@ const tracesToPropOrParameter = (
   const source = symbol.initializer;
   if (!source) return false;
   if (isNodeOfType(source, "Identifier")) {
-    if (source.name === "props") return true;
     return isComponentParameterSymbol(scopes.symbolFor(source));
   }
   // `const { renderItem } = this.props` / `const { renderItem } = props.slots`
@@ -60,12 +48,13 @@ const tracesToPropOrParameter = (
   return rootsInProps(source, scopes);
 };
 
-// True when a member-expression chain bottoms out in the `props` parameter
-// (`props.slots.header`), a `this.props` access (`this.props.slots`), or any
-// other COMPONENT parameter used as a prop bag (`slots.header` where `slots`
-// is a component parameter). Also gates the inline member-call receiver, so
-// `props.slots.renderItem()` is exempt for the same reason its destructured
-// form (`const { renderItem } = props.slots`) already is.
+// True when a member-expression chain bottoms out in a COMPONENT parameter
+// (`props.slots.header`, or `slots.header` where `slots` is a component
+// parameter) or a `this.props` access (`this.props.slots`). The root is
+// resolved through scope, so a local variable named `props` is NOT treated
+// as the component's props bag. Also gates the inline member-call receiver,
+// so `props.slots.renderItem()` is exempt for the same reason its
+// destructured form (`const { renderItem } = props.slots`) already is.
 const rootsInProps = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let current: EsTreeNode = node;
   while (isNodeOfType(current, "MemberExpression")) {
@@ -79,7 +68,6 @@ const rootsInProps = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
     current = current.object;
   }
   if (isNodeOfType(current, "Identifier")) {
-    if (current.name === "props") return true;
     return isComponentParameterSymbol(scopes.symbolFor(current));
   }
   return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -1,8 +1,90 @@
 import { RENDER_FUNCTION_PATTERN } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+
+// `props.renderX(...)` / `this.props.renderX(...)` is a render-prop
+// invocation: a function received FROM the parent, so its identity is
+// owned by the parent and calling it inline remounts nothing. This is
+// the idiomatic React render-prop pattern, not inline component
+// construction.
+const isRenderPropReceiver = (object: EsTreeNode): boolean => {
+  if (isNodeOfType(object, "Identifier")) return object.name === "props";
+  return (
+    isNodeOfType(object, "MemberExpression") &&
+    isNodeOfType(object.property, "Identifier") &&
+    object.property.name === "props"
+  );
+};
+
+// `this.renderX(...)` is a class-component render-helper method. It has a
+// stable identity (declared on the class, not rebuilt in render) and
+// returns JSX that React inlines in place, so it remounts nothing — the
+// canonical "split render() into methods" pattern the recommendation is
+// itself nudging toward. Only locally-declared inline helpers carry the
+// smell this rule targets, never `this.method` calls.
+const isStableMethodReceiver = (object: EsTreeNode): boolean =>
+  isNodeOfType(object, "ThisExpression");
+
+// `({ renderItem }) => …` / `(props) => { const { renderItem } = props }`:
+// the callee resolves to a function PARAMETER or a name destructured FROM
+// one (a render prop owned by the parent). Its identity is the parent's,
+// so calling it inline remounts nothing — the same render-prop carve-out
+// as the `props.renderX()` shape, just for the destructured spelling.
+// A locally-declared `renderRow` helper (kind "const"/"function" whose
+// source isn't a parameter) still carries the smell and stays flagged.
+const tracesToPropOrParameter = (
+  symbol: SymbolDescriptor | null,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!symbol) return false;
+  if (symbol.kind === "parameter") return true;
+  const declaration = symbol.declarationNode;
+  if (
+    !isNodeOfType(declaration, "VariableDeclarator") ||
+    (!isNodeOfType(declaration.id, "ObjectPattern") &&
+      !isNodeOfType(declaration.id, "ArrayPattern"))
+  ) {
+    return false;
+  }
+  const source = symbol.initializer;
+  if (!source) return false;
+  if (isNodeOfType(source, "Identifier")) {
+    if (source.name === "props") return true;
+    const sourceSymbol = scopes.symbolFor(source);
+    return sourceSymbol?.kind === "parameter";
+  }
+  // `const { renderItem } = this.props` / `const { renderItem } = props.slots`
+  // (a nested prop bag): the source still roots in the parent-owned `props`
+  // (or `this.props`), so the destructured render prop is parent-owned too.
+  return rootsInProps(source, scopes);
+};
+
+// True when a member-expression chain bottoms out in the `props` parameter
+// (`props.slots.header`), a `this.props` access (`this.props.slots`), or any
+// other function parameter used as a prop bag (`slots.header` where `slots`
+// is a parameter).
+const rootsInProps = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let current: EsTreeNode = node;
+  while (isNodeOfType(current, "MemberExpression")) {
+    if (
+      isNodeOfType(current.object, "ThisExpression") &&
+      isNodeOfType(current.property, "Identifier") &&
+      current.property.name === "props"
+    ) {
+      return true;
+    }
+    current = current.object;
+  }
+  if (isNodeOfType(current, "Identifier")) {
+    if (current.name === "props") return true;
+    return scopes.symbolFor(current)?.kind === "parameter";
+  }
+  return false;
+};
 
 export const noRenderInRender = defineRule({
   id: "no-render-in-render",
@@ -18,11 +100,16 @@ export const noRenderInRender = defineRule({
 
       let calleeName: string | null = null;
       if (isNodeOfType(expression.callee, "Identifier")) {
+        if (tracesToPropOrParameter(context.scopes.symbolFor(expression.callee), context.scopes)) {
+          return;
+        }
         calleeName = expression.callee.name;
       } else if (
         isNodeOfType(expression.callee, "MemberExpression") &&
         isNodeOfType(expression.callee.property, "Identifier")
       ) {
+        if (isRenderPropReceiver(expression.callee.object)) return;
+        if (isStableMethodReceiver(expression.callee.object)) return;
         calleeName = expression.callee.property.name;
       }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -1,26 +1,21 @@
 import { RENDER_FUNCTION_PATTERN } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { isComponentFunction } from "../../utils/is-component-function.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 
-// `props.renderX(...)` / `this.props.renderX(...)` is a render-prop
-// invocation: a function received FROM the parent, so its identity is
-// owned by the parent and calling it inline remounts nothing. This is
-// the idiomatic React render-prop pattern, not inline component
-// construction.
-const isRenderPropReceiver = (object: EsTreeNode): boolean => {
-  if (isNodeOfType(object, "Identifier")) return object.name === "props";
-  // Only `this.props.renderX()` — not an arbitrary `someObject.props.renderX()`,
-  // whose `.props` is an unrelated field and should not exempt an inline call.
-  return (
-    isNodeOfType(object, "MemberExpression") &&
-    isNodeOfType(object.property, "Identifier") &&
-    object.property.name === "props" &&
-    isNodeOfType(object.object, "ThisExpression")
-  );
+// A render prop is a parameter of a COMPONENT — the props object, or a
+// render callback destructured from it. Its identity is the parent's, so
+// calling it inline remounts nothing. A parameter of an ordinary nested
+// helper (`function runRow(renderRow) { … }`) is just a local: its identity
+// is rebuilt on each call, so an inline `renderRow()` still carries the
+// smell and stays flagged.
+const isComponentParameterSymbol = (symbol: SymbolDescriptor | null): boolean => {
+  if (!symbol || symbol.kind !== "parameter") return false;
+  return isComponentFunction(symbol.scope.node);
 };
 
 // `this.renderX(...)` is a class-component render-helper method. It has a
@@ -33,18 +28,18 @@ const isStableMethodReceiver = (object: EsTreeNode): boolean =>
   isNodeOfType(object, "ThisExpression");
 
 // `({ renderItem }) => …` / `(props) => { const { renderItem } = props }`:
-// the callee resolves to a function PARAMETER or a name destructured FROM
+// the callee resolves to a COMPONENT parameter or a name destructured FROM
 // one (a render prop owned by the parent). Its identity is the parent's,
 // so calling it inline remounts nothing — the same render-prop carve-out
 // as the `props.renderX()` shape, just for the destructured spelling.
-// A locally-declared `renderRow` helper (kind "const"/"function" whose
-// source isn't a parameter) still carries the smell and stays flagged.
+// A locally-declared `renderRow` helper, or a parameter of an ordinary
+// nested helper, still carries the smell and stays flagged.
 const tracesToPropOrParameter = (
   symbol: SymbolDescriptor | null,
   scopes: ScopeAnalysis,
 ): boolean => {
   if (!symbol) return false;
-  if (symbol.kind === "parameter") return true;
+  if (isComponentParameterSymbol(symbol)) return true;
   const declaration = symbol.declarationNode;
   if (
     !isNodeOfType(declaration, "VariableDeclarator") ||
@@ -57,8 +52,7 @@ const tracesToPropOrParameter = (
   if (!source) return false;
   if (isNodeOfType(source, "Identifier")) {
     if (source.name === "props") return true;
-    const sourceSymbol = scopes.symbolFor(source);
-    return sourceSymbol?.kind === "parameter";
+    return isComponentParameterSymbol(scopes.symbolFor(source));
   }
   // `const { renderItem } = this.props` / `const { renderItem } = props.slots`
   // (a nested prop bag): the source still roots in the parent-owned `props`
@@ -68,8 +62,10 @@ const tracesToPropOrParameter = (
 
 // True when a member-expression chain bottoms out in the `props` parameter
 // (`props.slots.header`), a `this.props` access (`this.props.slots`), or any
-// other function parameter used as a prop bag (`slots.header` where `slots`
-// is a parameter).
+// other COMPONENT parameter used as a prop bag (`slots.header` where `slots`
+// is a component parameter). Also gates the inline member-call receiver, so
+// `props.slots.renderItem()` is exempt for the same reason its destructured
+// form (`const { renderItem } = props.slots`) already is.
 const rootsInProps = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let current: EsTreeNode = node;
   while (isNodeOfType(current, "MemberExpression")) {
@@ -84,7 +80,7 @@ const rootsInProps = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   }
   if (isNodeOfType(current, "Identifier")) {
     if (current.name === "props") return true;
-    return scopes.symbolFor(current)?.kind === "parameter";
+    return isComponentParameterSymbol(scopes.symbolFor(current));
   }
   return false;
 };
@@ -111,7 +107,7 @@ export const noRenderInRender = defineRule({
         isNodeOfType(expression.callee, "MemberExpression") &&
         isNodeOfType(expression.callee.property, "Identifier")
       ) {
-        if (isRenderPropReceiver(expression.callee.object)) return;
+        if (rootsInProps(expression.callee.object, context.scopes)) return;
         if (isStableMethodReceiver(expression.callee.object)) return;
         calleeName = expression.callee.property.name;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -13,10 +13,13 @@ import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analy
 // construction.
 const isRenderPropReceiver = (object: EsTreeNode): boolean => {
   if (isNodeOfType(object, "Identifier")) return object.name === "props";
+  // Only `this.props.renderX()` — not an arbitrary `someObject.props.renderX()`,
+  // whose `.props` is an unrelated field and should not exempt an inline call.
   return (
     isNodeOfType(object, "MemberExpression") &&
     isNodeOfType(object.property, "Identifier") &&
-    object.property.name === "props"
+    object.property.name === "props" &&
+    isNodeOfType(object.object, "ThisExpression")
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-prop-children.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-prop-children.regressions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noRenderPropChildren } from "./no-render-prop-children.js";
+
+describe("architecture/no-render-prop-children regressions", () => {
+  // react-pdf forwards `renderMode` (a 'canvas' | 'svg' | … mode string),
+  // `renderTextLayerProps` and `renderAnnotationLayerProps` (layer config bags).
+  // None of them are render slots, so the element is not render-prop proliferation.
+  it("does not count `render*Props` config bags or a `renderMode` mode prop", () => {
+    const { diagnostics } = runRule(
+      noRenderPropChildren,
+      `
+        const Page = () => (
+          <PageChildren
+            renderMode={renderMode}
+            renderTextLayerProps={renderTextLayerProps}
+            renderAnnotationLayerProps={renderAnnotationLayerProps}
+          />
+        );
+      `,
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("does not count literal-valued `render*` props (mode/flag, not a render slot)", () => {
+    const { diagnostics } = runRule(
+      noRenderPropChildren,
+      `
+        const View = () => (
+          <Widget renderMode="canvas" renderInline={true} renderDepth={2} />
+        );
+      `,
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("still flags 3+ genuine render-slot props", () => {
+    const { diagnostics } = runRule(
+      noRenderPropChildren,
+      `
+        const Panel = () => (
+          <Layout
+            renderHeader={() => <h1>Title</h1>}
+            renderFooter={() => <footer>Footer</footer>}
+            renderActions={() => <button>Go</button>}
+          />
+        );
+      `,
+    );
+    expect(diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-prop-children.ts
@@ -7,6 +7,27 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const RENDER_PROP_PATTERN = /^render[A-Z]/;
 
+// A render prop hands a render slot (a function/JSX node) to the child. Two
+// `render*`-prefixed shapes are NOT render slots and must not inflate the count:
+//   - a `render*Props` config bag (e.g. react-pdf's `renderTextLayerProps`,
+//     `renderAnnotationLayerProps`) is an options object passed to a layer, and
+//   - a data literal value (e.g. `renderMode="canvas"`, `renderable={false}`) is
+//     a mode/flag, not a render function.
+// Counting either misreads a plain forwarding component as render-prop
+// proliferation.
+const looksLikeRenderSlot = (attr: EsTreeNodeOfType<"JSXAttribute">, name: string): boolean => {
+  if (name.endsWith("Props")) return false;
+  if (attr.value === null) return false;
+  if (isNodeOfType(attr.value, "Literal")) return false;
+  if (
+    isNodeOfType(attr.value, "JSXExpressionContainer") &&
+    isNodeOfType(attr.value.expression, "Literal")
+  ) {
+    return false;
+  }
+  return true;
+};
+
 // HACK: render-prop proliferation (`<Foo renderHeader={…} renderFooter={…}
 // renderActions={…} />`) is the smell — a single render-prop is often
 // the legitimate library API (MUI Autocomplete's `renderInput`, FlatList's
@@ -30,6 +51,7 @@ export const noRenderPropChildren = defineRule({
         if (!isNodeOfType(attr.name, "JSXIdentifier")) continue;
         const name = attr.name.name;
         if (!RENDER_PROP_PATTERN.test(name)) continue;
+        if (!looksLikeRenderSlot(attr, name)) continue;
         renderPropAttrs.push({ name, node: attr });
       }
       if (renderPropAttrs.length < RENDER_PROP_PROLIFERATION_THRESHOLD) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { preferModuleScopeStaticValue } from "./prefer-module-scope-static-value.js";
+
+const run = (code: string) =>
+  runRule(preferModuleScopeStaticValue, code, { filename: "fixture.tsx" });
+
+describe("architecture/prefer-module-scope-static-value — regressions", () => {
+  it("does not flag an object initializer that calls Date.now()", () => {
+    const result = run(
+      `function Banner() { const meta = { renderedAt: Date.now() }; return <span>{meta.renderedAt}</span>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an array initializer built from Math.random()", () => {
+    const result = run(
+      `function Sparkles() { const seeds = [Math.random(), Math.random()]; return <div>{seeds.join()}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an object built from crypto.randomUUID()", () => {
+    const result = run(
+      `function Row() { const id = { value: crypto.randomUUID() }; return <li>{id.value}</li>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an array built from nanoid() (impure id generator)", () => {
+    const result = run(
+      `import { nanoid } from "nanoid"; function Row() { const ids = [nanoid(), nanoid()]; return <div>{ids.join()}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a pure literal array with no impure call", () => {
+    const result = run(
+      `function List() { const items = [1, 2, 3]; return <div>{items.join()}</div>; }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
@@ -40,4 +40,118 @@ describe("architecture/prefer-module-scope-static-value — regressions", () => 
     );
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("does not flag the geist-ui shape: static array consumed only by .includes", () => {
+    const result = run(`
+      import React from "react";
+      import { ScalePropKeys } from "./scale-context";
+      const withScale = (Render) => {
+        const ScaleFC = React.forwardRef((props, ref) => {
+          const allScalePropKeys = [...ScalePropKeys, "scale", "unit"];
+          const filtered = Object.fromEntries(
+            Object.entries(props).filter(([key]) => !allScalePropKeys.includes(key)),
+          );
+          return <Render ref={ref} {...filtered} />;
+        });
+        return ScaleFC;
+      };
+      export default withScale;
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a tiny literal array fed only to .includes", () => {
+    const result = run(`
+      function Toolbar({ kind }) {
+        const hiddenKinds = ["draft", "archived"];
+        if (hiddenKinds.includes(kind)) return null;
+        return <div>{kind}</div>;
+      }
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a static array consumed via .map into JSX", () => {
+    const result = run(`
+      function Tabs() {
+        const tabNames = ["home", "settings"];
+        return <div>{tabNames.map((tabName) => <span key={tabName}>{tabName}</span>)}</div>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a static array passed as a JSX prop even when also used by .includes", () => {
+    const result = run(`
+      function Filters({ active }) {
+        const filterKinds = ["all", "done"];
+        const isActive = filterKinds.includes(active);
+        return <FilterList kinds={filterKinds} highlighted={isActive} />;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a static array listed in a hook dependency array", () => {
+    const result = run(`
+      import { useEffect } from "react";
+      function Sync() {
+        const channels = ["email", "sms"];
+        useEffect(() => { subscribe(channels); }, [channels]);
+        return null;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a static object that is returned from a hook", () => {
+    const result = run(`
+      function useDefaults() {
+        const defaults = { pageSize: 10, sort: "asc" };
+        return defaults;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a static array built from a pure module-scope helper named `random`", () => {
+    const result = run(`
+      const random = (seed) => (seed * 9301 + 49297) % 233280;
+      function List() {
+        const weights = [random(1), random(2)];
+        return <div>{weights.join()}</div>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a static array built from a deterministic module-scope `generateId` helper", () => {
+    const result = run(`
+      function Columns() {
+        const columns = [{ id: generateId("name") }, { id: generateId("age") }];
+        return <div>{columns.length}</div>;
+      }
+      const generateId = (label) => "col-" + label;
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an array built from an imported generateId helper", () => {
+    const result = run(`
+      import { generateId } from "./ids";
+      function Columns() {
+        const columns = [{ id: generateId("name") }, { id: generateId("age") }];
+        return <div>{columns.length}</div>;
+      }
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an array built from a bare unresolved randomUUID()", () => {
+    const result = run(
+      `function Row() { const ids = [randomUUID(), randomUUID()]; return <div>{ids.join()}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
@@ -160,6 +160,62 @@ const isHoistableValueExpression = (expression: EsTreeNode): boolean => {
   return isNodeOfType(stripped, "ArrayExpression") || isNodeOfType(stripped, "ObjectExpression");
 };
 
+// Known-impure global namespaces whose calls produce a fresh value every
+// render (`Date.now()`, `Math.random()`, `performance.now()`,
+// `crypto.randomUUID()`, …). Hoisting an initializer that calls one of
+// these to module scope freezes it to a single module-load evaluation,
+// changing observable behavior — so such initializers are NOT hoistable.
+const IMPURE_MEMBER_RECEIVERS = new Map<string, ReadonlySet<string>>([
+  ["Math", new Set(["random"])],
+  ["Date", new Set(["now"])],
+  ["performance", new Set(["now"])],
+  ["crypto", new Set(["randomUUID", "getRandomValues", "randomBytes"])],
+]);
+
+// Bare-function ID / random generators (`nanoid()`, `uuid()`, `v4()`,
+// `randomUUID()`). Like the member-call generators above, each produces a
+// fresh value every render, so hoisting freezes/shares it — abstain.
+const IMPURE_BARE_CALL_NAMES = new Set([
+  "nanoid",
+  "uuid",
+  "v4",
+  "cuid",
+  "ulid",
+  "createId",
+  "randomUUID",
+  "generateId",
+  "random",
+]);
+
+const isImpureCall = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "NewExpression")) {
+    return isNodeOfType(node.callee, "Identifier") && node.callee.name === "Date";
+  }
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = node.callee;
+  if (isNodeOfType(callee, "Identifier")) return IMPURE_BARE_CALL_NAMES.has(callee.name);
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.object, "Identifier")) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  return Boolean(IMPURE_MEMBER_RECEIVERS.get(callee.object.name)?.has(callee.property.name));
+};
+
+// True when the initializer contains a call to a known-impure global.
+// Such values legitimately differ per render, so hoisting them would
+// freeze the value and change behavior — the rule must abstain.
+const containsImpureExpression = (expression: EsTreeNode): boolean => {
+  let foundImpure = false;
+  walkAst(expression, (node) => {
+    if (foundImpure) return false;
+    if (isImpureCall(node)) {
+      foundImpure = true;
+      return false;
+    }
+    return undefined;
+  });
+  return foundImpure;
+};
+
 // Detects array / object literals defined inside a component or hook
 // whose contents reference NO local state. Such allocations are
 // per-render waste and (more importantly) break referential equality
@@ -213,6 +269,10 @@ export const preferModuleScopeStaticValue = defineRule({
       if (hasComponentLocalReferences(initializer, component.bodyScope, context.scopes)) {
         return;
       }
+      // Impure initializers (`Date.now()`, `Math.random()`, …) are meant
+      // to recompute each render; hoisting would freeze them to a single
+      // module-load value and change observable behavior.
+      if (containsImpureExpression(initializer)) return;
       // Hoisting a mutated binding to module scope would either
       // silently lose the per-render reinitialisation OR turn the
       // const into a shared mutable singleton. Either way the rule's

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
@@ -121,6 +121,55 @@ const isBindingMutatedAfterInit = (
   return false;
 };
 
+// Read-only scalar-lookup method names. When EVERY reference to the
+// binding is the receiver of one of these calls (`KEYS.includes(k)`,
+// `IDS.indexOf(id)`, …) the produced value is a scalar answer, never
+// the array/object itself — so the allocation can't escape into JSX,
+// props, or hook dependency arrays and referential identity is
+// irrelevant. Deliberately EXCLUDES `.map` / `.filter` / `.join` /
+// property reads: those results can feed JSX or memoized consumers,
+// where per-render identity still matters.
+const READ_ONLY_SCALAR_LOOKUP_METHOD_NAMES = new Set([
+  "includes",
+  "indexOf",
+  "lastIndexOf",
+  "has",
+  "some",
+  "every",
+  "find",
+  "findIndex",
+]);
+
+const isScalarLookupReceiverContext = (referenceIdentifier: EsTreeNode): boolean => {
+  const parent = referenceIdentifier.parent;
+  if (!parent) return false;
+  if (!isNodeOfType(parent, "MemberExpression") || parent.object !== referenceIdentifier) {
+    return false;
+  }
+  if (parent.computed || !isNodeOfType(parent.property, "Identifier")) return false;
+  if (!READ_ONLY_SCALAR_LOOKUP_METHOD_NAMES.has(parent.property.name)) return false;
+  const grandparent = parent.parent;
+  return Boolean(
+    grandparent && isNodeOfType(grandparent, "CallExpression") && grandparent.callee === parent,
+  );
+};
+
+const isBindingOnlyUsedForScalarLookups = (
+  declaratorNode: EsTreeNodeOfType<"VariableDeclarator">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(declaratorNode.id, "Identifier")) return false;
+  const symbol = scopes.symbolFor(declaratorNode.id);
+  if (!symbol) return false;
+  let lookupReferenceCount = 0;
+  for (const reference of symbol.references) {
+    if (reference.identifier === declaratorNode.id) continue;
+    if (!isScalarLookupReceiverContext(reference.identifier)) return false;
+    lookupReferenceCount += 1;
+  }
+  return lookupReferenceCount > 0;
+};
+
 // Walks the expression and collects every referenced identifier whose
 // binding lives INSIDE the component scope. Used to decide whether the
 // value is hoistable.
@@ -175,6 +224,10 @@ const IMPURE_MEMBER_RECEIVERS = new Map<string, ReadonlySet<string>>([
 // Bare-function ID / random generators (`nanoid()`, `uuid()`, `v4()`,
 // `randomUUID()`). Like the member-call generators above, each produces a
 // fresh value every render, so hoisting freezes/shares it — abstain.
+// Only applies when the callee is an unresolved global or an import:
+// a LOCAL binding that merely collides with one of these names is
+// user-owned code and presumed pure (deterministic helpers named
+// `random` / `generateId` are common).
 const IMPURE_BARE_CALL_NAMES = new Set([
   "nanoid",
   "uuid",
@@ -187,13 +240,23 @@ const IMPURE_BARE_CALL_NAMES = new Set([
   "random",
 ]);
 
-const isImpureCall = (node: EsTreeNode): boolean => {
+const isImpureBareCallee = (
+  callee: EsTreeNodeOfType<"Identifier">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!IMPURE_BARE_CALL_NAMES.has(callee.name)) return false;
+  const resolvedSymbol = scopes.referenceFor(callee)?.resolvedSymbol;
+  if (!resolvedSymbol) return true;
+  return resolvedSymbol.kind === "import";
+};
+
+const isImpureCall = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   if (isNodeOfType(node, "NewExpression")) {
     return isNodeOfType(node.callee, "Identifier") && node.callee.name === "Date";
   }
   if (!isNodeOfType(node, "CallExpression")) return false;
   const callee = node.callee;
-  if (isNodeOfType(callee, "Identifier")) return IMPURE_BARE_CALL_NAMES.has(callee.name);
+  if (isNodeOfType(callee, "Identifier")) return isImpureBareCallee(callee, scopes);
   if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
   if (!isNodeOfType(callee.object, "Identifier")) return false;
   if (!isNodeOfType(callee.property, "Identifier")) return false;
@@ -203,11 +266,11 @@ const isImpureCall = (node: EsTreeNode): boolean => {
 // True when the initializer contains a call to a known-impure global.
 // Such values legitimately differ per render, so hoisting them would
 // freeze the value and change behavior — the rule must abstain.
-const containsImpureExpression = (expression: EsTreeNode): boolean => {
+const containsImpureExpression = (expression: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let foundImpure = false;
   walkAst(expression, (node) => {
     if (foundImpure) return false;
-    if (isImpureCall(node)) {
+    if (isImpureCall(node, scopes)) {
       foundImpure = true;
       return false;
     }
@@ -272,7 +335,11 @@ export const preferModuleScopeStaticValue = defineRule({
       // Impure initializers (`Date.now()`, `Math.random()`, …) are meant
       // to recompute each render; hoisting would freeze them to a single
       // module-load value and change observable behavior.
-      if (containsImpureExpression(initializer)) return;
+      if (containsImpureExpression(initializer, context.scopes)) return;
+      // A binding consumed ONLY as the receiver of scalar lookups
+      // (`KEYS.includes(k)`) never escapes as a value — identity can't
+      // break memoized children, so the hoist advice is pure noise.
+      if (isBindingOnlyUsedForScalarLookups(node, context.scopes)) return;
       // Hoisting a mutated binding to module scope would either
       // silently lose the per-render reinitialisation OR turn the
       // const into a shared mutable singleton. Either way the rule's

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.regressions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { reactCompilerDestructureMethod } from "./react-compiler-destructure-method.js";
+
+const run = (code: string) =>
+  runRule(reactCompilerDestructureMethod, code, { filename: "fixture.tsx" });
+
+describe("architecture/react-compiler-destructure-method — regressions", () => {
+  it("does not flag useSearchParams().get() — its methods need their `this` receiver", () => {
+    const result = run(
+      `import { useSearchParams } from "next/navigation";
+       function Page() { const searchParams = useSearchParams(); const q = searchParams.get("q"); return <div>{q}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags useRouter().push() (a bound function property)", () => {
+    const result = run(
+      `function Page() { const router = useRouter(); return <button onClick={() => router.push("/x")}>go</button>; }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags useNavigation().navigate() (a bound function property)", () => {
+    const result = run(
+      `function Screen() { const navigation = useNavigation(); return <button onClick={() => navigation.navigate("Home")}>go</button>; }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-destructure-method.ts
@@ -8,13 +8,18 @@ import { isImportedFromModule } from "../../utils/find-import-source-for-name.js
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+// Only hooks that return an object of BOUND function properties belong
+// here. `useSearchParams` is intentionally excluded: it returns a
+// `ReadonlyURLSearchParams` instance whose methods (`get`/`has`/…) are
+// unbound prototype methods that need their `this` receiver, so the
+// destructure recommendation (`const { get } = useSearchParams()`)
+// throws `TypeError: Illegal invocation`.
 const HOOK_OBJECTS_WITH_METHODS = new Map<string, Set<string>>([
   ["useRouter", new Set(["push", "replace", "back", "forward", "refresh", "prefetch"])],
   [
     "useNavigation",
     new Set(["navigate", "push", "goBack", "popToTop", "reset", "replace", "dispatch"]),
   ],
-  ["useSearchParams", new Set(["get", "getAll", "has", "set"])],
 ]);
 
 // Some libraries expose method-bearing hook objects where destructuring is not

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.regressions.test.ts
@@ -17,4 +17,42 @@ describe("architecture/react-compiler-no-manual-memoization — regressions", ()
     const result = run(`import { memo } from "react"; const C = memo(Inner);`);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
+
+  it("flags memo(Inner, undefined) — React falls back to shallow compare", () => {
+    const result = run(`import { memo } from "react"; const C = memo(Inner, undefined);`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("flags memo(Inner, null) — React falls back to shallow compare", () => {
+    const result = run(`import { memo } from "react"; const C = memo(Inner, null);`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag memo(Inner, ...rest) — the spread could carry a comparator", () => {
+    const result = run(
+      `import { memo } from "react"; const rest = []; const C = memo(Inner, ...rest);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an aliased memo import with a comparator", () => {
+    const result = run(
+      `import { memo as wrapMemo } from "react"; const C = wrapMemo(Inner, (a, b) => a.id === b.id);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag React.memo with a comparator", () => {
+    const result = run(
+      `import React from "react"; const C = React.memo(Inner, (a, b) => a.id === b.id);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag memo(Inner, comparatorIdentifier)", () => {
+    const result = run(
+      `import { memo } from "react"; const areEqual = (a, b) => a.id === b.id; const C = memo(Inner, areEqual);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.regressions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { reactCompilerNoManualMemoization } from "./react-compiler-no-manual-memoization.js";
+
+const run = (code: string) =>
+  runRule(reactCompilerNoManualMemoization, code, { filename: "fixture.tsx" });
+
+describe("architecture/react-compiler-no-manual-memoization — regressions", () => {
+  it("does not flag memo() with a custom comparator", () => {
+    const result = run(
+      `import { memo } from "react"; const C = memo(Inner, (prev, next) => prev.id === next.id);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a plain memo() with no comparator", () => {
+    const result = run(`import { memo } from "react"; const C = memo(Inner);`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.test.ts
@@ -124,19 +124,6 @@ const Component = () => {
     expectFlaggedApiNames(`_react.useMemo(() => 1, []);`, ["useMemo"]);
   });
 
-  it("does not flag `React.memo(Component, areEqual)` with a custom comparator", () => {
-    // A bespoke comparator encodes equality the compiler can't replicate,
-    // so the memo() is not redundant.
-    expectDiagnosticCount(
-      `import React from "react";
-const Inner = ({ value }) => <span>{value}</span>;
-const areEqual = (prev, next) => prev.value === next.value;
-const Wrapped = React.memo(Inner, areEqual);
-export default Wrapped;`,
-      0,
-    );
-  });
-
   it("emits one diagnostic per manual-memoization call in the file", () => {
     expectDiagnosticCount(
       `import { memo, useCallback, useMemo } from "react";
@@ -306,6 +293,19 @@ export { created };`,
     expectDiagnosticCount(
       `const cached = Reactosaurus.useMemo(() => 1, []);
 export { cached };`,
+      0,
+    );
+  });
+
+  it("does not flag `React.memo(Component, areEqual)` with a custom comparator", () => {
+    // A bespoke comparator encodes equality the compiler can't replicate,
+    // so the memo() is not redundant.
+    expectDiagnosticCount(
+      `import React from "react";
+const Inner = ({ value }) => <span>{value}</span>;
+const areEqual = (prev, next) => prev.value === next.value;
+const Wrapped = React.memo(Inner, areEqual);
+export default Wrapped;`,
       0,
     );
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.test.ts
@@ -124,14 +124,16 @@ const Component = () => {
     expectFlaggedApiNames(`_react.useMemo(() => 1, []);`, ["useMemo"]);
   });
 
-  it("flags `React.memo(Component, areEqual)` with custom comparator", () => {
-    expectFlaggedApiNames(
+  it("does not flag `React.memo(Component, areEqual)` with a custom comparator", () => {
+    // A bespoke comparator encodes equality the compiler can't replicate,
+    // so the memo() is not redundant.
+    expectDiagnosticCount(
       `import React from "react";
 const Inner = ({ value }) => <span>{value}</span>;
 const areEqual = (prev, next) => prev.value === next.value;
 const Wrapped = React.memo(Inner, areEqual);
 export default Wrapped;`,
-      ["memo()"],
+      0,
     );
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
@@ -58,6 +58,15 @@ const resolveReactApiNameForMemberExpression = (callee: EsTreeNode): string | nu
 const resolveReactApiNameForCallee = (callee: EsTreeNode): string | null =>
   resolveReactApiNameForIdentifier(callee) ?? resolveReactApiNameForMemberExpression(callee);
 
+// `memo(Inner, undefined)` / `memo(Inner, null)` make React fall back to
+// the default shallow compare — exactly as redundant under React Compiler
+// as `memo(Inner)`. Any other second-arg shape (function expression,
+// identifier, member/call expression, spread) could be a real comparator,
+// so it keeps the exemption.
+const isNullishComparatorArgument = (argumentNode: EsTreeNode): boolean =>
+  (isNodeOfType(argumentNode, "Identifier") && argumentNode.name === "undefined") ||
+  (isNodeOfType(argumentNode, "Literal") && argumentNode.value === null);
+
 // Active only when React Compiler is detected (`requires:
 // ["react-compiler"]` in the rule registry). Userland helpers and
 // `useMemo` from non-react packages are filtered out by the import-
@@ -82,8 +91,12 @@ export const reactCompilerNoManualMemoization = defineRule({
       if (!apiName) return;
       // `memo(Component, areEqual)` with a custom comparator encodes
       // bespoke equality the compiler can't replicate, so it isn't
-      // redundant — leave it alone.
-      if (apiName === "memo" && (node.arguments?.length ?? 0) >= 2) return;
+      // redundant — leave it alone. A nullish second arg is no comparator
+      // at all, so it doesn't earn the exemption.
+      if (apiName === "memo") {
+        const comparatorArgument = node.arguments?.[1];
+        if (comparatorArgument && !isNullishComparatorArgument(comparatorArgument)) return;
+      }
       const removalMessage = REMOVAL_MESSAGE_BY_REACT_API_NAME.get(apiName);
       if (!removalMessage) return;
       context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
@@ -55,12 +55,8 @@ const resolveReactApiNameForMemberExpression = (callee: EsTreeNode): string | nu
   return null;
 };
 
-const resolveRemovalMessageForCallee = (callee: EsTreeNode): string | null => {
-  const apiName =
-    resolveReactApiNameForIdentifier(callee) ?? resolveReactApiNameForMemberExpression(callee);
-  if (!apiName) return null;
-  return REMOVAL_MESSAGE_BY_REACT_API_NAME.get(apiName) ?? null;
-};
+const resolveReactApiNameForCallee = (callee: EsTreeNode): string | null =>
+  resolveReactApiNameForIdentifier(callee) ?? resolveReactApiNameForMemberExpression(callee);
 
 // Active only when React Compiler is detected (`requires:
 // ["react-compiler"]` in the rule registry). Userland helpers and
@@ -82,7 +78,13 @@ export const reactCompilerNoManualMemoization = defineRule({
     "Delete the `useMemo` / `useCallback` / `memo` call and use the plain value or component. React Compiler caches it for you.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      const removalMessage = resolveRemovalMessageForCallee(node.callee);
+      const apiName = resolveReactApiNameForCallee(node.callee);
+      if (!apiName) return;
+      // `memo(Component, areEqual)` with a custom comparator encodes
+      // bespoke equality the compiler can't replicate, so it isn't
+      // redundant — leave it alone.
+      if (apiName === "memo" && (node.arguments?.length ?? 0) >= 2) return;
+      const removalMessage = REMOVAL_MESSAGE_BY_REACT_API_NAME.get(apiName);
       if (!removalMessage) return;
       context.report({
         node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.test.ts
@@ -114,4 +114,24 @@ describe("html-no-invalid-paragraph-child", () => {
 
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  // The explicit `children` prop IS a real DOM child — React renders
+  // `<p children={<ul/>} />` exactly like `<p><ul/></p>`.
+  it("flags a block element passed via the explicit `children` prop of `<p>`", () => {
+    const result = runRule(
+      htmlNoInvalidParagraphChild,
+      `const N = () => <p children={<ul><li>a</li></ul>} />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a block element in a non-children prop inside a `children` prop value", () => {
+    const result = runRule(
+      htmlNoInvalidParagraphChild,
+      `const N = () => <p children={<Tooltip overlay={<ul><li>a</li></ul>}>hint</Tooltip>} />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.test.ts
@@ -103,4 +103,15 @@ describe("html-no-invalid-paragraph-child", () => {
 
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  // A block element passed as a PROP is not a DOM child of the `<p>` —
+  // the prop boundary stops the ancestor walk.
+  it("does not flag a block element passed as a prop on a child of `<p>`", () => {
+    const result = runRule(
+      htmlNoInvalidParagraphChild,
+      `const N = () => <p>See <Tooltip overlay={<ul><li>One</li></ul>}>list</Tooltip>.</p>;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.ts
@@ -84,7 +84,13 @@ const findEnclosingParagraph = (openingElement: EsTreeNode): EsTreeNode | null =
     // An element passed as a PROP (`<Tooltip overlay={<ul/>} />`) is not
     // a DOM child of any enclosing `<p>`, so stop at the attribute
     // boundary before mistaking the host element's `<p>` for an ancestor.
-    if (isNodeOfType(ancestor, "JSXAttribute")) return null;
+    // The explicit `children` prop is the one exception — React renders
+    // `<p children={<ul/>} />` as a real DOM child, so keep walking.
+    if (isNodeOfType(ancestor, "JSXAttribute")) {
+      const isExplicitChildrenProp =
+        isNodeOfType(ancestor.name, "JSXIdentifier") && ancestor.name.name === "children";
+      if (!isExplicitChildrenProp) return null;
+    }
     if (isParagraphElement(ancestor)) return ancestor;
     ancestor = ancestor.parent ?? null;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.ts
@@ -81,6 +81,10 @@ const findEnclosingParagraph = (openingElement: EsTreeNode): EsTreeNode | null =
   if (!owningElement) return null;
   let ancestor: EsTreeNode | null | undefined = owningElement.parent;
   while (ancestor) {
+    // An element passed as a PROP (`<Tooltip overlay={<ul/>} />`) is not
+    // a DOM child of any enclosing `<p>`, so stop at the attribute
+    // boundary before mistaking the host element's `<p>` for an ancestor.
+    if (isNodeOfType(ancestor, "JSXAttribute")) return null;
     if (isParagraphElement(ancestor)) return ancestor;
     ancestor = ancestor.parent ?? null;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.test.ts
@@ -79,4 +79,15 @@ describe("html-no-nested-interactive", () => {
 
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  // An interactive element passed as a PROP isn't nested inside the host
+  // element — the prop boundary stops the ancestor walk.
+  it("does not flag a `<button>` passed as a prop on an outer `<button>`", () => {
+    const result = runRule(
+      htmlNoNestedInteractive,
+      `const R = () => <button onClick={s}>Go<Tooltip trigger={<button aria-label="i">i</button>} /></button>;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.test.ts
@@ -90,4 +90,24 @@ describe("html-no-nested-interactive", () => {
 
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  // The explicit `children` prop IS a real DOM child — React renders
+  // `<button children={<button/>} />` exactly like `<button><button/></button>`.
+  it("flags a `<button>` passed via the explicit `children` prop of a `<button>`", () => {
+    const result = runRule(
+      htmlNoNestedInteractive,
+      `const R = () => <button children={<button>x</button>} />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a `<button>` in a non-children prop inside a `children` prop value", () => {
+    const result = runRule(
+      htmlNoNestedInteractive,
+      `const R = () => <button children={<Tooltip trigger={<button>x</button>}>hint</Tooltip>} />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.ts
@@ -34,6 +34,10 @@ const findEnclosingSameTag = (openingElement: EsTreeNode, tagName: string): EsTr
   if (!owningElement) return null;
   let ancestor: EsTreeNode | null | undefined = owningElement.parent;
   while (ancestor) {
+    // An interactive element passed as a PROP (`<button trigger={<button/>} />`)
+    // isn't nested inside the host element, so stop at the attribute
+    // boundary before treating the host's same-tag element as an ancestor.
+    if (isNodeOfType(ancestor, "JSXAttribute")) return null;
     if (isJsxElementWithTagName(ancestor, tagName)) return ancestor;
     ancestor = ancestor.parent ?? null;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.ts
@@ -37,7 +37,13 @@ const findEnclosingSameTag = (openingElement: EsTreeNode, tagName: string): EsTr
     // An interactive element passed as a PROP (`<button trigger={<button/>} />`)
     // isn't nested inside the host element, so stop at the attribute
     // boundary before treating the host's same-tag element as an ancestor.
-    if (isNodeOfType(ancestor, "JSXAttribute")) return null;
+    // The explicit `children` prop is the one exception — React renders
+    // `<button children={<button/>} />` as a real DOM child, so keep walking.
+    if (isNodeOfType(ancestor, "JSXAttribute")) {
+      const isExplicitChildrenProp =
+        isNodeOfType(ancestor.name, "JSXIdentifier") && ancestor.name.name === "children";
+      if (!isExplicitChildrenProp) return null;
+    }
     if (isJsxElementWithTagName(ancestor, tagName)) return ancestor;
     ancestor = ancestor.parent ?? null;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.test.ts
@@ -35,4 +35,17 @@ describe("no-polymorphic-children", () => {
     );
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  // Bugbot: a body alias of the props (`const { children } = props`) is the
+  // same smell as the `({ children })` parameter form and must be flagged.
+  it("flags `typeof children` when children is aliased from props in the body", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `const Card = (props) => {
+        const { children } = props;
+        return typeof children === "string" ? <span>{children}</span> : <div>{children}</div>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noPolymorphicChildren } from "./no-polymorphic-children.js";
+
+describe("no-polymorphic-children", () => {
+  it('flags `typeof children === "string"` on a destructured prop', () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `const Button = ({ children }) =>
+        typeof children === "string" ? <span>{children}</span> : <div>{children}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it('flags `typeof props.children === "string"`', () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `const Button = (props) =>
+        typeof props.children === "string" ? <span /> : <div />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  // A `children` destructured from local data (not the component's
+  // props) is an ordinary variable, not a polymorphic-children smell.
+  it("does not flag `children` destructured from a local variable", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `const r = (node) => {
+        const { children } = node;
+        if (typeof children === "string") return <Leaf text={children} />;
+        return <Branch>{children.map(r)}</Branch>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -1,19 +1,53 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { isComponentParameterSymbol } from "../../utils/is-component-parameter-symbol.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+// `const { children } = props` / `const { children } = this.props`: a body
+// alias of the component's children prop is the same smell as the
+// destructured-parameter form. Only a destructure whose SOURCE is the
+// component's props counts — `const { children } = node` (a non-prop object,
+// e.g. a recursive tree walker's parameter) stays quiet.
+const isChildrenDestructuredFromProps = (
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const declaration = symbol.declarationNode;
+  if (
+    !isNodeOfType(declaration, "VariableDeclarator") ||
+    !isNodeOfType(declaration.id, "ObjectPattern")
+  ) {
+    return false;
+  }
+  const source = symbol.initializer;
+  if (!source) return false;
+  if (isNodeOfType(source, "Identifier")) {
+    return isComponentParameterSymbol(scopes.symbolFor(source));
+  }
+  return (
+    isNodeOfType(source, "MemberExpression") &&
+    !source.computed &&
+    isNodeOfType(source.property, "Identifier") &&
+    source.property.name === "props" &&
+    isNodeOfType(source.object, "ThisExpression")
+  );
+};
+
 // True only when the `children` operand resolves to the enclosing
 // component's `props.children` — a destructured prop binding
-// (`({ children }) => …`, a `parameter` symbol) or a `props.children`
-// member access where `props` is the component's parameter. A local
-// variable or data field that happens to be named `children`
-// (`const { children } = node`) is not a polymorphic-children smell.
+// (`({ children }) => …`), a body alias of the props
+// (`const { children } = props`), or a `props.children` member access where
+// `props` is the component's parameter. A local variable or data field that
+// happens to be named `children` (`const { children } = node`) is not a
+// polymorphic-children smell.
 const resolvesToPropsChildren = (operand: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   if (isNodeOfType(operand, "Identifier") && operand.name === "children") {
-    return scopes.symbolFor(operand)?.kind === "parameter";
+    const symbol = scopes.symbolFor(operand);
+    if (isComponentParameterSymbol(symbol)) return true;
+    return symbol !== null && isChildrenDestructuredFromProps(symbol, scopes);
   }
   if (
     isNodeOfType(operand, "MemberExpression") &&
@@ -22,7 +56,7 @@ const resolvesToPropsChildren = (operand: EsTreeNode, scopes: ScopeAnalysis): bo
     operand.property.name === "children" &&
     isNodeOfType(operand.object, "Identifier")
   ) {
-    return scopes.symbolFor(operand.object)?.kind === "parameter";
+    return isComponentParameterSymbol(scopes.symbolFor(operand.object));
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -1,8 +1,31 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// True only when the `children` operand resolves to the enclosing
+// component's `props.children` — a destructured prop binding
+// (`({ children }) => …`, a `parameter` symbol) or a `props.children`
+// member access where `props` is the component's parameter. A local
+// variable or data field that happens to be named `children`
+// (`const { children } = node`) is not a polymorphic-children smell.
+const resolvesToPropsChildren = (operand: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (isNodeOfType(operand, "Identifier") && operand.name === "children") {
+    return scopes.symbolFor(operand)?.kind === "parameter";
+  }
+  if (
+    isNodeOfType(operand, "MemberExpression") &&
+    !operand.computed &&
+    isNodeOfType(operand.property, "Identifier") &&
+    operand.property.name === "children" &&
+    isNodeOfType(operand.object, "Identifier")
+  ) {
+    return scopes.symbolFor(operand.object)?.kind === "parameter";
+  }
+  return false;
+};
 
 // HACK: `typeof children === "string"` (or `=== 'object'`) is a
 // polymorphic-children smell — the component switches behavior based on
@@ -23,8 +46,7 @@ export const noPolymorphicChildren = defineRule({
       const isTypeofChildren = (operand: EsTreeNode | undefined): boolean =>
         isNodeOfType(operand, "UnaryExpression") &&
         operand.operator === "typeof" &&
-        isNodeOfType(operand.argument, "Identifier") &&
-        operand.argument.name === "children";
+        resolvesToPropsChildren(operand.argument, context.scopes);
 
       if (!isTypeofChildren(node.left) && !isTypeofChildren(node.right)) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.regressions.test.ts
@@ -22,4 +22,114 @@ describe("correctness/no-prevent-default — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
+
+  it("stays silent on the ant-design dropdown trigger anchor in a demo file (test-noise)", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function App() {
+        return (
+          <Dropdown menu={{ items }}>
+            <a onClick={(e) => e.preventDefault()}>
+              <Space>Hover me</Space>
+            </a>
+          </Dropdown>
+        );
+      }`,
+      { filename: "components/dropdown/demo/basic.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on the same anchor in a __tests__ file (test-noise)", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function App() { return <a onClick={(e) => e.preventDefault()}>Hover me</a>; }`,
+      { filename: "components/dropdown/__tests__/index.test.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a bare preventDefault anchor in a production file", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function C() { return <a onClick={(e) => e.preventDefault()}>Hover me</a>; }`,
+      { filename: "src/app.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a dead link whose handler only tracks analytics", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function C() {
+        return <a href="/pricing" onClick={(e) => { e.preventDefault(); analytics.track("clicked"); }}>Pricing</a>;
+      }`,
+      { filename: "src/app.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a dead link whose handler only logs", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function C() {
+        return <a href="#" onClick={(e) => { e.preventDefault(); console.log("clicked"); }}>Go</a>;
+      }`,
+      { filename: "src/app.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("stays silent on an anchor whose handler pushes through the router", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function C() {
+        return <a href="/pricing" onClick={(e) => { e.preventDefault(); router.push("/pricing"); }}>Pricing</a>;
+      }`,
+      { filename: "src/app.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an anchor whose handler calls a navigate-shaped function", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function C() {
+        return <a href="/pricing" onClick={(e) => { e.preventDefault(); navigate("/pricing"); }}>Pricing</a>;
+      }`,
+      { filename: "src/app.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an anchor whose handler opens through window", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function C() {
+        return <a href="/docs" onClick={(e) => { e.preventDefault(); window.open("/docs", "_blank"); }}>Docs</a>;
+      }`,
+      { filename: "src/app.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an anchor delegating to a component prop handler", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function LinkButton({ href, onNavigate }) {
+        return <a href={href} onClick={(e) => { e.preventDefault(); onNavigate(href); }}>Go</a>;
+      }`,
+      { filename: "src/link-button.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.regressions.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noPreventDefault } from "./no-prevent-default.js";
+
+describe("correctness/no-prevent-default — regressions", () => {
+  it("stays silent on a progressively-enhanced form with a native action", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function C() { return <form action="/submit" method="post" onSubmit={(e) => { e.preventDefault(); clientSubmit(); }}><button>Go</button></form>; }`,
+      { filename: "app/page.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags an action-less form whose handler only does local work", () => {
+    const result = runRule(
+      noPreventDefault,
+      `export default function C() { return <form onSubmit={(e) => { e.preventDefault(); setOpen(true); }}><button>Go</button></form>; }`,
+      { filename: "app/page.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -1,6 +1,9 @@
+import { NAVIGATION_RECEIVER_NAMES } from "../../constants/react.js";
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import { getReactDoctorStringSetting } from "../../utils/get-react-doctor-setting.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -64,35 +67,74 @@ const containsPreventDefaultCall = (node: EsTreeNode): boolean => {
   return didFindPreventDefault;
 };
 
-// Event-object methods that only suppress the browser default — they
-// never navigate. A handler whose ONLY calls are these is the harmful
-// "dead link" the rule targets. Any OTHER call (a router push, a
-// `platform.openLink(href)`, `props.onNavigate()`, …) means the handler
-// performs its own navigation/side-effect, so `preventDefault()` is
-// intentional and the link is not dead.
-const NON_NAVIGATING_EVENT_METHOD_NAMES: ReadonlySet<string> = new Set([
-  "preventDefault",
-  "stopPropagation",
-  "stopImmediatePropagation",
-  "persist",
-]);
+// A dead-link anchor stays flagged unless the handler carries POSITIVE
+// navigation evidence: a member call whose property is a navigation verb
+// (`router.push`, `location.assign`, `history.go`), a member call on a
+// navigation-shaped receiver (`router.*`, `window.*`, …), an identifier
+// call whose name reads like navigation (`navigate(...)`, `redirectTo(...)`,
+// `openLink(...)`), or delegation to a component prop / enclosing parameter
+// (`onNavigate()`). Non-navigating side effects (`analytics.track(...)`,
+// `console.log(...)`) do NOT count — the link is still dead for the user.
+const NAVIGATION_METHOD_NAME_PATTERN = /^(?:push|replace|navigate|open|assign|go|back|reload)$/;
 
-const containsNavigationOrSideEffectCall = (node: EsTreeNode): boolean => {
-  let didFindSideEffectCall = false;
-  walkAst(node, (child) => {
-    if (didFindSideEffectCall) return;
+const NAVIGATION_FUNCTION_NAME_PATTERN = /^(?:navigate|redirect|open)/i;
+
+const isNavigationReceiverName = (receiverName: string): boolean =>
+  NAVIGATION_RECEIVER_NAMES.has(receiverName) || receiverName === "window";
+
+const isNavigationReceiver = (receiverNode: EsTreeNode): boolean => {
+  if (isNodeOfType(receiverNode, "Identifier")) {
+    return isNavigationReceiverName(receiverNode.name);
+  }
+  if (
+    isNodeOfType(receiverNode, "MemberExpression") &&
+    isNodeOfType(receiverNode.property, "Identifier")
+  ) {
+    return isNavigationReceiverName(receiverNode.property.name);
+  }
+  return false;
+};
+
+const collectEnclosingParameterNames = (handlerExpression: EsTreeNode): Set<string> => {
+  const parameterNames = new Set<string>();
+  let ancestor: EsTreeNode | null | undefined = handlerExpression;
+  while (ancestor) {
+    if (isFunctionLike(ancestor)) {
+      for (const parameter of ancestor.params ?? []) {
+        collectPatternNames(parameter, parameterNames);
+      }
+    }
+    ancestor = ancestor.parent ?? null;
+  }
+  return parameterNames;
+};
+
+const containsNavigationEvidenceCall = (handlerExpression: EsTreeNode): boolean => {
+  const enclosingParameterNames = collectEnclosingParameterNames(handlerExpression);
+  let didFindNavigationCall = false;
+  walkAst(handlerExpression, (child) => {
+    if (didFindNavigationCall) return;
     if (!isNodeOfType(child, "CallExpression")) return;
     const callee = child.callee;
-    if (
-      isNodeOfType(callee, "MemberExpression") &&
-      isNodeOfType(callee.property, "Identifier") &&
-      NON_NAVIGATING_EVENT_METHOD_NAMES.has(callee.property.name)
-    ) {
+    if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
+      if (
+        NAVIGATION_METHOD_NAME_PATTERN.test(callee.property.name) ||
+        isNavigationReceiver(callee.object)
+      ) {
+        didFindNavigationCall = true;
+      }
       return;
     }
-    didFindSideEffectCall = true;
+    if (isNodeOfType(callee, "Identifier")) {
+      if (
+        NAVIGATION_FUNCTION_NAME_PATTERN.test(callee.name) ||
+        enclosingParameterNames.has(callee.name)
+      ) {
+        didFindNavigationCall = true;
+      }
+    }
   });
-  return didFindSideEffectCall;
+  return didFindNavigationCall;
 };
 
 const selectFormMessage = (framework: string | undefined): string =>
@@ -104,6 +146,7 @@ export const noPreventDefault = defineRule({
   id: "no-prevent-default",
   title: "preventDefault on a form or link",
   severity: "warn",
+  tags: ["test-noise"],
   recommendation:
     "Use `<form action>` where your framework supports it (it works without JS), or use a `<button>` instead of an `<a>` with preventDefault.",
   create: (context: RuleContext) => {
@@ -143,11 +186,11 @@ export const noPreventDefault = defineRule({
 
           if (!containsPreventDefaultCall(expression)) continue;
 
-          // An anchor whose handler also navigates / side-effects after
+          // An anchor whose handler performs its own navigation after
           // preventDefault() is custom SPA / desktop navigation, not a
           // dead link — the ANCHOR_MESSAGE ("nothing navigates") would
           // be false. The <form> variant keeps its existing behavior.
-          if (elementName === "a" && containsNavigationOrSideEffectCall(expression)) continue;
+          if (elementName === "a" && containsNavigationEvidenceCall(expression)) continue;
 
           context.report({
             node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -64,6 +64,37 @@ const containsPreventDefaultCall = (node: EsTreeNode): boolean => {
   return didFindPreventDefault;
 };
 
+// Event-object methods that only suppress the browser default — they
+// never navigate. A handler whose ONLY calls are these is the harmful
+// "dead link" the rule targets. Any OTHER call (a router push, a
+// `platform.openLink(href)`, `props.onNavigate()`, …) means the handler
+// performs its own navigation/side-effect, so `preventDefault()` is
+// intentional and the link is not dead.
+const NON_NAVIGATING_EVENT_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "preventDefault",
+  "stopPropagation",
+  "stopImmediatePropagation",
+  "persist",
+]);
+
+const containsNavigationOrSideEffectCall = (node: EsTreeNode): boolean => {
+  let didFindSideEffectCall = false;
+  walkAst(node, (child) => {
+    if (didFindSideEffectCall) return;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = child.callee;
+    if (
+      isNodeOfType(callee, "MemberExpression") &&
+      isNodeOfType(callee.property, "Identifier") &&
+      NON_NAVIGATING_EVENT_METHOD_NAMES.has(callee.property.name)
+    ) {
+      return;
+    }
+    didFindSideEffectCall = true;
+  });
+  return didFindSideEffectCall;
+};
+
 const selectFormMessage = (framework: string | undefined): string =>
   framework !== undefined && SERVER_CAPABLE_FRAMEWORKS.has(framework)
     ? FORM_MESSAGE_SERVER_CAPABLE
@@ -93,6 +124,12 @@ export const noPreventDefault = defineRule({
         // we don't recommend a server-action story the project can't use.
         if (elementName === "form" && isClientOnlyFramework) return;
 
+        // A `<form action=…>` already has a native no-JS submit path: with
+        // JS off the onSubmit handler never runs, so preventDefault() never
+        // fires and the browser performs the native action. The "won't work
+        // without JS" advice is false here — only flag action-less forms.
+        if (elementName === "form" && findJsxAttribute(node.attributes ?? [], "action")) return;
+
         for (const targetEventProp of targetEventProps) {
           const eventAttribute = findJsxAttribute(node.attributes ?? [], targetEventProp);
           if (
@@ -105,6 +142,12 @@ export const noPreventDefault = defineRule({
           if (!isInlineFunctionExpression(expression)) continue;
 
           if (!containsPreventDefaultCall(expression)) continue;
+
+          // An anchor whose handler also navigates / side-effects after
+          // preventDefault() is custom SPA / desktop navigation, not a
+          // dead link — the ANCHOR_MESSAGE ("nothing navigates") would
+          // be false. The <form> variant keeps its existing behavior.
+          if (elementName === "a" && containsNavigationOrSideEffectCall(expression)) continue;
 
           context.report({
             node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noUncontrolledInput } from "./no-uncontrolled-input.js";
+
+describe("correctness/no-uncontrolled-input — regressions", () => {
+  it("stays silent on a `disabled` value input (React suppresses the missing-onChange warning)", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Profile({ email }) { return <input type="text" value={email ?? ""} disabled />; }`,
+      { filename: "app/profile.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a value input wired to `onInput` (SolidJS-port idiom)", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Field({ text, setText }) { return <input value={text} onInput={(e) => setText(e.currentTarget.value)} />; }`,
+      { filename: "app/field.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a genuinely uncontrolled value input (no handler, not disabled)", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Field({ text }) { return <input type="text" value={text} />; }`,
+      { filename: "app/field.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
@@ -32,4 +32,40 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
+
+  it("stays silent on a static input mock in a __tests__ file (test-noise)", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `const StaticInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({
+        id,
+        value = '',
+      }) => {
+        shouldNotRender();
+        return <input id={id} value={value} />;
+      };`,
+      { filename: "components/form/__tests__/index.test.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a value input whose only partner is a literal `disabled={false}`", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Field({ text }) { return <input type="text" value={text} disabled={false} />; }`,
+      { filename: "app/field.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("stays silent on a value input with a dynamic `disabled={expression}`", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Field({ text, isSubmitting }) { return <input type="text" value={text} disabled={isSubmitting} />; }`,
+      { filename: "app/field.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -20,7 +20,10 @@ const UNCONTROLLED_INPUT_TAGS = new Set(["input", "textarea", "select"]);
 // rules.
 const VALUE_BYPASS_INPUT_TYPES = new Set(["hidden", "checkbox", "radio"]);
 
-const VALUE_PARTNER_ATTRIBUTES = ["onChange", "readOnly"];
+// `onInput` fires on every value change in React's DOM model exactly
+// like `onChange`, so a `value`-bound input wired to `onInput` is just
+// as controlled (the SolidJS-port idiom keeps `onInput`).
+const VALUE_PARTNER_ATTRIBUTES = ["onChange", "onInput", "readOnly"];
 
 const getInputTypeLiteral = (attributes: EsTreeNode[]): string | null => {
   const typeAttribute = findJsxAttribute(attributes, "type");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -25,8 +25,16 @@ const VALUE_BYPASS_INPUT_TYPES = new Set(["hidden", "checkbox", "radio"]);
 // as controlled (the SolidJS-port idiom keeps `onInput`). `disabled`
 // (like `readOnly`) suppresses React's own missing-`onChange` warning —
 // the user can't type into a disabled/read-only field, so a static
-// `value` needs no handler and must not be flagged.
+// `value` needs no handler and must not be flagged. The one statically
+// decidable exception: a literal `disabled={false}` is never disabled,
+// so it doesn't excuse the missing handler (dynamic `disabled={expr}`
+// stays exempt — we can't prove it's ever enabled).
 const VALUE_PARTNER_ATTRIBUTES = ["onChange", "onInput", "readOnly", "disabled"];
+
+const isLiteralFalseAttributeValue = (attribute: EsTreeNodeOfType<"JSXAttribute">): boolean =>
+  isNodeOfType(attribute.value, "JSXExpressionContainer") &&
+  isNodeOfType(attribute.value.expression, "Literal") &&
+  attribute.value.expression.value === false;
 
 const getInputTypeLiteral = (attributes: EsTreeNode[]): string | null => {
   const typeAttribute = findJsxAttribute(attributes, "type");
@@ -82,6 +90,7 @@ export const noUncontrolledInput = defineRule({
   id: "no-uncontrolled-input",
   title: "Uncontrolled input value",
   severity: "warn",
+  tags: ["test-noise"],
   recommendation:
     'Give `useState` a starting value (e.g. `useState("")` instead of `useState()`), add `onChange` (or `readOnly`) whenever you set `value`, and drop `defaultValue` on controlled inputs since React ignores it.',
   create: (context: RuleContext) => {
@@ -112,9 +121,13 @@ export const noUncontrolledInput = defineRule({
           if (inputType !== null && VALUE_BYPASS_INPUT_TYPES.has(inputType)) return;
         }
 
-        const hasAllowedPartner = VALUE_PARTNER_ATTRIBUTES.some((partnerAttributeName) =>
-          findJsxAttribute(attributes, partnerAttributeName),
-        );
+        const hasAllowedPartner = VALUE_PARTNER_ATTRIBUTES.some((partnerAttributeName) => {
+          const partnerAttribute = findJsxAttribute(attributes, partnerAttributeName);
+          if (!partnerAttribute) return false;
+          if (partnerAttributeName === "disabled" && isLiteralFalseAttributeValue(partnerAttribute))
+            return false;
+          return true;
+        });
 
         if (
           isNodeOfType(valueAttribute.value, "JSXExpressionContainer") &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -22,8 +22,11 @@ const VALUE_BYPASS_INPUT_TYPES = new Set(["hidden", "checkbox", "radio"]);
 
 // `onInput` fires on every value change in React's DOM model exactly
 // like `onChange`, so a `value`-bound input wired to `onInput` is just
-// as controlled (the SolidJS-port idiom keeps `onInput`).
-const VALUE_PARTNER_ATTRIBUTES = ["onChange", "onInput", "readOnly"];
+// as controlled (the SolidJS-port idiom keeps `onInput`). `disabled`
+// (like `readOnly`) suppresses React's own missing-`onChange` warning —
+// the user can't type into a disabled/read-only field, so a static
+// `value` needs no handler and must not be flagged.
+const VALUE_PARTNER_ATTRIBUTES = ["onChange", "onInput", "readOnly", "disabled"];
 
 const getInputTypeLiteral = (attributes: EsTreeNode[]): string | null => {
   const typeAttribute = findJsxAttribute(attributes, "type");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/rendering-svg-precision.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/rendering-svg-precision.regressions.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { renderingSvgPrecision } from "./rendering-svg-precision.js";
+
+const CODEPEN_ICON_D =
+  "M14.777304,4.75062256 L7.77734505,0.0839936563 C7.60939924,-0.0279665065 7.39060662,-0.0279665065 7.22266081,0.0839936563 L0.222701813,4.75062256 Z";
+
+describe("correctness/rendering-svg-precision — regressions", () => {
+  it("fires on a hand-maintained icon path with many over-precise tokens in src", () => {
+    const result = runRule(
+      renderingSvgPrecision,
+      `
+      const CodePenIcon = () => (
+        <svg viewBox="0 0 15 15" fill="currentColor">
+          <path d="${CODEPEN_ICON_D}" />
+        </svg>
+      );
+      `,
+      { filename: "/repo/src/icons/CodePenIcon.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("fires on an Inkscape uniform-scale matrix that repeats one over-precise factor", () => {
+    const result = runRule(
+      renderingSvgPrecision,
+      `
+      const Exported = () => (
+        <svg>
+          <g transform="matrix(0.26458333,0,0,0.26458333,0,0)">
+            <path d="M 0 0 L 10 10 Z" />
+          </g>
+        </svg>
+      );
+      `,
+      { filename: "/repo/src/exported.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("fires on a machine-exported path with many distinct over-precise coordinates", () => {
+    const result = runRule(
+      renderingSvgPrecision,
+      `
+      const Exported = () => (
+        <svg>
+          <path d="M 10.293847 20.847362 L 30.192837 40.564738 Z" />
+        </svg>
+      );
+      `,
+      { filename: "/repo/src/exported.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on a single stray over-precise token in a hand-written glyph", () => {
+    const result = runRule(
+      renderingSvgPrecision,
+      `
+      const Glyph = () => (
+        <svg>
+          <path d="M 10 10 L 12.333333 14 L 15 15 Z" />
+        </svg>
+      );
+      `,
+      { filename: "/repo/src/glyph.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent under /generated/", () => {
+    const result = runRule(
+      renderingSvgPrecision,
+      `
+      const Icon = () => (
+        <svg>
+          <path d="${CODEPEN_ICON_D}" />
+        </svg>
+      );
+      `,
+      { filename: "/repo/src/generated/icon.tsx" },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent under /__generated__/", () => {
+    const result = runRule(
+      renderingSvgPrecision,
+      `
+      const Icon = () => (
+        <svg>
+          <path d="${CODEPEN_ICON_D}" />
+        </svg>
+      );
+      `,
+      { filename: "/repo/src/__generated__/icon.tsx" },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on vendored icon paths under a .dumi docs-site directory", () => {
+    const result = runRule(
+      renderingSvgPrecision,
+      `
+      const CodePenIcon = () => (
+        <svg viewBox="0 0 15 15" fill="currentColor">
+          <path d="${CODEPEN_ICON_D}" />
+        </svg>
+      );
+      `,
+      { filename: "/repo/.dumi/theme/icons/CodePenIcon.tsx" },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent in a .test.tsx file", () => {
+    const result = runRule(
+      renderingSvgPrecision,
+      `
+      const Fixture = () => (
+        <svg>
+          <path d="${CODEPEN_ICON_D}" />
+        </svg>
+      );
+      `,
+      { filename: "/repo/src/icon.test.tsx" },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
@@ -1,4 +1,4 @@
-import { MIN_DISTINCT_OVERPRECISE_SVG_TOKENS } from "../../constants/thresholds.js";
+import { MIN_OVERPRECISE_SVG_TOKEN_OCCURRENCES } from "../../constants/thresholds.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -9,10 +9,10 @@ const SVG_PATH_HIGH_PRECISION_PATTERN = /\d+\.\d{4,}/g;
 
 const SVG_PATH_ATTRIBUTES = new Set(["d", "points", "transform"]);
 
-const countDistinctHighPrecisionTokens = (value: string): number => {
+const countHighPrecisionTokenOccurrences = (value: string): number => {
   const matches = value.match(SVG_PATH_HIGH_PRECISION_PATTERN);
   if (matches === null) return 0;
-  return new Set(matches).size;
+  return matches.length;
 };
 
 // Directory segments that EXPLICITLY signal machine-generated output
@@ -52,6 +52,7 @@ export const renderingSvgPrecision = defineRule({
   title: "Overly precise SVG path values",
   severity: "warn",
   category: "Performance",
+  tags: ["test-noise"],
   recommendation:
     "Round path, points, and transform decimals to 1 or 2 digits. The extra precision adds bytes with no visible difference.",
   create: (context: RuleContext) => {
@@ -67,7 +68,8 @@ export const renderingSvgPrecision = defineRule({
         if (!isNodeOfType(node.value, "Literal")) return;
         const value = node.value.value;
         if (typeof value !== "string") return;
-        if (countDistinctHighPrecisionTokens(value) < MIN_DISTINCT_OVERPRECISE_SVG_TOKENS) return;
+        if (countHighPrecisionTokenOccurrences(value) < MIN_OVERPRECISE_SVG_TOKEN_OCCURRENCES)
+          return;
 
         context.report({
           node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
@@ -1,3 +1,4 @@
+import { MIN_DISTINCT_OVERPRECISE_SVG_TOKENS } from "../../constants/thresholds.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -7,13 +8,6 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 const SVG_PATH_HIGH_PRECISION_PATTERN = /\d+\.\d{4,}/g;
 
 const SVG_PATH_ATTRIBUTES = new Set(["d", "points", "transform"]);
-
-// Materiality gate: a single over-precise coordinate (even repeated) in a
-// one-off hand-written glyph saves only a handful of bytes once — not a
-// download cost worth a diagnostic. Real machine-exported / wasteful paths
-// carry many DISTINCT over-precise coordinates. Require at least this many
-// distinct over-precise tokens before reporting.
-const MIN_DISTINCT_OVERPRECISE_TOKENS = 2;
 
 const countDistinctHighPrecisionTokens = (value: string): number => {
   const matches = value.match(SVG_PATH_HIGH_PRECISION_PATTERN);
@@ -73,7 +67,7 @@ export const renderingSvgPrecision = defineRule({
         if (!isNodeOfType(node.value, "Literal")) return;
         const value = node.value.value;
         if (typeof value !== "string") return;
-        if (countDistinctHighPrecisionTokens(value) < MIN_DISTINCT_OVERPRECISE_TOKENS) return;
+        if (countDistinctHighPrecisionTokens(value) < MIN_DISTINCT_OVERPRECISE_SVG_TOKENS) return;
 
         context.report({
           node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/rendering-svg-precision.ts
@@ -4,9 +4,22 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const SVG_PATH_HIGH_PRECISION_PATTERN = /\d+\.\d{4,}/;
+const SVG_PATH_HIGH_PRECISION_PATTERN = /\d+\.\d{4,}/g;
 
 const SVG_PATH_ATTRIBUTES = new Set(["d", "points", "transform"]);
+
+// Materiality gate: a single over-precise coordinate (even repeated) in a
+// one-off hand-written glyph saves only a handful of bytes once — not a
+// download cost worth a diagnostic. Real machine-exported / wasteful paths
+// carry many DISTINCT over-precise coordinates. Require at least this many
+// distinct over-precise tokens before reporting.
+const MIN_DISTINCT_OVERPRECISE_TOKENS = 2;
+
+const countDistinctHighPrecisionTokens = (value: string): number => {
+  const matches = value.match(SVG_PATH_HIGH_PRECISION_PATTERN);
+  if (matches === null) return 0;
+  return new Set(matches).size;
+};
 
 // Directory segments that EXPLICITLY signal machine-generated output
 // — codegen sinks, design-tool export folders. The high-precision
@@ -60,7 +73,7 @@ export const renderingSvgPrecision = defineRule({
         if (!isNodeOfType(node.value, "Literal")) return;
         const value = node.value.value;
         if (typeof value !== "string") return;
-        if (!SVG_PATH_HIGH_PRECISION_PATTERN.test(value)) return;
+        if (countDistinctHighPrecisionTokens(value) < MIN_DISTINCT_OVERPRECISE_TOKENS) return;
 
         context.report({
           node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.regressions.test.ts
@@ -41,4 +41,33 @@ describe("design/no-gray-on-colored-background — regressions", () => {
     const result = run(`const C = () => <div className="dark:bg-blue-600 dark:text-gray-500" />;`);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("flags base gray text under a variant colored bg with no text override", () => {
+    const result = run(`const C = () => <div className="text-gray-500 dark:bg-blue-600">Hi</div>;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a base colored bg with a variant-only gray text override", () => {
+    const result = run(
+      `const C = () => <div className="bg-blue-600 text-white dark:text-gray-500">Hi</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the important modifier !text-gray-500 on bg-blue-600", () => {
+    const result = run(`const C = () => <div className="bg-blue-600 !text-gray-500">Hi</div>;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags reordered variant stacks as the same scope (md:hover == hover:md)", () => {
+    const result = run(
+      `const C = () => <div className="md:hover:text-gray-500 hover:md:bg-blue-600">Hi</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags near-black text-gray-950 on a dark colored background", () => {
+    const result = run(`const C = () => <div className="bg-emerald-900 text-gray-950">Hi</div>;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.regressions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noGrayOnColoredBackground } from "./no-gray-on-colored-background.js";
+
+const run = (code: string) => runRule(noGrayOnColoredBackground, code, { filename: "fixture.tsx" });
+
+describe("design/no-gray-on-colored-background — regressions", () => {
+  it("does not flag near-white text-gray-100 (the recommended choice)", () => {
+    const result = run(`const C = () => <div className="bg-blue-600 text-gray-100">Hi</div>;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag near-white text-zinc-200", () => {
+    const result = run(`const C = () => <div className="bg-rose-700 text-zinc-200">Hi</div>;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag near-white text-slate-300", () => {
+    const result = run(`const C = () => <div className="bg-blue-600 text-slate-300">Hi</div>;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags washed-out text-gray-400", () => {
+    const result = run(`const C = () => <div className="bg-blue-600 text-gray-400">Hi</div>;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags washed-out text-slate-500", () => {
+    const result = run(`const C = () => <div className="bg-blue-600 text-slate-500">Hi</div>;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag gray text and colored bg living in different variant scopes", () => {
+    const result = run(
+      `const C = () => <div className="bg-white text-gray-500 dark:bg-blue-600 dark:text-white" />;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags gray text and colored bg sharing the same variant scope", () => {
+    const result = run(`const C = () => <div className="dark:bg-blue-600 dark:text-gray-500" />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noGrayOnColoredBackground } from "./no-gray-on-colored-background.js";
+
+describe("no-gray-on-colored-background", () => {
+  it("flags gray text on a saturated background", () => {
+    const result = runRule(
+      noGrayOnColoredBackground,
+      `const C = () => <div className="bg-blue-600 text-gray-400">Hi</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags gray text on a dark background", () => {
+    const result = runRule(
+      noGrayOnColoredBackground,
+      `const C = () => <div className="bg-emerald-900 text-slate-500">Hi</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  // Light tints (`-50`/`-100`…`-400`) are near-white pastels where gray
+  // text reads fine — only saturated `-500`..`-950` backgrounds qualify.
+  it("does not flag gray text on a light tint background", () => {
+    const result = runRule(
+      noGrayOnColoredBackground,
+      `const C = () => <div className="bg-blue-50 text-gray-600">Hi</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag gray text on a -300 tint background", () => {
+    const result = runRule(
+      noGrayOnColoredBackground,
+      `const C = () => <div className="bg-blue-300 text-gray-600">Hi</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
@@ -3,20 +3,26 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const GRAY_TEXT_PATTERN = /^text-(?:gray|slate|zinc|neutral|stone)-[4-9]00\b/;
+const GRAY_TEXT_PATTERN = /^text-(?:gray|slate|zinc|neutral|stone)-(?:[4-9]00|950)\b/;
 const COLORED_BG_PATTERN =
   /^bg-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:[5-9]00|950)\b/;
 
-// The variant prefix of a Tailwind token is everything before the final
-// `:` (`dark:hover:text-gray-500` → `dark:hover`); the utility itself is
-// the remainder. A gray-text token and a colored-bg token only render
-// simultaneously when they share the same variant scope — `bg-white
-// text-gray-500 dark:bg-blue-600 dark:text-white` never shows gray text
-// on the colored background, so it must not fire.
+const TEXT_COLOR_PATTERN =
+  /^text-(?:white|black|transparent|current|inherit|\[|(?:gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-)/;
+const BG_COLOR_PATTERN =
+  /^bg-(?:white|black|transparent|current|inherit|\[|(?:gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-)/;
+
+// The variant scope of a Tailwind token is every segment before the
+// utility (`dark:hover:text-gray-500` → `dark:hover`), sorted so
+// reordered stacks (`md:hover` vs `hover:md`) share one key. A leading
+// `!` (the important modifier) is not part of the utility name.
 const splitVariantScope = (token: string): { scope: string; utility: string } => {
-  const lastColonIndex = token.lastIndexOf(":");
-  if (lastColonIndex === -1) return { scope: "", utility: token };
-  return { scope: token.slice(0, lastColonIndex), utility: token.slice(lastColonIndex + 1) };
+  const segments = token.split(":");
+  const rawUtility = segments[segments.length - 1];
+  return {
+    scope: segments.slice(0, -1).sort().join(":"),
+    utility: rawUtility.startsWith("!") ? rawUtility.slice(1) : rawUtility,
+  };
 };
 
 export const noGrayOnColoredBackground = defineRule({
@@ -34,9 +40,13 @@ export const noGrayOnColoredBackground = defineRule({
 
       const grayTextByScope = new Map<string, string>();
       const coloredBgByScope = new Map<string, string>();
+      const textColorScopes = new Set<string>();
+      const bgColorScopes = new Set<string>();
       for (const token of classStr.split(/\s+/)) {
         if (!token) continue;
         const { scope, utility } = splitVariantScope(token);
+        if (TEXT_COLOR_PATTERN.test(utility)) textColorScopes.add(scope);
+        if (BG_COLOR_PATTERN.test(utility)) bgColorScopes.add(scope);
         const grayMatch = utility.match(GRAY_TEXT_PATTERN);
         if (grayMatch && !grayTextByScope.has(scope)) grayTextByScope.set(scope, grayMatch[0]);
         const coloredMatch = utility.match(COLORED_BG_PATTERN);
@@ -44,14 +54,39 @@ export const noGrayOnColoredBackground = defineRule({
           coloredBgByScope.set(scope, coloredMatch[0]);
       }
 
-      for (const [scope, grayUtility] of grayTextByScope) {
-        const coloredUtility = coloredBgByScope.get(scope);
-        if (!coloredUtility) continue;
+      const reportPair = (grayUtility: string, coloredUtility: string): void => {
         context.report({
           node,
           message: `Your users see washed-out gray text (${grayUtility}) on a colored background (${coloredUtility}), so use white or a darker shade of the background color.`,
         });
+      };
+
+      for (const [scope, grayUtility] of grayTextByScope) {
+        const coloredUtility = coloredBgByScope.get(scope);
+        if (!coloredUtility) continue;
+        reportPair(grayUtility, coloredUtility);
         return;
+      }
+
+      // Variants are additive: a base-scope utility still applies under a
+      // variant unless that scope overrides the same property, so base
+      // gray text pairs with `dark:bg-blue-600` when there is no
+      // `dark:text-*`, and vice versa.
+      const baseGrayText = grayTextByScope.get("");
+      if (baseGrayText) {
+        for (const [scope, coloredUtility] of coloredBgByScope) {
+          if (scope === "" || textColorScopes.has(scope)) continue;
+          reportPair(baseGrayText, coloredUtility);
+          return;
+        }
+      }
+      const baseColoredBg = coloredBgByScope.get("");
+      if (baseColoredBg) {
+        for (const [scope, grayUtility] of grayTextByScope) {
+          if (scope === "" || bgColorScopes.has(scope)) continue;
+          reportPair(grayUtility, baseColoredBg);
+          return;
+        }
       }
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
@@ -3,6 +3,22 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+const GRAY_TEXT_PATTERN = /^text-(?:gray|slate|zinc|neutral|stone)-[4-9]00\b/;
+const COLORED_BG_PATTERN =
+  /^bg-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(?:[5-9]00|950)\b/;
+
+// The variant prefix of a Tailwind token is everything before the final
+// `:` (`dark:hover:text-gray-500` → `dark:hover`); the utility itself is
+// the remainder. A gray-text token and a colored-bg token only render
+// simultaneously when they share the same variant scope — `bg-white
+// text-gray-500 dark:bg-blue-600 dark:text-white` never shows gray text
+// on the colored background, so it must not fire.
+const splitVariantScope = (token: string): { scope: string; utility: string } => {
+  const lastColonIndex = token.lastIndexOf(":");
+  if (lastColonIndex === -1) return { scope: "", utility: token };
+  return { scope: token.slice(0, lastColonIndex), utility: token.slice(lastColonIndex + 1) };
+};
+
 export const noGrayOnColoredBackground = defineRule({
   id: "no-gray-on-colored-background",
   title: "Gray text on colored background",
@@ -16,16 +32,26 @@ export const noGrayOnColoredBackground = defineRule({
       const classStr = getStringFromClassNameAttr(node);
       if (!classStr) return;
 
-      const grayTextMatch = classStr.match(/\btext-(?:gray|slate|zinc|neutral|stone)-\d+\b/);
-      const coloredBgMatch = classStr.match(
-        /\bbg-(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+\b/,
-      );
+      const grayTextByScope = new Map<string, string>();
+      const coloredBgByScope = new Map<string, string>();
+      for (const token of classStr.split(/\s+/)) {
+        if (!token) continue;
+        const { scope, utility } = splitVariantScope(token);
+        const grayMatch = utility.match(GRAY_TEXT_PATTERN);
+        if (grayMatch && !grayTextByScope.has(scope)) grayTextByScope.set(scope, grayMatch[0]);
+        const coloredMatch = utility.match(COLORED_BG_PATTERN);
+        if (coloredMatch && !coloredBgByScope.has(scope))
+          coloredBgByScope.set(scope, coloredMatch[0]);
+      }
 
-      if (grayTextMatch && coloredBgMatch) {
+      for (const [scope, grayUtility] of grayTextByScope) {
+        const coloredUtility = coloredBgByScope.get(scope);
+        if (!coloredUtility) continue;
         context.report({
           node,
-          message: `Your users see washed-out gray text (${grayTextMatch[0]}) on a colored background (${coloredBgMatch[0]}), so use white or a darker shade of the background color.`,
+          message: `Your users see washed-out gray text (${grayUtility}) on a colored background (${coloredUtility}), so use white or a darker shade of the background color.`,
         });
+        return;
       }
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.regressions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noLayoutTransitionInline } from "./no-layout-transition-inline.js";
+
+const run = (code: string) => runRule(noLayoutTransitionInline, code, { filename: "fixture.tsx" });
+
+describe("design/no-layout-transition-inline — regressions", () => {
+  it("does not flag a transition on `scroll-margin` (scroll-snap offset, not box model)", () => {
+    const result = run(`const C = () => <div style={{ transition: "scroll-margin 0.3s" }} />;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a transition on `scroll-padding`", () => {
+    const result = run(`const C = () => <div style={{ transition: "scroll-padding 0.3s" }} />;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a transition on plain `margin`", () => {
+    const result = run(`const C = () => <div style={{ transition: "margin 0.3s" }} />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a transition on `padding-top`", () => {
+    const result = run(`const C = () => <div style={{ transition: "padding-top 0.3s" }} />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.regressions.test.ts
@@ -24,4 +24,19 @@ describe("design/no-layout-transition-inline — regressions", () => {
     const result = run(`const C = () => <div style={{ transition: "padding-top 0.3s" }} />;`);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("flags a transition on `border-width`", () => {
+    const result = run(`const C = () => <div style={{ transition: "border-width 0.3s" }} />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a transition on `line-height`", () => {
+    const result = run(`const C = () => <div style={{ transition: "line-height 0.3s" }} />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a transition on `column-width`", () => {
+    const result = run(`const C = () => <div style={{ transition: "column-width 0.2s" }} />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noLayoutTransitionInline } from "./no-layout-transition-inline.js";
+
+describe("no-layout-transition-inline", () => {
+  it("flags a transition on `width`", () => {
+    const result = runRule(
+      noLayoutTransitionInline,
+      `const I = () => <div style={{ transition: "width 0.3s" }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a transition on `margin`", () => {
+    const result = runRule(
+      noLayoutTransitionInline,
+      `const I = () => <div style={{ transition: "margin 0.2s" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a transition on `max-height`", () => {
+    const result = runRule(
+      noLayoutTransitionInline,
+      `const I = () => <div style={{ transition: "max-height 0.2s" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  // `stroke-width` is an SVG paint property, not a layout property — the
+  // `width` token is only the hyphenated tail and must not match.
+  it("does not flag a transition on `stroke-width`", () => {
+    const result = runRule(
+      noLayoutTransitionInline,
+      `const I = () => <svg style={{ transition: "stroke-width 0.2s" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a transition on `transform`", () => {
+    const result = runRule(
+      noLayoutTransitionInline,
+      `const I = () => <div style={{ transition: "transform 0.2s" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
@@ -5,6 +5,35 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+// Exact property names that trigger reflow when animated. Matching whole
+// tokens (not substrings) keeps non-layout lookalikes like `stroke-width`
+// (SVG paint) and `scroll-margin` (scroll-snap offset) silent.
+const LAYOUT_TRANSITION_PROPERTIES = new Set([
+  "width",
+  "height",
+  "min-width",
+  "min-height",
+  "max-width",
+  "max-height",
+  "padding",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "margin",
+  "margin-top",
+  "margin-right",
+  "margin-bottom",
+  "margin-left",
+  "border-width",
+  "border-top-width",
+  "border-right-width",
+  "border-bottom-width",
+  "border-left-width",
+  "line-height",
+  "column-width",
+]);
+
 export const noLayoutTransitionInline = defineRule({
   id: "no-layout-transition-inline",
   title: "Animating layout properties",
@@ -25,16 +54,16 @@ export const noLayoutTransitionInline = defineRule({
         const value = getStylePropertyStringValue(property);
         if (!value) continue;
 
-        const lower = value.toLowerCase();
-        if (/\ball\b/.test(lower)) continue;
+        const valueTokens = value.toLowerCase().split(/[\s,]+/);
+        if (valueTokens.includes("all")) continue;
 
-        const layoutMatch = lower.match(
-          /(?<![\w-])(?:max-|min-)?(?:width|height)\b|(?<![\w-])padding(?:-(?:top|right|bottom|left))?\b|(?<![\w-])margin(?:-(?:top|right|bottom|left))?\b/,
+        const layoutProperty = valueTokens.find((valueToken) =>
+          LAYOUT_TRANSITION_PROPERTIES.has(valueToken),
         );
-        if (layoutMatch) {
+        if (layoutProperty) {
           context.report({
             node: property,
-            message: `Your users see janky, stuttering animation because "${layoutMatch[0]}" relayouts the page every frame, so animate transform & opacity instead.`,
+            message: `Your users see janky, stuttering animation because "${layoutProperty}" relayouts the page every frame, so animate transform & opacity instead.`,
           });
         }
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-layout-transition-inline.ts
@@ -29,7 +29,7 @@ export const noLayoutTransitionInline = defineRule({
         if (/\ball\b/.test(lower)) continue;
 
         const layoutMatch = lower.match(
-          /\b(?:(?:max|min)-)?(?:width|height)\b|\bpadding(?:-(?:top|right|bottom|left))?\b|\bmargin(?:-(?:top|right|bottom|left))?\b/,
+          /(?<![\w-])(?:max-|min-)?(?:width|height)\b|(?<![\w-])padding(?:-(?:top|right|bottom|left))?\b|(?<![\w-])margin(?:-(?:top|right|bottom|left))?\b/,
         );
         if (layoutMatch) {
           context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.regressions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noLongTransitionDuration } from "./no-long-transition-duration.js";
+
+const run = (code: string) => runRule(noLongTransitionDuration, code, { filename: "fixture.tsx" });
+
+describe("design/no-long-transition-duration — regressions", () => {
+  // Mined FP (ant-design LuminousBg): a decorative aria-hidden background
+  // bubble drifting via a 5s transition — ambient scenery, not a state
+  // change the user waits through.
+  it("does not flag a long transition on a decorative aria-hidden element", () => {
+    const result = run(
+      `const Bubble = ({ opacity, size, color, left, top, offset, sizeOffset }) => (
+        <div
+          aria-hidden="true"
+          style={{
+            opacity,
+            width: size,
+            height: size,
+            borderRadius: '50%',
+            background: color,
+            filter: 'blur(100px)',
+            left,
+            top,
+            transform: \`translate(-50%, -50%) translate(\${offset[0]}px, \${offset[1]}px) scale(\${sizeOffset})\`,
+            transition: 'all 5s ease-in-out',
+            position: 'absolute',
+          }}
+        />
+      );`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags the long finite animation in a shorthand that also lists an infinite one", () => {
+    const result = run(
+      `const S = () => <div style={{ animation: "slide 3s ease-out, pulse 1s linear infinite" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a long one-shot animation whose NAME contains 'infinite'", () => {
+    const result = run(`const S = () => <div style={{ animation: "infinite-scroll 3s ease" }} />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a long transition despite an unrelated infinite animation sibling", () => {
+    const result = run(
+      `const S = () => <div style={{ transition: "opacity 2s", animationIterationCount: "infinite" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noLongTransitionDuration } from "./no-long-transition-duration.js";
+
+describe("no-long-transition-duration", () => {
+  it("flags a finite long transition", () => {
+    const result = runRule(
+      noLongTransitionDuration,
+      `const S = () => <div style={{ transition: "width 2s ease" }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a finite long one-shot animation", () => {
+    const result = runRule(
+      noLongTransitionDuration,
+      `const S = () => <div style={{ animation: "slide 2s ease-out" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a short transition", () => {
+    const result = runRule(
+      noLongTransitionDuration,
+      `const S = () => <div style={{ transition: "opacity 0.2s" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  // A looping animation is a background loop, not a transition the user
+  // waits through, so a long duration is fine.
+  it("does not flag a looping animation with the `infinite` keyword", () => {
+    const result = runRule(
+      noLongTransitionDuration,
+      `const S = () => <div style={{ animation: "pulse 2s ease-in-out infinite" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag animationDuration with a sibling infinite iteration count", () => {
+    const stringCount = runRule(
+      noLongTransitionDuration,
+      `const S = () => <div style={{ animationDuration: "2s", animationIterationCount: "infinite" }} />;`,
+    );
+    const infinityCount = runRule(
+      noLongTransitionDuration,
+      `const S = () => <div style={{ animationDuration: "2s", animationIterationCount: Infinity }} />;`,
+    );
+    expect(stringCount.diagnostics).toHaveLength(0);
+    expect(infinityCount.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
@@ -1,6 +1,7 @@
 import { LONG_TRANSITION_DURATION_THRESHOLD_MS } from "../../constants/design.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
@@ -8,11 +9,8 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const INFINITE_ITERATION_KEYWORD = /\binfinite\b/;
-
-// A looping animation (the `infinite` keyword in the `animation`
-// shorthand, or a sibling `animationIterationCount` of `infinite` /
-// `Infinity`) is a background loop, not a one-shot transition the user
+// A looping animation (a sibling `animationIterationCount` of `infinite`
+// / `Infinity`) is a background loop, not a one-shot transition the user
 // waits through — so the long-duration threshold doesn't apply.
 const hasInfiniteIterationCount = (properties: ReadonlyArray<EsTreeNode>): boolean =>
   properties.some((property) => {
@@ -24,6 +22,11 @@ const hasInfiniteIterationCount = (properties: ReadonlyArray<EsTreeNode>): boole
       property.value.name === "Infinity"
     );
   });
+
+// `infinite` must be a standalone token of the shorthand segment —
+// hyphenated animation NAMES like `infinite-scroll` are still one-shot.
+const isInfiniteAnimationSegment = (segment: string): boolean =>
+  segment.trim().split(/\s+/).includes("infinite");
 
 export const noLongTransitionDuration = defineRule({
   id: "no-long-transition-duration",
@@ -37,6 +40,17 @@ export const noLongTransitionDuration = defineRule({
     JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
+
+      // An aria-hidden element is decorative — its slow drift is ambient
+      // scenery, not a state change the user waits through.
+      const openingElement = node.parent;
+      if (
+        openingElement &&
+        isNodeOfType(openingElement, "JSXOpeningElement") &&
+        isHiddenFromScreenReader(openingElement, context.settings)
+      ) {
+        return;
+      }
 
       const properties = expression.properties ?? [];
       const isLoopingAnimation = hasInfiniteIterationCount(properties);
@@ -72,8 +86,8 @@ export const noLongTransitionDuration = defineRule({
 
         if (key === "transition" || key === "animation") {
           let longestDurationMs = 0;
-          const segments = value.split(",");
-          for (const segment of segments) {
+          for (const segment of value.split(",")) {
+            if (key === "animation" && isInfiniteAnimationSegment(segment)) continue;
             const firstTimeMatch = segment.match(/(?<![a-zA-Z\d])([\d.]+)(m?s)(?![a-zA-Z\d-])/);
             if (!firstTimeMatch) continue;
             const segmentDurationMs =
@@ -86,9 +100,7 @@ export const noLongTransitionDuration = defineRule({
         }
 
         const isAnimationProperty = key === "animation" || key === "animationDuration";
-        if (isAnimationProperty && (isLoopingAnimation || INFINITE_ITERATION_KEYWORD.test(value))) {
-          continue;
-        }
+        if (isAnimationProperty && isLoopingAnimation) continue;
 
         if (durationMs !== null && durationMs > LONG_TRANSITION_DURATION_THRESHOLD_MS) {
           context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
@@ -1,10 +1,29 @@
 import { LONG_TRANSITION_DURATION_THRESHOLD_MS } from "../../constants/design.js";
 import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+const INFINITE_ITERATION_KEYWORD = /\binfinite\b/;
+
+// A looping animation (the `infinite` keyword in the `animation`
+// shorthand, or a sibling `animationIterationCount` of `infinite` /
+// `Infinity`) is a background loop, not a one-shot transition the user
+// waits through — so the long-duration threshold doesn't apply.
+const hasInfiniteIterationCount = (properties: ReadonlyArray<EsTreeNode>): boolean =>
+  properties.some((property) => {
+    if (getStylePropertyKey(property) !== "animationIterationCount") return false;
+    if (getStylePropertyStringValue(property) === "infinite") return true;
+    return (
+      isNodeOfType(property, "Property") &&
+      isNodeOfType(property.value, "Identifier") &&
+      property.value.name === "Infinity"
+    );
+  });
 
 export const noLongTransitionDuration = defineRule({
   id: "no-long-transition-duration",
@@ -19,7 +38,10 @@ export const noLongTransitionDuration = defineRule({
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
 
-      for (const property of expression.properties ?? []) {
+      const properties = expression.properties ?? [];
+      const isLoopingAnimation = hasInfiniteIterationCount(properties);
+
+      for (const property of properties) {
         const key = getStylePropertyKey(property);
         if (!key) continue;
 
@@ -61,6 +83,11 @@ export const noLongTransitionDuration = defineRule({
             longestDurationMs = Math.max(longestDurationMs, segmentDurationMs);
           }
           if (longestDurationMs > 0) durationMs = longestDurationMs;
+        }
+
+        const isAnimationProperty = key === "animation" || key === "animationDuration";
+        if (isAnimationProperty && (isLoopingAnimation || INFINITE_ITERATION_KEYWORD.test(value))) {
+          continue;
         }
 
         if (durationMs !== null && durationMs > LONG_TRANSITION_DURATION_THRESHOLD_MS) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.regressions.test.ts
@@ -16,4 +16,22 @@ describe("design/no-outline-none — regressions", () => {
     const result = run(`<button style={{ outline: "none" }} />`);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
+
+  // Bugbot: `focus:outline-none` / `focus:shadow-none` REMOVE focus styling —
+  // they must not be read as a replacement focus ring.
+  it("still flags outline:none when the className only removes focus styling", () => {
+    const outlineNone = run(
+      `<button style={{ outline: "none" }} className="focus:outline-none" />`,
+    );
+    expect(outlineNone.diagnostics.length).toBeGreaterThan(0);
+    const shadowNone = run(`<button style={{ outline: "none" }} className="focus:shadow-none" />`);
+    expect(shadowNone.diagnostics.length).toBeGreaterThan(0);
+    const ringZero = run(`<button style={{ outline: "none" }} className="focus:ring-0" />`);
+    expect(ringZero.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag outline:none paired with a shadow-based focus ring", () => {
+    const result = run(`<button style={{ outline: "none" }} className="focus:shadow-outline" />`);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.regressions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noOutlineNone } from "./no-outline-none.js";
+
+const run = (code: string) => runRule(noOutlineNone, code, { filename: "fixture.tsx" });
+
+describe("design/no-outline-none — regressions", () => {
+  it("does not flag outline:none paired with a tailwind focus-visible ring", () => {
+    const result = run(
+      `<button style={{ outline: "none" }} className="focus-visible:ring-2 focus-visible:ring-blue-500" />`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags outline:none with no replacement focus indicator", () => {
+    const result = run(`<button style={{ outline: "none" }} />`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.regressions.test.ts
@@ -34,4 +34,50 @@ describe("design/no-outline-none — regressions", () => {
     const result = run(`<button style={{ outline: "none" }} className="focus:shadow-outline" />`);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("flags the all-removal combo focus:outline-none focus:ring-0 focus:ring-offset-0", () => {
+    const result = run(
+      `<button style={{ outline: "none" }} className="focus:outline-none focus:ring-0 focus:ring-offset-0" />`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("flags focus:ring-offset-0 alone (an offset knob adds no ring)", () => {
+    const result = run(`<button style={{ outline: "none" }} className="focus:ring-offset-0" />`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("flags the tailwind v4 removal utility focus:outline-hidden", () => {
+    const result = run(`<button style={{ outline: "none" }} className="focus:outline-hidden" />`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("flags focus:ring-transparent (an invisible ring)", () => {
+    const result = run(`<button style={{ outline: "none" }} className="focus:ring-transparent" />`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("flags group-focus:ring-2 (styles the group's focus, not this element's)", () => {
+    const result = run(`<button style={{ outline: "none" }} className="group-focus:ring-2" />`);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag a stacked-variant own-focus ring like dark:focus:ring-2", () => {
+    const result = run(`<button style={{ outline: "none" }} className="dark:focus:ring-2" />`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a conditional tabIndex that is focusable in one branch", () => {
+    const result = run(
+      `const T = ({ open }) => <div tabIndex={open ? -1 : 0} style={{ outline: "none" }} />;`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("does not flag a conditional tabIndex that is negative in both branches", () => {
+    const result = run(
+      `const T = ({ open }) => <div tabIndex={open ? -1 : -2} style={{ outline: "none" }} />;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noOutlineNone } from "./no-outline-none.js";
+
+describe("no-outline-none", () => {
+  it("flags a focusable element with outline:none and no replacement ring", () => {
+    const result = runRule(
+      noOutlineNone,
+      `const T = () => <button style={{ outline: "none" }}>Save</button>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an element with a non-negative tabIndex", () => {
+    const result = runRule(
+      noOutlineNone,
+      `const T = () => <div tabIndex={0} style={{ outline: "none" }}>x</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when a box-shadow focus ring replaces the outline", () => {
+    const result = runRule(
+      noOutlineNone,
+      `const T = () => <button style={{ outline: "none", boxShadow: "0 0 0 2px blue" }}>Save</button>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  // A negative tabIndex removes the element from the tab order, so it's
+  // never keyboard-focused and dropping the focus ring is fine.
+  it("does not flag an element with a negative tabIndex", () => {
+    const result = runRule(
+      noOutlineNone,
+      `const T = ({ children }) => <div tabIndex={-1} style={{ outline: "none" }}>{children}</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.ts
@@ -1,11 +1,31 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { parseJsxValue } from "../../utils/parse-jsx-value.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
+import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+// A focus-variant ring/outline/shadow utility (`focus-visible:ring-2`,
+// `focus:shadow-outline`) IS the replacement focus indicator, so
+// `outline: none` alongside one is intentional, not an accessibility bug.
+const FOCUS_RING_CLASS_PATTERN = /\b(?:focus|focus-visible)[:-][^"'\s]*\b(?:ring|outline|shadow)/;
+
+// An element with a negative `tabIndex` is removed from the tab order,
+// so keyboard users never focus it — dropping its focus ring is fine.
+const isNotKeyboardFocusable = (styleAttribute: EsTreeNode): boolean => {
+  const openingElement = styleAttribute.parent;
+  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
+  const tabIndexAttribute = findJsxAttribute(openingElement.attributes, "tabIndex");
+  if (!tabIndexAttribute) return false;
+  const tabIndexValue = parseJsxValue(tabIndexAttribute.value);
+  return tabIndexValue !== null && tabIndexValue < 0;
+};
 
 export const noOutlineNone = defineRule({
   id: "no-outline-none",
@@ -19,6 +39,8 @@ export const noOutlineNone = defineRule({
     JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       const expression = getInlineStyleExpression(node);
       if (!expression) return;
+
+      if (isNotKeyboardFocusable(node)) return;
 
       let hasOutlineNone = false;
       let outlineProperty: EsTreeNode | null = null;
@@ -38,10 +60,13 @@ export const noOutlineNone = defineRule({
 
       if (!hasOutlineNone || !outlineProperty) return;
 
-      const hasCustomFocusRing = expression.properties?.some((property: EsTreeNode) => {
+      const hasInlineBoxShadowRing = expression.properties?.some((property: EsTreeNode) => {
         const key = getStylePropertyKey(property);
         return key === "boxShadow";
       });
+      const className = node.parent ? getStringFromClassNameAttr(node.parent) : null;
+      const hasClassNameFocusRing = Boolean(className && FOCUS_RING_CLASS_PATTERN.test(className));
+      const hasCustomFocusRing = hasInlineBoxShadowRing || hasClassNameFocusRing;
 
       if (!hasCustomFocusRing) {
         context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.ts
@@ -11,23 +11,81 @@ import { getStylePropertyKey } from "./utils/get-style-property-key.js";
 import { getStylePropertyNumberValue } from "./utils/get-style-property-number-value.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-// A focus-variant ring/outline/shadow utility (`focus-visible:ring-2`,
-// `focus:shadow-outline`) IS the replacement focus indicator, so
-// `outline: none` alongside one is intentional, not an accessibility bug.
-// The trailing `(?!-(?:none|0)\b)` excludes the REMOVAL utilities
-// (`focus:outline-none`, `focus:shadow-none`, `focus:ring-0`), which strip
-// focus styling rather than add a ring — treating them as a replacement
-// would hide a genuinely invisible keyboard focus.
-const FOCUS_RING_CLASS_PATTERN =
-  /\b(?:focus|focus-visible)[:-][^"'\s]*\b(?:ring|outline|shadow)(?!-(?:none|0)\b)/;
+// Only utilities that ADD visible focus styling count as a replacement
+// focus indicator. The REMOVAL utilities (`outline-none`, `outline-0`,
+// `outline-hidden`, `ring-0`, `ring-transparent`, `shadow-none`) and the
+// ring positioning knob `ring-offset-*` strip or offset styling rather
+// than draw a ring — treating them as a replacement would hide a
+// genuinely invisible keyboard focus.
+const isFocusStyleAddingUtility = (utility: string): boolean => {
+  if (utility === "ring" || utility === "outline" || utility === "shadow") return true;
+  if (utility.startsWith("ring-offset")) return false;
+  if (utility === "ring-0" || utility === "ring-transparent") return false;
+  if (utility.startsWith("ring-")) return true;
+  if (utility === "outline-none" || utility === "outline-0" || utility === "outline-hidden")
+    return false;
+  if (utility.startsWith("outline-")) return true;
+  if (utility === "shadow-none") return false;
+  return utility.startsWith("shadow-");
+};
+
+// The ring must be keyed to the ELEMENT'S OWN focus (`focus:` /
+// `focus-visible:`) — `group-focus:` / `peer-focus:` / `focus-within:`
+// style on an ancestor's or sibling's focus, so this element's keyboard
+// focus stays invisible.
+const hasOwnFocusRingClass = (className: string): boolean =>
+  className.split(/\s+/).some((token) => {
+    const segments = token.split(":");
+    if (segments.length < 2) return false;
+    const variants = segments.slice(0, -1);
+    if (!variants.some((variant) => variant === "focus" || variant === "focus-visible"))
+      return false;
+    const rawUtility = segments[segments.length - 1];
+    const utility = rawUtility.startsWith("!") ? rawUtility.slice(1) : rawUtility;
+    return isFocusStyleAddingUtility(utility);
+  });
+
+const parseNumericExpression = (expression: EsTreeNode): number | null => {
+  if (isNodeOfType(expression, "Literal")) {
+    if (typeof expression.value === "number") return expression.value;
+    if (typeof expression.value === "string") {
+      const parsed = Number(expression.value);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+  }
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "-") {
+    const argumentValue = parseNumericExpression(expression.argument);
+    return argumentValue === null ? null : -argumentValue;
+  }
+  return null;
+};
 
 // An element with a negative `tabIndex` is removed from the tab order,
-// so keyboard users never focus it — dropping its focus ring is fine.
+// so keyboard users never focus it — dropping its focus ring is fine. A
+// conditional `tabIndex` with a non-static test only qualifies when BOTH
+// branches are negative, since either branch can render.
 const isNotKeyboardFocusable = (styleAttribute: EsTreeNode): boolean => {
   const openingElement = styleAttribute.parent;
   if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
   const tabIndexAttribute = findJsxAttribute(openingElement.attributes, "tabIndex");
   if (!tabIndexAttribute) return false;
+  const attributeValue = tabIndexAttribute.value;
+  if (attributeValue && isNodeOfType(attributeValue, "JSXExpressionContainer")) {
+    const expression = attributeValue.expression;
+    if (
+      isNodeOfType(expression, "ConditionalExpression") &&
+      !isNodeOfType(expression.test, "Literal")
+    ) {
+      const consequentValue = parseNumericExpression(expression.consequent);
+      const alternateValue = parseNumericExpression(expression.alternate);
+      return (
+        consequentValue !== null &&
+        consequentValue < 0 &&
+        alternateValue !== null &&
+        alternateValue < 0
+      );
+    }
+  }
   const tabIndexValue = parseJsxValue(tabIndexAttribute.value);
   return tabIndexValue !== null && tabIndexValue < 0;
 };
@@ -70,7 +128,7 @@ export const noOutlineNone = defineRule({
         return key === "boxShadow";
       });
       const className = node.parent ? getStringFromClassNameAttr(node.parent) : null;
-      const hasClassNameFocusRing = Boolean(className && FOCUS_RING_CLASS_PATTERN.test(className));
+      const hasClassNameFocusRing = Boolean(className && hasOwnFocusRingClass(className));
       const hasCustomFocusRing = hasInlineBoxShadowRing || hasClassNameFocusRing;
 
       if (!hasCustomFocusRing) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-outline-none.ts
@@ -14,7 +14,12 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 // A focus-variant ring/outline/shadow utility (`focus-visible:ring-2`,
 // `focus:shadow-outline`) IS the replacement focus indicator, so
 // `outline: none` alongside one is intentional, not an accessibility bug.
-const FOCUS_RING_CLASS_PATTERN = /\b(?:focus|focus-visible)[:-][^"'\s]*\b(?:ring|outline|shadow)/;
+// The trailing `(?!-(?:none|0)\b)` excludes the REMOVAL utilities
+// (`focus:outline-none`, `focus:shadow-none`, `focus:ring-0`), which strip
+// focus styling rather than add a ring — treating them as a replacement
+// would hide a genuinely invisible keyboard focus.
+const FOCUS_RING_CLASS_PATTERN =
+  /\b(?:focus|focus-visible)[:-][^"'\s]*\b(?:ring|outline|shadow)(?!-(?:none|0)\b)/;
 
 // An element with a negative `tabIndex` is removed from the tab order,
 // so keyboard users never focus it — dropping its focus ring is fine.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.regressions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noSideTabBorder } from "./no-side-tab-border.js";
+
+const run = (code: string) => runRule(noSideTabBorder, code, { filename: "fixture.tsx" });
+
+describe("design/no-side-tab-border — regressions", () => {
+  it("does not flag an achromatic arbitrary border (border-[#e5e7eb] == gray-200)", () => {
+    const result = run(`const C = () => <div className="border-l-4 border-[#e5e7eb]" />;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an achromatic arbitrary rgb border", () => {
+    const result = run(`const C = () => <div className="border-l-4 border-[rgb(229,231,235)]" />;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still does not flag a named neutral border (control)", () => {
+    const result = run(`const C = () => <div className="border-l-4 border-gray-200" />;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a colored arbitrary border", () => {
+    const result = run(`const C = () => <div className="border-l-4 border-[#ff0000]" />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.regressions.test.ts
@@ -24,4 +24,38 @@ describe("design/no-side-tab-border — regressions", () => {
     const result = run(`const C = () => <div className="border-l-4 border-[#ff0000]" />;`);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("does not flag a side-scoped achromatic arbitrary color (border-l-[#e5e7eb])", () => {
+    const result = run(`const C = () => <div className="border-l-4 border-l-[#e5e7eb]" />;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags an achromatic base with a COLORED arbitrary side accent", () => {
+    const result = run(
+      `const C = () => <div className="border border-[#e5e7eb] border-l-4 border-l-[#ef4444]" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a neutral named base with a colored named side accent", () => {
+    const result = run(
+      `const C = () => <div className="border border-gray-200 border-l-4 border-l-red-500" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an achromatic tailwind underscore rgb border", () => {
+    const result = run(`const C = () => <div className="border-l-4 border-[rgb(229_231_235)]" />;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an achromatic hsl arbitrary border", () => {
+    const result = run(`const C = () => <div className="border-l-4 border-[hsl(0,0%,90%)]" />;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a colored arbitrary border when only the base carries the color", () => {
+    const result = run(`const C = () => <div className="border-l-4 border-[#dc2626]" />;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.ts
@@ -52,6 +52,12 @@ const BORDER_SIDE_WIDTH_KEYS = new Set([
   "borderInlineEndWidth",
 ]);
 
+const ARBITRARY_BORDER_COLOR_PATTERN = /\bborder(?:-([lrse]))?-\[([^\]]+)\]/g;
+const NAMED_BORDER_COLOR_PATTERN =
+  /\bborder(?:-([lrse]))?-((?:gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+|white|black|transparent)\b/g;
+const NEUTRAL_NAMED_BORDER_COLOR_PATTERN =
+  /^(?:(?:gray|slate|zinc|neutral|stone)-\d+|white|black|transparent)$/;
+
 export const noSideTabBorder = defineRule({
   id: "no-side-tab-border",
   title: "Thick one-sided border",
@@ -137,26 +143,32 @@ export const noSideTabBorder = defineRule({
       const classStr = getStringFromClassNameAttr(node);
       if (!classStr) return;
 
-      const sideMatch = classStr.match(/\bborder-[lrse]-(\d+)\b/);
+      const sideMatch = classStr.match(/\bborder-([lrse])-(\d+)\b/);
       if (!sideMatch) return;
+      const flaggedSideLetter = sideMatch[1];
 
-      const hasNeutralBorderColor =
-        /\bborder-(?:(?:gray|slate|zinc|neutral|stone)-\d+|white|black|transparent)\b/.test(
-          classStr,
+      // The color that decides is the one scoped to the flagged side
+      // (`border-l-[#e5e7eb]`, `border-l-red-500`), falling back to the
+      // base border color (`border-[#e5e7eb]`, `border-gray-200`).
+      // Arbitrary hex / rgb / hsl values run through the same chroma
+      // check the inline-style path uses; achromatic borders are exempt.
+      const isBorderColorNeutralBySide = new Map<string, boolean>();
+      for (const namedColorMatch of classStr.matchAll(NAMED_BORDER_COLOR_PATTERN)) {
+        isBorderColorNeutralBySide.set(
+          namedColorMatch[1] ?? "",
+          NEUTRAL_NAMED_BORDER_COLOR_PATTERN.test(namedColorMatch[2]),
         );
-      if (hasNeutralBorderColor) return;
-
-      // An arbitrary border color (`border-[#e5e7eb]`) written as a hex /
-      // rgb / hsl value renders identically to a named neutral palette,
-      // so run it through the same chroma check the inline-style path uses
-      // and skip when achromatic.
-      const arbitraryBorderColorMatch = classStr.match(/\bborder-\[([^\]]+)\]/);
-      if (arbitraryBorderColorMatch) {
-        const parsed = parseColorToRgb(arbitraryBorderColorMatch[1]);
-        if (parsed && !hasColorChroma(parsed)) return;
       }
+      for (const arbitraryColorMatch of classStr.matchAll(ARBITRARY_BORDER_COLOR_PATTERN)) {
+        const parsed = parseColorToRgb(arbitraryColorMatch[2]);
+        if (parsed)
+          isBorderColorNeutralBySide.set(arbitraryColorMatch[1] ?? "", !hasColorChroma(parsed));
+      }
+      const isDecidingBorderColorNeutral =
+        isBorderColorNeutralBySide.get(flaggedSideLetter) ?? isBorderColorNeutralBySide.get("");
+      if (isDecidingBorderColorNeutral) return;
 
-      const width = parseInt(sideMatch[1], 10);
+      const width = parseInt(sideMatch[2], 10);
       const hasRounded =
         /\brounded(?:-(?!none\b)\w+)?\b/.test(classStr) && !/\brounded-none\b/.test(classStr);
       const tailwindThreshold = hasRounded

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-side-tab-border.ts
@@ -146,6 +146,16 @@ export const noSideTabBorder = defineRule({
         );
       if (hasNeutralBorderColor) return;
 
+      // An arbitrary border color (`border-[#e5e7eb]`) written as a hex /
+      // rgb / hsl value renders identically to a named neutral palette,
+      // so run it through the same chroma check the inline-style path uses
+      // and skip when achromatic.
+      const arbitraryBorderColorMatch = classStr.match(/\bborder-\[([^\]]+)\]/);
+      if (arbitraryBorderColorMatch) {
+        const parsed = parseColorToRgb(arbitraryBorderColorMatch[1]);
+        if (parsed && !hasColorChroma(parsed)) return;
+      }
+
       const width = parseInt(sideMatch[1], 10);
       const hasRounded =
         /\brounded(?:-(?!none\b)\w+)?\b/.test(classStr) && !/\brounded-none\b/.test(classStr);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/utils/parse-color-to-rgb.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/utils/parse-color-to-rgb.ts
@@ -1,7 +1,42 @@
 import type { ParsedRgb } from "../../../utils/parsed-rgb.js";
 
+const FULL_HUE_DEGREES = 360;
+const HUE_SEXTANT_DEGREES = 60;
+const MAX_RGB_CHANNEL_VALUE = 255;
+const PERCENT_SCALE = 100;
+
+const convertHslToRgb = (
+  hueDegrees: number,
+  saturationPercent: number,
+  lightnessPercent: number,
+): ParsedRgb => {
+  const hue = ((hueDegrees % FULL_HUE_DEGREES) + FULL_HUE_DEGREES) % FULL_HUE_DEGREES;
+  const saturation = saturationPercent / PERCENT_SCALE;
+  const lightness = lightnessPercent / PERCENT_SCALE;
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const secondary = chroma * (1 - Math.abs(((hue / HUE_SEXTANT_DEGREES) % 2) - 1));
+  const lightnessOffset = lightness - chroma / 2;
+  const sextant = Math.floor(hue / HUE_SEXTANT_DEGREES);
+  const channelTriples: ReadonlyArray<readonly [number, number, number]> = [
+    [chroma, secondary, 0],
+    [secondary, chroma, 0],
+    [0, chroma, secondary],
+    [0, secondary, chroma],
+    [secondary, 0, chroma],
+    [chroma, 0, secondary],
+  ];
+  const [redChannel, greenChannel, blueChannel] = channelTriples[sextant] ?? channelTriples[0];
+  return {
+    red: Math.round((redChannel + lightnessOffset) * MAX_RGB_CHANNEL_VALUE),
+    green: Math.round((greenChannel + lightnessOffset) * MAX_RGB_CHANNEL_VALUE),
+    blue: Math.round((blueChannel + lightnessOffset) * MAX_RGB_CHANNEL_VALUE),
+  };
+};
+
 export const parseColorToRgb = (value: string): ParsedRgb | null => {
-  const trimmed = value.trim().toLowerCase();
+  // HACK: Tailwind arbitrary values spell spaces as underscores
+  // (`border-[rgb(229_231_235)]`), so normalize before matching.
+  const trimmed = value.trim().toLowerCase().replace(/_/g, " ");
 
   const hex8Match = trimmed.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})[0-9a-f]{2}$/);
   if (hex8Match) {
@@ -39,13 +74,22 @@ export const parseColorToRgb = (value: string): ParsedRgb | null => {
     };
   }
 
-  const rgbMatch = trimmed.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  const rgbMatch = trimmed.match(/rgba?\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)/);
   if (rgbMatch) {
     return {
       red: parseInt(rgbMatch[1], 10),
       green: parseInt(rgbMatch[2], 10),
       blue: parseInt(rgbMatch[3], 10),
     };
+  }
+
+  const hslMatch = trimmed.match(/hsla?\(\s*([\d.]+)(?:deg)?[\s,]+([\d.]+)%[\s,]+([\d.]+)%/);
+  if (hslMatch) {
+    return convertHslToRgb(
+      parseFloat(hslMatch[1]),
+      parseFloat(hslMatch[2]),
+      parseFloat(hslMatch[3]),
+    );
   }
 
   return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-component-prop-stack-tracker.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-component-prop-stack-tracker.ts
@@ -2,6 +2,7 @@ import { collectPatternNames } from "./collect-pattern-names.js";
 import type { ComponentPropStackTrackerCallbacks } from "./component-prop-stack-tracker-callbacks.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isComponentFunction } from "./is-component-function.js";
 import { isFunctionLike } from "./is-function-like.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isUppercaseName } from "./is-uppercase-name.js";
@@ -53,46 +54,6 @@ const getNearestComponentFunction = (
     cursor = cursor.parent ?? null;
   }
   return null;
-};
-
-const isFunctionAssignedToComponent = (
-  functionNode:
-    | EsTreeNodeOfType<"ArrowFunctionExpression">
-    | EsTreeNodeOfType<"FunctionDeclaration">
-    | EsTreeNodeOfType<"FunctionExpression">,
-): boolean => {
-  let cursor: EsTreeNode | null = functionNode.parent ?? null;
-  while (isNodeOfType(cursor, "CallExpression")) {
-    cursor = cursor.parent ?? null;
-  }
-
-  if (
-    isNodeOfType(cursor, "VariableDeclarator") &&
-    isNodeOfType(cursor.id, "Identifier") &&
-    isUppercaseName(cursor.id.name)
-  ) {
-    return true;
-  }
-
-  return isNodeOfType(cursor, "ExportDefaultDeclaration");
-};
-
-const isComponentFunction = (
-  functionNode:
-    | EsTreeNodeOfType<"ArrowFunctionExpression">
-    | EsTreeNodeOfType<"FunctionDeclaration">
-    | EsTreeNodeOfType<"FunctionExpression">,
-): boolean => {
-  if (isNodeOfType(functionNode, "FunctionDeclaration")) {
-    return (
-      !functionNode.id ||
-      functionNode.id.name === "default" ||
-      isUppercaseName(functionNode.id.name) ||
-      isNodeOfType(functionNode.parent, "ExportDefaultDeclaration")
-    );
-  }
-
-  return isFunctionAssignedToComponent(functionNode);
 };
 
 // HACK: barrier-frame predicate - a non-component arrow / function-expression

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
@@ -12,6 +12,23 @@ const NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
   "ClassExpression",
 ]);
 
+// A function expression passed directly as a call argument
+// (`items.map(item => <li/>)`, `useMemo(() => <div/>, deps)`) feeds the
+// enclosing component's render output, so JSX inside it still counts as
+// render evidence. Function expressions in any other position (assigned
+// handlers, JSX attribute values) and declarations/classes stay boundaries.
+const isCallArgumentFunctionExpression = (node: EsTreeNode): boolean => {
+  if (node.type !== "ArrowFunctionExpression" && node.type !== "FunctionExpression") {
+    return false;
+  }
+  const parent = node.parent;
+  if (!isNodeOfType(parent, "CallExpression")) return false;
+  return parent.arguments.some((argumentNode) => argumentNode === node);
+};
+
+const isNestedRenderEvidenceBoundary = (node: EsTreeNode): boolean =>
+  NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES.has(node.type) && !isCallArgumentFunctionExpression(node);
+
 const isReactImport = (symbol: SymbolDescriptor): boolean => {
   let importDeclaration: EsTreeNode | null | undefined = symbol.declarationNode?.parent;
   while (importDeclaration && !isNodeOfType(importDeclaration, "ImportDeclaration")) {
@@ -65,7 +82,7 @@ const containsRenderOutput = (
   rootNode: EsTreeNode,
   scopes: ScopeAnalysis,
 ): boolean => {
-  if (node !== rootNode && NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES.has(node.type)) {
+  if (node !== rootNode && isNestedRenderEvidenceBoundary(node)) {
     return false;
   }
   if (node.type === "JSXElement" || node.type === "JSXFragment") {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-component-function.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-component-function.ts
@@ -1,0 +1,40 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { isUppercaseName } from "./is-uppercase-name.js";
+
+// A function-expression / arrow whose binding — reached through any
+// wrapping calls (`memo(forwardRef(() => …))`) — is a PascalCase variable
+// or a default export. That binding is what makes it a component.
+const isFunctionAssignedToComponent = (functionNode: EsTreeNode): boolean => {
+  let cursor: EsTreeNode | null = functionNode.parent ?? null;
+  while (isNodeOfType(cursor, "CallExpression")) {
+    cursor = cursor.parent ?? null;
+  }
+  if (
+    isNodeOfType(cursor, "VariableDeclarator") &&
+    isNodeOfType(cursor.id, "Identifier") &&
+    isUppercaseName(cursor.id.name)
+  ) {
+    return true;
+  }
+  return isNodeOfType(cursor, "ExportDefaultDeclaration");
+};
+
+// True when a function-like node is a React component: a PascalCase (or
+// anonymous / default-exported) function declaration, or an arrow /
+// function expression bound to a PascalCase variable or default export.
+// A lowercase-named helper (`renderRow`, `formatDate`) is NOT a component,
+// so its parameters are ordinary locals, not props.
+export const isComponentFunction = (node: EsTreeNode): boolean => {
+  if (!isFunctionLike(node)) return false;
+  if (isNodeOfType(node, "FunctionDeclaration")) {
+    return (
+      !node.id ||
+      node.id.name === "default" ||
+      isUppercaseName(node.id.name) ||
+      isNodeOfType(node.parent, "ExportDefaultDeclaration")
+    );
+  }
+  return isFunctionAssignedToComponent(node);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-component-parameter-symbol.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-component-parameter-symbol.ts
@@ -1,0 +1,12 @@
+import type { SymbolDescriptor } from "../semantic/scope-analysis.js";
+import { isComponentFunction } from "./is-component-function.js";
+
+// True when a symbol is a parameter of a React COMPONENT — the props object,
+// or a value destructured from it in the parameter list. A parameter of an
+// ordinary helper (`function runRow(renderRow) {}`), or a local variable that
+// merely shares the name `props` / `children`, is NOT the component's props,
+// so callers must not treat its members as parent-owned props.
+export const isComponentParameterSymbol = (symbol: SymbolDescriptor | null): boolean => {
+  if (!symbol || symbol.kind !== "parameter") return false;
+  return isComponentFunction(symbol.scope.node);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-event-handler-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-event-handler-attribute.ts
@@ -1,0 +1,13 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+// A JSX event-handler attribute: an `on*` prop whose name is `on` followed by
+// an uppercase letter (`onClick`, `onValueChange`). React wires these to
+// callback functions, not to data or on/off props.
+export const isEventHandlerAttribute = (
+  node: EsTreeNode | null | undefined,
+): node is EsTreeNodeOfType<"JSXAttribute"> =>
+  isNodeOfType(node, "JSXAttribute") &&
+  isNodeOfType(node.name, "JSXIdentifier") &&
+  /^on[A-Z]/.test(node.name.name);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-testlike-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-testlike-filename.ts
@@ -1,5 +1,6 @@
 // Directory names that mark a file as part of a test / fixture /
-// Storybook / Cypress / example surface, regardless of the file's own suffix.
+// Storybook / Cypress / docs-site (`.dumi`) / example surface, regardless
+// of the file's own suffix.
 const NON_PRODUCTION_PATH_SEGMENTS: ReadonlyArray<string> = [
   "/test/",
   "/tests/",
@@ -11,6 +12,7 @@ const NON_PRODUCTION_PATH_SEGMENTS: ReadonlyArray<string> = [
   "/mocks/",
   "/cypress/",
   "/.storybook/",
+  "/.dumi/",
   "/stories/",
   "/__stories__/",
   "/playground/",

--- a/packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts
@@ -31,8 +31,8 @@ export interface RunRuleResult {
 
 const dispatchTreeWalk = (root: EsTreeNode, visitors: RuleVisitors): void => {
   const visit = (node: EsTreeNode): void => {
-    const handler = visitors[node.type];
-    if (typeof handler === "function") handler(node);
+    const enterHandler = visitors[node.type];
+    if (typeof enterHandler === "function") enterHandler(node);
     const nodeRecord = node as unknown as Record<string, unknown>;
     for (const key of Object.keys(nodeRecord)) {
       if (key === "parent") continue;
@@ -45,10 +45,10 @@ const dispatchTreeWalk = (root: EsTreeNode, visitors: RuleVisitors): void => {
         visit(child);
       }
     }
+    const exitHandler = visitors[`${node.type}:exit`];
+    if (typeof exitHandler === "function") exitHandler(node);
   };
   visit(root);
-  const programExitHandler = visitors["Program:exit"];
-  if (typeof programExitHandler === "function") programExitHandler(root);
 };
 
 // Pure-TS rule runner mirroring what oxlint does at runtime: parse code,

--- a/packages/react-doctor/tests/regressions/non-react-typescript.test.ts
+++ b/packages/react-doctor/tests/regressions/non-react-typescript.test.ts
@@ -96,9 +96,9 @@ export const cloned = _.cloneDeep({ a: 1 });
     const projectDir = setupTypeScriptProject("nested-component-with-react", {
       "src/app.tsx": `export function Outer() {
   function Inner() {
-    return 1;
+    return <div>inner</div>;
   }
-  return Inner();
+  return <Inner />;
 }
 `,
     });

--- a/packages/react-doctor/tests/regressions/prop-stack-barrier.test.ts
+++ b/packages/react-doctor/tests/regressions/prop-stack-barrier.test.ts
@@ -71,6 +71,54 @@ export const Outer = ({ value }: { value: string }) => {
   });
 });
 
+describe("no-derived-useState — re-seeded draft buffer", () => {
+  it("does NOT flag a draft re-seeded from the prop inside an event handler", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-derived-usestate-draft-buffer", {
+      files: {
+        "src/RenameTab.tsx": `import { useState } from "react";
+
+export const RenameTab = (props: { terminal: { title: string; update: (next: string) => void } }) => {
+  const [title, setTitle] = useState(props.terminal.title);
+  const edit = () => {
+    setTitle(props.terminal.title);
+  };
+  const commit = () => props.terminal.update(title);
+  return (
+    <div>
+      <span>{props.terminal.title}</span>
+      <input value={title} onChange={(event) => setTitle(event.target.value)} onBlur={commit} onFocus={edit} />
+    </div>
+  );
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-derived-useState");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("STILL flags a genuine prop mirror that only re-syncs inside an effect", async () => {
+    const projectDir = setupReactProject(tempRoot, "no-derived-usestate-effect-mirror", {
+      files: {
+        "src/Mirror.tsx": `import { useEffect, useState } from "react";
+
+export const Mirror = ({ value }: { value: string }) => {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+  return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
+};
+`,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-derived-useState");
+    expect(hits).toHaveLength(1);
+  });
+});
+
 describe("no-prop-callback-in-effect — empty-frame barrier", () => {
   it("flags the canonical `useEffect(() => onChange(state), [state, onChange])` shape", async () => {
     const projectDir = setupReactProject(tempRoot, "no-prop-callback-real-prop", {

--- a/packages/react-doctor/tests/regressions/prop-stack-barrier.test.ts
+++ b/packages/react-doctor/tests/regressions/prop-stack-barrier.test.ts
@@ -71,54 +71,6 @@ export const Outer = ({ value }: { value: string }) => {
   });
 });
 
-describe("no-derived-useState — re-seeded draft buffer", () => {
-  it("does NOT flag a draft re-seeded from the prop inside an event handler", async () => {
-    const projectDir = setupReactProject(tempRoot, "no-derived-usestate-draft-buffer", {
-      files: {
-        "src/RenameTab.tsx": `import { useState } from "react";
-
-export const RenameTab = (props: { terminal: { title: string; update: (next: string) => void } }) => {
-  const [title, setTitle] = useState(props.terminal.title);
-  const edit = () => {
-    setTitle(props.terminal.title);
-  };
-  const commit = () => props.terminal.update(title);
-  return (
-    <div>
-      <span>{props.terminal.title}</span>
-      <input value={title} onChange={(event) => setTitle(event.target.value)} onBlur={commit} onFocus={edit} />
-    </div>
-  );
-};
-`,
-      },
-    });
-
-    const hits = await collectRuleHits(projectDir, "no-derived-useState");
-    expect(hits).toHaveLength(0);
-  });
-
-  it("STILL flags a genuine prop mirror that only re-syncs inside an effect", async () => {
-    const projectDir = setupReactProject(tempRoot, "no-derived-usestate-effect-mirror", {
-      files: {
-        "src/Mirror.tsx": `import { useEffect, useState } from "react";
-
-export const Mirror = ({ value }: { value: string }) => {
-  const [draft, setDraft] = useState(value);
-  useEffect(() => {
-    setDraft(value);
-  }, [value]);
-  return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
-};
-`,
-      },
-    });
-
-    const hits = await collectRuleHits(projectDir, "no-derived-useState");
-    expect(hits).toHaveLength(1);
-  });
-});
-
 describe("no-prop-callback-in-effect — empty-frame barrier", () => {
   it("flags the canonical `useEffect(() => onChange(state), [state, onChange])` shape", async () => {
     const projectDir = setupReactProject(tempRoot, "no-prop-callback-real-prop", {


### PR DESCRIPTION
## FP-FIX — Architecture / correctness / design rules

Part of the false-positive hardening stack. Removes false positives across the **architecture, correctness, and design** families. Based on #988 (foundation) — merge that first.

### Highlights
- **`no-many-boolean-props`** — only counts genuine on/off props: boolean-prefixed names invoked as callbacks (`props.showMenu()`) or wired as JSX event handlers (`onClick={props.showMenu}`) are excluded for both the destructured and `props`-object shapes; also requires real render output before treating a param as component props.
- **`no-render-in-render`** — `rootsInProps` traces render props destructured from nested prop bags, so legitimate render-prop calls aren't flagged.
- **`no-nested-component-definition`** — only a PascalCase binding actually rendered as JSX (`<Name/>`) is flagged; one exclusively invoked as `Name()` is inlined, not a remounting child.
- **`react-compiler-no-manual-memoization` / `react-compiler-destructure-method` / `prefer-module-scope-static-value`** and the `correctness/` (invalid-paragraph-child, nested-interactive, polymorphic-children, uncontrolled-input, prevent-default, svg-precision) + `design/` (outline-none, gray-on-colored, transition rules, side-tab-border) rules tightened.

### Bugbot follow-ups
- **`no-many-boolean-props` handler exclusion incomplete** — FIXED: the `props`-object path now also excludes names wired as `onClick={props.x}`, matching the destructured path.
- **`no-nested-component-definition` file-wide JSX match** — declined (consistent with the earlier call on the combined PR): making it precise requires scope/binding resolution to prove a `<Name/>` usage resolves to *this* nested definition rather than an import or a same-named sibling. The residual FP is rare; tracked rather than shipping a half-measure. (See thread.)

### Test plan
- [x] architecture / correctness / design unit + regression suites green
- [x] typecheck clean
- [ ] Full CI after foundation merges + retarget to `main`

## RDE eval results

Validated all 18 rules in this PR against the OSS corpus with the `react-doctor-evals` harness (**local** runner — cloud reports a misleading `0` for oxlint AST rules).

| Check                    | Result                                                              |
| ------------------------ | ------------------------------------------------------------------- |
| Repos scanned (distinct) | `64`                                                                |
| RootDir scans            | `500` (495 reported, 5 failed)                                      |
| Manifest                 | `repos.json` (8,423 entries)                                        |
| Target diagnostics       | `~8,490`                                                            |
| False positives found    | `1` class — `no-uncontrolled-input` on `disabled` inputs (3×)       |
| Fix                      | exempt `disabled` inputs + regression tests (landed in this PR)     |

Per-rule (every hit sampled/inspected — all true positives by contract except the one FP class, now fixed):

| Rule                                   | Hits | Notes                                                              |
| -------------------------------------- | ---- | ----------------------------------------------------------------- |
| rendering-svg-precision                | 5379 | over-precise machine-exported SVG; ≥2-distinct-token gate verified |
| react-compiler-no-manual-memoization   | 1463 | only fires where React Compiler is configured (verified)          |
| no-render-in-render                    | 692  | local render helpers, not render props (carve-out verified)       |
| prefer-module-scope-static-value       | 491  | static config/arrays; impure carve-out correct                    |
| no-many-boolean-props                  | 176  | genuine boolean props                                             |
| no-nested-component-definition         | 103  | real nested components rendered as JSX                            |
| no-prevent-default                     | 46   | forms without `action=` / non-navigating anchors                  |
| no-outline-none                        | 44   | `outline:none` without a focus ring                               |
| no-polymorphic-children                | 35   | `typeof children` resolving to props                              |
| html-no-invalid-paragraph-child        | 30   | invalid `<p>` descendants                                         |
| no-render-prop-children                | 13   | ≥3 real render props (no `*Props` bags / literals)                |
| no-layout-transition-inline            | 6    | animating width/height                                            |
| html-no-nested-interactive             | 5    | nested interactive elements                                       |
| no-long-transition-duration            | 4    | >1000 ms                                                          |
| **no-uncontrolled-input**              | 2    | TPs (value+defaultValue; undefined-state) after the `disabled` fix |
| no-gray-on-colored-background / no-side-tab-border / react-compiler-destructure-method | 0 | no hits in corpus |

The lone false positive — `<input value={…} disabled />` (supabase's read-only email field, ported 3 ways) — is fixed in this PR by `fix(no-uncontrolled-input): exempt disabled inputs`, backed by a new regression suite. React suppresses its missing-`onChange` warning for `disabled` fields exactly like `readOnly`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are precision-focused lint heuristics with extensive regression tests; risk is mainly missed true positives on edge cases, not runtime or security impact.
> 
> **Overview**
> This PR **reduces false positives** across ~15 oxlint-plugin-react-doctor rules in architecture, correctness, and design, while keeping the underlying smells. Shared helpers (`isComponentFunction`, `isComponentParameterSymbol`, scope-aware props tracing) and test harness fixes (`:exit` visitors) underpin several rule changes.
> 
> **Architecture** rules now distinguish real components from factories and callbacks from boolean flags: render-output gates, callback/event-handler exclusions, deferred reporting for nested components only when actually rendered (JSX or `component={…}`), render-prop carve-outs, impure-global / scalar-lookup abstentions for hoisting advice, and React Compiler carve-outs for `useSearchParams` and custom `memo` comparators.
> 
> **Correctness** rules stop treating JSX passed as non-`children` props as DOM ancestry, resolve `children` / props via scope, relax `preventDefault` / uncontrolled-input checks for progressive enhancement and React-aligned cases, and add an SVG precision materiality threshold plus test/docs paths.
> 
> **Design** rules tighten Tailwind variant pairing for gray-on-color, exact layout-transition tokens, infinite/`aria-hidden` animation exemptions, stricter focus-ring detection for `outline: none`, and achromatic arbitrary border colors for side-tab borders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ddc33b10232d2c5baab2e85f7d679455dc49ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

