### PR TITLE
RD-NEW-RR-RULE: correctness — 30 rules

### DIFF
--- a/.changeset/rd-new-rules-correctness.md
+++ b/.changeset/rd-new-rules-correctness.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 30 new correctness rules, corpus-validated and FP-hardened

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -115,6 +115,7 @@ import { jsxNoNewObjectAsProp } from "./rules/react-builtins/jsx-no-new-object-a
 import { jsxNoScriptUrl } from "./rules/react-builtins/jsx-no-script-url.js";
 import { jsxNoUndef } from "./rules/react-builtins/jsx-no-undef.js";
 import { jsxNoUselessFragment } from "./rules/react-builtins/jsx-no-useless-fragment.js";
+import { jsxNumericAndLeakedRender } from "./rules/correctness/jsx-numeric-and-leaked-render.js";
 import { jsxPascalCase } from "./rules/react-builtins/jsx-pascal-case.js";
 import { jsxPropsNoSpreadMulti } from "./rules/react-builtins/jsx-props-no-spread-multi.js";
 import { jsxPropsNoSpreading } from "./rules/react-builtins/jsx-props-no-spreading.js";
@@ -154,7 +155,10 @@ import { nextjsNoVercelOgImport } from "./rules/nextjs/nextjs-no-vercel-og-impor
 import { noAccessKey } from "./rules/a11y/no-access-key.js";
 import { noAdjustStateOnPropChange } from "./rules/state-and-effects/no-adjust-state-on-prop-change.js";
 import { noAriaHiddenOnFocusable } from "./rules/a11y/no-aria-hidden-on-focusable.js";
+import { noArithmeticOnOptionalChainedOperand } from "./rules/correctness/no-arithmetic-on-optional-chained-operand.js";
+import { noArrayFindResultMemberAccessWithoutGuard } from "./rules/correctness/no-array-find-result-member-access-without-guard.js";
 import { noArrayIndexAsKey } from "./rules/correctness/no-array-index-as-key.js";
+import { noArrayIndexDerefWithoutBoundsOrEmptyGuard } from "./rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.js";
 import { noArrayIndexKey } from "./rules/react-builtins/no-array-index-key.js";
 import { noAsyncEffectCallback } from "./rules/state-and-effects/no-async-effect-callback.js";
 import { noAsyncEventHandlerWithoutReentryGuard } from "./rules/state-and-effects/no-async-event-handler-without-reentry-guard.js";
@@ -166,6 +170,8 @@ import { noCascadingSetState } from "./rules/state-and-effects/no-cascading-set-
 import { noChainStateUpdates } from "./rules/state-and-effects/no-chain-state-updates.js";
 import { noChildrenProp } from "./rules/react-builtins/no-children-prop.js";
 import { noCloneElement } from "./rules/react-builtins/no-clone-element.js";
+import { noCollapsedLiteralOrChainAsValue } from "./rules/correctness/no-collapsed-literal-or-chain-as-value.js";
+import { noControlledInputValueWithoutStateUpdate } from "./rules/correctness/no-controlled-input-value-without-state-update.js";
 import { noCreateContextInRender } from "./rules/state-and-effects/no-create-context-in-render.js";
 import { noCreateObjectUrlWithoutRevoke } from "./rules/js-performance/no-create-object-url-without-revoke.js";
 import { noCreateRefInFunctionComponent } from "./rules/react-builtins/no-create-ref-in-function-component.js";
@@ -174,6 +180,7 @@ import { noDanger } from "./rules/react-builtins/no-danger.js";
 import { noDangerWithChildren } from "./rules/react-builtins/no-danger-with-children.js";
 import { noDarkModeGlow } from "./rules/design/no-dark-mode-glow.js";
 import { noDefaultProps } from "./rules/architecture/no-default-props.js";
+import { noDeprecatedKeyboardEventKeycodeWhich } from "./rules/correctness/no-deprecated-keyboard-event-keycode-which.js";
 import { noDerivedState } from "./rules/state-and-effects/no-derived-state.js";
 import { noDerivedStateEffect } from "./rules/state-and-effects/no-derived-state-effect.js";
 import { noDerivedUseState } from "./rules/state-and-effects/no-derived-use-state.js";
@@ -192,11 +199,15 @@ import { noEffectEventHandler } from "./rules/state-and-effects/no-effect-event-
 import { noEffectEventInDeps } from "./rules/state-and-effects/no-effect-event-in-deps.js";
 import { noEffectWithFreshDeps } from "./rules/state-and-effects/no-effect-with-fresh-deps.js";
 import { noEffectWrapperDiscardsCallbackCleanupReturn } from "./rules/state-and-effects/no-effect-wrapper-discards-callback-cleanup-return.js";
+import { noEnterSubmitWithoutImeCompositionGuard } from "./rules/correctness/no-enter-submit-without-ime-composition-guard.js";
 import { noEval } from "./rules/security/no-eval.js";
 import { noEventHandler } from "./rules/state-and-effects/no-event-handler.js";
 import { noEventTriggerState } from "./rules/state-and-effects/no-event-trigger-state.js";
 import { noFetchInEffect } from "./rules/state-and-effects/no-fetch-in-effect.js";
+import { noFetchResponseUsedWithoutStatusCheck } from "./rules/correctness/no-fetch-response-used-without-status-check.js";
+import { noFillMapElementAsKey } from "./rules/correctness/no-fill-map-element-as-key.js";
 import { noFindDomNode } from "./rules/react-builtins/no-find-dom-node.js";
+import { noFloatingThenInJsxHandler } from "./rules/correctness/no-floating-then-in-jsx-handler.js";
 import { noFlushSync } from "./rules/view-transitions/no-flush-sync.js";
 import { noFullLodashImport } from "./rules/bundle-size/no-full-lodash-import.js";
 import { noGenericHandlerNames } from "./rules/architecture/no-generic-handler-names.js";
@@ -205,6 +216,7 @@ import { noGlobalCssVariableAnimation } from "./rules/performance/no-global-css-
 import { noGradientText } from "./rules/design/no-gradient-text.js";
 import { noGrayOnColoredBackground } from "./rules/design/no-gray-on-colored-background.js";
 import { noImgLazyWithHighFetchpriority } from "./rules/performance/no-img-lazy-with-high-fetchpriority.js";
+import { noImpureCallAtModuleScope } from "./rules/correctness/no-impure-call-at-module-scope.js";
 import { noInitializeState } from "./rules/state-and-effects/no-initialize-state.js";
 import { noInlineBounceEasing } from "./rules/design/no-inline-bounce-easing.js";
 import { noInlineExhaustiveStyle } from "./rules/design/no-inline-exhaustive-style.js";
@@ -227,18 +239,27 @@ import { noMirrorPropEffect } from "./rules/state-and-effects/no-mirror-prop-eff
 import { noMoment } from "./rules/bundle-size/no-moment.js";
 import { noMultiComp } from "./rules/react-builtins/no-multi-comp.js";
 import { noMutableInDeps } from "./rules/state-and-effects/no-mutable-in-deps.js";
+import { noMutateQueriedDomNodeInComponent } from "./rules/correctness/no-mutate-queried-dom-node-in-component.js";
 import { noMutateThenSetOrReturnSameReference } from "./rules/state-and-effects/no-mutate-then-set-or-return-same-reference.js";
+import { noMutatingArrayMethodOnPropOrHookResult } from "./rules/correctness/no-mutating-array-method-on-prop-or-hook-result.js";
 import { noMutatingReducerState } from "./rules/state-and-effects/no-mutating-reducer-state.js";
 import { noNamespace } from "./rules/react-builtins/no-namespace.js";
 import { noNestedComponentDefinition } from "./rules/architecture/no-nested-component-definition.js";
+import { noNonLiteralSelectorQueryWithoutTryCatch } from "./rules/correctness/no-non-literal-selector-query-without-try-catch.js";
+import { noNonNullAssertionOnMaybeUndefinedResult } from "./rules/correctness/no-non-null-assertion-on-maybe-undefined-result.js";
+import { noNondeterministicIdValueInRenderBody } from "./rules/correctness/no-nondeterministic-id-value-in-render-body.js";
 import { noNoninteractiveElementInteractions } from "./rules/a11y/no-noninteractive-element-interactions.js";
 import { noNoninteractiveElementToInteractiveRole } from "./rules/a11y/no-noninteractive-element-to-interactive-role.js";
 import { noNoninteractiveTabindex } from "./rules/a11y/no-noninteractive-tabindex.js";
+import { noNullishCoalescingArithmeticPrecedence } from "./rules/correctness/no-nullish-coalescing-arithmetic-precedence.js";
+import { noObjectKeysValuesEntriesOnMaybeUndefined } from "./rules/correctness/no-object-keys-values-entries-on-maybe-undefined.js";
+import { noObjectOrArrayCoercedToStringInTemplateLiteral } from "./rules/correctness/no-object-or-array-coerced-to-string-in-template-literal.js";
 import { noOutlineNone } from "./rules/design/no-outline-none.js";
 import { noPassDataToParent } from "./rules/state-and-effects/no-pass-data-to-parent.js";
 import { noPassLiveStateToParent } from "./rules/state-and-effects/no-pass-live-state-to-parent.js";
 import { noPermanentWillChange } from "./rules/performance/no-permanent-will-change.js";
 import { noPolymorphicChildren } from "./rules/correctness/no-polymorphic-children.js";
+import { noPredicateFunctionReferenceInBooleanPosition } from "./rules/correctness/no-predicate-function-reference-in-boolean-position.js";
 import { noPreventDefault } from "./rules/correctness/no-prevent-default.js";
 import { noPromiseThenSideEffectInEffectWithoutCatch } from "./rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.js";
 import { noPropCallbackInEffect } from "./rules/state-and-effects/no-prop-callback-in-effect.js";
@@ -274,11 +295,18 @@ import { noTinyText } from "./rules/design/no-tiny-text.js";
 import { noTransitionAll } from "./rules/performance/no-transition-all.js";
 import { noUncontrolledInput } from "./rules/correctness/no-uncontrolled-input.js";
 import { noUndeferredThirdParty } from "./rules/bundle-size/no-undeferred-third-party.js";
+import { noUnescapedDynamicStringInRegexp } from "./rules/correctness/no-unescaped-dynamic-string-in-regexp.js";
 import { noUnescapedEntities } from "./rules/react-builtins/no-unescaped-entities.js";
+import { noUnguardedBrowserGlobalAtModuleScope } from "./rules/correctness/no-unguarded-browser-global-at-module-scope.js";
+import { noUnguardedBrowserGlobalInRenderOrHookInit } from "./rules/correctness/no-unguarded-browser-global-in-render-or-hook-init.js";
+import { noUnguardedNumericInputParse } from "./rules/correctness/no-unguarded-numeric-input-parse.js";
+import { noUnguardedThrowingParseCall } from "./rules/correctness/no-unguarded-throwing-parse-call.js";
 import { noUnknownProperty } from "./rules/react-builtins/no-unknown-property.js";
 import { noUnsafe } from "./rules/react-builtins/no-unsafe.js";
+import { noUnsafeJsonParse } from "./rules/correctness/no-unsafe-json-parse.js";
 import { noUnstableNestedComponents } from "./rules/react-builtins/no-unstable-nested-components.js";
 import { noUsememoSimpleExpression } from "./rules/performance/no-usememo-simple-expression.js";
+import { noWholeObjectDefaultLosingPerKeyDefaults } from "./rules/correctness/no-whole-object-default-losing-per-key-defaults.js";
 import { noWholeObjectDepWithMemberReads } from "./rules/state-and-effects/no-whole-object-dep-with-member-reads.js";
 import { noWideLetterSpacing } from "./rules/design/no-wide-letter-spacing.js";
 import { noWillUpdateSetState } from "./rules/react-builtins/no-will-update-set-state.js";
@@ -317,6 +345,7 @@ import { queryNoRestDestructuring } from "./rules/tanstack-query/query-no-rest-d
 import { queryNoUseQueryForMutation } from "./rules/tanstack-query/query-no-use-query-for-mutation.js";
 import { queryNoVoidQueryFn } from "./rules/tanstack-query/query-no-void-query-fn.js";
 import { queryStableQueryClient } from "./rules/tanstack-query/query-stable-query-client.js";
+import { radioInputMissingName } from "./rules/correctness/radio-input-missing-name.js";
 import { rawSqlInjectionRisk } from "./rules/security-scan/raw-sql-injection-risk.js";
 import { reactCompilerNoManualMemoization } from "./rules/architecture/react-compiler-no-manual-memoization.js";
 import { reactInJsxScope } from "./rules/react-builtins/react-in-jsx-scope.js";
@@ -394,6 +423,7 @@ import { serverSequentialIndependentAwait } from "./rules/server/server-sequenti
 import { stateInConstructor } from "./rules/react-builtins/state-in-constructor.js";
 import { stylePropObject } from "./rules/react-builtins/style-prop-object.js";
 import { styledComponentsDuplicateCssPropertyInBlock } from "./rules/design/styled-components-duplicate-css-property-in-block.js";
+import { styledComponentsNonTransientCustomPropOnIntrinsicElement } from "./rules/correctness/styled-components-non-transient-custom-prop-on-intrinsic-element.js";
 import { supabaseClientOwnedAuthzField } from "./rules/security-scan/supabase-client-owned-authz-field.js";
 import { supabaseRlsPolicyRisk } from "./rules/security-scan/supabase-rls-policy-risk.js";
 import { supabaseTableMissingRls } from "./rules/security-scan/supabase-table-missing-rls.js";
@@ -1698,6 +1728,17 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/jsx-numeric-and-leaked-render",
+    id: "jsx-numeric-and-leaked-render",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...jsxNumericAndLeakedRender,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/jsx-pascal-case",
     id: "jsx-pascal-case",
     source: "react-doctor",
@@ -2143,12 +2184,45 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-arithmetic-on-optional-chained-operand",
+    id: "no-arithmetic-on-optional-chained-operand",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noArithmeticOnOptionalChainedOperand,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-array-find-result-member-access-without-guard",
+    id: "no-array-find-result-member-access-without-guard",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noArrayFindResultMemberAccessWithoutGuard,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/no-array-index-as-key",
     id: "no-array-index-as-key",
     source: "react-doctor",
     originallyExternal: false,
     rule: {
       ...noArrayIndexAsKey,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-array-index-deref-without-bounds-or-empty-guard",
+    id: "no-array-index-deref-without-bounds-or-empty-guard",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noArrayIndexDerefWithoutBoundsOrEmptyGuard,
       framework: "global",
       category: "Bugs",
     },
@@ -2285,6 +2359,28 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-collapsed-literal-or-chain-as-value",
+    id: "no-collapsed-literal-or-chain-as-value",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noCollapsedLiteralOrChainAsValue,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-controlled-input-value-without-state-update",
+    id: "no-controlled-input-value-without-state-update",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noControlledInputValueWithoutStateUpdate,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/no-create-context-in-render",
     id: "no-create-context-in-render",
     source: "react-doctor",
@@ -2375,6 +2471,17 @@ export const reactDoctorRules = [
       ...noDefaultProps,
       framework: "global",
       category: "Maintainability",
+    },
+  },
+  {
+    key: "react-doctor/no-deprecated-keyboard-event-keycode-which",
+    id: "no-deprecated-keyboard-event-keycode-which",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noDeprecatedKeyboardEventKeycodeWhich,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {
@@ -2593,6 +2700,17 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-enter-submit-without-ime-composition-guard",
+    id: "no-enter-submit-without-ime-composition-guard",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noEnterSubmitWithoutImeCompositionGuard,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/no-eval",
     id: "no-eval",
     source: "react-doctor",
@@ -2640,6 +2758,28 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-fetch-response-used-without-status-check",
+    id: "no-fetch-response-used-without-status-check",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noFetchResponseUsedWithoutStatusCheck,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-fill-map-element-as-key",
+    id: "no-fill-map-element-as-key",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noFillMapElementAsKey,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/no-find-dom-node",
     id: "no-find-dom-node",
     source: "react-doctor",
@@ -2649,6 +2789,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(noFindDomNode.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-floating-then-in-jsx-handler",
+    id: "no-floating-then-in-jsx-handler",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noFloatingThenInJsxHandler,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {
@@ -2740,6 +2891,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Performance",
       requires: [...new Set(["react", ...(noImgLazyWithHighFetchpriority.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-impure-call-at-module-scope",
+    id: "no-impure-call-at-module-scope",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noImpureCallAtModuleScope,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {
@@ -2997,6 +3159,17 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-mutate-queried-dom-node-in-component",
+    id: "no-mutate-queried-dom-node-in-component",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noMutateQueriedDomNodeInComponent,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/no-mutate-then-set-or-return-same-reference",
     id: "no-mutate-then-set-or-return-same-reference",
     source: "react-doctor",
@@ -3006,6 +3179,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(noMutateThenSetOrReturnSameReference.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-mutating-array-method-on-prop-or-hook-result",
+    id: "no-mutating-array-method-on-prop-or-hook-result",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noMutatingArrayMethodOnPropOrHookResult,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {
@@ -3039,6 +3223,39 @@ export const reactDoctorRules = [
     originallyExternal: false,
     rule: {
       ...noNestedComponentDefinition,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-non-literal-selector-query-without-try-catch",
+    id: "no-non-literal-selector-query-without-try-catch",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noNonLiteralSelectorQueryWithoutTryCatch,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-non-null-assertion-on-maybe-undefined-result",
+    id: "no-non-null-assertion-on-maybe-undefined-result",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noNonNullAssertionOnMaybeUndefinedResult,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-nondeterministic-id-value-in-render-body",
+    id: "no-nondeterministic-id-value-in-render-body",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noNondeterministicIdValueInRenderBody,
       framework: "global",
       category: "Bugs",
     },
@@ -3079,6 +3296,39 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Accessibility",
       requires: [...new Set(["react", ...(noNoninteractiveTabindex.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-nullish-coalescing-arithmetic-precedence",
+    id: "no-nullish-coalescing-arithmetic-precedence",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noNullishCoalescingArithmeticPrecedence,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-object-keys-values-entries-on-maybe-undefined",
+    id: "no-object-keys-values-entries-on-maybe-undefined",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noObjectKeysValuesEntriesOnMaybeUndefined,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-object-or-array-coerced-to-string-in-template-literal",
+    id: "no-object-or-array-coerced-to-string-in-template-literal",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noObjectOrArrayCoercedToStringInTemplateLiteral,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {
@@ -3137,6 +3387,17 @@ export const reactDoctorRules = [
       ...noPolymorphicChildren,
       framework: "global",
       category: "Maintainability",
+    },
+  },
+  {
+    key: "react-doctor/no-predicate-function-reference-in-boolean-position",
+    id: "no-predicate-function-reference-in-boolean-position",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noPredicateFunctionReferenceInBooleanPosition,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {
@@ -3549,6 +3810,17 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-unescaped-dynamic-string-in-regexp",
+    id: "no-unescaped-dynamic-string-in-regexp",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noUnescapedDynamicStringInRegexp,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/no-unescaped-entities",
     id: "no-unescaped-entities",
     source: "react-doctor",
@@ -3558,6 +3830,50 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(noUnescapedEntities.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-unguarded-browser-global-at-module-scope",
+    id: "no-unguarded-browser-global-at-module-scope",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noUnguardedBrowserGlobalAtModuleScope,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-unguarded-browser-global-in-render-or-hook-init",
+    id: "no-unguarded-browser-global-in-render-or-hook-init",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noUnguardedBrowserGlobalInRenderOrHookInit,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-unguarded-numeric-input-parse",
+    id: "no-unguarded-numeric-input-parse",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noUnguardedNumericInputParse,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-unguarded-throwing-parse-call",
+    id: "no-unguarded-throwing-parse-call",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noUnguardedThrowingParseCall,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {
@@ -3585,6 +3901,17 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-unsafe-json-parse",
+    id: "no-unsafe-json-parse",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noUnsafeJsonParse,
+      framework: "global",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/no-unstable-nested-components",
     id: "no-unstable-nested-components",
     source: "react-doctor",
@@ -3606,6 +3933,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Performance",
       requires: [...new Set(["react", ...(noUsememoSimpleExpression.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-whole-object-default-losing-per-key-defaults",
+    id: "no-whole-object-default-losing-per-key-defaults",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noWholeObjectDefaultLosingPerKeyDefaults,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {
@@ -4042,6 +4380,17 @@ export const reactDoctorRules = [
       ...queryStableQueryClient,
       framework: "tanstack-query",
       category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/radio-input-missing-name",
+    id: "radio-input-missing-name",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...radioInputMissingName,
+      framework: "global",
+      category: "Accessibility",
     },
   },
   {
@@ -4962,6 +5311,17 @@ export const reactDoctorRules = [
       ...styledComponentsDuplicateCssPropertyInBlock,
       framework: "global",
       category: "Maintainability",
+    },
+  },
+  {
+    key: "react-doctor/styled-components-non-transient-custom-prop-on-intrinsic-element",
+    id: "styled-components-non-transient-custom-prop-on-intrinsic-element",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...styledComponentsNonTransientCustomPropOnIntrinsicElement,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/jsx-numeric-and-leaked-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/jsx-numeric-and-leaked-render.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jsxNumericAndLeakedRender } from "./jsx-numeric-and-leaked-render.js";
+
+describe("jsx-numeric-and-leaked-render", () => {
+  it("flags {items.length && <List/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ items }) => <div>{items.length && <List items={items} />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a parenthesized JSX right operand {cart.items.length && (<Summary/>)}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ cart }) => <div>{cart.items.length && (<Summary />)}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .size on a binding provably initialized to a Set", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ ids }) => {
+        const selected = new Set(ids);
+        return <div>{selected.size && <Badge />}</div>;
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .size on a useState(new Set()) destructure", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = () => {
+        const [selected, setSelected] = useState(new Set());
+        return <div>{selected.size && <Badge />}</div>;
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .size on a useRef(new Map()) current", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = () => {
+        const cacheRef = useRef(new Map());
+        return <div>{cacheRef.current.size && <Badge />}</div>;
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags {(count - 1) && <More/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ count }) => <div>{(count - 1) && <More />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags {Number(value) && <Chip/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ value }) => <div>{Number(value) && <Chip />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the JSX-adjacent .length in a chain {!isLoading && items.length && <X/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ isLoading, items }) => <div>{!isLoading && items.length && <List />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a numeric operand earlier in the chain {items.length && isOpen && <List/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ items, isOpen }) => <div>{items.length && isOpen && <List />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags numeric && inside a ternary branch {ready ? items.length && <List/> : <Spinner/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ ready, items }) => <div>{ready ? items.length && <List /> : <Spinner />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags numeric && in the right arm of || {empty || (items.length && <List/>)}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ empty, items }) => <div>{empty || (items.length && <List />)}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags {items.length && items.map(i => <Item/>)}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ items }) => <ul>{items.length && items.map((i) => <Item key={i.id} />)}</ul>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag react-hook-form errors.size (FieldError for a field named size)", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ errors }) => <div>{errors.size && <FieldError message={errors.size.message} />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a string size prop {props.size && <SizeBadge/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = (props) => <div>{props.size && <SizeBadge size={props.size} />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag .size on a bare prop with no provable Map/Set origin", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ selected }) => <div>{selected.size && <Badge />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a boolean LHS {isOpen && <Modal/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ isOpen }) => <div>{isOpen && <Modal />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a comparison {arr.length > 0 && <X/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ arr }) => <div>{arr.length > 0 && <X />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag inequality {items.length !== 0 && <X/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ items }) => <div>{items.length !== 0 && <X />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a double-negation {!!arr.length && <X/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ arr }) => <div>{!!arr.length && <X />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a ternary {arr.length ? <X/> : null}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ arr }) => <div>{arr.length ? <X /> : null}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a string/identifier LHS {name && <X/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ name }) => <div>{name && <X />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a numeric && used as an attribute value", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ items }) => <X hidden={items.length && <Y />} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the left arm of || where a falsy 0 never renders {(items.length && <List/>) || <Empty/>}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const C = ({ items }) => <div>{(items.length && <List />) || <Empty />}</div>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a map call whose callback renders no JSX {count && names.map(n => n.toUpperCase())}", () => {
+    const result = runRule(
+      jsxNumericAndLeakedRender,
+      `const total = ({ count, names }) => count && names.map((n) => n.toUpperCase());`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/jsx-numeric-and-leaked-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/jsx-numeric-and-leaked-render.ts
@@ -1,0 +1,226 @@
+import { containsJsxElement } from "../../utils/contains-jsx-element.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { flattenLogicalAndChain } from "../../utils/flatten-logical-and-chain.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const ARITHMETIC_BINARY_OPERATORS = new Set(["-", "+", "*", "/", "%"]);
+const NUMERIC_COERCION_CALLEE_NAMES = new Set(["Number", "parseInt", "parseFloat"]);
+const MAP_OR_SET_CONSTRUCTOR_NAMES = new Set(["Map", "Set"]);
+const PASSTHROUGH_WRAPPER_PARENT_TYPES = new Set<string>([
+  "ParenthesizedExpression",
+  "TSAsExpression",
+  "TSSatisfiesExpression",
+  "TSTypeAssertion",
+  "TSNonNullExpression",
+  "TSInstantiationExpression",
+  "ChainExpression",
+]);
+
+const isJsxNode = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "JSXElement") || isNodeOfType(node, "JSXFragment");
+
+const isMapOrSetConstruction = (node: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(node);
+  return (
+    isNodeOfType(stripped, "NewExpression") &&
+    isNodeOfType(stripped.callee, "Identifier") &&
+    MAP_OR_SET_CONSTRUCTOR_NAMES.has(stripped.callee.name)
+  );
+};
+
+const isHookCallNamed = (node: EsTreeNode, hookName: string): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  if (isNodeOfType(callee, "Identifier")) return callee.name === hookName;
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === hookName
+  );
+};
+
+const isHookCallSeededWithMapOrSet = (node: EsTreeNode, hookName: string): boolean => {
+  if (!isHookCallNamed(node, hookName) || !isNodeOfType(node, "CallExpression")) return false;
+  const firstArgument = node.arguments[0];
+  return Boolean(firstArgument && isMapOrSetConstruction(firstArgument));
+};
+
+const isFirstElementOfUseStateWithMapOrSet = (bindingIdentifier: EsTreeNode): boolean => {
+  const pattern = bindingIdentifier.parent;
+  if (!pattern || !isNodeOfType(pattern, "ArrayPattern")) return false;
+  if (pattern.elements[0] !== bindingIdentifier) return false;
+  const declarator = pattern.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator") || !declarator.init) {
+    return false;
+  }
+  return isHookCallSeededWithMapOrSet(stripParenExpression(declarator.init), "useState");
+};
+
+const identifierResolvesToMapOrSet = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding) return false;
+  if (binding.initializer && isMapOrSetConstruction(binding.initializer)) return true;
+  return isFirstElementOfUseStateWithMapOrSet(binding.bindingIdentifier);
+};
+
+const isRefCurrentOfMapOrSet = (objectNode: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(objectNode, "MemberExpression") ||
+    objectNode.computed ||
+    !isNodeOfType(objectNode.property, "Identifier") ||
+    objectNode.property.name !== "current"
+  ) {
+    return false;
+  }
+  const refIdentifier = stripParenExpression(objectNode.object);
+  if (!isNodeOfType(refIdentifier, "Identifier")) return false;
+  const binding = findVariableInitializer(refIdentifier, refIdentifier.name);
+  if (!binding || !binding.initializer) return false;
+  return isHookCallSeededWithMapOrSet(stripParenExpression(binding.initializer), "useRef");
+};
+
+// `.size` collides with react-hook-form FieldError objects and string
+// `size` props ("sm"/"md") far more often than it identifies a Map/Set,
+// so it only counts when the receiver provably is one: a direct
+// `new Map`/`new Set`, a binding initialized to one (including
+// `useState(new Set())` destructures), or a `ref.current` whose ref was
+// seeded with one.
+const isProvableCollectionReceiver = (objectNode: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(objectNode);
+  if (isMapOrSetConstruction(stripped)) return true;
+  if (isNodeOfType(stripped, "Identifier")) return identifierResolvesToMapOrSet(stripped);
+  return isRefCurrentOfMapOrSet(stripped);
+};
+
+// True only for expressions whose runtime value is syntactically numeric, so
+// short-circuiting to a falsy `0`/`NaN` leaks a visible text node. No type
+// inference — comparisons, `!`/`!!`, `Boolean(...)`, strings, and bare
+// identifiers are deliberately excluded because their falsy values render
+// nothing.
+const isSyntacticallyNumeric = (node: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(node);
+
+  if (
+    isNodeOfType(stripped, "MemberExpression") &&
+    !stripped.computed &&
+    isNodeOfType(stripped.property, "Identifier")
+  ) {
+    if (stripped.property.name === "length") return true;
+    if (stripped.property.name === "size") return isProvableCollectionReceiver(stripped.object);
+    return false;
+  }
+
+  if (
+    isNodeOfType(stripped, "BinaryExpression") &&
+    ARITHMETIC_BINARY_OPERATORS.has(stripped.operator)
+  ) {
+    return true;
+  }
+
+  if (
+    isNodeOfType(stripped, "CallExpression") &&
+    isNodeOfType(stripped.callee, "Identifier") &&
+    NUMERIC_COERCION_CALLEE_NAMES.has(stripped.callee.name)
+  ) {
+    return true;
+  }
+
+  if (isNodeOfType(stripped, "Literal") && typeof stripped.value === "number") return true;
+
+  return false;
+};
+
+const isJsxProducingMapCall = (node: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(node, "CallExpression") ||
+    !isNodeOfType(node.callee, "MemberExpression") ||
+    node.callee.computed ||
+    !isNodeOfType(node.callee.property, "Identifier") ||
+    node.callee.property.name !== "map"
+  ) {
+    return false;
+  }
+  const callback = node.arguments[0];
+  return Boolean(
+    callback &&
+    (isNodeOfType(callback, "ArrowFunctionExpression") ||
+      isNodeOfType(callback, "FunctionExpression")) &&
+    containsJsxElement(callback),
+  );
+};
+
+const isRenderExpression = (node: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(node);
+  return isJsxNode(stripped) || isJsxProducingMapCall(stripped);
+};
+
+// A falsy-numeric `&&` leaks its `0` whenever the expression's value
+// reaches a JSX child position, including through ternary branches, the
+// right arm of `||` / `??`, and the right arm of an enclosing `&&`.
+const flowsIntoJsxChild = (node: EsTreeNode): boolean => {
+  let current: EsTreeNode = node;
+  let parent: EsTreeNode | null | undefined = current.parent;
+  while (parent) {
+    if (isNodeOfType(parent, "JSXExpressionContainer")) {
+      const containerParent = parent.parent;
+      return Boolean(
+        containerParent &&
+        (isNodeOfType(containerParent, "JSXElement") ||
+          isNodeOfType(containerParent, "JSXFragment")),
+      );
+    }
+    const isPassthroughWrapper = PASSTHROUGH_WRAPPER_PARENT_TYPES.has(parent.type);
+    const isFlowingConditionalBranch =
+      isNodeOfType(parent, "ConditionalExpression") &&
+      (parent.consequent === current || parent.alternate === current);
+    const isFlowingLogicalRightArm =
+      isNodeOfType(parent, "LogicalExpression") && parent.right === current;
+    if (!isPassthroughWrapper && !isFlowingConditionalBranch && !isFlowingLogicalRightArm) {
+      return false;
+    }
+    current = parent;
+    parent = parent.parent;
+  }
+  return false;
+};
+
+export const jsxNumericAndLeakedRender = defineRule({
+  id: "jsx-numeric-and-leaked-render",
+  title: "Numeric && renders a stray 0",
+  severity: "warn",
+  recommendation:
+    "In `{items.length && <List/>}` React renders a literal `0` when the count is 0. Compare explicitly (`items.length > 0 && <List/>`) or use a ternary (`items.length ? <List/> : null`).",
+  create: (context: RuleContext) => ({
+    LogicalExpression(node: EsTreeNodeOfType<"LogicalExpression">) {
+      if (node.operator !== "&&") return;
+
+      // Only handle the outermost `&&` of a chain; inner ones are folded in
+      // via `flattenLogicalAndChain` below.
+      const parent = node.parent;
+      if (isNodeOfType(parent, "LogicalExpression") && parent.operator === "&&") return;
+
+      if (!flowsIntoJsxChild(node)) return;
+
+      const operands = flattenLogicalAndChain(node);
+      const renderOperand = operands[operands.length - 1];
+      if (!renderOperand || !isRenderExpression(renderOperand)) return;
+
+      const leakingOperand = operands
+        .slice(0, -1)
+        .find((guardOperand) => isSyntacticallyNumeric(guardOperand));
+      if (!leakingOperand) return;
+
+      context.report({
+        node: leakingOperand,
+        message:
+          "React renders a literal `0` into your page when this count is 0 instead of nothing — compare it explicitly (`count > 0 && <X/>`) or use a ternary (`count ? <X/> : null`).",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.test.ts
@@ -153,6 +153,46 @@ describe("no-arithmetic-on-optional-chained-operand", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("still flags when the binding is reassigned only after the numeric consumer", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `let ratio = entry?.points / total;
+      const label = ratio.toFixed(2);
+      ratio = 0;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags when the binding is only compound-assigned before the consumer (NaN survives `*=`)", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `let ratio = entry?.points / total;
+      ratio *= 2;
+      ratio.toFixed(2);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when only a shadowing inner binding of the same name is consumed", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `function Share({ entry, total, others }) {
+        const share = entry?.points / total;
+        return others.map((share) => share.toFixed(2));
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a consumer inside a nested closure without shadowing", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const share = entry?.points / total;
+      const render = () => share.toFixed(2);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags an unguarded alias binding despite an unrelated preceding if", () => {
     const result = runRule(
       noArithmeticOnOptionalChainedOperand,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noArithmeticOnOptionalChainedOperand } from "./no-arithmetic-on-optional-chained-operand.js";
+
+describe("no-arithmetic-on-optional-chained-operand", () => {
+  it("flags an optional-chained operand divided then formatted via a binding", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const share = entry?.points / total; share.toFixed(2);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a variable assigned from an optional chain multiplied and formatted", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const selectedPlanSize = priceSelected?.bytes; const total = selectedPlanSize * planLimit; total.toFixed(0);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an optional-chained operand in a comparison", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `if (config?.limit * factor < threshold) {}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an optional-chained operand inside a Math call argument", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const rounded = Math.round(lineRef?.clientHeight * index);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports only once when both operands are optional chains", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const ratio = a?.x / b?.y; ratio.toFixed(1);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag additive operators (string-concat / index math)", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const lastIndex = items?.length - 1; lastIndex.toString();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the operand has a ?? fallback", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const pct = (file?.progress ?? 0) * 100; pct.toFixed(2);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when a binding has a ?? fallback in its initializer", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const p = file?.progress ?? 0; const pct = p * 100; pct.toFixed(2);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when an enclosing if narrows the same root", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `if (invoice) { const amount = invoice?.total * taxRate; amount.toFixed(2); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when an && guard narrows the same root", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const price = product && (product?.unitPrice * qty).toFixed(2);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when a ternary test narrows the same root", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const price = product ? (product?.unitPrice * qty).toFixed(2) : "0";`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when an if guards the alias binding of a chain (real-world `const size = box?.width; if (size) {...}` idiom)", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const size = box?.width;
+      if (size) { const total = size * scale; total.toFixed(0); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when a ternary test guards the alias binding (real-world `percent != null ? percent / 100 : undefined` idiom)", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const percent = leadContext?.contextUsedPercent;
+      const label = percent != null ? (percent / 100).toFixed(2) : undefined;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when an && test guards the alias binding (real-world `x ? 0.9 * x : false` shape via &&)", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const width = node?.width; const scaled = width && (0.9 * width).toFixed(1);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag after a preceding early-return guard on the chain root (real-world `if (!invoice) return null;` prelude)", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `function Total({ invoice, taxRate }) {
+        if (!invoice) return null;
+        const amount = invoice?.total * taxRate;
+        return amount.toFixed(2);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('does not flag after a preceding early-return guard on the alias binding (real-world `if (typeof value !== "number") return` prelude)', () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `function Chart({ box }) {
+        const size = box?.width;
+        if (typeof size !== "number") return null;
+        const total = size * 2;
+        return total.toFixed(0);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the result binding is NaN-clamped before the consumer (real-world `if (Number.isNaN(ratio)) ratio = 0;` clamp)", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `let ratio = entry?.points / total;
+      if (Number.isNaN(ratio)) ratio = 0;
+      ratio.toFixed(2);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags an unguarded alias binding despite an unrelated preceding if", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `function Total({ invoice, taxRate, verbose }) {
+        if (verbose) console.log("computing");
+        const amount = invoice?.total * taxRate;
+        return amount.toFixed(2);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an optional call form whose result is not the operand", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const label = stepNumberLabel?.(index * 1); label.toString();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when there is no numeric consumer downstream", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const offset = lineRef?.clientHeight * index;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag plain multiplication without an optional chain", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const area = width * height; area.toFixed(2);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a computed optional index operand", () => {
+    const result = runRule(
+      noArithmeticOnOptionalChainedOperand,
+      `const v = row?.[key] * factor; v.toFixed(2);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isEarlyExitStatement } from "../../utils/is-early-exit-statement.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -283,20 +284,6 @@ const isGuardedByEnclosingTest = (binaryNode: EsTreeNode, guardNames: string[]):
     ancestor = ancestor.parent ?? null;
   }
   return false;
-};
-
-const isEarlyExitStatement = (statement: EsTreeNode | null | undefined): boolean => {
-  if (!statement) return false;
-  if (isNodeOfType(statement, "BlockStatement")) {
-    const statements = statement.body;
-    return isEarlyExitStatement(statements.at(-1));
-  }
-  return (
-    isNodeOfType(statement, "ReturnStatement") ||
-    isNodeOfType(statement, "ThrowStatement") ||
-    isNodeOfType(statement, "ContinueStatement") ||
-    isNodeOfType(statement, "BreakStatement")
-  );
 };
 
 // A preceding sibling `if (!x) return;`-style guard dominates the arithmetic

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.ts
@@ -160,13 +160,20 @@ const findScopeOwner = (node: EsTreeNode): EsTreeNode | null => {
 
 const NAN_CHECK_CALLEE_NAMES = new Set(["isNaN", "isFinite"]);
 
-// The result binding is reassigned or NaN-checked (`if (Number.isNaN(ratio))
-// ratio = 0;`) — the code already handles the failure the rule warns about,
-// so the binding no longer flows unhandled into the numeric consumer.
+// The result binding is plainly reassigned (a flow break — the consumer no
+// longer reads the arithmetic result) or NaN-checked (`if (Number.isNaN(ratio))
+// ratio = 0;`). Compound assignments (`ratio *= 2`) keep NaN NaN, so only the
+// `=` operator counts as a flow break.
 const isNanHandledReference = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
   const parent = identifier.parent;
   if (!parent) return false;
-  if (isNodeOfType(parent, "AssignmentExpression") && parent.left === identifier) return true;
+  if (
+    isNodeOfType(parent, "AssignmentExpression") &&
+    parent.operator === "=" &&
+    parent.left === identifier
+  ) {
+    return true;
+  }
   if (
     isNodeOfType(parent, "CallExpression") &&
     (parent.arguments ?? []).some((argument) => argument === identifier)
@@ -187,8 +194,30 @@ const isNanHandledReference = (identifier: EsTreeNodeOfType<"Identifier">): bool
   return false;
 };
 
+// oxlint runtime nodes carry `range`; the oxc-parser test AST carries
+// numeric `start` offsets instead — accept either.
+const nodeStartOffset = (node: EsTreeNode): number => {
+  if (node.range) return node.range[0];
+  const nodeWithOffsets = node as { start?: number };
+  return typeof nodeWithOffsets.start === "number"
+    ? nodeWithOffsets.start
+    : Number.MAX_SAFE_INTEGER;
+};
+
+// A same-named inner binding (shadowing parameter or nested declarator) is
+// not a use of the arithmetic result — only identifiers that resolve back to
+// the declarator's own id count.
+const isReferenceToBinding = (
+  referenceIdentifier: EsTreeNodeOfType<"Identifier">,
+  bindingIdentifier: EsTreeNode,
+): boolean =>
+  findVariableInitializer(referenceIdentifier, referenceIdentifier.name)?.bindingIdentifier ===
+  bindingIdentifier;
+
 // A numeric consumer reached through an intermediate binding:
-// `const share = a?.b / total; share.toFixed(2)`.
+// `const share = a?.b / total; share.toFixed(2)`. Order-aware: a NaN check or
+// plain reassignment suppresses only the consumers that come after it — a
+// consumer that reads the binding first already received the NaN.
 const flowsIntoNumericConsumerViaBinding = (binaryNode: EsTreeNode): boolean => {
   const { consumed, consumer } = unwrapUpwards(binaryNode);
   if (
@@ -199,23 +228,36 @@ const flowsIntoNumericConsumerViaBinding = (binaryNode: EsTreeNode): boolean => 
   ) {
     return false;
   }
-  const bindingName = consumer.id.name;
+  const bindingIdentifier = consumer.id;
   const scopeOwner = findScopeOwner(binaryNode);
   if (!scopeOwner) return false;
-  let reachesConsumer = false;
-  let isNanHandled = false;
+  let firstConsumerOffset: number | null = null;
+  let firstNanHandledOffset: number | null = null;
   walkAst(scopeOwner, (child: EsTreeNode) => {
-    if (isNanHandled) return false;
-    if (!isNodeOfType(child, "Identifier") || child.name !== bindingName || child === consumer.id) {
+    if (
+      !isNodeOfType(child, "Identifier") ||
+      child.name !== bindingIdentifier.name ||
+      child === bindingIdentifier ||
+      !isReferenceToBinding(child, bindingIdentifier)
+    ) {
       return;
     }
     if (isNanHandledReference(child)) {
-      isNanHandled = true;
-      return false;
+      const handledOffset = nodeStartOffset(child);
+      if (firstNanHandledOffset === null || handledOffset < firstNanHandledOffset) {
+        firstNanHandledOffset = handledOffset;
+      }
+      return;
     }
-    if (isDirectNumericConsumer(child)) reachesConsumer = true;
+    if (isDirectNumericConsumer(child)) {
+      const consumerOffset = nodeStartOffset(child);
+      if (firstConsumerOffset === null || consumerOffset < firstConsumerOffset) {
+        firstConsumerOffset = consumerOffset;
+      }
+    }
   });
-  return reachesConsumer && !isNanHandled;
+  if (firstConsumerOffset === null) return false;
+  return firstNanHandledOffset === null || firstConsumerOffset < firstNanHandledOffset;
 };
 
 const isNumericConsumerContext = (binaryNode: EsTreeNode): boolean =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-arithmetic-on-optional-chained-operand.ts
@@ -1,0 +1,354 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const MESSAGE =
+  "Multiplying or dividing an optional-chained value yields NaN when the chain short-circuits to undefined, and NaN spreads silently into formatting and comparisons. Add a `?? fallback` or guard the value before the math.";
+
+const MULTIPLICATIVE_OPERATORS = new Set(["*", "/", "%"]);
+const COMPARISON_OPERATORS = new Set(["<", ">", "<=", ">=", "==", "!=", "===", "!=="]);
+const NUMERIC_FORMAT_METHOD_NAMES = new Set([
+  "toFixed",
+  "toString",
+  "toPrecision",
+  "toLocaleString",
+]);
+// `ParenthesizedExpression` is a real oxc runtime node absent from the
+// TSESTree union, so it is matched by `.type` string rather than `isNodeOfType`.
+const TRANSPARENT_WRAPPER_TYPES = new Set<string>([
+  "ParenthesizedExpression",
+  "TSAsExpression",
+  "TSSatisfiesExpression",
+  "TSNonNullExpression",
+  "TSTypeAssertion",
+  "TSInstantiationExpression",
+]);
+
+// Peels parens / TS wrappers but PRESERVES `ChainExpression`, because the
+// whole rule turns on whether the operand is an optional chain (the shared
+// `stripParenExpression` strips the chain wrapper and loses that signal).
+const stripKeepingChain = (node: EsTreeNode): EsTreeNode => {
+  let current = node;
+  while (
+    current &&
+    TRANSPARENT_WRAPPER_TYPES.has(current.type) &&
+    "expression" in current &&
+    current.expression
+  ) {
+    current = current.expression as EsTreeNode;
+  }
+  return current;
+};
+
+// The optional-chained MEMBER access when `node` is exactly `a?.b`
+// (non-computed). Call forms (`a?.()`) and computed forms (`a?.[k]`) are
+// intentionally excluded so the chained value is the direct arithmetic operand.
+const asDirectOptionalChainMember = (
+  node: EsTreeNode,
+): EsTreeNodeOfType<"MemberExpression"> | null => {
+  const stripped = stripKeepingChain(node);
+  if (!isNodeOfType(stripped, "ChainExpression")) return null;
+  const inner = stripped.expression as EsTreeNode;
+  if (!isNodeOfType(inner, "MemberExpression")) return null;
+  if (inner.computed) return null;
+  return inner;
+};
+
+const optionalChainRootName = (memberExpression: EsTreeNode): string | null => {
+  let current: EsTreeNode | null | undefined = memberExpression;
+  while (current) {
+    const stripped = stripKeepingChain(current);
+    if (isNodeOfType(stripped, "ChainExpression")) {
+      current = stripped.expression as EsTreeNode;
+      continue;
+    }
+    if (isNodeOfType(stripped, "MemberExpression")) {
+      current = stripped.object;
+      continue;
+    }
+    if (isNodeOfType(stripped, "CallExpression")) {
+      current = stripped.callee;
+      continue;
+    }
+    if (isNodeOfType(stripped, "Identifier")) return stripped.name;
+    return null;
+  }
+  return null;
+};
+
+// The names a guard may test to prove the operand can never be undefined:
+// the chain root, plus the alias binding itself when the operand is an
+// identifier bound to a chain (`const size = a?.b` — guarding `size` is just
+// as sound as guarding `a`). A `??`/`||` fallback on the binding makes its
+// initializer a LogicalExpression, so it naturally fails the chain check and
+// is not treated as unguarded. Returns null when the operand is not an
+// optional-chain value at all.
+const resolveOptionalChainOperandGuardNames = (operand: EsTreeNode): string[] | null => {
+  const direct = asDirectOptionalChainMember(operand);
+  if (direct) {
+    const rootName = optionalChainRootName(direct);
+    return rootName ? [rootName] : null;
+  }
+
+  const stripped = stripKeepingChain(operand);
+  if (!isNodeOfType(stripped, "Identifier")) return null;
+  const binding = findVariableInitializer(stripped, stripped.name);
+  if (!binding?.initializer) return null;
+  const initializerMember = asDirectOptionalChainMember(binding.initializer);
+  if (!initializerMember) return null;
+  const rootName = optionalChainRootName(initializerMember);
+  return rootName ? [rootName, stripped.name] : null;
+};
+
+const unwrapUpwards = (node: EsTreeNode): { consumed: EsTreeNode; consumer: EsTreeNode | null } => {
+  let consumed = node;
+  let consumer = node.parent ?? null;
+  while (consumer && TRANSPARENT_WRAPPER_TYPES.has(consumer.type)) {
+    consumed = consumer;
+    consumer = consumer.parent ?? null;
+  }
+  return { consumed, consumer };
+};
+
+// The arithmetic result reaches a numeric consumer directly: `.toFixed()` etc.,
+// a comparison, or a `Math.*` argument.
+const isDirectNumericConsumer = (valueNode: EsTreeNode): boolean => {
+  const { consumed, consumer } = unwrapUpwards(valueNode);
+  if (!consumer) return false;
+  if (
+    isNodeOfType(consumer, "MemberExpression") &&
+    consumer.object === consumed &&
+    !consumer.computed &&
+    isNodeOfType(consumer.property, "Identifier") &&
+    NUMERIC_FORMAT_METHOD_NAMES.has(consumer.property.name)
+  ) {
+    return true;
+  }
+  if (
+    isNodeOfType(consumer, "BinaryExpression") &&
+    COMPARISON_OPERATORS.has(consumer.operator) &&
+    (consumer.left === consumed || consumer.right === consumed)
+  ) {
+    return true;
+  }
+  if (
+    isNodeOfType(consumer, "CallExpression") &&
+    isNodeOfType(consumer.callee, "MemberExpression") &&
+    isNodeOfType(consumer.callee.object, "Identifier") &&
+    consumer.callee.object.name === "Math" &&
+    (consumer.arguments ?? []).includes(consumed as never)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const findScopeOwner = (node: EsTreeNode): EsTreeNode | null => {
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor) {
+    if (isFunctionLike(ancestor) || isNodeOfType(ancestor, "Program")) return ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return null;
+};
+
+const NAN_CHECK_CALLEE_NAMES = new Set(["isNaN", "isFinite"]);
+
+// The result binding is reassigned or NaN-checked (`if (Number.isNaN(ratio))
+// ratio = 0;`) — the code already handles the failure the rule warns about,
+// so the binding no longer flows unhandled into the numeric consumer.
+const isNanHandledReference = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const parent = identifier.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "AssignmentExpression") && parent.left === identifier) return true;
+  if (
+    isNodeOfType(parent, "CallExpression") &&
+    (parent.arguments ?? []).some((argument) => argument === identifier)
+  ) {
+    const callee = stripKeepingChain(parent.callee);
+    if (isNodeOfType(callee, "Identifier") && NAN_CHECK_CALLEE_NAMES.has(callee.name)) return true;
+    if (
+      isNodeOfType(callee, "MemberExpression") &&
+      isNodeOfType(callee.object, "Identifier") &&
+      callee.object.name === "Number" &&
+      !callee.computed &&
+      isNodeOfType(callee.property, "Identifier") &&
+      NAN_CHECK_CALLEE_NAMES.has(callee.property.name)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// A numeric consumer reached through an intermediate binding:
+// `const share = a?.b / total; share.toFixed(2)`.
+const flowsIntoNumericConsumerViaBinding = (binaryNode: EsTreeNode): boolean => {
+  const { consumed, consumer } = unwrapUpwards(binaryNode);
+  if (
+    !consumer ||
+    !isNodeOfType(consumer, "VariableDeclarator") ||
+    consumer.init !== consumed ||
+    !isNodeOfType(consumer.id, "Identifier")
+  ) {
+    return false;
+  }
+  const bindingName = consumer.id.name;
+  const scopeOwner = findScopeOwner(binaryNode);
+  if (!scopeOwner) return false;
+  let reachesConsumer = false;
+  let isNanHandled = false;
+  walkAst(scopeOwner, (child: EsTreeNode) => {
+    if (isNanHandled) return false;
+    if (!isNodeOfType(child, "Identifier") || child.name !== bindingName || child === consumer.id) {
+      return;
+    }
+    if (isNanHandledReference(child)) {
+      isNanHandled = true;
+      return false;
+    }
+    if (isDirectNumericConsumer(child)) reachesConsumer = true;
+  });
+  return reachesConsumer && !isNanHandled;
+};
+
+const isNumericConsumerContext = (binaryNode: EsTreeNode): boolean =>
+  isDirectNumericConsumer(binaryNode) || flowsIntoNumericConsumerViaBinding(binaryNode);
+
+const subtreeReferencesName = (node: EsTreeNode | null | undefined, name: string): boolean => {
+  if (!node) return false;
+  let found = false;
+  walkAst(node, (child: EsTreeNode) => {
+    if (found) return false;
+    if (isNodeOfType(child, "Identifier") && child.name === name) {
+      const parent = child.parent;
+      // A non-computed member property (`foo.<name>`) or an object property key
+      // is not a reference to the guarded root binding.
+      if (
+        parent &&
+        isNodeOfType(parent, "MemberExpression") &&
+        parent.property === child &&
+        !parent.computed
+      ) {
+        return;
+      }
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+const subtreeReferencesAnyName = (
+  node: EsTreeNode | null | undefined,
+  guardNames: string[],
+): boolean => guardNames.some((guardName) => subtreeReferencesName(node, guardName));
+
+// The chain can never short-circuit because an enclosing `if`/ternary
+// test or `&&`-guard already narrowed the chain root or its alias binding.
+// The arithmetic must sit in the guarded BRANCH, not in the test itself
+// (otherwise the test of `if (a?.b * n < x)` would suppress its own finding).
+const isGuardedByEnclosingTest = (binaryNode: EsTreeNode, guardNames: string[]): boolean => {
+  let child: EsTreeNode = binaryNode;
+  let ancestor: EsTreeNode | null | undefined = binaryNode.parent;
+  while (ancestor) {
+    if (
+      isNodeOfType(ancestor, "IfStatement") &&
+      (child === ancestor.consequent || child === ancestor.alternate) &&
+      subtreeReferencesAnyName(ancestor.test, guardNames)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "ConditionalExpression") &&
+      (child === ancestor.consequent || child === ancestor.alternate) &&
+      subtreeReferencesAnyName(ancestor.test, guardNames)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "LogicalExpression") &&
+      (ancestor.operator === "&&" || ancestor.operator === "||") &&
+      child === ancestor.right &&
+      subtreeReferencesAnyName(ancestor.left, guardNames)
+    ) {
+      return true;
+    }
+    child = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+const isEarlyExitStatement = (statement: EsTreeNode | null | undefined): boolean => {
+  if (!statement) return false;
+  if (isNodeOfType(statement, "BlockStatement")) {
+    const statements = statement.body;
+    return isEarlyExitStatement(statements.at(-1));
+  }
+  return (
+    isNodeOfType(statement, "ReturnStatement") ||
+    isNodeOfType(statement, "ThrowStatement") ||
+    isNodeOfType(statement, "ContinueStatement") ||
+    isNodeOfType(statement, "BreakStatement")
+  );
+};
+
+// A preceding sibling `if (!x) return;`-style guard dominates the arithmetic
+// just like an enclosing test does — the single most common React narrowing
+// idiom (`if (!invoice) return null;` before the math).
+const isGuardedByPrecedingEarlyExit = (binaryNode: EsTreeNode, guardNames: string[]): boolean => {
+  let child: EsTreeNode = binaryNode;
+  let ancestor: EsTreeNode | null | undefined = binaryNode.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "BlockStatement") || isNodeOfType(ancestor, "Program")) {
+      const statements = ancestor.body;
+      const childStatementIndex = statements.findIndex((statement) => statement === child);
+      for (const precedingStatement of statements.slice(0, Math.max(childStatementIndex, 0))) {
+        if (
+          isNodeOfType(precedingStatement, "IfStatement") &&
+          isEarlyExitStatement(precedingStatement.consequent) &&
+          subtreeReferencesAnyName(precedingStatement.test, guardNames)
+        ) {
+          return true;
+        }
+      }
+    }
+    child = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+// Flags `a?.b * n` / `a?.b / n` / `a?.b % n` (or a variable bound to `a?.b`)
+// when the result flows into a numeric consumer and no `??` fallback or
+// enclosing guard on the chain root exists. Additive operators, the
+// `?.length - 1` index idiom, `?.()` call forms, and guarded roots stay quiet.
+export const noArithmeticOnOptionalChainedOperand = defineRule({
+  id: "no-arithmetic-on-optional-chained-operand",
+  title: "Multiplicative math on optional-chained value can be NaN",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "An optional chain is `undefined` when it short-circuits, so `*`/`/`/`%` on it produces `NaN`, which silently corrupts formatting and comparisons. Provide a `?? fallback` or guard the chain root before the arithmetic.",
+  create: (context: RuleContext) => ({
+    BinaryExpression(node: EsTreeNodeOfType<"BinaryExpression">) {
+      if (!MULTIPLICATIVE_OPERATORS.has(node.operator)) return;
+      const operands: EsTreeNode[] = [node.left as EsTreeNode, node.right as EsTreeNode];
+      for (const operand of operands) {
+        const guardNames = resolveOptionalChainOperandGuardNames(operand);
+        if (!guardNames) continue;
+        if (isGuardedByEnclosingTest(node as EsTreeNode, guardNames)) continue;
+        if (isGuardedByPrecedingEarlyExit(node as EsTreeNode, guardNames)) continue;
+        if (!isNumericConsumerContext(node as EsTreeNode)) continue;
+        context.report({ node, message: MESSAGE });
+        return;
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-find-result-member-access-without-guard.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-find-result-member-access-without-guard.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noArrayFindResultMemberAccessWithoutGuard } from "./no-array-find-result-member-access-without-guard.js";
+
+describe("no-array-find-result-member-access-without-guard", () => {
+  it("flags a property read on a find() result (locale-lookup shape)", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const id = response.data.locales.find((i) => i.locale === targetLocale).id;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an index access on a find() result", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const first = items.find((item) => item.active)[0];`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a call on a find() result", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const value = handlers.find((h) => h.type === type)();`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags findLast() the same way", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const name = users.findLast((u) => u.enabled).name;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an identifier-predicate find()", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const isActive = (u) => u.active; const email = users.find(isActive).email;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags through parentheses", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const id = (rows.find((r) => r.ok)).id;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag optional-chained access", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const id = items.find((item) => item.active)?.id;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag optional-chained call", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const value = handlers.find((h) => h.type === type)?.();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a nullish-coalescing fallback", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const item = items.find((item) => item.active) ?? defaultItem;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a find() result bound to a variable then guarded", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `
+      const found = items.find((item) => item.active);
+      if (found) {
+        doSomething(found.id);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag ORM Model.find(callback) with a capitalized receiver", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const email = User.find((u) => u.id === 5).email;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag ORM Model.find({ where }) object query", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const email = repo.find({ where: { id: 5 } }).email;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-null-asserted result (owned by the no-non-null rule)", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const id = items.find((item) => item.active)!.id;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the find() result is not immediately accessed", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const found = items.find((item) => item.active);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an enzyme wrapper.find(Component).instance() chain", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const inst = wrapper.find(AvatarImage).instance();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an enzyme wrapper.find(Component).first().props() chain", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const pop = wrapper.find(Tooltip).first().props();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an enzyme wrapper.find(Component).length read", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `expect(wrapper.find(VisuallyHidden).length).toBe(4);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags find(Boolean) first-truthy dereference (not an enzyme component selector)", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const first = values.find(Boolean).id;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the pre-ES2020 `find(f) && find(f).x` repeated-call guard", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const label = items.find((i) => i.active) && items.find((i) => i.active).label;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the `find(f) ? find(f).x : y` repeated-call ternary guard", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const label = items.find((i) => i.id === id) ? items.find((i) => i.id === id).label : "";`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a repeated-call guard inside an if statement", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `
+      if (items.find((i) => i.id === id)) {
+        doSomething(items.find((i) => i.id === id).label);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags when the truthiness test is a different find call", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const label = items.find((i) => i.active) && items.find((i) => i.selected).label;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a self-derived equality lookup over an array it also maps (algolia ModalDropdown shape)", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `
+      const Dropdown = ({ items }) => (
+        <ModalDropdown
+          options={items.map((item) => item.label)}
+          onSelect={(value) => selectItem(items.find((item) => item.label === value).value)}
+        />
+      );
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags an equality lookup whose key does not come from a sibling map of the array", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const name = users.find((u) => u.id === userId).name;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a non-identity predicate even when the array is mapped in the same scope", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `
+      const Sessions = ({ sessions }) => {
+        const labels = sessions.map((session) => session.label);
+        return renderBadge(labels, sessions.find((session) => session.confirmed === true).id);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a real array find() dereference inside a test file", () => {
+    const result = runRule(
+      noArrayFindResultMemberAccessWithoutGuard,
+      `const id = items.find((item) => item.active).id;`,
+      { filename: "widget.test.ts" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-find-result-member-access-without-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-find-result-member-access-without-guard.ts
@@ -1,10 +1,10 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { isAstNode } from "../../utils/is-ast-node.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
 
 const MESSAGE =
   "`find` returns `undefined` when nothing matches, so reading from its result here throws `Cannot read properties of undefined` — use optional chaining (`?.`) or guard the result before you use it.";
@@ -95,23 +95,15 @@ const subtreeContainsMatch = (
   root: EsTreeNode,
   matches: (node: EsTreeNode) => boolean,
 ): boolean => {
-  const pending: EsTreeNode[] = [root];
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (!current) continue;
-    if (matches(current)) return true;
-    for (const [key, value] of Object.entries(current)) {
-      if (key === "parent") continue;
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          if (isAstNode(item)) pending.push(item);
-        }
-      } else if (isAstNode(value)) {
-        pending.push(value);
-      }
+  let found = false;
+  walkAst(root, (node) => {
+    if (found) return false;
+    if (matches(node)) {
+      found = true;
+      return false;
     }
-  }
-  return false;
+  });
+  return found;
 };
 
 // `items.find(f) && items.find(f).x` / `items.find(f) ? items.find(f).x : y`

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-find-result-member-access-without-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-find-result-member-access-without-guard.ts
@@ -1,0 +1,286 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const MESSAGE =
+  "`find` returns `undefined` when nothing matches, so reading from its result here throws `Cannot read properties of undefined` — use optional chaining (`?.`) or guard the result before you use it.";
+
+const FIND_METHOD_NAMES = new Set(["find", "findLast"]);
+// A PascalCase identifier names a class / model / component, never array data.
+// It rules out `User.find(...)` (an ORM static) as a RECEIVER and
+// `wrapper.find(Component)` (an enzyme/RTL component-selector query) as the
+// ARGUMENT — neither result is an array element that can be `undefined`.
+const PASCAL_CASE_IDENTIFIER_PATTERN = /^[A-Z]/;
+// Capitalized globals that are real element predicates (`values.find(Boolean)`),
+// not component selectors — exempt from the PascalCase argument bail.
+const KNOWN_GLOBAL_PREDICATE_NAMES = new Set(["Boolean"]);
+// `ParenthesizedExpression` is a real runtime node but is absent from the
+// TSESTree type union, so it is matched via a string set rather than
+// `isNodeOfType`.
+const GROUPING_EXPRESSION_TYPES = new Set<string>(["ParenthesizedExpression"]);
+const FUNCTION_NODE_TYPES = new Set<string>([
+  "ArrowFunctionExpression",
+  "FunctionExpression",
+  "FunctionDeclaration",
+]);
+const STRUCTURAL_IDENTITY_IGNORED_KEYS = new Set(["parent", "loc", "range", "start", "end"]);
+
+// A callback-shaped first argument distinguishes `Array.prototype.find` from
+// ORM query builders like `Model.find({ where: ... })` (an ObjectExpression
+// argument, a hydrated row result) and from enzyme/RTL `wrapper.find(Component)`
+// component-selector queries (a PascalCase identifier argument, a wrapper
+// result), whose `.instance()`/`.first()`/`.props()` chains must stay quiet.
+const hasArrayCallbackFirstArgument = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const firstArgument = node.arguments?.[0];
+  if (!firstArgument) return false;
+  if (
+    isNodeOfType(firstArgument, "ArrowFunctionExpression") ||
+    isNodeOfType(firstArgument, "FunctionExpression")
+  ) {
+    return true;
+  }
+  // A bare identifier is a predicate reference (`items.find(isActive)`), unless
+  // it is PascalCase — a component selector (`wrapper.find(Modal)`), not a
+  // predicate — except for known global predicates like `Boolean`.
+  return (
+    isNodeOfType(firstArgument, "Identifier") &&
+    (KNOWN_GLOBAL_PREDICATE_NAMES.has(firstArgument.name) ||
+      !PASCAL_CASE_IDENTIFIER_PATTERN.test(firstArgument.name))
+  );
+};
+
+const isArrayFindCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = node.callee;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  if (!FIND_METHOD_NAMES.has(callee.property.name)) return false;
+  // `User.find(...)` / `Model.find(...)`: a capitalized receiver is a
+  // class/model static method, not an array instance method.
+  const receiver = stripParenExpression(callee.object as EsTreeNode);
+  if (isNodeOfType(receiver, "Identifier") && PASCAL_CASE_IDENTIFIER_PATTERN.test(receiver.name)) {
+    return false;
+  }
+  return hasArrayCallbackFirstArgument(node);
+};
+
+const areNodesStructurallyIdentical = (left: unknown, right: unknown): boolean => {
+  if (left === right) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((item, index) => areNodesStructurallyIdentical(item, right[index]))
+    );
+  }
+  if (typeof left !== "object" || typeof right !== "object" || left === null || right === null) {
+    return false;
+  }
+  const leftEntries = Object.entries(left).filter(
+    ([key]) => !STRUCTURAL_IDENTITY_IGNORED_KEYS.has(key),
+  );
+  const rightEntries = new Map(
+    Object.entries(right).filter(([key]) => !STRUCTURAL_IDENTITY_IGNORED_KEYS.has(key)),
+  );
+  if (leftEntries.length !== rightEntries.size) return false;
+  return leftEntries.every(
+    ([key, value]) =>
+      rightEntries.has(key) && areNodesStructurallyIdentical(value, rightEntries.get(key)),
+  );
+};
+
+const subtreeContainsMatch = (
+  root: EsTreeNode,
+  matches: (node: EsTreeNode) => boolean,
+): boolean => {
+  const pending: EsTreeNode[] = [root];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) continue;
+    if (matches(current)) return true;
+    for (const [key, value] of Object.entries(current)) {
+      if (key === "parent") continue;
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (isAstNode(item)) pending.push(item);
+        }
+      } else if (isAstNode(value)) {
+        pending.push(value);
+      }
+    }
+  }
+  return false;
+};
+
+// `items.find(f) && items.find(f).x` / `items.find(f) ? items.find(f).x : y`
+// / `if (items.find(f)) items.find(f).x` — the pre-ES2020 repeat-the-call
+// guard idiom: an identical find expression is truthiness-tested before the
+// dereference, so the access cannot throw.
+const isGuardedByRepeatedFindTest = (findCall: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const isIdenticalFindCall = (candidate: EsTreeNode): boolean =>
+    isNodeOfType(candidate, "CallExpression") && areNodesStructurallyIdentical(candidate, findCall);
+  let child: EsTreeNode = findCall;
+  let ancestor: EsTreeNode | null = findCall.parent ?? null;
+  while (ancestor) {
+    if (FUNCTION_NODE_TYPES.has(ancestor.type)) return false;
+    if (
+      isNodeOfType(ancestor, "LogicalExpression") &&
+      ancestor.operator === "&&" &&
+      ancestor.right === child &&
+      subtreeContainsMatch(ancestor.left, isIdenticalFindCall)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "ConditionalExpression") &&
+      ancestor.consequent === child &&
+      subtreeContainsMatch(ancestor.test, isIdenticalFindCall)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "IfStatement") &&
+      ancestor.consequent === child &&
+      subtreeContainsMatch(ancestor.test, isIdenticalFindCall)
+    ) {
+      return true;
+    }
+    child = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+const memberExpressionRootName = (expression: EsTreeNode): string | null => {
+  let current = expression;
+  while (isNodeOfType(current, "MemberExpression")) {
+    current = stripParenExpression(current.object as EsTreeNode);
+  }
+  return isNodeOfType(current, "Identifier") ? current.name : null;
+};
+
+const singleExpressionPredicateBody = (
+  predicate: EsTreeNodeOfType<"ArrowFunctionExpression"> | EsTreeNodeOfType<"FunctionExpression">,
+): EsTreeNode | null => {
+  let body: EsTreeNode = predicate.body;
+  if (isNodeOfType(body, "BlockStatement")) {
+    if (body.body.length !== 1) return null;
+    const onlyStatement = body.body[0];
+    if (!isNodeOfType(onlyStatement, "ReturnStatement") || !onlyStatement.argument) return null;
+    body = onlyStatement.argument;
+  }
+  return stripParenExpression(body);
+};
+
+const enclosingScopeMapsOverReceiver = (
+  findCall: EsTreeNodeOfType<"CallExpression">,
+  receiverName: string,
+): boolean => {
+  let outermostFunction: EsTreeNode | null = null;
+  let programRoot: EsTreeNode | null = null;
+  let current: EsTreeNode | null = findCall.parent ?? null;
+  while (current) {
+    if (FUNCTION_NODE_TYPES.has(current.type)) outermostFunction = current;
+    if (isNodeOfType(current, "Program")) programRoot = current;
+    current = current.parent ?? null;
+  }
+  const searchRoot = outermostFunction ?? programRoot;
+  if (!searchRoot) return false;
+  return subtreeContainsMatch(searchRoot, (node) => {
+    if (!isNodeOfType(node, "CallExpression")) return false;
+    const callee = node.callee;
+    if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+    if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "map") {
+      return false;
+    }
+    if ((node.arguments?.length ?? 0) === 0) return false;
+    const mapReceiver = stripParenExpression(callee.object as EsTreeNode);
+    return isNodeOfType(mapReceiver, "Identifier") && mapReceiver.name === receiverName;
+  });
+};
+
+// Self-derived equality lookup: `items.find((item) => item.key === value).prop`
+// where the same `items` array is also `.map(...)`-ed in the enclosing
+// function/component — the candidate values are drawn from the array being
+// searched (`options={items.map((item) => item.label)}` feeding
+// `onSelect`/`renderRow`), so the find cannot miss and a `?.` guard is dead
+// code. Non-identity predicates (`s.confirmed === true`) and lookups without
+// the sibling `.map` keep firing.
+const isSelfDerivedEqualityLookup = (findCall: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = findCall.callee;
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object as EsTreeNode);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const predicate = findCall.arguments?.[0];
+  if (
+    !isNodeOfType(predicate, "ArrowFunctionExpression") &&
+    !isNodeOfType(predicate, "FunctionExpression")
+  ) {
+    return false;
+  }
+  const parameter = predicate.params?.[0];
+  if (!isNodeOfType(parameter, "Identifier")) return false;
+  const predicateBody = singleExpressionPredicateBody(predicate);
+  if (
+    !predicateBody ||
+    !isNodeOfType(predicateBody, "BinaryExpression") ||
+    predicateBody.operator !== "==="
+  ) {
+    return false;
+  }
+  const leftSide = stripParenExpression(predicateBody.left as EsTreeNode);
+  const rightSide = stripParenExpression(predicateBody.right as EsTreeNode);
+  const sidePairs: Array<[EsTreeNode, EsTreeNode]> = [
+    [leftSide, rightSide],
+    [rightSide, leftSide],
+  ];
+  const isEqualityLookupShape = sidePairs.some(
+    ([elementKeyRead, comparedValue]) =>
+      isNodeOfType(elementKeyRead, "MemberExpression") &&
+      memberExpressionRootName(elementKeyRead) === parameter.name &&
+      isNodeOfType(comparedValue, "Identifier") &&
+      comparedValue.name !== parameter.name,
+  );
+  if (!isEqualityLookupShape) return false;
+  return enclosingScopeMapsOverReceiver(findCall, receiver.name);
+};
+
+export const noArrayFindResultMemberAccessWithoutGuard = defineRule({
+  id: "no-array-find-result-member-access-without-guard",
+  title: "Unguarded member access on find() result",
+  severity: "warn",
+  tags: ["test-noise"],
+  recommendation:
+    "`Array.prototype.find`/`findLast` return `undefined` when no element matches, so guard the result with optional chaining (`?.`) or a null check before reading a property, indexing, or calling it.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isArrayFindCall(node)) return;
+
+      let consumed: EsTreeNode = node;
+      let consumer: EsTreeNode | null = node.parent ?? null;
+      while (consumer && GROUPING_EXPRESSION_TYPES.has(consumer.type)) {
+        consumed = consumer;
+        consumer = consumer.parent ?? null;
+      }
+      if (!consumer) return;
+
+      // An intervening `!` token (TSNonNullExpression) hands the finding to
+      // the existing no-non-null-assertion rule, so only a bare, non-optional
+      // property read/index/call on the result is reported here.
+      const isUnguardedMemberRead =
+        isNodeOfType(consumer, "MemberExpression") &&
+        consumer.object === consumed &&
+        !consumer.optional;
+      const isUnguardedCall =
+        isNodeOfType(consumer, "CallExpression") &&
+        consumer.callee === consumed &&
+        !consumer.optional;
+      if (!isUnguardedMemberRead && !isUnguardedCall) return;
+      if (isGuardedByRepeatedFindTest(node)) return;
+      if (isSelfDerivedEqualityLookup(node)) return;
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.test.ts
@@ -121,6 +121,22 @@ describe("no-array-index-deref-without-bounds-or-empty-guard", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("still flags a split guarded by a RegExp .test() over an unrelated value", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `if (/^https:/.test(url)) { const token = header.split(':')[1].trim(); }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a member-receiver split under a RegExp .test() over the same receiver", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `if (/:/.test(line.text)) { const part = line.text.split(':')[1].trim(); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a split dominated by a predicate helper call over the same value (rsuite idiom)", () => {
     const result = runRule(
       noArrayIndexDerefWithoutBoundsOrEmptyGuard,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noArrayIndexDerefWithoutBoundsOrEmptyGuard } from "./no-array-index-deref-without-bounds-or-empty-guard.js";
+
+describe("no-array-index-deref-without-bounds-or-empty-guard", () => {
+  it("flags a regex exec result indexed and dereferenced", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const version = /v(\\d+)/.exec(input)[1].trim();`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a string match result indexed and dereferenced", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const first = raw.match(/(\\w+)/)[1].toLowerCase();`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags touches[0] deref inside a touchend addEventListener handler", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `element.addEventListener('touchend', (event) => { const y = event.touches[0].clientY; });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags touches[0] deref inside an onTouchEnd JSX handler", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const el = <div onTouchEnd={(event) => setY(event.touches[0].clientY)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .split(delim)[k] for k >= 1 dereferenced", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const ext = fileName.split('.')[1].toUpperCase();`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an arithmetic index into a parameter array (caller invariants dominate on real code)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function goTo(views, activeViewIndex) { return views[activeViewIndex - 1].id; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the previous-item map idiom guarded by an index > 0 check", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function List({ items }) {
+        return items.map((item, index) => (
+          <Row key={item.id} previous={index > 0 ? items[index - 1].label : null} />
+        ));
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a reduce accumulator arithmetic deref under an index === 0 ternary (algolia idiom)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const totals = values.reduce((acc, value, index) => {
+        acc.push(index === 0 ? value : acc[index - 1].sum + value);
+        return acc;
+      }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a virtualized-grid cellRenderer deref backed by columnCount invariants (dtale idiom)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const cellRenderer = ({ columnIndex, columns }) => {
+        if (columnIndex === 0) return null;
+        return <div>{columns[columnIndex - 1].name}</div>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a delta computed in a map callback under an outer length early return", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function Chart(points) {
+        if (points.length < 2) return null;
+        return points.map((p, i) => (i === 0 ? 0 : p.y - points[i - 1].y));
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag .split(delim)[0]", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const host = url.split('://')[0].toLowerCase();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an includes()-guarded split (delimiter presence guarantees the part)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `if (line.includes(':')) { const value = line.split(':')[1].trim(); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a split under a RegExp .test() precondition (rsuite delimiter guard)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `if (/^\\d+:\\d+$/.test(value)) { const minutes = value.split(':')[1].padStart(2, '0'); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a split dominated by a predicate helper call over the same value (rsuite idiom)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function getDecimalLength(value) {
+        if (isNumber(value)) {
+          return value.toString().split('.')[1].length;
+        }
+        return 0;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a match deref dominated by a predicate helper call over the matched value", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const hue = isHexColor(color) ? color.match(/#(\\w+)/)[1].toLowerCase() : null;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a split when the dominating predicate call is over a different value", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function getDecimalLength(value, other) {
+        if (isNumber(other)) {
+          return value.toString().split('.')[1].length;
+        }
+        return 0;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an unconditional member-chain split deref in a hook body (Mern delivery-app shape)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function useEditProfileForm() {
+        const { currentUser } = useStorage();
+        const defaultsValues = {
+          city: currentUser.address.split(",")[1].trim(),
+        };
+        return defaultsValues;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a split on a string literal with a statically guaranteed part count", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const minor = "1.2.3".split(".")[1].padStart(2, "0");`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a string-literal split whose static part count is too short", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const missing = "no-dots".split(".")[1].trim();`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the ternary double-match idiom (test repeats the same match call)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const v = str.match(/#(\\w+)/) ? str.match(/#(\\w+)/)[1].trim() : '';`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an &&-guarded repeated exec read", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const version = /v(\\d+)/.exec(input) && /v(\\d+)/.exec(input)[1].trim();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a match deref guarded by a DIFFERENT match call", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const v = str.match(/a/) ? str.match(/#(\\w+)/)[1].trim() : '';`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an includes()-guarded split when the delimiter differs", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `if (line.includes(';')) { const value = line.split(':')[1].trim(); }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag touches[0] inside a touchstart handler", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `element.addEventListener('touchstart', (event) => { startY = event.touches[0].clientY; });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a literal index with a dominating length guard", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `if (invoice.lineItems.length) { const first = invoice.lineItems[0].amount; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a literal index into a local array", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const size = [rect.width, rect.height]; const w = size[0].x;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an optional-chained deref", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const y = event.touches[0]?.clientY;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a runtime-source arithmetic index guarded by a length check", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function useMenu(items, i) { if (items.length) { return items[i - 1].label; } }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare-identifier index into a parameter (object-key ambiguous)", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function useMenu(items) { return items[selectedIndex].label; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a dynamic object-key read on a reduce accumulator", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `jobs.reduce((acc, job) => { acc[job.teamName] = acc[job.teamName] || []; acc[job.teamName].push(job); return acc; }, {});`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a string-keyed member write on a parameter dictionary", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `function setVar(styles, breakpoint) { styles[breakpoint]['--gap'] = '0px'; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-literal index into a non-parameter local array", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const arr = [1, 2, 3]; const v = arr[selectedIndex].value;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips minified/dist files", () => {
+    const result = runRule(
+      noArrayIndexDerefWithoutBoundsOrEmptyGuard,
+      `const ext = fileName.split('.')[1].toUpperCase();`,
+      { filename: "vendor/lib.min.js" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.ts
@@ -1,4 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { nearestEnclosingFunction } from "../../utils/component-or-hook-display-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -47,20 +48,11 @@ const isTouchListAccess = (node: EsTreeNode): boolean =>
   isNodeOfType(node.property, "Identifier") &&
   TOUCH_LIST_PROPERTY_NAMES.has(node.property.name);
 
-const findNearestFunction = (node: EsTreeNode): EsTreeNode | null => {
-  let cursor: EsTreeNode | null | undefined = node.parent;
-  while (cursor) {
-    if (isFunctionLike(cursor)) return cursor;
-    cursor = cursor.parent ?? null;
-  }
-  return null;
-};
-
 // True when the nearest enclosing function is wired to a
 // `touchend`/`touchcancel` listener — the only touch phase where the
 // TouchList is empty and `touches[0]` throws.
 const isInsideTouchEndHandler = (node: EsTreeNode): boolean => {
-  const handler = findNearestFunction(node);
+  const handler = nearestEnclosingFunction(node);
   if (!handler) return false;
   const parent = handler.parent;
   if (!parent) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.ts
@@ -1,0 +1,341 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
+
+// Bundled / minified output is not actionable source; the `test-noise`
+// tag already skips test/spec/story/script files.
+const NON_SOURCE_FILENAME_MARKERS = ["/dist/", "/build/", ".min.", ".umd."];
+
+const REGEX_RESULT_METHOD_NAMES = new Set(["exec", "match"]);
+const TOUCH_LIST_PROPERTY_NAMES = new Set(["touches", "targetTouches"]);
+const TOUCH_END_EVENT_NAMES = new Set(["touchend", "touchcancel"]);
+const TOUCH_END_HANDLER_PROP_PATTERN = /^ontouch(?:end|cancel)$/i;
+
+const MESSAGE =
+  "This dereferences an array index result that can be undefined at runtime (empty list, no regex match, or a short split), which throws `Cannot read properties of undefined`. Guard with a length/emptiness check or optional chaining before the access.";
+
+const isNumericLiteral = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "Literal") && typeof node.value === "number";
+
+// A call whose method is `.exec(...)` / `.match(...)` — the result is
+// `null` on no match and each capture group can be undefined.
+const isRegexResultCall = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") &&
+  isNodeOfType(node.callee, "MemberExpression") &&
+  !node.callee.computed &&
+  isNodeOfType(node.callee.property, "Identifier") &&
+  REGEX_RESULT_METHOD_NAMES.has(node.callee.property.name);
+
+const isSplitCall = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") &&
+  isNodeOfType(node.callee, "MemberExpression") &&
+  !node.callee.computed &&
+  isNodeOfType(node.callee.property, "Identifier") &&
+  node.callee.property.name === "split";
+
+// `evt.touches` / `evt.targetTouches` — an empty TouchList inside
+// touchend/touchcancel handlers.
+const isTouchListAccess = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "MemberExpression") &&
+  !node.computed &&
+  isNodeOfType(node.property, "Identifier") &&
+  TOUCH_LIST_PROPERTY_NAMES.has(node.property.name);
+
+const findNearestFunction = (node: EsTreeNode): EsTreeNode | null => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor) {
+    if (isFunctionLike(cursor)) return cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+// True when the nearest enclosing function is wired to a
+// `touchend`/`touchcancel` listener — the only touch phase where the
+// TouchList is empty and `touches[0]` throws.
+const isInsideTouchEndHandler = (node: EsTreeNode): boolean => {
+  const handler = findNearestFunction(node);
+  if (!handler) return false;
+  const parent = handler.parent;
+  if (!parent) return false;
+
+  if (
+    isNodeOfType(parent, "CallExpression") &&
+    isNodeOfType(parent.callee, "MemberExpression") &&
+    isNodeOfType(parent.callee.property, "Identifier") &&
+    parent.callee.property.name === "addEventListener" &&
+    parent.arguments[1] === handler
+  ) {
+    const eventNameArgument = parent.arguments[0];
+    return (
+      Boolean(eventNameArgument) &&
+      isNodeOfType(eventNameArgument as EsTreeNode, "Literal") &&
+      typeof (eventNameArgument as EsTreeNodeOfType<"Literal">).value === "string" &&
+      TOUCH_END_EVENT_NAMES.has(String((eventNameArgument as EsTreeNodeOfType<"Literal">).value))
+    );
+  }
+
+  if (
+    isNodeOfType(parent, "JSXExpressionContainer") &&
+    isNodeOfType(parent.parent, "JSXAttribute")
+  ) {
+    const attributeName = parent.parent.name;
+    return (
+      isNodeOfType(attributeName as EsTreeNode, "JSXIdentifier") &&
+      TOUCH_END_HANDLER_PROP_PATTERN.test((attributeName as EsTreeNodeOfType<"JSXIdentifier">).name)
+    );
+  }
+
+  if (isNodeOfType(parent, "Property") && isNodeOfType(parent.key, "Identifier")) {
+    return TOUCH_END_HANDLER_PROP_PATTERN.test(parent.key.name);
+  }
+
+  if (
+    isNodeOfType(parent, "AssignmentExpression") &&
+    isNodeOfType(parent.left, "MemberExpression") &&
+    isNodeOfType(parent.left.property, "Identifier")
+  ) {
+    return TOUCH_END_HANDLER_PROP_PATTERN.test(parent.left.property.name);
+  }
+
+  return false;
+};
+
+// Structural equality for guard-shaped expressions (identifier / literal /
+// member / call), with regex literals compared by raw source so
+// `str.match(/x/) ? str.match(/x/)[1] : ...` recognizes both calls as the
+// same read. Local (not the shared util) because the shared helper compares
+// regex literals by RegExp object identity, which is never equal.
+const areGuardExpressionsEqual = (
+  first: EsTreeNode | null | undefined,
+  second: EsTreeNode | null | undefined,
+): boolean => {
+  if (!first || !second) return false;
+  if (first.type !== second.type) return false;
+  if (isNodeOfType(first, "Identifier") && isNodeOfType(second, "Identifier")) {
+    return first.name === second.name;
+  }
+  if (isNodeOfType(first, "Literal") && isNodeOfType(second, "Literal")) {
+    if ("regex" in first || "regex" in second) return first.raw === second.raw;
+    return first.value === second.value;
+  }
+  if (isNodeOfType(first, "MemberExpression") && isNodeOfType(second, "MemberExpression")) {
+    return (
+      first.computed === second.computed &&
+      areGuardExpressionsEqual(first.object, second.object) &&
+      areGuardExpressionsEqual(first.property, second.property)
+    );
+  }
+  if (isNodeOfType(first, "CallExpression") && isNodeOfType(second, "CallExpression")) {
+    if (!areGuardExpressionsEqual(first.callee, second.callee)) return false;
+    if (first.arguments.length !== second.arguments.length) return false;
+    return first.arguments.every((argument, argumentIndex) =>
+      areGuardExpressionsEqual(argument, second.arguments[argumentIndex]),
+    );
+  }
+  return false;
+};
+
+// Conditions that dominate the deref within the nearest enclosing function:
+// tests of if/ternary consequents the deref sits in, and left operands of
+// `&&` chains it sits on the right of.
+const collectDominatingConditionTests = (node: EsTreeNode): EsTreeNode[] => {
+  const dominatingTests: EsTreeNode[] = [];
+  let cursor: EsTreeNode = node;
+  let parent = cursor.parent ?? null;
+  while (parent && !isFunctionLike(parent)) {
+    if (isNodeOfType(parent, "IfStatement") && parent.consequent === cursor) {
+      dominatingTests.push(parent.test);
+    }
+    if (isNodeOfType(parent, "ConditionalExpression") && parent.consequent === cursor) {
+      dominatingTests.push(parent.test);
+    }
+    if (
+      isNodeOfType(parent, "LogicalExpression") &&
+      parent.operator === "&&" &&
+      parent.right === cursor
+    ) {
+      dominatingTests.push(parent.left);
+    }
+    cursor = parent;
+    parent = parent.parent ?? null;
+  }
+  return dominatingTests;
+};
+
+// Walks a value expression down to the identifier it reads from:
+// `value.toString()` -> `value`, `currentUser.address` -> `currentUser`.
+const findValueBaseIdentifier = (node: EsTreeNode): EsTreeNodeOfType<"Identifier"> | null => {
+  let cursor = stripParenExpression(node);
+  while (!isNodeOfType(cursor, "Identifier")) {
+    if (isNodeOfType(cursor, "CallExpression") && isNodeOfType(cursor.callee, "MemberExpression")) {
+      cursor = stripParenExpression(cursor.callee.object);
+      continue;
+    }
+    if (isNodeOfType(cursor, "MemberExpression")) {
+      cursor = stripParenExpression(cursor.object);
+      continue;
+    }
+    return null;
+  }
+  return cursor;
+};
+
+// A same-file predicate helper invoked over the dereferenced value
+// (`isNumber(value)` dominating `value.toString().split('.')[1]`) —
+// its body is invisible to intra-procedural analysis, so treat it as a
+// guard the rule cannot refute.
+const isPredicateCallOverBaseIdentifier = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  baseIdentifier: EsTreeNodeOfType<"Identifier"> | null,
+): boolean =>
+  Boolean(baseIdentifier) &&
+  call.arguments.some((argument) =>
+    areGuardExpressionsEqual(stripParenExpression(argument), baseIdentifier),
+  );
+
+const someDominatingTestHasCall = (
+  node: EsTreeNode,
+  isGuardCall: (call: EsTreeNodeOfType<"CallExpression">) => boolean,
+): boolean =>
+  collectDominatingConditionTests(node).some((test) => {
+    let didFindGuardCall = false;
+    walkAst(test, (child: EsTreeNode) => {
+      if (didFindGuardCall) return false;
+      if (isNodeOfType(child, "CallExpression") && isGuardCall(child)) {
+        didFindGuardCall = true;
+        return false;
+      }
+    });
+    return didFindGuardCall;
+  });
+
+// The double-read idiom `str.match(re) ? str.match(re)[1].trim() : ''` —
+// a dominating condition repeats the same exec/match call, so the indexed
+// read is proven non-null on this branch — or an opaque predicate call is
+// made over the matched value (`isHex(color) ? color.match(re)[1] : ...`).
+const isRegexResultDerefGuarded = (node: EsTreeNode, regexResultCall: EsTreeNode): boolean => {
+  const matchedValueIdentifier =
+    isNodeOfType(regexResultCall, "CallExpression") &&
+    isNodeOfType(regexResultCall.callee, "MemberExpression") &&
+    isNodeOfType(regexResultCall.callee.property, "Identifier")
+      ? findValueBaseIdentifier(
+          regexResultCall.callee.property.name === "exec"
+            ? (regexResultCall.arguments[0] ?? regexResultCall.callee.object)
+            : regexResultCall.callee.object,
+        )
+      : null;
+  return someDominatingTestHasCall(
+    node,
+    (call) =>
+      areGuardExpressionsEqual(call, regexResultCall) ||
+      isPredicateCallOverBaseIdentifier(call, matchedValueIdentifier),
+  );
+};
+
+// `"1.2.3".split(".")[1]` — splitting a string literal by a string-literal
+// delimiter has a statically known part count.
+const isStaticallyPresentSplitPart = (splitCall: EsTreeNode, partIndex: number): boolean => {
+  if (!isNodeOfType(splitCall, "CallExpression")) return false;
+  if (!isNodeOfType(splitCall.callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(splitCall.callee.object);
+  const delimiter = splitCall.arguments[0];
+  if (!isNodeOfType(receiver, "Literal") || typeof receiver.value !== "string") return false;
+  if (!delimiter || !isNodeOfType(delimiter, "Literal") || typeof delimiter.value !== "string") {
+    return false;
+  }
+  return receiver.value.split(delimiter.value).length > partIndex;
+};
+
+// A dominating condition that guarantees the delimiter exists before the
+// split is read: `receiver.includes(delimiter)` on the same receiver and
+// delimiter, a regex precondition via `.test(...)` (the delimiter's
+// presence is asserted by the pattern), or an opaque predicate call over
+// the split value (`isNumber(value)` before `value.toString().split('.')[1]`).
+const isSplitPartDerefGuarded = (node: EsTreeNode, splitCall: EsTreeNode): boolean => {
+  if (!isNodeOfType(splitCall, "CallExpression")) return false;
+  if (!isNodeOfType(splitCall.callee, "MemberExpression")) return false;
+  const splitReceiver = stripParenExpression(splitCall.callee.object);
+  const splitDelimiter = splitCall.arguments[0] ?? null;
+  const splitValueIdentifier = findValueBaseIdentifier(splitReceiver);
+  return someDominatingTestHasCall(node, (call) => {
+    if (isPredicateCallOverBaseIdentifier(call, splitValueIdentifier)) return true;
+    if (!isNodeOfType(call.callee, "MemberExpression") || call.callee.computed) return false;
+    if (!isNodeOfType(call.callee.property, "Identifier")) return false;
+    const guardMethodName = call.callee.property.name;
+    if (guardMethodName === "test") return true;
+    if (guardMethodName !== "includes") return false;
+    const guardArgument = call.arguments[0] ?? null;
+    return (
+      areGuardExpressionsEqual(stripParenExpression(call.callee.object), splitReceiver) &&
+      areGuardExpressionsEqual(guardArgument, splitDelimiter)
+    );
+  });
+};
+
+// Flags an immediate deref (`.foo`, `.foo()`, further `[k]`) on the
+// result of an empty-prone numeric bracket read with no dominating
+// guard: (a) regex `.exec/.match` results, (b) `touches[0]` in
+// touchend/touchcancel handlers, and (c) `.split(delim)[k]` for k>=1.
+// Arithmetic indexing into parameter arrays is deliberately out of scope:
+// caller-side index/length invariants (virtualized-grid cell renderers,
+// reduce accumulators) make that pattern overwhelmingly safe in practice.
+export const noArrayIndexDerefWithoutBoundsOrEmptyGuard = defineRule({
+  id: "no-array-index-deref-without-bounds-or-empty-guard",
+  title: "Array index result dereferenced without a guard",
+  severity: "warn",
+  category: "Correctness",
+  tags: ["test-noise"],
+  recommendation:
+    "An array index read is typed `T` but is `T | undefined` at runtime, so dereferencing it on an empty list, a non-matching regex, or a short split throws. Add a length/emptiness check or optional chaining before the access.",
+  create: (context: RuleContext): RuleVisitors => {
+    const filename = context.filename ?? "";
+    if (NON_SOURCE_FILENAME_MARKERS.some((marker) => filename.includes(marker))) return {};
+
+    return {
+      MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+        // The deref boundary itself is optional-chained — already null-safe.
+        if (node.optional) return;
+
+        const indexRead = stripParenExpression(node.object as EsTreeNode);
+        if (!isNodeOfType(indexRead, "MemberExpression") || !indexRead.computed) return;
+        // `base?.[i]` guards the base being nullish already.
+        if (indexRead.optional) return;
+
+        const base = stripParenExpression(indexRead.object as EsTreeNode);
+        const index = indexRead.property as EsTreeNode;
+
+        // (a) regex exec/match result indexed then dereferenced.
+        if (isRegexResultCall(base)) {
+          if (isRegexResultDerefGuarded(node, base)) return;
+          context.report({ node, message: MESSAGE });
+          return;
+        }
+
+        // (c) `.split(delim)[k]` for k >= 1 (index 0 is always present).
+        if (
+          isSplitCall(base) &&
+          isNumericLiteral(index) &&
+          Number((index as EsTreeNodeOfType<"Literal">).value) >= 1
+        ) {
+          const partIndex = Number((index as EsTreeNodeOfType<"Literal">).value);
+          if (isStaticallyPresentSplitPart(base, partIndex)) return;
+          if (isSplitPartDerefGuarded(node, base)) return;
+          context.report({ node, message: MESSAGE });
+          return;
+        }
+
+        // (b) `touches[0]` / `targetTouches[0]` inside touchend/touchcancel.
+        if (isTouchListAccess(base) && isInsideTouchEndHandler(node)) {
+          context.report({ node, message: MESSAGE });
+        }
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-deref-without-bounds-or-empty-guard.ts
@@ -247,9 +247,10 @@ const isStaticallyPresentSplitPart = (splitCall: EsTreeNode, partIndex: number):
 
 // A dominating condition that guarantees the delimiter exists before the
 // split is read: `receiver.includes(delimiter)` on the same receiver and
-// delimiter, a regex precondition via `.test(...)` (the delimiter's
-// presence is asserted by the pattern), or an opaque predicate call over
-// the split value (`isNumber(value)` before `value.toString().split('.')[1]`).
+// delimiter, a regex precondition via `.test(...)` over the same receiver
+// or split value (the delimiter's presence is asserted by the pattern), or
+// an opaque predicate call over the split value (`isNumber(value)` before
+// `value.toString().split('.')[1]`).
 const isSplitPartDerefGuarded = (node: EsTreeNode, splitCall: EsTreeNode): boolean => {
   if (!isNodeOfType(splitCall, "CallExpression")) return false;
   if (!isNodeOfType(splitCall.callee, "MemberExpression")) return false;
@@ -261,7 +262,16 @@ const isSplitPartDerefGuarded = (node: EsTreeNode, splitCall: EsTreeNode): boole
     if (!isNodeOfType(call.callee, "MemberExpression") || call.callee.computed) return false;
     if (!isNodeOfType(call.callee.property, "Identifier")) return false;
     const guardMethodName = call.callee.property.name;
-    if (guardMethodName === "test") return true;
+    if (guardMethodName === "test") {
+      const testedValue = call.arguments[0] ? stripParenExpression(call.arguments[0]) : null;
+      if (!testedValue) return false;
+      if (areGuardExpressionsEqual(testedValue, splitReceiver)) return true;
+      const testedValueIdentifier = findValueBaseIdentifier(testedValue);
+      return (
+        testedValueIdentifier !== null &&
+        areGuardExpressionsEqual(testedValueIdentifier, splitValueIdentifier)
+      );
+    }
     if (guardMethodName !== "includes") return false;
     const guardArgument = call.arguments[0] ?? null;
     return (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-collapsed-literal-or-chain-as-value.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-collapsed-literal-or-chain-as-value.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noCollapsedLiteralOrChainAsValue } from "./no-collapsed-literal-or-chain-as-value.js";
+
+describe("no-collapsed-literal-or-chain-as-value", () => {
+  it("flags foo.includes('a' || 'b')", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `foo.includes("a" || "b");`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags startsWith with a two-literal chain", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `x.startsWith("http://" || "https://");`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an equality comparison against a parenthesized literal chain", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `const bad = status === ("open" || "pending");`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a numeric literal chain in a !== comparison", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `const bad = code !== (404 || 500);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the ResizeObserver message-filter shape", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `e.message.includes("ResizeObserver loop completed" || "ResizeObserver loop limit");`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a && chain of literals consumed as a value", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `foo.includes("a" && "b");`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a template-literal chain with no embedded expressions", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, "foo.includes(`a` || `b`);");
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a real default/fallback where an operand is an identifier", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `foo.includes(x || "default");`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when an operand is a member/call expression", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `foo.includes(config.prefix || "https://");`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('does not flag `value ?? ""` nullish coalescing', () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `foo.includes(value ?? "");`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a ternary", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `const y = cond ? "a" : "b"; foo.includes(y);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag string concatenation", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `foo.includes("a" + "b");`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a standalone boolean test outside a consuming context", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `if ("a" || "b") { doThing(); }`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chain assigned to a variable then used elsewhere", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `const combined = "a" || "b"; foo.includes(combined);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag mixed string/number operands", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `foo.includes("a" || 1);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-search method call", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `foo.push("a" || "b");`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports only once for a three-literal chain", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `foo.includes("a" || "b" || "c");`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an all-literal chain as the receiver of a string-search call", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `const isKnownRole = ("admin" || "owner").includes(role);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an all-literal chain used as a switch case test", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `switch (method) { case "GET" || "HEAD": allow(); break; }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a switch case fallback where an operand is an identifier", () => {
+    const result = runRule(
+      noCollapsedLiteralOrChainAsValue,
+      `switch (method) { case preferredMethod || "GET": allow(); break; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a literal-chain receiver of a non-search member access", () => {
+    const result = runRule(noCollapsedLiteralOrChainAsValue, `const length = ("a" || "b").length;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-collapsed-literal-or-chain-as-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-collapsed-literal-or-chain-as-value.ts
@@ -1,0 +1,137 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// String-search methods whose single argument, when written as an
+// all-literal `||`/`&&` chain, silently checks only the first literal.
+const STRING_SEARCH_METHODS = new Set([
+  "includes",
+  "startsWith",
+  "endsWith",
+  "indexOf",
+  "lastIndexOf",
+  "search",
+  "match",
+  "test",
+]);
+
+const EQUALITY_OPERATORS = new Set(["===", "!==", "==", "!="]);
+
+type LiteralKind = "string" | "number";
+
+// Classifies a chain LEAF: a bare string/number literal or an
+// expression-free template literal (a string). Any other operand —
+// Identifier, MemberExpression, CallExpression, boolean/null literal —
+// returns null so the whole chain is rejected (a real default/fallback
+// like `x || "default"` must never match).
+const classifyCollapsibleLiteral = (node: EsTreeNode): LiteralKind | null => {
+  if (isNodeOfType(node, "Literal")) {
+    if (typeof node.value === "string") return "string";
+    if (typeof node.value === "number") return "number";
+    return null;
+  }
+  if (isNodeOfType(node, "TemplateLiteral")) {
+    return getStaticTemplateLiteralValue(node) === null ? null : "string";
+  }
+  return null;
+};
+
+// Walks a `||`/`&&` chain and returns the single literal kind shared by
+// every operand, or null when any operand is non-literal, a nested `??`
+// chain, or the operands mix string and number types.
+const collectSharedLiteralKind = (rawNode: EsTreeNode): LiteralKind | null => {
+  const node = stripGroupingParens(rawNode);
+  if (isNodeOfType(node, "LogicalExpression")) {
+    if (node.operator !== "||" && node.operator !== "&&") return null;
+    const leftKind = collectSharedLiteralKind(node.left as EsTreeNode);
+    if (!leftKind) return null;
+    const rightKind = collectSharedLiteralKind(node.right as EsTreeNode);
+    if (!rightKind) return null;
+    return leftKind === rightKind ? leftKind : null;
+  }
+  return classifyCollapsibleLiteral(node);
+};
+
+const isConsumedByStringSearchCall = (chainOrWrapper: EsTreeNode, parent: EsTreeNode): boolean => {
+  if (!isNodeOfType(parent, "CallExpression")) return false;
+  const callee = parent.callee;
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    callee.computed ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    !STRING_SEARCH_METHODS.has(callee.property.name)
+  ) {
+    return false;
+  }
+  return parent.arguments.some((argument) => argument === chainOrWrapper);
+};
+
+const isReceiverOfStringSearchCall = (chainOrWrapper: EsTreeNode, parent: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(parent, "MemberExpression") ||
+    parent.object !== chainOrWrapper ||
+    parent.computed ||
+    !isNodeOfType(parent.property, "Identifier") ||
+    !STRING_SEARCH_METHODS.has(parent.property.name)
+  ) {
+    return false;
+  }
+  const grandparent = parent.parent ?? null;
+  return (
+    grandparent !== null &&
+    isNodeOfType(grandparent, "CallExpression") &&
+    grandparent.callee === parent
+  );
+};
+
+const isConsumedByEqualityComparison = (chainOrWrapper: EsTreeNode, parent: EsTreeNode): boolean =>
+  isNodeOfType(parent, "BinaryExpression") &&
+  EQUALITY_OPERATORS.has(parent.operator) &&
+  (parent.left === chainOrWrapper || parent.right === chainOrWrapper);
+
+const isConsumedAsSwitchCaseTest = (chainOrWrapper: EsTreeNode, parent: EsTreeNode): boolean =>
+  isNodeOfType(parent, "SwitchCase") && parent.test === chainOrWrapper;
+
+export const noCollapsedLiteralOrChainAsValue = defineRule({
+  id: "no-collapsed-literal-or-chain-as-value",
+  title: "All-literal logical chain collapses to its first value",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "Compare against each value separately (or use an array `.includes(x)`) instead of an all-literal `||`/`&&` chain, which short-circuits to its first literal and drops the rest.",
+  create: (context: RuleContext) => ({
+    LogicalExpression(node: EsTreeNodeOfType<"LogicalExpression">) {
+      if (node.operator !== "||" && node.operator !== "&&") return;
+      if (!collectSharedLiteralKind(node)) return;
+
+      // Climb through grouping parentheses to find the consuming node,
+      // then confirm this chain is the DIRECT argument / operand there. A
+      // grouping paren is identified by `stripGroupingParens` peeling it.
+      let wrapper: EsTreeNode = node;
+      let parent = node.parent ?? null;
+      while (parent && stripGroupingParens(parent) !== parent) {
+        wrapper = parent;
+        parent = parent.parent ?? null;
+      }
+      if (!parent) return;
+
+      if (
+        !isConsumedByStringSearchCall(wrapper, parent) &&
+        !isReceiverOfStringSearchCall(wrapper, parent) &&
+        !isConsumedByEqualityComparison(wrapper, parent) &&
+        !isConsumedAsSwitchCaseTest(wrapper, parent)
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        message: `\`${node.operator}\` short-circuits to its first literal at runtime, so only the first value is ever used and the rest are dead — compare against each value separately or use an array \`.includes(x)\` check.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-controlled-input-value-without-state-update.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-controlled-input-value-without-state-update.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noControlledInputValueWithoutStateUpdate } from "./no-controlled-input-value-without-state-update.js";
+
+describe("no-controlled-input-value-without-state-update", () => {
+  it("flags input with a string-literal value and an onChange", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input value="hello" onChange={(e) => log(e)} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags input with a numeric-literal value {123} and an onChange", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input value={123} onChange={handleChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags textarea with a literal value and an onChange", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <textarea value="frozen" onChange={handleChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag value bound to state with an updating onChange", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => {
+        const [value, setValue] = useState("");
+        return <input value={value} onChange={(e) => setValue(e.target.value)} />;
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a value bound to a prop identifier (syntax-only, no FP)", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const MyInput = ({ value }) => <input value={value} onChange={(e) => log(e)} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a readOnly input with a literal value", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input value="hello" readOnly onChange={handleChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a disabled input with a literal value", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input value="hello" disabled onChange={handleChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a literal value with no onChange (a different footgun)", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input value="hello" />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a radio whose literal value is the submission token", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input type="radio" value="a" checked onChange={handleChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a checkbox literal value", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input type="checkbox" value="a" onChange={handleChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a generic radio component with dynamic type and explicit checked", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const Radio = ({ type, checked, onChange }) => <input type={type} checked={checked} value="a" onChange={onChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag type={'radio'} written as an expression container", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input type={"radio"} value="a" checked={sel} onChange={h} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a dynamic type={type} input, which may resolve to radio/checkbox/hidden", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const Field = ({ type, onChange }) => <input type={type} value="a" onChange={onChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag Solid files, where a static value only sets the initial value", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `import { createSignal } from "solid-js";
+const C = () => <input value="" onChange={(e) => setQuery(e.currentTarget.value)} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when a spread could supply onChange/value", () => {
+    const result = runRule(
+      noControlledInputValueWithoutStateUpdate,
+      `const C = () => <input value="hello" {...rest} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-controlled-input-value-without-state-update.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-controlled-input-value-without-state-update.ts
@@ -1,0 +1,92 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const CONTROLLED_INPUT_TAGS = new Set(["input", "textarea"]);
+
+// `checked` drives radio/checkbox state, `hidden` never needs onChange, so a
+// literal `value` on these is the submission token, not a frozen field.
+const VALUE_BYPASS_INPUT_TYPES = new Set(["hidden", "checkbox", "radio"]);
+
+const READONLY_ATTRIBUTES = ["readOnly", "disabled"];
+
+// True when the `value` JSXAttribute is a bare string/number literal —
+// `value="x"` or `value={123}`. Identifier references (state, props, consts)
+// are deliberately excluded: telling them apart needs scope analysis, and the
+// applied revision keeps this detector syntax-only to avoid the prop FP.
+const isLiteralValueAttribute = (valueAttribute: EsTreeNodeOfType<"JSXAttribute">): boolean => {
+  const value = valueAttribute.value;
+  if (!value) return false;
+  if (isNodeOfType(value, "Literal")) {
+    return typeof value.value === "string" || typeof value.value === "number";
+  }
+  if (isNodeOfType(value, "JSXExpressionContainer")) {
+    const expression: EsTreeNode = stripParenExpression(value.expression);
+    return (
+      isNodeOfType(expression, "Literal") &&
+      (typeof expression.value === "string" || typeof expression.value === "number")
+    );
+  }
+  return false;
+};
+
+// Mirrors `isLiteralValueAttribute`'s two accepted shapes for the `type`
+// attribute: `type="radio"` and `type={"radio"}` both resolve statically.
+const getStaticStringAttributeValue = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+): string | null => {
+  const value = attribute.value;
+  if (!value) return null;
+  if (isNodeOfType(value, "Literal") && typeof value.value === "string") return value.value;
+  if (isNodeOfType(value, "JSXExpressionContainer")) {
+    const expression: EsTreeNode = stripParenExpression(value.expression);
+    if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
+      return expression.value;
+    }
+  }
+  return null;
+};
+
+export const noControlledInputValueWithoutStateUpdate = defineRule({
+  id: "no-controlled-input-value-without-state-update",
+  title: "Controlled input value is a fixed literal",
+  severity: "warn",
+  tags: ["react-jsx-only"],
+  recommendation:
+    "Drive the input's `value` from state (`const [value, setValue] = useState(...)`) that `onChange` updates, or drop `value` if the field is meant to be read-only.",
+  create: (context: RuleContext) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+      const tagName = node.name.name;
+      if (!CONTROLLED_INPUT_TAGS.has(tagName)) return;
+
+      const attributes = node.attributes ?? [];
+      if (hasJsxSpreadAttribute(attributes)) return;
+
+      const valueAttribute = findJsxAttribute(attributes, "value");
+      if (!valueAttribute || !isLiteralValueAttribute(valueAttribute)) return;
+
+      if (!findJsxAttribute(attributes, "onChange")) return;
+      if (READONLY_ATTRIBUTES.some((name) => findJsxAttribute(attributes, name))) return;
+
+      if (tagName === "input") {
+        if (findJsxAttribute(attributes, "checked")) return;
+        const typeAttribute = findJsxAttribute(attributes, "type");
+        if (typeAttribute) {
+          const inputType = getStaticStringAttributeValue(typeAttribute);
+          if (inputType === null || VALUE_BYPASS_INPUT_TYPES.has(inputType)) return;
+        }
+      }
+
+      context.report({
+        node,
+        message: `Typing does nothing in this <${tagName}> because its \`value\` is a fixed literal that \`onChange\` never updates, so drive \`value\` from state or drop it if the field should be read-only.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.test.ts
@@ -248,4 +248,59 @@ describe("no-deprecated-keyboard-event-keycode-which", () => {
     );
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("flags a layout-sensitive keyCode branch when event.key is only logged", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         console.log(event.key);
+         if (event.keyCode === 65) selectAll();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when a key-derived comparison guards the fallback", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         if (event.key.toLowerCase() === 'a') { selectAll(); return; }
+         if (event.keyCode === 65) selectAll();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when event.key is aliased for later logic", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         const pressed = event.key;
+         if (event.keyCode === 65 && pressed !== 'a') selectAll();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when event.key feeds a matcher helper whose result branches", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         if (isHotkey(event.key)) { selectAll(); return; }
+         if (event.keyCode === 65) selectAll();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags when event.key only rides an analytics payload", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         analytics({ key: event.key });
+         if (event.keyCode === 65) selectAll();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noDeprecatedKeyboardEventKeycodeWhich } from "./no-deprecated-keyboard-event-keycode-which.js";
+
+describe("no-deprecated-keyboard-event-keycode-which", () => {
+  it("flags switch on event.which over layout-sensitive letter codes", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         switch (event.which) {
+           case 65: moveLeft(); break;
+           case 68: moveRight(); break;
+         }
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags keyCode compared to a layout-sensitive punctuation literal", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (e: React.KeyboardEvent) => {
+         if (e.keyCode === 191) openSearch();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags keyCode compared to a same-file const resolving to a letter code", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const KEY_S = 83;
+       const onKeyDown = (e: KeyboardEvent) => {
+         if (e.keyCode === KEY_S) save();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a relational character-range check on keyCode", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (e: KeyboardEvent) => {
+         if (e.keyCode >= 65 && e.keyCode <= 90) typeLetter();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("flags any charCode branch even against a control-key code", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyPress = (e: KeyboardEvent) => {
+         if (e.charCode === 32) toggle();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an untyped inline JSX onKeyDown handler comparing a letter code", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const Row = () => <div onKeyDown={(e) => { if (e.keyCode === 75) focusSearch(); }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a class arrow-field keyboard handler comparing a letter code", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `class Modal extends React.Component {
+         handleKeyDown = (e) => {
+           if (e.keyCode === 191) this.props.onSlash();
+         };
+         render() { return <div onKeyDown={this.handleKeyDown} />; }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a class method keyboard handler comparing a letter code", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `class Grid extends React.Component {
+         onKeyDown(e) {
+           if (e.keyCode === 65) this.selectAll();
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet on layout-invariant control-key literals (ant-design-style Escape check)", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (e: React.KeyboardEvent) => {
+         if (e.keyCode === 27) close();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a switch over arrow-key codes (carousel navigation idiom)", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         switch (event.which) {
+           case 37: slidePrev(); break;
+           case 39: slideNext(); break;
+         }
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on unresolvable named key constants (shared KeyCode module idiom)", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const handleKeyDown = (e: KeyboardEvent) => {
+         if (e.keyCode === ArrowKeys.Left) {
+           slide(SlideDirection.Left);
+         }
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a same-file const resolving to a control-key code", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const ESCAPE_KEY = 27;
+       const onKeyDown = (e: KeyboardEvent) => {
+         if (e.keyCode === ESCAPE_KEY) close();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on an else-if progressive-enhancement fallback after an event.key branch", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         if (event.key !== undefined) {
+           if (event.key === "/") openSearch();
+         } else if (event.keyCode === 191) {
+           openSearch();
+         }
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a ternary feature-detect fallback between event.key and keyCode", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         const isSlash = event.key !== undefined ? event.key === "/" : event.keyCode === 191;
+         if (isSlash) openSearch();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on an early-return event.key guard before a keyCode fallback", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         if (event.key) {
+           handleByKey(event.key);
+           return;
+         }
+         if (event.keyCode === 191) openSearch();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on mouse-button which detection", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onMouseDown = (e: MouseEvent) => {
+         if (e.which === 3) return;
+         if (e.which === 2) openInNewTab();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on the keyCode === 229 IME idiom", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (e: KeyboardEvent) => {
+         if (e.keyCode === 229) return;
+         act();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a key || which transitional fallback", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (event: KeyboardEvent) => {
+         switch (event.key || event.which) {
+           case 'Escape': close(); break;
+           case 'ArrowLeft': slidePrev(); break;
+         }
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on object-literal keyCode event synthesis", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `fireEvent.keyDown(el, { keyCode: 13 });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on an untyped receiver with no keyboard-handler context", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const handler = (e) => { if (e.keyCode === 65) select(); };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a dynamic computed member access", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onKeyDown = (e: KeyboardEvent) => {
+         const prop = 'keyCode';
+         if (e[prop] === 27) close();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when which is read alongside button in the same handler", () => {
+    const result = runRule(
+      noDeprecatedKeyboardEventKeycodeWhich,
+      `const onPointer = (e: KeyboardEvent) => {
+         if (e.button === 0) return;
+         if (e.which === 3) contextMenu();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.ts
@@ -3,6 +3,8 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { getMeaningfulParent } from "../../utils/get-meaningful-parent.js";
+import { nearestEnclosingFunction } from "../../utils/component-or-hook-display-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
@@ -35,12 +37,6 @@ const KEYBOARD_LISTENER_EVENTS = new Set(["keydown", "keyup", "keypress"]);
 const MESSAGE =
   "`KeyboardEvent.keyCode`/`which`/`charCode` are deprecated, and this comparison targets a character code that varies by keyboard layout, browser, and input method, so the branch fires on the wrong key (or never) for untested layouts. Branch on the standardized `event.key` (logical key) or `event.code` (physical key) instead.";
 
-const meaningfulParent = (node: EsTreeNode): EsTreeNode | null => {
-  let parent = node.parent ?? null;
-  while (parent && parent.type === PARENTHESIZED_EXPRESSION) parent = parent.parent ?? null;
-  return parent;
-};
-
 const resolveNumericValue = (operand: EsTreeNode): number | null => {
   const valueNode = stripGroupingParens(operand);
   if (isNodeOfType(valueNode, "Literal") && typeof valueNode.value === "number") {
@@ -66,7 +62,7 @@ interface DeprecatedReadComparison {
 }
 
 const getComparison = (memberNode: EsTreeNode): DeprecatedReadComparison | null => {
-  const parent = meaningfulParent(memberNode);
+  const parent = getMeaningfulParent(memberNode);
   if (!parent || !isNodeOfType(parent, "BinaryExpression")) return null;
   if (!COMPARISON_OPERATORS.has(parent.operator)) return null;
   const otherOperand =
@@ -100,11 +96,13 @@ const switchTargetsLayoutSensitiveCode = (conditionRoot: EsTreeNode): boolean =>
 interface BranchingContext {
   conditionRoot: EsTreeNode;
   branching: boolean;
+  climbedThroughLogical: boolean;
 }
 
 const resolveBranchingContext = (memberNode: EsTreeNode): BranchingContext => {
   let node = memberNode;
   let climbedThroughComparison = false;
+  let climbedThroughLogical = false;
   while (node.parent) {
     const parent = node.parent;
     if (parent.type === PARENTHESIZED_EXPRESSION || parent.type === "UnaryExpression") {
@@ -112,6 +110,7 @@ const resolveBranchingContext = (memberNode: EsTreeNode): BranchingContext => {
       continue;
     }
     if (parent.type === "LogicalExpression") {
+      climbedThroughLogical = true;
       node = parent;
       continue;
     }
@@ -135,16 +134,59 @@ const resolveBranchingContext = (memberNode: EsTreeNode): BranchingContext => {
   return {
     conditionRoot: node,
     branching: climbedThroughComparison || isTestOrDiscriminant,
+    climbedThroughLogical,
   };
 };
 
-const getEnclosingFunction = (node: EsTreeNode): EsTreeNode | null => {
-  let ancestor = node.parent ?? null;
-  while (ancestor) {
-    if (isFunctionLike(ancestor)) return ancestor;
-    ancestor = ancestor.parent ?? null;
+const LOGIC_SINK_PARENT_TYPES = new Set([
+  "VariableDeclarator",
+  "AssignmentExpression",
+  "ReturnStatement",
+]);
+
+// Climbs from a property read to the value it produces: through grouping
+// parens, member chains rooted at the read (`event.key.toLowerCase()`),
+// and calls of those chains, so the classification below sees where the
+// derived value lands rather than the raw read.
+const readValueRoot = (readNode: EsTreeNode): EsTreeNode => {
+  let current = readNode;
+  while (current.parent) {
+    const parent = current.parent;
+    if (parent.type === PARENTHESIZED_EXPRESSION || isNodeOfType(parent, "ChainExpression")) {
+      current = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "MemberExpression") && parent.object === current) {
+      current = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "CallExpression") && parent.callee === current) {
+      current = parent;
+      continue;
+    }
+    break;
   }
-  return null;
+  return current;
+};
+
+// A `key`/`code` read only signals the progressive-enhancement fallback
+// idiom when its value feeds logic: a comparison, a branch test or switch
+// discriminant, a `||`/`??` fallback chain, an alias/assignment/return
+// that carries it onward, or a helper call whose RESULT feeds logic
+// (`if (isHotkey(event.key))`). A read whose value is discarded
+// (`console.log(event.key);`) leaves the deprecated branching as the
+// sole control path and must not suppress the report.
+const readFeedsLogic = (readNode: EsTreeNode): boolean => {
+  const valueRoot = readValueRoot(readNode);
+  const { conditionRoot, branching, climbedThroughLogical } = resolveBranchingContext(valueRoot);
+  if (branching || climbedThroughLogical) return true;
+  const parent = conditionRoot.parent ?? null;
+  if (!parent) return false;
+  if (LOGIC_SINK_PARENT_TYPES.has(parent.type)) return true;
+  if (isNodeOfType(parent, "CallExpression") && parent.callee !== conditionRoot) {
+    return readFeedsLogic(parent as EsTreeNode);
+  }
+  return false;
 };
 
 const typeReferenceIsKeyboardEvent = (typeAnnotation: EsTreeNode | null | undefined): boolean => {
@@ -222,6 +264,7 @@ const receiverReadsAnyProperty = (
   scopeNode: EsTreeNode,
   receiverName: string,
   propertyNames: Set<string>,
+  readQualifies?: (readNode: EsTreeNode) => boolean,
 ): boolean => {
   let found = false;
   walkAst(scopeNode, (child) => {
@@ -232,7 +275,8 @@ const receiverReadsAnyProperty = (
       isNodeOfType(child.object, "Identifier") &&
       child.object.name === receiverName &&
       isNodeOfType(child.property, "Identifier") &&
-      propertyNames.has(child.property.name)
+      propertyNames.has(child.property.name) &&
+      (!readQualifies || readQualifies(child))
     ) {
       found = true;
       return false;
@@ -248,9 +292,11 @@ const receiverReadsAnyProperty = (
 // or punctuation (which drift across keyboard layouts). Stays quiet on
 // layout-invariant control keys (Enter, Escape, Space, Tab, arrows, …),
 // unresolvable named key constants (`KeyCode.ENTER`), mouse-button
-// `which`, the IME `keyCode === 229` idiom, handlers that already read
-// `key`/`code` as a progressive-enhancement fallback, and object-literal
-// event-synthesis keys.
+// `which`, the IME `keyCode === 229` idiom, handlers whose `key`/`code`
+// reads feed logic (comparisons, branch tests, fallback chains, aliases)
+// as a progressive-enhancement fallback — a read that is only a bare call
+// argument like `console.log(event.key)` does not suppress — and
+// object-literal event-synthesis keys.
 export const noDeprecatedKeyboardEventKeycodeWhich = defineRule({
   id: "no-deprecated-keyboard-event-keycode-which",
   title: "Deprecated KeyboardEvent keyCode or which",
@@ -271,7 +317,7 @@ export const noDeprecatedKeyboardEventKeycodeWhich = defineRule({
       const { conditionRoot, branching } = resolveBranchingContext(node as EsTreeNode);
       if (!branching) return;
 
-      const enclosingFunction = getEnclosingFunction(node as EsTreeNode);
+      const enclosingFunction = nearestEnclosingFunction(node as EsTreeNode);
       if (!enclosingFunction || !isFunctionLike(enclosingFunction)) return;
       const firstParam = enclosingFunction.params?.[0];
       if (!firstParam || !isNodeOfType(firstParam as EsTreeNode, "Identifier")) return;
@@ -307,7 +353,16 @@ export const noDeprecatedKeyboardEventKeycodeWhich = defineRule({
       ) {
         return;
       }
-      if (receiverReadsAnyProperty(enclosingFunction, receiverName, STANDARD_KEY_MEMBERS)) return;
+      if (
+        receiverReadsAnyProperty(
+          enclosingFunction,
+          receiverName,
+          STANDARD_KEY_MEMBERS,
+          readFeedsLogic,
+        )
+      ) {
+        return;
+      }
 
       if (propertyName !== "charCode") {
         const isRelationalRangeCheck = Boolean(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.ts
@@ -1,0 +1,331 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// oxc-parser surfaces `(...)` as a node kind outside the TSESTree union,
+// so it is matched via a `string`-typed constant to avoid a literal
+// "no overlap" comparison error.
+const PARENTHESIZED_EXPRESSION: string = "ParenthesizedExpression";
+const DEPRECATED_NUMERIC_MEMBERS = new Set(["keyCode", "which", "charCode"]);
+const COMPARISON_OPERATORS = new Set(["===", "!==", "==", "!=", "<", ">", "<=", ">="]);
+const RELATIONAL_OPERATORS = new Set(["<", ">", "<=", ">="]);
+const MOUSE_BUTTON_LITERALS = new Set([1, 2, 3, 4]);
+const IME_COMPOSITION_KEYCODE = 229;
+// Control/navigation/activation keyCodes (Backspace, Tab, Enter,
+// modifiers, Escape, Space, PageUp/Down, End/Home, arrows, Insert,
+// Delete, Meta, F1-F12, locks) are identical across keyboard layouts,
+// browsers, and IMEs — comparing keyCode against them is layout-safe,
+// unlike letter (65-90), digit (48-57), and punctuation (186-222) codes.
+const LAYOUT_INVARIANT_CONTROL_KEYCODES = new Set([
+  8, 9, 13, 16, 17, 18, 19, 20, 27, 32, 33, 34, 35, 36, 37, 38, 39, 40, 45, 46, 91, 92, 93, 112,
+  113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 144, 145,
+]);
+const STANDARD_KEY_MEMBERS = new Set(["key", "code"]);
+const MOUSE_BUTTON_MEMBERS = new Set(["button", "buttons"]);
+const KEYBOARD_HANDLER_NAME_PATTERN = /key(down|up|press)/i;
+const KEYBOARD_LISTENER_EVENTS = new Set(["keydown", "keyup", "keypress"]);
+
+const MESSAGE =
+  "`KeyboardEvent.keyCode`/`which`/`charCode` are deprecated, and this comparison targets a character code that varies by keyboard layout, browser, and input method, so the branch fires on the wrong key (or never) for untested layouts. Branch on the standardized `event.key` (logical key) or `event.code` (physical key) instead.";
+
+const meaningfulParent = (node: EsTreeNode): EsTreeNode | null => {
+  let parent = node.parent ?? null;
+  while (parent && parent.type === PARENTHESIZED_EXPRESSION) parent = parent.parent ?? null;
+  return parent;
+};
+
+const resolveNumericValue = (operand: EsTreeNode): number | null => {
+  const valueNode = stripGroupingParens(operand);
+  if (isNodeOfType(valueNode, "Literal") && typeof valueNode.value === "number") {
+    return valueNode.value;
+  }
+  if (isNodeOfType(valueNode, "Identifier")) {
+    const binding = findVariableInitializer(valueNode, valueNode.name);
+    const initializer = binding?.initializer ?? null;
+    if (
+      initializer &&
+      isNodeOfType(initializer, "Literal") &&
+      typeof initializer.value === "number"
+    ) {
+      return initializer.value;
+    }
+  }
+  return null;
+};
+
+interface DeprecatedReadComparison {
+  operator: string;
+  comparedValue: number | null;
+}
+
+const getComparison = (memberNode: EsTreeNode): DeprecatedReadComparison | null => {
+  const parent = meaningfulParent(memberNode);
+  if (!parent || !isNodeOfType(parent, "BinaryExpression")) return null;
+  if (!COMPARISON_OPERATORS.has(parent.operator)) return null;
+  const otherOperand =
+    stripGroupingParens(parent.left as EsTreeNode) === memberNode ? parent.right : parent.left;
+  return {
+    operator: parent.operator,
+    comparedValue: resolveNumericValue(otherOperand as EsTreeNode),
+  };
+};
+
+const isLayoutSensitiveCode = (value: number): boolean =>
+  value !== IME_COMPOSITION_KEYCODE && !LAYOUT_INVARIANT_CONTROL_KEYCODES.has(value);
+
+const switchTargetsLayoutSensitiveCode = (conditionRoot: EsTreeNode): boolean => {
+  const parent = conditionRoot.parent ?? null;
+  if (
+    !parent ||
+    !isNodeOfType(parent, "SwitchStatement") ||
+    parent.discriminant !== conditionRoot
+  ) {
+    return false;
+  }
+  return parent.cases.some((switchCase) => {
+    const testNode = switchCase.test;
+    if (!testNode) return false;
+    const caseValue = resolveNumericValue(testNode as EsTreeNode);
+    return caseValue !== null && isLayoutSensitiveCode(caseValue);
+  });
+};
+
+interface BranchingContext {
+  conditionRoot: EsTreeNode;
+  branching: boolean;
+}
+
+const resolveBranchingContext = (memberNode: EsTreeNode): BranchingContext => {
+  let node = memberNode;
+  let climbedThroughComparison = false;
+  while (node.parent) {
+    const parent = node.parent;
+    if (parent.type === PARENTHESIZED_EXPRESSION || parent.type === "UnaryExpression") {
+      node = parent;
+      continue;
+    }
+    if (parent.type === "LogicalExpression") {
+      node = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "BinaryExpression") && COMPARISON_OPERATORS.has(parent.operator)) {
+      climbedThroughComparison = true;
+      node = parent;
+      continue;
+    }
+    break;
+  }
+  const parent = node.parent ?? null;
+  const isTestOrDiscriminant = Boolean(
+    parent &&
+    ((isNodeOfType(parent, "SwitchStatement") && parent.discriminant === node) ||
+      ((isNodeOfType(parent, "IfStatement") ||
+        isNodeOfType(parent, "ConditionalExpression") ||
+        isNodeOfType(parent, "WhileStatement") ||
+        isNodeOfType(parent, "DoWhileStatement")) &&
+        parent.test === node)),
+  );
+  return {
+    conditionRoot: node,
+    branching: climbedThroughComparison || isTestOrDiscriminant,
+  };
+};
+
+const getEnclosingFunction = (node: EsTreeNode): EsTreeNode | null => {
+  let ancestor = node.parent ?? null;
+  while (ancestor) {
+    if (isFunctionLike(ancestor)) return ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return null;
+};
+
+const typeReferenceIsKeyboardEvent = (typeAnnotation: EsTreeNode | null | undefined): boolean => {
+  if (!typeAnnotation || !isNodeOfType(typeAnnotation, "TSTypeAnnotation")) return false;
+  const typeNode = typeAnnotation.typeAnnotation as EsTreeNode;
+  if (!isNodeOfType(typeNode, "TSTypeReference")) return false;
+  const typeName = typeNode.typeName;
+  if (isNodeOfType(typeName, "Identifier")) return typeName.name === "KeyboardEvent";
+  if (isNodeOfType(typeName, "TSQualifiedName")) {
+    return isNodeOfType(typeName.right, "Identifier") && typeName.right.name === "KeyboardEvent";
+  }
+  return false;
+};
+
+const nameLooksLikeKeyboardHandler = (name: string | null | undefined): boolean =>
+  Boolean(name && KEYBOARD_HANDLER_NAME_PATTERN.test(name));
+
+const functionIsKeyboardHandler = (fnNode: EsTreeNode): boolean => {
+  if (isNodeOfType(fnNode, "FunctionDeclaration") && fnNode.id) {
+    if (nameLooksLikeKeyboardHandler(fnNode.id.name)) return true;
+  }
+  const parent = fnNode.parent ?? null;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "VariableDeclarator") && isNodeOfType(parent.id, "Identifier")) {
+    return nameLooksLikeKeyboardHandler(parent.id.name);
+  }
+  if (isNodeOfType(parent, "Property") && isNodeOfType(parent.key, "Identifier")) {
+    return nameLooksLikeKeyboardHandler(parent.key.name);
+  }
+  if (isNodeOfType(parent, "PropertyDefinition") && isNodeOfType(parent.key, "Identifier")) {
+    return nameLooksLikeKeyboardHandler(parent.key.name);
+  }
+  if (isNodeOfType(parent, "MethodDefinition") && isNodeOfType(parent.key, "Identifier")) {
+    return nameLooksLikeKeyboardHandler(parent.key.name);
+  }
+  if (
+    isNodeOfType(parent, "AssignmentExpression") &&
+    isNodeOfType(parent.left, "MemberExpression")
+  ) {
+    const property = parent.left.property;
+    if (!parent.left.computed && isNodeOfType(property, "Identifier")) {
+      return nameLooksLikeKeyboardHandler(property.name);
+    }
+  }
+  if (isNodeOfType(parent, "JSXExpressionContainer") && parent.parent) {
+    const attribute = parent.parent;
+    if (isNodeOfType(attribute, "JSXAttribute")) {
+      const attributeName = getJsxAttributeName(attribute.name as EsTreeNode);
+      if (attributeName && /^onkey/i.test(attributeName)) return true;
+    }
+  }
+  if (isNodeOfType(parent, "CallExpression")) {
+    const callee = parent.callee;
+    const isAddListener =
+      isNodeOfType(callee, "MemberExpression") &&
+      !callee.computed &&
+      isNodeOfType(callee.property, "Identifier") &&
+      callee.property.name === "addEventListener";
+    const firstArg = parent.arguments?.[0];
+    if (
+      isAddListener &&
+      parent.arguments?.[1] === fnNode &&
+      firstArg &&
+      isNodeOfType(firstArg as EsTreeNode, "Literal") &&
+      typeof (firstArg as EsTreeNodeOfType<"Literal">).value === "string" &&
+      KEYBOARD_LISTENER_EVENTS.has(String((firstArg as EsTreeNodeOfType<"Literal">).value))
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const receiverReadsAnyProperty = (
+  scopeNode: EsTreeNode,
+  receiverName: string,
+  propertyNames: Set<string>,
+): boolean => {
+  let found = false;
+  walkAst(scopeNode, (child) => {
+    if (found) return false;
+    if (
+      isNodeOfType(child, "MemberExpression") &&
+      !child.computed &&
+      isNodeOfType(child.object, "Identifier") &&
+      child.object.name === receiverName &&
+      isNodeOfType(child.property, "Identifier") &&
+      propertyNames.has(child.property.name)
+    ) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+// Flags branching on a KeyboardEvent's deprecated numeric `keyCode` /
+// `which` / `charCode` where the targeted code is genuinely layout- or
+// IME-sensitive: any `charCode` read, relational character-range checks,
+// and comparisons against resolvable numeric codes for letters, digits,
+// or punctuation (which drift across keyboard layouts). Stays quiet on
+// layout-invariant control keys (Enter, Escape, Space, Tab, arrows, …),
+// unresolvable named key constants (`KeyCode.ENTER`), mouse-button
+// `which`, the IME `keyCode === 229` idiom, handlers that already read
+// `key`/`code` as a progressive-enhancement fallback, and object-literal
+// event-synthesis keys.
+export const noDeprecatedKeyboardEventKeycodeWhich = defineRule({
+  id: "no-deprecated-keyboard-event-keycode-which",
+  title: "Deprecated KeyboardEvent keyCode or which",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "`KeyboardEvent.keyCode`/`which`/`charCode` are deprecated and layout/engine dependent for character keys. Branch on `event.key` (logical key like `'/'`) or `event.code` (physical position) so the handler works across keyboard layouts and browsers.",
+  create: (context: RuleContext) => ({
+    MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+      if (node.computed) return;
+      if (!isNodeOfType(node.property, "Identifier")) return;
+      const propertyName = node.property.name;
+      if (!DEPRECATED_NUMERIC_MEMBERS.has(propertyName)) return;
+      const receiver = node.object;
+      if (!isNodeOfType(receiver, "Identifier")) return;
+      const receiverName = receiver.name;
+
+      const { conditionRoot, branching } = resolveBranchingContext(node as EsTreeNode);
+      if (!branching) return;
+
+      const enclosingFunction = getEnclosingFunction(node as EsTreeNode);
+      if (!enclosingFunction || !isFunctionLike(enclosingFunction)) return;
+      const firstParam = enclosingFunction.params?.[0];
+      if (!firstParam || !isNodeOfType(firstParam as EsTreeNode, "Identifier")) return;
+      const firstParamIdentifier = firstParam as EsTreeNodeOfType<"Identifier">;
+      if (firstParamIdentifier.name !== receiverName) return;
+
+      const signalTypedKeyboardEvent = typeReferenceIsKeyboardEvent(
+        (firstParamIdentifier.typeAnnotation as EsTreeNode) ?? null,
+      );
+      const signalHandlerContext = functionIsKeyboardHandler(enclosingFunction);
+      if (!signalTypedKeyboardEvent && !signalHandlerContext) return;
+
+      // A same-file binding could shadow an outer param name, but the
+      // first-param match above already anchors the receiver to this
+      // handler's event parameter. Guard against a stray outer binding
+      // that resolves to a non-parameter declaration.
+      const binding = findVariableInitializer(receiver, receiverName);
+      if (binding && binding.scopeOwner !== enclosingFunction) return;
+
+      const comparison = getComparison(node as EsTreeNode);
+      const comparedValue = comparison ? comparison.comparedValue : null;
+      if (comparedValue === IME_COMPOSITION_KEYCODE) return;
+      if (
+        propertyName === "which" &&
+        comparedValue !== null &&
+        MOUSE_BUTTON_LITERALS.has(comparedValue)
+      ) {
+        return;
+      }
+      if (
+        propertyName === "which" &&
+        receiverReadsAnyProperty(enclosingFunction, receiverName, MOUSE_BUTTON_MEMBERS)
+      ) {
+        return;
+      }
+      if (receiverReadsAnyProperty(enclosingFunction, receiverName, STANDARD_KEY_MEMBERS)) return;
+
+      if (propertyName !== "charCode") {
+        const isRelationalRangeCheck = Boolean(
+          comparison && RELATIONAL_OPERATORS.has(comparison.operator),
+        );
+        const comparesLayoutSensitiveCode =
+          comparedValue !== null && isLayoutSensitiveCode(comparedValue);
+        const switchesOnLayoutSensitiveCode = switchTargetsLayoutSensitiveCode(conditionRoot);
+        if (
+          !isRelationalRangeCheck &&
+          !comparesLayoutSensitiveCode &&
+          !switchesOnLayoutSensitiveCode
+        ) {
+          return;
+        }
+      }
+
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-enter-submit-without-ime-composition-guard.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-enter-submit-without-ime-composition-guard.test.ts
@@ -245,4 +245,50 @@ describe("no-enter-submit-without-ime-composition-guard", () => {
     );
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("flags an unguarded field even when a sibling control has composition wiring", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Form = ({ isComposing, setComposing, saveTitle, saveNote }) => (
+         <form>
+           <input
+             onCompositionStart={() => setComposing(true)}
+             onCompositionEnd={() => setComposing(false)}
+             onKeyDown={(e) => { if (e.key === 'Enter' && !isComposing) saveTitle(); }}
+           />
+           <input onKeyDown={(e) => { if (e.key === 'Enter') saveNote(); }} />
+         </form>
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the composition guard lives inside the called commit helper", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Field = ({ isComposingRef, onSave }) => {
+         const commitEdit = () => {
+           if (isComposingRef.current) return;
+           onSave();
+         };
+         return <input onKeyDown={(e) => { if (e.key === 'Enter') commitEdit(); }} />;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the guard sits two helper hops below the handler", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Field = ({ isComposingRef, onSave }) => {
+         const guardedCommit = () => {
+           if (isComposingRef.current) return;
+           onSave();
+         };
+         const submitDraft = () => guardedCommit();
+         return <input onKeyDown={(e) => { if (e.key === 'Enter') submitDraft(); }} />;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-enter-submit-without-ime-composition-guard.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-enter-submit-without-ime-composition-guard.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noEnterSubmitWithoutImeCompositionGuard } from "./no-enter-submit-without-ime-composition-guard.js";
+
+describe("no-enter-submit-without-ime-composition-guard", () => {
+  it("flags an input Enter-to-commit with no composition guard", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const EventTitle = ({ onSave }) => (
+         <input
+           onKeyDown={(e) => {
+             if (e.key === 'Enter') onSave();
+           }}
+         />
+       );`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a role=textbox contentEditable committing on Enter", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Tags = ({ value }) => (
+         <div
+           role="textbox"
+           contentEditable
+           onKeyDown={(e) => {
+             if (e.key === 'Enter') {
+               e.preventDefault();
+               commitTag(value);
+             }
+           }}
+         />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a textarea keyCode 13 submit", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Box = () => (
+         <textarea
+           onKeyDown={(e) => {
+             if (e.keyCode === 13) submitDialog();
+           }}
+         />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the logical && submit shape", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Field = () => (
+         <input onKeyDown={(e) => { e.key === 'Enter' && onSave(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet on a role=radio activation handler", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Rating = ({ rating }) => (
+         <div role="radio" onKeyDown={(e) => { if (e.key === 'Enter') selectValue(rating); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a role=button Space+Enter activation", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Btn = () => (
+         <div role="button" onKeyDown={(e) => { if (e.key === ' ' || e.key === 'Enter') onActivate(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a modifier-gated Cmd/Ctrl+Enter submit", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Composer = () => (
+         <textarea onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) sendMessage(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when composition state is tracked in the component", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Field = ({ isComposing, setComposing }) => (
+         <input
+           onCompositionStart={() => setComposing(true)}
+           onCompositionEnd={() => setComposing(false)}
+           onKeyDown={(e) => {
+             if (e.key === 'Enter' && !isComposing) onSave();
+           }}
+         />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the handler bails on nativeEvent.isComposing", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Field = () => (
+         <input onKeyDown={(e) => {
+           if (e.nativeEvent.isComposing) return;
+           if (e.key === 'Enter') onSave();
+         }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a type=checkbox input", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Check = () => (
+         <input type="checkbox" onKeyDown={(e) => { if (e.key === 'Enter') toggle(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a textarea Space+Enter activation", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Box = () => (
+         <textarea onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') activate(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a type=number field where IME composition cannot commit (time-picker idiom)", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const TimePicker = ({ commit }) => (
+         <input type="number" onKeyDown={(e) => { if (e.key === 'Enter') commit(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on an inputMode=numeric text field (numeric-semantics idiom)", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const PxField = ({ apply }) => (
+         <input inputMode="numeric" onKeyDown={(e) => { if (e.key === 'Enter') apply(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when onChange coerces the value with Number() (seat-stepper idiom)", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const SeatStepper = ({ setSeats, confirm }) => (
+         <input
+           onChange={(e) => setSeats(Number(e.target.value))}
+           onKeyDown={(e) => { if (e.key === 'Enter') confirm(); }}
+         />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when onChange coerces the value with parseInt (max-dimension option idiom)", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const MaxDimension = ({ update, save }) => (
+         <input
+           onChange={(e) => { update(parseInt(e.target.value, 10)); }}
+           onKeyDown={(e) => { if (e.key === 'Enter') save(); }}
+         />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on an Enter handler that only calls preventDefault (implicit-submit blocker idiom)", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Field = () => (
+         <input onKeyDown={(e) => { if (e.key === 'Enter') e.preventDefault(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on an Enter handler that only stops propagation", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Field = () => (
+         <input onKeyDown={(e) => { if (e.key === 'Enter') e.stopPropagation(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a readOnly input trigger (date-picker/combobox idiom)", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const DateField = ({ openCalendar }) => (
+         <input readOnly onKeyDown={(e) => { if (e.key === 'Enter') openCalendar(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a type=password Enter-to-login field", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Login = ({ handleLogin }) => (
+         <input type="password" onKeyDown={(e) => { if (e.key === 'Enter') handleLogin(); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags the chat-composer send-on-Enter with a negated Shift gate", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const Chat = ({ send }) => (
+         <textarea onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an unguarded Enter-commit even when nearby names contain 'composer'", () => {
+    const result = runRule(
+      noEnterSubmitWithoutImeCompositionGuard,
+      `const ChatComposer = ({ composerText, onSend }) => (
+         <textarea onKeyDown={(e) => { if (e.key === 'Enter') onSend(composerText); }} />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-enter-submit-without-ime-composition-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-enter-submit-without-ime-composition-guard.ts
@@ -1,0 +1,351 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
+import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const KEY_HANDLER_ATTRS = ["onKeyDown", "onKeyUp"] as const;
+const NON_TEXT_ENTRY_ROLES = new Set([
+  "button",
+  "radio",
+  "checkbox",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "tab",
+  "switch",
+  "link",
+  "slider",
+  "spinbutton",
+  "treeitem",
+  "gridcell",
+]);
+const TEXT_ENTRY_ROLES = new Set(["textbox", "searchbox", "combobox"]);
+const NON_TEXT_INPUT_TYPES = new Set([
+  "radio",
+  "checkbox",
+  "button",
+  "submit",
+  "reset",
+  "file",
+  "range",
+  "color",
+  "image",
+  "hidden",
+  "number",
+  "password",
+  "date",
+  "time",
+  "week",
+  "month",
+  "datetime-local",
+]);
+const NUMERIC_INPUT_MODES = new Set(["numeric", "decimal"]);
+const NUMERIC_COERCION_CALLEES = new Set(["Number", "parseInt", "parseFloat"]);
+const NON_COMMIT_CALL_PROPERTIES = new Set([
+  "preventDefault",
+  "stopPropagation",
+  "stopImmediatePropagation",
+]);
+const MODIFIER_PROPERTIES = new Set(["metaKey", "ctrlKey", "shiftKey", "altKey"]);
+const COMPOSITION_TEXT_PATTERN = /composi/i;
+const IME_COMPOSITION_KEYCODE = 229;
+const ENTER_KEYCODE = 13;
+const SPACE_KEYCODE = 32;
+
+const MESSAGE =
+  "This text-entry Enter handler commits/submits without bailing on IME composition, so it fires mid-composition for CJK users pressing Enter to confirm a candidate. Bail first with `if (e.nativeEvent.isComposing) return;` (or track `onCompositionStart`/`onCompositionEnd`) before acting on Enter.";
+
+const getStringAttr = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  name: string,
+): string | null => {
+  const attribute = hasJsxPropIgnoreCase(node.attributes, name);
+  return attribute ? getJsxPropStringValue(attribute) : null;
+};
+
+const memberPropertyName = (node: EsTreeNode): string | null => {
+  if (
+    isNodeOfType(node, "MemberExpression") &&
+    !node.computed &&
+    isNodeOfType(node.property, "Identifier")
+  ) {
+    return node.property.name;
+  }
+  return null;
+};
+
+const argumentReadsValueMember = (argument: EsTreeNode): boolean => {
+  let readsValue = false;
+  walkAst(argument, (child) => {
+    if (readsValue) return false;
+    if (memberPropertyName(child) === "value") {
+      readsValue = true;
+      return false;
+    }
+  });
+  return readsValue;
+};
+
+const isNumericCoercionOfValue = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripGroupingParens(node.callee as EsTreeNode);
+  let calleeName: string | null = null;
+  if (isNodeOfType(callee, "Identifier")) {
+    calleeName = callee.name;
+  } else if (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.object, "Identifier") &&
+    callee.object.name === "Number" &&
+    isNodeOfType(callee.property, "Identifier")
+  ) {
+    calleeName = callee.property.name;
+  }
+  if (!calleeName || !NUMERIC_COERCION_CALLEES.has(calleeName)) return false;
+  const firstArgument = node.arguments[0];
+  return Boolean(firstArgument) && argumentReadsValueMember(firstArgument as EsTreeNode);
+};
+
+const onChangeCoercesValueNumerically = (node: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
+  const attribute = hasJsxPropIgnoreCase(node.attributes, "onChange");
+  if (!attribute || !attribute.value) return false;
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return false;
+  const changeHandler = stripGroupingParens(attribute.value.expression as EsTreeNode);
+  if (!isFunctionLike(changeHandler)) return false;
+  let coercesValue = false;
+  walkAst(changeHandler, (child) => {
+    if (coercesValue) return false;
+    if (isNumericCoercionOfValue(child)) {
+      coercesValue = true;
+      return false;
+    }
+  });
+  return coercesValue;
+};
+
+const isTextEntryElement = (node: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
+  const role = getStringAttr(node, "role");
+  if (role && NON_TEXT_ENTRY_ROLES.has(role)) return false;
+  if (hasJsxPropIgnoreCase(node.attributes, "readOnly")) return false;
+
+  const inputMode = getStringAttr(node, "inputMode");
+  if (inputMode && NUMERIC_INPUT_MODES.has(inputMode.toLowerCase())) return false;
+  if (onChangeCoercesValueNumerically(node)) return false;
+
+  const tag = isNodeOfType(node.name, "JSXIdentifier") ? node.name.name.toLowerCase() : "";
+  if (tag === "textarea") return true;
+  if (tag === "input") {
+    const inputType = getStringAttr(node, "type");
+    if (inputType && NON_TEXT_INPUT_TYPES.has(inputType.toLowerCase())) return false;
+    return true;
+  }
+  if (hasJsxPropIgnoreCase(node.attributes, "contentEditable")) return true;
+  if (role && TEXT_ENTRY_ROLES.has(role)) return true;
+  return false;
+};
+
+const isEnterKeyTest = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "BinaryExpression")) return false;
+  if (node.operator !== "===" && node.operator !== "==") return false;
+  const left = stripGroupingParens(node.left as EsTreeNode);
+  const right = stripGroupingParens(node.right as EsTreeNode);
+  const check = (memberSide: EsTreeNode, valueSide: EsTreeNode): boolean => {
+    const property = memberPropertyName(memberSide);
+    if (property === "key") {
+      return isNodeOfType(valueSide, "Literal") && valueSide.value === "Enter";
+    }
+    if (property === "keyCode" || property === "which") {
+      return isNodeOfType(valueSide, "Literal") && valueSide.value === ENTER_KEYCODE;
+    }
+    return false;
+  };
+  return check(left, right) || check(right, left);
+};
+
+interface EnterBranch {
+  testExpr: EsTreeNode;
+  actionNode: EsTreeNode;
+}
+
+const analyzeEnterBranch = (enterTest: EsTreeNode): EnterBranch | null => {
+  let prev = enterTest;
+  let cursor = enterTest.parent ?? null;
+  while (cursor) {
+    if (isFunctionLike(cursor)) break;
+    if (isNodeOfType(cursor, "IfStatement")) {
+      if (cursor.test === prev)
+        return {
+          testExpr: cursor.test as EsTreeNode,
+          actionNode: cursor.consequent as EsTreeNode,
+        };
+      break;
+    }
+    if (isNodeOfType(cursor, "ConditionalExpression")) {
+      if (cursor.test === prev)
+        return {
+          testExpr: cursor.test as EsTreeNode,
+          actionNode: cursor.consequent as EsTreeNode,
+        };
+      break;
+    }
+    if (isNodeOfType(cursor, "ExpressionStatement")) {
+      const expr = stripGroupingParens(cursor.expression as EsTreeNode);
+      if (isNodeOfType(expr, "LogicalExpression") && expr.operator === "&&") {
+        return { testExpr: expr, actionNode: expr };
+      }
+      break;
+    }
+    prev = cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+const testUsesModifierOrSpace = (testExpr: EsTreeNode): boolean => {
+  let found = false;
+  walkAst(testExpr, (child) => {
+    if (found) return false;
+    if (isNodeOfType(child, "UnaryExpression") && child.operator === "!") return false;
+    const property = memberPropertyName(child);
+    if (property && MODIFIER_PROPERTIES.has(property)) {
+      found = true;
+      return false;
+    }
+    if (
+      isNodeOfType(child, "BinaryExpression") &&
+      (child.operator === "===" || child.operator === "==")
+    ) {
+      const left = stripGroupingParens(child.left as EsTreeNode);
+      const right = stripGroupingParens(child.right as EsTreeNode);
+      const checkSpace = (memberSide: EsTreeNode, valueSide: EsTreeNode): boolean => {
+        const memberProperty = memberPropertyName(memberSide);
+        if (memberProperty === "key") {
+          return (
+            isNodeOfType(valueSide, "Literal") &&
+            (valueSide.value === " " || valueSide.value === "Spacebar")
+          );
+        }
+        if (memberProperty === "keyCode" || memberProperty === "which") {
+          return isNodeOfType(valueSide, "Literal") && valueSide.value === SPACE_KEYCODE;
+        }
+        return false;
+      };
+      if (checkSpace(left, right) || checkSpace(right, left)) {
+        found = true;
+        return false;
+      }
+    }
+  });
+  return found;
+};
+
+const branchPerformsCommit = (actionNode: EsTreeNode): boolean => {
+  let found = false;
+  walkAst(actionNode, (child) => {
+    if (found) return false;
+    if (isNodeOfType(child, "CallExpression")) {
+      const calleeProperty = memberPropertyName(stripGroupingParens(child.callee as EsTreeNode));
+      if (calleeProperty && NON_COMMIT_CALL_PROPERTIES.has(calleeProperty)) return;
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+const componentHasCompositionGuard = (scope: EsTreeNode): boolean => {
+  let found = false;
+  walkAst(scope, (child) => {
+    if (found) return false;
+    if (
+      (isNodeOfType(child, "Identifier") || isNodeOfType(child, "JSXIdentifier")) &&
+      COMPOSITION_TEXT_PATTERN.test(child.name)
+    ) {
+      found = true;
+      return false;
+    }
+    if (isNodeOfType(child, "Literal") && child.value === IME_COMPOSITION_KEYCODE) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+const getHandlerFunction = (node: EsTreeNodeOfType<"JSXOpeningElement">): EsTreeNode | null => {
+  for (const attributeName of KEY_HANDLER_ATTRS) {
+    const attribute = hasJsxPropIgnoreCase(node.attributes, attributeName);
+    if (!attribute || !attribute.value) continue;
+    if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) continue;
+    const expression = stripGroupingParens(attribute.value.expression as EsTreeNode);
+    if (isFunctionLike(expression)) return expression;
+  }
+  return null;
+};
+
+const findCompositionScope = (node: EsTreeNode): EsTreeNode => {
+  let ancestor = node.parent ?? null;
+  while (ancestor) {
+    if (isFunctionLike(ancestor)) return ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return node.parent ?? node;
+};
+
+// Flags an `onKeyDown`/`onKeyUp` handler on a text-entry element that
+// commits/submits on plain Enter without an IME-composition bail-out.
+// Pressing Enter while an IME is composing confirms the candidate, so a
+// bare Enter-submit fires mid-composition and corrupts input for CJK
+// users. Stays quiet on non-text-entry roles (button/radio/menuitem),
+// inputs that cannot host composition (type number/password/date/time,
+// `inputMode` numeric/decimal, `readOnly`, or an `onChange` that coerces
+// the value via Number/parseInt/parseFloat), modifier-gated
+// (Cmd/Ctrl+Enter) or Space+Enter activation, `preventDefault`-only
+// handlers, and handlers already guarded by `isComposing` /
+// `keyCode === 229` / composition state. A negated modifier
+// (`!e.shiftKey`) is not a gate — plain Enter still commits there.
+export const noEnterSubmitWithoutImeCompositionGuard = defineRule({
+  id: "no-enter-submit-without-ime-composition-guard",
+  title: "Enter submit without IME composition guard",
+  severity: "warn",
+  category: "Correctness",
+  tags: ["react-jsx-only"],
+  recommendation:
+    "Bail on IME composition before acting on Enter: `if (e.nativeEvent.isComposing) return;` (or track composition with `onCompositionStart`/`onCompositionEnd`). Otherwise Enter fires mid-composition and commits a half-typed value for CJK users.",
+  create: (context: RuleContext) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (!isTextEntryElement(node)) return;
+      const handler = getHandlerFunction(node);
+      if (!handler) return;
+
+      const enterTests: EsTreeNode[] = [];
+      walkAst(handler, (child) => {
+        if (isEnterKeyTest(child)) enterTests.push(child);
+      });
+      if (enterTests.length === 0) return;
+
+      let hasBareEnterCommit = false;
+      for (const enterTest of enterTests) {
+        const branch = analyzeEnterBranch(enterTest);
+        if (!branch) continue;
+        if (testUsesModifierOrSpace(branch.testExpr)) continue;
+        if (!branchPerformsCommit(branch.actionNode)) continue;
+        hasBareEnterCommit = true;
+        break;
+      }
+      if (!hasBareEnterCommit) return;
+
+      const scope = findCompositionScope(node as EsTreeNode);
+      if (componentHasCompositionGuard(scope)) return;
+
+      context.report({ node: node.name as EsTreeNode, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-enter-submit-without-ime-composition-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-enter-submit-without-ime-composition-guard.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -260,7 +261,7 @@ const branchPerformsCommit = (actionNode: EsTreeNode): boolean => {
   return found;
 };
 
-const componentHasCompositionGuard = (scope: EsTreeNode): boolean => {
+const scopeHasCompositionGuard = (scope: EsTreeNode): boolean => {
   let found = false;
   walkAst(scope, (child) => {
     if (found) return false;
@@ -279,6 +280,33 @@ const componentHasCompositionGuard = (scope: EsTreeNode): boolean => {
   return found;
 };
 
+// Same-file function bodies reachable from the handler through bare
+// identifier calls (`commitEdit()` resolved to its `const commitEdit = …`
+// or `function commitEdit` initializer, then that body's own callees,
+// transitively) — a composition guard may live inside the commit helper
+// chain rather than the inline handler.
+const handlerCalleeInitializers = (handler: EsTreeNode): EsTreeNode[] => {
+  const initializers: EsTreeNode[] = [];
+  const seenCalleeNames = new Set<string>();
+  const pendingScopes: EsTreeNode[] = [handler];
+  while (pendingScopes.length > 0) {
+    const scope = pendingScopes.pop();
+    if (!scope) continue;
+    walkAst(scope, (child) => {
+      if (!isNodeOfType(child, "CallExpression")) return;
+      const callee = stripGroupingParens(child.callee as EsTreeNode);
+      if (!isNodeOfType(callee, "Identifier") || seenCalleeNames.has(callee.name)) return;
+      seenCalleeNames.add(callee.name);
+      const binding = findVariableInitializer(callee, callee.name);
+      if (binding?.initializer) {
+        initializers.push(binding.initializer);
+        pendingScopes.push(binding.initializer);
+      }
+    });
+  }
+  return initializers;
+};
+
 const getHandlerFunction = (node: EsTreeNodeOfType<"JSXOpeningElement">): EsTreeNode | null => {
   for (const attributeName of KEY_HANDLER_ATTRS) {
     const attribute = hasJsxPropIgnoreCase(node.attributes, attributeName);
@@ -290,15 +318,6 @@ const getHandlerFunction = (node: EsTreeNodeOfType<"JSXOpeningElement">): EsTree
   return null;
 };
 
-const findCompositionScope = (node: EsTreeNode): EsTreeNode => {
-  let ancestor = node.parent ?? null;
-  while (ancestor) {
-    if (isFunctionLike(ancestor)) return ancestor;
-    ancestor = ancestor.parent ?? null;
-  }
-  return node.parent ?? node;
-};
-
 // Flags an `onKeyDown`/`onKeyUp` handler on a text-entry element that
 // commits/submits on plain Enter without an IME-composition bail-out.
 // Pressing Enter while an IME is composing confirms the candidate, so a
@@ -308,8 +327,10 @@ const findCompositionScope = (node: EsTreeNode): EsTreeNode => {
 // `inputMode` numeric/decimal, `readOnly`, or an `onChange` that coerces
 // the value via Number/parseInt/parseFloat), modifier-gated
 // (Cmd/Ctrl+Enter) or Space+Enter activation, `preventDefault`-only
-// handlers, and handlers already guarded by `isComposing` /
-// `keyCode === 229` / composition state. A negated modifier
+// handlers, and handlers guarded by `isComposing` / `keyCode === 229` /
+// composition wiring on the element itself, in the handler body, or in a
+// same-file function the handler calls — a sibling control's guard does
+// not protect this handler and does not suppress. A negated modifier
 // (`!e.shiftKey`) is not a gate — plain Enter still commits there.
 export const noEnterSubmitWithoutImeCompositionGuard = defineRule({
   id: "no-enter-submit-without-ime-composition-guard",
@@ -342,8 +363,14 @@ export const noEnterSubmitWithoutImeCompositionGuard = defineRule({
       }
       if (!hasBareEnterCommit) return;
 
-      const scope = findCompositionScope(node as EsTreeNode);
-      if (componentHasCompositionGuard(scope)) return;
+      // A composition guard only protects THIS handler when it is wired
+      // on the element itself (`onCompositionStart`/`onCompositionEnd`
+      // attrs), read inside the handler (`isComposing`, `229`), or
+      // checked inside a same-file function the handler calls. A sibling
+      // control's guard elsewhere in the component does not stop this
+      // handler firing mid-composition, so it must not suppress.
+      const guardScopes = [node as EsTreeNode, ...handlerCalleeInitializers(handler)];
+      if (guardScopes.some(scopeHasCompositionGuard)) return;
 
       context.report({ node: node.name as EsTreeNode, message: MESSAGE });
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fetch-response-used-without-status-check.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fetch-response-used-without-status-check.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noFetchResponseUsedWithoutStatusCheck } from "./no-fetch-response-used-without-status-check.js";
+
+describe("no-fetch-response-used-without-status-check", () => {
+  it("flags a .then callback consuming json without a status check", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `fetch(url, { signal }).then(async (response) => ({
+         emojis: await response.json(),
+       }));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an awaited response consumed without a status check", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         const response = await fetch(endpoint);
+         const data = await response.json();
+         return data;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags immediate double-await consumption", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         const data = await (await fetch(url)).json();
+         return data;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a dead truthiness guard on the Response", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function reload() {
+         const shouldReload = await fetch(url);
+         if (!shouldReload) return;
+         const json = await shouldReload.json();
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the Response is returned to the caller", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function http(url, options) {
+         const response = await fetch(url, options);
+         const json = await response.json();
+         return { response, json };
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when response.ok is checked before consuming", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         const response = await fetch(endpoint);
+         if (!response.ok) throw new Error(response.statusText);
+         return response.json();
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when response.status is checked", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function reload() {
+         const shouldReload = await fetch(url);
+         if (shouldReload.status !== 200) return;
+         const json = await shouldReload.json();
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for an imported / aliased fetch wrapper", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `import { fetch } from 'cross-fetch';
+       async function load() {
+         const response = await fetch(endpoint);
+         const data = await response.json();
+         return data;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a member-call wrapper (api.fetch)", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         const response = await api.fetch(endpoint);
+         const data = await response.json();
+         return data;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when fetch appears only inside a comment", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `// fetch(url).then((r) => r.json())
+       const value = 1;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the Response is returned without being consumed", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function raw(url) {
+         const response = await fetch(url);
+         return response;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the Response is passed to a throw-on-error validator (assertOk idiom)", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         const response = await fetch(endpoint);
+         assertOk(response);
+         return response.json();
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when ok/status is checked through destructuring", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         const response = await fetch(endpoint);
+         const { ok, status } = response;
+         if (!ok) throw new Error(String(status));
+         return response.json();
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on the live offline-ping guard (`let response; try { response = await fetch } catch {}`)", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function ping() {
+         let response;
+         try {
+           response = await fetch(url);
+         } catch {}
+         if (!response) setOffline(true);
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when only a shadowed inner response is consumed, not the outer fetch Response", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function warmCache() {
+         const response = await fetch(url);
+         registerRefresh(async () => {
+           const response = await client.load(other);
+           const data = await response.json();
+           return data;
+         });
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an unchecked consume even when a shadowed inner response is ok-checked", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         const response = await fetch(url);
+         const data = await response.json();
+         onRefresh(async () => {
+           const response = await authorizedFetch(other);
+           if (!response.ok) throw new Error();
+           return response.json();
+         });
+         return data;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the flagship pattern at module top level (top-level await)", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `const response = await fetch(url);
+       const data = await response.json();
+       export default data;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when a .catch link materializes the failure with a fallback value", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `fetch(url)
+         .then((response) => response.json())
+         .then((posts) => setPosts(posts))
+         .catch(() => setPosts([]));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when a two-arg .then routes rejections into error state", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `fetch(url).then(
+         (response) => response.json(),
+         (error) => setError(error),
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a chain whose only .catch merely logs", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `fetch(url)
+         .then((response) => response.json())
+         .then(setData)
+         .catch((error) => console.error(error));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when an enclosing try/catch surfaces the failure as error state", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         try {
+           const response = await fetch(url);
+           const data = await response.json();
+           setItems(data);
+         } catch (error) {
+           setError(error);
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags an awaited consume whose enclosing catch only logs", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function load() {
+         try {
+           const response = await fetch(url);
+           const data = await response.json();
+           setItems(data);
+         } catch (error) {
+           console.error(error);
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when fetching a data: URL literal (no HTTP status possible)", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `fetch('data:image/png;base64,AAAA')
+         .then((response) => response.blob())
+         .then(save);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when fetching a data: template URL through a local binding", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function download(mime, base64) {
+         const dataUrl = \`data:\${mime};base64,\${base64}\`;
+         const blob = await fetch(dataUrl).then((response) => response.blob());
+         save(blob);
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when fetching a blob: object URL", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function read(objectUrl) {
+         const blobUrl = 'blob:' + objectUrl;
+         const response = await fetch(blobUrl);
+         const buffer = await response.arrayBuffer();
+         return buffer;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when an awaited .then chain sits in a try whose catch materializes the failure", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function download(url) {
+         try {
+           const blob = await fetch(url).then((response) => response.blob());
+           save(blob);
+         } catch (error) {
+           setError('Failed to download');
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a non-awaited .then chain inside a materializing try (the try never sees the rejection)", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `function load(url) {
+         try {
+           fetch(url)
+             .then((response) => response.json())
+             .then(setData);
+         } catch (error) {
+           setError(error);
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an awaited .then consume with no try (getServerSideProps shape)", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `export async function getServerSideProps() {
+         const repositoryData = await fetch(
+           'https://api.github.com/repos/example/repo'
+         ).then((res) => res.json());
+         return { props: { repositoryData } };
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an https template URL resolved through a constant base", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `const BASE_URL = 'https://internxt.com';
+       async function getDownloadAppUrl() {
+         const fetchDownloadResponse = await fetch(\`\${BASE_URL}/api/download\`, { method: 'GET' });
+         const response = await fetchDownloadResponse.json();
+         return response.platforms;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet in gatsby-node build scripts", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `export const sourceNodes = async () => {
+         const response = await fetch('https://api.github.com/repos/example/repo');
+         const data = await response.json();
+         return data;
+       };`,
+      { filename: "docs/gatsby-node.mjs" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet in Storybook loader/demo files", () => {
+    const result = runRule(
+      noFetchResponseUsedWithoutStatusCheck,
+      `async function loadAvatar() {
+         const response = await fetch(endpoint);
+         const data = await response.json();
+         render(data);
+       }`,
+      { filename: "src/components/avatar.stories.tsx" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fetch-response-used-without-status-check.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fetch-response-used-without-status-check.ts
@@ -1,0 +1,533 @@
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
+
+// oxc-parser surfaces `(...)` as a node kind outside the TSESTree union,
+// so it is matched via a `string`-typed constant.
+const PARENTHESIZED_EXPRESSION: string = "ParenthesizedExpression";
+const BODY_CONSUMER_METHODS = new Set(["json", "text", "blob", "arrayBuffer", "formData"]);
+const STATUS_CHECK_PROPERTIES = new Set(["ok", "status"]);
+const PROMISE_CHAIN_METHODS = new Set(["then", "catch", "finally"]);
+// `data:` / `blob:` URLs decode in-process — they can never produce an
+// HTTP 4xx/5xx, so the Response is always ok and a status check is noise.
+const INERT_URL_SCHEME_PATTERN = /^(?:data|blob):/i;
+const MAX_URL_BINDING_RESOLUTION_DEPTH = 4;
+// Build-time scripts (Gatsby node APIs, *.config.* files) run once at
+// build and fail the build loudly on a bad response — not user-facing.
+const BUILD_SCRIPT_BASENAME_PATTERN = /^gatsby-(?:node|config|ssr|browser)\.|\.config\./i;
+
+const MESSAGE =
+  "`fetch()` resolves (does not reject) on HTTP 4xx/5xx, so consuming this Response without checking `response.ok`/`response.status` parses an error body as success or crashes on a truthiness guard that is always true. Check `if (!response.ok) throw ...` before reading `.json()`/`.text()`/`.blob()`.";
+
+const meaningfulParent = (node: EsTreeNode): EsTreeNode | null => {
+  let parent = node.parent ?? null;
+  while (parent && parent.type === PARENTHESIZED_EXPRESSION) parent = parent.parent ?? null;
+  return parent;
+};
+
+const isGlobalFetchCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = node.callee;
+  if (!isNodeOfType(callee, "Identifier") || callee.name !== "fetch") return false;
+  // An imported / aliased / locally-bound `fetch` is a wrapper whose
+  // status check the detector can't see; only root at the DOM global.
+  if (findVariableInitializer(callee, "fetch")) return false;
+  return true;
+};
+
+const resolveStaticUrlPrefix = (argument: EsTreeNode, depth: number): string | null => {
+  if (depth > MAX_URL_BINDING_RESOLUTION_DEPTH) return null;
+  const expression = stripGroupingParens(argument);
+  if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
+    return expression.value;
+  }
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    return expression.quasis[0]?.value.cooked ?? null;
+  }
+  if (isNodeOfType(expression, "BinaryExpression") && expression.operator === "+") {
+    return resolveStaticUrlPrefix(expression.left as EsTreeNode, depth + 1);
+  }
+  if (isNodeOfType(expression, "Identifier")) {
+    const binding = findVariableInitializer(expression, expression.name);
+    if (!binding?.initializer || binding.initializer === expression) return null;
+    return resolveStaticUrlPrefix(binding.initializer, depth + 1);
+  }
+  return null;
+};
+
+const fetchesInertUrlScheme = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const firstArgument = node.arguments?.[0];
+  if (!firstArgument) return false;
+  const urlPrefix = resolveStaticUrlPrefix(firstArgument as EsTreeNode, 0);
+  return urlPrefix !== null && INERT_URL_SCHEME_PATTERN.test(urlPrefix);
+};
+
+const nearestFunctionOrProgram = (node: EsTreeNode): EsTreeNode | null => {
+  let ancestor = node.parent ?? null;
+  while (ancestor) {
+    if (isFunctionLike(ancestor) || isNodeOfType(ancestor, "Program")) return ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return null;
+};
+
+const functionRebindsName = (functionNode: EsTreeNode, name: string): boolean => {
+  if (!isFunctionLike(functionNode)) return false;
+  const parameterNames = new Set<string>();
+  for (const parameter of functionNode.params ?? []) {
+    collectPatternNames(parameter as EsTreeNode, parameterNames);
+  }
+  if (parameterNames.has(name)) return true;
+  let didRebind = false;
+  walkAst(functionNode.body as EsTreeNode, (child) => {
+    if (didRebind) return false;
+    if (isNodeOfType(child, "VariableDeclarator")) {
+      const declaredNames = new Set<string>();
+      collectPatternNames(child.id as EsTreeNode, declaredNames);
+      if (declaredNames.has(name)) {
+        didRebind = true;
+        return false;
+      }
+    }
+  });
+  return didRebind;
+};
+
+// Walks `scope` without descending into nested functions that rebind
+// `responseName` — a shadowed inner `response` is a different variable,
+// so its checks/consumes must not be attributed to the outer Response.
+const walkScopeSkippingShadows = (
+  scope: EsTreeNode,
+  responseName: string,
+  visitor: (child: EsTreeNode) => boolean | void,
+): void => {
+  walkAst(scope, (child) => {
+    if (child !== scope && isFunctionLike(child) && functionRebindsName(child, responseName)) {
+      return false;
+    }
+    return visitor(child);
+  });
+};
+
+const isBodyConsumeCall = (node: EsTreeNode, responseName: string): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = node.callee;
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.object, "Identifier") &&
+    callee.object.name === responseName &&
+    isNodeOfType(callee.property, "Identifier") &&
+    BODY_CONSUMER_METHODS.has(callee.property.name)
+  );
+};
+
+const isTruthinessTest = (node: EsTreeNode, responseName: string): boolean =>
+  isNodeOfType(node, "UnaryExpression") &&
+  node.operator === "!" &&
+  isNodeOfType(node.argument, "Identifier") &&
+  node.argument.name === responseName;
+
+const scopeConsumesResponse = (
+  scope: EsTreeNode,
+  responseName: string,
+  countTruthinessGuard: boolean,
+): boolean => {
+  let found = false;
+  walkScopeSkippingShadows(scope, responseName, (child) => {
+    if (found) return false;
+    if (
+      isBodyConsumeCall(child, responseName) ||
+      (countTruthinessGuard && isTruthinessTest(child, responseName))
+    ) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+const isStatusMemberAccess = (node: EsTreeNode, responseName: string): boolean =>
+  isNodeOfType(node, "MemberExpression") &&
+  !node.computed &&
+  isNodeOfType(node.object, "Identifier") &&
+  node.object.name === responseName &&
+  isNodeOfType(node.property, "Identifier") &&
+  STATUS_CHECK_PROPERTIES.has(node.property.name);
+
+// `const { ok, status } = response` is a status check performed through
+// destructuring rather than member access.
+const isStatusDestructuring = (node: EsTreeNode, responseName: string): boolean => {
+  if (!isNodeOfType(node, "VariableDeclarator") || !isNodeOfType(node.id, "ObjectPattern")) {
+    return false;
+  }
+  if (!node.init) return false;
+  const initializer = stripGroupingParens(node.init as EsTreeNode);
+  if (!isNodeOfType(initializer, "Identifier") || initializer.name !== responseName) return false;
+  return (node.id.properties ?? []).some(
+    (property) =>
+      isNodeOfType(property, "Property") &&
+      !property.computed &&
+      isNodeOfType(property.key, "Identifier") &&
+      STATUS_CHECK_PROPERTIES.has(property.key.name),
+  );
+};
+
+const scopeChecksStatus = (scope: EsTreeNode, responseName: string): boolean => {
+  let found = false;
+  walkScopeSkippingShadows(scope, responseName, (child) => {
+    if (found) return false;
+    if (isStatusMemberAccess(child, responseName) || isStatusDestructuring(child, responseName)) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+const isConsumingReceiver = (identifier: EsTreeNode): boolean => {
+  const parent = identifier.parent;
+  return Boolean(
+    parent &&
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.object === identifier &&
+    !parent.computed &&
+    isNodeOfType(parent.property, "Identifier") &&
+    (BODY_CONSUMER_METHODS.has(parent.property.name) ||
+      STATUS_CHECK_PROPERTIES.has(parent.property.name)),
+  );
+};
+
+const isPassedAsCallArgument = (identifier: EsTreeNode): boolean => {
+  const parent = identifier.parent;
+  if (!parent) return false;
+  if (!isNodeOfType(parent, "CallExpression") && !isNodeOfType(parent, "NewExpression")) {
+    return false;
+  }
+  if (parent.callee === identifier) return false;
+  return (parent.arguments ?? []).some((argument) => argument === identifier);
+};
+
+// The Response escapes the scope — returned to a caller
+// (`return response` / `return { response }`) or handed to another
+// function (`assertOk(response)`, the throw-on-error validator idiom) —
+// so its status check is legitimately deferred to the receiver.
+const scopeResponseEscapes = (scope: EsTreeNode, responseName: string): boolean => {
+  let found = false;
+  walkScopeSkippingShadows(scope, responseName, (child) => {
+    if (found) return false;
+    if (isNodeOfType(child, "ReturnStatement") && child.argument) {
+      walkAst(child.argument as EsTreeNode, (inner) => {
+        if (found) return false;
+        if (
+          isNodeOfType(inner, "Identifier") &&
+          inner.name === responseName &&
+          !isConsumingReceiver(inner)
+        ) {
+          found = true;
+          return false;
+        }
+      });
+      if (found) return false;
+      return;
+    }
+    if (
+      isNodeOfType(child, "Identifier") &&
+      child.name === responseName &&
+      isPassedAsCallArgument(child)
+    ) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+const isConsoleCall = (expression: EsTreeNode): boolean => {
+  const call = stripGroupingParens(expression);
+  return (
+    isNodeOfType(call, "CallExpression") &&
+    isNodeOfType(call.callee, "MemberExpression") &&
+    isNodeOfType(call.callee.object, "Identifier") &&
+    call.callee.object.name === "console"
+  );
+};
+
+const isLoggingOnlyStatement = (statement: EsTreeNode): boolean =>
+  isNodeOfType(statement, "ExpressionStatement") &&
+  isConsoleCall(statement.expression as EsTreeNode);
+
+const statementsMaterializeError = (statements: ReadonlyArray<EsTreeNode>): boolean =>
+  statements.some((statement) => !isLoggingOnlyStatement(statement));
+
+// A rejection handler "materializes" the failure when it does more than
+// log — sets error state, returns a fallback value, rethrows. A named
+// handler reference is trusted the same way (its body is out of view but
+// it exists to handle the failure).
+const isErrorMaterializingHandler = (handlerExpression: EsTreeNode): boolean => {
+  const handler = stripGroupingParens(handlerExpression);
+  if (!isFunctionLike(handler)) {
+    return isNodeOfType(handler, "Identifier") || isNodeOfType(handler, "MemberExpression");
+  }
+  if (isNodeOfType(handler.body, "BlockStatement")) {
+    return statementsMaterializeError(handler.body.body ?? []);
+  }
+  return Boolean(handler.body) && !isConsoleCall(handler.body as EsTreeNode);
+};
+
+// Walks the member-call chain rooted at the fetch CallExpression looking
+// for a `.catch(fn)` link (or a two-argument `.then(fn, rejectionFn)`)
+// whose handler materializes the failure — the dominant real-world shape
+// where the author already routes fetch errors somewhere visible.
+const chainMaterializesRejection = (fetchCall: EsTreeNode): boolean => {
+  let chainLink: EsTreeNode = fetchCall;
+  while (true) {
+    const member = meaningfulParent(chainLink);
+    if (
+      !member ||
+      !isNodeOfType(member, "MemberExpression") ||
+      stripGroupingParens(member.object as EsTreeNode) !== chainLink ||
+      member.computed ||
+      !isNodeOfType(member.property, "Identifier") ||
+      !PROMISE_CHAIN_METHODS.has(member.property.name)
+    ) {
+      return false;
+    }
+    const chainCall = meaningfulParent(member);
+    if (
+      !chainCall ||
+      !isNodeOfType(chainCall, "CallExpression") ||
+      stripGroupingParens(chainCall.callee as EsTreeNode) !== member
+    ) {
+      return false;
+    }
+    const chainArguments = chainCall.arguments ?? [];
+    if (
+      member.property.name === "catch" &&
+      chainArguments[0] &&
+      isErrorMaterializingHandler(chainArguments[0] as EsTreeNode)
+    ) {
+      return true;
+    }
+    if (
+      member.property.name === "then" &&
+      chainArguments[1] &&
+      isErrorMaterializingHandler(chainArguments[1] as EsTreeNode)
+    ) {
+      return true;
+    }
+    chainLink = chainCall;
+  }
+};
+
+const outermostPromiseChainCall = (fetchCall: EsTreeNode): EsTreeNode => {
+  let chainLink: EsTreeNode = fetchCall;
+  while (true) {
+    const member = meaningfulParent(chainLink);
+    if (
+      !member ||
+      !isNodeOfType(member, "MemberExpression") ||
+      stripGroupingParens(member.object as EsTreeNode) !== chainLink ||
+      member.computed ||
+      !isNodeOfType(member.property, "Identifier") ||
+      !PROMISE_CHAIN_METHODS.has(member.property.name)
+    ) {
+      return chainLink;
+    }
+    const chainCall = meaningfulParent(member);
+    if (
+      !chainCall ||
+      !isNodeOfType(chainCall, "CallExpression") ||
+      stripGroupingParens(chainCall.callee as EsTreeNode) !== member
+    ) {
+      return chainLink;
+    }
+    chainLink = chainCall;
+  }
+};
+
+// A `try { ... await fetch ... } catch` whose catch clause materializes
+// the failure covers the awaited Response the same way a `.catch` link
+// covers a promise chain.
+const enclosingTryMaterializesErrors = (node: EsTreeNode): boolean => {
+  let current: EsTreeNode = node;
+  let ancestor = node.parent ?? null;
+  while (ancestor && !isFunctionLike(ancestor)) {
+    if (
+      isNodeOfType(ancestor, "TryStatement") &&
+      ancestor.block === current &&
+      ancestor.handler &&
+      isNodeOfType(ancestor.handler, "CatchClause") &&
+      statementsMaterializeError(ancestor.handler.body?.body ?? [])
+    ) {
+      return true;
+    }
+    current = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+// `await fetch(...).then(...)` inside a materializing try-catch: the
+// await routes the chain's rejection into the catch clause, so the
+// failure is covered the same way the awaited-declarator shapes are.
+// Without the await the try never sees the rejection, so it exempts
+// nothing.
+const awaitedChainCoveredByMaterializingTry = (fetchCall: EsTreeNode): boolean => {
+  const chainConsumer = meaningfulParent(outermostPromiseChainCall(fetchCall));
+  return Boolean(
+    chainConsumer &&
+    isNodeOfType(chainConsumer, "AwaitExpression") &&
+    enclosingTryMaterializesErrors(chainConsumer),
+  );
+};
+
+interface UnguardedReportInput {
+  context: RuleContext;
+  reportNode: EsTreeNode;
+  scope: EsTreeNode;
+  responseName: string;
+  // `let response; try { response = await fetch(...) } catch {}` leaves the
+  // binding undefined on network error, so a `!response` guard is live —
+  // only count truthiness guards as dead when the binding is a declarator
+  // (or a callback parameter) that always holds a Response.
+  responseBindingCanBeUndefined: boolean;
+}
+
+const reportUnguarded = ({
+  context,
+  reportNode,
+  scope,
+  responseName,
+  responseBindingCanBeUndefined,
+}: UnguardedReportInput): void => {
+  if (!scopeConsumesResponse(scope, responseName, !responseBindingCanBeUndefined)) return;
+  if (scopeChecksStatus(scope, responseName)) return;
+  if (scopeResponseEscapes(scope, responseName)) return;
+  context.report({ node: reportNode, message: MESSAGE });
+};
+
+// Flags consuming a global-`fetch` Response without an `ok`/`status`
+// check: `.json()`/`.text()`/`.blob()` (or a truthiness test on the
+// Response, which is always truthy) with no preceding `response.ok` /
+// `response.status`. `fetch` resolves on 4xx/5xx, so the error body is
+// parsed as success. Roots only at the literal global `fetch`, and stays
+// quiet when the Response escapes to a caller or validator, when a
+// `.catch` / two-arg `.then` / enclosing try-catch materializes the
+// failure beyond logging, when the URL is a `data:`/`blob:` scheme that
+// can never yield a non-ok response, and in non-production files
+// (stories, demos, tests, build config, gatsby-node scripts).
+export const noFetchResponseUsedWithoutStatusCheck = defineRule({
+  id: "no-fetch-response-used-without-status-check",
+  title: "fetch Response consumed without status check",
+  severity: "warn",
+  category: "Correctness",
+  tags: ["test-noise"],
+  recommendation:
+    "Check `response.ok` (or `response.status`) before consuming a `fetch` Response with `.json()`/`.text()`/`.blob()`. `fetch` resolves on HTTP 4xx/5xx, so an unchecked response parses the error body as success or crashes on an always-truthy guard.",
+  create: (context: RuleContext): RuleVisitors => {
+    const normalizedFilename = (context.filename ?? "").replaceAll("\\", "/");
+    const basename = normalizedFilename.slice(normalizedFilename.lastIndexOf("/") + 1);
+    if (BUILD_SCRIPT_BASENAME_PATTERN.test(basename)) return {};
+    return {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!isGlobalFetchCall(node)) return;
+        if (fetchesInertUrlScheme(node)) return;
+        const parent = meaningfulParent(node as EsTreeNode);
+        if (!parent) return;
+
+        // Shape: fetch(...).then((response) => ...consume...)
+        if (
+          isNodeOfType(parent, "MemberExpression") &&
+          parent.object === (node as EsTreeNode) &&
+          !parent.computed &&
+          isNodeOfType(parent.property, "Identifier") &&
+          parent.property.name === "then"
+        ) {
+          const thenCall = meaningfulParent(parent);
+          if (!thenCall || !isNodeOfType(thenCall, "CallExpression")) return;
+          const callback = thenCall.arguments?.[0]
+            ? stripGroupingParens(thenCall.arguments[0] as EsTreeNode)
+            : null;
+          if (!callback || !isFunctionLike(callback)) return;
+          const firstParam = callback.params?.[0];
+          if (!firstParam || !isNodeOfType(firstParam as EsTreeNode, "Identifier")) return;
+          if (chainMaterializesRejection(node as EsTreeNode)) return;
+          if (awaitedChainCoveredByMaterializingTry(node as EsTreeNode)) return;
+          reportUnguarded({
+            context,
+            reportNode: node as EsTreeNode,
+            scope: callback,
+            responseName: (firstParam as EsTreeNodeOfType<"Identifier">).name,
+            responseBindingCanBeUndefined: false,
+          });
+          return;
+        }
+
+        // Shape: fetch(...).json() — immediate consume, no status possible.
+        if (
+          isNodeOfType(parent, "MemberExpression") &&
+          parent.object === (node as EsTreeNode) &&
+          !parent.computed &&
+          isNodeOfType(parent.property, "Identifier") &&
+          BODY_CONSUMER_METHODS.has(parent.property.name)
+        ) {
+          context.report({ node: node as EsTreeNode, message: MESSAGE });
+          return;
+        }
+
+        if (isNodeOfType(parent, "AwaitExpression")) {
+          const afterAwait = meaningfulParent(parent);
+          if (!afterAwait) return;
+
+          // (await fetch(...)).json()
+          if (
+            isNodeOfType(afterAwait, "MemberExpression") &&
+            stripGroupingParens(afterAwait.object as EsTreeNode) === parent &&
+            !afterAwait.computed &&
+            isNodeOfType(afterAwait.property, "Identifier") &&
+            BODY_CONSUMER_METHODS.has(afterAwait.property.name)
+          ) {
+            if (enclosingTryMaterializesErrors(parent)) return;
+            context.report({ node: node as EsTreeNode, message: MESSAGE });
+            return;
+          }
+
+          // const response = await fetch(...)
+          let responseName: string | null = null;
+          let responseBindingCanBeUndefined = false;
+          if (
+            isNodeOfType(afterAwait, "VariableDeclarator") &&
+            isNodeOfType(afterAwait.id, "Identifier")
+          ) {
+            responseName = afterAwait.id.name;
+          } else if (
+            isNodeOfType(afterAwait, "AssignmentExpression") &&
+            isNodeOfType(afterAwait.left, "Identifier")
+          ) {
+            responseName = afterAwait.left.name;
+            responseBindingCanBeUndefined = true;
+          }
+          if (!responseName) return;
+          if (enclosingTryMaterializesErrors(parent)) return;
+          const scope = nearestFunctionOrProgram(afterAwait);
+          if (!scope) return;
+          reportUnguarded({
+            context,
+            reportNode: node as EsTreeNode,
+            scope,
+            responseName,
+            responseBindingCanBeUndefined,
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fetch-response-used-without-status-check.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fetch-response-used-without-status-check.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getMeaningfulParent } from "../../utils/get-meaningful-parent.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
@@ -10,9 +11,6 @@ import { walkAst } from "../../utils/walk-ast.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 
-// oxc-parser surfaces `(...)` as a node kind outside the TSESTree union,
-// so it is matched via a `string`-typed constant.
-const PARENTHESIZED_EXPRESSION: string = "ParenthesizedExpression";
 const BODY_CONSUMER_METHODS = new Set(["json", "text", "blob", "arrayBuffer", "formData"]);
 const STATUS_CHECK_PROPERTIES = new Set(["ok", "status"]);
 const PROMISE_CHAIN_METHODS = new Set(["then", "catch", "finally"]);
@@ -26,12 +24,6 @@ const BUILD_SCRIPT_BASENAME_PATTERN = /^gatsby-(?:node|config|ssr|browser)\.|\.c
 
 const MESSAGE =
   "`fetch()` resolves (does not reject) on HTTP 4xx/5xx, so consuming this Response without checking `response.ok`/`response.status` parses an error body as success or crashes on a truthiness guard that is always true. Check `if (!response.ok) throw ...` before reading `.json()`/`.text()`/`.blob()`.";
-
-const meaningfulParent = (node: EsTreeNode): EsTreeNode | null => {
-  let parent = node.parent ?? null;
-  while (parent && parent.type === PARENTHESIZED_EXPRESSION) parent = parent.parent ?? null;
-  return parent;
-};
 
 const isGlobalFetchCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
   const callee = node.callee;
@@ -289,7 +281,7 @@ const isErrorMaterializingHandler = (handlerExpression: EsTreeNode): boolean => 
 const chainMaterializesRejection = (fetchCall: EsTreeNode): boolean => {
   let chainLink: EsTreeNode = fetchCall;
   while (true) {
-    const member = meaningfulParent(chainLink);
+    const member = getMeaningfulParent(chainLink);
     if (
       !member ||
       !isNodeOfType(member, "MemberExpression") ||
@@ -300,7 +292,7 @@ const chainMaterializesRejection = (fetchCall: EsTreeNode): boolean => {
     ) {
       return false;
     }
-    const chainCall = meaningfulParent(member);
+    const chainCall = getMeaningfulParent(member);
     if (
       !chainCall ||
       !isNodeOfType(chainCall, "CallExpression") ||
@@ -330,7 +322,7 @@ const chainMaterializesRejection = (fetchCall: EsTreeNode): boolean => {
 const outermostPromiseChainCall = (fetchCall: EsTreeNode): EsTreeNode => {
   let chainLink: EsTreeNode = fetchCall;
   while (true) {
-    const member = meaningfulParent(chainLink);
+    const member = getMeaningfulParent(chainLink);
     if (
       !member ||
       !isNodeOfType(member, "MemberExpression") ||
@@ -341,7 +333,7 @@ const outermostPromiseChainCall = (fetchCall: EsTreeNode): EsTreeNode => {
     ) {
       return chainLink;
     }
-    const chainCall = meaningfulParent(member);
+    const chainCall = getMeaningfulParent(member);
     if (
       !chainCall ||
       !isNodeOfType(chainCall, "CallExpression") ||
@@ -381,7 +373,7 @@ const enclosingTryMaterializesErrors = (node: EsTreeNode): boolean => {
 // Without the await the try never sees the rejection, so it exempts
 // nothing.
 const awaitedChainCoveredByMaterializingTry = (fetchCall: EsTreeNode): boolean => {
-  const chainConsumer = meaningfulParent(outermostPromiseChainCall(fetchCall));
+  const chainConsumer = getMeaningfulParent(outermostPromiseChainCall(fetchCall));
   return Boolean(
     chainConsumer &&
     isNodeOfType(chainConsumer, "AwaitExpression") &&
@@ -440,7 +432,7 @@ export const noFetchResponseUsedWithoutStatusCheck = defineRule({
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!isGlobalFetchCall(node)) return;
         if (fetchesInertUrlScheme(node)) return;
-        const parent = meaningfulParent(node as EsTreeNode);
+        const parent = getMeaningfulParent(node as EsTreeNode);
         if (!parent) return;
 
         // Shape: fetch(...).then((response) => ...consume...)
@@ -451,7 +443,7 @@ export const noFetchResponseUsedWithoutStatusCheck = defineRule({
           isNodeOfType(parent.property, "Identifier") &&
           parent.property.name === "then"
         ) {
-          const thenCall = meaningfulParent(parent);
+          const thenCall = getMeaningfulParent(parent);
           if (!thenCall || !isNodeOfType(thenCall, "CallExpression")) return;
           const callback = thenCall.arguments?.[0]
             ? stripGroupingParens(thenCall.arguments[0] as EsTreeNode)
@@ -484,7 +476,7 @@ export const noFetchResponseUsedWithoutStatusCheck = defineRule({
         }
 
         if (isNodeOfType(parent, "AwaitExpression")) {
-          const afterAwait = meaningfulParent(parent);
+          const afterAwait = getMeaningfulParent(parent);
           if (!afterAwait) return;
 
           // (await fetch(...)).json()

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fill-map-element-as-key.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fill-map-element-as-key.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noFillMapElementAsKey } from "./no-fill-map-element-as-key.js";
+
+describe("no-fill-map-element-as-key", () => {
+  it("flags Array(n).fill(null).map((index) => key={index})", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Skeleton = ({ count }) => (
+        <>{Array(count).fill(null).map((index) => <Row key={index} />)}</>
+      );`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags new Array(5).fill(0).map((i) => key={i})", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `function Stars() {
+        return new Array(5).fill(0).map((i) => <Star key={i} />);
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Array(3).fill(null).map((idx) => key={String(idx)}) coercion", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Loading = () => (
+        <div>{Array(3).fill(null).map((idx) => <li key={String(idx)}>loading</li>)}</div>
+      );`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Array(n).fill('').map((index) => key={String(index)})", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Placeholders = ({ n }) => Array(n).fill('').map((index) => <Card key={String(index)} />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags template-literal coercion key={`${index}`}", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      "const P = ({ n }) => Array(n).fill(null).map((index) => <Card key={`${index}`} />);",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the correct two-param form (_, index)", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Ok = ({ n }) => Array(n).fill(null).map((_, index) => <Row key={index} />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a real element + index two-param callback", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Ok2 = ({ items }) => items.map((item, i) => <Row key={i} />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a single-param map on a non-fill receiver", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Ok3 = ({ items }) => items.map((index) => <Row key={index} />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a single param not named like an index", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Ok4 = () => Array(3).fill('a').map((letter) => <Row key={letter} />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag Array.from with a mapfn (out of scope in v1)", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Ok5 = () => Array.from({ length: 3 }, (_, index) => <Row key={index} />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the harmless single-element Array(1).fill() case", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const One = () => Array(1).fill(null).map((index) => <Row key={index} />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a for-loop counter shadowing the map param (calendar week/day grid idiom)", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Calendar = ({ weeks }) =>
+        Array(weeks).fill(null).map((i) => {
+          const days = [];
+          for (let i = 0; i < 7; i++) days.push(<Day key={i} />);
+          return <Week>{days}</Week>;
+        });`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a for-of [i, v] entries() destructure shadowing the map param", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Grid = ({ rows, cells }) =>
+        Array(rows).fill(null).map((i) => {
+          const rendered = [];
+          for (const [i, cell] of cells.entries()) rendered.push(<Cell key={i} value={cell} />);
+          return <Row>{rendered}</Row>;
+        });`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a nested-block const shadowing the map param", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Blocks = ({ n }) =>
+        Array(n).fill(null).map((i) => {
+          {
+            const i = nextStableId();
+            return <Row key={i} />;
+          }
+        });`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a const fill array mapped through a variable (skeleton-loader idiom)", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Skeletons = ({ count }) => {
+        const slots = Array(count).fill(null);
+        return slots.map((index) => <Row key={index} />);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a const fill array whose elements are mutated before mapping", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Positions = ({ count }) => {
+        const slots = Array(count).fill(0);
+        slots.forEach((_, position) => { slots[position] = position * 2; });
+        return slots.map((i) => <Row key={i} />);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a let fill array that may be reassigned before mapping", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Rows = ({ count, loaded }) => {
+        let slots = Array(count).fill(null);
+        if (loaded) slots = fetchRows();
+        return slots.map((index) => <Row key={index} />);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the index key lives inside a nested function, not the map callback", () => {
+    const result = runRule(
+      noFillMapElementAsKey,
+      `const Nested = ({ n }) =>
+        Array(n).fill(null).map((outer) => {
+          const render = (index) => <Row key={index} />;
+          return render(outer);
+        });`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fill-map-element-as-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-fill-map-element-as-key.ts
@@ -1,0 +1,285 @@
+import { INDEX_PARAMETER_NAMES } from "../../constants/react.js";
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const STRING_COERCION_FUNCTIONS = new Set(["String", "Number"]);
+
+const ARRAY_MUTATING_METHODS = new Set([
+  "copyWithin",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "shift",
+  "sort",
+  "splice",
+  "unshift",
+]);
+
+// Name of the index-shaped identifier a `key=` expression resolves to, or
+// null. Mirrors the coverage of no-array-index-as-key's `extractIndexName`
+// (bare identifier, `String(i)`/`Number(i)`, `i.toString()`, `` `${i}` ``)
+// but returns the identifier regardless of whether the name is in the index
+// set — the caller matches it against the map callback's single parameter.
+const extractKeyIdentifierName = (node: EsTreeNode): string | null => {
+  if (isNodeOfType(node, "Identifier")) return node.name;
+
+  if (isNodeOfType(node, "TemplateLiteral")) {
+    const expressions = node.expressions ?? [];
+    if (expressions.length === 1 && isNodeOfType(expressions[0], "Identifier")) {
+      return expressions[0].name;
+    }
+    return null;
+  }
+
+  if (
+    isNodeOfType(node, "CallExpression") &&
+    isNodeOfType(node.callee, "MemberExpression") &&
+    isNodeOfType(node.callee.object, "Identifier") &&
+    isNodeOfType(node.callee.property, "Identifier") &&
+    node.callee.property.name === "toString"
+  ) {
+    return node.callee.object.name;
+  }
+
+  if (
+    isNodeOfType(node, "CallExpression") &&
+    isNodeOfType(node.callee, "Identifier") &&
+    STRING_COERCION_FUNCTIONS.has(node.callee.name) &&
+    isNodeOfType(node.arguments?.[0], "Identifier")
+  ) {
+    return node.arguments[0].name;
+  }
+
+  return null;
+};
+
+// `Array(n)` or `new Array(n)` — returns the length argument node so the
+// caller can suppress the harmless single-element case (`Array(1)`).
+const getArrayConstructorLengthArgument = (node: EsTreeNode): EsTreeNode | null => {
+  const isArrayConstructor =
+    (isNodeOfType(node, "CallExpression") || isNodeOfType(node, "NewExpression")) &&
+    isNodeOfType(node.callee, "Identifier") &&
+    node.callee.name === "Array";
+  if (!isArrayConstructor) return null;
+  return node.arguments?.[0] ?? null;
+};
+
+// Length argument of the `Array(n).fill(...)` / `new Array(n).fill(...)`
+// receiver, or null when the receiver is not that shape.
+const getFillReceiverLengthArgument = (receiver: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(receiver, "CallExpression")) return null;
+  const callee = receiver.callee;
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    callee.property.name !== "fill"
+  ) {
+    return null;
+  }
+  return getArrayConstructorLengthArgument(callee.object);
+};
+
+const doesPatternBindName = (pattern: EsTreeNode | null | undefined, name: string): boolean => {
+  if (!pattern) return false;
+  const boundNames = new Set<string>();
+  collectPatternNames(pattern, boundNames);
+  return boundNames.has(name);
+};
+
+const doesDeclarationBindName = (statement: EsTreeNode | null | undefined, name: string): boolean =>
+  Boolean(
+    statement &&
+    isNodeOfType(statement, "VariableDeclaration") &&
+    statement.declarations.some((declarator) => doesPatternBindName(declarator.id, name)),
+  );
+
+// Whether anything between the key expression and the map callback rebinds
+// (or reassigns) the callback parameter's name — a for-loop counter, a
+// destructured `[i, v]` from `.entries()`, a nested-block const, a catch
+// param, a switch-case declaration. When it does, the key identifier is
+// NOT the fill element and the keys can be genuinely distinct.
+const isKeyNameReboundBetween = (
+  attributeNode: EsTreeNode,
+  callback: EsTreeNode,
+  keyName: string,
+): boolean => {
+  let current: EsTreeNode | null | undefined = attributeNode.parent;
+  while (current && current !== callback) {
+    if (isNodeOfType(current, "ForStatement")) {
+      if (doesDeclarationBindName(current.init, keyName)) return true;
+      if (
+        isNodeOfType(current.init, "AssignmentExpression") &&
+        isNodeOfType(current.init.left, "Identifier") &&
+        current.init.left.name === keyName
+      ) {
+        return true;
+      }
+    }
+    if (isNodeOfType(current, "ForOfStatement") || isNodeOfType(current, "ForInStatement")) {
+      if (doesDeclarationBindName(current.left, keyName)) return true;
+      if (isNodeOfType(current.left, "Identifier") && current.left.name === keyName) return true;
+    }
+    if (
+      isNodeOfType(current, "BlockStatement") &&
+      current.body.some((statement) => doesDeclarationBindName(statement, keyName))
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(current, "SwitchStatement") &&
+      current.cases.some((switchCase) =>
+        switchCase.consequent.some((statement) => doesDeclarationBindName(statement, keyName)),
+      )
+    ) {
+      return true;
+    }
+    if (isNodeOfType(current, "CatchClause") && doesPatternBindName(current.param, keyName)) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+};
+
+const isConstDeclaredBinding = (bindingIdentifier: EsTreeNode): boolean => {
+  const declarator = bindingIdentifier.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
+  if (declarator.id !== bindingIdentifier) return false;
+  const declaration = declarator.parent;
+  return Boolean(
+    declaration && isNodeOfType(declaration, "VariableDeclaration") && declaration.kind === "const",
+  );
+};
+
+// Whether the named array is reassigned, index-assigned, or hit with a
+// mutating method anywhere in its scope — after that, elements may no
+// longer be the identical fill value, so a param bound to them can be a
+// legitimate key.
+const isFilledArrayMutatedInScope = (scopeOwner: EsTreeNode, arrayName: string): boolean => {
+  let didFindMutation = false;
+  walkAst(scopeOwner, (descendant) => {
+    if (didFindMutation) return false;
+    if (isNodeOfType(descendant, "AssignmentExpression")) {
+      const target = descendant.left;
+      if (isNodeOfType(target, "Identifier") && target.name === arrayName) {
+        didFindMutation = true;
+        return false;
+      }
+      if (
+        isNodeOfType(target, "MemberExpression") &&
+        isNodeOfType(target.object, "Identifier") &&
+        target.object.name === arrayName
+      ) {
+        didFindMutation = true;
+        return false;
+      }
+    }
+    if (
+      isNodeOfType(descendant, "CallExpression") &&
+      isNodeOfType(descendant.callee, "MemberExpression") &&
+      isNodeOfType(descendant.callee.object, "Identifier") &&
+      descendant.callee.object.name === arrayName &&
+      isNodeOfType(descendant.callee.property, "Identifier") &&
+      ARRAY_MUTATING_METHODS.has(descendant.callee.property.name)
+    ) {
+      didFindMutation = true;
+      return false;
+    }
+    return undefined;
+  });
+  return didFindMutation;
+};
+
+// Length argument of the fill chain the `.map` receiver resolves to: the
+// inline `Array(n).fill(...).map(...)` chain, or an identifier whose sole
+// `const` initializer is that chain and which is never mutated afterwards
+// (`const slots = Array(n).fill(null); slots.map(...)`).
+const resolveFillReceiverLengthArgument = (receiver: EsTreeNode): EsTreeNode | null => {
+  const inlineLengthArgument = getFillReceiverLengthArgument(receiver);
+  if (inlineLengthArgument) return inlineLengthArgument;
+
+  if (!isNodeOfType(receiver, "Identifier")) return null;
+  const binding = findVariableInitializer(receiver, receiver.name);
+  if (!binding || !binding.initializer) return null;
+  if (!isConstDeclaredBinding(binding.bindingIdentifier)) return null;
+  const initializerLengthArgument = getFillReceiverLengthArgument(binding.initializer);
+  if (!initializerLengthArgument) return null;
+  if (isFilledArrayMutatedInScope(binding.scopeOwner, receiver.name)) return null;
+  return initializerLengthArgument;
+};
+
+// The nearest enclosing `.map(callback)` when the given node lives directly
+// in that callback (not behind an intervening nested function), plus the
+// receiver the `.map` was called on.
+const findEnclosingMapCall = (
+  node: EsTreeNode,
+): {
+  callback:
+    | EsTreeNodeOfType<"ArrowFunctionExpression">
+    | EsTreeNodeOfType<"FunctionExpression">
+    | EsTreeNodeOfType<"FunctionDeclaration">;
+  receiver: EsTreeNode;
+} | null => {
+  let current = node;
+  while (current.parent) {
+    if (isFunctionLike(current)) {
+      const parent = current.parent;
+      if (
+        isNodeOfType(parent, "CallExpression") &&
+        parent.arguments.includes(current as never) &&
+        isNodeOfType(parent.callee, "MemberExpression") &&
+        isNodeOfType(parent.callee.property, "Identifier") &&
+        parent.callee.property.name === "map"
+      ) {
+        return { callback: current, receiver: parent.callee.object };
+      }
+      return null;
+    }
+    current = current.parent;
+  }
+  return null;
+};
+
+export const noFillMapElementAsKey = defineRule({
+  id: "no-fill-map-element-as-key",
+  title: "fill().map() first param is the element, not the index",
+  severity: "warn",
+  recommendation:
+    "After `.fill(value)` every element is identical, so a lone `.map((index) => …)` binds `index` to that value and gives every child the same key. Add the index as the second parameter: `.map((_, index) => …)`.",
+  create: (context: RuleContext) => ({
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
+      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "key") return;
+      if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
+
+      const keyName = extractKeyIdentifierName(node.value.expression);
+      if (!keyName || !INDEX_PARAMETER_NAMES.has(keyName)) return;
+
+      const enclosingMap = findEnclosingMapCall(node);
+      if (!enclosingMap) return;
+
+      const parameters = enclosingMap.callback.params;
+      if (parameters.length !== 1) return;
+      const soleParameter = parameters[0];
+      if (!isNodeOfType(soleParameter, "Identifier") || soleParameter.name !== keyName) return;
+
+      if (isKeyNameReboundBetween(node, enclosingMap.callback, keyName)) return;
+
+      const lengthArgument = resolveFillReceiverLengthArgument(enclosingMap.receiver);
+      if (!lengthArgument) return;
+      if (isNodeOfType(lengthArgument, "Literal") && lengthArgument.value === 1) return;
+
+      context.report({
+        node,
+        message: `Every item in this list gets the same key because \`.fill()\` makes every element identical and "${keyName}" is bound to that element, not the position — add the index as the second parameter (\`.map((_, ${keyName}) => …)\`) so React can tell your list items apart.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-floating-then-in-jsx-handler.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-floating-then-in-jsx-handler.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noFloatingThenInJsxHandler } from "./no-floating-then-in-jsx-handler.js";
+
+describe("no-floating-then-in-jsx-handler", () => {
+  it("flags a concise-arrow floating then", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => doThing().then(handleResult)} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a block-body floating then", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <form onSubmit={() => { saveForm().then(() => setOpen(false)); }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a member-call then chain", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <input onChange={() => api.update(x).then(refetch)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a logout().then() navigation handler", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <a onClick={() => logout().then(() => (window.location.href = '/'))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an if-guarded floating then (confirm-before-delete idiom)", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => { if (window.confirm('Delete?')) removeItem().then(refetch); }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a &&-guarded concise floating then", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => isDirty && save().then(refetch)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags both branches of a ternary with floating thens", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => (isNew ? create().then(done) : update().then(done))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("flags a .then chain whose only settlement handler is .finally — .finally re-throws rejections", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => { fetchData().then(setData).finally(() => setLoading(false)); }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an async handler", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={async () => { await save(); }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an explicit void fire-and-forget", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => void save().then(refetch)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chain with a .catch", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => save().then(refetch).catch(reportError)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a two-argument then with onRejected", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => save().then(onOk, onErr)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chain whose rejection is handled by a mid-chain .then(null, onErr)", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => save().then(null, onErr).then(onOk)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare .finally with no .then in the chain", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => save().finally(done)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a .catch followed by a trailing .finally", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => save().then(r).catch(reportError).finally(done)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a returned promise chain", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => { return save().then(refetch); }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a handler with no .then token", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => setOpen(true)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an identifier handler reference", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={handleClick} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a .then inside a nested callback within the handler", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <button onClick={() => { items.forEach((x) => save(x).then(done)); }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-handler prop", () => {
+    const result = runRule(
+      noFloatingThenInJsxHandler,
+      `const el = <Comp render={() => load().then(show)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-floating-then-in-jsx-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-floating-then-in-jsx-handler.ts
@@ -1,0 +1,174 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const HANDLER_PROP_PATTERN = /^on[A-Z]/;
+
+const promiseChainMethodName = (call: EsTreeNodeOfType<"CallExpression">): string | null => {
+  const callee = call.callee;
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    callee.computed ||
+    !isNodeOfType(callee.property, "Identifier")
+  ) {
+    return null;
+  }
+  return callee.property.name;
+};
+
+const isNullishArgument = (argument: EsTreeNode): boolean =>
+  (isNodeOfType(argument, "Literal") && argument.value === null) ||
+  (isNodeOfType(argument, "Identifier") && argument.name === "undefined");
+
+// True when the chain carries a rejection handler anywhere along it: a
+// `.catch(...)` call, or a two-argument `.then(onOk, onErr)` whose
+// onRejected is a real handler. `.finally` is NOT a rejection handler —
+// it re-throws the rejection.
+const chainHasRejectionHandler = (node: EsTreeNode): boolean => {
+  let cursor: EsTreeNode | null | undefined = node;
+  while (cursor) {
+    if (isNodeOfType(cursor, "ChainExpression")) {
+      cursor = cursor.expression as EsTreeNode;
+      continue;
+    }
+    if (isNodeOfType(cursor, "CallExpression")) {
+      const methodName = promiseChainMethodName(cursor);
+      if (methodName === "catch") return true;
+      if (
+        methodName === "then" &&
+        cursor.arguments.length >= 2 &&
+        !isNullishArgument(cursor.arguments[1] as EsTreeNode)
+      ) {
+        return true;
+      }
+      cursor = cursor.callee as EsTreeNode;
+      continue;
+    }
+    if (isNodeOfType(cursor, "MemberExpression")) {
+      cursor = cursor.object as EsTreeNode;
+      continue;
+    }
+    break;
+  }
+  return false;
+};
+
+// Returns the last `.then(...)` call when `expression` is a `.then`-ended
+// chain (optionally followed by `.finally` calls, which re-throw
+// rejections) with no rejection handler, else null. Keyed purely off the
+// literal `.then(` shape — no inference about whether a bare call returns
+// a promise.
+const floatingThenCall = (expression: EsTreeNode): EsTreeNodeOfType<"CallExpression"> | null => {
+  let terminal = stripParenExpression(expression);
+  while (
+    isNodeOfType(terminal, "CallExpression") &&
+    promiseChainMethodName(terminal) === "finally"
+  ) {
+    const callee = terminal.callee;
+    if (!isNodeOfType(callee, "MemberExpression")) return null;
+    terminal = stripParenExpression(callee.object as EsTreeNode);
+  }
+  if (!isNodeOfType(terminal, "CallExpression")) return null;
+  if (promiseChainMethodName(terminal) !== "then") return null;
+  if (chainHasRejectionHandler(terminal)) return null;
+  return terminal;
+};
+
+// Discarded expression positions inside the handler: the expression
+// itself, the right side of a `&&`/`||`/`??` guard, and both ternary
+// branches. `void expr` is an explicit discard and never matches.
+const collectExpressionFloatingThenCalls = (
+  expression: EsTreeNode,
+  found: EsTreeNodeOfType<"CallExpression">[],
+): void => {
+  const stripped = stripParenExpression(expression);
+  if (isNodeOfType(stripped, "LogicalExpression")) {
+    collectExpressionFloatingThenCalls(stripped.right as EsTreeNode, found);
+    return;
+  }
+  if (isNodeOfType(stripped, "ConditionalExpression")) {
+    collectExpressionFloatingThenCalls(stripped.consequent as EsTreeNode, found);
+    collectExpressionFloatingThenCalls(stripped.alternate as EsTreeNode, found);
+    return;
+  }
+  const floating = floatingThenCall(stripped);
+  if (floating) found.push(floating);
+};
+
+// Statements that execute synchronously when the handler fires:
+// ExpressionStatements plus both branches of `if` (through nested
+// blocks). Nested functions are intentionally NOT descended into — their
+// `.then` chains don't run when the handler fires.
+const collectStatementFloatingThenCalls = (
+  statement: EsTreeNode,
+  found: EsTreeNodeOfType<"CallExpression">[],
+): void => {
+  if (isNodeOfType(statement, "ExpressionStatement")) {
+    collectExpressionFloatingThenCalls(statement.expression as EsTreeNode, found);
+    return;
+  }
+  if (isNodeOfType(statement, "BlockStatement")) {
+    for (const innerStatement of statement.body) {
+      collectStatementFloatingThenCalls(innerStatement as EsTreeNode, found);
+    }
+    return;
+  }
+  if (isNodeOfType(statement, "IfStatement")) {
+    collectStatementFloatingThenCalls(statement.consequent as EsTreeNode, found);
+    if (statement.alternate) {
+      collectStatementFloatingThenCalls(statement.alternate as EsTreeNode, found);
+    }
+  }
+};
+
+const collectDirectFloatingThenCalls = (
+  handler: EsTreeNodeOfType<"ArrowFunctionExpression"> | EsTreeNodeOfType<"FunctionExpression">,
+): EsTreeNodeOfType<"CallExpression">[] => {
+  const found: EsTreeNodeOfType<"CallExpression">[] = [];
+  const body = handler.body as EsTreeNode;
+  if (isNodeOfType(body, "BlockStatement")) {
+    collectStatementFloatingThenCalls(body, found);
+  } else {
+    collectExpressionFloatingThenCalls(body, found);
+  }
+  return found;
+};
+
+export const noFloatingThenInJsxHandler = defineRule({
+  id: "no-floating-then-in-jsx-handler",
+  title: "Floating .then in a JSX event handler",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "A `.then()` chain with no `.catch` in an event handler becomes an uncaught promise rejection no error boundary can catch; add a `.catch` handler (or make the handler `async` and `try/catch`).",
+  create: (context: RuleContext) => ({
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
+      const name = getJsxAttributeName(node.name as EsTreeNode);
+      if (!name || !HANDLER_PROP_PATTERN.test(name)) return;
+      if (!node.value || !isNodeOfType(node.value, "JSXExpressionContainer")) return;
+
+      const handler = stripParenExpression(node.value.expression as EsTreeNode);
+      if (
+        !isNodeOfType(handler, "ArrowFunctionExpression") &&
+        !isNodeOfType(handler, "FunctionExpression")
+      ) {
+        return;
+      }
+      // An `async` handler propagates rejections differently (its own
+      // promise), so it's out of scope.
+      if (handler.async) return;
+
+      for (const floating of collectDirectFloatingThenCalls(handler)) {
+        context.report({
+          node: floating,
+          message:
+            "This `.then()` runs in an event handler with no `.catch`, so a rejection becomes an uncaught promise error no React error boundary can catch — add a `.catch` handler or make the handler `async` with `try/catch`.",
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-floating-then-in-jsx-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-floating-then-in-jsx-handler.ts
@@ -1,24 +1,13 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getCallMethodName } from "../../utils/get-call-method-name.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 const HANDLER_PROP_PATTERN = /^on[A-Z]/;
-
-const promiseChainMethodName = (call: EsTreeNodeOfType<"CallExpression">): string | null => {
-  const callee = call.callee;
-  if (
-    !isNodeOfType(callee, "MemberExpression") ||
-    callee.computed ||
-    !isNodeOfType(callee.property, "Identifier")
-  ) {
-    return null;
-  }
-  return callee.property.name;
-};
 
 const isNullishArgument = (argument: EsTreeNode): boolean =>
   (isNodeOfType(argument, "Literal") && argument.value === null) ||
@@ -36,7 +25,7 @@ const chainHasRejectionHandler = (node: EsTreeNode): boolean => {
       continue;
     }
     if (isNodeOfType(cursor, "CallExpression")) {
-      const methodName = promiseChainMethodName(cursor);
+      const methodName = getCallMethodName(cursor.callee as EsTreeNode);
       if (methodName === "catch") return true;
       if (
         methodName === "then" &&
@@ -66,14 +55,14 @@ const floatingThenCall = (expression: EsTreeNode): EsTreeNodeOfType<"CallExpress
   let terminal = stripParenExpression(expression);
   while (
     isNodeOfType(terminal, "CallExpression") &&
-    promiseChainMethodName(terminal) === "finally"
+    getCallMethodName(terminal.callee as EsTreeNode) === "finally"
   ) {
     const callee = terminal.callee;
     if (!isNodeOfType(callee, "MemberExpression")) return null;
     terminal = stripParenExpression(callee.object as EsTreeNode);
   }
   if (!isNodeOfType(terminal, "CallExpression")) return null;
-  if (promiseChainMethodName(terminal) !== "then") return null;
+  if (getCallMethodName(terminal.callee as EsTreeNode) !== "then") return null;
   if (chainHasRejectionHandler(terminal)) return null;
   return terminal;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-impure-call-at-module-scope.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-impure-call-at-module-scope.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noImpureCallAtModuleScope } from "./no-impure-call-at-module-scope.js";
+
+describe("no-impure-call-at-module-scope", () => {
+  it("flags Math.random() sampling at module scope (retailer-visitor shape)", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `const SHOULD_TRACK = Math.random() * 100 < SAMPLE_RATE;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("Math.random()");
+  });
+
+  it("flags new Date().getTimezoneOffset() date math at module scope", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `const USER_TIMEZONE_OFFSET_IN_MILLIS = new Date().getTimezoneOffset() * 60000;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new Date()");
+  });
+
+  it("flags a bare new Date() constant at module scope", () => {
+    const result = runRule(noImpureCallAtModuleScope, `const CURRENT_TIMESTAMP = new Date();`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Date.now() at module scope", () => {
+    const result = runRule(noImpureCallAtModuleScope, `const RENDERED = Date.now();`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags performance.now() at module scope", () => {
+    const result = runRule(noImpureCallAtModuleScope, `const MARK = performance.now();`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a static class-field initializer", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `
+      class Sampler {
+        static sample = Math.random();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an exported module-scope constant", () => {
+    const result = runRule(noImpureCallAtModuleScope, `export const RATE = Math.random();`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the same call inside a function body", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `
+      function sample() {
+        const value = Math.random();
+        return value;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the same call inside a component", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `
+      const Clock = () => {
+        const now = Date.now();
+        return null;
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a lazy getter arrow", () => {
+    const result = runRule(noImpureCallAtModuleScope, `const getNow = () => Date.now();`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag new Date(timestamp) with an argument", () => {
+    const result = runRule(noImpureCallAtModuleScope, `const AT = new Date(1700000000000);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag crypto.randomUUID() (dropped per revision)", () => {
+    const result = runRule(noImpureCallAtModuleScope, `const INSTANCE = crypto.randomUUID();`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-static (instance) class field", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `
+      class Sampler {
+        sample = Math.random();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a per-process-named binding (uptime/instance id)", () => {
+    const result = runRule(noImpureCallAtModuleScope, `const bootTime = Date.now();`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag camelCase per-process uptime names (startTime/appBootTime/serverStartedAt)", () => {
+    expect(
+      runRule(noImpureCallAtModuleScope, `const startTime = Date.now();`).diagnostics,
+    ).toHaveLength(0);
+    expect(
+      runRule(noImpureCallAtModuleScope, `const appBootTime = Date.now();`).diagnostics,
+    ).toHaveLength(0);
+    expect(
+      runRule(noImpureCallAtModuleScope, `const serverStartedAt = Date.now();`).diagnostics,
+    ).toHaveLength(0);
+    expect(
+      runRule(noImpureCallAtModuleScope, `const SERVER_START_TIME = Date.now();`).diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it("does not flag a jotai atom seeded with Date.now() (TaskTrove refresh-trigger shape)", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `
+      import { atom } from "jotai";
+      export const appRefreshTriggerAtom = atom<number>(Date.now());
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag state-container factory seeds (svelte writable, rxjs BehaviorSubject)", () => {
+    expect(
+      runRule(noImpureCallAtModuleScope, `export const lastUpdated = writable(Date.now());`)
+        .diagnostics,
+    ).toHaveLength(0);
+    expect(
+      runRule(noImpureCallAtModuleScope, `const clock$ = new BehaviorSubject(Date.now());`)
+        .diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it("does not flag a static field of a class created inside a factory/mixin", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `export const withInstanceKey = (Base) => class extends Base { static key = Math.random().toString(36); };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when Date is shadowed by a local binding", () => {
+    const result = runRule(
+      noImpureCallAtModuleScope,
+      `
+      const Date = FakeDate;
+      const NOW = new Date();
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag inside test/story files (test-noise)", () => {
+    const result = runRule(noImpureCallAtModuleScope, `const NOW = Date.now();`, {
+      filename: "src/widget.stories.tsx",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-impure-call-at-module-scope.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-impure-call-at-module-scope.ts
@@ -1,0 +1,147 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Per the applied revision, `crypto.*` id/byte generators are dropped:
+// stable per-process ids are the dominant, correct idiom at module scope.
+// What remains fires regardless of intent: Math.random() sampling and
+// wall-clock reads used in date/timezone math.
+const IMPURE_MEMBER_CALLS = new Map<string, ReadonlySet<string>>([
+  ["Math", new Set(["random"])],
+  ["Date", new Set(["now"])],
+  ["performance", new Set(["now"])],
+]);
+
+// Bindings whose name advertises an intentional per-process value
+// (instance/boot/startup ids, uptime timestamps). Applied from the
+// revision to spare those correct-by-design constants.
+const PER_PROCESS_NAME_KEYWORDS = new Set([
+  "instance",
+  "boot",
+  "startup",
+  "start",
+  "started",
+  "process",
+  "server",
+  "build",
+]);
+
+const isPerProcessBindingName = (bindingName: string): boolean =>
+  bindingName
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .toLowerCase()
+    .split(/[_-]+/)
+    .some((nameWord) => PER_PROCESS_NAME_KEYWORDS.has(nameWord));
+
+const impureBuiltinLabel = (node: EsTreeNode): string | null => {
+  if (isNodeOfType(node, "NewExpression")) {
+    // Only the zero-argument `new Date()` is nondeterministic; a
+    // timestamp/parts argument is deterministic.
+    if (
+      isNodeOfType(node.callee, "Identifier") &&
+      node.callee.name === "Date" &&
+      (node.arguments?.length ?? 0) === 0 &&
+      !findVariableInitializer(node.callee, "Date")
+    ) {
+      return "new Date()";
+    }
+    return null;
+  }
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  const callee = node.callee;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
+  if (!isNodeOfType(callee.object, "Identifier")) return null;
+  if (!isNodeOfType(callee.property, "Identifier")) return null;
+  const allowedMethods = IMPURE_MEMBER_CALLS.get(callee.object.name);
+  if (!allowedMethods?.has(callee.property.name)) return null;
+  // A same-file binding named `Math`/`Date`/`performance` shadows the global.
+  if (findVariableInitializer(callee.object, callee.object.name)) return null;
+  return `${callee.object.name}.${callee.property.name}()`;
+};
+
+interface ModuleScopeBinding {
+  readonly bindingName: string | null;
+}
+
+// Walks up from an impure call to decide whether it is evaluated once at
+// module load — either in a top-level variable initializer or a static
+// class-field initializer of a module-scope class — returning the bound
+// name, or null when a function boundary is crossed first or the impure
+// value is an argument to a factory call (`atom(Date.now())`,
+// `signal(Date.now())`), a deliberate mutable seed rather than a frozen
+// constant.
+const resolveModuleScopeBinding = (impureNode: EsTreeNode): ModuleScopeBinding | null => {
+  let child: EsTreeNode = impureNode;
+  let cursor: EsTreeNode | null = impureNode.parent ?? null;
+  let staticFieldBinding: ModuleScopeBinding | null = null;
+  while (cursor) {
+    if (isFunctionLike(cursor) || isNodeOfType(cursor, "MethodDefinition")) return null;
+
+    if (
+      (isNodeOfType(cursor, "CallExpression") || isNodeOfType(cursor, "NewExpression")) &&
+      cursor.arguments?.some((argumentNode) => argumentNode === child)
+    ) {
+      return null;
+    }
+
+    if (isNodeOfType(cursor, "PropertyDefinition")) {
+      if (cursor.static !== true || cursor.key === child) return null;
+      staticFieldBinding = {
+        bindingName: isNodeOfType(cursor.key, "Identifier") ? cursor.key.name : null,
+      };
+    }
+
+    if (isNodeOfType(cursor, "VariableDeclarator")) {
+      const declaration = cursor.parent;
+      if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return null;
+      let declarationParent = declaration.parent ?? null;
+      if (declarationParent && isNodeOfType(declarationParent, "ExportNamedDeclaration")) {
+        declarationParent = declarationParent.parent ?? null;
+      }
+      if (!declarationParent || !isNodeOfType(declarationParent, "Program")) return null;
+      return {
+        bindingName: isNodeOfType(cursor.id, "Identifier") ? cursor.id.name : null,
+      };
+    }
+
+    child = cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return staticFieldBinding;
+};
+
+export const noImpureCallAtModuleScope = defineRule({
+  id: "no-impure-call-at-module-scope",
+  title: "Nondeterministic built-in at module scope",
+  severity: "warn",
+  requires: ["ssr"],
+  tags: ["test-noise"],
+  recommendation:
+    "`Math.random()`, `Date.now()`, `performance.now()`, and `new Date()` run once at module load, so the value is frozen for the whole server process. Move the call into a function/component so it evaluates per request.",
+  create: (context: RuleContext) => {
+    const check = (node: EsTreeNode): void => {
+      const label = impureBuiltinLabel(node);
+      if (!label) return;
+      const binding = resolveModuleScopeBinding(node);
+      if (!binding) return;
+      if (binding.bindingName && isPerProcessBindingName(binding.bindingName)) return;
+      context.report({
+        node,
+        message: `\`${label}\` runs once when this module loads, so the value is frozen for the whole server process and every SSR request reuses it — move it into a function or component so it evaluates per request.`,
+      });
+    };
+    return {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        check(node);
+      },
+      NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
+        check(node);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-mutate-queried-dom-node-in-component.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-mutate-queried-dom-node-in-component.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noMutateQueriedDomNodeInComponent } from "./no-mutate-queried-dom-node-in-component.js";
+
+describe("no-mutate-queried-dom-node-in-component", () => {
+  it("flags classList.add on a queried, component-owned class", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        useEffect(() => {
+          document.querySelector('.panel').classList.add('open');
+        }, []);
+        return <div className="panel" />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a style mutation on a getElementById result bound to a var", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Overlay() {
+        const el = document.getElementById('main-content');
+        el.style.filter = 'blur(3px)';
+        return <section id="main-content" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags classList.remove on a queried #id owned by the component", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Menu() {
+        const container = document.querySelector('#right');
+        container.classList.remove('noscroll');
+        return <aside id="right" className="noscroll" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a chained getElementById style mutation", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Row() {
+        document.getElementById('row-1').style.zIndex = '1';
+        return <div id="row-1" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag mutating a createElement node", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Download() {
+        const a = document.createElement('a');
+        a.style.display = 'none';
+        return <div className="panel" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag setAttribute (not in the mutation set)", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        document.querySelector('.panel').setAttribute('data-x', '1');
+        return <div className="panel" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a read-only query call", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        document.getElementById('panel').scrollIntoView();
+        return <div id="panel" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag document.body style mutations", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        document.body.style.overflow = 'hidden';
+        return <div className="panel" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a ref.current style mutation", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        const ref = useRef(null);
+        ref.current.style.color = 'red';
+        return <div ref={ref} className="panel" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a selector the component does not render (no ownership link)", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        document.querySelector('.external-widget').classList.add('open');
+        return <div className="panel" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag innerHTML (dropped from the mutation set)", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        const el = document.getElementById('x');
+        el.innerHTML = html;
+        return <div id="x" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a dynamic (non-static) query id", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Row({ rowId }) {
+        document.getElementById(rowId).style.zIndex = '1';
+        return <div id="row-1" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag mutations outside a component or hook", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function setup() {
+        document.querySelector('.panel').classList.add('open');
+      }
+      const markup = <div className="panel" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a shadowed createElement node whose name matches an owned query var (download-link idiom)", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        const el = document.getElementById('panel');
+        const width = el.offsetWidth;
+        const download = () => {
+          const el = document.createElement('a');
+          el.style.display = 'none';
+          document.body.appendChild(el);
+        };
+        return <div id="panel" onClick={download} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a callback parameter that shadows an owned query var (helper decorating its own argument)", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function List() {
+        const item = document.querySelector('.item');
+        const top = item.offsetTop;
+        const decorate = (item) => {
+          item.style.opacity = '0.5';
+        };
+        return <div className="item" onMouseEnter={decorate} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags the queried node when a nested handler shadows a different name", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        const el = document.getElementById('panel');
+        el.style.filter = 'blur(3px)';
+        const download = () => {
+          const link = document.createElement('a');
+          link.style.display = 'none';
+        };
+        return <div id="panel" onClick={download} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags style mutation over an owned querySelectorAll forEach callback", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function List() {
+        document.querySelectorAll('.row').forEach((row) => {
+          row.style.background = 'red';
+        });
+        return <div className="row" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags classList mutation inside a for-of over an owned querySelectorAll", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function List() {
+        for (const row of document.querySelectorAll('.row')) {
+          row.classList.add('active');
+        }
+        return <div className="row" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag forEach over a selector the component does not render", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function List() {
+        document.querySelectorAll('.external-row').forEach((row) => {
+          row.style.background = 'red';
+        });
+        return <div className="row" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags style.setProperty on an owned queried node", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        const el = document.getElementById('panel');
+        el.style.setProperty('--width', '10px');
+        return <div id="panel" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag style.setProperty on a ref.current node", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function Panel() {
+        const ref = useRef(null);
+        ref.current.style.setProperty('--width', '10px');
+        return <div ref={ref} className="panel" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the excluded #root token even when rendered", () => {
+    const result = runRule(
+      noMutateQueriedDomNodeInComponent,
+      `function App() {
+        document.getElementById('root').style.overflow = 'hidden';
+        return <div id="root" />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-mutate-queried-dom-node-in-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-mutate-queried-dom-node-in-component.ts
@@ -1,0 +1,362 @@
+import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const DOM_QUERY_METHODS = new Set(["getElementById", "querySelector", "querySelectorAll"]);
+const CLASS_LIST_MUTATION_METHODS = new Set(["add", "remove", "toggle", "replace"]);
+// App-shell / third-party roots are never a component's own reconciled subtree.
+const EXCLUDED_QUERY_TOKENS = new Set(["root", "__next"]);
+
+interface OwnedTokens {
+  ids: Set<string>;
+  classNames: Set<string>;
+  testIds: Set<string>;
+}
+
+interface QueryTarget {
+  kind: "id" | "class" | "testid";
+  value: string;
+}
+
+const literalStringFromJsxAttributeValue = (
+  value: EsTreeNode | null | undefined,
+): string | null => {
+  if (!value) return null;
+  if (isNodeOfType(value, "Literal") && typeof value.value === "string") return value.value;
+  if (isNodeOfType(value, "JSXExpressionContainer")) {
+    const expression = value.expression;
+    if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
+      return expression.value;
+    }
+  }
+  return null;
+};
+
+// Collects the literal id / className / data-testid tokens the file's JSX
+// renders. The ownership link — a queried selector must match one of these —
+// is what proves a mutated node is React-owned by this file, suppressing the
+// portal / third-party / non-React node false positives.
+const collectOwnedTokens = (programRoot: EsTreeNode): OwnedTokens => {
+  const owned: OwnedTokens = {
+    ids: new Set(),
+    classNames: new Set(),
+    testIds: new Set(),
+  };
+  walkAst(programRoot, (node: EsTreeNode) => {
+    if (!isNodeOfType(node, "JSXAttribute")) return;
+    const attributeName = getJsxAttributeName(node.name);
+    if (!attributeName) return;
+    const value = literalStringFromJsxAttributeValue(node.value);
+    if (value === null) return;
+    if (attributeName === "id") {
+      owned.ids.add(value);
+    } else if (attributeName === "className" || attributeName === "class") {
+      for (const className of value.split(/\s+/)) {
+        if (className) owned.classNames.add(className);
+      }
+    } else if (attributeName === "data-testid") {
+      owned.testIds.add(value);
+    }
+  });
+  return owned;
+};
+
+const parseSelectorTarget = (selector: string): QueryTarget | null => {
+  const idMatch = /^#([\w-]+)$/.exec(selector);
+  if (idMatch) return { kind: "id", value: idMatch[1] };
+  const classMatch = /^\.([\w-]+)$/.exec(selector);
+  if (classMatch) return { kind: "class", value: classMatch[1] };
+  const testIdMatch = /^\[data-testid=["']([^"']+)["']\]$/.exec(selector);
+  if (testIdMatch) return { kind: "testid", value: testIdMatch[1] };
+  return null;
+};
+
+// The static id / selector a `document.getElementById/querySelector(All)(...)`
+// call targets, or null when the argument isn't a static string or the callee
+// isn't a literal `document` query.
+const queryCallTarget = (node: EsTreeNode): QueryTarget | null => {
+  const stripped = stripParenExpression(node);
+  if (!isNodeOfType(stripped, "CallExpression")) return null;
+  const callee = stripped.callee;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
+  if (!isNodeOfType(callee.object, "Identifier") || callee.object.name !== "document") return null;
+  if (
+    !isNodeOfType(callee.property, "Identifier") ||
+    !DOM_QUERY_METHODS.has(callee.property.name)
+  ) {
+    return null;
+  }
+  const argument = stripped.arguments?.[0];
+  if (!isNodeOfType(argument, "Literal") || typeof argument.value !== "string") return null;
+  if (callee.property.name === "getElementById") return { kind: "id", value: argument.value };
+  return parseSelectorTarget(argument.value);
+};
+
+const isOwnedQueryTarget = (target: QueryTarget | null, owned: OwnedTokens): boolean => {
+  if (!target || EXCLUDED_QUERY_TOKENS.has(target.value)) return false;
+  if (target.kind === "id") return owned.ids.has(target.value);
+  if (target.kind === "class") return owned.classNames.has(target.value);
+  return owned.testIds.has(target.value);
+};
+
+// `X.style.<prop>` / `X.style.cssText` → the mutated node `X`, else null.
+const styleAssignmentReceiver = (assignmentTarget: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(assignmentTarget, "MemberExpression")) return null;
+  const object = assignmentTarget.object;
+  if (
+    isNodeOfType(object, "MemberExpression") &&
+    !object.computed &&
+    isNodeOfType(object.property, "Identifier") &&
+    object.property.name === "style"
+  ) {
+    return object.object;
+  }
+  return null;
+};
+
+// `X.classList.add|remove|toggle|replace(...)` → the mutated node `X`, else null.
+const classListMutationReceiver = (callee: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
+  if (!isNodeOfType(callee.property, "Identifier")) return null;
+  if (!CLASS_LIST_MUTATION_METHODS.has(callee.property.name)) return null;
+  const object = callee.object;
+  if (
+    isNodeOfType(object, "MemberExpression") &&
+    !object.computed &&
+    isNodeOfType(object.property, "Identifier") &&
+    object.property.name === "classList"
+  ) {
+    return object.object;
+  }
+  return null;
+};
+
+// `X.style.setProperty(...)` → the mutated node `X`, else null.
+const stylePropertyCallReceiver = (callee: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
+  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "setProperty") {
+    return null;
+  }
+  const object = callee.object;
+  if (
+    isNodeOfType(object, "MemberExpression") &&
+    !object.computed &&
+    isNodeOfType(object.property, "Identifier") &&
+    object.property.name === "style"
+  ) {
+    return object.object;
+  }
+  return null;
+};
+
+const collectPatternIdentifiers = (
+  pattern: EsTreeNode | null | undefined,
+  visit: (identifier: EsTreeNodeOfType<"Identifier">) => void,
+): void => {
+  if (!pattern) return;
+  if (isNodeOfType(pattern, "Identifier")) {
+    visit(pattern);
+    return;
+  }
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    collectPatternIdentifiers(pattern.left, visit);
+    return;
+  }
+  if (isNodeOfType(pattern, "RestElement")) {
+    collectPatternIdentifiers(pattern.argument, visit);
+    return;
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    for (const element of pattern.elements) {
+      collectPatternIdentifiers(element, visit);
+    }
+    return;
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    for (const property of pattern.properties) {
+      if (isNodeOfType(property, "Property")) {
+        collectPatternIdentifiers(property.value, visit);
+      } else if (isNodeOfType(property, "RestElement")) {
+        collectPatternIdentifiers(property.argument, visit);
+      }
+    }
+  }
+};
+
+// `document.querySelectorAll('.owned').forEach((row) => ...)` → the callback
+// parameter that binds each owned node, else null.
+const ownedNodeListCallbackParam = (
+  node: EsTreeNode,
+  owned: OwnedTokens,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  const callee = node.callee;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
+  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "forEach") {
+    return null;
+  }
+  if (!isOwnedQueryTarget(queryCallTarget(callee.object), owned)) return null;
+  const callbackArgument = node.arguments[0];
+  if (!callbackArgument) return null;
+  const callback = stripParenExpression(callbackArgument);
+  if (
+    !isNodeOfType(callback, "ArrowFunctionExpression") &&
+    !isNodeOfType(callback, "FunctionExpression")
+  ) {
+    return null;
+  }
+  const firstParam = callback.params[0];
+  return isNodeOfType(firstParam, "Identifier") ? firstParam : null;
+};
+
+// `for (const row of document.querySelectorAll('.owned'))` → the loop
+// binding that holds each owned node, else null.
+const ownedNodeListLoopBinding = (
+  node: EsTreeNode,
+  owned: OwnedTokens,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  if (!isNodeOfType(node, "ForOfStatement")) return null;
+  if (!isOwnedQueryTarget(queryCallTarget(node.right), owned)) return null;
+  const left = node.left;
+  if (!isNodeOfType(left, "VariableDeclaration")) return null;
+  const declarator = left.declarations[0];
+  if (!declarator || !isNodeOfType(declarator.id, "Identifier")) return null;
+  return declarator.id;
+};
+
+export const noMutateQueriedDomNodeInComponent = defineRule({
+  id: "no-mutate-queried-dom-node-in-component",
+  title: "Mutating a queried DOM node this component renders",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "Drive the node with state/props (or a ref for genuinely uncontrolled nodes) instead of querying it and mutating its style/class. Imperative edits to a node React renders are invisible to the virtual DOM and get reverted or clobbered on the next render.",
+  create: (context: RuleContext) => {
+    let ownedTokens: OwnedTokens | null = null;
+    const reported = new WeakSet<EsTreeNode>();
+
+    const receiverIsOwnedQuery = (
+      receiver: EsTreeNode,
+      ownedQueryVariables: Set<string>,
+      owned: OwnedTokens,
+    ): boolean => {
+      const stripped = stripParenExpression(receiver);
+      if (isNodeOfType(stripped, "Identifier")) return ownedQueryVariables.has(stripped.name);
+      if (isNodeOfType(stripped, "CallExpression")) {
+        return isOwnedQueryTarget(queryCallTarget(stripped), owned);
+      }
+      return false;
+    };
+
+    const reportMutation = (node: EsTreeNode, mutatedSurface: "style" | "classList"): void => {
+      if (reported.has(node)) return;
+      reported.add(node);
+      context.report({
+        node,
+        message: `You mutate the ${mutatedSurface} of a DOM node this component renders, so React reverts your change on the next render; drive it with state/props or a ref instead.`,
+      });
+    };
+
+    const analyzeComponent = (functionNode: EsTreeNode, owned: OwnedTokens): void => {
+      const ownedBindingIdentifiers = new Set<EsTreeNode>();
+      const ownedQueryVariables = new Set<string>();
+      walkAst(functionNode, (node: EsTreeNode) => {
+        if (
+          isNodeOfType(node, "VariableDeclarator") &&
+          isNodeOfType(node.id, "Identifier") &&
+          node.init &&
+          isOwnedQueryTarget(queryCallTarget(node.init), owned)
+        ) {
+          ownedBindingIdentifiers.add(node.id);
+          ownedQueryVariables.add(node.id.name);
+          return;
+        }
+        const iterationBinding =
+          ownedNodeListCallbackParam(node, owned) ?? ownedNodeListLoopBinding(node, owned);
+        if (iterationBinding) {
+          ownedBindingIdentifiers.add(iterationBinding);
+          ownedQueryVariables.add(iterationBinding.name);
+        }
+      });
+
+      // A same-named binding elsewhere in the component (shadowing const,
+      // callback parameter, catch param) means the bare name no longer proves
+      // the receiver is the queried node, so drop the name entirely.
+      const dropShadowedName = (identifier: EsTreeNodeOfType<"Identifier">): void => {
+        if (!ownedBindingIdentifiers.has(identifier)) {
+          ownedQueryVariables.delete(identifier.name);
+        }
+      };
+      walkAst(functionNode, (node: EsTreeNode) => {
+        if (isNodeOfType(node, "VariableDeclarator")) {
+          collectPatternIdentifiers(node.id, dropShadowedName);
+          return;
+        }
+        if (
+          isNodeOfType(node, "FunctionDeclaration") ||
+          isNodeOfType(node, "FunctionExpression") ||
+          isNodeOfType(node, "ArrowFunctionExpression")
+        ) {
+          for (const parameter of node.params) {
+            collectPatternIdentifiers(parameter, dropShadowedName);
+          }
+          return;
+        }
+        if (isNodeOfType(node, "CatchClause")) {
+          collectPatternIdentifiers(node.param, dropShadowedName);
+        }
+      });
+
+      walkAst(functionNode, (node: EsTreeNode) => {
+        if (isNodeOfType(node, "AssignmentExpression")) {
+          const receiver = styleAssignmentReceiver(node.left);
+          if (receiver && receiverIsOwnedQuery(receiver, ownedQueryVariables, owned)) {
+            reportMutation(node, "style");
+          }
+          return;
+        }
+        if (isNodeOfType(node, "CallExpression")) {
+          const classListReceiver = classListMutationReceiver(node.callee);
+          if (
+            classListReceiver &&
+            receiverIsOwnedQuery(classListReceiver, ownedQueryVariables, owned)
+          ) {
+            reportMutation(node, "classList");
+            return;
+          }
+          const styleReceiver = stylePropertyCallReceiver(node.callee);
+          if (styleReceiver && receiverIsOwnedQuery(styleReceiver, ownedQueryVariables, owned)) {
+            reportMutation(node, "style");
+          }
+        }
+      });
+    };
+
+    const visitFunction = (functionNode: EsTreeNode): void => {
+      if (!ownedTokens) return;
+      if (!componentOrHookDisplayNameForFunction(functionNode)) return;
+      analyzeComponent(functionNode, ownedTokens);
+    };
+
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        ownedTokens = collectOwnedTokens(node);
+      },
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+        visitFunction(node);
+      },
+      FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
+        visitFunction(node);
+      },
+      ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
+        visitFunction(node);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-mutating-array-method-on-prop-or-hook-result.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-mutating-array-method-on-prop-or-hook-result.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noMutatingArrayMethodOnPropOrHookResult } from "./no-mutating-array-method-on-prop-or-hook-result.js";
+
+describe("no-mutating-array-method-on-prop-or-hook-result", () => {
+  it("flags .sort() on a destructured-prop member (experiment-list shape)", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function CustomExperimentListItem({ customExperiment }) {
+        customExperiment.tags.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .reverse() on a prop array (InsiderView shape)", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function InsiderView({ memberships }) {
+        memberships.reverse();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .splice() on a prop array", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ items }) {
+        items.splice(0, 1);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .sort() on a hook-call result", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const data = useQuery();
+        data.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .sort() on a destructured hook result", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const { rows } = useTableData();
+        rows.reverse();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag [...array].sort() copy-first", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ items }) {
+        const sorted = [...items].sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag array.slice().sort() copy-first", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ items }) {
+        const sorted = items.slice().sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag toSorted / toReversed immutable methods", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ items }) {
+        const a = items.toSorted();
+        const b = items.toReversed();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a locally-constructed array", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const local = [3, 1, 2];
+        local.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a plain utility function's array parameter", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function sortInPlace(arr) {
+        arr.sort();
+        return arr;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an Immer produce draft parameter", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ items }) {
+        const next = produce(items, (draft) => {
+          draft.sort();
+        });
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a useMutation callback parameter", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        useMutation((rows) => {
+          rows.sort();
+        });
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a binding whose name advertises mutability", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ items }) {
+        const mutableItems = items;
+        mutableItems.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag splicing a ref's current array", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const stackRef = useRef([]);
+        stackRef.current.splice(index, 1);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reversing a keyed ref-current array", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const mapRef = useRef({});
+        mapRef.current[collection].splice(index, 1);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a sorted copy from spread bound to a variable", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ items }) {
+        const copy = [...items];
+        copy.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a useCallback callback's own parameter (memoized-handler idiom)", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function Select({ onChange }) {
+        const handleChange = useCallback((selectedValues) => {
+          selectedValues.sort();
+          onChange(selectedValues);
+        }, [onChange]);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a callback parameter inside a hook's options object (useMutation onSuccess idiom)", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const mutation = useMutation({ onSuccess: (rows) => rows.sort() });
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a prop rebound to a fresh filtered array first (react-big-calendar Agenda idiom)", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function Agenda({ events }) {
+        events = events.filter((event) => inRange(event));
+        events.sort((a, b) => +a.end - +b.end);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags when the rebind happens only after the mutating call", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function Agenda({ events }) {
+        events.sort((a, b) => +a.end - +b.end);
+        events = events.filter((event) => inRange(event));
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags self-assignment of the in-place sort result", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ items }) {
+        items = items.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a setter-less useState container accessed by key (yet-another-react-lightbox events idiom)", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function useEvents() {
+        const [subscriptions] = React.useState({});
+        const unsubscribe = (topic, callback) => {
+          subscriptions[topic].splice(subscriptions[topic].indexOf(callback), 1);
+        };
+        return unsubscribe;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a direct sort of a setter-less useState array", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const [rows] = useState([]);
+        rows.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a prop destructured in the function body", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List(props) {
+        const { items } = props;
+        items.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a prop-member alias bound in the function body", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List(props) {
+        const list = props.items;
+        list.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a prop whose name merely contains 'mutation' as a substring", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List({ permutations }) {
+        permutations.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag splicing a rest-element copy of a prop array (Breadcrumbs idiom)", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function Breadcrumbs({ items }) {
+        const [firstItem, ...restItems] = items;
+        restItems.splice(0, restItems.length - 1);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag sorting a rest-element copy of a hook result", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const [firstRow, ...otherRows] = useRows();
+        otherRows.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag splicing an object rest-element copy of a hook result", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const { first, ...rest } = useEntries();
+        rest.splice(0, 1);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a member array reached through an object rest binding", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List(props) {
+        const { onClick, ...rest } = props;
+        rest.items.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a non-rest array-destructured element of a prop (nested array alias)", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function Grid({ matrix }) {
+        const [firstRow] = matrix;
+        firstRow.sort();
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an alias of a ref's current array", () => {
+    const result = runRule(
+      noMutatingArrayMethodOnPropOrHookResult,
+      `
+      function List() {
+        const stackRef = useRef([]);
+        const stack = stackRef.current;
+        stack.splice(0, 1);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-mutating-array-method-on-prop-or-hook-result.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-mutating-array-method-on-prop-or-hook-result.ts
@@ -1,0 +1,293 @@
+import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import type { BindingInfo } from "../../utils/find-variable-initializer.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactHookName } from "../../utils/is-react-hook-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+interface AliasSource {
+  rootIdentifier: EsTreeNodeOfType<"Identifier">;
+  isMemberAccess: boolean;
+}
+
+// Only the in-place reorder/remove mutators this rule targets — a deliberate
+// subset of the canonical `MUTATING_ARRAY_METHODS`; named distinctly so it does
+// not shadow that nine-method set.
+const REORDERING_ARRAY_METHODS = new Set(["sort", "reverse", "splice"]);
+
+// Immer drafts and mutation-callback targets are deliberately mutable, and
+// their binding names conventionally advertise it. Matched as whole camel /
+// snake words so ordinary names that merely contain the letters (e.g.
+// `permutations`) are not exempted.
+const MUTATION_SAFE_WORDS = new Set(["draft", "mutable", "mutation"]);
+
+const ALIAS_RESOLUTION_DEPTH_LIMIT = 3;
+
+const identifierWords = (name: string): string[] =>
+  name
+    .split(/[^a-zA-Z]+/)
+    .flatMap((chunk) => chunk.split(/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/))
+    .filter(Boolean);
+
+const hasMutationSafeWord = (name: string): boolean =>
+  identifierWords(name).some((word) => MUTATION_SAFE_WORDS.has(word.toLowerCase()));
+
+// A `.current` in the receiver chain (`stackRef.current.splice()`,
+// `mapRef.current[key].splice()`) means the array lives inside a React ref.
+// `useRef` is itself a hook, so the root would otherwise be misclassified as
+// a "hook result" — but a ref is a deliberately mutable container the docs
+// endorse mutating, not shared/cached state, so mutating it is not the bug
+// this rule targets. (useState arrays keep no such contract and stay flagged.)
+const receiverReachesThroughRefCurrent = (receiver: EsTreeNode): boolean => {
+  let cursor: EsTreeNode = receiver;
+  while (isNodeOfType(cursor, "MemberExpression")) {
+    if (
+      !cursor.computed &&
+      isNodeOfType(cursor.property, "Identifier") &&
+      cursor.property.name === "current"
+    ) {
+      return true;
+    }
+    cursor = stripParenExpression(cursor.object as EsTreeNode);
+  }
+  return false;
+};
+
+const rootIdentifierNode = (node: EsTreeNode): EsTreeNodeOfType<"Identifier"> | null => {
+  let cursor: EsTreeNode | null | undefined = node;
+  while (cursor) {
+    if (isNodeOfType(cursor, "Identifier")) return cursor;
+    if (isNodeOfType(cursor, "ChainExpression")) {
+      cursor = cursor.expression as unknown as EsTreeNode;
+      continue;
+    }
+    if (isNodeOfType(cursor, "MemberExpression")) {
+      cursor = cursor.object;
+      continue;
+    }
+    return null;
+  }
+  return null;
+};
+
+const isHookCallExpression = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const calleeName = getCalleeName(node);
+  return calleeName !== null && isReactHookName(calleeName);
+};
+
+// Stops at function boundaries so a callback parameter nested inside a hook
+// call (`const handler = useCallback((rows) => rows.sort(), [])`) never
+// tunnels out to the enclosing declarator and gets misread as a hook result.
+const nearestVariableDeclarator = (
+  node: EsTreeNode,
+): EsTreeNodeOfType<"VariableDeclarator"> | null => {
+  let cursor: EsTreeNode | null | undefined = node;
+  while (cursor) {
+    if (isNodeOfType(cursor, "VariableDeclarator")) return cursor;
+    if (isNodeOfType(cursor, "VariableDeclaration") || isFunctionLike(cursor)) return null;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+// A rest-element destructuring binding (`const [a, ...rest] = arr`,
+// `const { a, ...rest } = obj`) materializes a freshly allocated array /
+// object, so mutating the binding itself never touches the source. Member
+// access through the binding (`rest.items.sort()`) still reaches shared
+// inner values and stays flagged.
+const isBoundThroughRestElement = (binding: BindingInfo): boolean => {
+  let cursor: EsTreeNode | null | undefined = binding.bindingIdentifier;
+  while (cursor && !isNodeOfType(cursor, "VariableDeclarator") && !isFunctionLike(cursor)) {
+    if (isNodeOfType(cursor, "RestElement")) return true;
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+const declaratorInitFor = (binding: BindingInfo): EsTreeNode | null => {
+  const declarator = nearestVariableDeclarator(binding.bindingIdentifier);
+  return declarator ? ((declarator.init as EsTreeNode | null) ?? null) : null;
+};
+
+const isDerivedFromHookCall = (binding: BindingInfo): boolean => {
+  if (binding.initializer && isHookCallExpression(stripParenExpression(binding.initializer))) {
+    return true;
+  }
+  // Destructured hook result: `const { data } = useQuery()`.
+  const declaratorInit = declaratorInitFor(binding);
+  return Boolean(declaratorInit && isHookCallExpression(stripParenExpression(declaratorInit)));
+};
+
+// `const [store] = useState({...})` with the setter never destructured is the
+// deliberate ref-like mutable-container idiom (same rationale as the
+// `.current` carve-out). Only applies when the array is reached through a
+// member access on the container — direct `stateArray.sort()` stays flagged.
+const isSetterlessUseStateBinding = (binding: BindingInfo): boolean => {
+  const declarator = nearestVariableDeclarator(binding.bindingIdentifier);
+  if (!declarator || !isNodeOfType(declarator.id, "ArrayPattern")) return false;
+  const boundElements = declarator.id.elements.filter(Boolean);
+  if (boundElements.length !== 1) return false;
+  if (!declarator.init) return false;
+  return getCalleeName(stripParenExpression(declarator.init as EsTreeNode)) === "useState";
+};
+
+// True when the binding is a parameter of its scope-owning function
+// (rather than a local declaration inside it).
+const isParameterBinding = (binding: BindingInfo): boolean => {
+  const owner = binding.scopeOwner;
+  const params = (owner as { params?: EsTreeNode[] }).params;
+  if (!Array.isArray(params)) return false;
+  let cursor: EsTreeNode | null | undefined = binding.bindingIdentifier;
+  while (cursor && cursor !== owner) {
+    if (params.includes(cursor)) return true;
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+// oxlint runtime nodes carry `range`; the oxc-parser test AST carries
+// numeric `start`/`end` fields instead — accept either.
+const nodeSpan = (node: EsTreeNode): [number, number] | null => {
+  if (node.range) return [node.range[0], node.range[1]];
+  const nodeWithOffsets = node as { start?: number; end?: number };
+  if (typeof nodeWithOffsets.start === "number" && typeof nodeWithOffsets.end === "number") {
+    return [nodeWithOffsets.start, nodeWithOffsets.end];
+  }
+  return null;
+};
+
+// `events = events.filter(...)` before the flagged call rebinds the name to a
+// fresh array, so the mutating call no longer touches the prop / hook result.
+// The assignment must complete before the call starts, so `items = items.sort()`
+// (which still mutates the shared array in place) stays flagged.
+const hasRebindBeforeCall = (
+  binding: BindingInfo,
+  identifierName: string,
+  callNode: EsTreeNodeOfType<"CallExpression">,
+): boolean => {
+  const callSpan = nodeSpan(callNode);
+  const bindingSpan = nodeSpan(binding.bindingIdentifier);
+  if (!callSpan || !bindingSpan) return false;
+  let didFindRebind = false;
+  walkAst(binding.scopeOwner, (candidate) => {
+    if (didFindRebind) return false;
+    if (
+      isNodeOfType(candidate, "AssignmentExpression") &&
+      candidate.operator === "=" &&
+      isNodeOfType(candidate.left, "Identifier") &&
+      candidate.left.name === identifierName
+    ) {
+      const assignmentSpan = nodeSpan(candidate);
+      if (
+        assignmentSpan &&
+        assignmentSpan[0] > bindingSpan[0] &&
+        assignmentSpan[1] <= callSpan[0]
+      ) {
+        didFindRebind = true;
+        return false;
+      }
+    }
+    return undefined;
+  });
+  return didFindRebind;
+};
+
+// Body-level prop aliases: `const { items } = props` / `const list = props.items`
+// keep pointing at the parent's array, so follow the initializer chain back to
+// its root identifier. Copies (`[...items]`, `items.slice()`) are call / array
+// expressions and produce no alias, and a `.current` chain stays exempt.
+const aliasSourceFor = (binding: BindingInfo): AliasSource | null => {
+  const aliasCandidates = [binding.initializer, declaratorInitFor(binding)];
+  for (const aliasCandidate of aliasCandidates) {
+    if (!aliasCandidate) continue;
+    const strippedCandidate = stripParenExpression(aliasCandidate);
+    if (isNodeOfType(strippedCandidate, "Identifier")) {
+      return { rootIdentifier: strippedCandidate, isMemberAccess: false };
+    }
+    if (
+      isNodeOfType(strippedCandidate, "MemberExpression") &&
+      !receiverReachesThroughRefCurrent(strippedCandidate)
+    ) {
+      const aliasRoot = rootIdentifierNode(strippedCandidate);
+      if (aliasRoot) return { rootIdentifier: aliasRoot, isMemberAccess: true };
+    }
+  }
+  return null;
+};
+
+type SharedArraySource = "prop" | "hook-result";
+
+const resolveSharedArraySource = (
+  rootIdentifier: EsTreeNodeOfType<"Identifier">,
+  callNode: EsTreeNodeOfType<"CallExpression">,
+  reachesThroughMemberAccess: boolean,
+  depth: number,
+): SharedArraySource | null => {
+  if (depth > ALIAS_RESOLUTION_DEPTH_LIMIT) return null;
+  if (hasMutationSafeWord(rootIdentifier.name)) return null;
+  const binding = findVariableInitializer(rootIdentifier, rootIdentifier.name);
+  if (!binding) return null;
+  if (hasRebindBeforeCall(binding, rootIdentifier.name, callNode)) return null;
+  if (!reachesThroughMemberAccess && isBoundThroughRestElement(binding)) return null;
+  if (isDerivedFromHookCall(binding)) {
+    if (reachesThroughMemberAccess && isSetterlessUseStateBinding(binding)) return null;
+    return "hook-result";
+  }
+  // A parameter of a React component (or hook) is a prop — shared with
+  // the parent across renders. Plain-function/utility params and the
+  // draft/mutation params of `produce`/`useMutation` callbacks are not
+  // components, so they never reach this branch.
+  if (isParameterBinding(binding)) {
+    return componentOrHookDisplayNameForFunction(binding.scopeOwner) ? "prop" : null;
+  }
+  const aliasSource = aliasSourceFor(binding);
+  if (!aliasSource) return null;
+  return resolveSharedArraySource(
+    aliasSource.rootIdentifier,
+    callNode,
+    reachesThroughMemberAccess || aliasSource.isMemberAccess,
+    depth + 1,
+  );
+};
+
+const messageFor = (source: SharedArraySource): string => {
+  const origin =
+    source === "prop"
+      ? "a prop, so you mutate the parent's array"
+      : "a hook result, so you mutate shared/cached state";
+  return `\`sort\`, \`reverse\`, and \`splice\` mutate the array in place; this one comes from ${origin} and corrupts it across renders and components. Copy it first with \`[...array]\` or use \`toSorted\`/\`toReversed\`.`;
+};
+
+export const noMutatingArrayMethodOnPropOrHookResult = defineRule({
+  id: "no-mutating-array-method-on-prop-or-hook-result",
+  title: "In-place array mutation on a prop or hook result",
+  severity: "warn",
+  recommendation:
+    "`sort`, `reverse`, and `splice` mutate in place, so calling them on a prop or hook result corrupts shared state. Copy the array first (`[...array]`) or use the immutable `toSorted`/`toReversed`/`toSpliced`.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const callee = node.callee;
+      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+      if (!isNodeOfType(callee.property, "Identifier")) return;
+      if (!REORDERING_ARRAY_METHODS.has(callee.property.name)) return;
+
+      const receiver = stripParenExpression(callee.object as EsTreeNode);
+      if (receiverReachesThroughRefCurrent(receiver)) return;
+      const rootIdentifier = rootIdentifierNode(receiver);
+      if (!rootIdentifier) return;
+
+      const receiverIsMemberAccess = isNodeOfType(receiver, "MemberExpression");
+      const source = resolveSharedArraySource(rootIdentifier, node, receiverIsMemberAccess, 0);
+      if (!source) return;
+      context.report({ node, message: messageFor(source) });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-literal-selector-query-without-try-catch.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-literal-selector-query-without-try-catch.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noNonLiteralSelectorQueryWithoutTryCatch } from "./no-non-literal-selector-query-without-try-catch.js";
+
+describe("no-non-literal-selector-query-without-try-catch", () => {
+  it("flags closest() on a value from an href-named helper", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const targetSelector = getHashFromHref(el); el.closest(targetSelector);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags querySelector on a getAttribute('href') value", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const selector = elementRef.current.getAttribute('href'); document.querySelector(selector);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags matches() on a location.hash argument", () => {
+    const result = runRule(noNonLiteralSelectorQueryWithoutTryCatch, `el.matches(location.hash);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a string-literal selector", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `document.querySelector('.foo > a');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a CSS-module template interpolation", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      "node.querySelector(`.${styles['dismiss-button']}`);",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a SCREAMING_SNAKE selector constant", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const FOCUSABLE_ELEMENTS_SELECTOR = 'a, button'; container.querySelectorAll(FOCUSABLE_ELEMENTS_SELECTOR);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an opaque props selector value", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const target = document.querySelector(props.targetSelector);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a CSS.escape-wrapped template", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      "container.querySelector(`#${CSS.escape(id)}`);",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an href selector already wrapped in try/catch", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const selector = el.getAttribute('href'); try { document.querySelector(selector); } catch (error) {}`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a dynamic computed query method", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const selector = el.getAttribute('href'); document[method](selector);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag getAttribute for a non-href attribute", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const selector = el.getAttribute('data-target'); document.querySelector(selector);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a CSS.escape-wrapping helper just because its name contains 'hash'", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const buildHashSelector = (raw) => '#' + CSS.escape(raw.slice(1)); document.querySelector(buildHashSelector(location.hash));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a router pattern's matches() on location.hash", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const activeRoute = routes.find((candidateRoute) => candidateRoute.matches(location.hash));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a hash query dominated by a regex shape guard (rsuite docs idiom)", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const hash = location.hash; if (/^#[a-zA-Z][\\w-]*$/.test(hash)) { document.querySelector(hash); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a hash query dominated by an indexOf containment guard (semiotic docs idiom)", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `if (this.state.marked.indexOf(window.location.hash) !== -1) { document.querySelector(window.location.hash); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a hash query behind an early-return startsWith guard", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const scrollToHash = () => { const hash = location.hash; if (!hash.startsWith('#')) return; document.querySelector(hash); };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a bare truthiness guard over an href prop (design-react-kit idiom)", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `const href = el.getAttribute('href'); if (href) { document.querySelector(href); }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an href-derived query inside a deferred callback defined in a try block", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `try { button.addEventListener('click', () => { document.querySelector(anchor.getAttribute('href')); }); } catch {}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a deferred callback whose own body wraps the query in try/catch", () => {
+    const result = runRule(
+      noNonLiteralSelectorQueryWithoutTryCatch,
+      `button.addEventListener('click', () => { try { document.querySelector(anchor.getAttribute('href')); } catch {} });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-literal-selector-query-without-try-catch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-literal-selector-query-without-try-catch.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
+import { isEarlyExitStatement } from "../../utils/is-early-exit-statement.js";
 import { isInsideTryStatement } from "../../utils/is-inside-try-statement.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -206,19 +207,6 @@ const isShapeValidatingCall = (
   if (someNodeInSubtree(node.callee.object, referencesTaintedValue)) return true;
   return (node.arguments ?? []).some((argument) =>
     someNodeInSubtree(argument, referencesTaintedValue),
-  );
-};
-
-const isEarlyExitStatement = (node: EsTreeNode): boolean => {
-  if (isNodeOfType(node, "BlockStatement")) {
-    const lastStatement = node.body[node.body.length - 1];
-    return Boolean(lastStatement && isEarlyExitStatement(lastStatement));
-  }
-  return (
-    node.type === "ReturnStatement" ||
-    node.type === "ThrowStatement" ||
-    node.type === "ContinueStatement" ||
-    node.type === "BreakStatement"
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-literal-selector-query-without-try-catch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-literal-selector-query-without-try-catch.ts
@@ -1,0 +1,353 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
+import { isInsideTryStatement } from "../../utils/is-inside-try-statement.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+// Static property name of a member access (`a.b` / `a["b"]`), or null for a
+// dynamic computed access (`a[key]`).
+const getStaticMemberPropertyName = (node: EsTreeNode | null | undefined): string | null => {
+  if (!node) return null;
+  const unwrapped = stripParenExpression(node);
+  if (!isNodeOfType(unwrapped, "MemberExpression")) return null;
+  if (!unwrapped.computed && isNodeOfType(unwrapped.property, "Identifier")) {
+    return unwrapped.property.name;
+  }
+  if (
+    unwrapped.computed &&
+    isNodeOfType(unwrapped.property, "Literal") &&
+    typeof unwrapped.property.value === "string"
+  ) {
+    return unwrapped.property.value;
+  }
+  return null;
+};
+
+const someNodeInSubtree = (root: EsTreeNode, predicate: (node: EsTreeNode) => boolean): boolean => {
+  if (predicate(root)) return true;
+  const rootRecord = root as unknown as Record<string, unknown>;
+  for (const key of Object.keys(rootRecord)) {
+    if (key === "parent") continue;
+    const child = rootRecord[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (isAstNode(item) && someNodeInSubtree(item, predicate)) return true;
+      }
+    } else if (isAstNode(child) && someNodeInSubtree(child, predicate)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const MESSAGE =
+  "This passes an href/hash-derived string to a `querySelector` call, which throws a `DOMException` on an invalid CSS selector instead of returning null. Wrap the call in try/catch or escape the value with `CSS.escape`.";
+
+const SELECTOR_QUERY_METHOD_NAMES = new Set([
+  "querySelector",
+  "querySelectorAll",
+  "matches",
+  "closest",
+]);
+const ELEMENT_RECEIVER_METHOD_NAMES = new Set(["matches", "closest"]);
+const HREF_ATTRIBUTE_NAMES = new Set(["href", "hash"]);
+const HREF_HASH_FUNCTION_PATTERN = /href|hash/i;
+const SHAPE_VALIDATION_METHOD_NAMES = new Set([
+  "match",
+  "test",
+  "startsWith",
+  "endsWith",
+  "indexOf",
+  "includes",
+]);
+const DEFERRED_CALLBACK_REGISTRAR_NAMES = new Set([
+  "addEventListener",
+  "setTimeout",
+  "setInterval",
+  "requestAnimationFrame",
+  "requestIdleCallback",
+  "queueMicrotask",
+  "setImmediate",
+]);
+const DOM_ELEMENT_NAME_SEGMENTS = new Set([
+  "el",
+  "elem",
+  "element",
+  "node",
+  "anchor",
+  "target",
+  "current",
+  "ref",
+  "dom",
+  "body",
+  "document",
+  "container",
+  "parent",
+  "link",
+  "button",
+]);
+
+const isHrefOrHashAttributeName = (value: unknown): boolean =>
+  typeof value === "string" && HREF_ATTRIBUTE_NAMES.has(value);
+
+// `el.getAttribute("href")` / `el.getAttribute("hash")`.
+const isHrefGetAttributeCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (!isNodeOfType(node.callee, "MemberExpression")) return false;
+  if (getStaticMemberPropertyName(node.callee) !== "getAttribute") return false;
+  const firstArgument = node.arguments?.[0];
+  return Boolean(
+    firstArgument &&
+    isNodeOfType(firstArgument, "Literal") &&
+    isHrefOrHashAttributeName(firstArgument.value),
+  );
+};
+
+// A member access whose property is `href`/`hash` (`el.href`, `location.hash`).
+const isHrefHashMemberAccess = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "MemberExpression")) return false;
+  const propertyName = getStaticMemberPropertyName(node);
+  return Boolean(propertyName && HREF_ATTRIBUTE_NAMES.has(propertyName));
+};
+
+// A call to a helper named like `getHashFromHref` / `getHref` / `hashFor`.
+const isHrefHashNamedCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = node.callee;
+  if (isNodeOfType(callee, "Identifier")) return HREF_HASH_FUNCTION_PATTERN.test(callee.name);
+  const propertyName = getStaticMemberPropertyName(callee);
+  return Boolean(propertyName && HREF_HASH_FUNCTION_PATTERN.test(propertyName));
+};
+
+const isCssEscapeCall = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") &&
+  isNodeOfType(node.callee, "MemberExpression") &&
+  isNodeOfType(node.callee.object, "Identifier") &&
+  node.callee.object.name === "CSS" &&
+  getStaticMemberPropertyName(node.callee) === "escape";
+
+// An href/hash-named helper whose in-file definition sanitizes with
+// `CSS.escape` — its output is exactly the fix the rule recommends.
+const isSanitizedSelectorHelperCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const binding = findVariableInitializer(callee, callee.name);
+  return Boolean(binding?.initializer && someNodeInSubtree(binding.initializer, isCssEscapeCall));
+};
+
+const isHrefHashDerivedExpression = (node: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(node);
+  if (isHrefGetAttributeCall(stripped) || isHrefHashMemberAccess(stripped)) return true;
+  return isHrefHashNamedCall(stripped) && !isSanitizedSelectorHelperCall(stripped);
+};
+
+// The selector argument taints to an href/hash value: either directly, or
+// through a same-file binding whose initializer is href/hash-derived.
+const selectorArgumentTaintsToHref = (argument: EsTreeNode): boolean => {
+  if (isHrefHashDerivedExpression(argument)) return true;
+  const stripped = stripParenExpression(argument);
+  if (!isNodeOfType(stripped, "Identifier")) return false;
+  const binding = findVariableInitializer(stripped, stripped.name);
+  return Boolean(binding?.initializer && isHrefHashDerivedExpression(binding.initializer));
+};
+
+const isStringLiteralSelector = (argument: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(argument);
+  if (isNodeOfType(stripped, "Literal")) return typeof stripped.value === "string";
+  return isNodeOfType(stripped, "TemplateLiteral") && stripped.expressions.length === 0;
+};
+
+const hasDomElementNameSegment = (name: string): boolean =>
+  name
+    .split(/[^A-Za-z]+/)
+    .flatMap((word) => word.split(/(?=[A-Z])/))
+    .some((segment) => DOM_ELEMENT_NAME_SEGMENTS.has(segment.toLowerCase()));
+
+// `matches`/`closest` also exist on route matchers, URLPattern-style objects,
+// and hash routers, none of which throw on an invalid CSS selector — only
+// fire when the receiver's name reads as a DOM element.
+const isLikelyDomElementReceiver = (node: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(node);
+  if (isNodeOfType(stripped, "Identifier")) return hasDomElementNameSegment(stripped.name);
+  const propertyName = getStaticMemberPropertyName(stripped);
+  return Boolean(propertyName && hasDomElementNameSegment(propertyName));
+};
+
+const makeTaintedReferenceMatcher = (
+  selectorArgument: EsTreeNode,
+): ((candidate: EsTreeNode) => boolean) => {
+  const stripped = stripParenExpression(selectorArgument);
+  const taintedName = isNodeOfType(stripped, "Identifier") ? stripped.name : null;
+  return (candidate: EsTreeNode): boolean => {
+    if (taintedName && isNodeOfType(candidate, "Identifier") && candidate.name === taintedName) {
+      return true;
+    }
+    return isHrefHashDerivedExpression(candidate);
+  };
+};
+
+// `hash.startsWith('#')`, `HASH_PATTERN.test(hash)`,
+// `knownIds.indexOf(location.hash) !== -1` — the tainted value appears as the
+// receiver or an argument of a string/regex shape check, not a bare
+// truthiness read.
+const isShapeValidatingCall = (
+  node: EsTreeNode,
+  referencesTaintedValue: (candidate: EsTreeNode) => boolean,
+): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (!isNodeOfType(node.callee, "MemberExpression")) return false;
+  const methodName = getStaticMemberPropertyName(node.callee);
+  if (!methodName || !SHAPE_VALIDATION_METHOD_NAMES.has(methodName)) return false;
+  if (someNodeInSubtree(node.callee.object, referencesTaintedValue)) return true;
+  return (node.arguments ?? []).some((argument) =>
+    someNodeInSubtree(argument, referencesTaintedValue),
+  );
+};
+
+const isEarlyExitStatement = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "BlockStatement")) {
+    const lastStatement = node.body[node.body.length - 1];
+    return Boolean(lastStatement && isEarlyExitStatement(lastStatement));
+  }
+  return (
+    node.type === "ReturnStatement" ||
+    node.type === "ThrowStatement" ||
+    node.type === "ContinueStatement" ||
+    node.type === "BreakStatement"
+  );
+};
+
+// Every conditional test that dominates the query call: enclosing
+// if/ternary/logical-&& tests plus preceding early-exit guards
+// (`if (…) return;`) in the statement lists between the call and the root.
+const collectDominatingGuardTests = (callNode: EsTreeNode): EsTreeNode[] => {
+  const guardTests: EsTreeNode[] = [];
+  let child: EsTreeNode = callNode;
+  let ancestor: EsTreeNode | null | undefined = callNode.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "IfStatement") && ancestor.test !== child) {
+      guardTests.push(ancestor.test);
+    } else if (isNodeOfType(ancestor, "ConditionalExpression") && ancestor.test !== child) {
+      guardTests.push(ancestor.test);
+    } else if (isNodeOfType(ancestor, "LogicalExpression") && ancestor.right === child) {
+      guardTests.push(ancestor.left);
+    } else if (isNodeOfType(ancestor, "BlockStatement") || isNodeOfType(ancestor, "Program")) {
+      const statements = ancestor.body;
+      const childStatementIndex = statements.findIndex((statement) => statement === child);
+      for (let statementIndex = 0; statementIndex < childStatementIndex; statementIndex += 1) {
+        const statement = statements[statementIndex];
+        if (isNodeOfType(statement, "IfStatement") && isEarlyExitStatement(statement.consequent)) {
+          guardTests.push(statement.test);
+        }
+      }
+    }
+    child = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return guardTests;
+};
+
+// A dominating guard already shape-validated the tainted value (regex test,
+// prefix check, containment check) — the selector's shape is self-controlled,
+// so the DOMException the rule warns about cannot occur in practice. Bare
+// truthiness guards (`if (href)`) do NOT count.
+const isShapeValidatedByDominatingGuard = (
+  callNode: EsTreeNode,
+  selectorArgument: EsTreeNode,
+): boolean => {
+  const referencesTaintedValue = makeTaintedReferenceMatcher(selectorArgument);
+  return collectDominatingGuardTests(callNode).some((guardTest) =>
+    someNodeInSubtree(guardTest, (candidate) =>
+      isShapeValidatingCall(candidate, referencesTaintedValue),
+    ),
+  );
+};
+
+const isFunctionLikeNode = (node: EsTreeNode): boolean =>
+  node.type === "FunctionDeclaration" ||
+  node.type === "FunctionExpression" ||
+  node.type === "ArrowFunctionExpression";
+
+const getCalleeStaticName = (callNode: EsTreeNodeOfType<"CallExpression">): string | null => {
+  const callee = stripParenExpression(callNode.callee);
+  if (isNodeOfType(callee, "Identifier")) return callee.name;
+  return getStaticMemberPropertyName(callee);
+};
+
+// The nearest enclosing function that is passed to a deferred-callback
+// registrar (addEventListener, setTimeout, …). A try block around the
+// registration does NOT guard the callback body — it runs after the try
+// frame is gone — so the try walk must stop there.
+const findDeferredCallbackBoundary = (node: EsTreeNode): EsTreeNode | null => {
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor) {
+    if (isFunctionLikeNode(ancestor)) {
+      const enclosingCall = ancestor.parent;
+      if (
+        enclosingCall &&
+        isNodeOfType(enclosingCall, "CallExpression") &&
+        enclosingCall.arguments?.some((argument) => argument === ancestor)
+      ) {
+        const registrarName = getCalleeStaticName(enclosingCall);
+        if (registrarName && DEFERRED_CALLBACK_REGISTRAR_NAMES.has(registrarName)) {
+          return ancestor;
+        }
+      }
+    }
+    ancestor = ancestor.parent ?? null;
+  }
+  return null;
+};
+
+// Flags `document.querySelector(x)` / `querySelectorAll` / `Element.matches` /
+// `closest` when the selector argument taints to an anchor href/hash value and
+// the call is not inside try/catch. The query throws a `DOMException` on an
+// invalid selector, so an href fragment like `#section 1` crashes the handler.
+//
+// v1 scope: only the high-confidence href/hash sink fires. String literals,
+// CSS-module templates, `CSS.escape` outputs (including in-file helpers that
+// wrap it), SCREAMING_SNAKE selector constants, opaque `props.*Selector`
+// config values, non-DOM `matches()`/`closest()` receivers (route matchers),
+// and values shape-validated by a dominating guard (regex test, prefix or
+// containment check) are intentionally quiet.
+export const noNonLiteralSelectorQueryWithoutTryCatch = defineRule({
+  id: "no-non-literal-selector-query-without-try-catch",
+  title: "Unguarded querySelector with href-derived selector",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "`querySelector`/`querySelectorAll`/`matches`/`closest` throw a `DOMException` on an invalid CSS selector, and href/hash fragments are frequently invalid. Wrap the call in try/catch or normalize the value with `CSS.escape`.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const callee = node.callee;
+      if (!isNodeOfType(callee, "MemberExpression")) return;
+      const methodName = getStaticMemberPropertyName(callee);
+      if (!methodName || !SELECTOR_QUERY_METHOD_NAMES.has(methodName)) return;
+      if (
+        ELEMENT_RECEIVER_METHOD_NAMES.has(methodName) &&
+        !isLikelyDomElementReceiver(callee.object)
+      ) {
+        return;
+      }
+      const selectorArgument = node.arguments?.[0];
+      if (!selectorArgument || isNodeOfType(selectorArgument, "SpreadElement")) return;
+      if (isStringLiteralSelector(selectorArgument)) return;
+      if (!selectorArgumentTaintsToHref(selectorArgument)) return;
+      if (isShapeValidatedByDominatingGuard(node, selectorArgument)) return;
+      if (
+        isInsideTryStatement(node as EsTreeNode, {
+          region: "block",
+          boundary: findDeferredCallbackBoundary(node),
+        })
+      ) {
+        return;
+      }
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-null-assertion-on-maybe-undefined-result.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-null-assertion-on-maybe-undefined-result.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noNonNullAssertionOnMaybeUndefinedResult } from "./no-non-null-assertion-on-maybe-undefined-result.js";
+
+describe("no-non-null-assertion-on-maybe-undefined-result", () => {
+  it("flags .find(predicate)! followed by a member access", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const field = columns.find((col) => col.isKey)!.field;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .findLast(predicate)! followed by a member access", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const value = parts.findLast((d) => d.type === 'group')!.value;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags .match(/re/)! followed by an index access", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const first = input.match(/(\\d+)/)![1];`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags map.get(dynamicKey)! when the map is a local bare new Map() never populated in scope", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `function read(key) { const lookup = new Map(); return lookup.get(key)!.value; }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an index access (not an enumerated callee)", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const item = someArray[i]!.id;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an optional property assertion", () => {
+    const result = runRule(noNonNullAssertionOnMaybeUndefinedResult, `const b = obj.foo!.bar;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a loop-guarded queue drain with shift", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `while (frontier.length) { const x = frontier.shift()!.id; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag pop", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const x = stack.pop()!.value;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag map.get with a literal key", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const v = cache.get('fixed')!.value;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag map.get when the map is set in scope", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `function build(key) { const map = new Map(); map.set(key, 1); return map.get(key)!.value; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag this.map.get(key)! guarded by this.map.has/set in the same method", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `class C { add(key, cb) { if (!this.listeners.has(key)) { this.listeners.set(key, new Set()); } this.listeners.get(key)!.add(cb); } }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag map.get(id)! in a nested callback when the enclosing function populates the map", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `function assign(edges) { const sides = new Map(); for (const e of edges) sides.set(e.id, {}); edges.forEach((e) => { sides.get(e.id)!.side = 1; }); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag map.get on a function parameter (caller-populated invariant map, semiotic computeNode idiom)", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `function computeNode(sides, edge) { return sides.get(edge.id)!.top; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag map.get on a call-initialized variable (map built exhaustively by a helper)", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `function layout(edges) { const sides = assignSides(edges); for (const e of edges) { e.left = sides.get(e.id)!.left; } }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag this.#field.get(key)! guarded by has/set on the same private field", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `class C { #listeners = new Map(); add(key, cb) { if (!this.#listeners.has(key)) { this.#listeners.set(key, new Set()); } this.#listeners.get(key)!.add(cb); } }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a lookup built via the new Map(entries) constructor", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `function pick(options, value) { const lookup = new Map(options.map((o) => [o.value, o])); return lookup.get(value)!.label; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag .match(re)! after the same regex literal was validated with .test (validate-then-extract)", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `function parse(line) { if (!/^(\\d+)/.test(line)) return null; return line.match(/^(\\d+)/)![1]; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag .match(re)! after the same regex identifier was validated with .test", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const versionPattern = /v(\\d+)/; function parse(line) { if (!versionPattern.test(line)) return null; return line.match(versionPattern)![1]; }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags .match! when a different regex was tested", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `function parse(line) { if (!/^#/.test(line)) return null; return line.match(/(\\d+)/)![1]; }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a non-dereferenced find assertion", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const found = list.find((x) => x.ok)!;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag .find without a predicate function argument", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const el = $(root).find('.selector')!.first;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet in test files", () => {
+    const result = runRule(
+      noNonNullAssertionOnMaybeUndefinedResult,
+      `const field = columns.find((col) => col.isKey)!.field;`,
+      { filename: "table.test.tsx" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-null-assertion-on-maybe-undefined-result.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-non-null-assertion-on-maybe-undefined-result.ts
@@ -1,0 +1,211 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isObjectOfMemberAccess } from "../../utils/is-object-of-member-access.js";
+import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Built-in methods the language spec types as `T | undefined` / `T | null`
+// on a miss: Array `find`/`findLast` (undefined), String `match` (null),
+// Map/cache `get` (undefined). `pop`/`shift` are intentionally excluded —
+// under a `.length` loop guard they are the idiomatic safe queue-drain —
+// and `matchAll` returns an (empty) iterator, never null.
+const NO_MATCH_MESSAGES: Readonly<Record<string, string>> = {
+  find: "`.find(...)` returns `undefined` when nothing matches, so asserting `!` here crashes on the next access when the predicate misses; handle the missing case with optional chaining or a guard.",
+  findLast:
+    "`.findLast(...)` returns `undefined` when nothing matches, so asserting `!` here crashes on the next access when the predicate misses; handle the missing case with optional chaining or a guard.",
+  match:
+    "`.match(...)` returns `null` when the pattern does not match, so asserting `!` here crashes on the next index or access; check the result before reading it.",
+  get: "`.get(...)` returns `undefined` when the key is absent, so asserting `!` here crashes on the next access when the key misses; check for the key or handle the missing value.",
+};
+
+// Normalize a `.get(...)` receiver to a comparable path key so the
+// presence proof can match the exact same map: `sides` (Identifier),
+// `this` (ThisExpression), or a non-computed member chain like
+// `this.updateCallbacks`. Computed or deeper shapes are not comparable.
+const receiverPathKey = (node: EsTreeNode): string | null => {
+  const target = stripParenExpression(node);
+  if (isNodeOfType(target, "Identifier")) return target.name;
+  if (isNodeOfType(target, "ThisExpression")) return "this";
+  if (
+    isNodeOfType(target, "MemberExpression") &&
+    !target.computed &&
+    isNodeOfType(target.property, "Identifier")
+  ) {
+    const objectKey = receiverPathKey(target.object as EsTreeNode);
+    return objectKey ? `${objectKey}.${target.property.name}` : null;
+  }
+  return null;
+};
+
+// The outermost enclosing function (or Program at top level). A
+// `map.get(key)!` inside a nested callback is still provably safe when the
+// map is populated in the enclosing function (`for (...) sides.set(...)`),
+// so the proof must look past the immediate scope up to the outermost one.
+const findOutermostScope = (node: EsTreeNode): EsTreeNode | null => {
+  let ancestor = node.parent;
+  let outermostFunction: EsTreeNode | null = null;
+  let program: EsTreeNode | null = null;
+  while (ancestor) {
+    if (isFunctionLike(ancestor)) outermostFunction = ancestor;
+    if (isNodeOfType(ancestor, "Program")) {
+      program = ancestor;
+      break;
+    }
+    ancestor = ancestor.parent ?? null;
+  }
+  return outermostFunction ?? program;
+};
+
+// A `map.get(key)!` is likely safe when the same map is populated or
+// checked (`map.set(...)` / `map.has(...)`) somewhere in the enclosing
+// scope, so abstain there — a false negative is preferable to a false
+// positive. Matches `this.updateCallbacks`-style member receivers too, not
+// just bare identifiers.
+const scopeProvesKeyPresence = (assertion: EsTreeNode, receiverKey: string): boolean => {
+  const scope = findOutermostScope(assertion);
+  if (!scope) return false;
+  let proven = false;
+  walkAst(scope, (child) => {
+    if (proven) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = child.callee;
+    if (
+      isNodeOfType(callee, "MemberExpression") &&
+      !callee.computed &&
+      isNodeOfType(callee.property, "Identifier") &&
+      (callee.property.name === "set" || callee.property.name === "has") &&
+      receiverPathKey(callee.object as EsTreeNode) === receiverKey
+    ) {
+      proven = true;
+      return false;
+    }
+  });
+  return proven;
+};
+
+// The `get` branch only fires when the map's emptiness at construction is
+// provable in scope: the receiver must be a local variable initialized with
+// a bare `new Map()` / `new WeakMap()` (no entries argument). Parameters,
+// call-initialized variables (`const sides = assignSides(...)`), `new
+// Map(entries)` lookups, `this.*` fields, and unresolvable receivers all
+// carry cross-function population invariants the rule cannot see, so they
+// abstain.
+const isBareMapConstruction = (node: EsTreeNode | null | undefined): boolean => {
+  if (!node) return false;
+  const target = stripParenExpression(node);
+  return (
+    isNodeOfType(target, "NewExpression") &&
+    isNodeOfType(target.callee, "Identifier") &&
+    (target.callee.name === "Map" || target.callee.name === "WeakMap") &&
+    target.arguments.length === 0
+  );
+};
+
+const scopeDeclaresEmptyMap = (assertion: EsTreeNode, receiverName: string): boolean => {
+  const scope = findOutermostScope(assertion);
+  if (!scope) return false;
+  let didFindDeclaration = false;
+  walkAst(scope, (child) => {
+    if (didFindDeclaration) return false;
+    if (!isNodeOfType(child, "VariableDeclarator")) return;
+    if (!isNodeOfType(child.id, "Identifier") || child.id.name !== receiverName) return;
+    if (isBareMapConstruction(child.init ? (child.init as EsTreeNode) : null)) {
+      didFindDeclaration = true;
+      return false;
+    }
+  });
+  return didFindDeclaration;
+};
+
+// Normalize the regex a `.match(...)` receives so it can be compared with
+// the receiver of a `.test(...)` call: same identifier, or a regex literal
+// with the same source text.
+const regexComparableKey = (node: EsTreeNode): string | null => {
+  const target = stripParenExpression(node);
+  if (isNodeOfType(target, "Identifier")) return `id:${target.name}`;
+  if (isNodeOfType(target, "Literal") && "regex" in target) return `regex:${target.raw}`;
+  return null;
+};
+
+// `str.match(re)!` is likely on a proven-matching path when the enclosing
+// scope also runs `re.test(...)` (validate-then-extract), so abstain there.
+const scopeProvesMatchTested = (assertion: EsTreeNode, regexKey: string): boolean => {
+  const scope = findOutermostScope(assertion);
+  if (!scope) return false;
+  let proven = false;
+  walkAst(scope, (child) => {
+    if (proven) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = child.callee;
+    if (
+      isNodeOfType(callee, "MemberExpression") &&
+      !callee.computed &&
+      isNodeOfType(callee.property, "Identifier") &&
+      callee.property.name === "test" &&
+      regexComparableKey(callee.object as EsTreeNode) === regexKey
+    ) {
+      proven = true;
+      return false;
+    }
+  });
+  return proven;
+};
+
+const isPredicateArgument = (node: EsTreeNode | null | undefined): boolean =>
+  Boolean(
+    node &&
+    (isNodeOfType(node, "ArrowFunctionExpression") || isNodeOfType(node, "FunctionExpression")),
+  );
+
+export const noNonNullAssertionOnMaybeUndefinedResult = defineRule({
+  id: "no-non-null-assertion-on-maybe-undefined-result",
+  title: "Non-null assertion on a maybe-undefined result",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "Drop the `!` on `.find`/`.match`/`.get` results and handle the miss (optional chaining, a guard, or a fallback). These built-ins return `undefined`/`null` when nothing matches, so the assertion just moves the crash one line later.",
+  create: (context: RuleContext) => {
+    const skipTestlikeFile = isTestlikeFilename(context.filename);
+    return {
+      TSNonNullExpression(node: EsTreeNodeOfType<"TSNonNullExpression">) {
+        if (skipTestlikeFile) return;
+        if (!isObjectOfMemberAccess(node as EsTreeNode)) return;
+        const inner = stripParenExpression(node.expression as EsTreeNode);
+        if (!isNodeOfType(inner, "CallExpression")) return;
+        const callee = inner.callee;
+        if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+        if (!isNodeOfType(callee.property, "Identifier")) return;
+        const methodName = callee.property.name;
+        const message = NO_MATCH_MESSAGES[methodName];
+        if (!message) return;
+
+        const args = inner.arguments ?? [];
+        if (methodName === "find" || methodName === "findLast") {
+          if (!isPredicateArgument(args[0] ? stripParenExpression(args[0]) : null)) return;
+        }
+        if (methodName === "match") {
+          const pattern = args[0] ? stripParenExpression(args[0]) : null;
+          const regexKey = pattern ? regexComparableKey(pattern) : null;
+          if (regexKey && scopeProvesMatchTested(node as EsTreeNode, regexKey)) return;
+        }
+        if (methodName === "get") {
+          const key = args[0] ? stripParenExpression(args[0]) : null;
+          // A static literal key is often known-present; only dynamic keys
+          // carry real miss risk.
+          if (!key || isNodeOfType(key, "Literal")) return;
+          const receiver = stripParenExpression(callee.object as EsTreeNode);
+          if (!isNodeOfType(receiver, "Identifier")) return;
+          if (!scopeDeclaresEmptyMap(node as EsTreeNode, receiver.name)) return;
+          if (scopeProvesKeyPresence(node as EsTreeNode, receiver.name)) return;
+        }
+
+        context.report({ node, message });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-nondeterministic-id-value-in-render-body.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-nondeterministic-id-value-in-render-body.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noNondeterministicIdValueInRenderBody } from "./no-nondeterministic-id-value-in-render-body.js";
+
+describe("no-nondeterministic-id-value-in-render-body", () => {
+  it("flags uniqueId bound in render body wired to htmlFor", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { uniqueId } from "lodash";
+      const Toggle = ({ label, onChange }) => {
+        const id = uniqueId();
+        return (<><label htmlFor={id}>{label}</label><input id={id} onChange={onChange} /></>);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags crypto.randomUUID bound in render body wired to aria", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `const TextInput = ({ error }) => {
+        const describedById = crypto.randomUUID();
+        return (<><input aria-describedby={describedById} /><span id={describedById}>{error}</span></>);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags nanoid bound in render body used as an SVG clip-path reference", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { nanoid } from "nanoid";
+      const RadioInput = () => {
+        const clipId = nanoid();
+        return (<svg><clipPath id={clipId} /><rect clipPath={\`url(#\${clipId})\`} /></svg>);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the useMemo one-shot variant even without a JSX sink", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { uniqueId } from "lodash";
+      const useBundleChartData = () => {
+        const chartId = useMemo(() => uniqueId(), []);
+        return { chartId };
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the id is minted inside an event handler", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `const TaskCommentInput = () => {
+        const submit = () => {
+          const commentId = crypto.randomUUID();
+          addComment({ id: commentId });
+        };
+        return <button onClick={submit}>Send</button>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the id is minted inside a provider callback", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { nanoid } from "nanoid";
+      const AlertProvider = ({ children }) => {
+        const addAlert = (message) => {
+          const id = nanoid();
+          setAlerts((prev) => [...prev, { id, message }]);
+        };
+        return <AlertContext.Provider value={{ addAlert }}>{children}</AlertContext.Provider>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a generated value used only for logging (no identity sink)", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `const Demo = () => {
+        const traceId = crypto.randomUUID();
+        logger.debug('render', traceId);
+        return <CodeDiff />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the value is already wrapped in useState", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { uniqueId } from "lodash";
+      const VictoryPortal = () => {
+        const [id] = useState(uniqueId());
+        return <div id={id} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for key usage (deferred to no-random-key)", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { uniqueId } from "lodash";
+      const List = ({ items }) => {
+        const id = uniqueId();
+        return <ul>{items.map((item) => <li key={id}>{item}</li>)}</ul>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the generator name is a local shadow", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `const uniqueId = () => "stable-id";
+      const Toggle = () => {
+        const id = uniqueId();
+        return <input id={id} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet outside a component or hook body", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { nanoid } from "nanoid";
+      const makeThing = () => {
+        const id = nanoid();
+        return { id };
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for Date.now / Math.random (deferred to the time rule)", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `const Widget = () => {
+        const id = Date.now().toString();
+        return <div id={id} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the sink reads a member property of the same name (todo.id list idiom)", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { nanoid } from "nanoid";
+      const TodoList = ({ todos, onDraft }) => {
+        const id = nanoid();
+        const startDraft = () => onDraft({ id });
+        return (<ul onMouseDown={startDraft}>{todos.map((todo) => <li key={todo.id} id={\`todo-\${todo.id}\`}>{todo.text}</li>)}</ul>);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when a map-callback destructured param shadows the generated id (htmlFor={id} field-list idiom)", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { nanoid } from "nanoid";
+      const Fields = ({ fields, onAdd }) => {
+        const id = nanoid();
+        const addField = () => onAdd({ id, value: "" });
+        return (<div onFocus={addField}>{fields.map(({ id, label }) => <label key={id} htmlFor={id}>{label}</label>)}</div>);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags the pre-useId fallback idiom `providedId || uniqueId()` wired to htmlFor", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { uniqueId } from "lodash";
+      const Toggle = ({ label, id: providedId }) => {
+        const id = providedId || uniqueId();
+        return (<><label htmlFor={id}>{label}</label><input id={id} /></>);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a template-literal-prefixed generated id flowing into an SVG clipPath sink", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { nanoid } from "nanoid";
+      const Chart = () => {
+        const clipId = \`clip-\${nanoid()}\`;
+        return (<svg><clipPath id={clipId} /><rect clipPath={\`url(#\${clipId})\`} /></svg>);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat useMemo with real deps as a one-shot", () => {
+    const result = runRule(
+      noNondeterministicIdValueInRenderBody,
+      `import { uniqueId } from "lodash";
+      const useThing = (seed) => {
+        const chartId = useMemo(() => uniqueId(), [seed]);
+        return { chartId };
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-nondeterministic-id-value-in-render-body.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-nondeterministic-id-value-in-render-body.ts
@@ -1,0 +1,257 @@
+import {
+  componentOrHookDisplayNameForFunction,
+  nearestEnclosingFunction,
+} from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Impure id generators (bare-identifier forms). A local same-file
+// binding of the same name shadows the library import, so those are
+// resolved away before matching.
+const IMPURE_GENERATOR_IDENTIFIER_NAMES = new Set(["uniqueId", "nanoid", "shortid"]);
+
+// JSX attributes whose value is an *identity reference*: another element
+// or an aria/SVG relationship points at this id. When the id changes
+// every render the reference and its target drift apart.
+const IDENTITY_SINK_ATTRIBUTE_NAMES = new Set([
+  "id",
+  "htmlFor",
+  "clipPath",
+  "mask",
+  "filter",
+  "fill",
+  "stroke",
+]);
+
+const isImportSpecifierNode = (node: EsTreeNode | null | undefined): boolean =>
+  Boolean(
+    node &&
+    (isNodeOfType(node, "ImportSpecifier") ||
+      isNodeOfType(node, "ImportDefaultSpecifier") ||
+      isNodeOfType(node, "ImportNamespaceSpecifier")),
+  );
+
+// True when `identifier` refers to the real library generator, not a
+// same-file local binding that shadows it. Unresolved names (global /
+// auto-imported) and names bound to an import specifier both qualify;
+// a local function / variable of the same name does not.
+const isUnshadowedLibraryReference = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding) return true;
+  return isImportSpecifierNode(binding.initializer);
+};
+
+// True when `node` is a call to an impure id generator:
+// `uniqueId()` / `nanoid()` / `shortid()`, `crypto.randomUUID()`,
+// `_.uniqueId()` / `lodash.uniqueId()`, or `shortid.generate()`.
+// Time/random primitives (`Date.now`, `new Date`, `Math.random`) are
+// deliberately excluded — those belong to `rendering-hydration-mismatch-time`.
+const isImpureIdGeneratorCall = (node: EsTreeNode): boolean => {
+  const unwrapped = stripParenExpression(node);
+  if (!isNodeOfType(unwrapped, "CallExpression")) return false;
+  const callee = unwrapped.callee;
+
+  if (isNodeOfType(callee, "Identifier")) {
+    if (!IMPURE_GENERATOR_IDENTIFIER_NAMES.has(callee.name)) return false;
+    return isUnshadowedLibraryReference(callee);
+  }
+
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  const propertyName = callee.property.name;
+
+  if (propertyName === "randomUUID") {
+    return (
+      isNodeOfType(callee.object, "Identifier") &&
+      callee.object.name === "crypto" &&
+      isUnshadowedLibraryReference(callee.object)
+    );
+  }
+  // `_.uniqueId()` / `lodash.uniqueId()` — the distinctive method name
+  // is enough; the object is a lodash-shaped namespace.
+  if (propertyName === "uniqueId") return true;
+  // `shortid.generate()`
+  if (propertyName === "generate") {
+    return isNodeOfType(callee.object, "Identifier") && callee.object.name === "shortid";
+  }
+  return false;
+};
+
+// True when `node` is — or wraps, through the fallback/prefix spellings
+// (`providedId || uniqueId()`, `cond ? a : nanoid()`, `` `clip-${nanoid()}` ``,
+// `"clip-" + nanoid()`) — an impure id generator call.
+const containsImpureIdGeneratorCall = (node: EsTreeNode): boolean => {
+  const unwrapped = stripParenExpression(node);
+  if (isImpureIdGeneratorCall(unwrapped)) return true;
+  if (isNodeOfType(unwrapped, "LogicalExpression")) {
+    return (
+      containsImpureIdGeneratorCall(unwrapped.left) ||
+      containsImpureIdGeneratorCall(unwrapped.right)
+    );
+  }
+  if (isNodeOfType(unwrapped, "ConditionalExpression")) {
+    return (
+      containsImpureIdGeneratorCall(unwrapped.consequent) ||
+      containsImpureIdGeneratorCall(unwrapped.alternate)
+    );
+  }
+  if (isNodeOfType(unwrapped, "TemplateLiteral")) {
+    return (unwrapped.expressions ?? []).some((expression) =>
+      containsImpureIdGeneratorCall(expression),
+    );
+  }
+  if (isNodeOfType(unwrapped, "BinaryExpression") && unwrapped.operator === "+") {
+    return (
+      containsImpureIdGeneratorCall(unwrapped.left) ||
+      containsImpureIdGeneratorCall(unwrapped.right)
+    );
+  }
+  return false;
+};
+
+// The single returned expression of an arrow/function callback, or null
+// when the body doesn't reduce to one returned expression.
+const soleReturnedExpression = (callback: EsTreeNode): EsTreeNode | null => {
+  if (!isFunctionLike(callback)) return null;
+  const body = callback.body as EsTreeNode;
+  if (!isNodeOfType(body, "BlockStatement")) return body;
+  const statements = body.body ?? [];
+  const returnStatement = statements.find((statement) =>
+    isNodeOfType(statement, "ReturnStatement"),
+  );
+  if (returnStatement && isNodeOfType(returnStatement, "ReturnStatement")) {
+    return (returnStatement.argument as EsTreeNode | null) ?? null;
+  }
+  return null;
+};
+
+// `useMemo(() => <impure>, [])`. React may discard and recompute a
+// memoized value, so this is NOT a stable id — flag it too.
+const isUseMemoOneShotImpureGenerator = (node: EsTreeNode): boolean => {
+  const unwrapped = stripParenExpression(node);
+  if (!isNodeOfType(unwrapped, "CallExpression")) return false;
+  if (getCalleeName(unwrapped) !== "useMemo") return false;
+  const callback = unwrapped.arguments?.[0];
+  const dependencies = unwrapped.arguments?.[1];
+  if (!callback || !isFunctionLike(callback)) return false;
+  if (!dependencies || !isNodeOfType(dependencies, "ArrayExpression")) return false;
+  if ((dependencies.elements ?? []).length !== 0) return false;
+  const returned = soleReturnedExpression(callback);
+  return Boolean(returned && containsImpureIdGeneratorCall(returned));
+};
+
+const jsxAttributeName = (attribute: EsTreeNode): string | null => {
+  if (!isNodeOfType(attribute, "JSXAttribute")) return null;
+  if (isNodeOfType(attribute.name, "JSXIdentifier")) return attribute.name.name;
+  return null;
+};
+
+// Filters out identifier positions that are not variable references:
+// a non-computed member property (`todo.id`) and a non-shorthand,
+// non-computed object key (`{ id: value }`) reuse the name without
+// reading the binding.
+const isVariableReferencePosition = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const parent = identifier.parent;
+  if (!parent) return true;
+  if (
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.property === identifier &&
+    !parent.computed
+  ) {
+    return false;
+  }
+  if (
+    isNodeOfType(parent, "Property") &&
+    parent.key === identifier &&
+    !parent.computed &&
+    !parent.shorthand
+  ) {
+    return false;
+  }
+  return true;
+};
+
+// True when the subtree reads the exact render-body binding — same name
+// alone is not enough: a map-callback param `({ id }) => …` shadows the
+// outer `const id = nanoid()`, so each candidate identifier is resolved
+// back to its declaration before it counts.
+const subtreeReferencesBinding = (
+  subtree: EsTreeNode,
+  bindingIdentifier: EsTreeNodeOfType<"Identifier">,
+): boolean => {
+  let found = false;
+  walkAst(subtree, (child) => {
+    if (found) return false;
+    if (!isNodeOfType(child, "Identifier") || child.name !== bindingIdentifier.name) return;
+    if (!isVariableReferencePosition(child)) return;
+    const resolvedBinding = findVariableInitializer(child, child.name);
+    if (!resolvedBinding || resolvedBinding.bindingIdentifier !== bindingIdentifier) return;
+    found = true;
+    return false;
+  });
+  return found;
+};
+
+// True when the binding is threaded into an identity-reference JSX
+// attribute (`id` / `htmlFor` / `aria-*` / an SVG `clip-path` /
+// `url(#...)` paint) anywhere inside the component/hook body.
+const bindingFlowsIntoIdentityReferenceSink = (
+  functionNode: EsTreeNode,
+  bindingIdentifier: EsTreeNodeOfType<"Identifier">,
+): boolean => {
+  let flows = false;
+  walkAst(functionNode, (child) => {
+    if (flows) return false;
+    const attributeName = jsxAttributeName(child);
+    if (!attributeName) return;
+    const isSink =
+      IDENTITY_SINK_ATTRIBUTE_NAMES.has(attributeName) || attributeName.startsWith("aria-");
+    if (!isSink) return;
+    const value = isNodeOfType(child, "JSXAttribute") ? (child.value as EsTreeNode | null) : null;
+    if (value && subtreeReferencesBinding(value, bindingIdentifier)) {
+      flows = true;
+      return false;
+    }
+  });
+  return flows;
+};
+
+const GENERATOR_MESSAGE =
+  "This id generator runs on every render, so the id changes each render and its htmlFor/aria/SVG reference stops matching (and mismatches during SSR). Use useId for reference ids, or a useRef/useState initializer to mint it once.";
+
+const USE_MEMO_MESSAGE =
+  "useMemo does not guarantee a stable value (React may recompute it), so this id can change mid-session and break its reference. Mint it once with useRef or a useState initializer instead.";
+
+export const noNondeterministicIdValueInRenderBody = defineRule({
+  id: "no-nondeterministic-id-value-in-render-body",
+  title: "Nondeterministic id generated in render body",
+  severity: "warn",
+  category: "Correctness",
+  tags: ["react-jsx-only"],
+  recommendation:
+    "An id generator (uniqueId/nanoid/crypto.randomUUID/shortid) bound in the render body re-runs every render, so the id is unstable and breaks htmlFor/aria/SVG references and SSR hydration. Use useId for reference ids, or a useRef/useState initializer to mint it once.",
+  create: (context: RuleContext) => ({
+    VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+      if (!isNodeOfType(node.id, "Identifier") || !node.init) return;
+      const enclosingFunction = nearestEnclosingFunction(node);
+      if (!enclosingFunction || !componentOrHookDisplayNameForFunction(enclosingFunction)) return;
+
+      const initializer = stripParenExpression(node.init);
+      if (isUseMemoOneShotImpureGenerator(initializer)) {
+        context.report({ node: node.init, message: USE_MEMO_MESSAGE });
+        return;
+      }
+      if (!containsImpureIdGeneratorCall(initializer)) return;
+      if (!bindingFlowsIntoIdentityReferenceSink(enclosingFunction, node.id)) return;
+      context.report({ node: node.init, message: GENERATOR_MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-nullish-coalescing-arithmetic-precedence.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-nullish-coalescing-arithmetic-precedence.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noNullishCoalescingArithmeticPrecedence } from "./no-nullish-coalescing-arithmetic-precedence.js";
+
+describe("no-nullish-coalescing-arithmetic-precedence", () => {
+  it("flags x ?? 0 / y", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = x ?? 0 / y;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a ?? 0 - b", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = a ?? 0 - b;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the comparator swallow with a -1 fallback (indexOf/priority sentinel)", () => {
+    const result = runRule(
+      noNullishCoalescingArithmeticPrecedence,
+      `list.sort((a, b) => a.priority ?? -1 - (b.priority ?? -1));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the OpenOrders sort-comparator shape", () => {
+    const result = runRule(
+      noNullishCoalescingArithmeticPrecedence,
+      `list.sort((a, b) => b.at ?? 0 - (a.at ?? 0));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a chained left-spine numeric literal", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = a ?? 0 - b - c;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the parenthesized (x ?? 0) / y", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = (x ?? 0) / y;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a computed default with two identifiers", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = x ?? count - max;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a scaled default whose leftmost leaf is an identifier", () => {
+    const result = runRule(
+      noNullishCoalescingArithmeticPrecedence,
+      `const r = x ?? carouselWidth * 5;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a call-expression fallback", () => {
+    const result = runRule(
+      noNullishCoalescingArithmeticPrecedence,
+      `const r = x ?? Math.floor(y);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag ?? mixed with a comparison", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = x ?? y > 0;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag string concatenation with a string literal", () => {
+    const result = runRule(
+      noNullishCoalescingArithmeticPrecedence,
+      `const r = name ?? "" + suffix;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an explicitly parenthesized arithmetic fallback", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = x ?? (0 / y);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a plain ?? with a literal fallback", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = x ?? 0;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a fully-constant unit-math default (60 * 1000 ms poll interval)", () => {
+    const result = runRule(
+      noNullishCoalescingArithmeticPrecedence,
+      `const pollInterval = props.interval ?? 60 * 1000;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a fully-constant bytes default (100 * 1024 * 1024 upload cap)", () => {
+    const result = runRule(
+      noNullishCoalescingArithmeticPrecedence,
+      `const cap = maxUploadBytes ?? 100 * 1024 * 1024;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a fully-constant default with a negated literal operand", () => {
+    const result = runRule(noNullishCoalescingArithmeticPrecedence, `const r = a ?? -1 * 60;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-nullish-coalescing-arithmetic-precedence.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-nullish-coalescing-arithmetic-precedence.ts
@@ -1,0 +1,69 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const ARITHMETIC_OPERATORS = new Set(["*", "/", "%", "-", "+"]);
+
+const isNumericLiteralLeaf = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "UnaryExpression") && (node.operator === "-" || node.operator === "+")) {
+    return isNumericLiteralLeaf(node.argument as EsTreeNode);
+  }
+  return isNodeOfType(node, "Literal") && typeof node.value === "number";
+};
+
+// The intended fallback is the token immediately after `??`. When the
+// right operand is a bare (unparenthesized) arithmetic expression whose
+// leftmost leaf is a numeric literal, that literal got swallowed into the
+// arithmetic: `x ?? 0 / y` parsed as `x ?? (0 / y)` rather than the
+// intended `(x ?? 0) / y`. A leftmost identifier/member (e.g.
+// `x ?? count - max`, `x ?? itemGap / 2`) is a legitimate computed
+// default and stays quiet.
+const leftmostLeafIsNumericLiteral = (node: EsTreeNode): boolean => {
+  let current = node;
+  while (isNodeOfType(current, "BinaryExpression")) {
+    current = current.left as EsTreeNode;
+  }
+  return isNumericLiteralLeaf(current);
+};
+
+// A fully-constant fallback (`x ?? 100 * 1024 * 1024`, `x ?? 60 * 1000`)
+// evaluates to a fixed value regardless of precedence — the swallowed-fallback
+// bug needs an identifier/member operand in the arithmetic.
+const hasNonNumericLiteralLeaf = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "BinaryExpression")) {
+    return (
+      hasNonNumericLiteralLeaf(node.left as EsTreeNode) ||
+      hasNonNumericLiteralLeaf(node.right as EsTreeNode)
+    );
+  }
+  return !isNumericLiteralLeaf(node);
+};
+
+export const noNullishCoalescingArithmeticPrecedence = defineRule({
+  id: "no-nullish-coalescing-arithmetic-precedence",
+  title: "Nullish coalescing swallowed by adjacent arithmetic",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "Arithmetic binds tighter than `??`, so wrap the nullish part in parentheses (`(x ?? 0) / y`) to compute the value you actually intend.",
+  create: (context: RuleContext) => ({
+    LogicalExpression(node: EsTreeNodeOfType<"LogicalExpression">) {
+      if (node.operator !== "??") return;
+      const right = node.right as EsTreeNode;
+      // Only a BARE arithmetic BinaryExpression — an explicitly
+      // parenthesized right operand means the author disambiguated intent.
+      if (!isNodeOfType(right, "BinaryExpression")) return;
+      if (!ARITHMETIC_OPERATORS.has(right.operator)) return;
+      if (!leftmostLeafIsNumericLiteral(right)) return;
+      if (!hasNonNumericLiteralLeaf(right)) return;
+
+      context.report({
+        node,
+        message:
+          "Arithmetic binds tighter than `??`, so this runs as `x ?? (0 / y)` and divides the fallback instead of the value. Wrap the nullish part in parentheses like `(x ?? 0) / y`.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-keys-values-entries-on-maybe-undefined.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-keys-values-entries-on-maybe-undefined.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noObjectKeysValuesEntriesOnMaybeUndefined } from "./no-object-keys-values-entries-on-maybe-undefined.js";
+
+describe("no-object-keys-values-entries-on-maybe-undefined", () => {
+  it("flags Object.entries on an optional param (api-client shape)", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function buildParams(params?: any) {
+        return Object.entries(params);
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Object.keys on an optional param", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(options?: Record<string, unknown>) {
+        return Object.keys(options);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Object.values on an optional param", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      const f = (data?: any) => Object.values(data);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Object.keys on an optional-chained member argument", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `const list = Object.keys(response?.data);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a `?? {}` fallback", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params?: any) {
+        return Object.keys(params ?? {});
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an optional-chained member with a `?? {}` fallback", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `const list = Object.keys(response?.data ?? {});`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a required (non-optional) param", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params: Record<string, any>) {
+        return Object.keys(params);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a param with a default value", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params = {}) {
+        return Object.keys(params);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag inside an enclosing `if (x)` guard", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params?: any) {
+        if (params) {
+          return Object.keys(params);
+        }
+        return [];
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag after an early-return guard", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params?: any) {
+        if (!params) return [];
+        return Object.entries(params);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a `&&` short-circuit guard", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params?: any) {
+        return params && Object.keys(params);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a ternary consequent guarded by the param", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params?: any) {
+        return params ? Object.keys(params) : [];
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a plain local variable", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f() {
+        const data = { a: 1 };
+        return Object.keys(data);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when Object is shadowed by a local binding", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params?: any) {
+        const Object = { keys: () => [] };
+        return Object.keys(params);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a `&&` guard wrapped in a `.length > 0` comparison", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(hunkContextHashes?: Record<number, string>) {
+        if (hunkContextHashes && Object.keys(hunkContextHashes).length > 0) {
+          return true;
+        }
+        return false;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the isEmpty idiom `!x || Object.keys(x).length === 0`", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function isEmpty(params?: Record<string, unknown>) {
+        return !params || Object.keys(params).length === 0;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a re-chained argument behind a `&&` guard on the same path", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `const x = response?.data && Object.keys(response?.data);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a re-chained argument inside an `if` guard on the same path", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(response) {
+        if (response?.data) {
+          return Object.keys(response?.data);
+        }
+        return [];
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag after a `params = params ?? {}` normalization", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params?: Record<string, unknown>) {
+        params = params ?? {};
+        return Object.keys(params);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag after an `if (!params) params = {}` normalization", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function g(params?: Record<string, unknown>) {
+        if (!params) params = {};
+        return Object.keys(params);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a negated ternary with the call in the alternate", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(params?: any) {
+        return !params ? [] : Object.keys(params);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a negated `if`/`else` with the call in the else branch", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function g(params?: any) {
+        if (!params) {
+          return [];
+        } else {
+          return Object.entries(params);
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a re-chained argument when the guard covers a different path", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `
+      function f(response) {
+        if (response?.meta) {
+          return Object.keys(response?.data);
+        }
+        return [];
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an optional-chained argument inside a test file", () => {
+    const result = runRule(
+      noObjectKeysValuesEntriesOnMaybeUndefined,
+      `const list = Object.keys(response?.data);`,
+      { filename: "keys.test.ts" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-keys-values-entries-on-maybe-undefined.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-keys-values-entries-on-maybe-undefined.ts
@@ -1,0 +1,243 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isEarlyExitIfStatement } from "../../utils/is-early-exit-if-statement.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { subtreeReferencesIdentifierName } from "../../utils/subtree-references-identifier-name.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const OBJECT_ITERATION_METHODS = new Set(["keys", "values", "entries"]);
+
+// Value-position wrappers that a short-circuit still guards THROUGH:
+// `x && Object.keys(x).length > 0` reads the call inside `.length`/`> 0`
+// before the `&&`, so the logical-operand walk — which stops at the first
+// non-logical ancestor — must be entered from the OUTERMOST wrapper to see
+// the guard. Climbing these is safe: an enclosing `&&`/`||` short-circuits
+// the whole subtree regardless of the wrappers in between.
+const GUARD_TRANSPARENT_WRAPPER_TYPES = new Set<string>([
+  "MemberExpression",
+  "BinaryExpression",
+  "UnaryExpression",
+  "TSNonNullExpression",
+  "ParenthesizedExpression",
+]);
+
+// Climb from the call through value-position wrappers to the highest node
+// still wrapped in one, so the guard walk starts where a logical operator
+// can hold it on its right.
+const outermostGuardTransparentWrapper = (node: EsTreeNode): EsTreeNode => {
+  let current = node;
+  while (current.parent && GUARD_TRANSPARENT_WRAPPER_TYPES.has(current.parent.type)) {
+    current = current.parent;
+  }
+  return current;
+};
+
+const MESSAGE =
+  "`Object.keys/values/entries` throws `Cannot convert undefined or null to object` when this value is missing — add a `?? {}` fallback or a null check so the call always receives an object.";
+
+const isObjectIterationCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = node.callee;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.object, "Identifier") || callee.object.name !== "Object") return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  if (!OBJECT_ITERATION_METHODS.has(callee.property.name)) return false;
+  // A same-file binding named `Object` shadows the global — bail out.
+  if (findVariableInitializer(callee.object, "Object")) return false;
+  return true;
+};
+
+// Left operands of `&&`/`||` ancestors that evaluated before `node` runs.
+// Both operators count: `x && Object.keys(x)` runs the call only when `x`
+// is truthy, and the isEmpty idiom `!x || Object.keys(x).length === 0`
+// reaches the call only after `!x` was falsy. `??` is excluded — its right
+// side runs exactly when the left was nullish, so a mention there proves
+// nothing.
+const collectShortCircuitLeftOperands = (node: EsTreeNode): EsTreeNode[] => {
+  const leftOperands: EsTreeNode[] = [];
+  let currentNode: EsTreeNode = node;
+  let parentNode: EsTreeNode | null = currentNode.parent ?? null;
+  while (parentNode) {
+    if (isNodeOfType(parentNode, "LogicalExpression")) {
+      if (parentNode.operator !== "??" && parentNode.right === currentNode) {
+        leftOperands.push(parentNode.left);
+      }
+      currentNode = parentNode;
+      parentNode = currentNode.parent ?? null;
+      continue;
+    }
+    if (isNodeOfType(parentNode, "ChainExpression")) {
+      currentNode = parentNode;
+      parentNode = currentNode.parent ?? null;
+      continue;
+    }
+    break;
+  }
+  return leftOperands;
+};
+
+// Dotted access path for `a.b.c` / `a?.b!.c` shapes (Identifier root,
+// non-computed properties only); null when the shape is anything richer.
+const memberAccessPath = (node: EsTreeNode): string | null => {
+  if (isNodeOfType(node, "ChainExpression") || isNodeOfType(node, "TSNonNullExpression")) {
+    return memberAccessPath(node.expression);
+  }
+  if (isNodeOfType(node, "Identifier")) return node.name;
+  if (
+    isNodeOfType(node, "MemberExpression") &&
+    !node.computed &&
+    isNodeOfType(node.property, "Identifier")
+  ) {
+    const objectPath = memberAccessPath(node.object);
+    return objectPath === null ? null : `${objectPath}.${node.property.name}`;
+  }
+  return null;
+};
+
+const subtreeContainsMemberPath = (node: EsTreeNode | null | undefined, path: string): boolean => {
+  if (!node) return false;
+  let found = false;
+  walkAst(node, (child: EsTreeNode) => {
+    if (found) return false;
+    if (
+      (isNodeOfType(child, "MemberExpression") || isNodeOfType(child, "Identifier")) &&
+      memberAccessPath(child) === path
+    ) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+// The normalize-then-use idiom: `params = params ?? {}` or
+// `if (!params) params = {}` before the call reassigns the binding, so a
+// later `Object.keys(params)` no longer sees the optional-param value.
+const subtreeAssignsIdentifierName = (node: EsTreeNode, name: string): boolean => {
+  let found = false;
+  walkAst(node, (child: EsTreeNode) => {
+    if (found) return false;
+    if (
+      isNodeOfType(child, "AssignmentExpression") &&
+      isNodeOfType(child.left, "Identifier") &&
+      child.left.name === name
+    ) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+// True when a guard mentioning the value short-circuits, encloses, or
+// precedes the call — the `x && Object.keys(x)`, `!x || …`, `if (x) { … }`,
+// `!x ? [] : Object.keys(x)`, and `if (!x) return; …` shapes. Branch checks
+// credit both the consequent and the alternate: which branch is safe depends
+// on the test's polarity, and requiring a mention (not a polarity proof)
+// keeps the rule precise on real-world guards.
+const isValueGuardedBeforeCall = (
+  callNode: EsTreeNode,
+  guardMentionsValue: (guard: EsTreeNode) => boolean,
+  earlierStatementNormalizesValue?: (statement: EsTreeNode) => boolean,
+): boolean => {
+  const guardEntry = outermostGuardTransparentWrapper(callNode);
+  for (const leftOperand of collectShortCircuitLeftOperands(guardEntry)) {
+    if (guardMentionsValue(leftOperand)) return true;
+  }
+  let child: EsTreeNode = callNode;
+  let ancestor: EsTreeNode | null = callNode.parent ?? null;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "IfStatement") || isNodeOfType(ancestor, "ConditionalExpression")) {
+      if (
+        (ancestor.consequent === child || ancestor.alternate === child) &&
+        guardMentionsValue(ancestor.test)
+      ) {
+        return true;
+      }
+    }
+    if (isNodeOfType(ancestor, "BlockStatement")) {
+      const statements = ancestor.body ?? [];
+      const childIndex = statements.indexOf(child as never);
+      for (let index = 0; index < childIndex; index += 1) {
+        const statement = statements[index] as EsTreeNode;
+        if (
+          isEarlyExitIfStatement(statement) &&
+          isNodeOfType(statement, "IfStatement") &&
+          guardMentionsValue(statement.test)
+        ) {
+          return true;
+        }
+        if (earlierStatementNormalizesValue && earlierStatementNormalizesValue(statement)) {
+          return true;
+        }
+      }
+    }
+    child = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+const isOptionalParameterBinding = (identifierNode: EsTreeNodeOfType<"Identifier">): boolean => {
+  const binding = findVariableInitializer(identifierNode, identifierNode.name);
+  if (!binding) return false;
+  // Optional params (`params?: T`) carry `optional: true` and no default
+  // initializer; only parameters and class members can be `optional`, so
+  // the flag alone is a reliable syntactic optionality marker.
+  return (
+    binding.initializer === null &&
+    isNodeOfType(binding.bindingIdentifier, "Identifier") &&
+    binding.bindingIdentifier.optional === true
+  );
+};
+
+export const noObjectKeysValuesEntriesOnMaybeUndefined = defineRule({
+  id: "no-object-keys-values-entries-on-maybe-undefined",
+  title: "Object.keys/values/entries on maybe-undefined value",
+  severity: "warn",
+  tags: ["test-noise"],
+  recommendation:
+    "`Object.keys`, `Object.values`, and `Object.entries` throw on `undefined`/`null`, so pass a `?? {}` fallback or guard the value with a null check before calling them.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isObjectIterationCall(node)) return;
+      const argument = node.arguments?.[0];
+      if (!argument) return;
+      const unwrapped = stripParenExpression(argument as EsTreeNode);
+
+      // Case A: the argument itself carries optional chaining (`a?.b`),
+      // so it is `undefined` whenever the chain short-circuits — unless a
+      // guard mentioning the same access path already proved it present.
+      // A `?? {}` fallback makes the argument a LogicalExpression instead,
+      // which never reaches this branch.
+      if (isNodeOfType(argument as EsTreeNode, "ChainExpression")) {
+        const chainPath = memberAccessPath(argument as EsTreeNode);
+        const isChainGuarded =
+          chainPath !== null &&
+          isValueGuardedBeforeCall(node, (guard: EsTreeNode) =>
+            subtreeContainsMemberPath(guard, chainPath),
+          );
+        if (!isChainGuarded) context.report({ node, message: MESSAGE });
+        return;
+      }
+
+      // Case B: the argument is an optional parameter that was never
+      // narrowed by a preceding/enclosing truthiness guard or normalized
+      // by a reassignment.
+      if (isNodeOfType(unwrapped, "Identifier")) {
+        if (!isOptionalParameterBinding(unwrapped)) return;
+        const parameterName = unwrapped.name;
+        const isParameterGuarded = isValueGuardedBeforeCall(
+          node,
+          (guard: EsTreeNode) => subtreeReferencesIdentifierName(guard, parameterName),
+          (statement: EsTreeNode) => subtreeAssignsIdentifierName(statement, parameterName),
+        );
+        if (isParameterGuarded) return;
+        context.report({ node, message: MESSAGE });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-or-array-coerced-to-string-in-template-literal.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-or-array-coerced-to-string-in-template-literal.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noObjectOrArrayCoercedToStringInTemplateLiteral } from "./no-object-or-array-coerced-to-string-in-template-literal.js";
+
+describe("no-object-or-array-coerced-to-string-in-template-literal", () => {
+  it("flags interpolating an identifier bound to an object literal", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const meta = { id: 1 }; return `meta: ${meta}`; }",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags interpolating an identifier bound to an array literal", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const sizes = [1, 2, 3]; return `sizes: ${sizes}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useRef object interpolated bare", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function C() { const ref = useRef({ x: 0 }); return `ref: ${ref}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useState value whose initializer is an array literal", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function C() { const [items] = useState([]); return `items: ${items}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags string + concatenation of an object literal", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      'function f() { const err = { code: 1 }; return "Error: " + err; }',
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a member access on the interpolated value", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const meta = { id: 1 }; return `meta: ${meta.id}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an array joined explicitly", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const sizes = [1, 2, 3]; return `sizes: ${sizes.join(',')}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag JSON.stringify", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const meta = { id: 1 }; return `meta: ${JSON.stringify(meta)}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a function parameter typed as an object", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f(err) { return `Error: ${err}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an identifier bound to a string", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const name = 'ada'; return `name: ${name}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an imported/unresolved identifier", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { return `value: ${imported}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag numeric + arithmetic (no string sibling)", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const data = [1]; return data + count; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reading a leaf property built into a template", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const source = { slack: { channel: { name: 'x' } } }; return `ch: ${source.slack.channel.name}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a bare object literal interpolated directly", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { return `obj: ${{ id: 1 }}`; }",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare array literal interpolated directly", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { return `pair: ${[1, 2]}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an array interpolated into a styled-components tagged template", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "const flexStyles = ['display: flex;', 'align-items: center;']; const Row = styled.div`${flexStyles} color: red;`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an array of templates interpolated into a lit-html tagged template", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function view() { const parts = [html`<li>a</li>`, html`<li>b</li>`]; return html`<ul>${parts}</ul>`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an object literal that defines its own toString", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const point = { x: 1, y: 2, toString() { return this.x + ',' + this.y; } }; return `point: ${point}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an object literal that defines [Symbol.toPrimitive]", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { const money = { amount: 5, [Symbol.toPrimitive]() { return '$5'; } }; return `cost: ${money}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an object literal that spreads unknown properties", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f(base) { const merged = { ...base, id: 1 }; return `merged: ${merged}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the string-builder idiom (let array reassigned to a joined string)", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { let lines = ['a', 'b']; lines = lines.join('\\n'); return `text: ${lines}`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a var array reassigned to a joined string before interpolation (Emscripten glue idiom)", () => {
+    const result = runRule(
+      noObjectOrArrayCoercedToStringInTemplateLiteral,
+      "function f() { var argsList = []; argsList = argsList.join(','); return `fn(${argsList})`; }",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-or-array-coerced-to-string-in-template-literal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-or-array-coerced-to-string-in-template-literal.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingDeclarator } from "../../utils/find-enclosing-declarator.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
-import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -60,21 +60,6 @@ const firstArgumentLiteralKind = (call: EsTreeNodeOfType<"CallExpression">): Lit
   const firstArgument = call.arguments[0];
   if (!firstArgument) return null;
   return objectOrArrayKind(stripParenExpression(firstArgument as EsTreeNode));
-};
-
-// The VariableDeclarator that declares `bindingIdentifier`, or null when
-// the binding is a function parameter (skipped — a parameter typed as an
-// object/array may have a meaningful `toString()`, per the revision).
-const findEnclosingDeclarator = (
-  bindingIdentifier: EsTreeNode,
-): EsTreeNodeOfType<"VariableDeclarator"> | null => {
-  let cursor: EsTreeNode | null | undefined = bindingIdentifier.parent;
-  while (cursor) {
-    if (isNodeOfType(cursor, "VariableDeclarator")) return cursor;
-    if (isFunctionLike(cursor)) return null;
-    cursor = cursor.parent ?? null;
-  }
-  return null;
 };
 
 const isConstDeclarator = (declarator: EsTreeNodeOfType<"VariableDeclarator">): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-or-array-coerced-to-string-in-template-literal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-object-or-array-coerced-to-string-in-template-literal.ts
@@ -1,0 +1,170 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+type LiteralKind = "object" | "array";
+
+const STRING_COERCION_METHOD_NAMES = new Set(["toString", "valueOf"]);
+
+const isSymbolToPrimitiveKey = (key: EsTreeNode): boolean =>
+  isNodeOfType(key, "MemberExpression") &&
+  !key.computed &&
+  isNodeOfType(key.object, "Identifier") &&
+  key.object.name === "Symbol" &&
+  isNodeOfType(key.property, "Identifier") &&
+  key.property.name === "toPrimitive";
+
+// A spread or a custom `toString` / `valueOf` / `[Symbol.toPrimitive]`
+// means interpolation may produce a meaningful string, not
+// `[object Object]` — the diagnostic's claim would be false.
+const propertyMayCustomizeStringCoercion = (property: EsTreeNode): boolean => {
+  if (isNodeOfType(property, "SpreadElement")) return true;
+  if (!isNodeOfType(property, "Property")) return false;
+  const key = property.key as EsTreeNode;
+  if (property.computed) return isSymbolToPrimitiveKey(key);
+  if (isNodeOfType(key, "Identifier")) return STRING_COERCION_METHOD_NAMES.has(key.name);
+  return (
+    isNodeOfType(key, "Literal") &&
+    typeof key.value === "string" &&
+    STRING_COERCION_METHOD_NAMES.has(key.value)
+  );
+};
+
+const objectOrArrayKind = (node: EsTreeNode): LiteralKind | null => {
+  if (isNodeOfType(node, "ObjectExpression")) {
+    const mayCustomizeCoercion = node.properties.some((property) =>
+      propertyMayCustomizeStringCoercion(property as EsTreeNode),
+    );
+    return mayCustomizeCoercion ? null : "object";
+  }
+  if (isNodeOfType(node, "ArrayExpression")) return "array";
+  return null;
+};
+
+const isHookCallee = (callee: EsTreeNode, hookName: string): boolean => {
+  if (isNodeOfType(callee, "Identifier")) return callee.name === hookName;
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === hookName
+  );
+};
+
+const firstArgumentLiteralKind = (call: EsTreeNodeOfType<"CallExpression">): LiteralKind | null => {
+  const firstArgument = call.arguments[0];
+  if (!firstArgument) return null;
+  return objectOrArrayKind(stripParenExpression(firstArgument as EsTreeNode));
+};
+
+// The VariableDeclarator that declares `bindingIdentifier`, or null when
+// the binding is a function parameter (skipped — a parameter typed as an
+// object/array may have a meaningful `toString()`, per the revision).
+const findEnclosingDeclarator = (
+  bindingIdentifier: EsTreeNode,
+): EsTreeNodeOfType<"VariableDeclarator"> | null => {
+  let cursor: EsTreeNode | null | undefined = bindingIdentifier.parent;
+  while (cursor) {
+    if (isNodeOfType(cursor, "VariableDeclarator")) return cursor;
+    if (isFunctionLike(cursor)) return null;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+const isConstDeclarator = (declarator: EsTreeNodeOfType<"VariableDeclarator">): boolean => {
+  const declaration = declarator.parent;
+  return Boolean(
+    declaration && isNodeOfType(declaration, "VariableDeclaration") && declaration.kind === "const",
+  );
+};
+
+// Resolves an interpolated identifier to the object/array literal it is
+// provably bound to: a direct `const x = {…}/[…]`, a `useRef({…})` whose
+// ref object is interpolated bare, or the state of a
+// `const [x] = useState({…})`. Returns null for anything not provably a
+// literal in scope (imports, params, reassigned/unknown values) —
+// `var`/`let` bindings are skipped because a later reassignment (e.g.
+// `lines = lines.join("\n")`) can replace the literal with a string.
+const resolveInterpolatedLiteralKind = (identifier: EsTreeNode): LiteralKind | null => {
+  if (!isNodeOfType(identifier, "Identifier")) return null;
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding) return null;
+
+  const declarator = findEnclosingDeclarator(binding.bindingIdentifier);
+  if (!declarator || !isConstDeclarator(declarator)) return null;
+  const init = declarator.init ? stripParenExpression(declarator.init as EsTreeNode) : null;
+  if (!init) return null;
+
+  if (declarator.id === binding.bindingIdentifier) {
+    const directKind = objectOrArrayKind(init);
+    if (directKind) return directKind;
+    if (isNodeOfType(init, "CallExpression") && isHookCallee(init.callee as EsTreeNode, "useRef")) {
+      return firstArgumentLiteralKind(init);
+    }
+    return null;
+  }
+
+  const id = declarator.id as EsTreeNode;
+  if (
+    isNodeOfType(id, "ArrayPattern") &&
+    id.elements[0] === binding.bindingIdentifier &&
+    isNodeOfType(init, "CallExpression") &&
+    isHookCallee(init.callee as EsTreeNode, "useState")
+  ) {
+    return firstArgumentLiteralKind(init);
+  }
+  return null;
+};
+
+const messageFor = (kind: LiteralKind): string =>
+  kind === "object"
+    ? "Interpolating this object runs its default `toString()`, which produces `[object Object]` and hides the real value — read a specific property or wrap it in `JSON.stringify`."
+    : "Interpolating this array runs its default `toString()`, which comma-joins the values into unreadable output — read a specific element or use `.join`/`JSON.stringify`.";
+
+const isStringConcatSibling = (node: EsTreeNode): boolean =>
+  (isNodeOfType(node, "Literal") && typeof node.value === "string") ||
+  isNodeOfType(node, "TemplateLiteral");
+
+export const noObjectOrArrayCoercedToStringInTemplateLiteral = defineRule({
+  id: "no-object-or-array-coerced-to-string-in-template-literal",
+  title: "Object or array coerced to string in a template literal",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "Interpolating an object/array runs its default `toString()` (`[object Object]` / comma-joined garbage); read a specific property/element or wrap the value in `JSON.stringify`.",
+  create: (context: RuleContext) => {
+    const reportIfCoercedLiteral = (expression: EsTreeNode): void => {
+      const strippedExpression = stripParenExpression(expression);
+      const kind =
+        objectOrArrayKind(strippedExpression) ?? resolveInterpolatedLiteralKind(strippedExpression);
+      if (!kind) return;
+      context.report({ node: expression, message: messageFor(kind) });
+    };
+    return {
+      TemplateLiteral(node: EsTreeNodeOfType<"TemplateLiteral">) {
+        const parent = node.parent;
+        if (parent && isNodeOfType(parent, "TaggedTemplateExpression")) return;
+        for (const expression of node.expressions) {
+          reportIfCoercedLiteral(expression as EsTreeNode);
+        }
+      },
+      BinaryExpression(node: EsTreeNodeOfType<"BinaryExpression">) {
+        if (node.operator !== "+") return;
+        const left = node.left as EsTreeNode;
+        const right = node.right as EsTreeNode;
+        if (isNodeOfType(left, "Identifier") && isStringConcatSibling(right)) {
+          reportIfCoercedLiteral(left);
+        }
+        if (isNodeOfType(right, "Identifier") && isStringConcatSibling(left)) {
+          reportIfCoercedLiteral(right);
+        }
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-predicate-function-reference-in-boolean-position.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-predicate-function-reference-in-boolean-position.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noPredicateFunctionReferenceInBooleanPosition } from "./no-predicate-function-reference-in-boolean-position.js";
+
+describe("no-predicate-function-reference-in-boolean-position", () => {
+  it("flags `if (!isNewBoardsOn)` (production commit shape)", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function isNewBoardsOn() {
+        return featureFlags.newBoards;
+      }
+      function followBrand() {
+        if (!isNewBoardsOn) {
+          return;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("isNewBoardsOn()");
+  });
+
+  it("flags a bare predicate in an if test", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      const isReady = () => true;
+      if (isReady) {
+        start();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a predicate in a ternary test", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function hasAccess() { return true; }
+      const label = hasAccess ? "yes" : "no";
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a predicate in a while test", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function shouldContinue() { return false; }
+      while (shouldContinue) {
+        step();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a predicate operand inside an `if (a && ...)` test", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function canEdit() { return true; }
+      function render(user) {
+        if (user.loggedIn && canEdit) {
+          edit();
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare predicate as the left operand of `&&` in a JSX conditional render", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function isLoading() { return state.loading; }
+      function App() {
+        return <div>{isLoading && <Spinner />}</div>;
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("isLoading()");
+  });
+
+  it("flags a bare predicate guarding an expression statement via `&&`", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function isReady() { return true; }
+      isReady && start();
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when the predicate is called", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function isReady() { return true; }
+      if (isReady()) {
+        start();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a PascalCase component existence check", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function IsLazy() { return null; }
+      function App() {
+        if (IsLazy) {
+          return <IsLazy />;
+        }
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a boolean variable named like a predicate", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      const isActive = true;
+      if (isActive) {
+        run();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a predicate passed as a callback", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      const isEven = (n) => n % 2 === 0;
+      const evens = numbers.filter(isEven);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a one-arg predicate reference (a real callback shape)", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function isValid(value) { return Boolean(value); }
+      const check = isValid || defaultCheck;
+      if (check) {
+        run();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a predicate used for value selection with ||", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function isReady() { return true; }
+      const chosen = isReady || fallback;
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an imported predicate (arity/type unknown)", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      import { isMobile } from "./env";
+      if (isMobile) {
+        renderMobile();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a predicate stored then existence-checked before calling", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function isActive() { return true; }
+      const check = isActive;
+      if (check) {
+        check();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a reassignable `let` function slot guarded before its call (start/stop polling idiom)", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      let isPolling = () => false;
+      function stop() { isPolling = null; }
+      function tick() {
+        if (isPolling) {
+          isPolling();
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a hoisted `var` assigned only inside a conditional block (feature-detection idiom)", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function detect(flag) {
+        if (flag) {
+          var isSupported = function () { return true; };
+        }
+        if (isSupported) {
+          return isSupported();
+        }
+        return false;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a destructured prop with a function default (caller may pass a boolean)", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function Menu({ isOpen = () => false }) {
+        if (isOpen) {
+          return open();
+        }
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an existence guard whose branch invokes the predicate (defensive-call idiom)", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      function isEnabled() { return true; }
+      if (isEnabled) {
+        isEnabled();
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag `predicate && predicate()` (inline existence-guarded call idiom)", () => {
+    const result = runRule(
+      noPredicateFunctionReferenceInBooleanPosition,
+      `
+      const isDone = () => true;
+      isDone && isDone();
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-predicate-function-reference-in-boolean-position.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-predicate-function-reference-in-boolean-position.ts
@@ -1,0 +1,233 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findProgramRoot } from "../../utils/find-program-root.js";
+import type { BindingInfo } from "../../utils/find-variable-initializer.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+// `is*` / `has*` / `can*` / `should*` / `will*` followed by an uppercase
+// letter or digit. The lowercase-prefix requirement excludes PascalCase
+// component/existence checks like `if (LazyComponent)`.
+const PREDICATE_NAME_PATTERN = /^(is|has|can|should|will)[A-Z0-9]/;
+
+// `ParenthesizedExpression` is a real runtime node but is absent from the
+// TSESTree type union, so it is matched via a string set.
+const GROUPING_EXPRESSION_TYPES = new Set<string>(["ParenthesizedExpression"]);
+
+// Control-flow positions that coerce their operand to a boolean. A
+// same-file zero-argument function reference in any of these is always
+// truthy, so the guarded logic never runs.
+const isInBooleanContext = (node: EsTreeNode): boolean => {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (GROUPING_EXPRESSION_TYPES.has(parent.type)) return isInBooleanContext(parent);
+  if (isNodeOfType(parent, "UnaryExpression")) {
+    return parent.operator === "!" && parent.argument === node;
+  }
+  if (
+    isNodeOfType(parent, "IfStatement") ||
+    isNodeOfType(parent, "WhileStatement") ||
+    isNodeOfType(parent, "DoWhileStatement") ||
+    isNodeOfType(parent, "ForStatement")
+  ) {
+    return parent.test === node;
+  }
+  if (isNodeOfType(parent, "ConditionalExpression")) {
+    return parent.test === node;
+  }
+  if (isNodeOfType(parent, "LogicalExpression")) {
+    // The left operand of `&&` is always boolean-coerced — a truthy
+    // function reference there makes `{isLoading && <Spinner/>}` render
+    // unconditionally. `||` operands (and `&&` right operands) are only
+    // real conditions when the whole logical expression is, which keeps
+    // value-selection shapes like `customHandler || defaultHandler` quiet.
+    if (parent.operator === "&&" && parent.left === node) return true;
+    if (parent.operator !== "&&" && parent.operator !== "||") return false;
+    return isInBooleanContext(parent);
+  }
+  return false;
+};
+
+// "Always truthy" is only sound when the initializer is the binding's one
+// unconditional value. A parameter/destructuring DEFAULT (`{ isOpen = () =>
+// false }`) only applies when the caller passes undefined, so the guard is
+// legitimate.
+const isDeclaredAsDirectInitializer = (binding: BindingInfo): boolean => {
+  const declarationSite = binding.bindingIdentifier.parent;
+  if (!declarationSite) return false;
+  if (declarationSite === binding.initializer) {
+    return (
+      isNodeOfType(declarationSite, "FunctionDeclaration") ||
+      isNodeOfType(declarationSite, "FunctionExpression")
+    );
+  }
+  return (
+    isNodeOfType(declarationSite, "VariableDeclarator") &&
+    declarationSite.init === binding.initializer
+  );
+};
+
+const CONDITIONAL_EXECUTION_ANCESTOR_TYPES = new Set<string>([
+  "IfStatement",
+  "ConditionalExpression",
+  "LogicalExpression",
+  "SwitchStatement",
+  "ForStatement",
+  "ForInStatement",
+  "ForOfStatement",
+  "WhileStatement",
+  "DoWhileStatement",
+  "TryStatement",
+  "CatchClause",
+]);
+
+// A hoisted `var` (or Annex-B block function) assigned only inside a
+// conditional block is `undefined` on paths where the block did not run,
+// making a later existence check a real guard.
+const isInitializerExecutedUnconditionally = (binding: BindingInfo): boolean => {
+  let ancestor = binding.bindingIdentifier.parent ?? null;
+  while (ancestor && ancestor !== binding.scopeOwner) {
+    if (CONDITIONAL_EXECUTION_ANCESTOR_TYPES.has(ancestor.type)) return false;
+    ancestor = ancestor.parent ?? null;
+  }
+  return true;
+};
+
+const resolvesToZeroArgumentFunction = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  const initializer = binding?.initializer;
+  if (!binding || !initializer) return false;
+  if (
+    !isNodeOfType(initializer, "FunctionDeclaration") &&
+    !isNodeOfType(initializer, "FunctionExpression") &&
+    !isNodeOfType(initializer, "ArrowFunctionExpression")
+  ) {
+    return false;
+  }
+  if (!Array.isArray(initializer.params) || initializer.params.length > 0) return false;
+  if (!isDeclaredAsDirectInitializer(binding)) return false;
+  return isInitializerExecutedUnconditionally(binding);
+};
+
+const collectAssignmentTargetNames = (target: EsTreeNode, out: Set<string>): void => {
+  if (isNodeOfType(target, "Identifier")) {
+    out.add(target.name);
+    return;
+  }
+  if (isNodeOfType(target, "ObjectPattern")) {
+    for (const property of target.properties) {
+      if (isNodeOfType(property, "Property")) {
+        collectAssignmentTargetNames(property.value, out);
+      } else if (isNodeOfType(property, "RestElement")) {
+        collectAssignmentTargetNames(property.argument, out);
+      }
+    }
+    return;
+  }
+  if (isNodeOfType(target, "ArrayPattern")) {
+    for (const element of target.elements) {
+      if (element) collectAssignmentTargetNames(element, out);
+    }
+    return;
+  }
+  if (isNodeOfType(target, "AssignmentPattern")) {
+    collectAssignmentTargetNames(target.left, out);
+    return;
+  }
+  if (isNodeOfType(target, "RestElement")) {
+    collectAssignmentTargetNames(target.argument, out);
+  }
+};
+
+const reassignedNamesByProgram = new WeakMap<EsTreeNodeOfType<"Program">, Set<string>>();
+
+// A mutable function slot (`let isPolling = ...; isPolling = null;`) can be
+// falsy at runtime, so its existence checks are real guards, not dead code.
+const isReassignedInFile = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const programRoot = findProgramRoot(identifier);
+  if (!programRoot) return false;
+  let reassignedNames = reassignedNamesByProgram.get(programRoot);
+  if (!reassignedNames) {
+    const collectedNames = new Set<string>();
+    walkAst(programRoot, (node) => {
+      if (isNodeOfType(node, "AssignmentExpression")) {
+        collectAssignmentTargetNames(node.left, collectedNames);
+      }
+    });
+    reassignedNames = collectedNames;
+    reassignedNamesByProgram.set(programRoot, reassignedNames);
+  }
+  return reassignedNames.has(identifier.name);
+};
+
+const containsCallOf = (root: EsTreeNode, functionName: string): boolean => {
+  let didFindCall = false;
+  walkAst(root, (node) => {
+    if (didFindCall) return false;
+    if (
+      isNodeOfType(node, "CallExpression") &&
+      isNodeOfType(node.callee, "Identifier") &&
+      node.callee.name === functionName
+    ) {
+      didFindCall = true;
+      return false;
+    }
+  });
+  return didFindCall;
+};
+
+// `if (isPolling) { isPolling(); }` / `isPolling && isPolling()` is a
+// deliberate existence guard whose branch does evaluate the predicate, so
+// "the check never runs" would be wrong.
+const isExistenceGuardThatInvokesPredicate = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+): boolean => {
+  let current: EsTreeNode = identifier;
+  let parent = current.parent ?? null;
+  while (parent) {
+    if (GROUPING_EXPRESSION_TYPES.has(parent.type)) {
+      current = parent;
+      parent = parent.parent ?? null;
+      continue;
+    }
+    if (isNodeOfType(parent, "LogicalExpression") && parent.operator === "&&") {
+      if (parent.left === current && containsCallOf(parent.right, identifier.name)) return true;
+      current = parent;
+      parent = parent.parent ?? null;
+      continue;
+    }
+    break;
+  }
+  if (!parent) return false;
+  if (isNodeOfType(parent, "IfStatement") && parent.test === current) {
+    return containsCallOf(parent.consequent, identifier.name);
+  }
+  if (isNodeOfType(parent, "ConditionalExpression") && parent.test === current) {
+    return containsCallOf(parent.consequent, identifier.name);
+  }
+  return false;
+};
+
+export const noPredicateFunctionReferenceInBooleanPosition = defineRule({
+  id: "no-predicate-function-reference-in-boolean-position",
+  title: "Predicate function used without calling it",
+  severity: "warn",
+  recommendation:
+    "A bare `is*`/`has*`/`can*`/`should*`/`will*` function reference is always truthy in a condition, so the guarded branch never behaves as intended. Call the function (`isReady()`) to evaluate the predicate.",
+  create: (context: RuleContext) => ({
+    Identifier(node: EsTreeNodeOfType<"Identifier">) {
+      if (!PREDICATE_NAME_PATTERN.test(node.name)) return;
+      if (!isInBooleanContext(node)) return;
+      if (!resolvesToZeroArgumentFunction(node)) return;
+      if (isReassignedInFile(node)) return;
+      if (isExistenceGuardThatInvokesPredicate(node)) return;
+      context.report({
+        node,
+        message: `This condition is always true because \`${node.name}\` is a function reference, not its result, so the check never runs — call it as \`${node.name}()\` to evaluate the predicate.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noUnescapedDynamicStringInRegexp } from "./no-unescaped-dynamic-string-in-regexp.js";
+
+describe("no-unescaped-dynamic-string-in-regexp", () => {
+  it("flags a search term dropped straight into RegExp", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const search = params.get('search') ?? '';
+       const matcher = new RegExp(search, 'i');`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an unescaped user query", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const handleSearch = (query) => {
+        const re = new RegExp(query, 'gi');
+        return re;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a template pattern composed with a query term", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const regex = new RegExp('(^|\\\\s)' + queryString, 'i');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a highlight prop passed to RegExp without new", () => {
+    const result = runRule(noUnescapedDynamicStringInRegexp, `const re = RegExp(highlight, 'gi');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a try/catch-guarded regex-input UI", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `try {
+        new RegExp(searchPattern);
+        setError(null);
+      } catch {
+        setError('Invalid pattern');
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a value escaped before construction", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const escaped = escapeRegExp(query);
+       const re = new RegExp(escaped, 'gi');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag inline escapeRegExp in the same expression", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const re = new RegExp(escapeRegExp(searchTerm), 'gi');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a known-safe constant source", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const re = new RegExp(SAFE_TOKEN_SOURCE, 'g');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a fully-literal pattern", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const re = new RegExp('\\\\d+', 'g');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a source composed of other RegExp .source constants", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const re = new RegExp(ANSI_PATTERN.source + OSC_PATTERN.source, 'g');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an escaped value whose name keeps the search word (escapedQuery idiom)", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const escapedQuery = escapeRegExp(query);
+       const re = new RegExp(escapedQuery, 'gi');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a filter escaped on a prior line into a differently-named binding", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const resultFilter = escapeRegExp(filter);
+       const re = new RegExp(resultFilter, 'i');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a term sanitized via replaceAll on the preceding line (MDN escape idiom)", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      String.raw`const escapedSearchString = searchString.replaceAll(/[.*+?^$\{\}()|[\]\\]/g, '\\$&');
+       const re = new RegExp(escapedSearchString, 'i');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the ES2025 RegExp.escape builtin", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const re = new RegExp(RegExp.escape(searchTerm), 'gi');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a provably-literal local constant whose name contains a search word", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const QUERY_SEPARATOR = '[?&]';
+       const re = new RegExp(QUERY_SEPARATOR, 'g');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag recomposition from an existing regex's .source", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const re = new RegExp(searchWordRegex.source, 'gi');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag names where 'term' is only a substring (terminalSequence)", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const re = new RegExp(terminalSequence, 'g');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a two-hop chain back to an escaped binding", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const escaped = escapeRegExp(query);
+       const searchPattern = escaped;
+       const re = new RegExp(searchPattern, 'gi');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a search term interpolated into a template pattern (grid highlight idiom)", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      "const regex = new RegExp(`(${searchTerm})`, 'gi');",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a ternary initializer composed entirely from escaped bindings", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      "const escapedFilter = escapeRegExp(filter);\n" +
+        "const resultFilter = matchWholeWord ? `\\\\b${escapedFilter}\\\\b` : escapedFilter;\n" +
+        "const regExp = new RegExp(resultFilter, flags);",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a template initializer wrapping an escaped binding", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      "const escapedQuery = escapeRegExp(query);\n" +
+        "const queryPattern = `^${escapedQuery}`;\n" +
+        "const re = new RegExp(queryPattern, 'i');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a ternary initializer where one branch is a raw search term", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      "const escapedFilter = escapeRegExp(filter);\n" +
+        "const resultFilter = matchWholeWord ? escapedFilter : filter;\n" +
+        "const regExp = new RegExp(resultFilter, flags);",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a raw query concatenated next to an escaped prefix", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const re = new RegExp(escapeRegExp(prefix) + query, 'i');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.ts
@@ -1,0 +1,175 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isInsideTryStatement } from "../../utils/is-inside-try-statement.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Identifier names that resolve the RegExp source to a user/config search,
+// filter, highlight, or query term (the values that carry unescaped regex
+// metacharacters). Kept deliberately narrow so controlled/constant sources
+// stay quiet. `term(?!in)` keeps `searchTerm` while excluding
+// `terminalSequence` / `terminate`-shaped names.
+const SEARCH_TERM_NAME_PATTERN = /search|query|highlight|filter|term(?!in)|keyword/i;
+
+// An escape helper applied to the value makes the pattern safe. Also treat
+// `.replace(...)` / `.replaceAll(...)` as author-driven sanitization.
+const ESCAPE_HELPER_NAME_PATTERN = /escape.*reg|safe.*reg/i;
+
+// A binding named like `escapedSearchString` is an explicit author claim
+// that the value was sanitized before construction.
+const SANITIZED_NAME_PATTERN = /escap|sanitiz/i;
+
+// How many identifier-to-initializer hops to follow when checking whether
+// a binding was escaped on a prior line (`const escaped = escapeRegExp(q);
+// const pattern = escaped; new RegExp(pattern)`).
+const INITIALIZER_RESOLUTION_HOPS = 2;
+
+const isRegExpConstruction = (node: EsTreeNode): boolean => {
+  const callee = isNodeOfType(node, "CallExpression")
+    ? node.callee
+    : isNodeOfType(node, "NewExpression")
+      ? node.callee
+      : null;
+  return Boolean(callee && isNodeOfType(callee, "Identifier") && callee.name === "RegExp");
+};
+
+const isFullyLiteralPattern = (argument: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(argument);
+  if (isNodeOfType(stripped, "Literal")) return true;
+  if (isNodeOfType(stripped, "TemplateLiteral") && (stripped.expressions?.length ?? 0) === 0) {
+    return true;
+  }
+  return false;
+};
+
+const isRegExpEscapeBuiltin = (callee: EsTreeNode): boolean =>
+  isNodeOfType(callee, "MemberExpression") &&
+  isNodeOfType(callee.object, "Identifier") &&
+  callee.object.name === "RegExp" &&
+  isNodeOfType(callee.property, "Identifier") &&
+  callee.property.name === "escape";
+
+const isEscapingCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (isRegExpEscapeBuiltin(node.callee)) return true;
+  const calleeName = getCalleeName(node);
+  return Boolean(
+    calleeName &&
+    (ESCAPE_HELPER_NAME_PATTERN.test(calleeName) ||
+      calleeName === "replace" ||
+      calleeName === "replaceAll"),
+  );
+};
+
+const isRegexSourceAccess = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "MemberExpression") &&
+  !node.computed &&
+  isNodeOfType(node.property, "Identifier") &&
+  node.property.name === "source";
+
+const collectRawSearchTermIdentifiers = (
+  argument: EsTreeNode,
+): EsTreeNodeOfType<"Identifier">[] => {
+  const rawSearchTermIdentifiers: EsTreeNodeOfType<"Identifier">[] = [];
+  walkAst(argument, (child: EsTreeNode) => {
+    if (isEscapingCall(child) || isRegexSourceAccess(child)) return false;
+    if (isNodeOfType(child, "Identifier") && SEARCH_TERM_NAME_PATTERN.test(child.name)) {
+      rawSearchTermIdentifiers.push(child);
+    }
+  });
+  return rawSearchTermIdentifiers;
+};
+
+const collectLeafIdentifiers = (node: EsTreeNode): EsTreeNodeOfType<"Identifier">[] => {
+  const leafIdentifiers: EsTreeNodeOfType<"Identifier">[] = [];
+  walkAst(node, (child: EsTreeNode) => {
+    if (isEscapingCall(child) || isRegexSourceAccess(child)) return false;
+    if (isNodeOfType(child, "Identifier")) leafIdentifiers.push(child);
+  });
+  return leafIdentifiers;
+};
+
+const compositeInitializerResolvesEscaped = (
+  strippedInitializer: EsTreeNode,
+  remainingHops: number,
+): boolean => {
+  let didResolveAnyLeafEscaped = false;
+  for (const leafIdentifier of collectLeafIdentifiers(strippedInitializer)) {
+    if (identifierResolvesToEscapedValue(leafIdentifier, remainingHops)) {
+      didResolveAnyLeafEscaped = true;
+    } else if (SEARCH_TERM_NAME_PATTERN.test(leafIdentifier.name)) {
+      return false;
+    }
+  }
+  return didResolveAnyLeafEscaped;
+};
+
+const initializerLooksEscaped = (initializer: EsTreeNode, remainingHops: number): boolean => {
+  const strippedInitializer = stripParenExpression(initializer);
+  if (isFullyLiteralPattern(strippedInitializer)) return true;
+  let didFindEscapingCall = false;
+  walkAst(strippedInitializer, (child: EsTreeNode) => {
+    if (isEscapingCall(child)) didFindEscapingCall = true;
+  });
+  if (didFindEscapingCall) return true;
+  if (remainingHops > 0) {
+    if (isNodeOfType(strippedInitializer, "Identifier")) {
+      return identifierResolvesToEscapedValue(strippedInitializer, remainingHops - 1);
+    }
+    return compositeInitializerResolvesEscaped(strippedInitializer, remainingHops - 1);
+  }
+  return false;
+};
+
+const identifierResolvesToEscapedValue = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  remainingHops: number,
+): boolean => {
+  if (SANITIZED_NAME_PATTERN.test(identifier.name)) return true;
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding?.initializer) return false;
+  return initializerLooksEscaped(binding.initializer, remainingHops);
+};
+
+export const noUnescapedDynamicStringInRegexp = defineRule({
+  id: "no-unescaped-dynamic-string-in-regexp",
+  title: "Unescaped dynamic string in RegExp constructor",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "A search/filter/highlight term dropped straight into `new RegExp(...)` lets its regex metacharacters act as operators, so a user typing `.` or `(` over-matches or throws. Escape the value with an `escapeRegExp` helper before constructing the pattern.",
+  create: (context: RuleContext) => {
+    const reportUnescapedConstruction = (
+      node: EsTreeNodeOfType<"CallExpression"> | EsTreeNodeOfType<"NewExpression">,
+    ): void => {
+      if (!isRegExpConstruction(node)) return;
+      const firstArgument = node.arguments?.[0];
+      if (!firstArgument || isNodeOfType(firstArgument, "SpreadElement")) return;
+      if (isFullyLiteralPattern(firstArgument)) return;
+      const rawSearchTermIdentifiers = collectRawSearchTermIdentifiers(firstArgument);
+      const hasUnescapedSearchTerm = rawSearchTermIdentifiers.some(
+        (identifier) => !identifierResolvesToEscapedValue(identifier, INITIALIZER_RESOLUTION_HOPS),
+      );
+      if (!hasUnescapedSearchTerm) return;
+      if (isInsideTryStatement(node, { region: "block" })) return;
+      context.report({
+        node,
+        message:
+          "This builds a `RegExp` from a dynamic search/filter term without escaping it, so regex metacharacters in the value act as operators and over-match or throw. Escape the value with an `escapeRegExp` helper first.",
+      });
+    };
+    return {
+      NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
+        reportUnescapedConstruction(node);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        reportUnescapedConstruction(node);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noUnguardedBrowserGlobalAtModuleScope } from "./no-unguarded-browser-global-at-module-scope.js";
+
+const prod = { filename: "src/lib/foo.ts" };
+
+describe("no-unguarded-browser-global-at-module-scope", () => {
+  it("flags a module-scope window member read", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `export const cancelIdleCallback = window.cancelIdleCallback ?? clearTimeout;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a module-scope window feature detect in a ternary", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const observeResizes = window.ResizeObserver ? a : b;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a module-scope navigator read", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const lang = navigator.language;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a top-level localStorage.getItem call", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const stored = localStorage.getItem('k');`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare matchMedia call at module scope", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const mq = matchMedia('(min-width: 600px)');`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a nested member read only once", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const sw = navigator.serviceWorker.controller;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a read inside an arrow body", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const tagClicked = () => window.alert('x');`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a read inside a class field initializer", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `class Widget { WINDOW_WIDTH = window.innerWidth; }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a typeof-guarded if block", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `let mode;
+       if (typeof window !== 'undefined') { mode = window.foo; }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a typeof-guarded && expression", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const ok = typeof window !== 'undefined' && window.matchMedia;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare typeof operand", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const isBrowser = typeof window === 'undefined' ? false : true;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag globalThis member access", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const s = globalThis.localStorage;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag document reads (excluded from the global set)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const root = document.getElementById('root');`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a locally-shadowed window binding", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `import { window } from './mocks';
+       const w = window.innerWidth;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a read guarded by an aliased typeof check (fbjs/exenv canUseDOM idiom)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const canUseDOM = typeof window !== 'undefined';
+       const initialWidth = canUseDOM ? window.innerWidth : 0;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a read guarded by an exported guard alias in an if block", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `export const isBrowser = typeof window !== 'undefined';
+       if (isBrowser) { window.addEventListener('resize', () => {}); }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a module-scope read inside try/catch (localStorage feature-detect idiom)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `let persisted = null;
+       try { persisted = localStorage.getItem('theme'); } catch { persisted = null; }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a read inside a try block without a catch handler", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `let persisted = null;
+       try { persisted = localStorage.getItem('theme'); } finally { persisted = persisted ?? null; }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag window reads guarded by typeof document (DOM-library guard shape)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `if (typeof document !== 'undefined') { window.addEventListener('resize', () => {}); }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reads guarded by import.meta.env.SSR (Vite docs idiom)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `if (!import.meta.env.SSR) { window.addEventListener('resize', () => {}); }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reads guarded by process.browser (legacy Next.js idiom)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `if (process.browser) { window.addEventListener('resize', () => {}); }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet in test/setup files", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `const lang = navigator.language;`,
+      { filename: "src/setupTests.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.ts
@@ -1,0 +1,246 @@
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
+
+// `document` is deliberately excluded — legacy SPA mount entrypoints read
+// `document.getElementById('root')` at module scope in files that are never
+// server-rendered, and flagging those is the dominant false positive.
+const BROWSER_GLOBAL_NAMES = new Set([
+  "window",
+  "navigator",
+  "localStorage",
+  "sessionStorage",
+  "matchMedia",
+]);
+
+// Guard recognition is broader than the report set: `typeof document` implies
+// a browser environment just as strongly, even though `document` reads are
+// not reported.
+const GUARD_GLOBAL_NAMES = new Set([...BROWSER_GLOBAL_NAMES, "document"]);
+
+// Scopes that run AFTER import time — a browser-global read inside any of
+// them is deferred to browser-only execution and never crashes Node SSR.
+const DEFERRED_EXECUTION_NODE_TYPES = new Set<string>([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+  "MethodDefinition",
+  "PropertyDefinition",
+  "AccessorProperty",
+  "StaticBlock",
+]);
+
+const isEvaluatedAtImportTime = (node: EsTreeNode): boolean => {
+  let ancestor = node.parent;
+  while (ancestor) {
+    if (DEFERRED_EXECUTION_NODE_TYPES.has(ancestor.type)) return false;
+    ancestor = ancestor.parent ?? null;
+  }
+  return true;
+};
+
+const isImportMetaEnvSsrRead = (node: EsTreeNodeOfType<"MemberExpression">): boolean => {
+  if (node.computed) return false;
+  if (!isNodeOfType(node.property, "Identifier") || node.property.name !== "SSR") return false;
+  const envObject = stripParenExpression(node.object);
+  if (!isNodeOfType(envObject, "MemberExpression") || envObject.computed) return false;
+  if (!isNodeOfType(envObject.property, "Identifier") || envObject.property.name !== "env") {
+    return false;
+  }
+  const metaObject = stripParenExpression(envObject.object);
+  return isNodeOfType(metaObject, "MetaProperty") && metaObject.meta.name === "import";
+};
+
+const isProcessBrowserRead = (node: EsTreeNodeOfType<"MemberExpression">): boolean => {
+  if (node.computed) return false;
+  if (!isNodeOfType(node.property, "Identifier") || node.property.name !== "browser") return false;
+  const processObject = stripParenExpression(node.object);
+  return isNodeOfType(processObject, "Identifier") && processObject.name === "process";
+};
+
+const subtreeHasBrowserEnvironmentGuard = (
+  subtree: EsTreeNode,
+  guardAliasNames: ReadonlySet<string>,
+): boolean => {
+  let found = false;
+  walkAst(subtree, (child) => {
+    if (found) return false;
+    if (isNodeOfType(child, "UnaryExpression") && child.operator === "typeof") {
+      const argument = stripParenExpression(child.argument);
+      if (isNodeOfType(argument, "Identifier") && GUARD_GLOBAL_NAMES.has(argument.name)) {
+        found = true;
+        return false;
+      }
+    }
+    if (isNodeOfType(child, "Identifier") && guardAliasNames.has(child.name)) {
+      found = true;
+      return false;
+    }
+    if (
+      isNodeOfType(child, "MemberExpression") &&
+      (isImportMetaEnvSsrRead(child) || isProcessBrowserRead(child))
+    ) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+// True when a browser-environment check dominates the read via an enclosing
+// `if` / ternary / `&&` (a `typeof <global>` test, a module-scope alias like
+// `canUseDOM`, or an `import.meta.env.SSR` / `process.browser` check), or
+// when an enclosing try/catch swallows the ReferenceError. Conservative: any
+// such guard suppresses the report (favouring a false negative over a false
+// positive).
+const isGuardedAgainstSsrCrash = (
+  node: EsTreeNode,
+  guardAliasNames: ReadonlySet<string>,
+): boolean => {
+  let current: EsTreeNode = node;
+  let ancestor = node.parent;
+  while (ancestor) {
+    if (
+      isNodeOfType(ancestor, "TryStatement") &&
+      Boolean(ancestor.handler) &&
+      ancestor.block === current
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "IfStatement") &&
+      subtreeHasBrowserEnvironmentGuard(ancestor.test, guardAliasNames)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "ConditionalExpression") &&
+      subtreeHasBrowserEnvironmentGuard(ancestor.test, guardAliasNames)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "LogicalExpression") &&
+      subtreeHasBrowserEnvironmentGuard(ancestor.left, guardAliasNames)
+    ) {
+      return true;
+    }
+    current = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+const NO_GUARD_ALIASES: ReadonlySet<string> = new Set();
+
+const collectGuardAliasNames = (program: EsTreeNodeOfType<"Program">): Set<string> => {
+  const aliasNames = new Set<string>();
+  const recordDeclaration = (declaration: EsTreeNode | null | undefined): void => {
+    if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return;
+    for (const declarator of declaration.declarations ?? []) {
+      if (!isNodeOfType(declarator.id, "Identifier") || !declarator.init) continue;
+      if (subtreeHasBrowserEnvironmentGuard(declarator.init, NO_GUARD_ALIASES)) {
+        aliasNames.add(declarator.id.name);
+      }
+    }
+  };
+  for (const statement of program.body ?? []) {
+    if (isNodeOfType(statement, "ExportNamedDeclaration")) {
+      recordDeclaration(statement.declaration);
+      continue;
+    }
+    recordDeclaration(statement);
+  }
+  return aliasNames;
+};
+
+const collectModuleScopeBindingNames = (program: EsTreeNodeOfType<"Program">): Set<string> => {
+  const names = new Set<string>();
+  const record = (declaration: EsTreeNode | null | undefined): void => {
+    if (!declaration) return;
+    if (isNodeOfType(declaration, "VariableDeclaration")) {
+      for (const declarator of declaration.declarations ?? []) {
+        collectPatternNames(declarator.id, names);
+      }
+      return;
+    }
+    if (
+      (isNodeOfType(declaration, "FunctionDeclaration") ||
+        isNodeOfType(declaration, "ClassDeclaration")) &&
+      declaration.id
+    ) {
+      names.add(declaration.id.name);
+    }
+  };
+
+  for (const statement of program.body ?? []) {
+    if (isNodeOfType(statement, "ImportDeclaration")) {
+      for (const specifier of statement.specifiers ?? []) {
+        names.add(specifier.local.name);
+      }
+      continue;
+    }
+    if (
+      isNodeOfType(statement, "ExportNamedDeclaration") ||
+      isNodeOfType(statement, "ExportDefaultDeclaration")
+    ) {
+      record(statement.declaration);
+      continue;
+    }
+    record(statement);
+  }
+  return names;
+};
+
+export const noUnguardedBrowserGlobalAtModuleScope = defineRule({
+  id: "no-unguarded-browser-global-at-module-scope",
+  title: "Browser global read at module scope",
+  severity: "warn",
+  requires: ["ssr"],
+  recommendation:
+    'Reading `window`/`navigator`/`localStorage` at module scope throws `ReferenceError: window is not defined` when the module is imported during SSR. Move the read inside a function/effect, or guard it with `typeof window !== "undefined"`.',
+  create: (context: RuleContext): RuleVisitors => {
+    if (isTestlikeFilename(context.filename)) return {};
+
+    let activeGlobalNames = BROWSER_GLOBAL_NAMES;
+    let guardAliasNames: ReadonlySet<string> = NO_GUARD_ALIASES;
+
+    const reportRead = (node: EsTreeNode, globalName: string): void => {
+      if (!isEvaluatedAtImportTime(node)) return;
+      if (isGuardedAgainstSsrCrash(node, guardAliasNames)) return;
+      context.report({
+        node,
+        message: `Reading \`${globalName}\` here crashes with "ReferenceError: ${globalName} is not defined" the instant this module is imported during SSR — move the read inside a function or effect, or guard it with \`typeof ${globalName} !== "undefined"\`.`,
+      });
+    };
+
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        const shadowed = collectModuleScopeBindingNames(node);
+        if ([...BROWSER_GLOBAL_NAMES].some((name) => shadowed.has(name))) {
+          activeGlobalNames = new Set(
+            [...BROWSER_GLOBAL_NAMES].filter((name) => !shadowed.has(name)),
+          );
+        }
+        guardAliasNames = collectGuardAliasNames(node);
+      },
+      MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+        const object = stripParenExpression(node.object);
+        if (!isNodeOfType(object, "Identifier") || !activeGlobalNames.has(object.name)) return;
+        reportRead(object, object.name);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        const callee = stripParenExpression(node.callee);
+        if (!isNodeOfType(callee, "Identifier") || !activeGlobalNames.has(callee.name)) return;
+        reportRead(callee, callee.name);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-in-render-or-hook-init.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-in-render-or-hook-init.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noUnguardedBrowserGlobalInRenderOrHookInit } from "./no-unguarded-browser-global-in-render-or-hook-init.js";
+
+describe("no-unguarded-browser-global-in-render-or-hook-init", () => {
+  it("flags navigator.onLine as a useState argument in a custom hook", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `export const useOnlineChange = () => {
+        const [online, setOnline] = useState(navigator.onLine);
+        return online;
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags document read inside a useState lazy initializer", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const useIsDocumentHidden = () => {
+        const [hidden, setHidden] = useState(() => document.hidden);
+        return hidden;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare window read in a component body", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const width = window.innerWidth;
+        return <div style={{ width }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags localStorage read in a useState initializer", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const useToken = () => {
+        const [token] = useState(() => localStorage.getItem('token'));
+        return token;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for a react-router location local (not window.location)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const usePath = () => {
+        const location = useLocation();
+        const pathname = location.pathname;
+        return pathname;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a read inside a useEffect callback", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const useOnline = () => {
+        const [online, setOnline] = useState(false);
+        useEffect(() => {
+          setOnline(navigator.onLine);
+        }, []);
+        return online;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a read inside an event handler", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const handleClick = () => {
+          const width = window.innerWidth;
+          return width;
+        };
+        return <button onClick={handleClick} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet behind a dominating typeof window guard", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const width = typeof window !== 'undefined' ? window.innerWidth : 0;
+        return <div style={{ width }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for the nested-deref guarded SSR-safe idiom", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const host = typeof window === 'undefined' ? '' : window.location.hostname;
+        return <div>{host}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet behind a canUseDOM guard", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const width = canUseDOM ? window.innerWidth : 0;
+        return <div style={{ width }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when navigator is a local shadow binding", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const useThing = () => {
+        const navigator = getFakeAgent();
+        const [online] = useState(navigator.onLine);
+        return online;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a read inside a useMemo callback", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const useWidth = () => {
+        const width = useMemo(() => window.innerWidth, []);
+        return width;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet after a typeof-window early return (the SSR guard the rule itself recommends)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        if (typeof window === 'undefined') return null;
+        return <div>{window.innerWidth}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet after a mounted-state early return (the useEffect-mounted idiom)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const [mounted, setMounted] = useState(false);
+        useEffect(() => setMounted(true), []);
+        if (!mounted) return null;
+        return <div>{window.innerWidth}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when an early return dominates a useState lazy initializer", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const useWidth = () => {
+        if (typeof window === 'undefined') return 0;
+        const [width] = useState(() => window.innerWidth);
+        return width;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a function stored in a useRef (never invoked at render time)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const cleanupRef = useRef(() => document.removeEventListener('click', noop));
+        return <div />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a bare browser read passed to useRef (evaluated during render)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const widthRef = useRef(window.innerWidth);
+        return <div />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for the try/catch persisted-state idiom in a useState lazy initializer", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const useToken = () => {
+        const [token] = useState(() => {
+          try {
+            return localStorage.getItem('token');
+          } catch {
+            return null;
+          }
+        });
+        return token;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet behind rc-util's lowercase canUseDom() guard", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `import canUseDom from 'rc-util/lib/Dom/canUseDom';
+      function App() {
+        const width = canUseDom() ? window.innerWidth : 0;
+        return <div style={{ width }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet behind an off-list const guard whose initializer is a typeof-window check", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const isBrowserEnv = typeof window !== 'undefined';
+      function App() {
+        const width = isBrowserEnv ? window.innerWidth : 0;
+        return <div style={{ width }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags destructuring a browser global in a component body", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const { innerWidth } = window;
+        return <div style={{ width: innerWidth }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags aliasing a browser global in a component body", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function App() {
+        const win = window;
+        return <div style={{ width: win.innerWidth }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for a createPortal container read behind an open early return", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function ColorPickerFloating({ open, onColorSelect }) {
+        if (!open) return null;
+        return createPortal(<div onClick={onColorSelect} />, document.body);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a createPortal container read without a preceding gate", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const Overlay = ({ children }) => {
+        return createPortal(children, document.body);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet after a flow-terminating negated showX gate (the tooltip idiom)", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const UndoButton = ({ showTooltip = true }) => {
+        const button = <button aria-label="Undo" />;
+        if (!showTooltip) {
+          return button;
+        }
+        return (
+          <Tooltip trigger={button}>
+            {navigator.platform.includes('Mac') ? 'Cmd+Z' : 'Ctrl+Z'}
+          </Tooltip>
+        );
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet after a negated isVisible early return", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function Modal({ isVisible }) {
+        if (!isVisible) return null;
+        return <div>{window.location.href}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags unconditional window.location reads at the top of a modal body", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `export default function ShareSurveyModal({ surveyId, isOpened, closeModal }) {
+        const link = \`\${window.location.protocol}//\${window.location.host}/survey/\${surveyId}\`;
+        return <StyledDialog isOpen={isOpened} onClose={closeModal}>{link}</StyledDialog>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("still flags a read after an early return on a non-visibility flag", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `function Profile({ user }) {
+        if (!user) return null;
+        const width = window.innerWidth;
+        return <div style={{ width }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet outside a component or hook body", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalInRenderOrHookInit,
+      `const readWidth = () => {
+        return window.innerWidth;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-in-render-or-hook-init.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-in-render-or-hook-init.ts
@@ -1,0 +1,290 @@
+import {
+  componentOrHookDisplayNameForFunction,
+  nearestEnclosingFunction,
+} from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Browser-only globals that do not exist during a Node SSR/SSG render.
+// Reading one on the render path throws `ReferenceError` on the server,
+// or seeds a client-only initial value that disagrees with the server
+// HTML (hydration mismatch).
+const BROWSER_GLOBAL_NAMES = new Set([
+  "window",
+  "document",
+  "navigator",
+  "localStorage",
+  "sessionStorage",
+  "matchMedia",
+]);
+
+// Hooks whose FIRST-render function argument runs during render (so a
+// browser read inside their lazy initializer is unsafe under SSR).
+// `useMemo` / `useEffect` are deliberately absent, and so is `useRef` —
+// React never invokes a function passed to useRef, and a bare
+// `useRef(window.innerWidth)` argument is already caught by the
+// component-body path.
+const RENDER_TIME_INITIALIZER_HOOKS = new Set(["useState", "useReducer"]);
+
+// Identifiers that, when present in a dominating condition, mark the
+// read as SSR-guarded (mounted-state / can-use-DOM feature checks).
+// Matched after `normalizeGuardName`, so `canUseDom`, `IS_BROWSER`,
+// and `isBrowserEnv` all count.
+const NORMALIZED_DOM_GUARD_NAMES = new Set([
+  "canusedom",
+  "ismounted",
+  "mounted",
+  "isbrowser",
+  "isbrowserenv",
+  "isclient",
+  "haswindow",
+]);
+
+// Interaction-driven visibility flags (`open` / `isVisible` / `showTooltip`)
+// that gate overlays: false during the initial server render, so a
+// flow-terminating `if (!open) return ...` before the read makes it
+// unreachable under SSR.
+const VISIBILITY_GATE_NAMES = new Set([
+  "open",
+  "isopen",
+  "opened",
+  "isopened",
+  "visible",
+  "isvisible",
+]);
+
+const normalizeGuardName = (name: string): string => name.toLowerCase().replace(/[_$]/g, "");
+
+const isVisibilityGateName = (name: string): boolean => {
+  const normalizedName = normalizeGuardName(name);
+  if (VISIBILITY_GATE_NAMES.has(normalizedName)) return true;
+  return normalizedName.startsWith("show") || normalizedName.startsWith("isshow");
+};
+
+const isBrowserGlobalIdentifier = (node: EsTreeNode): node is EsTreeNodeOfType<"Identifier"> =>
+  isNodeOfType(node, "Identifier") && BROWSER_GLOBAL_NAMES.has(node.name);
+
+// True when `identifier` is the real browser global and not a same-file
+// local binding of the same name (e.g. `const navigator = useAgent()`
+// or `location` from react-router's `useLocation()`).
+const isTrueBrowserGlobal = (identifier: EsTreeNodeOfType<"Identifier">): boolean =>
+  findVariableInitializer(identifier, identifier.name) === null;
+
+// A function passed as the lazy-initializer argument of
+// `useState` / `useReducer`.
+const isRenderTimeInitializerCallback = (functionNode: EsTreeNode): boolean => {
+  const parent = functionNode.parent;
+  if (!parent || !isNodeOfType(parent, "CallExpression")) return false;
+  if (!parent.arguments?.some((argument) => argument === functionNode)) return false;
+  const calleeName = getCalleeName(parent);
+  return Boolean(calleeName && RENDER_TIME_INITIALIZER_HOOKS.has(calleeName));
+};
+
+// True when `node` executes during a component/hook render: directly in
+// the component/hook body, or inside a useState/useReducer lazy
+// initializer within one. Reads inside effects, event handlers,
+// useMemo, or any other nested callback return false.
+const isOnRenderTimePath = (node: EsTreeNode): boolean => {
+  const enclosingFunction = nearestEnclosingFunction(node);
+  if (!enclosingFunction) return false;
+  if (componentOrHookDisplayNameForFunction(enclosingFunction)) return true;
+  if (isRenderTimeInitializerCallback(enclosingFunction)) {
+    const outerFunction = nearestEnclosingFunction(enclosingFunction);
+    return Boolean(outerFunction && componentOrHookDisplayNameForFunction(outerFunction));
+  }
+  return false;
+};
+
+const containsTypeofBrowserGlobalCheck = (node: EsTreeNode): boolean => {
+  let found = false;
+  walkAst(node, (child) => {
+    if (found) return false;
+    if (isNodeOfType(child, "UnaryExpression") && child.operator === "typeof") {
+      const argument = stripParenExpression(child.argument);
+      if (isNodeOfType(argument, "Identifier") && BROWSER_GLOBAL_NAMES.has(argument.name)) {
+        found = true;
+        return false;
+      }
+    }
+  });
+  return found;
+};
+
+const conditionContainsDomGuard = (condition: EsTreeNode): boolean => {
+  if (containsTypeofBrowserGlobalCheck(condition)) return true;
+  let guarded = false;
+  walkAst(condition, (child) => {
+    if (guarded) return false;
+    if (!isNodeOfType(child, "Identifier")) return;
+    if (NORMALIZED_DOM_GUARD_NAMES.has(normalizeGuardName(child.name))) {
+      guarded = true;
+      return false;
+    }
+    const binding = findVariableInitializer(child, child.name);
+    if (binding?.initializer && containsTypeofBrowserGlobalCheck(binding.initializer)) {
+      guarded = true;
+      return false;
+    }
+  });
+  return guarded;
+};
+
+// A statement after which control cannot fall through to the next
+// sibling — the shapes an SSR early-return guard body takes.
+const isFlowTerminatingStatement = (statement: EsTreeNode): boolean => {
+  if (isNodeOfType(statement, "ReturnStatement") || isNodeOfType(statement, "ThrowStatement")) {
+    return true;
+  }
+  if (isNodeOfType(statement, "BlockStatement")) {
+    const lastStatement = statement.body[statement.body.length - 1];
+    return Boolean(lastStatement && isFlowTerminatingStatement(lastStatement));
+  }
+  return false;
+};
+
+// `if (!open) ...` / `if (!props.showTooltip) ...` — the negated
+// visibility flag that gates overlay render paths off during SSR.
+const isNegatedVisibilityGateCondition = (condition: EsTreeNode): boolean => {
+  const strippedCondition = stripParenExpression(condition);
+  if (!isNodeOfType(strippedCondition, "UnaryExpression") || strippedCondition.operator !== "!") {
+    return false;
+  }
+  const negatedValue = stripParenExpression(strippedCondition.argument);
+  if (isNodeOfType(negatedValue, "Identifier")) {
+    return isVisibilityGateName(negatedValue.name);
+  }
+  return (
+    isNodeOfType(negatedValue, "MemberExpression") &&
+    isNodeOfType(negatedValue.property, "Identifier") &&
+    isVisibilityGateName(negatedValue.property.name)
+  );
+};
+
+// An earlier sibling `if (typeof window === 'undefined') return null;`
+// (or `if (!mounted) return null;` / `if (!open) return null;`)
+// dominates every statement after it.
+const hasDomGuardEarlyReturnBefore = (
+  block: EsTreeNodeOfType<"BlockStatement">,
+  statement: EsTreeNode,
+): boolean => {
+  for (const sibling of block.body) {
+    if (sibling === statement) return false;
+    if (
+      isNodeOfType(sibling, "IfStatement") &&
+      isFlowTerminatingStatement(sibling.consequent) &&
+      (conditionContainsDomGuard(sibling.test) || isNegatedVisibilityGateCondition(sibling.test))
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// A read anywhere inside an argument of `createPortal(...)` (the
+// `document.body` container idiom). Portal-returning render paths are
+// gated client-side in practice, and an ungated portal already breaks
+// the server render on its own — the browser-global read is not the
+// signal there.
+const isInsideCreatePortalArgument = (node: EsTreeNode): boolean => {
+  let previous: EsTreeNode = node;
+  let ancestor = node.parent;
+  while (ancestor) {
+    if (
+      isNodeOfType(ancestor, "CallExpression") &&
+      getCalleeName(ancestor) === "createPortal" &&
+      Boolean(ancestor.arguments?.some((argument) => argument === previous))
+    ) {
+      return true;
+    }
+    previous = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+// True when a `typeof window`/`canUseDOM`/`isMounted` check dominates
+// the read via an enclosing `if` / ternary / `&&`, a preceding
+// early-return guard, or a wrapping `try` with a catch handler (the
+// persisted-state idiom that swallows the server ReferenceError).
+// Conservative: any such guard suppresses the report.
+const isDominatedByDomGuard = (node: EsTreeNode): boolean => {
+  let previous: EsTreeNode = node;
+  let ancestor = node.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "IfStatement") && conditionContainsDomGuard(ancestor.test)) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "ConditionalExpression") &&
+      conditionContainsDomGuard(ancestor.test)
+    ) {
+      return true;
+    }
+    if (isNodeOfType(ancestor, "LogicalExpression") && conditionContainsDomGuard(ancestor.left)) {
+      return true;
+    }
+    if (isNodeOfType(ancestor, "TryStatement") && ancestor.handler && ancestor.block === previous) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "BlockStatement") &&
+      hasDomGuardEarlyReturnBefore(ancestor, previous)
+    ) {
+      return true;
+    }
+    previous = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+export const noUnguardedBrowserGlobalInRenderOrHookInit = defineRule({
+  id: "no-unguarded-browser-global-in-render-or-hook-init",
+  title: "Browser global read during render or hook init",
+  severity: "warn",
+  category: "Correctness",
+  requires: ["ssr"],
+  recommendation:
+    'Reading `window`/`document`/`navigator`/`localStorage`/`sessionStorage` during render or in a useState/useReducer/useRef initializer crashes the server render and causes hydration mismatches. Seed a stable default and read the browser global inside a useEffect after mount, or guard with `typeof window !== "undefined"`.',
+  create: (context: RuleContext) => {
+    const reportRead = (readNode: EsTreeNode, globalName: string): void => {
+      if (!isOnRenderTimePath(readNode)) return;
+      if (isDominatedByDomGuard(readNode)) return;
+      if (isInsideCreatePortalArgument(readNode)) return;
+      context.report({
+        node: readNode,
+        message: `Reading \`${globalName}\` during render or in a useState/useReducer/useRef initializer crashes SSR ("${globalName} is not defined") and causes hydration mismatches. Seed a stable default and read \`${globalName}\` inside a useEffect after mount, or guard it with \`typeof ${globalName} !== "undefined"\`.`,
+      });
+    };
+
+    return {
+      MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+        const object = stripParenExpression(node.object);
+        if (!isBrowserGlobalIdentifier(object) || !isTrueBrowserGlobal(object)) return;
+        reportRead(node, object.name);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        // Bare `matchMedia(...)` — the member form `window.matchMedia`
+        // is already covered by the MemberExpression visitor.
+        const callee = stripParenExpression(node.callee);
+        if (!isBrowserGlobalIdentifier(callee) || !isTrueBrowserGlobal(callee)) return;
+        reportRead(callee, callee.name);
+      },
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+        // `const { innerWidth } = window` / `const win = window` reads
+        // the global during render just like a member access.
+        if (!node.init) return;
+        const initializer = stripParenExpression(node.init);
+        if (!isBrowserGlobalIdentifier(initializer) || !isTrueBrowserGlobal(initializer)) return;
+        reportRead(initializer, initializer.name);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-numeric-input-parse.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-numeric-input-parse.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noUnguardedNumericInputParse } from "./no-unguarded-numeric-input-parse.js";
+
+describe("no-unguarded-numeric-input-parse", () => {
+  it("flags Number(e.target.value) in an input onChange", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(Number(e.target.value))} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a radix-carrying parseInt(e.target.value, 10) in an input onChange", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(parseInt(e.target.value, 10))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags parseFloat(e.currentTarget.value)", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onInput={(e) => save(parseFloat(e.currentTarget.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Number.parseInt(e.target.value, 10)", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(Number.parseInt(e.target.value, 10))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a radix-less parseInt now that no-parseint-without-radix is retired", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(parseInt(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a radix-less Number.parseInt now that no-parseint-without-radix is retired", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(Number.parseInt(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a coercion of e.target.valueAsNumber", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(Number(e.target.valueAsNumber))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a ternary-guarded coercion", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(e.target.value ? Number(e.target.value) : undefined)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an isNaN-guarded coercion", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(isNaN(e.target.valueAsNumber) ? undefined : Number.parseInt(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a ||-fallback coercion", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(Number(e.target.value) || 0)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a coercion sourced from a select onChange", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <select onChange={(e) => setX(Number(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a coercion on a component prop handler", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <Pagination onRowsPerPageChange={(e) => setPageSize(Number(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a coercion of option.value", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => setX(Number(option.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the element type cannot be resolved", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const handleChange = (e) => setX(Number(e.target.value));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the canonical slider idiom: Number(e.target.value) on <input type='range'>", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type="range" min={0} max={100} onChange={(e) => setVolume(Number(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a radio input whose value is a fixed numeric literal", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type="radio" value="2" checked={x === 2} onChange={(e) => setX(Number(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a range input whose type is an expression-container string literal", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type={"range"} onInput={(e) => setBlur(Number(e.currentTarget.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a type='number' field, whose .value is '' for partial input so NaN is unreachable", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type="number" value={alpha} onChange={(e) => setAlpha(Number(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a type='number' field when the type attribute follows the handler", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(event) => setRowHeight(Number(event.target.value))} type="number" value={rowHeight} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a wrapper-nested parse whose binding is isNaN-guarded on the next line", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type="text" onChange={(e) => {
+        const v = Math.max(1, Math.min(100000, Math.floor(Number(e.target.value))));
+        if (!isNaN(v)) update("games", v);
+      }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a wrapper-nested parse with no guard on its binding", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type="text" onChange={(e) => {
+        const v = Math.floor(Number(e.target.value));
+        update("games", v);
+      }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an unguarded coercion in a multi-statement type='text' handler", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type="text" maxLength={3} value={totalUsers} onChange={(e) => {
+        e.preventDefault();
+        setDisableApplyButton(false);
+        setTotalUsers(Number(e.target.value));
+      }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an unguarded parseInt on a type='text' field", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type="text" value={\`\${rows}\`} onChange={(e) => setRows(parseInt(e.target.value, 10))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an input whose type is a dynamic expression", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input type={inputType} onChange={(e) => setX(Number(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the empty-check early-return idiom before the parse", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => {
+        if (e.target.value === "") return;
+        setX(Number(e.target.value));
+      }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a && short-circuit whose left operand checks the value", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => e.target.value !== "" && setX(Number(e.target.value))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the parse-then-Number.isNaN-gate idiom the rule itself recommends", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => {
+        const next = Number(e.target.value);
+        if (!Number.isNaN(next)) setX(next);
+      }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a stored parse gated by a Number.isFinite ternary", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => {
+        const next = parseFloat(e.target.value);
+        setX(Number.isFinite(next) ? next : fallback);
+      }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags when the only if-statement in the handler is unrelated to the value", () => {
+    const result = runRule(
+      noUnguardedNumericInputParse,
+      `const F = () => <input onChange={(e) => {
+        if (isOpen) trackEvent();
+        setX(Number(e.target.value));
+      }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-numeric-input-parse.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-numeric-input-parse.ts
@@ -1,0 +1,279 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const MESSAGE =
+  "Coercing an input's value with this parse stores `0` for a cleared field and `NaN` for partial input, which then flows into state or a request body; guard the empty and NaN cases (for example `value ? Number(value) : undefined`) before using it.";
+
+const EVENT_VALUE_PROPERTIES: ReadonlySet<string> = new Set(["value", "valueAsNumber"]);
+const EVENT_TARGET_PROPERTIES: ReadonlySet<string> = new Set(["target", "currentTarget"]);
+const HANDLER_ATTRIBUTE_PATTERN = /^on[A-Z]/;
+const NAN_GUARD_FUNCTION_NAMES: ReadonlySet<string> = new Set(["isNaN", "isFinite"]);
+
+// The browser's value-sanitization algorithm guarantees these input types
+// never yield a partially-typed string (a range slider is always clamped to
+// a valid in-bounds number; radio/checkbox carry a fixed literal value; a
+// type="number" field's .value is "" whenever the field holds partial or
+// invalid text, so a numeric parse can never see NaN — only the empty->0
+// case remains, which real-world code guards downstream), so the harm this
+// rule warns about cannot occur on them.
+const BROWSER_SANITIZED_INPUT_TYPES: ReadonlySet<string> = new Set([
+  "number",
+  "range",
+  "checkbox",
+  "radio",
+  "color",
+  "date",
+  "time",
+  "datetime-local",
+  "month",
+  "week",
+]);
+
+const isNumericParseCallee = (callee: EsTreeNode): boolean => {
+  if (
+    isNodeOfType(callee, "Identifier") &&
+    (callee.name === "Number" || callee.name === "parseInt" || callee.name === "parseFloat")
+  ) {
+    return true;
+  }
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.object, "Identifier") &&
+    callee.object.name === "Number" &&
+    isNodeOfType(callee.property, "Identifier") &&
+    (callee.property.name === "parseInt" || callee.property.name === "parseFloat")
+  );
+};
+
+// Returns the root identifier name (the event parameter, e.g. `e`) when
+// `argument` is an event-input value read: `e.target.value`,
+// `e.currentTarget.value`, `e.target.valueAsNumber`. Otherwise null.
+const getEventValueRootName = (argument: EsTreeNode): string | null => {
+  const valueAccess = stripParenExpression(argument);
+  if (
+    !isNodeOfType(valueAccess, "MemberExpression") ||
+    valueAccess.computed ||
+    !isNodeOfType(valueAccess.property, "Identifier") ||
+    !EVENT_VALUE_PROPERTIES.has(valueAccess.property.name)
+  ) {
+    return null;
+  }
+  const targetAccess = stripParenExpression(valueAccess.object);
+  if (
+    !isNodeOfType(targetAccess, "MemberExpression") ||
+    targetAccess.computed ||
+    !isNodeOfType(targetAccess.property, "Identifier") ||
+    !EVENT_TARGET_PROPERTIES.has(targetAccess.property.name)
+  ) {
+    return null;
+  }
+  const root = stripParenExpression(targetAccess.object);
+  return isNodeOfType(root, "Identifier") ? root.name : null;
+};
+
+interface HandlerLookup {
+  handler: EsTreeNode | null;
+  isGuarded: boolean;
+}
+
+// Walk from the call up to the nearest enclosing function, recording
+// whether a guard (`?:` ternary or `||`/`??`/`&&` short-circuit) sits
+// between them. That nearest function is the handler candidate.
+const findEnclosingHandlerAndGuard = (call: EsTreeNode): HandlerLookup => {
+  let ancestor = call.parent;
+  let isGuarded = false;
+  while (ancestor) {
+    if (isFunctionLike(ancestor)) return { handler: ancestor, isGuarded };
+    if (isNodeOfType(ancestor, "ConditionalExpression")) isGuarded = true;
+    if (isNodeOfType(ancestor, "LogicalExpression")) isGuarded = true;
+    ancestor = ancestor.parent ?? null;
+  }
+  return { handler: null, isGuarded };
+};
+
+const isNanGuardCall = (node: EsTreeNode): node is EsTreeNodeOfType<"CallExpression"> => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = node.callee;
+  if (isNodeOfType(callee, "Identifier")) return NAN_GUARD_FUNCTION_NAMES.has(callee.name);
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.object, "Identifier") &&
+    callee.object.name === "Number" &&
+    isNodeOfType(callee.property, "Identifier") &&
+    (NAN_GUARD_FUNCTION_NAMES.has(callee.property.name) || callee.property.name === "isInteger")
+  );
+};
+
+const subtreeReferencesParsedValue = (
+  subtree: EsTreeNode,
+  eventRootName: string,
+  parseResultName: string | null,
+): boolean => {
+  let didFindReference = false;
+  walkAst(subtree, (child) => {
+    if (didFindReference) return false;
+    if (getEventValueRootName(child) === eventRootName) {
+      didFindReference = true;
+      return false;
+    }
+    if (
+      parseResultName !== null &&
+      isNodeOfType(child, "Identifier") &&
+      child.name === parseResultName
+    ) {
+      didFindReference = true;
+      return false;
+    }
+  });
+  return didFindReference;
+};
+
+// Recognizes guards the ancestor walk cannot see: a preceding early-return
+// (`if (e.target.value === "") return;`), a short-circuit whose left operand
+// checks the value, and the guard-on-next-line the rule's own recommendation
+// produces (`const next = Number(e.target.value); if (!Number.isNaN(next))
+// setX(next);`). A guard counts only when its test actually reads the event
+// value or the variable holding the parse result.
+const handlerGuardsParsedValue = (
+  handler: EsTreeNode,
+  eventRootName: string,
+  parseResultName: string | null,
+): boolean => {
+  let didFindGuard = false;
+  walkAst(handler, (node) => {
+    if (didFindGuard) return false;
+    if (isNodeOfType(node, "IfStatement") || isNodeOfType(node, "ConditionalExpression")) {
+      if (subtreeReferencesParsedValue(node.test, eventRootName, parseResultName)) {
+        didFindGuard = true;
+        return false;
+      }
+    }
+    if (
+      isNodeOfType(node, "LogicalExpression") &&
+      subtreeReferencesParsedValue(node.left, eventRootName, parseResultName)
+    ) {
+      didFindGuard = true;
+      return false;
+    }
+    if (isNanGuardCall(node)) {
+      const guardArgument = node.arguments[0];
+      if (
+        guardArgument &&
+        subtreeReferencesParsedValue(guardArgument, eventRootName, parseResultName)
+      ) {
+        didFindGuard = true;
+        return false;
+      }
+    }
+  });
+  return didFindGuard;
+};
+
+// Resolves the variable the parse result lands in, walking up through pure
+// wrapper calls so `const v = Math.floor(Number(e.target.value))` still binds
+// `v` and a later `if (!isNaN(v))` counts as a guard.
+const getParseResultBindingName = (call: EsTreeNode): string | null => {
+  let wrappedExpression: EsTreeNode = call;
+  let ancestor = call.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "VariableDeclarator")) {
+      return isNodeOfType(ancestor.id, "Identifier") ? ancestor.id.name : null;
+    }
+    const isCallArgumentWrapper =
+      isNodeOfType(ancestor, "CallExpression") &&
+      ancestor.arguments.some((callArgument) => callArgument === wrappedExpression);
+    if (!isCallArgumentWrapper) return null;
+    wrappedExpression = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return null;
+};
+
+const getStaticInputType = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): string | null => {
+  const typeAttribute = findJsxAttribute(openingElement.attributes ?? [], "type");
+  if (!typeAttribute) return null;
+  const literalValue = getJsxPropStringValue(typeAttribute);
+  if (literalValue !== null) return literalValue;
+  const attributeValue = typeAttribute.value;
+  if (!attributeValue || !isNodeOfType(attributeValue, "JSXExpressionContainer")) return null;
+  const expression = attributeValue.expression;
+  if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
+    return expression.value;
+  }
+  if (isNodeOfType(expression, "TemplateLiteral") && expression.expressions.length === 0) {
+    return expression.quasis[0]?.value.cooked ?? null;
+  }
+  return null;
+};
+
+const firstParameterName = (handler: EsTreeNode): string | null => {
+  const params = (handler as EsTreeNodeOfType<"ArrowFunctionExpression">).params ?? [];
+  const first = params[0];
+  return first && isNodeOfType(first, "Identifier") ? first.name : null;
+};
+
+// True only when the inline handler is bound to an `onX` attribute of an
+// intrinsic `<input>` element whose `type` can hold free text. A `<select>`,
+// `<textarea>`, a component (`<TextField>`, MUI pagination props), or an
+// input type the browser sanitizes (`type="range"` sliders, radio/checkbox)
+// cannot yield an empty or partially-typed value, so we bail — a false
+// negative over a false positive.
+const isTextualInputElementHandler = (handler: EsTreeNode): boolean => {
+  const container = handler.parent;
+  if (!container || !isNodeOfType(container, "JSXExpressionContainer")) return false;
+  const attribute = container.parent;
+  if (!attribute || !isNodeOfType(attribute, "JSXAttribute")) return false;
+  if (
+    !isNodeOfType(attribute.name, "JSXIdentifier") ||
+    !HANDLER_ATTRIBUTE_PATTERN.test(attribute.name.name)
+  ) {
+    return false;
+  }
+  const openingElement = attribute.parent;
+  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
+  if (!isNodeOfType(openingElement.name, "JSXIdentifier") || openingElement.name.name !== "input") {
+    return false;
+  }
+  const staticInputType = getStaticInputType(openingElement);
+  return staticInputType === null || !BROWSER_SANITIZED_INPUT_TYPES.has(staticInputType);
+};
+
+export const noUnguardedNumericInputParse = defineRule({
+  id: "no-unguarded-numeric-input-parse",
+  title: "Unguarded numeric parse of an input value",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "Guard `Number(e.target.value)` / `parseInt(e.target.value)` against empty and NaN before storing it. `Number('')` is `0` and `Number('abc')` is `NaN`, both of which silently ship a wrong value.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isNumericParseCallee(node.callee as EsTreeNode)) return;
+      const argumentList = (node.arguments ?? []) as EsTreeNode[];
+      const firstArgument = argumentList[0];
+      if (!firstArgument) return;
+      const rootName = getEventValueRootName(firstArgument);
+      if (!rootName) return;
+
+      const { handler, isGuarded } = findEnclosingHandlerAndGuard(node as EsTreeNode);
+      if (isGuarded || !handler) return;
+      if (firstParameterName(handler) !== rootName) return;
+      if (!isTextualInputElementHandler(handler)) return;
+      const parseResultName = getParseResultBindingName(node as EsTreeNode);
+      if (handlerGuardsParsedValue(handler, rootName, parseResultName)) return;
+
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-throwing-parse-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-throwing-parse-call.test.ts
@@ -1,0 +1,475 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noUnguardedThrowingParseCall } from "./no-unguarded-throwing-parse-call.js";
+
+describe("no-unguarded-throwing-parse-call", () => {
+  it("flags decodeURIComponent of a useParams path in a component body", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function RawFileViewer(params) {
+        const path = decodeURIComponent(params.path);
+        return path;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags decodeURIComponent of a searchParams value", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function Page() {
+        const target = decodeURIComponent(searchParams.get("redirect"));
+        return target;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags decodeURIComponent of a bare route param named branch", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `const getDecodedBranch = (branch) =>
+        branch ? decodeURIComponent(branch) : undefined;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags decodeURIComponent of a local traced back to searchParams.get", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function AsTemplatePage() {
+        const viewName = searchParams.get("viewName");
+        return viewName ? decodeURIComponent(viewName) : "";
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags readableColor of a runtime theme color in a hook", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function useGetContrastTextColor(actualColorForReadable) {
+        const contrast = readableColor(actualColorForReadable);
+        return contrast;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags chroma of a color prop member in render", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function Swatch(props) {
+        return chroma(props.color).hex();
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags chroma of a getComputedStyle custom-property read", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function useAccentColor(element) {
+        const accent = getComputedStyle(element).getPropertyValue("--accent");
+        return chroma(accent).hex();
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for chroma of a useTheme design-token member", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function EmojiPicker() {
+        const theme = useTheme();
+        const pickerCssVariables = useMemo(
+          () => ({
+            accent: chroma(theme.colorPrimary).rgb().join(", "),
+            background: chroma(theme.colorBgElevated).rgb().join(", "),
+          }),
+          [theme.colorPrimary, theme.colorBgElevated],
+        );
+        return pickerCssVariables;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for readableColor of a custom-named useTheme token object", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function Badge() {
+        const appTheme = useTheme();
+        return readableColor(appTheme.colorText);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for chroma of an antd theme.useToken() token member", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function Tag() {
+        const { token } = theme.useToken();
+        return chroma(token.colorPrimary).alpha(0.4).hex();
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a single-argument new URL of a searchParams value", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function open(searchParams) {
+        return new URL(searchParams.get("redirect"));
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for new URL of a bare url parameter (name alone is not evidence)", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function open(url) {
+        return new URL(url);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL of a url parameter inside a Promise executor", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function httpGet(url, redirectsLeft) {
+        return new Promise((resolve, reject) => {
+          const parsedUrl = new URL(url);
+          resolve(parsedUrl.protocol);
+        });
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL of a url parameter in an async upload callback", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `const upload = async (url) => {
+        const useProxy = !new URL(url).hostname.includes("internxt");
+        return useProxy;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags new URL of a local traced back to a searchParams read", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function Redirect() {
+        const target = searchParams.get("next");
+        return new URL(target);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags new URL of window.location.pathname (relative, throws)", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function readParams() {
+        return new URL(window.location.pathname);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for new URL with a base-origin second argument", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function middleware(request, path) {
+        return NextResponse.redirect(new URL(path, request.url));
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL of window.location.href", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function readParams() {
+        return new URL(window.location.href);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL of a framework request.url", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function handler(request) {
+        const { searchParams } = new URL(request.url);
+        return searchParams;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL of a page.url() accessor", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function origin(page) {
+        return new URL(page.url()).origin;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags new URL of location.pathname (not an absolute URL, throws)", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function readParams() {
+        return new URL(location.pathname);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags new URL of a deep request chain (user-controlled)", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function handler(request) {
+        return new URL(request.body.url);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for new URL of a module constant / env base", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `const endpoint = new URL("/api/users", process.env.PUBLIC_URL);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the decode is inside a try/catch", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function decode(redirectTo) {
+        try {
+          return decodeURIComponent(redirectTo);
+        } catch {
+          return null;
+        }
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when routed through a safe* helper", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function safeReadableColor(color) {
+        return readableColor(color);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for color parse work in a scripts/ file", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function mix(paletteHex) {
+        return chroma(paletteHex).mix("red");
+      }`,
+      { filename: "scripts/mixColorPalettes.ts" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for decodeURIComponent of a string literal", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `const value = decodeURIComponent("%20fixed%20");`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for decodeURIComponent of a non-URL local variable", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function run(token) {
+        return decodeURIComponent(token);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL(import.meta.url), the ESM __dirname idiom", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `const currentDirectory = new URL(import.meta.url).pathname;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL(window.location), MDN's canonical Location-stringify example", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function share() {
+        const url = new URL(window.location);
+        url.searchParams.set("tab", "1");
+        return url;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL(location.toString()) and new URL(window.location.toString())", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function shareUrl() {
+        return [new URL(location.toString()), new URL(window.location.toString())];
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL(String(window.location))", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function snapshotUrl() {
+        return new URL(String(window.location));
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL(location) and new URL(document.location.href)", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function snapshot() {
+        return [new URL(location), new URL(document.location.href)];
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a location.href-derived expression like the pre-'?' split prefix", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function reportLink() {
+        return new URL(\`\${location.href.split("?")[0]}#reports\`);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a URL.canParse early-return guard before new URL", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function LinkPreview({ href }) {
+        if (!URL.canParse(href)) return null;
+        return new URL(href).hostname;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for new URL of a route value pre-validated with URL.canParse", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function Redirect(searchParams) {
+        const target = searchParams.get("next");
+        if (!URL.canParse(target)) return null;
+        return new URL(target).hostname;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for chroma guarded by the documented chroma.valid ternary", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function Swatch({ color }) {
+        return chroma.valid(color) ? chroma(color).hex() : "#000";
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for tinycolor, which never throws and documents isValid()", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `import tinycolor from "tinycolor2";
+      function Swatch({ color }) {
+        const parsed = tinycolor(color);
+        return parsed.isValid() ? parsed.toHexString() : "#000";
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a template literal with a hardcoded absolute origin prefix", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function repoUrl(owner, repo) {
+        return new URL(\`https://github.com/\${owner}/\${repo}\`);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for the Next.js metadataBase imported-config idiom", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `import { config } from "./config";
+      export const metadata = { metadataBase: new URL(config.url) };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a this-rooted class config field like this.baseUrl", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `class ApiClient {
+        connect() {
+          return new URL(this.baseUrl);
+        }
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a validated app-config URL read off props in render", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function ServerBadge(props) {
+        const host = new URL(props.server.http.url).host;
+        return host;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a websocket URL builder templating validated config members", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function terminalWebsocketUrl(input) {
+        return new URL(\`\${input.url}/pty/\${input.id}/connect\`);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for vendored files under vendor/", () => {
+    const result = runRule(
+      noUnguardedThrowingParseCall,
+      `function track(params) {
+        return new URL(params.target);
+      }`,
+      { filename: "vendor/analytics.js" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-throwing-parse-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-throwing-parse-call.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingDeclarator } from "../../utils/find-enclosing-declarator.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -79,18 +80,6 @@ const hasEnclosingFunction = (node: EsTreeNode): boolean => {
 
 const isProcessEnvMember = (node: EsTreeNode): boolean =>
   isNodeOfType(node, "MemberExpression") && getRootIdentifierName(node) === "process";
-
-const findEnclosingDeclarator = (
-  bindingIdentifier: EsTreeNode,
-): EsTreeNodeOfType<"VariableDeclarator"> | null => {
-  let cursor: EsTreeNode | null | undefined = bindingIdentifier.parent;
-  while (cursor) {
-    if (isNodeOfType(cursor, "VariableDeclarator")) return cursor;
-    if (isFunctionLike(cursor)) return null;
-    cursor = cursor.parent ?? null;
-  }
-  return null;
-};
 
 // True when the argument is a literal, a template with a hardcoded absolute
 // origin prefix, a `process.env.*` read, or an identifier bound to a

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-throwing-parse-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-throwing-parse-call.ts
@@ -1,0 +1,500 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isInsideTryStatement } from "../../utils/is-inside-try-statement.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { subtreeReferencesIdentifierName } from "../../utils/subtree-references-identifier-name.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const DECODE_MESSAGE =
+  "This decodes a URL/route value with `decodeURIComponent`/`decodeURI`, which throws `URIError` on a malformed percent-escape (a lone `%`, `100%off`) and unwinds render or aborts the handler. Wrap it in a try/catch, or route it through a `safe*` helper that returns a fallback.";
+const COLOR_MESSAGE =
+  "This parses a runtime color with a library that throws on input it cannot resolve (most often a `var(--x)` CSS variable), crashing render on exactly the theme values you did not test. Wrap it in a try/catch, or route it through a `safe*` helper that returns a fallback.";
+const URL_MESSAGE =
+  "This builds a `URL` from a runtime URL/route value (`params`, `searchParams`, a `location` field), which throws `TypeError` on a malformed string and crashes render. Guard it with `URL.canParse`, pass a base-URL second argument, or wrap the call in a try/catch.";
+
+const DECODE_CALLEE_NAMES = new Set(["decodeURIComponent", "decodeURI"]);
+const COLOR_CALLEE_NAMES = new Set(["readableColor", "parseToRgb", "chroma"]);
+
+// A prop/param named after a URL/route field, or a well-known route source.
+const URL_ROUTE_FIELD_NAMES = new Set(["url", "path", "ref", "branch", "query"]);
+const URL_ROUTE_SOURCE_ROOTS = new Set(["searchParams", "params", "location"]);
+
+// Roots whose values are runtime URL/route input: route params, query strings,
+// location fields, and framework request objects. The `new URL(x)` arm only
+// fires when the argument traces to one of these — an app-internal config URL
+// (imported constant, `this.baseUrl`, `props.server.http.url`) is a validated
+// invariant, not runtime-malformed input.
+const URL_UNTRUSTED_ROOT_NAMES = new Set(["searchParams", "params", "location", "request", "req"]);
+
+const MAX_INITIALIZER_TRACE_DEPTH = 5;
+
+// Non-render/library plumbing, vendored/static artifacts, and controlled-input
+// files where the throw is not a user-facing render/handler crash.
+const EXCLUDED_FILE_PATTERN =
+  /(\.test\.|\.spec\.|__tests__|\/dist\/|\/build\/|\.min\.|(^|\/)(scripts|vendor|public)\/)/;
+
+// A template literal whose first quasi hard-codes an absolute scheme+host
+// prefix (`https://github.com/${owner}/…`) cannot make `new URL` throw: after
+// a valid origin the remainder is percent-encoded, never rejected.
+const ABSOLUTE_ORIGIN_PREFIX_PATTERN = /^[a-z][a-z0-9+.-]*:\/\/[^/\s]/i;
+
+const nameOfFunction = (fn: EsTreeNode): string | null => {
+  if (isNodeOfType(fn, "FunctionDeclaration") && fn.id) return fn.id.name;
+  const parent = fn.parent;
+  if (isNodeOfType(parent, "VariableDeclarator") && isNodeOfType(parent.id, "Identifier")) {
+    return parent.id.name;
+  }
+  if (isNodeOfType(parent, "Property") && isNodeOfType(parent.key, "Identifier")) {
+    return parent.key.name;
+  }
+  return null;
+};
+
+const isRoutedThroughSafeHelper = (node: EsTreeNode): boolean => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor) {
+    if (isFunctionLike(cursor)) {
+      const name = nameOfFunction(cursor);
+      if (name && /^safe/i.test(name)) return true;
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+const hasEnclosingFunction = (node: EsTreeNode): boolean => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor) {
+    if (isFunctionLike(cursor)) return true;
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+const isProcessEnvMember = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "MemberExpression") && getRootIdentifierName(node) === "process";
+
+const findEnclosingDeclarator = (
+  bindingIdentifier: EsTreeNode,
+): EsTreeNodeOfType<"VariableDeclarator"> | null => {
+  let cursor: EsTreeNode | null | undefined = bindingIdentifier.parent;
+  while (cursor) {
+    if (isNodeOfType(cursor, "VariableDeclarator")) return cursor;
+    if (isFunctionLike(cursor)) return null;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+// True when the argument is a literal, a template with a hardcoded absolute
+// origin prefix, a `process.env.*` read, or an identifier bound to a
+// module-scope `const` literal/env value — none are runtime-malformed input,
+// so `new URL(x)` cannot throw on user data.
+const isCompileTimeOrModuleConst = (argument: EsTreeNode): boolean => {
+  const inner = stripParenExpression(argument);
+  if (isNodeOfType(inner, "Literal")) return true;
+  if (isNodeOfType(inner, "TemplateLiteral")) {
+    if (inner.expressions.length === 0) return true;
+    const firstQuasi = inner.quasis[0];
+    return Boolean(firstQuasi && ABSOLUTE_ORIGIN_PREFIX_PATTERN.test(firstQuasi.value.raw));
+  }
+  if (isProcessEnvMember(inner)) return true;
+  if (isNodeOfType(inner, "Identifier")) {
+    const binding = findVariableInitializer(inner, inner.name);
+    if (!binding) return false;
+    const declarator = findEnclosingDeclarator(binding.bindingIdentifier);
+    if (!declarator || declarator.id !== binding.bindingIdentifier) return false;
+    const declaration = declarator.parent;
+    if (!isNodeOfType(declaration, "VariableDeclaration") || declaration.kind !== "const") {
+      return false;
+    }
+    const init = declarator.init ? stripParenExpression(declarator.init as EsTreeNode) : null;
+    if (!init) return false;
+    return isNodeOfType(init, "Literal") || isProcessEnvMember(init);
+  }
+  return false;
+};
+
+const argumentTracesToUrlRouteSource = (argument: EsTreeNode): boolean => {
+  const inner = stripParenExpression(argument);
+  const rootName = getRootIdentifierName(inner);
+  if (rootName && URL_ROUTE_SOURCE_ROOTS.has(rootName)) return true;
+  if (isNodeOfType(inner, "Identifier") && URL_ROUTE_FIELD_NAMES.has(inner.name)) return true;
+  if (
+    isNodeOfType(inner, "MemberExpression") &&
+    isNodeOfType(inner.property, "Identifier") &&
+    URL_ROUTE_FIELD_NAMES.has(inner.property.name)
+  ) {
+    return true;
+  }
+  if (subtreeReferencesIdentifierName(inner, URL_ROUTE_SOURCE_ROOTS)) return true;
+  if (isNodeOfType(inner, "Identifier")) {
+    const binding = findVariableInitializer(inner, inner.name);
+    const declarator = binding ? findEnclosingDeclarator(binding.bindingIdentifier) : null;
+    if (declarator && declarator.init) {
+      return argumentTracesToUrlRouteSource(declarator.init as EsTreeNode);
+    }
+  }
+  return false;
+};
+
+// Design-token theme objects (antd-style/emotion `useTheme()`, antd
+// `theme.useToken()`) hold concrete computed color values, never `var(--x)`
+// CSS custom properties — a color parse of `theme.<token>` cannot throw.
+const THEME_TOKEN_ROOT_NAMES = new Set(["theme", "token", "tokens"]);
+const THEME_HOOK_NAMES = new Set(["useTheme", "useToken"]);
+const COMPUTED_STYLE_READ_NAMES = new Set(["getComputedStyle", "getPropertyValue"]);
+const CSS_CUSTOM_PROPERTY_PATTERN = /var\(/;
+
+const findRootIdentifier = (node: EsTreeNode): EsTreeNodeOfType<"Identifier"> | null => {
+  let cursor: EsTreeNode | null = stripParenExpression(node);
+  while (cursor) {
+    if (isNodeOfType(cursor, "ChainExpression")) {
+      cursor = cursor.expression;
+      continue;
+    }
+    if (isNodeOfType(cursor, "MemberExpression")) {
+      cursor = cursor.object;
+      continue;
+    }
+    break;
+  }
+  return cursor && isNodeOfType(cursor, "Identifier") ? cursor : null;
+};
+
+const isThemeTokenReference = (rootIdentifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  if (THEME_TOKEN_ROOT_NAMES.has(rootIdentifier.name)) return true;
+  const binding = findVariableInitializer(rootIdentifier, rootIdentifier.name);
+  const initializer = binding?.initializer ?? null;
+  if (!initializer || !isNodeOfType(initializer, "CallExpression")) return false;
+  const hookCallee = initializer.callee;
+  if (isNodeOfType(hookCallee, "Identifier")) return THEME_HOOK_NAMES.has(hookCallee.name);
+  return (
+    isNodeOfType(hookCallee, "MemberExpression") &&
+    !hookCallee.computed &&
+    isNodeOfType(hookCallee.property, "Identifier") &&
+    THEME_HOOK_NAMES.has(hookCallee.property.name)
+  );
+};
+
+// The color arm only fires when the argument can actually carry a value the
+// parser rejects at runtime — a `var(--x)` CSS custom property or an empty
+// computed-style read: a string/template containing `var(`, a
+// `getComputedStyle`/`getPropertyValue` read, or a component prop/param
+// (traced through initializers). Theme/design-token members are concrete
+// computed colors and are skipped.
+const canCarryCssCustomProperty = (argument: EsTreeNode, traceDepth: number): boolean => {
+  if (traceDepth > MAX_INITIALIZER_TRACE_DEPTH) return false;
+  const inner = stripParenExpression(argument);
+  if (isNodeOfType(inner, "Literal")) {
+    return typeof inner.value === "string" && CSS_CUSTOM_PROPERTY_PATTERN.test(inner.value);
+  }
+  if (isNodeOfType(inner, "TemplateLiteral")) {
+    return (
+      inner.quasis.some((quasi) => CSS_CUSTOM_PROPERTY_PATTERN.test(quasi.value.raw)) ||
+      inner.expressions.some((expression) =>
+        canCarryCssCustomProperty(expression as EsTreeNode, traceDepth + 1),
+      )
+    );
+  }
+  if (isNodeOfType(inner, "ConditionalExpression")) {
+    return (
+      canCarryCssCustomProperty(inner.consequent as EsTreeNode, traceDepth + 1) ||
+      canCarryCssCustomProperty(inner.alternate as EsTreeNode, traceDepth + 1)
+    );
+  }
+  if (isNodeOfType(inner, "LogicalExpression")) {
+    return (
+      canCarryCssCustomProperty(inner.left as EsTreeNode, traceDepth + 1) ||
+      canCarryCssCustomProperty(inner.right as EsTreeNode, traceDepth + 1)
+    );
+  }
+  if (subtreeReferencesIdentifierName(inner, COMPUTED_STYLE_READ_NAMES)) return true;
+  if (!isNodeOfType(inner, "Identifier") && !isNodeOfType(inner, "MemberExpression")) {
+    return false;
+  }
+  const rootIdentifier = findRootIdentifier(inner);
+  if (!rootIdentifier) return false;
+  if (isThemeTokenReference(rootIdentifier)) return false;
+  const binding = findVariableInitializer(rootIdentifier, rootIdentifier.name);
+  if (!binding) return false;
+  const declarator = findEnclosingDeclarator(binding.bindingIdentifier);
+  if (declarator && declarator.init) {
+    return canCarryCssCustomProperty(declarator.init as EsTreeNode, traceDepth + 1);
+  }
+  return !declarator && isFunctionLike(binding.scopeOwner);
+};
+
+// Request objects whose `.url` is a framework-guaranteed valid absolute URL.
+const REQUEST_URL_ROOTS = new Set(["request", "req"]);
+// Receivers whose zero-arg `.url()` returns a valid absolute URL (Playwright
+// `page.url()`, a framework request's `.url()`). Gated to these so an arbitrary
+// `anything.url()` no longer defeats the rule.
+const LIVE_URL_ACCESSOR_RECEIVERS = new Set(["page", "request", "req"]);
+
+const LOCATION_OWNER_NAMES = new Set(["window", "document", "globalThis"]);
+
+// A reference to the Location object itself: bare `location`,
+// `window.location`, `document.location`. Passing the object to `new URL`
+// stringifies it to `href`, a spec-guaranteed valid absolute URL.
+const isLocationObjectReference = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "Identifier")) return node.name === "location";
+  return (
+    isNodeOfType(node, "MemberExpression") &&
+    !node.computed &&
+    isNodeOfType(node.property, "Identifier") &&
+    node.property.name === "location" &&
+    isNodeOfType(node.object, "Identifier") &&
+    LOCATION_OWNER_NAMES.has(node.object.name)
+  );
+};
+
+// Expressions that always yield a syntactically-valid absolute URL string:
+// `location.href` / `location.toString()` / `String(location)` on any Location
+// reference (NOT `.pathname`/`.search`/`.hash`, which are not absolute URLs
+// and DO throw), `document.URL`, `import.meta.url`, a framework request's own
+// `.url`, and a live-URL accessor call on a known receiver. Each arm requires
+// the exact shape so a user-controlled deep chain (`request.body.url`) still
+// gets flagged.
+const isValidUrlStringSource = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "CallExpression")) {
+    if (
+      node.arguments.length === 1 &&
+      isNodeOfType(node.callee, "Identifier") &&
+      node.callee.name === "String"
+    ) {
+      const stringifiedArgument = node.arguments[0];
+      return Boolean(
+        stringifiedArgument &&
+        isLocationObjectReference(stripParenExpression(stringifiedArgument as EsTreeNode)),
+      );
+    }
+    if (
+      node.arguments.length !== 0 ||
+      !isNodeOfType(node.callee, "MemberExpression") ||
+      node.callee.computed ||
+      !isNodeOfType(node.callee.property, "Identifier")
+    ) {
+      return false;
+    }
+    if (node.callee.property.name === "toString") {
+      return isLocationObjectReference(node.callee.object);
+    }
+    return (
+      node.callee.property.name === "url" &&
+      isNodeOfType(node.callee.object, "Identifier") &&
+      LIVE_URL_ACCESSOR_RECEIVERS.has(node.callee.object.name)
+    );
+  }
+  if (!isNodeOfType(node, "MemberExpression") || node.computed) return false;
+  if (!isNodeOfType(node.property, "Identifier")) return false;
+  const propertyName = node.property.name;
+  if (propertyName === "href") return isLocationObjectReference(node.object);
+  if (propertyName === "URL") {
+    return isNodeOfType(node.object, "Identifier") && node.object.name === "document";
+  }
+  if (propertyName === "url") {
+    if (isNodeOfType(node.object, "MetaProperty")) return true;
+    return isNodeOfType(node.object, "Identifier") && REQUEST_URL_ROOTS.has(node.object.name);
+  }
+  return false;
+};
+
+// True for the Location object itself and for any member/call chain derived
+// from an always-valid URL string (`location.href.split("?")[0]`) — stripping
+// the query/fragment off an absolute URL keeps it parseable, so `new URL`
+// cannot throw. Descent stops at plain identifiers so `location.pathname`
+// (derived from the object, not from `.href`) still gets flagged.
+const isAlwaysValidUrlArgument = (argument: EsTreeNode): boolean => {
+  const inner = stripParenExpression(argument);
+  if (isLocationObjectReference(inner)) return true;
+  let cursor: EsTreeNode | null = inner;
+  while (cursor) {
+    if (isValidUrlStringSource(cursor)) return true;
+    if (isNodeOfType(cursor, "ChainExpression")) {
+      cursor = cursor.expression;
+      continue;
+    }
+    if (isNodeOfType(cursor, "MemberExpression")) {
+      cursor = cursor.object;
+      continue;
+    }
+    if (isNodeOfType(cursor, "CallExpression")) {
+      cursor = cursor.callee;
+      continue;
+    }
+    break;
+  }
+  return false;
+};
+
+const isUntrustedUrlArgument = (argument: EsTreeNode, traceDepth: number): boolean => {
+  if (traceDepth > MAX_INITIALIZER_TRACE_DEPTH) return false;
+  const inner = stripParenExpression(argument);
+  if (isCompileTimeOrModuleConst(inner)) return false;
+  if (isAlwaysValidUrlArgument(inner)) return false;
+  if (isNodeOfType(inner, "TemplateLiteral")) {
+    return inner.expressions.some((expression) =>
+      isUntrustedUrlArgument(expression as EsTreeNode, traceDepth + 1),
+    );
+  }
+  if (isNodeOfType(inner, "Identifier")) {
+    const binding = findVariableInitializer(inner, inner.name);
+    const declarator = binding ? findEnclosingDeclarator(binding.bindingIdentifier) : null;
+    if (declarator && declarator.init) {
+      return isUntrustedUrlArgument(declarator.init as EsTreeNode, traceDepth + 1);
+    }
+    // A bare parameter (or untraceable binding) merely NAMED `url`/`path` is
+    // not evidence of runtime-malformed input — only fire when the value
+    // traces to a route/query/location/request source.
+    return false;
+  }
+  const rootName = getRootIdentifierName(inner, { followCallChains: true });
+  if (rootName && URL_UNTRUSTED_ROOT_NAMES.has(rootName)) return true;
+  return subtreeReferencesIdentifierName(inner, URL_ROUTE_SOURCE_ROOTS);
+};
+
+// Non-throwing validity pre-checks these APIs document precisely so callers
+// can avoid try/catch: `URL.canParse(x)`, `chroma.valid(x)`, `x.isValid()`.
+const VALIDITY_CHECK_METHOD_NAMES = new Set(["canParse", "valid", "isValid"]);
+
+const containsValidityCheckCall = (node: EsTreeNode | null | undefined): boolean => {
+  if (!node) return false;
+  let didFindCheck = false;
+  walkAst(node, (child: EsTreeNode) => {
+    if (didFindCheck) return false;
+    if (
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "MemberExpression") &&
+      !child.callee.computed &&
+      isNodeOfType(child.callee.property, "Identifier") &&
+      VALIDITY_CHECK_METHOD_NAMES.has(child.callee.property.name)
+    ) {
+      didFindCheck = true;
+      return false;
+    }
+  });
+  return didFindCheck;
+};
+
+const isEarlyExitStatement = (statement: EsTreeNode): boolean =>
+  isNodeOfType(statement, "ReturnStatement") ||
+  isNodeOfType(statement, "ThrowStatement") ||
+  isNodeOfType(statement, "ContinueStatement") ||
+  isNodeOfType(statement, "BreakStatement");
+
+const guardConsequentExitsEarly = (consequent: EsTreeNode): boolean => {
+  if (isEarlyExitStatement(consequent)) return true;
+  if (isNodeOfType(consequent, "BlockStatement")) {
+    return consequent.body.some((statement) => isEarlyExitStatement(statement));
+  }
+  return false;
+};
+
+// True when the parse call is dominated by a validity pre-check within the
+// same function: the guarded branch of an `if`/ternary/`&&` whose test runs a
+// validity check, or preceded by an early-exit `if (!check(x)) return` guard.
+const isGuardedByValidityCheck = (node: EsTreeNode): boolean => {
+  let cursor: EsTreeNode = node;
+  let parent: EsTreeNode | null | undefined = node.parent;
+  while (parent) {
+    if (
+      isNodeOfType(parent, "IfStatement") &&
+      parent.consequent === cursor &&
+      containsValidityCheckCall(parent.test)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(parent, "ConditionalExpression") &&
+      parent.test !== cursor &&
+      containsValidityCheckCall(parent.test)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(parent, "LogicalExpression") &&
+      parent.operator === "&&" &&
+      parent.right === cursor &&
+      containsValidityCheckCall(parent.left)
+    ) {
+      return true;
+    }
+    if (isNodeOfType(parent, "BlockStatement") || isNodeOfType(parent, "Program")) {
+      for (const statement of parent.body) {
+        if (statement === cursor) break;
+        if (
+          isNodeOfType(statement, "IfStatement") &&
+          containsValidityCheckCall(statement.test) &&
+          guardConsequentExitsEarly(statement.consequent)
+        ) {
+          return true;
+        }
+      }
+    }
+    if (isFunctionLike(parent)) return false;
+    cursor = parent;
+    parent = parent.parent ?? null;
+  }
+  return false;
+};
+
+export const noUnguardedThrowingParseCall = defineRule({
+  id: "no-unguarded-throwing-parse-call",
+  title: "Unguarded call to a throwing parse API",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "`decodeURIComponent`/`decodeURI`, color parsers (`readableColor`/`parseToRgb`/`chroma`), and single-arg `new URL(x)` on a URL/route value throw on malformed runtime input and crash render; guard with a validity pre-check (`URL.canParse`, `chroma.valid`), a try/catch, or a `safe*` helper that returns a fallback.",
+  create: (context: RuleContext) => {
+    const filename = context.filename ?? "";
+    const fileIsExcluded = EXCLUDED_FILE_PATTERN.test(filename);
+    return {
+      NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
+        if (fileIsExcluded) return;
+        if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "URL") return;
+        if (node.arguments.length !== 1) return;
+        const argument = node.arguments[0];
+        if (!argument) return;
+        if (isCompileTimeOrModuleConst(argument as EsTreeNode)) return;
+        if (isAlwaysValidUrlArgument(argument as EsTreeNode)) return;
+        if (!isUntrustedUrlArgument(argument as EsTreeNode, 0)) return;
+        if (isInsideTryStatement(node as EsTreeNode)) return;
+        if (isRoutedThroughSafeHelper(node as EsTreeNode)) return;
+        if (isGuardedByValidityCheck(node as EsTreeNode)) return;
+        context.report({ node: node as EsTreeNode, message: URL_MESSAGE });
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (fileIsExcluded) return;
+        if (!isNodeOfType(node.callee, "Identifier")) return;
+        const calleeName = node.callee.name;
+        const isDecode = DECODE_CALLEE_NAMES.has(calleeName);
+        const isColor = COLOR_CALLEE_NAMES.has(calleeName);
+        if (!isDecode && !isColor) return;
+
+        const argument = node.arguments[0];
+        if (!argument) return;
+        if (isInsideTryStatement(node as EsTreeNode)) return;
+        if (isRoutedThroughSafeHelper(node as EsTreeNode)) return;
+
+        if (isDecode) {
+          if (!argumentTracesToUrlRouteSource(argument as EsTreeNode)) return;
+          context.report({ node: node as EsTreeNode, message: DECODE_MESSAGE });
+          return;
+        }
+
+        // Color arm: a runtime color value parsed in a render/hook path.
+        if (!canCarryCssCustomProperty(argument as EsTreeNode, 0)) return;
+        if (!hasEnclosingFunction(node as EsTreeNode)) return;
+        if (isGuardedByValidityCheck(node as EsTreeNode)) return;
+        context.report({ node: node as EsTreeNode, message: COLOR_MESSAGE });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unsafe-json-parse.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unsafe-json-parse.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noUnsafeJsonParse } from "./no-unsafe-json-parse.js";
+
+describe("no-unsafe-json-parse", () => {
+  it("flags immediate member access on the parse result", () => {
+    const result = runRule(noUnsafeJsonParse, `const m = JSON.parse(raw).foo;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a chained member access on the parse result", () => {
+    const result = runRule(
+      noUnsafeJsonParse,
+      `const m = JSON.parse(schedule.api_response).error.message;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags member access through parentheses", () => {
+    const result = runRule(noUnsafeJsonParse, `const m = (JSON.parse(raw)).foo;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a network-text parse dereference outside try", () => {
+    const result = runRule(noUnsafeJsonParse, `const id = JSON.parse(networkText).id;`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags object destructuring straight off the parse result", () => {
+    const result = runRule(noUnsafeJsonParse, `const { foo } = JSON.parse(raw);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags array destructuring straight off the parse result", () => {
+    const result = runRule(noUnsafeJsonParse, `const [first] = JSON.parse(raw);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a parse dereference in a handler merely defined inside a try block", () => {
+    const result = runRule(
+      noUnsafeJsonParse,
+      `
+      try {
+        socket.onmessage = (event) => setItems(JSON.parse(event.data).items);
+      } catch (error) {
+        handle(error);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a bare assignment with no member access", () => {
+    const result = runRule(noUnsafeJsonParse, `const data = JSON.parse(raw);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a parse/stringify round-trip clone", () => {
+    const result = runRule(
+      noUnsafeJsonParse,
+      `const copy = JSON.parse(JSON.stringify(value)).foo;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a parse dereference inside an enclosing try block", () => {
+    const result = runRule(
+      noUnsafeJsonParse,
+      `try { const m = JSON.parse(raw).foo; } catch (error) { handle(error); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a synchronous array-callback parse inside an enclosing try block", () => {
+    const result = runRule(
+      noUnsafeJsonParse,
+      `
+      try {
+        const values = items.map((item) => JSON.parse(item).value);
+      } catch (error) {
+        handle(error);
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag object destructuring inside an enclosing try block", () => {
+    const result = runRule(
+      noUnsafeJsonParse,
+      `try { const { foo } = JSON.parse(raw); } catch (error) { handle(error); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag destructuring when the result is annotated with an as-cast", () => {
+    const result = runRule(noUnsafeJsonParse, `const { foo } = JSON.parse(raw) as Payload;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the result is annotated with an as-cast", () => {
+    const result = runRule(noUnsafeJsonParse, `const m = (JSON.parse(raw) as Payload).error;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the result is wrapped in a validator", () => {
+    const result = runRule(noUnsafeJsonParse, `const parsed = schema.parse(JSON.parse(raw));`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a parse passed as a call argument", () => {
+    const result = runRule(noUnsafeJsonParse, `doThing(JSON.parse(raw));`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('does not flag a `?? "{}"` fallback argument', () => {
+    const result = runRule(noUnsafeJsonParse, `const value = JSON.parse(input ?? "{}").value;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it('does not flag a `|| "[]"` fallback argument', () => {
+    const result = runRule(noUnsafeJsonParse, `const length = JSON.parse(input || "[]").length;`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when JSON is shadowed by a local binding", () => {
+    const result = runRule(
+      noUnsafeJsonParse,
+      `
+      function read(raw) {
+        const JSON = { parse: () => ({ value: 1 }) };
+        return JSON.parse(raw).value;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a parse dereference inside a test file", () => {
+    const result = runRule(noUnsafeJsonParse, `const m = JSON.parse(raw).foo;`, {
+      filename: "payload.test.ts",
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unsafe-json-parse.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unsafe-json-parse.ts
@@ -1,0 +1,128 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isInsideTryStatement } from "../../utils/is-inside-try-statement.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isObjectOfMemberAccess } from "../../utils/is-object-of-member-access.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const MESSAGE =
+  "Reading a property straight off `JSON.parse(...)` is a double crash: `JSON.parse` throws `SyntaxError` on malformed or empty input, and its `any` result lets an undefined property pass the type-checker and throw at runtime; wrap the parse in try/catch and validate the result before accessing fields.";
+
+// `JSON.<method>(...)` with a non-computed `JSON` member callee. Computed
+// access (`JSON["parse"]`) is a v1 non-goal (vanishingly rare).
+const isJsonMethodCall = (node: EsTreeNode, method: string): boolean =>
+  isNodeOfType(node, "CallExpression") &&
+  isNodeOfType(node.callee, "MemberExpression") &&
+  !node.callee.computed &&
+  isNodeOfType(node.callee.object, "Identifier") &&
+  node.callee.object.name === "JSON" &&
+  isNodeOfType(node.callee.property, "Identifier") &&
+  node.callee.property.name === method;
+
+// oxc surfaces redundant parens as a `ParenthesizedExpression` wrapper,
+// which TSESTree's node-type union doesn't model — compare `type` as a
+// plain string to walk past it.
+const PARENTHESIZED_EXPRESSION_TYPE: string = "ParenthesizedExpression";
+
+// A `??` / `||` fallback (`JSON.parse(input ?? "{}")`) supplies valid JSON when
+// the source is missing, so the parse is guarded by construction.
+const hasFallbackArgument = (argument: EsTreeNode): boolean =>
+  isNodeOfType(argument, "LogicalExpression") &&
+  (argument.operator === "??" || argument.operator === "||");
+
+const skipParenthesizedParents = (node: EsTreeNode): EsTreeNode => {
+  let current = node;
+  while (current.parent && current.parent.type === PARENTHESIZED_EXPRESSION_TYPE) {
+    current = current.parent;
+  }
+  return current;
+};
+
+// Destructuring reads properties straight off the parse result:
+// `const { foo } = JSON.parse(raw)` / `const [first] = JSON.parse(raw)`.
+const isDestructuredDeclaratorInit = (node: EsTreeNode): boolean => {
+  const parent = node.parent;
+  return Boolean(
+    parent &&
+    isNodeOfType(parent, "VariableDeclarator") &&
+    parent.init === node &&
+    (isNodeOfType(parent.id, "ObjectPattern") || isNodeOfType(parent.id, "ArrayPattern")),
+  );
+};
+
+// True when a property is read directly off the call result — a member access
+// (`JSON.parse(x).foo`, tolerating `(JSON.parse(x)).foo` parens) or a
+// destructuring declarator. A `TSAsExpression` / `TSSatisfiesExpression`
+// parent means the author annotated the result and is intentionally out of
+// scope, so it is NOT treated as an unsafe deref.
+const isResultImmediatelyRead = (call: EsTreeNode): boolean => {
+  const unwrapped = skipParenthesizedParents(call);
+  return isObjectOfMemberAccess(unwrapped) || isDestructuredDeclaratorInit(unwrapped);
+};
+
+// A function passed straight to a call (`items.map(item => ...)`, an IIFE) can
+// run synchronously inside an enclosing `try`, so the try still guards it; a
+// function that is merely defined there (assigned to `socket.onmessage`,
+// stored, returned) runs later, outside the try.
+const isInvokedAtDefinitionSite = (functionNode: EsTreeNode): boolean => {
+  const parent = skipParenthesizedParents(functionNode).parent;
+  return Boolean(
+    parent && (isNodeOfType(parent, "CallExpression") || isNodeOfType(parent, "NewExpression")),
+  );
+};
+
+// The nearest enclosing function whose execution is deferred past its
+// definition site — an enclosing `try` beyond it wraps only the definition,
+// not the parse, so the try-walk must stop there.
+const findDeferredExecutionBoundary = (node: EsTreeNode): EsTreeNode | null => {
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor) {
+    if (isFunctionLike(ancestor) && !isInvokedAtDefinitionSite(ancestor)) return ancestor;
+    ancestor = ancestor.parent;
+  }
+  return null;
+};
+
+export const noUnsafeJsonParse = defineRule({
+  id: "no-unsafe-json-parse",
+  title: "Unsafe JSON.parse dereference",
+  severity: "warn",
+  category: "Correctness",
+  tags: ["test-noise"],
+  recommendation:
+    "Wrap `JSON.parse(x)` in try/catch and validate the result (for example with a schema) before reading properties off it. A bare `JSON.parse(x).foo` throws on bad input and lets undefined fields slip past the type-checker.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isJsonMethodCall(node as EsTreeNode, "parse")) return;
+      // A same-file binding named `JSON` shadows the global — bail out.
+      const callee = node.callee;
+      if (
+        isNodeOfType(callee, "MemberExpression") &&
+        isNodeOfType(callee.object, "Identifier") &&
+        findVariableInitializer(callee.object, "JSON")
+      )
+        return;
+      const firstArgument = node.arguments?.[0];
+      if (firstArgument) {
+        const unwrappedArgument = stripParenExpression(firstArgument);
+        // `JSON.parse(JSON.stringify(x))` is the deep-clone idiom; stringify
+        // output is always valid JSON.
+        if (isJsonMethodCall(unwrappedArgument, "stringify")) return;
+        if (hasFallbackArgument(unwrappedArgument)) return;
+      }
+      if (!isResultImmediatelyRead(node as EsTreeNode)) return;
+      if (
+        isInsideTryStatement(node as EsTreeNode, {
+          region: "block",
+          boundary: findDeferredExecutionBoundary(node as EsTreeNode),
+        })
+      )
+        return;
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-whole-object-default-losing-per-key-defaults.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-whole-object-default-losing-per-key-defaults.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noWholeObjectDefaultLosingPerKeyDefaults } from "./no-whole-object-default-losing-per-key-defaults.js";
+
+describe("no-whole-object-default-losing-per-key-defaults", () => {
+  it("flags a multi-key whole-object default with undefaulted bindings", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const useActive = ({ exact, loading } = { exact: true, loading: false }) => {};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a function declaration with a partial whole-object default", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `function setup({ path, type } = { path: '' }) {}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a single-key whole-object default with an undefaulted binding", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `function useConvertD3ToBreadcrumbs({ data } = { data: someDefault }) {}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags when only some bindings carry their own default", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const f = ({ a = 1, b } = { a: 1, b: 2 }) => {};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when every binding already carries its own default", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const useNavLinks = ({ provider = p, owner = o } = { provider: p, owner: o }) => {};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for the empty-object default idiom", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const fn = ({ a = 1, b = false } = {}) => {};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a test-helper with every binding pre-defaulted", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `function setup({ triggerError = false, showStaticAnalysis = true, plan = free } = { triggerError: false, showStaticAnalysis: true, plan: free }) {}`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when there is no whole-object default at all", () => {
+    const result = runRule(noWholeObjectDefaultLosingPerKeyDefaults, `const f = ({ a, b }) => {};`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a spread-only default object (no per-key value)", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const f = ({ a, b } = { ...base }) => {};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat a nested destructuring default as a parameter default", () => {
+    const result = runRule(noWholeObjectDefaultLosingPerKeyDefaults, `const { a, b } = { a: 1 };`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the default is not an object expression", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const f = ({ a, b } = base) => {};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for an all-false boolean-flag bag (antd onReset idiom: undefined is truthiness-identical to the dropped false)", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const onReset = ({ confirm, closeDropdown } = { confirm: false, closeDropdown: false }) => { if (confirm) {} if (closeDropdown) {} };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a flag bag when any dropped fallback is a truthy literal", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const fn = ({ confirm, closeDropdown } = { confirm: false, closeDropdown: true }) => {};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a dropped empty-string fallback (falsy literals other than false diverge from undefined under member access)", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const fn = ({ path, ok } = { path: '', ok: false }) => {};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the default object only covers bindings that already carry their own default (hook options idiom)", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `function useThing({ signal, retries = 3 } = { retries: 5 }) {}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the undefaulted binding has no matching key in the default object", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `const f = ({ a = 1, b } = { a: 1 }) => {};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a whole-object default wrapped in a TS `as` assertion", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `function f({ a, b } = { a: 1 } as Options) {}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a whole-object default wrapped in a TS `satisfies` expression", () => {
+    const result = runRule(
+      noWholeObjectDefaultLosingPerKeyDefaults,
+      `function f({ a, b } = { a: 1 } satisfies Partial<Options>) {}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-whole-object-default-losing-per-key-defaults.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-whole-object-default-losing-per-key-defaults.ts
@@ -1,0 +1,119 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+// A whole-object parameter default (`({ a, b } = { a: 1, b: 'x' })`)
+// only applies when the argument is omitted ENTIRELY. The instant a
+// caller passes any object, the default object is discarded wholesale
+// and every key the caller left out becomes `undefined` — silently
+// bypassing the intended fallback. The correct form applies each
+// default independently: `({ a = 1, b = 'x' } = {})`.
+//
+// Scope-fix (fires only when a per-key default is actually reachable to
+// lose, and losing it changes behavior):
+//   1. the parameter is `ObjectPattern = ObjectExpression` (TS wrappers
+//      like `as` / `satisfies` around the object are peeled first),
+//   2. at least one destructured binding lacks its OWN default AND has a
+//      matching `key: value` property in the default object — that value
+//      is the fallback a partial call silently drops,
+//   3. at least one such dropped fallback is something other than the
+//      literal `false` — boolean-flag bags defaulting everything to
+//      `false` are consumed in truthiness checks where `undefined`
+//      behaves identically, so nothing observable is lost.
+// `= {}` (the recommended idiom), patterns where every binding is
+// already defaulted, and all-`false` flag bags stay quiet.
+
+const getStaticPropertyKey = (property: EsTreeNodeOfType<"Property">): string | null => {
+  if (property.computed) return null;
+  const key = property.key as EsTreeNode;
+  if (isNodeOfType(key, "Identifier")) return key.name;
+  if (isNodeOfType(key, "Literal")) return String(key.value);
+  return null;
+};
+
+// Keys of bindings that carry no `= default` of their own — the bindings
+// whose fallback the whole-object default silently drops on a
+// partial-argument call.
+const collectUndefaultedBindingKeys = (
+  objectPattern: EsTreeNodeOfType<"ObjectPattern">,
+): Set<string> => {
+  const undefaultedBindingKeys = new Set<string>();
+  for (const property of objectPattern.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) continue;
+    if (isNodeOfType(property.value as EsTreeNode, "AssignmentPattern")) continue;
+    const bindingKey = getStaticPropertyKey(property);
+    if (bindingKey !== null) undefaultedBindingKeys.add(bindingKey);
+  }
+  return undefaultedBindingKeys;
+};
+
+// The default-object values that a partial call actually drops: each
+// `key: value` whose key matches an undefaulted binding.
+const collectDroppedFallbackValues = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+  undefaultedBindingKeys: Set<string>,
+): Array<EsTreeNode> => {
+  const droppedFallbackValues: Array<EsTreeNode> = [];
+  for (const property of objectExpression.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) continue;
+    const propertyKey = getStaticPropertyKey(property);
+    if (propertyKey === null || !undefaultedBindingKeys.has(propertyKey)) continue;
+    droppedFallbackValues.push(property.value as EsTreeNode);
+  }
+  return droppedFallbackValues;
+};
+
+// `false` fallbacks feed truthiness checks where `undefined` behaves
+// identically, so dropping them is a runtime no-op.
+const isFalseLiteral = (value: EsTreeNode): boolean => {
+  const innerValue = stripParenExpression(value);
+  return isNodeOfType(innerValue, "Literal") && innerValue.value === false;
+};
+
+// True when the AssignmentPattern is a direct parameter of a function
+// (not a nested destructuring default inside another pattern).
+const isFunctionParameter = (assignmentPattern: EsTreeNode): boolean => {
+  const parent = assignmentPattern.parent;
+  return Boolean(
+    parent &&
+    isFunctionLike(parent) &&
+    parent.params?.some((parameter) => parameter === assignmentPattern),
+  );
+};
+
+export const noWholeObjectDefaultLosingPerKeyDefaults = defineRule({
+  id: "no-whole-object-default-losing-per-key-defaults",
+  title: "Whole-object param default loses per-key defaults",
+  severity: "warn",
+  category: "Correctness",
+  tags: ["test-noise"],
+  recommendation:
+    "A whole-object parameter default applies only when the argument is omitted entirely, so a partial argument makes every omitted key undefined. Move each fallback onto its own binding instead: `({ a = 1, b = false } = {})`.",
+  create: (context: RuleContext): RuleVisitors => ({
+    AssignmentPattern(node: EsTreeNodeOfType<"AssignmentPattern">) {
+      if (!isFunctionParameter(node)) return;
+      const pattern = node.left as EsTreeNode;
+      const defaultValue = stripParenExpression(node.right as EsTreeNode);
+      if (!isNodeOfType(pattern, "ObjectPattern")) return;
+      if (!isNodeOfType(defaultValue, "ObjectExpression")) return;
+      const undefaultedBindingKeys = collectUndefaultedBindingKeys(pattern);
+      if (undefaultedBindingKeys.size === 0) return;
+      const droppedFallbackValues = collectDroppedFallbackValues(
+        defaultValue,
+        undefaultedBindingKeys,
+      );
+      if (droppedFallbackValues.length === 0) return;
+      if (droppedFallbackValues.every(isFalseLiteral)) return;
+      context.report({
+        node,
+        message:
+          "This whole-object default is discarded the moment a caller passes any object, so every omitted key becomes undefined instead of falling back. Give each binding its own default instead: `({ a = 1, b = false } = {})`.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/radio-input-missing-name.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/radio-input-missing-name.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { radioInputMissingName } from "./radio-input-missing-name.js";
+
+const withRadioComponents = {
+  "react-doctor": { "radioInputMissingName.radioComponents": ["Radio"] },
+};
+
+describe("radio-input-missing-name", () => {
+  it("flags a native radio input with no name", () => {
+    const result = runRule(radioInputMissingName, `<input type="radio" value="yes" />;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a radio with checked/onChange but still no name", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `<input type="radio" value="no" checked onChange={handleChange} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags two sibling radios in a fieldset, neither with name", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `function Options() {
+        return (
+          <fieldset>
+            <input type="radio" value="a" />
+            <input type="radio" value="b" />
+          </fieldset>
+        );
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("flags an allowlisted Radio component with no name", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `<Radio value="a" align="flex-start" onClick={onSelect} active={selected} />;`,
+      { settings: withRadioComponents },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an allowlisted member-expression radio component with no name (semantic-ui Form.Radio)", () => {
+    const result = runRule(radioInputMissingName, `<Form.Radio value="a" />;`, {
+      settings: {
+        "react-doctor": { "radioInputMissingName.radioComponents": ["Form.Radio"] },
+      },
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a native radio inside a Group-named wrapper, which cannot supply name via context", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `<InputGroup><input type="radio" value="a" /></InputGroup>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag allowlisted Radios whose name comes from the group provider (antd/Mantine Radio.Group)", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `<Radio.Group name="framework"><Radio value="react" /><Radio value="vue" /></Radio.Group>;`,
+      { settings: withRadioComponents },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag allowlisted Radios inside a nameless RadioGroup, which auto-generates a name (Chakra/Mantine)", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `<RadioGroup value={value} onChange={setValue}><div><Radio value="react" /></div></RadioGroup>;`,
+      { settings: withRadioComponents },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a radio that has a name", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `<input type="radio" name="answer" value="yes" />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a radio with a dynamic name expression", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `<input type="radio" name={fieldName} value="yes" />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a radio with a spread attribute", () => {
+    const result = runRule(
+      radioInputMissingName,
+      `<input type="radio" {...register('answer')} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a radio with a generic spread", () => {
+    const result = runRule(radioInputMissingName, `<input type="radio" {...props} value="yes" />;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a checkbox", () => {
+    const result = runRule(radioInputMissingName, `<input type="checkbox" value="yes" />;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a text input", () => {
+    const result = runRule(radioInputMissingName, `<input type="text" />;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an input with a dynamic type", () => {
+    const result = runRule(radioInputMissingName, `<input type={dynamicType} value="yes" />;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a Radio component when the allowlist is empty (default)", () => {
+    const result = runRule(radioInputMissingName, `<MyRadio value="a" />;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare Radio when it is not in the allowlist", () => {
+    const result = runRule(radioInputMissingName, `<Radio value="a" />;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/radio-input-missing-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/radio-input-missing-name.ts
@@ -1,0 +1,79 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { flattenJsxName } from "../../utils/flatten-jsx-name.js";
+import { getElementType } from "../../utils/get-element-type.js";
+import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
+import { getReactDoctorStringArraySetting } from "../../utils/get-react-doctor-setting.js";
+import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const RADIO_COMPONENTS_SETTING = "radioInputMissingName.radioComponents";
+const GROUP_PROVIDER_NAME_SUFFIX = "Group";
+
+const isGroupProviderName = (elementName: string): boolean => {
+  const finalSegment = elementName.split(".").at(-1) ?? "";
+  return finalSegment.endsWith(GROUP_PROVIDER_NAME_SUFFIX);
+};
+
+const hasGroupProviderAncestor = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): boolean => {
+  let ancestor: EsTreeNode | null | undefined = openingElement.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "JSXElement")) {
+      const ancestorName = flattenJsxName(ancestor.openingElement.name);
+      if (ancestorName && isGroupProviderName(ancestorName)) return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+export const radioInputMissingName = defineRule({
+  id: "radio-input-missing-name",
+  title: "Radio input missing name",
+  category: "Accessibility",
+  severity: "warn",
+  recommendation:
+    'Give every radio in the same group the same `name` prop (e.g. `<input type="radio" name="shippingSpeed" />`). The browser groups radios and enables arrow-key navigation only when they share a `name`.',
+  create: (context: RuleContext) => {
+    const radioComponents = new Set(
+      getReactDoctorStringArraySetting(context.settings, RADIO_COMPONENTS_SETTING),
+    );
+
+    return {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        const attributes = node.attributes ?? [];
+
+        // A spread could supply `name` at runtime (react-hook-form's
+        // `register()`, Radix, Headless UI) — proving its absence is
+        // impossible, so stay quiet.
+        if (hasJsxSpreadAttribute(attributes)) return;
+
+        const elementType = getElementType(node, context.settings);
+        const isAllowlistedRadioComponent = radioComponents.has(elementType);
+
+        if (!isAllowlistedRadioComponent) {
+          if (elementType !== "input") return;
+          const typeAttribute = findJsxAttribute(attributes, "type");
+          if (!typeAttribute || getJsxPropStringValue(typeAttribute) !== "radio") return;
+        }
+
+        // Library group wrappers (Mantine/antd `Radio.Group`, Chakra
+        // `RadioGroup`, …) supply `name` to their radios via context.
+        if (isAllowlistedRadioComponent && hasGroupProviderAncestor(node)) return;
+
+        if (findJsxAttribute(attributes, "name")) return;
+
+        context.report({
+          node,
+          message:
+            "Users can check several of these radios at once and keyboard users can't arrow between them because they share no `name`. Give every radio in this group the same `name` prop.",
+        });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/styled-components-non-transient-custom-prop-on-intrinsic-element.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/styled-components-non-transient-custom-prop-on-intrinsic-element.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { styledComponentsNonTransientCustomPropOnIntrinsicElement } from "./styled-components-non-transient-custom-prop-on-intrinsic-element.js";
+
+const rule = styledComponentsNonTransientCustomPropOnIntrinsicElement;
+
+describe("styled-components-non-transient-custom-prop-on-intrinsic-element", () => {
+  it("flags a custom boolean prop on styled.div", () => {
+    const result = runRule(rule, "const D = styled.div<{ selected: boolean }>`color: red;`;");
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an invented prop on styled.button", () => {
+    const result = runRule(rule, "const B = styled.button<{ active: boolean }>`color: red;`;");
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags backgroundImage on styled.div", () => {
+    const result = runRule(
+      rule,
+      "const D = styled.div<{ backgroundImage: string }>`background: none;`;",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags multiple invented props", () => {
+    const result = runRule(
+      rule,
+      "const D = styled.div<{ isTarget: boolean; showActions: boolean; grabbing: boolean }>`color: red;`;",
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("does not flag transient $-prefixed props", () => {
+    const result = runRule(rule, "const D = styled.div<{ $active: boolean }>`color: red;`;");
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag styled(Component) wrapping a component", () => {
+    const result = runRule(rule, "const D = styled(Base)<{ active: boolean }>`color: red;`;");
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a custom prop behind an .attrs() chain — .attrs merges attributes and strips nothing", () => {
+    const result = runRule(
+      rule,
+      'const B = styled.button.attrs({ type: "button" })<{ active: boolean }>`color: red;`;',
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag withConfig chains where shouldForwardProp can filter the prop", () => {
+    const result = runRule(
+      rule,
+      "const D = styled.div.withConfig({ shouldForwardProp: (prop) => prop !== 'active' })<{ active: boolean }>`color: red;`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag @emotion/styled, which filters invalid props on string tags by default", () => {
+    const result = runRule(
+      rule,
+      'import styled from "@emotion/styled";\nconst D = styled.div<{ active: boolean }>`color: red;`;',
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag @linaria/react styled, a different library sharing the tagged-template syntax", () => {
+    const result = runRule(
+      rule,
+      'import { styled } from "@linaria/react";\nconst D = styled.div<{ active: boolean }>`color: red;`;',
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags when styled is explicitly imported from styled-components", () => {
+    const result = runRule(
+      rule,
+      'import styled from "styled-components";\nconst D = styled.div<{ active: boolean }>`color: red;`;',
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag theme, the per-component theme-typing idiom consumed internally by styled-components", () => {
+    const result = runRule(
+      rule,
+      "const D = styled.div<{ theme: AppTheme }>`color: ${(p) => p.theme.text};`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag as / forwardedAs, polymorphic props consumed internally by styled-components", () => {
+    const result = runRule(
+      rule,
+      "const D = styled.div<{ as: string; forwardedAs: string }>`color: red;`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag valid element-specific attributes on their tag", () => {
+    const cases = [
+      "const I = styled.input<{ value: string }>`color: red;`;",
+      "const I = styled.input<{ checked: boolean }>`color: red;`;",
+      "const M = styled.img<{ loading: string }>`color: red;`;",
+      "const T = styled.details<{ open: boolean }>`color: red;`;",
+      "const S = styled.select<{ multiple: boolean }>`color: red;`;",
+      "const X = styled.textarea<{ rows: number }>`color: red;`;",
+    ];
+    for (const code of cases) {
+      const result = runRule(rule, code);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("does not flag global attributes on any tag", () => {
+    const result = runRule(
+      rule,
+      "const D = styled.div<{ id: string; role: string; title: string; hidden: boolean; tabIndex: number }>`color: red;`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag svg fill on svg", () => {
+    const result = runRule(rule, "const S = styled.svg<{ fill: string }>`color: red;`;");
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag data-* / aria-* string keys", () => {
+    const result = runRule(
+      rule,
+      "const D = styled.div<{ 'data-testid': string; 'aria-label': string }>`color: red;`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag event handler props", () => {
+    const result = runRule(
+      rule,
+      "const D = styled.div<{ onCustomThing: () => void }>`color: red;`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag styled.div without a generic", () => {
+    const result = runRule(rule, "const D = styled.div`color: red;`;");
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags selected on div but not on option", () => {
+    const div = runRule(rule, "const D = styled.div<{ selected: boolean }>`color: red;`;");
+    expect(div.diagnostics).toHaveLength(1);
+    const option = runRule(rule, "const O = styled.option<{ selected: boolean }>`color: red;`;");
+    expect(option.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/styled-components-non-transient-custom-prop-on-intrinsic-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/styled-components-non-transient-custom-prop-on-intrinsic-element.ts
@@ -1,0 +1,128 @@
+import {
+  DOM_PROPERTY_NAMES,
+  DOM_PROPERTY_NAMES_LOWER,
+} from "../../constants/dom-property-names.js";
+import { DOM_PROPERTY_TO_ALLOWED_TAGS } from "../../constants/dom-property-tags.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+
+// Attributes that live in the global known-attribute set but are only
+// valid on specific elements, and are NOT already scoped by
+// `DOM_PROPERTY_TO_ALLOWED_TAGS`. Keeps `styled.div<{ selected }>` (a real
+// leak — `selected` belongs on `<option>`) flaggable without touching the
+// shared no-unknown-property tables.
+const ELEMENT_RESTRICTED_ATTRIBUTES: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["selected", new Set(["option"])],
+]);
+
+const EVENT_HANDLER_PROP_PATTERN = /^on[A-Z]/;
+
+// Props styled-components consumes internally (v6 createStyledComponent
+// skips them when building the element's props), so they never reach the
+// DOM node and prefixing them with `$` would break their behavior.
+const STYLED_COMPONENTS_CONSUMED_PROPS: ReadonlySet<string> = new Set([
+  "theme",
+  "as",
+  "forwardedAs",
+]);
+
+interface StyledIntrinsicTag {
+  readonly tagName: string;
+}
+
+// Unwraps `.attrs(...)` chains — `.attrs()` merges attributes and strips
+// nothing, so `styled.div.attrs({...})` is still an intrinsic target whose
+// non-transient custom props forward to the DOM. `withConfig(...)` stays
+// opaque because `shouldForwardProp` can legitimately filter the prop.
+const unwrapAttrsCalls = (tag: EsTreeNode): EsTreeNode => {
+  let current = tag;
+  while (
+    isNodeOfType(current, "CallExpression") &&
+    isNodeOfType(current.callee, "MemberExpression") &&
+    !current.callee.computed &&
+    isNodeOfType(current.callee.property, "Identifier") &&
+    current.callee.property.name === "attrs"
+  ) {
+    current = current.callee.object;
+  }
+  return current;
+};
+
+// `styled.div` / `styled.button` — a non-computed `.<lowercase>` member off
+// the `styled` identifier, optionally behind `.attrs(...)` calls.
+// `styled(Component)` and `withConfig(...)` produce non-matching shapes,
+// so they never match here — matching the "only intrinsic, un-stripped"
+// scope.
+const readStyledIntrinsicTag = (tag: EsTreeNode): StyledIntrinsicTag | null => {
+  const base = unwrapAttrsCalls(tag);
+  if (!isNodeOfType(base, "MemberExpression") || base.computed) return null;
+  if (!isNodeOfType(base.object, "Identifier") || base.object.name !== "styled") return null;
+  if (!isNodeOfType(base.property, "Identifier")) return null;
+  const firstCharacterCode = base.property.name.charCodeAt(0);
+  if (firstCharacterCode < 97 || firstCharacterCode > 122) return null;
+  return { tagName: base.property.name };
+};
+
+const getPropertySignatureName = (member: EsTreeNode): string | null => {
+  if (!isNodeOfType(member, "TSPropertySignature") || member.computed) return null;
+  if (isNodeOfType(member.key, "Identifier")) return member.key.name;
+  if (isNodeOfType(member.key, "Literal") && typeof member.key.value === "string") {
+    return member.key.value;
+  }
+  return null;
+};
+
+const isKnownAttributeName = (propName: string): boolean =>
+  DOM_PROPERTY_NAMES.has(propName) ||
+  DOM_PROPERTY_NAMES_LOWER.has(propName.toLowerCase()) ||
+  DOM_PROPERTY_TO_ALLOWED_TAGS.has(propName) ||
+  ELEMENT_RESTRICTED_ATTRIBUTES.has(propName);
+
+const allowedTagsFor = (propName: string): ReadonlySet<string> | null =>
+  ELEMENT_RESTRICTED_ATTRIBUTES.get(propName) ?? DOM_PROPERTY_TO_ALLOWED_TAGS.get(propName) ?? null;
+
+// A prop is safely forwardable to the DOM node when it's transient (`$`),
+// a data-*/aria-* attribute, an event handler, or a known attribute that is
+// valid on this element. Everything else reaches the DOM node verbatim.
+const isForwardableToTag = (propName: string, tagName: string): boolean => {
+  if (propName.startsWith("$")) return true;
+  if (propName.startsWith("data-") || propName.startsWith("aria-")) return true;
+  if (EVENT_HANDLER_PROP_PATTERN.test(propName)) return true;
+  if (STYLED_COMPONENTS_CONSUMED_PROPS.has(propName)) return true;
+  if (!isKnownAttributeName(propName)) return false;
+  const allowedTags = allowedTagsFor(propName);
+  return allowedTags === null || allowedTags.has(tagName);
+};
+
+export const styledComponentsNonTransientCustomPropOnIntrinsicElement = defineRule({
+  id: "styled-components-non-transient-custom-prop-on-intrinsic-element",
+  title: "Non-transient custom prop on styled intrinsic element",
+  severity: "warn",
+  requires: ["styled-components"],
+  recommendation:
+    "Prefix custom styled-components props with `$` (e.g. `$active`) so styled-components v6 keeps them off the DOM node instead of forwarding them as invalid attributes.",
+  create: (context) => ({
+    TaggedTemplateExpression(node: EsTreeNodeOfType<"TaggedTemplateExpression">) {
+      const intrinsic = readStyledIntrinsicTag(node.tag);
+      if (!intrinsic) return;
+      const styledImportSource = getImportSourceForName(node, "styled");
+      if (styledImportSource !== null && styledImportSource !== "styled-components") return;
+      const typeArguments = node.typeArguments;
+      if (!typeArguments || typeArguments.params.length === 0) return;
+      const typeLiteral = typeArguments.params[0];
+      if (!isNodeOfType(typeLiteral, "TSTypeLiteral")) return;
+
+      for (const member of typeLiteral.members) {
+        const propName = getPropertySignatureName(member);
+        if (!propName || isForwardableToTag(propName, intrinsic.tagName)) continue;
+        context.report({
+          node: member,
+          message: `styled-components v6 forwards the custom prop \`${propName}\` to the <${intrinsic.tagName}> DOM node, producing a React unknown-prop warning — prefix it with \`$\` to make it transient.`,
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-enclosing-declarator.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-enclosing-declarator.ts
@@ -1,0 +1,19 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+// The VariableDeclarator that declares `bindingIdentifier`, or null when
+// the binding is a function parameter (a parameter typed as an object/array
+// may have a meaningful `toString()`, so callers skip it).
+export const findEnclosingDeclarator = (
+  bindingIdentifier: EsTreeNode,
+): EsTreeNodeOfType<"VariableDeclarator"> | null => {
+  let cursor: EsTreeNode | null | undefined = bindingIdentifier.parent;
+  while (cursor) {
+    if (isNodeOfType(cursor, "VariableDeclarator")) return cursor;
+    if (isFunctionLike(cursor)) return null;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-meaningful-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-meaningful-parent.ts
@@ -1,0 +1,12 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+
+// oxc-parser surfaces `(...)` as a node kind outside the TSESTree union,
+// so it is matched via a `string`-typed constant.
+const PARENTHESIZED_EXPRESSION: string = "ParenthesizedExpression";
+
+// The nearest ancestor that is not a grouping parenthesis.
+export const getMeaningfulParent = (node: EsTreeNode): EsTreeNode | null => {
+  let parent = node.parent ?? null;
+  while (parent && parent.type === PARENTHESIZED_EXPRESSION) parent = parent.parent ?? null;
+  return parent;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-early-exit-statement.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-early-exit-statement.ts
@@ -1,0 +1,17 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+// A statement that unconditionally leaves the enclosing flow — or a block
+// whose final statement does.
+export const isEarlyExitStatement = (statement: EsTreeNode | null | undefined): boolean => {
+  if (!statement) return false;
+  if (isNodeOfType(statement, "BlockStatement")) {
+    return isEarlyExitStatement(statement.body.at(-1));
+  }
+  return (
+    isNodeOfType(statement, "ReturnStatement") ||
+    isNodeOfType(statement, "ThrowStatement") ||
+    isNodeOfType(statement, "ContinueStatement") ||
+    isNodeOfType(statement, "BreakStatement")
+  );
+};


### PR DESCRIPTION
> **Stacked PR:** this branch is stacked on the foundation PR (#1000 — package-version detection, SSR capability detection, and shared AST utils). It will be retargeted to `main` once #1000 merges; only the rule commits belong to this PR.

## Why

These 30 rules target code that parses, typechecks, and looks right — then crashes or silently misbehaves at runtime: unguarded throwing parses (`decodeURIComponent`, `new URL`, `JSON.parse`), `undefined` dereferences (`.find()`, array indexing, `Object.keys`), `NaN` propagation, SSR `ReferenceError`s, and React-specific traps (leaked `0` renders, dead controlled inputs, IME-hostile Enter handlers). The batch's most impactful rule, `no-unguarded-throwing-parse-call` (86 corpus hits pre-hardening), catches render-path crashes like:

```tsx
// Bad: throws URIError on a malformed percent-escape ("100%off") and unwinds render
function RawFileViewer({ params }) {
  const path = decodeURIComponent(params.path);
  return <Viewer path={path} />;
}

// Good: guarded, with a fallback
let path = params.path;
try { path = decodeURIComponent(params.path); } catch {}
```

## Rules

| Rule | Catches | Notable exemptions |
|---|---|---|
| `jsx-numeric-and-leaked-render` | `{count && <X/>}` renders a literal `0` into the page when the count is 0 | Comparisons/ternaries/`!!`, boolean or string LHS, left arm of `\|\|`, react-hook-form `errors.size`, `.size` props with no provable Map/Set origin |
| `no-arithmetic-on-optional-chained-operand` | `a?.b * c` (and `/`, `%`, comparisons) yields `NaN` when the chain short-circuits, spreading silently into formatting | `?? fallback` (inline or in the binding initializer), narrowing `if`/`&&`/ternary on the root or alias, early-return guards, `Number.isNaN` clamps, additive operators |
| `no-array-find-result-member-access-without-guard` | Immediate member access on `.find()`/`.findLast()` results — throws when the predicate misses | `?.`, `??`, guarded bindings, PascalCase ORM `Model.find`, enzyme `wrapper.find(...)` chains, the pre-ES2020 `find(f) && find(f).x` idiom |
| `no-array-index-deref-without-bounds-or-empty-guard` | Dereferencing `arr[i].x` where the index result can be `undefined` (empty list, short `split`, no regex match) | Length/emptiness guards, `includes()`-guaranteed splits, `split(...)[0]`, regex `.test()` preconditions, arithmetic indexes into parameter arrays, guarded map/reduce idioms |
| `no-collapsed-literal-or-chain-as-value` | `x === "a" \|\| "b"`-style chains of literals that short-circuit to the first literal, leaving the rest dead | Identifier/member/call operands (real defaults), `??`, ternaries, string concatenation, standalone boolean tests |
| `no-controlled-input-value-without-state-update` | `<input value="fixed" onChange={...}>` where `value` is a literal `onChange` never updates — typing does nothing | `readOnly`/`disabled`, radio/checkbox literal values (submission tokens), dynamic `type`, spreads that could supply `value`/`onChange`, Solid files |
| `no-deprecated-keyboard-event-keycode-which` | `keyCode`/`which`/`charCode` compared against character codes that vary by keyboard layout, browser, and IME | Layout-invariant control keys (Escape/arrows), the `keyCode === 229` IME idiom, `event.key` feature-detect fallbacks, mouse-button `which`, unresolvable named key constants |
| `no-enter-submit-without-ime-composition-guard` | Text-entry Enter handlers that submit without bailing on IME composition — fires mid-composition for CJK users | Tracked composition state, `nativeEvent.isComposing` bail, modifier-gated Cmd/Ctrl+Enter, `role=button`/`radio` activation, numeric inputs (`type=number`, `inputMode=numeric`, coercing `onChange`) |
| `no-fetch-response-used-without-status-check` | Consuming a `fetch` Response (`.json()`/`.text()`/`.blob()`) with no `ok`/`status` check — parses 4xx/5xx error bodies as success; also flags always-true truthiness guards | Response returned to the caller, `ok`/`status` checked (incl. via destructuring), imported/member-call fetch wrappers, throw-on-error validators (`assertOk`), `.catch` links with fallback values |
| `no-fill-map-element-as-key` | `Array(n).fill(x).map(v => <li key={v}>)` — every element is identical, so every key collides | The `(_, index)` two-param form, `Array(1)`, arrays mutated or reassigned before mapping, shadowed loop counters, `Array.from` with a mapfn |
| `no-floating-then-in-jsx-handler` | `.then()` with no `.catch` inside a JSX event handler — rejections become uncaught errors no error boundary sees | `async` handlers, explicit `void`, `.catch`/two-arg `then`/mid-chain `onRejected`, returned chains, `.then` inside nested callbacks |
| `no-impure-call-at-module-scope` | `new Date()`/`Date.now()` etc. at module scope — evaluated once per server process, so every SSR request reuses a frozen value | Function/component bodies, lazy getters, `new Date(arg)`, per-process-named bindings (`startTime`, uptime), state-container seeds (jotai atoms, `BehaviorSubject`), `crypto.randomUUID` |
| `no-mutate-queried-dom-node-in-component` | Mutating text/style of a queried DOM node the component itself renders — React reverts the change on the next render | `createElement` nodes, refs, `document.body`, `setAttribute`/`innerHTML` (out of the mutation set), selectors the component doesn't render, dynamic query ids, shadowing bindings |
| `no-mutating-array-method-on-prop-or-hook-result` | `sort`/`reverse`/`splice` in place on a prop or hook-result array — corrupts the parent's or cache's state across renders | Copy-first `[...a].sort()`/`.slice().sort()`, `toSorted`/`toReversed`, local arrays, Immer drafts, `ref.current` arrays, mutability-advertising names, `useCallback`/`useMutation` params |
| `no-non-literal-selector-query-without-try-catch` | href/hash-derived strings passed to `querySelector` — throws `DOMException` on an invalid CSS selector instead of returning null | `CSS.escape` (incl. wrapping helpers), enclosing try/catch, literal/constant selectors, regex- or `indexOf`-shape-guarded values, CSS-module templates |
| `no-non-null-assertion-on-maybe-undefined-result` | `!` asserted on `find`/`findLast`/`match`/`Map.get` results that are `undefined`/`null` on a miss | Loop-guarded `pop`/`shift` queue drains, `has`/`set` presence proofs in scope (incl. `this.#field`), literal-key `get` on locally-populated or `new Map(entries)` maps, caller-populated parameter maps |
| `no-nondeterministic-id-value-in-render-body` | Ids minted per render (nanoid/uuid) flowing into `htmlFor`/aria/SVG references — the reference breaks every render and mismatches under SSR; also `useMemo`-minted ids (not guaranteed stable) | Event handlers/callbacks, `useState`/`useRef` initializers, non-identity sinks (logging), `key` usage (owned by `no-random-key`), `Date.now`/`Math.random` (owned by the time rule) |
| `no-nullish-coalescing-arithmetic-precedence` | `x ?? 0 / y` parses as `x ?? (0 / y)` — the fallback gets divided, not the value | Parenthesized `(x ?? 0) / y`, identifier-leaf and call-expression fallbacks, fully-constant unit math (`60 * 1000`), comparisons and string concat |
| `no-object-keys-values-entries-on-maybe-undefined` | `Object.keys/values/entries` on an optional param or optional-chained value — throws `Cannot convert undefined or null to object` | `?? {}` fallbacks, parameter defaults, dominating guards (`if`, early return, `&&`, ternary), the `!x \|\| Object.keys(x).length === 0` isEmpty idiom, plain locals, shadowed `Object` |
| `no-object-or-array-coerced-to-string-in-template-literal` | Interpolating an object/array into a template literal — prints `[object Object]` or a comma-join | Member access, `.join`/`JSON.stringify`, tagged templates (styled-components, lit-html), custom `toString`/`Symbol.toPrimitive`, imported/unresolved identifiers |
| `no-predicate-function-reference-in-boolean-position` | `if (canEdit)` where `canEdit` is a local zero-arg function — the reference is always truthy, so the check never runs | Called predicates, PascalCase component existence checks, callback positions, one-arg predicates, imported functions, `let`/`var` function slots existence-checked before calling |
| `no-unescaped-dynamic-string-in-regexp` | `new RegExp(searchTerm)` from a dynamic search/filter value — metacharacters act as operators and over-match or throw | `escapeRegExp` helpers (incl. prior-line/`replaceAll`/ES2025 `RegExp.escape`), try/catch-guarded regex-input UIs, fully-literal patterns, `.source` recomposition, provably-literal constants |
| `no-unguarded-browser-global-at-module-scope` | `window`/`navigator`/`localStorage` read at module scope — `ReferenceError` the instant the module is imported during SSR | `typeof` guards (incl. aliased `canUseDOM`), `globalThis`, function/class-field bodies, try/catch feature-detects, local shadows; `document` deliberately excluded |
| `no-unguarded-browser-global-in-render-or-hook-init` | The same reads during render or in `useState`/`useReducer`/`useRef` initializers — crashes SSR and causes hydration mismatches | `useEffect`/`useMemo`/event handlers, dominating `typeof`/`canUseDOM` guards, typeof-window and mounted-state early returns, router `location` locals, shadow bindings |
| `no-unguarded-numeric-input-parse` | `Number(e.target.value)` on text inputs — stores `0` for a cleared field and `NaN` for partial input, flowing into state or request bodies | Ternary/`isNaN`/`\|\|` guards, `<select>` and component-prop handlers, `option.value`, `type="range"` sliders, `type="number"` fields (empty string, so `NaN` unreachable), radio numeric tokens |
| `no-unguarded-throwing-parse-call` | `decodeURIComponent`/`new URL`/color parses (`chroma`, `readableColor`) on runtime route/theme values — throws on malformed input and unwinds render | try/catch, `URL.canParse` or a base-URL argument, module constants/env bases, `window.location.href`/`request.url`/`page.url()`, `useTheme` design tokens, bare `url` params (name alone is not evidence) |
| `no-unsafe-json-parse` | Property reads straight off `JSON.parse(...)` — `SyntaxError` on malformed input plus an unchecked `any` result | Enclosing try blocks, validator wrappers, `as`-cast annotations, `?? "{}"`/`\|\| "[]"` fallback arguments, round-trip clones, parse passed as a call argument |
| `no-whole-object-default-losing-per-key-defaults` | `({ a, b } = { a: 1, b: 2 })` — the whole-object default is discarded the moment a caller passes any object, so omitted keys become `undefined` | Per-key defaults, the `= {}` idiom, all-`false` boolean flag bags (truthiness-identical), spread-only defaults, non-object defaults, defaults covering only already-defaulted bindings |
| `radio-input-missing-name` | Radio inputs sharing no `name` — users can check several at once and keyboard users can't arrow between them | Dynamic `name` expressions, spreads, allowlisted `Radio` inside group providers (antd/Mantine/Chakra `Radio.Group`), checkboxes/text inputs/dynamic `type` |
| `styled-components-non-transient-custom-prop-on-intrinsic-element` | styled-components v6 forwarding a non-`$` custom prop to the DOM node — React unknown-prop warning | `$`-prefixed transient props, `styled(Component)`, `withConfig`/`shouldForwardProp`, `@emotion/styled` and `@linaria/react`, `theme`/`as`/`forwardedAs`, valid HTML/SVG/`data-*`/`aria-*` attributes |

## Validation

Every rule was validated against 67 production OSS repos at pinned SHAs plus 88 reconstructed merged-PR gold solutions. Per-rule sampled hits were judged and adversarially re-verified by two independent reviewers, and each rule went through up to three FP-hardening waves. Across the batch, hardening cut corpus hits from 336 to 175; the biggest reductions were `no-unguarded-throwing-parse-call` (86 → 39), `no-unguarded-numeric-input-parse` (33 → 9), `no-fetch-response-used-without-status-check` (57 → 23), and `no-deprecated-keyboard-event-keycode-which` (16 → 0). Per-rule numbers are in the batch stats; the verdict split:

| Final verdict | Rules | Meaning |
|---|---|---|
| clean-keep | 12 | Remaining hits judged majority true-positive |
| silent-precise | 11 | Zero corpus hits by design (precision-first detectors) |
| needs-narrowing | 7 | A further narrowing shipped in this PR, with regression tests locking it in |

## Test plan

- 704 focused `it()` cases across the 30 rule test suites (invalid shapes plus the exemptions listed above as regression guards)
- `pnpm typecheck` and `pnpm format:check` on `packages/oxlint-plugin-react-doctor`
- Registry `gen:check` to confirm the generated rule registry is in sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large batch of new lint rules can increase noise until tuned, but changes are additive detectors with extensive exemption logic rather than modifying runtime or security-critical app code.
> 
> **Overview**
> Adds **30 new first-party correctness rules** under `rules/correctness/`, wires them into `rule-registry.ts` as global **Bugs** (or Accessibility where relevant) checks, and bumps `oxlint-plugin-react-doctor` with a changeset.
> 
> The rules target runtime failures and silent wrong behavior that still typecheck: unguarded parses and `JSON.parse`, optional-chain math → `NaN`, `.find()` / index derefs, leaked numeric `&&` in JSX, frozen controlled inputs, deprecated `keyCode`/`which`, Enter-without-IME guards, fetch bodies without status checks, SSR `window`/`localStorage`, in-place array mutation on props/hooks, and related footguns. Each rule ships with **focused unit tests** and **FP-hardening** (guards, ORM/enzyme exemptions, progressive-enhancement keyboard patterns, etc.).
> 
> This is a large expansion of default lint surface area; behavior is additive (new warnings) rather than changes to existing rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4335bfe345721ed2dc9a081f6eeccf7211552030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->