### PR TITLE
RD-NEW-RR-RULE: js-performance — 2 rules

### DIFF
--- a/.changeset/rd-new-rules-js-performance.md
+++ b/.changeset/rd-new-rules-js-performance.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 2 new js-performance rules, corpus-validated and FP-hardened

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -156,6 +156,7 @@ import { noChainStateUpdates } from "./rules/state-and-effects/no-chain-state-up
 import { noChildrenProp } from "./rules/react-builtins/no-children-prop.js";
 import { noCloneElement } from "./rules/react-builtins/no-clone-element.js";
 import { noCreateContextInRender } from "./rules/state-and-effects/no-create-context-in-render.js";
+import { noCreateObjectUrlWithoutRevoke } from "./rules/js-performance/no-create-object-url-without-revoke.js";
 import { noCreateRefInFunctionComponent } from "./rules/react-builtins/no-create-ref-in-function-component.js";
 import { noCreateStoreInRender } from "./rules/state-and-effects/no-create-store-in-render.js";
 import { noDanger } from "./rules/react-builtins/no-danger.js";
@@ -242,6 +243,7 @@ import { noSelfUpdatingEffect } from "./rules/state-and-effects/no-self-updating
 import { noSetState } from "./rules/react-builtins/no-set-state.js";
 import { noSetStateInRender } from "./rules/state-and-effects/no-set-state-in-render.js";
 import { noSideTabBorder } from "./rules/design/no-side-tab-border.js";
+import { noSpreadAccumulatorInReduce } from "./rules/js-performance/no-spread-accumulator-in-reduce.js";
 import { noStaticElementInteractions } from "./rules/a11y/no-static-element-interactions.js";
 import { noStringFalseOnBooleanAttribute } from "./rules/react-builtins/no-string-false-on-boolean-attribute.js";
 import { noStringRefs } from "./rules/react-builtins/no-string-refs.js";
