### PR TITLE
RD-NEW-RR-RULE: design — 1 rule (styled-components duplicate conditional CSS property)

### DIFF
--- a/.changeset/rd-new-rules-design.md
+++ b/.changeset/rd-new-rules-design.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 1 new design rules, corpus-validated and FP-hardened

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -367,6 +367,7 @@ import { serverNoMutableModuleState } from "./rules/server/server-no-mutable-mod
 import { serverSequentialIndependentAwait } from "./rules/server/server-sequential-independent-await.js";
 import { stateInConstructor } from "./rules/react-builtins/state-in-constructor.js";
 import { stylePropObject } from "./rules/react-builtins/style-prop-object.js";
+import { styledComponentsDuplicateCssPropertyInBlock } from "./rules/design/styled-components-duplicate-css-property-in-block.js";
 import { supabaseClientOwnedAuthzField } from "./rules/security-scan/supabase-client-owned-authz-field.js";
 import { supabaseRlsPolicyRisk } from "./rules/security-scan/supabase-rls-policy-risk.js";
 import { supabaseTableMissingRls } from "./rules/security-scan/supabase-table-missing-rls.js";
@@ -4604,6 +4605,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(stylePropObject.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/styled-components-duplicate-css-property-in-block",
+    id: "styled-components-duplicate-css-property-in-block",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...styledComponentsDuplicateCssPropertyInBlock,
+      framework: "global",
+      category: "Maintainability",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/styled-components-duplicate-css-property-in-block.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/styled-components-duplicate-css-property-in-block.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { styledComponentsDuplicateCssPropertyInBlock } from "./styled-components-duplicate-css-property-in-block.js";
+
+const rule = styledComponentsDuplicateCssPropertyInBlock;
+
+describe("styled-components-duplicate-css-property-in-block", () => {
+  it("flags a property declared twice as conditionals at the same level", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`padding-bottom: ${p => p.$isLayoutVariant ? '8px' : '0'}; padding-bottom: ${p => p.$isCtaVariant ? '4px' : '16px'};`;",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags duplicates inside a css block", () => {
+    const result = runRule(
+      rule,
+      "const shared = css`opacity: ${p => p.$a ? 1 : 0}; opacity: ${p => p.$b ? 1 : 0.5};`;",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a block-body return ternary duplicate", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`margin: ${p => { return p.$a ? '8px' : '0'; }}; margin: ${p => p.$b ? '4px' : '0'};`;",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Prettier-formatted paren-wrapped ternary arrow bodies", () => {
+    const result = runRule(
+      rule,
+      'const B = styled.div`padding-bottom: ${(p) => (p.$isLayoutVariant ? "8px" : "0")}; padding-bottom: ${(p) => (p.$isCtaVariant ? "4px" : "16px")};`;',
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a duplicate whose last declaration omits the optional trailing semicolon", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`opacity: ${p => p.$a ? 1 : 0}; opacity: ${p => p.$b ? 1 : 0.5}`;",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a layered computed + conditional pair", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`opacity: ${p => getComputedOpacity(p)}; opacity: ${p => p.$isHidden ? 0 : 'inherit'};`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the same property in a nested pseudo-selector", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`padding-bottom: ${p => p.$a ? '8px' : '0'}; &:hover { padding-bottom: ${p => p.$b ? '4px' : '0'}; }`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the same property in distinct @media blocks", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`padding-bottom: ${p => p.$a ? '8px' : '0'}; @media (min-width: 700px) { padding-bottom: ${p => p.$b ? '4px' : '0'}; }`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag shorthand versus longhand", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`padding: ${p => p.$a ? '8px' : '0'}; padding-bottom: ${p => p.$b ? '4px' : '0'};`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reassigned custom properties", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`--gap: ${p => p.$a ? '8px' : '0'}; --gap: ${p => p.$b ? '4px' : '0'};`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag two static duplicate declarations", () => {
+    const result = runRule(rule, "const B = styled.div`color: red; color: blue;`;");
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a single declaration", () => {
+    const result = runRule(
+      rule,
+      "const B = styled.div`padding-bottom: ${p => p.$a ? '8px' : '0'};`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-styled template tag", () => {
+    const result = runRule(
+      rule,
+      "const q = other`color: ${p => p.$a ? 'x' : 'y'}; color: ${p => p.$b ? 'x' : 'y'};`;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/styled-components-duplicate-css-property-in-block.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/styled-components-duplicate-css-property-in-block.ts
@@ -1,0 +1,146 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+// Opaque marker substituted for each `${...}` interpolation while scanning
+// the CSS text, so an interpolation never contributes a `;`/`{`/`}`/`:`
+// separator of its own.
+const INTERPOLATION_MARKER = "\u0000";
+const CSS_PROPERTY_PATTERN = /^-?[a-z][a-z-]*$/;
+
+interface CssDeclaration {
+  readonly property: string;
+  readonly isConditional: boolean;
+}
+
+// The unwrapped root identifier of a tagged-template tag: `styled` for
+// `styled.div` / `styled(Comp)` / `styled.div.attrs(...)`, or `css` for the
+// `css` helper. Anything else returns null.
+const getTagRootName = (tag: EsTreeNode): string | null => {
+  let current: EsTreeNode = tag;
+  while (true) {
+    if (isNodeOfType(current, "Identifier")) return current.name;
+    if (isNodeOfType(current, "MemberExpression")) {
+      current = current.object;
+      continue;
+    }
+    if (isNodeOfType(current, "CallExpression")) {
+      current = current.callee;
+      continue;
+    }
+    return null;
+  }
+};
+
+// A `${props => cond ? a : b}` (or a concise/return-body ternary): the shape
+// that signals the author expected this to be the effective value, so
+// silently losing it to a later same-property declaration is the bug.
+const isTernaryInterpolation = (expression: EsTreeNode | undefined): boolean => {
+  if (!expression) return false;
+  const stripped = stripParenExpression(expression);
+  if (isNodeOfType(stripped, "ConditionalExpression")) return true;
+  if (
+    isNodeOfType(stripped, "ArrowFunctionExpression") ||
+    isNodeOfType(stripped, "FunctionExpression")
+  ) {
+    const body = stripParenExpression(stripped.body);
+    if (isNodeOfType(body, "ConditionalExpression")) return true;
+    if (isNodeOfType(body, "BlockStatement")) {
+      return body.body.some((statement) => {
+        if (!isNodeOfType(statement, "ReturnStatement")) return false;
+        const returnArgument = statement.argument;
+        if (!returnArgument) return false;
+        return isNodeOfType(stripParenExpression(returnArgument), "ConditionalExpression");
+      });
+    }
+  }
+  return false;
+};
+
+const finalizeDeclaration = (
+  text: string,
+  hasTernary: boolean,
+  declarations: CssDeclaration[],
+): void => {
+  const colonIndex = text.indexOf(":");
+  if (colonIndex === -1) return;
+  const property = text.slice(0, colonIndex).trim().toLowerCase();
+  if (!property || property.startsWith("--") || !CSS_PROPERTY_PATTERN.test(property)) return;
+  declarations.push({ property, isConditional: hasTernary });
+};
+
+// Scan the interleaved static text + interpolations, collecting only the
+// declarations at the top brace level (depth 0). Declarations inside nested
+// selectors, pseudo-classes, and @media/@supports blocks live at depth > 0
+// and are intentionally skipped — that cascade is deliberate.
+const collectTopLevelDeclarations = (
+  template: EsTreeNodeOfType<"TemplateLiteral">,
+): CssDeclaration[] => {
+  const declarations: CssDeclaration[] = [];
+  let braceDepth = 0;
+  let currentText = "";
+  let currentHasTernary = false;
+  const resetSegment = (): void => {
+    currentText = "";
+    currentHasTernary = false;
+  };
+
+  template.quasis.forEach((quasi, quasiIndex) => {
+    const staticText = quasi.value.cooked ?? quasi.value.raw ?? "";
+    for (const character of staticText) {
+      if (character === "{") {
+        braceDepth += 1;
+        resetSegment();
+      } else if (character === "}") {
+        braceDepth = Math.max(0, braceDepth - 1);
+        resetSegment();
+      } else if (character === ";") {
+        if (braceDepth === 0) finalizeDeclaration(currentText, currentHasTernary, declarations);
+        resetSegment();
+      } else {
+        currentText += character;
+      }
+    }
+    const expression = template.expressions[quasiIndex];
+    if (expression && braceDepth === 0) {
+      currentText += INTERPOLATION_MARKER;
+      if (isTernaryInterpolation(expression)) currentHasTernary = true;
+    }
+  });
+  if (braceDepth === 0) finalizeDeclaration(currentText, currentHasTernary, declarations);
+  return declarations;
+};
+
+export const styledComponentsDuplicateCssPropertyInBlock = defineRule({
+  id: "styled-components-duplicate-css-property-in-block",
+  title: "Duplicate CSS property in styled block",
+  severity: "warn",
+  requires: ["styled-components"],
+  recommendation:
+    "Merge repeated declarations of the same CSS property in a styled block into one, so a later conditional value doesn't silently override an earlier one.",
+  create: (context) => ({
+    TaggedTemplateExpression(node: EsTreeNodeOfType<"TaggedTemplateExpression">) {
+      const rootName = getTagRootName(node.tag);
+      if (rootName !== "styled" && rootName !== "css") return;
+
+      const declarations = collectTopLevelDeclarations(node.quasi);
+      const occurrencesByProperty = new Map<string, CssDeclaration[]>();
+      for (const declaration of declarations) {
+        const existing = occurrencesByProperty.get(declaration.property);
+        if (existing) existing.push(declaration);
+        else occurrencesByProperty.set(declaration.property, [declaration]);
+      }
+
+      for (const [property, occurrences] of occurrencesByProperty) {
+        if (occurrences.length < 2) continue;
+        if (!occurrences.every((occurrence) => occurrence.isConditional)) continue;
+        context.report({
+          node,
+          message: `The CSS property \`${property}\` is declared ${occurrences.length} times at the same level here, so the last conditional value always wins and the earlier ones never apply — merge them into a single declaration.`,
+        });
+      }
+    },
+  }),
+});


### PR DESCRIPTION
> Stacked on the foundation PR (#1000 — package-version detection + SSR capability + shared AST utils). Retargets `main` when that merges.

## Why

In styled-components, when the same CSS property is declared twice at the top level of one styled block, the last declaration always wins — CSS cascade order, not the props, decides. When both declarations are prop-driven ternaries, the author clearly believed each conditional value could take effect, so the earlier one silently never applies for any prop combination.

```tsx
// Bad: the first padding-bottom can never win — the second declaration
// always overrides it, whatever $isLayoutVariant evaluates to.
const Banner = styled.div`
  padding-bottom: ${(p) => (p.$isLayoutVariant ? "8px" : "0")};
  padding-bottom: ${(p) => (p.$isCtaVariant ? "4px" : "16px")};
`;

// Good: one declaration that encodes the intended precedence.
const Banner = styled.div`
  padding-bottom: ${(p) =>
    p.$isCtaVariant ? "4px" : p.$isLayoutVariant ? "8px" : "16px"};
`;
```

## Rules

| Rule | Catches | Notable exemptions |
| --- | --- | --- |
| `styled-components-duplicate-css-property-in-block` | The same CSS property declared 2+ times at the top brace level of a `styled.*` / `styled(Comp)` / `css` tagged template, where **every** occurrence is a conditional (ternary) interpolation — so the last conditional always wins and the earlier branches are dead. | Only runs when `styled-components` is a dependency. Skips declarations inside nested selectors, pseudo-classes, and `@media`/`@supports` blocks (that cascade is deliberate); custom properties (`--x`); shorthand vs. longhand pairs (`padding` + `padding-bottom`); static duplicates (`color: red; color: blue` — a common intentional-fallback idiom); and mixed computed + conditional layering. Recognizes Prettier's paren-wrapped ternary arrow bodies and block bodies returning a ternary. |

## Validation

Every rule in this batch was validated against 67 production OSS repos at pinned SHAs plus 88 reconstructed merged-PR gold solutions. Per-rule sampled hits were judged and adversarially re-verified by two independent reviewers, and rules went through up to three FP-hardening waves.

| Rule | Pre-hardening hits | Remaining hits | Verdict |
| --- | --- | --- | --- |
| `styled-components-duplicate-css-property-in-block` | 0 | 0 | silent-precise |

`silent-precise` means the rule produced zero hits across the corpus by design: the all-occurrences-conditional gate plus the top-level-only scan restrict it to the unambiguous dead-branch shape, so it stays quiet on healthy code and fires only on the genuine bug.

## Test plan

- 13 focused `it()` cases in `styled-components-duplicate-css-property-in-block.test.ts`, covering the ternary-duplicate positives (including Prettier paren-wrapping, block-body returns, and a missing trailing semicolon) and every exemption listed above.
- Package `typecheck`, `format:check`, and registry `gen:check` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint-only change gated on styled-components; no runtime or security impact beyond new warnings in matching code.
> 
> **Overview**
> Adds a **Maintainability** design lint **`styled-components-duplicate-css-property-in-block`** to `oxlint-plugin-react-doctor` (minor changeset), wired into the generated rule registry.
> 
> The rule runs only when **`styled-components`** is a dependency and visits **`styled` / `css` tagged templates**. It parses top-level declarations in the template literal and warns when the **same property appears twice or more at brace depth 0** and **every** occurrence uses a **ternary-style** interpolation—cases where cascade order makes earlier conditional branches dead. It **ignores** nested selectors/`@media`, custom properties, shorthand vs longhand, static duplicate `color` lines, mixed computed + conditional values, and non-`styled`/`css` tags.
> 
> Ships with **13 unit tests** covering positives (including Prettier paren bodies and missing trailing semicolons) and the exemption cases above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745e1b9e46e9f47a5bfbfb877f11d281fd5d8940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->