@@ -2131,6 +2133,17 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-create-object-url-without-revoke",
+    id: "no-create-object-url-without-revoke",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noCreateObjectUrlWithoutRevoke,
+      framework: "global",
+      category: "Performance",
+    },
+  },
+  {
     key: "react-doctor/no-create-ref-in-function-component",
     id: "no-create-ref-in-function-component",
     source: "react-doctor",
@@ -3129,6 +3142,17 @@ export const reactDoctorRules = [
       ...noSideTabBorder,
       framework: "global",
       category: "Maintainability",
+    },
+  },
+  {
+    key: "react-doctor/no-spread-accumulator-in-reduce",
+    id: "no-spread-accumulator-in-reduce",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noSpreadAccumulatorInReduce,
+      framework: "global",
+      category: "Performance",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noCreateObjectUrlWithoutRevoke } from "./no-create-object-url-without-revoke.js";
+
+describe("no-create-object-url-without-revoke", () => {
+  it("flags an object URL assigned to an anchor href with no revoke", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const download = (blob) => {
+         a.href = URL.createObjectURL(blob);
+         a.download = 'README.md';
+         a.click();
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a guarded object URL stored into a variable and state", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const useImage = (data) => {
+         const imageObjectUrl = data && URL.createObjectURL(data);
+         setImgObjectUrl(imageObjectUrl);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a guarded object URL assigned to a pre-declared variable", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const useImage = (data) => {
+         let imageObjectUrl;
+         imageObjectUrl = data && URL.createObjectURL(data);
+         setImgObjectUrl(imageObjectUrl);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an if-guarded object URL assigned to a pre-declared variable", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const useImage = (data) => {
+         let imageObjectUrl;
+         if (data) imageObjectUrl = URL.createObjectURL(data);
+         setImgObjectUrl(imageObjectUrl);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an object URL set as an anchor href via setAttribute", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const download = (blob) => {
+         a.setAttribute('href', URL.createObjectURL(blob));
+         a.click();
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an inline per-render src object URL", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const Preview = ({ file }) => <img src={URL.createObjectURL(file)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a direct state setter argument", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const onDrop = (blob) => { setUrl(URL.createObjectURL(blob)); };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a returned object URL", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `function make(blob) { return URL.createObjectURL(blob); }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the module revokes elsewhere", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const url = URL.createObjectURL(blob);
+       img.src = url;
+       URL.revokeObjectURL(url);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a page-lifetime worker src global", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `GlobalWorkerOptions.workerSrc = URL.createObjectURL(workerBlob);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for the unguarded avatar preview stored in state", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const onSelect = (file) => {
+         const preview = URL.createObjectURL(file);
+         setAvatar(preview);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet in a demo file", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `export default () => <a href={URL.createObjectURL(blob)}>download</a>;`,
+      { filename: "/src/demos/index.tsx" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when URL is a local binding, not the DOM global", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const URL = getPolyfill();
+       a.href = URL.createObjectURL(blob);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for an unguarded object URL assigned to a pre-declared variable", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const onSelect = (file) => {
+         let preview;
+         preview = URL.createObjectURL(file);
+         setAvatar(preview);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for setAttribute with a non-URL attribute name", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `element.setAttribute('data-preview', URL.createObjectURL(blob));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a bare discarded createObjectURL expression", () => {
+    const result = runRule(
+      noCreateObjectUrlWithoutRevoke,
+      `const warmup = (blob) => { URL.createObjectURL(blob); };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.ts
@@ -5,7 +5,6 @@ import { findVariableInitializer } from "../../utils/find-variable-initializer.j
 import { isMemberProperty } from "../../utils/is-member-property.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
-import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import {
   PARENTHESIZED_EXPRESSION_TYPE,
   stripGroupingParens,
@@ -165,20 +164,19 @@ const escapeIsLeaky = (callNode: EsTreeNode): boolean => {
 export const noCreateObjectUrlWithoutRevoke = defineRule({
   id: "no-create-object-url-without-revoke",
   title: "createObjectURL without revokeObjectURL",
+  tags: ["test-noise"],
   severity: "warn",
   category: "Performance",
   recommendation:
     "Call `URL.revokeObjectURL(url)` once the object URL is no longer needed (after the download, in a `useEffect` cleanup, or on unmount). An object URL keeps its Blob/File alive for the document lifetime until it is revoked.",
   create: (context: RuleContext) => {
-    const isTestlikeFile = isTestlikeFilename(context.filename);
     let moduleHasRevoke = false;
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
-        if (isTestlikeFile) return;
         moduleHasRevoke = moduleReferencesRevoke(node);
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (isTestlikeFile || moduleHasRevoke) return;
+        if (moduleHasRevoke) return;
         if (!isCreateObjectUrlCall(node)) return;
         if (!escapeIsLeaky(node)) return;
         context.report({ node, message: MESSAGE });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.ts
@@ -2,15 +2,17 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isMemberProperty } from "../../utils/is-member-property.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
-import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
+import {
+  PARENTHESIZED_EXPRESSION_TYPE,
+  stripGroupingParens,
+} from "../../utils/strip-grouping-parens.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
-// oxc-parser surfaces `(...)` as a node kind outside the TSESTree union,
-// so it is matched via a `string`-typed constant.
-const PARENTHESIZED_EXPRESSION: string = "ParenthesizedExpression";
 const ESCAPE_ASSIGNMENT_TARGET_PROPERTIES = new Set(["href", "src", "current"]);
 
 const MESSAGE =
@@ -18,16 +20,13 @@ const MESSAGE =
 
 const meaningfulParent = (node: EsTreeNode): EsTreeNode | null => {
   let parent = node.parent ?? null;
-  while (parent && parent.type === PARENTHESIZED_EXPRESSION) parent = parent.parent ?? null;
+  while (parent && parent.type === PARENTHESIZED_EXPRESSION_TYPE) parent = parent.parent ?? null;
   return parent;
 };
 
 const isCreateObjectUrlCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
   const callee = node.callee;
-  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
-  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "createObjectURL") {
-    return false;
-  }
+  if (!isMemberProperty(callee, "createObjectURL") || callee.computed) return false;
   const object = callee.object;
   if (isNodeOfType(object, "Identifier")) {
     if (object.name !== "URL") return false;
@@ -50,57 +49,20 @@ const moduleReferencesRevoke = (programRoot: EsTreeNode): boolean => {
   let found = false;
   walkAst(programRoot, (child) => {
     if (found) return false;
-    if (isNodeOfType(child, "MemberExpression") && !child.computed) {
-      if (isNodeOfType(child.property, "Identifier") && child.property.name === "revokeObjectURL") {
-        found = true;
-        return false;
-      }
-    }
-    if (isNodeOfType(child, "Identifier") && child.name === "revokeObjectURL") {
-      found = true;
-      return false;
-    }
+    if (isNodeOfType(child, "Identifier") && child.name === "revokeObjectURL") found = true;
   });
   return found;
 };
 
-interface EscapeContext {
-  guarded: boolean;
-  topNode: EsTreeNode;
-  parent: EsTreeNode | null;
-}
-
-const resolveEscapeContext = (callNode: EsTreeNode): EscapeContext => {
-  let node = callNode;
-  let guarded = false;
-  while (true) {
-    const parent = meaningfulParent(node);
-    if (!parent) break;
-    if (
-      isNodeOfType(parent, "LogicalExpression") &&
-      (stripGroupingParens(parent.left as EsTreeNode) === node ||
-        stripGroupingParens(parent.right as EsTreeNode) === node)
-    ) {
-      guarded = true;
-      node = parent;
-      continue;
-    }
-    if (
-      isNodeOfType(parent, "ConditionalExpression") &&
-      (stripGroupingParens(parent.consequent as EsTreeNode) === node ||
-        stripGroupingParens(parent.alternate as EsTreeNode) === node)
-    ) {
-      guarded = true;
-      node = parent;
-      continue;
-    }
-    break;
-  }
-  return { guarded, topNode: node, parent: meaningfulParent(node) };
-};
+const isGuardBranchOf = (parent: EsTreeNode, node: EsTreeNode): boolean =>
+  (isNodeOfType(parent, "LogicalExpression") &&
+    (stripGroupingParens(parent.left) === node || stripGroupingParens(parent.right) === node)) ||
+  (isNodeOfType(parent, "ConditionalExpression") &&
+    (stripGroupingParens(parent.consequent) === node ||
+      stripGroupingParens(parent.alternate) === node));
 
 const isStateSetterCallee = (callee: EsTreeNode): boolean =>
-  isNodeOfType(callee, "Identifier") && /^set[A-Z]/.test(callee.name);
+  isNodeOfType(callee, "Identifier") && isSetterIdentifier(callee.name);
 
 const SET_ATTRIBUTE_URL_NAMES = new Set(["href", "src"]);
 
@@ -109,10 +71,7 @@ const isUrlSetAttributeCall = (
   urlArgument: EsTreeNode,
 ): boolean => {
   const callee = call.callee;
-  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
-  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "setAttribute") {
-    return false;
-  }
+  if (!isMemberProperty(callee, "setAttribute") || callee.computed) return false;
   const [attributeName, attributeValue] = call.arguments;
   if (!attributeName || !attributeValue) return false;
   if (!isNodeOfType(attributeName, "Literal") || typeof attributeName.value !== "string") {
@@ -130,13 +89,20 @@ const isDirectIfBranchStatement = (assignment: EsTreeNode): boolean => {
   return container !== null && isNodeOfType(container, "IfStatement");
 };
 
-const escapeIsLeaky = (context: EscapeContext): boolean => {
-  const { guarded, topNode, parent } = context;
+const escapeIsLeaky = (callNode: EsTreeNode): boolean => {
+  let topNode = callNode;
+  let guarded = false;
+  let parent = meaningfulParent(topNode);
+  while (parent && isGuardBranchOf(parent, topNode)) {
+    guarded = true;
+    topNode = parent;
+    parent = meaningfulParent(topNode);
+  }
   if (!parent) return false;
 
   if (
     isNodeOfType(parent, "AssignmentExpression") &&
-    stripGroupingParens(parent.right as EsTreeNode) === topNode
+    stripGroupingParens(parent.right) === topNode
   ) {
     const target = parent.left;
     if (
@@ -159,7 +125,7 @@ const escapeIsLeaky = (context: EscapeContext): boolean => {
 
   if (
     isNodeOfType(parent, "ArrowFunctionExpression") &&
-    stripGroupingParens(parent.body as EsTreeNode) === topNode
+    stripGroupingParens(parent.body) === topNode
   ) {
     return true;
   }
@@ -174,7 +140,8 @@ const escapeIsLeaky = (context: EscapeContext): boolean => {
   // avatar/preview case the spec keeps quiet.
   if (
     isNodeOfType(parent, "VariableDeclarator") &&
-    stripGroupingParens((parent.init as EsTreeNode) ?? topNode) === topNode
+    parent.init &&
+    stripGroupingParens(parent.init) === topNode
   ) {
     return guarded;
   }
@@ -203,18 +170,17 @@ export const noCreateObjectUrlWithoutRevoke = defineRule({
   recommendation:
     "Call `URL.revokeObjectURL(url)` once the object URL is no longer needed (after the download, in a `useEffect` cleanup, or on unmount). An object URL keeps its Blob/File alive for the document lifetime until it is revoked.",
   create: (context: RuleContext) => {
-    const skipFile = isTestlikeFilename(context.filename);
+    const isTestlikeFile = isTestlikeFilename(context.filename);
     let moduleHasRevoke = false;
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
-        if (skipFile) return;
-        moduleHasRevoke = moduleReferencesRevoke(node as EsTreeNode);
+        if (isTestlikeFile) return;
+        moduleHasRevoke = moduleReferencesRevoke(node);
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (skipFile || moduleHasRevoke) return;
+        if (isTestlikeFile || moduleHasRevoke) return;
         if (!isCreateObjectUrlCall(node)) return;
-        const escape = resolveEscapeContext(node as EsTreeNode);
-        if (!escapeIsLeaky(escape)) return;
+        if (!escapeIsLeaky(node)) return;
         context.report({ node, message: MESSAGE });
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.ts
@@ -1,0 +1,222 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// oxc-parser surfaces `(...)` as a node kind outside the TSESTree union,
+// so it is matched via a `string`-typed constant.
+const PARENTHESIZED_EXPRESSION: string = "ParenthesizedExpression";
+const ESCAPE_ASSIGNMENT_TARGET_PROPERTIES = new Set(["href", "src", "current"]);
+
+const MESSAGE =
+  "`URL.createObjectURL(...)` pins the underlying Blob/File in memory until it is revoked, and this module never calls `URL.revokeObjectURL`. Store the URL, revoke it once you're done (in an effect cleanup, after the download, or on unmount) so the Blob can be freed.";
+
+const meaningfulParent = (node: EsTreeNode): EsTreeNode | null => {
+  let parent = node.parent ?? null;
+  while (parent && parent.type === PARENTHESIZED_EXPRESSION) parent = parent.parent ?? null;
+  return parent;
+};
+
+const isCreateObjectUrlCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = node.callee;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "createObjectURL") {
+    return false;
+  }
+  const object = callee.object;
+  if (isNodeOfType(object, "Identifier")) {
+    if (object.name !== "URL") return false;
+    // A same-file binding named `URL` (import or local class) is not the
+    // DOM global, whose `createObjectURL` is the only leaky surface.
+    if (findVariableInitializer(object, "URL")) return false;
+    return true;
+  }
+  if (
+    isNodeOfType(object, "MemberExpression") &&
+    !object.computed &&
+    isNodeOfType(object.property, "Identifier")
+  ) {
+    return object.property.name === "URL";
+  }
+  return false;
+};
+
+const moduleReferencesRevoke = (programRoot: EsTreeNode): boolean => {
+  let found = false;
+  walkAst(programRoot, (child) => {
+    if (found) return false;
+    if (isNodeOfType(child, "MemberExpression") && !child.computed) {
+      if (isNodeOfType(child.property, "Identifier") && child.property.name === "revokeObjectURL") {
+        found = true;
+        return false;
+      }
+    }
+    if (isNodeOfType(child, "Identifier") && child.name === "revokeObjectURL") {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+interface EscapeContext {
+  guarded: boolean;
+  topNode: EsTreeNode;
+  parent: EsTreeNode | null;
+}
+
+const resolveEscapeContext = (callNode: EsTreeNode): EscapeContext => {
+  let node = callNode;
+  let guarded = false;
+  while (true) {
+    const parent = meaningfulParent(node);
+    if (!parent) break;
+    if (
+      isNodeOfType(parent, "LogicalExpression") &&
+      (stripGroupingParens(parent.left as EsTreeNode) === node ||
+        stripGroupingParens(parent.right as EsTreeNode) === node)
+    ) {
+      guarded = true;
+      node = parent;
+      continue;
+    }
+    if (
+      isNodeOfType(parent, "ConditionalExpression") &&
+      (stripGroupingParens(parent.consequent as EsTreeNode) === node ||
+        stripGroupingParens(parent.alternate as EsTreeNode) === node)
+    ) {
+      guarded = true;
+      node = parent;
+      continue;
+    }
+    break;
+  }
+  return { guarded, topNode: node, parent: meaningfulParent(node) };
+};
+
+const isStateSetterCallee = (callee: EsTreeNode): boolean =>
+  isNodeOfType(callee, "Identifier") && /^set[A-Z]/.test(callee.name);
+
+const SET_ATTRIBUTE_URL_NAMES = new Set(["href", "src"]);
+
+const isUrlSetAttributeCall = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  urlArgument: EsTreeNode,
+): boolean => {
+  const callee = call.callee;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "setAttribute") {
+    return false;
+  }
+  const [attributeName, attributeValue] = call.arguments;
+  if (!attributeName || !attributeValue) return false;
+  if (!isNodeOfType(attributeName, "Literal") || typeof attributeName.value !== "string") {
+    return false;
+  }
+  if (!SET_ATTRIBUTE_URL_NAMES.has(attributeName.value)) return false;
+  return stripGroupingParens(attributeValue) === urlArgument;
+};
+
+const isDirectIfBranchStatement = (assignment: EsTreeNode): boolean => {
+  const statement = meaningfulParent(assignment);
+  if (!statement || !isNodeOfType(statement, "ExpressionStatement")) return false;
+  let container = statement.parent ?? null;
+  if (container && isNodeOfType(container, "BlockStatement")) container = container.parent ?? null;
+  return container !== null && isNodeOfType(container, "IfStatement");
+};
+
+const escapeIsLeaky = (context: EscapeContext): boolean => {
+  const { guarded, topNode, parent } = context;
+  if (!parent) return false;
+
+  if (
+    isNodeOfType(parent, "AssignmentExpression") &&
+    stripGroupingParens(parent.right as EsTreeNode) === topNode
+  ) {
+    const target = parent.left;
+    if (
+      isNodeOfType(target, "MemberExpression") &&
+      !target.computed &&
+      isNodeOfType(target.property, "Identifier") &&
+      ESCAPE_ASSIGNMENT_TARGET_PROPERTIES.has(target.property.name)
+    ) {
+      return true;
+    }
+    // The guarded creation assigned to a pre-declared variable is the same
+    // "object URL for fetched data" leak as the guarded VariableDeclarator.
+    if (isNodeOfType(target, "Identifier")) {
+      return guarded || isDirectIfBranchStatement(parent);
+    }
+    return false;
+  }
+
+  if (isNodeOfType(parent, "ReturnStatement")) return true;
+
+  if (
+    isNodeOfType(parent, "ArrowFunctionExpression") &&
+    stripGroupingParens(parent.body as EsTreeNode) === topNode
+  ) {
+    return true;
+  }
+
+  if (isNodeOfType(parent, "JSXExpressionContainer") && parent.parent) {
+    return isNodeOfType(parent.parent, "JSXAttribute");
+  }
+
+  // A conditional/logical creation stored in a variable is the
+  // "object URL for fetched data, kept in state" leak; an unguarded
+  // `const x = URL.createObjectURL(file)` is the ambiguous
+  // avatar/preview case the spec keeps quiet.
+  if (
+    isNodeOfType(parent, "VariableDeclarator") &&
+    stripGroupingParens((parent.init as EsTreeNode) ?? topNode) === topNode
+  ) {
+    return guarded;
+  }
+
+  // Passed directly to a state setter (`setImageUrl(URL.createObjectURL(...))`)
+  // or set as an element URL attribute (`a.setAttribute('href', ...)`).
+  if (isNodeOfType(parent, "CallExpression")) {
+    if (isStateSetterCallee(parent.callee)) return true;
+    if (isUrlSetAttributeCall(parent, topNode)) return true;
+  }
+
+  return false;
+};
+
+// Flags `URL.createObjectURL(...)` whose produced URL escapes (assigned to
+// an element `href`/`src` directly or via `setAttribute`, stored into a ref,
+// returned, rendered inline in JSX, passed to a state setter, or a guarded
+// value bound to a variable — declared or assigned)
+// when the module never references `URL.revokeObjectURL`. The blob URL
+// pins its Blob/File in memory until revoked, so an un-revoked URL leaks.
+export const noCreateObjectUrlWithoutRevoke = defineRule({
+  id: "no-create-object-url-without-revoke",
+  title: "createObjectURL without revokeObjectURL",
+  severity: "warn",
+  category: "Performance",
+  recommendation:
+    "Call `URL.revokeObjectURL(url)` once the object URL is no longer needed (after the download, in a `useEffect` cleanup, or on unmount). An object URL keeps its Blob/File alive for the document lifetime until it is revoked.",
+  create: (context: RuleContext) => {
+    const skipFile = isTestlikeFilename(context.filename);
+    let moduleHasRevoke = false;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        if (skipFile) return;
+        moduleHasRevoke = moduleReferencesRevoke(node as EsTreeNode);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (skipFile || moduleHasRevoke) return;
+        if (!isCreateObjectUrlCall(node)) return;
+        const escape = resolveEscapeContext(node as EsTreeNode);
+        if (!escapeIsLeaky(escape)) return;
+        context.report({ node, message: MESSAGE });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-spread-accumulator-in-reduce.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-spread-accumulator-in-reduce.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noSpreadAccumulatorInReduce } from "./no-spread-accumulator-in-reduce.js";
+
+describe("no-spread-accumulator-in-reduce", () => {
+  it("does not flag a single-spread keyed-lookup build ({ ...acc, [key]: value })", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = keys.reduce((acc, key) => ({ ...acc, [key]: value }), {});`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags array spread of the accumulator", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = items.reduce((acc, x) => [...acc, x], []);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an array-accumulator spread over a prop inside useMemo (gazebo Sparkline shape)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const data = useMemo(
+        () =>
+          datum.reduce((prev, curr, index) => {
+            const nextEntry = datum[index + 1];
+            return [...prev, { value: select(curr), end: nextEntry }];
+          }, []),
+        [datum, select],
+      );
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an entity-map fold with a computed key over CMS items (Faqs shape)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const expandedById = data.faqCollection.items.reduce(
+        (prevExpanded, item) => ({
+          ...prevExpanded,
+          [item.sys.id]: !allExpanded,
+        }),
+        {},
+      );
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags reduceRight too", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = items.reduceRight((acc, x) => [...acc, x], []);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an explicit return of the spread literal (block body)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const out = keys.reduce((acc, key) => {
+        return { ...acc, ...expandKey(key) };
+      }, {});
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a single static-key merge (bounded shape, O(n))", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const merged = items.reduce((acc, item) => ({ ...acc, label: item.name }), {});`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a fixed-shape accumulator built from static keys across returns", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const address = components.reduce((acc, component) => {
+        if (component.types.includes("locality")) return { ...acc, city: component };
+        if (component.types.includes("region")) return { ...acc, state: component };
+        return { ...acc, country: component };
+      }, {});
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a second spread merged into the accumulator (unbounded keys)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = values.reduce((acc, value) => ({ ...acc, ...getBoxMod(value) }), {});`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag mutate-and-return (the correct O(n) idiom)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const out = lines.reduce((acc, line) => {
+        acc[line.key] = line.value;
+        return acc;
+      }, {});
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag spreading the current item (O(1) per step)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = items.reduce((acc, x) => ({ ...x, foo: acc.foo }), {});`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag Object.assign(acc, ...)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const out = items.reduce((acc, x) => {
+        return Object.assign(acc, { [x]: 1 });
+      }, {});
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a member/call spread root (...acc.items)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = items.reduce((acc, x) => ({ ...acc.items, [x]: 1 }), {});`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag other reduce shapes with a numeric accumulator", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const total = items.reduce((sum, x) => sum + x, 0);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not fire on a non-reduce method named similarly", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = items.map((acc, x) => ({ ...acc, [x]: 1 }));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a variadic merge over a rest parameter (AppFlowy-style merge(...objects), bounded by call-site arity)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      function mergeAll(...objects) {
+        return objects.reduce((acc, object) => ({ ...acc, ...object }), {});
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a reduce over an inline array literal (fixed tiny collection of UI flags)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `const flags = ["alpha", "beta"].reduce((acc, name) => ({ ...acc, [name]: true }), {});`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a keyed lookup built from a const array literal of dropdown items", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const dropdownSizes = ["small", "medium", "large"];
+      const optionsBySize = dropdownSizes.reduce(
+        (acc, size) => ({ ...acc, [size]: renderOption(size) }),
+        {},
+      );
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag Object.keys of a locally constructed object literal (bounded key set)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const iconGlyphs = { plus: "+", minus: "-" };
+      const icons = Object.keys(iconGlyphs).reduce(
+        (acc, name) => ({ ...acc, [name]: buildIcon(name) }),
+        {},
+      );
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a filter/dedup shape with an unchanged `return acc` path (growth bounded by matches)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const selected = options.reduce((acc, option) => {
+        if (!option.selected) return acc;
+        return { ...acc, [option.value]: option };
+      }, {});
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a shadowed local that reuses the accumulator name (spreads the O(1) local, not the fold)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const out = items.reduce((acc, x) => {
+        if (x.override) {
+          const acc = x.base;
+          return { ...acc, [x.id]: x.value };
+        }
+        acc[x.id] = x.value;
+        return acc;
+      }, {});
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags the accumulator spread even when another spread comes first", () => {
+    const objectCase = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = items.reduce((acc, x) => ({ ...mapItem(x), ...acc }), {});`,
+    );
+    expect(objectCase.diagnostics).toHaveLength(1);
+    const arrayCase = runRule(
+      noSpreadAccumulatorInReduce,
+      `const out = groups.reduce((acc, g) => [...g.items, ...acc], []);`,
+    );
+    expect(arrayCase.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a keyed-lookup build over Object.keys of external data (single spread + computed key)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const rows = Object.keys(response.results).reduce(
+        (res, rowIdx) => ({ ...res, [rowIdx]: buildRow(response.results[rowIdx]) }),
+        {},
+      );
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a reduce over a const array behind a ternary initializer (bounded either way)", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const providerIds = isGeminiUiFrozen()
+        ? ["anthropic", "codex", "opencode"]
+        : ["anthropic", "codex", "gemini", "opencode"];
+      const rows = providerIds.reduce((acc, providerId) => [...acc, buildRow(providerId)], []);
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a two-spread object merge over external data", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const merged = response.chunks.reduce(
+        (acc, chunk) => ({ ...acc, ...normalizeChunk(chunk) }),
+        {},
+      );
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not confuse an inner callback's spread for the reducer's return", () => {
+    const result = runRule(
+      noSpreadAccumulatorInReduce,
+      `
+      const out = items.reduce((acc, x) => {
+        const mapped = x.values.map((v) => ({ ...v, done: true }));
+        acc[x.id] = mapped;
+        return acc;
+      }, {});
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-spread-accumulator-in-reduce.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-spread-accumulator-in-reduce.ts
@@ -1,0 +1,270 @@
+import { FUNCTION_LIKE_TYPES } from "../../constants/js.js";
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
+import { isMemberProperty } from "../../utils/is-member-property.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const REDUCE_METHOD_NAMES = new Set(["reduce", "reduceRight"]);
+
+const OBJECT_ENUMERATION_METHOD_NAMES = new Set(["keys", "entries", "values"]);
+
+const isSpreadFreeArrayLiteral = (node: EsTreeNode, mustHaveElements: boolean): boolean => {
+  if (!isNodeOfType(node, "ArrayExpression")) return false;
+  if (mustHaveElements && node.elements.length === 0) return false;
+  return node.elements.every(
+    (element) => !element || !isNodeOfType(element as EsTreeNode, "SpreadElement"),
+  );
+};
+
+const isSpreadFreeObjectLiteral = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "ObjectExpression") &&
+  node.properties.every(
+    (property) => !property || !isNodeOfType(property as EsTreeNode, "SpreadElement"),
+  );
+
+const isConstDeclaredBinding = (bindingIdentifier: EsTreeNode): boolean => {
+  const declarator = bindingIdentifier.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
+  const declaration = declarator.parent;
+  return Boolean(
+    declaration && isNodeOfType(declaration, "VariableDeclaration") && declaration.kind === "const",
+  );
+};
+
+const isRestParameterBinding = (bindingIdentifier: EsTreeNode): boolean => {
+  const restCandidate = bindingIdentifier.parent;
+  return Boolean(
+    restCandidate &&
+    isNodeOfType(restCandidate, "RestElement") &&
+    restCandidate.parent &&
+    FUNCTION_LIKE_TYPES.has(restCandidate.parent.type),
+  );
+};
+
+const isLocallyConstructedBoundedObject = (expression: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(expression);
+  if (isSpreadFreeObjectLiteral(stripped)) return true;
+  if (!isNodeOfType(stripped, "Identifier")) return false;
+  const binding = findVariableInitializer(stripped, stripped.name);
+  if (!binding?.initializer || !isConstDeclaredBinding(binding.bindingIdentifier)) return false;
+  return isSpreadFreeObjectLiteral(stripParenExpression(binding.initializer));
+};
+
+// A `const IDS = cond ? ["a", "b"] : ["a", "b", "c"]` initializer is as
+// statically bounded as a plain array literal — both branches enumerate a
+// fixed key set.
+const isBoundedArrayInitializer = (initializer: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(initializer);
+  if (isSpreadFreeArrayLiteral(stripped, true)) return true;
+  if (!isNodeOfType(stripped, "ConditionalExpression")) return false;
+  return (
+    isSpreadFreeArrayLiteral(stripParenExpression(stripped.consequent), true) &&
+    isSpreadFreeArrayLiteral(stripParenExpression(stripped.alternate), true)
+  );
+};
+
+// The empirical false-positive pattern is spreading the accumulator over a
+// statically bounded collection — a rest parameter (bounded by call-site
+// arity), an array literal, or the keys/entries of a locally constructed
+// object literal — where n is tiny and fixed, so the O(n²) copy cost is
+// unobservable and the immutable idiom is deliberate.
+const isStaticallyBoundedReduceSource = (source: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(source);
+  if (isSpreadFreeArrayLiteral(stripped, false)) return true;
+  if (isNodeOfType(stripped, "Identifier")) {
+    const binding = findVariableInitializer(stripped, stripped.name);
+    if (!binding) return false;
+    if (isRestParameterBinding(binding.bindingIdentifier)) return true;
+    return Boolean(
+      binding.initializer &&
+      isConstDeclaredBinding(binding.bindingIdentifier) &&
+      isBoundedArrayInitializer(binding.initializer),
+    );
+  }
+  if (!isNodeOfType(stripped, "CallExpression")) return false;
+  const enumerationCallee = stripParenExpression(stripped.callee);
+  if (!isNodeOfType(enumerationCallee, "MemberExpression")) return false;
+  if (
+    !isNodeOfType(enumerationCallee.object, "Identifier") ||
+    enumerationCallee.object.name !== "Object"
+  ) {
+    return false;
+  }
+  if (!isNodeOfType(enumerationCallee.property, "Identifier")) return false;
+  if (!OBJECT_ENUMERATION_METHOD_NAMES.has(enumerationCallee.property.name)) return false;
+  const enumeratedObject = stripped.arguments?.[0];
+  return Boolean(
+    enumeratedObject &&
+    isAstNode(enumeratedObject) &&
+    isLocallyConstructedBoundedObject(enumeratedObject),
+  );
+};
+
+interface ReducerReturnAnalysis {
+  returnedLiterals: EsTreeNode[];
+  // A `return acc` path unchanged alongside the spread is the filter /
+  // dedup shape — growth is bounded by matches, empirically benign.
+  hasAccumulatorPassthroughReturn: boolean;
+  // A local `const acc = …` inside the callback rebinds the name; the
+  // returned spread then copies the local, not the growing accumulator.
+  isAccumulatorNameShadowed: boolean;
+}
+
+// Collects the object/array literals a reducer callback returns — the
+// concise-body expression, or every top-level `return X`. Stops at
+// nested function boundaries so an inner callback's return isn't
+// mistaken for the reducer's own.
+const analyzeReducerReturns = (
+  callback: EsTreeNodeOfType<"ArrowFunctionExpression"> | EsTreeNodeOfType<"FunctionExpression">,
+  accumulatorName: string,
+): ReducerReturnAnalysis => {
+  const analysis: ReducerReturnAnalysis = {
+    returnedLiterals: [],
+    hasAccumulatorPassthroughReturn: false,
+    isAccumulatorNameShadowed: false,
+  };
+  const recordReturnedExpression = (expression: EsTreeNode | null | undefined): void => {
+    if (!expression) return;
+    const stripped = stripParenExpression(expression);
+    if (isNodeOfType(stripped, "ObjectExpression") || isNodeOfType(stripped, "ArrayExpression")) {
+      analysis.returnedLiterals.push(stripped);
+      return;
+    }
+    if (isNodeOfType(stripped, "Identifier") && stripped.name === accumulatorName) {
+      analysis.hasAccumulatorPassthroughReturn = true;
+    }
+  };
+
+  const body = callback.body;
+  if (!body) return analysis;
+  if (!isNodeOfType(body, "BlockStatement")) {
+    recordReturnedExpression(body);
+    return analysis;
+  }
+
+  const visit = (node: EsTreeNode): void => {
+    if (isNodeOfType(node, "ReturnStatement")) {
+      recordReturnedExpression(node.argument);
+      return;
+    }
+    if (isNodeOfType(node, "VariableDeclarator")) {
+      const declaredNames = new Set<string>();
+      collectPatternNames(node.id, declaredNames);
+      if (declaredNames.has(accumulatorName)) {
+        analysis.isAccumulatorNameShadowed = true;
+      }
+    }
+    const nodeRecord = node as unknown as Record<string, unknown>;
+    for (const key of Object.keys(nodeRecord)) {
+      if (key === "parent") continue;
+      const child = nodeRecord[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (isAstNode(item) && !FUNCTION_LIKE_TYPES.has(item.type)) visit(item);
+        }
+      } else if (isAstNode(child) && !FUNCTION_LIKE_TYPES.has(child.type)) {
+        visit(child);
+      }
+    }
+  };
+  visit(body);
+  return analysis;
+};
+
+// Any spread of the accumulator copies the whole growing collection,
+// no matter where it sits in the literal — `{ ...mapItem(x), ...acc }`
+// and `[...g.items, ...acc]` are as quadratic as the leading-spread form.
+const literalSpreadsAccumulator = (literal: EsTreeNode, accumulatorName: string): boolean => {
+  const members = isNodeOfType(literal, "ObjectExpression")
+    ? literal.properties
+    : isNodeOfType(literal, "ArrayExpression")
+      ? literal.elements
+      : null;
+  if (!members) return false;
+  for (const member of members) {
+    if (!member || !isNodeOfType(member as EsTreeNode, "SpreadElement")) continue;
+    const spreadArgument = stripParenExpression(
+      (member as EsTreeNodeOfType<"SpreadElement">).argument,
+    );
+    if (isNodeOfType(spreadArgument, "Identifier") && spreadArgument.name === accumulatorName) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// Only unambiguous growth shapes are worth reporting. An array literal always
+// appends. An object literal counts only with a second spread merged in
+// (`{ ...acc, ...chunk(x) }`) — a single accumulator spread plus one computed
+// key (`{ ...acc, [key]: value }`) is the keyed-lookup-build idiom over a
+// semantically bounded key set, empirically the dominant false positive.
+const literalGrowsAccumulatorPerIteration = (literal: EsTreeNode): boolean => {
+  if (isNodeOfType(literal, "ArrayExpression")) return true;
+  if (!isNodeOfType(literal, "ObjectExpression")) return false;
+  let spreadCount = 0;
+  for (const property of literal.properties) {
+    if (!property) continue;
+    if (isNodeOfType(property as EsTreeNode, "SpreadElement")) {
+      spreadCount += 1;
+      if (spreadCount >= 2) return true;
+    }
+  }
+  return false;
+};
+
+export const noSpreadAccumulatorInReduce = defineRule({
+  id: "no-spread-accumulator-in-reduce",
+  title: "Accumulator spread in reduce is quadratic",
+  tags: ["test-noise"],
+  severity: "warn",
+  category: "Performance",
+  recommendation:
+    "Mutate the accumulator and return it (`acc[key] = value; return acc`) so the fold stays O(n) instead of copying the whole accumulator every step.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const callee = node.callee;
+      if (!isMemberProperty(callee, "reduce") && !isMemberProperty(callee, "reduceRight")) {
+        return;
+      }
+      if (!isNodeOfType(callee, "MemberExpression")) return;
+      if (!isNodeOfType(callee.property, "Identifier")) return;
+      if (!REDUCE_METHOD_NAMES.has(callee.property.name)) return;
+      if (isStaticallyBoundedReduceSource(callee.object)) return;
+
+      const callback = node.arguments?.[0];
+      if (
+        !callback ||
+        (!isNodeOfType(callback, "ArrowFunctionExpression") &&
+          !isNodeOfType(callback, "FunctionExpression"))
+      ) {
+        return;
+      }
+      const accumulatorParam = callback.params?.[0];
+      if (!accumulatorParam || !isNodeOfType(accumulatorParam, "Identifier")) return;
+      const accumulatorName = accumulatorParam.name;
+
+      const analysis = analyzeReducerReturns(callback, accumulatorName);
+      if (analysis.isAccumulatorNameShadowed || analysis.hasAccumulatorPassthroughReturn) return;
+
+      for (const literal of analysis.returnedLiterals) {
+        if (
+          literalSpreadsAccumulator(literal, accumulatorName) &&
+          literalGrowsAccumulatorPerIteration(literal)
+        ) {
+          context.report({
+            node: literal,
+            message:
+              "This is O(n²) because spreading the accumulator copies the entire growing collection every step. Mutate and return the accumulator instead (acc[key] = value; return acc).",
+          });
+          return;
+        }
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-spread-accumulator-in-reduce.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-spread-accumulator-in-reduce.ts
@@ -9,24 +9,19 @@ import { isMemberProperty } from "../../utils/is-member-property.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-
-const REDUCE_METHOD_NAMES = new Set(["reduce", "reduceRight"]);
+import { walkAst } from "../../utils/walk-ast.js";
 
 const OBJECT_ENUMERATION_METHOD_NAMES = new Set(["keys", "entries", "values"]);
 
 const isSpreadFreeArrayLiteral = (node: EsTreeNode, mustHaveElements: boolean): boolean => {
   if (!isNodeOfType(node, "ArrayExpression")) return false;
   if (mustHaveElements && node.elements.length === 0) return false;
-  return node.elements.every(
-    (element) => !element || !isNodeOfType(element as EsTreeNode, "SpreadElement"),
-  );
+  return node.elements.every((element) => !isNodeOfType(element, "SpreadElement"));
 };
 
 const isSpreadFreeObjectLiteral = (node: EsTreeNode): boolean =>
   isNodeOfType(node, "ObjectExpression") &&
-  node.properties.every(
-    (property) => !property || !isNodeOfType(property as EsTreeNode, "SpreadElement"),
-  );
+  node.properties.every((property) => !isNodeOfType(property, "SpreadElement"));
 
 const isConstDeclaredBinding = (bindingIdentifier: EsTreeNode): boolean => {
   const declarator = bindingIdentifier.parent;
@@ -98,12 +93,8 @@ const isStaticallyBoundedReduceSource = (source: EsTreeNode): boolean => {
   }
   if (!isNodeOfType(enumerationCallee.property, "Identifier")) return false;
   if (!OBJECT_ENUMERATION_METHOD_NAMES.has(enumerationCallee.property.name)) return false;
-  const enumeratedObject = stripped.arguments?.[0];
-  return Boolean(
-    enumeratedObject &&
-    isAstNode(enumeratedObject) &&
-    isLocallyConstructedBoundedObject(enumeratedObject),
-  );
+  const enumeratedObject = stripped.arguments[0];
+  return isAstNode(enumeratedObject) && isLocallyConstructedBoundedObject(enumeratedObject);
 };
 
 interface ReducerReturnAnalysis {
@@ -148,32 +139,20 @@ const analyzeReducerReturns = (
     return analysis;
   }
 
-  const visit = (node: EsTreeNode): void => {
-    if (isNodeOfType(node, "ReturnStatement")) {
-      recordReturnedExpression(node.argument);
-      return;
+  walkAst(body, (child) => {
+    if (FUNCTION_LIKE_TYPES.has(child.type)) return false;
+    if (isNodeOfType(child, "ReturnStatement")) {
+      recordReturnedExpression(child.argument);
+      return false;
     }
-    if (isNodeOfType(node, "VariableDeclarator")) {
+    if (isNodeOfType(child, "VariableDeclarator")) {
       const declaredNames = new Set<string>();
-      collectPatternNames(node.id, declaredNames);
+      collectPatternNames(child.id, declaredNames);
       if (declaredNames.has(accumulatorName)) {
         analysis.isAccumulatorNameShadowed = true;
       }
     }
-    const nodeRecord = node as unknown as Record<string, unknown>;
-    for (const key of Object.keys(nodeRecord)) {
-      if (key === "parent") continue;
-      const child = nodeRecord[key];
-      if (Array.isArray(child)) {
-        for (const item of child) {
-          if (isAstNode(item) && !FUNCTION_LIKE_TYPES.has(item.type)) visit(item);
-        }
-      } else if (isAstNode(child) && !FUNCTION_LIKE_TYPES.has(child.type)) {
-        visit(child);
-      }
-    }
-  };
-  visit(body);
+  });
   return analysis;
 };
 
@@ -187,16 +166,11 @@ const literalSpreadsAccumulator = (literal: EsTreeNode, accumulatorName: string)
       ? literal.elements
       : null;
   if (!members) return false;
-  for (const member of members) {
-    if (!member || !isNodeOfType(member as EsTreeNode, "SpreadElement")) continue;
-    const spreadArgument = stripParenExpression(
-      (member as EsTreeNodeOfType<"SpreadElement">).argument,
-    );
-    if (isNodeOfType(spreadArgument, "Identifier") && spreadArgument.name === accumulatorName) {
-      return true;
-    }
-  }
-  return false;
+  return members.some((member) => {
+    if (!isNodeOfType(member, "SpreadElement")) return false;
+    const spreadArgument = stripParenExpression(member.argument);
+    return isNodeOfType(spreadArgument, "Identifier") && spreadArgument.name === accumulatorName;
+  });
 };
 
 // Only unambiguous growth shapes are worth reporting. An array literal always
@@ -207,15 +181,9 @@ const literalSpreadsAccumulator = (literal: EsTreeNode, accumulatorName: string)
 const literalGrowsAccumulatorPerIteration = (literal: EsTreeNode): boolean => {
   if (isNodeOfType(literal, "ArrayExpression")) return true;
   if (!isNodeOfType(literal, "ObjectExpression")) return false;
-  let spreadCount = 0;
-  for (const property of literal.properties) {
-    if (!property) continue;
-    if (isNodeOfType(property as EsTreeNode, "SpreadElement")) {
-      spreadCount += 1;
-      if (spreadCount >= 2) return true;
-    }
-  }
-  return false;
+  return (
+    literal.properties.filter((property) => isNodeOfType(property, "SpreadElement")).length >= 2
+  );
 };
 
 export const noSpreadAccumulatorInReduce = defineRule({
@@ -232,12 +200,9 @@ export const noSpreadAccumulatorInReduce = defineRule({
       if (!isMemberProperty(callee, "reduce") && !isMemberProperty(callee, "reduceRight")) {
         return;
       }
-      if (!isNodeOfType(callee, "MemberExpression")) return;
-      if (!isNodeOfType(callee.property, "Identifier")) return;
-      if (!REDUCE_METHOD_NAMES.has(callee.property.name)) return;
       if (isStaticallyBoundedReduceSource(callee.object)) return;
 
-      const callback = node.arguments?.[0];
+      const callback = node.arguments[0];
       if (
         !callback ||
         (!isNodeOfType(callback, "ArrowFunctionExpression") &&
@@ -245,7 +210,7 @@ export const noSpreadAccumulatorInReduce = defineRule({
       ) {
         return;
       }
-      const accumulatorParam = callback.params?.[0];
+      const accumulatorParam = callback.params[0];
       if (!accumulatorParam || !isNodeOfType(accumulatorParam, "Identifier")) return;
       const accumulatorName = accumulatorParam.name;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/strip-grouping-parens.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/strip-grouping-parens.ts
@@ -2,7 +2,7 @@ import type { EsTreeNode } from "./es-tree-node.js";
 
 // oxc-parser surfaces `(...)` as a `ParenthesizedExpression`, a node kind
 // outside the TSESTree union, so it is matched by string here.
-const PARENTHESIZED_EXPRESSION_TYPE: string = "ParenthesizedExpression";
+export const PARENTHESIZED_EXPRESSION_TYPE: string = "ParenthesizedExpression";
 
 // Peels ONLY grouping parentheses, leaving TS assertion (`as` / `satisfies`
 // / `!`) and optional-chaining wrappers intact — unlike


### PR DESCRIPTION
> Stacked on the foundation PR (#1000 — package-version detection + SSR capability + shared AST utils). Retargets `main` when that merges.

## Why

This batch catches two silent runtime-cost classes that never show up as errors: memory that is pinned forever (an object URL that is created but never revoked keeps its whole Blob/File alive for the document lifetime) and accidentally quadratic folds (spreading the accumulator inside `reduce` copies the entire growing collection on every step). Both are idioms that look clean in review and only hurt at production data sizes.

The most impactful shape, from `no-spread-accumulator-in-reduce`'s invalid tests:

```ts
// Bad — O(n²): every step copies the whole accumulator
const out = items.reduce((acc, x) => [...acc, x], []);

// Good — O(n): mutate and return
const out = items.reduce((acc, x) => {
  acc.push(x);
  return acc;
}, []);
```

## Rules

| Rule | Catches | Notable exemptions |
| --- | --- | --- |
| `no-create-object-url-without-revoke` | `URL.createObjectURL(...)` whose URL escapes — assigned to `href`/`src`/`.current` (directly or via `setAttribute`), returned, rendered inline in JSX, passed to a `setX(...)` state setter, or a guarded (`&&` / ternary / `if`-branch) value bound to a variable — in a module that never references `URL.revokeObjectURL` | Any `revokeObjectURL` reference anywhere in the module; a local binding named `URL` (polyfill, not the DOM global); unguarded `const preview = createObjectURL(file)` (the ambiguous avatar-preview case); bare discarded calls; `setAttribute` with non-URL attributes; test/demo-like filenames |
| `no-spread-accumulator-in-reduce` | A `reduce`/`reduceRight` callback returning a literal that spreads its own accumulator in an unambiguous growth shape: any array literal (`[...acc, x]`, even with the spread last), or an object literal merging a second spread (`{ ...acc, ...chunk(x) }`) | Single-spread keyed-lookup builds (`{ ...acc, [key]: value }`) and static-key merges; statically bounded sources (array literals, `const` arrays incl. ternary initializers, rest params, `Object.keys/entries/values` of a local object literal); a `return acc` passthrough path (filter/dedup shape); shadowed accumulator names; inner-callback returns |

## Validation

Every rule was validated against 67 production OSS repos at pinned SHAs plus 88 reconstructed merged-PR gold solutions. Per-rule sampled hits were judged and adversarially re-verified by two independent reviewers, and the rules went through up to three FP-hardening waves.

| Rule | Corpus hits (pre-hardening → remaining) | Verdict |
| --- | --- | --- |
| `no-create-object-url-without-revoke` | 11 → 13 | clean-keep (remaining hits judged majority true-positive) |
| `no-spread-accumulator-in-reduce` | 98 → 81 | needs-narrowing (further narrowing shipped in this PR, with regression tests) |

For `no-spread-accumulator-in-reduce`, the dominant false positive was the single-spread keyed-lookup build over a semantically bounded key set; this PR ships the narrowing that exempts it (plus bounded sources, `return acc` passthroughs, and accumulator shadowing) with regression tests for each exempted shape. `no-create-object-url-without-revoke`'s hardening broadened escape detection (hence 11 → 13) while adding the module-level revoke check, polyfill-binding guard, and unguarded-preview carve-out; the remaining hits were judged majority true-positive.

## Test plan

- 42 focused rule tests (16 for `no-create-object-url-without-revoke`, 26 for `no-spread-accumulator-in-reduce`), covering every invalid shape and exemption above
- Package `typecheck`, `format:check`, and registry `gen:check` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint rules and tests only; behavior is opt-in via the linter with warn severity and no runtime or API changes.
> 
> **Overview**
> Adds two **Performance** lint rules under `js-performance`, wires them into the generated rule registry, and bumps `oxlint-plugin-react-doctor` in a changeset.
> 
> **`no-create-object-url-without-revoke`** warns when the DOM `URL.createObjectURL` result can escape (e.g. `href`/`src`, JSX, state setters, returns, guarded bindings) and the file never mentions `revokeObjectURL`, with carve-outs for polyfill `URL` bindings, unguarded preview-style assigns, discarded calls, and similar.
> 
> **`no-spread-accumulator-in-reduce`** targets `reduce`/`reduceRight` callbacks that spread the accumulator in clearly quadratic shapes (`[...acc, x]`, `{ ...acc, ...chunk }`), while skipping bounded sources, single-spread keyed lookups, `return acc` filter paths, and shadowed accumulator names.
> 
> Both rules ship with large focused test suites. **`PARENTHESIZED_EXPRESSION_TYPE`** is exported from `strip-grouping-parens` so the object-URL rule can peel grouping parens consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b33e633ace3fb630538a96956681bd49e3417ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->