### PR TITLE
RD-NEW-RR-RULE: performance — 3 rules

### DIFF
--- a/.changeset/rd-new-rules-performance.md
+++ b/.changeset/rd-new-rules-performance.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 3 new performance rules, corpus-validated and FP-hardened

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -37,6 +37,7 @@ import { clickjackingRedirectRisk } from "./rules/security-scan/clickjacking-red
 import { clientLocalstorageNoVersion } from "./rules/client/client-localstorage-no-version.js";
 import { clientPassiveEventListeners } from "./rules/client/client-passive-event-listeners.js";
 import { commandExecutionInputRisk } from "./rules/security-scan/command-execution-input-risk.js";
+import { contextProviderValueFromUnmemoizedLocalLiteral } from "./rules/performance/context-provider-value-from-unmemoized-local-literal.js";
 import { controlHasAssociatedLabel } from "./rules/a11y/control-has-associated-label.js";
 import { corsCookieTrustRisk } from "./rules/security-scan/cors-cookie-trust-risk.js";
 import { dangerousHtmlSink } from "./rules/security-scan/dangerous-html-sink.js";
@@ -174,6 +175,7 @@ import { noDistractingElements } from "./rules/a11y/no-distracting-elements.js";
 import { noDocumentStartViewTransition } from "./rules/view-transitions/no-document-start-view-transition.js";
 import { noDocumentWrite } from "./rules/js-performance/no-document-write.js";
 import { noDynamicImportPath } from "./rules/bundle-size/no-dynamic-import-path.js";
+import { noEagerNewInUseStateInitializer } from "./rules/performance/no-eager-new-in-use-state-initializer.js";
 import { noEffectChain } from "./rules/state-and-effects/no-effect-chain.js";
 import { noEffectEventHandler } from "./rules/state-and-effects/no-effect-event-handler.js";
 import { noEffectEventInDeps } from "./rules/state-and-effects/no-effect-event-in-deps.js";
@@ -235,6 +237,7 @@ import { noRedundantShouldComponentUpdate } from "./rules/react-builtins/no-redu
 import { noRenderInRender } from "./rules/architecture/no-render-in-render.js";
 import { noRenderPropChildren } from "./rules/architecture/no-render-prop-children.js";
 import { noRenderReturnValue } from "./rules/react-builtins/no-render-return-value.js";
+import { noRepeatedLayoutReadSameElement } from "./rules/performance/no-repeated-layout-read-same-element.js";
 import { noResetAllStateOnPropChange } from "./rules/state-and-effects/no-reset-all-state-on-prop-change.js";
 import { noScaleFromZero } from "./rules/performance/no-scale-from-zero.js";
 import { noSecretsInClientCode } from "./rules/security/no-secrets-in-client-code.js";
@@ -742,6 +745,20 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Security",
       tags: [...new Set(["security-scan", ...(commandExecutionInputRisk.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/context-provider-value-from-unmemoized-local-literal",
+    id: "context-provider-value-from-unmemoized-local-literal",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...contextProviderValueFromUnmemoizedLocalLiteral,
+      framework: "global",
+      category: "Performance",
+      requires: [
+        ...new Set(["react", ...(contextProviderValueFromUnmemoizedLocalLiteral.requires ?? [])]),
+      ],
     },
   },
   {
@@ -2342,6 +2359,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-eager-new-in-use-state-initializer",
+    id: "no-eager-new-in-use-state-initializer",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noEagerNewInUseStateInitializer,
+      framework: "global",
+      category: "Performance",
+      requires: [...new Set(["react", ...(noEagerNewInUseStateInitializer.requires ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/no-effect-chain",
     id: "no-effect-chain",
     source: "react-doctor",
@@ -3047,6 +3076,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(noRenderReturnValue.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-repeated-layout-read-same-element",
+    id: "no-repeated-layout-read-same-element",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noRepeatedLayoutReadSameElement,
+      framework: "global",
+      category: "Performance",
+      requires: [...new Set(["react", ...(noRepeatedLayoutReadSameElement.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { contextProviderValueFromUnmemoizedLocalLiteral } from "./context-provider-value-from-unmemoized-local-literal.js";
+
+describe("context-provider-value-from-unmemoized-local-literal", () => {
+  it("flags a one-hop object literal on a legacy Provider", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ThemeContext = createContext(null);
+      function App({ theme }) {
+        const value = { theme };
+        return <ThemeContext.Provider value={value}><Child /></ThemeContext.Provider>;
+      }
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a one-hop array literal", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ListContext = createContext(null);
+      function App({ items }) {
+        const value = [...items];
+        return <ListContext.Provider value={value} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a one-hop arrow/function literal", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const CbContext = createContext(null);
+      function App() {
+        const value = () => {};
+        return <CbContext.Provider value={value} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the React 19 provider shorthand", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ThemeContext = createContext(null);
+      function App({ theme }) {
+        const value = { theme };
+        return <ThemeContext value={value}><Child /></ThemeContext>;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a value bound to useMemo", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext, useMemo } from "react";
+      const ThemeContext = createContext(null);
+      function App({ theme }) {
+        const value = useMemo(() => ({ theme }), [theme]);
+        return <ThemeContext.Provider value={value} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a value bound to useCallback/useState/useRef", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext, useCallback } from "react";
+      const CbContext = createContext(null);
+      function App() {
+        const value = useCallback(() => {}, []);
+        return <CbContext.Provider value={value} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a destructured prop", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ThemeContext = createContext(null);
+      function App({ value }) {
+        return <ThemeContext.Provider value={value} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a member/optional-chain initializer", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ThemeContext = createContext(null);
+      function App({ section }) {
+        const value = section?.edges;
+        return <ThemeContext.Provider value={value} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a module-scope literal const", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ThemeContext = createContext(null);
+      const value = { theme: "dark" };
+      function App() {
+        return <ThemeContext.Provider value={value} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an inline literal value (owned by jsx-no-constructed-context-values)", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ThemeContext = createContext(null);
+      function App({ theme }) {
+        return <ThemeContext.Provider value={{ theme }} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a Provider outside any component (module scope)", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ThemeContext = createContext(null);
+      const value = { theme: "dark" };
+      const element = <ThemeContext.Provider value={value} />;
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag inside a test file (test-noise)", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const DatabaseContext = createContext(null);
+      function wrapper({ children }) {
+        const contextValue = { db, view };
+        return <DatabaseContext.Provider value={contextValue}>{children}</DatabaseContext.Provider>;
+      }
+    `,
+      { filename: "src/__tests__/useGroup.test.tsx" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a hoisted local function declaration passed as the value", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const DispatchContext = createContext(null);
+      function App({ children }) {
+        function dispatch(action) { console.log(action); }
+        return <DispatchContext.Provider value={dispatch}>{children}</DispatchContext.Provider>;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a memo-wrapped component's render-local literal", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext, memo } from "react";
+      const ThemeContext = createContext(null);
+      const App = memo(({ theme, children }) => {
+        const value = { theme };
+        return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+      });
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a destructured-prop parameter default (lobe-ui `{ config = {} }` idiom)", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ConfigContext = createContext(null);
+      function App({ config = {}, children }) {
+        return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a per-item value inside a .map() render-loop callback (SegmentedControl idiom)", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ItemContext = createContext(null);
+      function List({ items }) {
+        return items.map((item) => {
+          const itemValue = { item, select: () => {} };
+          return <ItemContext.Provider value={itemValue} key={item.id}>{item.label}</ItemContext.Provider>;
+        });
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a value allocated once in an outer factory/HOC closure (createStore idiom)", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const StoreContext = createContext(null);
+      const createStoreProvider = (initialState) => {
+        const store = { state: initialState, listeners: [] };
+        const Provider = ({ children }) =>
+          <StoreContext.Provider value={store}>{children}</StoreContext.Provider>;
+        return Provider;
+      };
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a value built inside a useMemo callback that returns the Provider element", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext, useMemo } from "react";
+      const ThemeContext = createContext(null);
+      function App({ theme, children }) {
+        return useMemo(() => {
+          const value = { theme };
+          return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+        }, [theme, children]);
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a block-scoped literal declared inside the component's own if-block", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext } from "react";
+      const ThemeContext = createContext(null);
+      function App({ theme, children }) {
+        if (theme) {
+          const value = { theme };
+          return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+        }
+        return children;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the shorthand when the name is a local shadow, not a context", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      function App() {
+        const Wrapper = (props) => props.children;
+        const value = { a: 1 };
+        return <Wrapper value={value} />;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.ts
@@ -2,14 +2,14 @@ import {
   componentOrHookDisplayNameForFunction,
   nearestEnclosingFunction,
 } from "../../utils/component-or-hook-display-name.js";
+import { collectContextBindings } from "../../utils/collect-context-bindings.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { BindingInfo } from "../../utils/find-variable-initializer.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
-import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
-import { isAstNode } from "../../utils/is-ast-node.js";
-import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
+import { isContextProviderJsxName } from "../../utils/is-context-provider-jsx-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -17,9 +17,6 @@ import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const MESSAGE =
   "Every consumer of this context redraws on each render because its `value` is a fresh object/array/function rebuilt each render — wrap it in useMemo/useCallback (or move it out of the component).";
-
-// Modules whose `createContext` has React's identity semantics.
-const CONTEXT_MODULES = ["react", "use-context-selector", "react-tracked"];
 
 // Fresh per-render allocations — the literal shapes the revision
 // restricts this rule to. A useMemo/useCallback/useRef/useState call
@@ -65,68 +62,6 @@ const owningFunctionOfBinding = (binding: BindingInfo): EsTreeNode | null =>
     ? binding.scopeOwner
     : nearestEnclosingFunction(binding.scopeOwner);
 
-const isCreateContextCall = (expression: EsTreeNode): boolean => {
-  const stripped = stripParenExpression(expression);
-  if (!isNodeOfType(stripped, "CallExpression")) return false;
-  const callee = stripped.callee;
-  if (isNodeOfType(callee, "Identifier")) {
-    return CONTEXT_MODULES.some(
-      (moduleName) =>
-        getImportedNameFromModule(callee, callee.name, moduleName) === "createContext",
-    );
-  }
-  if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
-    const namespaceIdentifier = callee.object;
-    if (!isNodeOfType(namespaceIdentifier, "Identifier")) return false;
-    if (!isNodeOfType(callee.property, "Identifier")) return false;
-    if (callee.property.name !== "createContext") return false;
-    if (isCanonicalReactNamespaceName(namespaceIdentifier.name)) return true;
-    return CONTEXT_MODULES.some(
-      (moduleName) =>
-        getImportedNameFromModule(namespaceIdentifier, namespaceIdentifier.name, moduleName) !==
-        null,
-    );
-  }
-  return false;
-};
-
-// Top-level `const X = createContext(...)` binding names, used to detect
-// the React 19 `<X value={…}>` provider shorthand.
-const collectContextBindings = (programRoot: EsTreeNode): Set<string> => {
-  const bindings = new Set<string>();
-  if (!isNodeOfType(programRoot, "Program")) return bindings;
-  for (const topLevel of programRoot.body ?? []) {
-    let declaration: EsTreeNode | null = topLevel;
-    if (isNodeOfType(topLevel, "ExportNamedDeclaration") && topLevel.declaration) {
-      declaration = topLevel.declaration;
-    }
-    if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) continue;
-    for (const declarator of declaration.declarations ?? []) {
-      if (!isNodeOfType(declarator, "VariableDeclarator")) continue;
-      if (!isNodeOfType(declarator.id, "Identifier")) continue;
-      if (!declarator.init || !isAstNode(declarator.init)) continue;
-      if (!isCreateContextCall(declarator.init)) continue;
-      bindings.add(declarator.id.name);
-    }
-  }
-  return bindings;
-};
-
-const isLegacyProviderName = (node: EsTreeNode): boolean =>
-  isNodeOfType(node, "JSXMemberExpression") &&
-  isNodeOfType(node.property, "JSXIdentifier") &&
-  node.property.name === "Provider";
-
-const isContextShorthandName = (
-  node: EsTreeNode,
-  contextBindings: ReadonlySet<string>,
-): boolean => {
-  if (!isNodeOfType(node, "JSXIdentifier")) return false;
-  if (!contextBindings.has(node.name)) return false;
-  const binding = findVariableInitializer(node, node.name);
-  return binding?.scopeOwner.type === "Program";
-};
-
 // Complements `jsx-no-constructed-context-values` (which fires only when
 // the `value` attribute is ITSELF a literal). This rule resolves a
 // one-hop identifier bound in the SAME render scope to a fresh
@@ -147,10 +82,7 @@ export const contextProviderValueFromUnmemoizedLocalLiteral = defineRule({
         contextBindings = collectContextBindings(node);
       },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        const nameNode = node.name;
-        if (!isLegacyProviderName(nameNode) && !isContextShorthandName(nameNode, contextBindings)) {
-          return;
-        }
+        if (!isContextProviderJsxName(node.name, contextBindings)) return;
         // Only a component/hook body re-runs per render AND can host a
         // useMemo. An inline callback (a `.map()` render loop, a
         // `useMemo` factory) is neither: hooks cannot be called there,
@@ -159,29 +91,25 @@ export const contextProviderValueFromUnmemoizedLocalLiteral = defineRule({
         if (!renderFunction) return;
         if (componentOrHookDisplayNameForFunction(renderFunction) === null) return;
 
-        for (const attribute of node.attributes) {
-          if (!isNodeOfType(attribute, "JSXAttribute")) continue;
-          if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
-          if (attribute.name.name !== "value") continue;
-          const attributeValue = attribute.value;
-          if (!attributeValue || !isNodeOfType(attributeValue, "JSXExpressionContainer")) return;
-          const inner = stripParenExpression(attributeValue.expression);
-          if (!isNodeOfType(inner, "Identifier")) return;
+        const attribute = findJsxAttribute(node.attributes, "value");
+        if (!attribute) return;
+        const attributeValue = attribute.value;
+        if (!attributeValue || !isNodeOfType(attributeValue, "JSXExpressionContainer")) return;
+        const inner = stripParenExpression(attributeValue.expression);
+        if (!isNodeOfType(inner, "Identifier")) return;
 
-          const binding = findVariableInitializer(inner, inner.name);
-          if (!binding || !binding.initializer) return;
-          // Module-scope literals are stable; only render-local
-          // declarations are rebuilt each render.
-          if (binding.scopeOwner.type === "Program") return;
-          if (!isDirectDeclarationInitializer(binding)) return;
-          // A binding owned by an outer factory/HOC closure is
-          // allocated once, not per render of this component.
-          if (owningFunctionOfBinding(binding) !== renderFunction) return;
-          if (!isFreshLiteralInitializer(binding.initializer)) return;
+        const binding = findVariableInitializer(inner, inner.name);
+        if (!binding || !binding.initializer) return;
+        // Module-scope literals are stable; only render-local
+        // declarations are rebuilt each render.
+        if (binding.scopeOwner.type === "Program") return;
+        if (!isDirectDeclarationInitializer(binding)) return;
+        // A binding owned by an outer factory/HOC closure is
+        // allocated once, not per render of this component.
+        if (owningFunctionOfBinding(binding) !== renderFunction) return;
+        if (!isFreshLiteralInitializer(binding.initializer)) return;
 
-          context.report({ node: attribute, message: MESSAGE });
-          return;
-        }
+        context.report({ node: attribute, message: MESSAGE });
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.ts
@@ -1,0 +1,188 @@
+import {
+  componentOrHookDisplayNameForFunction,
+  nearestEnclosingFunction,
+} from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { BindingInfo } from "../../utils/find-variable-initializer.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
+import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const MESSAGE =
+  "Every consumer of this context redraws on each render because its `value` is a fresh object/array/function rebuilt each render — wrap it in useMemo/useCallback (or move it out of the component).";
+
+// Modules whose `createContext` has React's identity semantics.
+const CONTEXT_MODULES = ["react", "use-context-selector", "react-tracked"];
+
+// Fresh per-render allocations — the literal shapes the revision
+// restricts this rule to. A useMemo/useCallback/useRef/useState call
+// or member access is none of these, so it is naturally excluded.
+const isFreshLiteralInitializer = (expression: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(expression);
+  return (
+    isNodeOfType(stripped, "ObjectExpression") ||
+    isNodeOfType(stripped, "ArrayExpression") ||
+    isNodeOfType(stripped, "ArrowFunctionExpression") ||
+    isNodeOfType(stripped, "FunctionExpression") ||
+    isNodeOfType(stripped, "FunctionDeclaration")
+  );
+};
+
+// Only an UNCONDITIONAL `const/let/var name = <literal>` (or a hoisted
+// local `function name() {}`) is a per-render allocation. A parameter
+// or destructuring DEFAULT (`function App({ config = {} })`) records
+// its default as the initializer, but that value only allocates when
+// the source is undefined, and "wrap it in useMemo" is the wrong fix
+// for a prop — same contract as no-effect-with-fresh-deps.
+const isDirectDeclarationInitializer = (binding: BindingInfo): boolean => {
+  const declarationNode = binding.bindingIdentifier.parent;
+  if (
+    declarationNode &&
+    isNodeOfType(declarationNode, "VariableDeclarator") &&
+    declarationNode.init === binding.initializer
+  ) {
+    return true;
+  }
+  return Boolean(
+    binding.initializer &&
+    isNodeOfType(binding.initializer, "FunctionDeclaration") &&
+    binding.initializer.id === binding.bindingIdentifier,
+  );
+};
+
+// The function whose body re-runs to rebuild the binding. Block-scoped
+// declarations (`if (x) { const value = {...} }`) report the block as
+// scopeOwner; walk up to the owning function in that case.
+const owningFunctionOfBinding = (binding: BindingInfo): EsTreeNode | null =>
+  isFunctionLike(binding.scopeOwner)
+    ? binding.scopeOwner
+    : nearestEnclosingFunction(binding.scopeOwner);
+
+const isCreateContextCall = (expression: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(expression);
+  if (!isNodeOfType(stripped, "CallExpression")) return false;
+  const callee = stripped.callee;
+  if (isNodeOfType(callee, "Identifier")) {
+    return CONTEXT_MODULES.some(
+      (moduleName) =>
+        getImportedNameFromModule(callee, callee.name, moduleName) === "createContext",
+    );
+  }
+  if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
+    const namespaceIdentifier = callee.object;
+    if (!isNodeOfType(namespaceIdentifier, "Identifier")) return false;
+    if (!isNodeOfType(callee.property, "Identifier")) return false;
+    if (callee.property.name !== "createContext") return false;
+    if (isCanonicalReactNamespaceName(namespaceIdentifier.name)) return true;
+    return CONTEXT_MODULES.some(
+      (moduleName) =>
+        getImportedNameFromModule(namespaceIdentifier, namespaceIdentifier.name, moduleName) !==
+        null,
+    );
+  }
+  return false;
+};
+
+// Top-level `const X = createContext(...)` binding names, used to detect
+// the React 19 `<X value={…}>` provider shorthand.
+const collectContextBindings = (programRoot: EsTreeNode): Set<string> => {
+  const bindings = new Set<string>();
+  if (!isNodeOfType(programRoot, "Program")) return bindings;
+  for (const topLevel of programRoot.body ?? []) {
+    let declaration: EsTreeNode | null = topLevel;
+    if (isNodeOfType(topLevel, "ExportNamedDeclaration") && topLevel.declaration) {
+      declaration = topLevel.declaration;
+    }
+    if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) continue;
+    for (const declarator of declaration.declarations ?? []) {
+      if (!isNodeOfType(declarator, "VariableDeclarator")) continue;
+      if (!isNodeOfType(declarator.id, "Identifier")) continue;
+      if (!declarator.init || !isAstNode(declarator.init)) continue;
+      if (!isCreateContextCall(declarator.init)) continue;
+      bindings.add(declarator.id.name);
+    }
+  }
+  return bindings;
+};
+
+const isLegacyProviderName = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "JSXMemberExpression") &&
+  isNodeOfType(node.property, "JSXIdentifier") &&
+  node.property.name === "Provider";
+
+const isContextShorthandName = (
+  node: EsTreeNode,
+  contextBindings: ReadonlySet<string>,
+): boolean => {
+  if (!isNodeOfType(node, "JSXIdentifier")) return false;
+  if (!contextBindings.has(node.name)) return false;
+  const binding = findVariableInitializer(node, node.name);
+  return binding?.scopeOwner.type === "Program";
+};
+
+// Complements `jsx-no-constructed-context-values` (which fires only when
+// the `value` attribute is ITSELF a literal). This rule resolves a
+// one-hop identifier bound in the SAME render scope to a fresh
+// object/array/function literal — the identifier-indirection form the
+// base rule documents as a pass.
+export const contextProviderValueFromUnmemoizedLocalLiteral = defineRule({
+  id: "context-provider-value-from-unmemoized-local-literal",
+  title: "Context value from an unmemoized local literal",
+  tags: ["react-jsx-only", "test-noise"],
+  severity: "warn",
+  category: "Performance",
+  recommendation:
+    "Wrap the context value in useMemo/useCallback so consumers do not redraw every render, or move it outside the component if it never changes.",
+  create: (context: RuleContext) => {
+    let contextBindings: ReadonlySet<string> = new Set<string>();
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        contextBindings = collectContextBindings(node);
+      },
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        const nameNode = node.name;
+        if (!isLegacyProviderName(nameNode) && !isContextShorthandName(nameNode, contextBindings)) {
+          return;
+        }
+        // Only a component/hook body re-runs per render AND can host a
+        // useMemo. An inline callback (a `.map()` render loop, a
+        // `useMemo` factory) is neither: hooks cannot be called there,
+        // so the recommendation would be unactionable — bail.
+        const renderFunction = nearestEnclosingFunction(node);
+        if (!renderFunction) return;
+        if (componentOrHookDisplayNameForFunction(renderFunction) === null) return;
+
+        for (const attribute of node.attributes) {
+          if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+          if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
+          if (attribute.name.name !== "value") continue;
+          const attributeValue = attribute.value;
+          if (!attributeValue || !isNodeOfType(attributeValue, "JSXExpressionContainer")) return;
+          const inner = stripParenExpression(attributeValue.expression);
+          if (!isNodeOfType(inner, "Identifier")) return;
+
+          const binding = findVariableInitializer(inner, inner.name);
+          if (!binding || !binding.initializer) return;
+          // Module-scope literals are stable; only render-local
+          // declarations are rebuilt each render.
+          if (binding.scopeOwner.type === "Program") return;
+          if (!isDirectDeclarationInitializer(binding)) return;
+          // A binding owned by an outer factory/HOC closure is
+          // allocated once, not per render of this component.
+          if (owningFunctionOfBinding(binding) !== renderFunction) return;
+          if (!isFreshLiteralInitializer(binding.initializer)) return;
+
+          context.report({ node: attribute, message: MESSAGE });
+          return;
+        }
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-eager-new-in-use-state-initializer.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-eager-new-in-use-state-initializer.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noEagerNewInUseStateInitializer } from "./no-eager-new-in-use-state-initializer.js";
+
+describe("no-eager-new-in-use-state-initializer", () => {
+  it("does not flag the empty-Set selection-state idiom useState(new Set())", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [seen] = useState(new Set<string>());
+      }
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the empty-Map keyed-state idiom useState(new Map())", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [cache] = useState(new Map());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the current-date default idiom useState(new Date())", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [now] = useState(new Date());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a Set seeded with constant identifiers (agent-teams-ai idiom)", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [enabled] = useState(new Set([TAB_ONE, TAB_TWO, TAB_THREE]));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a Date fallback in a logical initializer (TaskTrove idiom)", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component({ initialDate }) {
+        const [date] = useState(initialDate || new Date());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a Map seeded from constant prop entries", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component({ defaults }) {
+        const [settings] = useState(new Map([["theme", defaults.theme]]));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the zero-arg DOM geometry idiom useState<DOMRect>(new DOMRect()) (agent-teams-ai idiom)", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [anchorRect, setAnchorRect] = useState<DOMRect>(new DOMRect());
+      }
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a DOMPoint built from constant coordinates", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [origin] = useState(new DOMPoint(0, 0));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a DOM geometry constructor fed a call result (new DOMRect(...measure()))", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component({ element }) {
+        const [rect] = useState(new DOMRect(0, 0, measureWidth(element), 0));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new DOMRect()");
+  });
+
+  it("flags a cheap builtin rebuilt from a call result (new Map(items.map(...)))", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component({ items }) {
+        const [byId] = useState(new Map(items.map((item) => [item.id, item])));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new Map()");
+  });
+
+  it("flags a user-defined class constructor", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      import { AudioEngine } from "./audio-engine";
+      function Component() {
+        const [engine] = useState(new AudioEngine());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new AudioEngine()");
+  });
+
+  it("flags a side-effecting constructor (new IntersectionObserver)", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [observer] = useState(new IntersectionObserver((e) => {}));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new IntersectionObserver()");
+  });
+
+  it("flags useState(new AbortController())", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [controller] = useState(new AbortController());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a typed React.useState with a call-fed Map", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import React from "react";
+      function Component({ entries }) {
+        const [m] = React.useState<Map<string, number>>(new Map(Object.entries(entries)));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the lazy form useState(() => new X())", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [seen] = useState(() => new Set());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a plain CallExpression initializer (owned by rerender-lazy-state-init)", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [thing] = useState(makeThing());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not chase an identifier initializer", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const initial = new Set();
+        const [seen] = useState(initial);
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag new inside a setter updater callback", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [seen, setSeen] = useState(() => new Set());
+        const add = (x) => setSeen((prev) => new Set(prev).add(x));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag useRef(new X()) (owned by rerender-lazy-ref-init)", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useRef } from "react";
+      function Component() {
+        const ref = useRef(new Map());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag trivial constructors (new Array / new Object)", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [a] = useState(new Array());
+        const [o] = useState(new Object());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag useState with no arguments", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component() {
+        const [x] = useState();
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a new expression in a conditional branch", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component({ enabled }) {
+        const [c] = useState(enabled ? new AbortController() : null);
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the non-trivial branch even when the other branch is an exempt constructor", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component({ flag }) {
+        const [c] = useState(flag ? new Array() : new AbortController());
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new AbortController()");
+  });
+
+  it("flags the non-trivial side of a logical initializer with an exempt left side", () => {
+    const result = runRule(
+      noEagerNewInUseStateInitializer,
+      `
+      import { useState } from "react";
+      function Component({ items }) {
+        const [c] = useState(new Boolean(false) && new Map(items.map((item) => [item.id, item])));
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-eager-new-in-use-state-initializer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-eager-new-in-use-state-initializer.ts
@@ -1,0 +1,136 @@
+import { TRIVIAL_INITIALIZER_NAMES } from "../../constants/react.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+// Sister rule to `rerender-lazy-ref-init` (which covers `useRef(new X())`)
+// and `rerender-lazy-state-init` (which bails on non-CallExpression
+// initializers, so `new X()` sails through). `useState` only uses its
+// argument on the first render but still evaluates it every render and
+// discards the result. Cheap built-in containers and DOM geometry value
+// objects with constant arguments (`new Set()`, `new Map()`, `new Date()`,
+// `new DOMRect()`) cost about as much as the lazy closure would, so they are
+// exempt; the rule targets user-defined class constructors, side-effecting
+// web APIs (new IntersectionObserver / AbortController / Worker), and
+// containers rebuilt from a call result (`new Map(items.map(...))`). The fix
+// is the lazy form `useState(() => new X())`.
+const CHEAP_BUILTIN_CONSTRUCTOR_NAMES = new Set([
+  "Map",
+  "Set",
+  "WeakMap",
+  "WeakSet",
+  "Date",
+  "RegExp",
+  "URL",
+  "URLSearchParams",
+  "Headers",
+  "DOMRect",
+  "DOMRectReadOnly",
+  "DOMPoint",
+  "DOMPointReadOnly",
+  "DOMMatrix",
+  "DOMMatrixReadOnly",
+  "DOMQuad",
+  "Path2D",
+]);
+
+const isConstantConstructorArgument = (argumentNode: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(argumentNode);
+  if (isNodeOfType(stripped, "Literal") || isNodeOfType(stripped, "Identifier")) return true;
+  if (isNodeOfType(stripped, "TemplateLiteral")) {
+    return stripped.expressions.every(isConstantConstructorArgument);
+  }
+  if (isNodeOfType(stripped, "UnaryExpression")) {
+    return isConstantConstructorArgument(stripped.argument);
+  }
+  if (isNodeOfType(stripped, "MemberExpression")) {
+    return (
+      isConstantConstructorArgument(stripped.object) &&
+      (!stripped.computed || isConstantConstructorArgument(stripped.property))
+    );
+  }
+  if (isNodeOfType(stripped, "SpreadElement")) {
+    return isConstantConstructorArgument(stripped.argument);
+  }
+  if (isNodeOfType(stripped, "ArrayExpression")) {
+    return stripped.elements.every(
+      (element: EsTreeNode | null) => element === null || isConstantConstructorArgument(element),
+    );
+  }
+  if (isNodeOfType(stripped, "ObjectExpression")) {
+    return stripped.properties.every((property: EsTreeNode) => {
+      if (isNodeOfType(property, "SpreadElement")) {
+        return isConstantConstructorArgument(property.argument);
+      }
+      return isNodeOfType(property, "Property") && isConstantConstructorArgument(property.value);
+    });
+  }
+  return false;
+};
+
+const isExemptNewExpression = (newExpression: EsTreeNodeOfType<"NewExpression">): boolean => {
+  const name = constructorName(newExpression);
+  if (TRIVIAL_INITIALIZER_NAMES.has(name)) return true;
+  return (
+    CHEAP_BUILTIN_CONSTRUCTOR_NAMES.has(name) &&
+    newExpression.arguments.every(isConstantConstructorArgument)
+  );
+};
+
+const findReportableNewExpression = (argument: EsTreeNode): EsTreeNode | null => {
+  const stripped = stripParenExpression(argument);
+  if (isNodeOfType(stripped, "NewExpression")) {
+    return isExemptNewExpression(stripped) ? null : stripped;
+  }
+  // `useState(cond ? new A() : new B())` / `useState(flag && new A())` —
+  // a branch that is directly a `new` expression still constructs eagerly.
+  if (isNodeOfType(stripped, "ConditionalExpression")) {
+    return (
+      findReportableNewExpression(stripped.consequent) ??
+      findReportableNewExpression(stripped.alternate)
+    );
+  }
+  if (isNodeOfType(stripped, "LogicalExpression")) {
+    return (
+      findReportableNewExpression(stripped.left) ?? findReportableNewExpression(stripped.right)
+    );
+  }
+  return null;
+};
+
+const constructorName = (newExpression: EsTreeNode): string => {
+  if (!isNodeOfType(newExpression, "NewExpression")) return "fn";
+  const callee = newExpression.callee;
+  if (isNodeOfType(callee, "Identifier")) return callee.name;
+  if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
+    return callee.property.name;
+  }
+  return "fn";
+};
+
+export const noEagerNewInUseStateInitializer = defineRule({
+  id: "no-eager-new-in-use-state-initializer",
+  title: "Eager new in useState initializer runs every render",
+  tags: ["test-noise"],
+  severity: "warn",
+  category: "Performance",
+  recommendation:
+    "Wrap the constructor in a function (`useState(() => new X())`) so it only runs on the first render instead of allocating (and leaking) a fresh instance every render.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isHookCall(node, "useState") || !node.arguments?.length) return;
+      const eagerNew = findReportableNewExpression(node.arguments[0]);
+      if (!eagerNew) return;
+
+      const name = constructorName(eagerNew);
+      context.report({
+        node: eagerNew,
+        message: `useState(new ${name}()) builds a fresh instance on every render and throws it away. Wrap it as useState(() => new ${name}()) so it only runs once.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-eager-new-in-use-state-initializer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-eager-new-in-use-state-initializer.ts
@@ -58,11 +58,11 @@ const isConstantConstructorArgument = (argumentNode: EsTreeNode): boolean => {
   }
   if (isNodeOfType(stripped, "ArrayExpression")) {
     return stripped.elements.every(
-      (element: EsTreeNode | null) => element === null || isConstantConstructorArgument(element),
+      (element) => element === null || isConstantConstructorArgument(element),
     );
   }
   if (isNodeOfType(stripped, "ObjectExpression")) {
-    return stripped.properties.every((property: EsTreeNode) => {
+    return stripped.properties.every((property) => {
       if (isNodeOfType(property, "SpreadElement")) {
         return isConstantConstructorArgument(property.argument);
       }
@@ -70,6 +70,15 @@ const isConstantConstructorArgument = (argumentNode: EsTreeNode): boolean => {
     });
   }
   return false;
+};
+
+const constructorName = (newExpression: EsTreeNodeOfType<"NewExpression">): string => {
+  const callee = newExpression.callee;
+  if (isNodeOfType(callee, "Identifier")) return callee.name;
+  if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
+    return callee.property.name;
+  }
+  return "fn";
 };
 
 const isExemptNewExpression = (newExpression: EsTreeNodeOfType<"NewExpression">): boolean => {
@@ -81,7 +90,9 @@ const isExemptNewExpression = (newExpression: EsTreeNodeOfType<"NewExpression">)
   );
 };
 
-const findReportableNewExpression = (argument: EsTreeNode): EsTreeNode | null => {
+const findReportableNewExpression = (
+  argument: EsTreeNode,
+): EsTreeNodeOfType<"NewExpression"> | null => {
   const stripped = stripParenExpression(argument);
   if (isNodeOfType(stripped, "NewExpression")) {
     return isExemptNewExpression(stripped) ? null : stripped;
@@ -100,16 +111,6 @@ const findReportableNewExpression = (argument: EsTreeNode): EsTreeNode | null =>
     );
   }
   return null;
-};
-
-const constructorName = (newExpression: EsTreeNode): string => {
-  if (!isNodeOfType(newExpression, "NewExpression")) return "fn";
-  const callee = newExpression.callee;
-  if (isNodeOfType(callee, "Identifier")) return callee.name;
-  if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
-    return callee.property.name;
-  }
-  return "fn";
 };
 
 export const noEagerNewInUseStateInitializer = defineRule({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.test.ts
@@ -45,6 +45,8 @@ describe("no-repeated-layout-read-same-element", () => {
     `,
     );
     expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("const style = getComputedStyle(el)");
+    expect(result.diagnostics[0].message).not.toContain("el.getComputedStyle");
   });
 
   it("flags window.getComputedStyle repeated on the same element", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noRepeatedLayoutReadSameElement } from "./no-repeated-layout-read-same-element.js";
+
+describe("no-repeated-layout-read-same-element", () => {
+  it("flags two getBoundingClientRect() reads on the same element", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function place(el) {
+        const top = el.getBoundingClientRect().top;
+        const bottom = el.getBoundingClientRect().bottom;
+        return top + bottom;
+      }
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags two rect reads on the same ref within one expression", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function place(collaboratorRef) {
+        return (
+          collaboratorRef.current.getBoundingClientRect().top +
+          collaboratorRef.current.getBoundingClientRect().height / 2
+        );
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags repeated getComputedStyle on the same element", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function read(el) {
+        const a = getComputedStyle(el).width;
+        const b = getComputedStyle(el).height;
+        return [a, b];
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags window.getComputedStyle repeated on the same element", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function read(el) {
+        const a = window.getComputedStyle(el).width;
+        const b = window.getComputedStyle(el).height;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports only once for three reads on the same element", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function place(el) {
+        const a = el.getBoundingClientRect().top;
+        const b = el.getBoundingClientRect().left;
+        const c = el.getBoundingClientRect().right;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag reads on different elements", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function place(tooltipEl, parentEl) {
+        const a = tooltipEl.getBoundingClientRect().top;
+        const b = parentEl.getBoundingClientRect().bottom;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reads in two different function scopes", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function first(el) {
+        return el.getBoundingClientRect().top;
+      }
+      function second(el) {
+        return el.getBoundingClientRect().bottom;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a single destructured read", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function place(el) {
+        const { width, height } = el.getBoundingClientRect();
+        return width + height;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag read-mutate-read when a style write intervenes", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function measure(el) {
+        const before = el.getBoundingClientRect();
+        el.style.height = 'auto';
+        const after = el.getBoundingClientRect();
+        return after.height - before.height;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag read-method-read when a mutating call intervenes", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function measure(el) {
+        const before = el.getBoundingClientRect();
+        el.scrollIntoView();
+        const after = el.getBoundingClientRect();
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reads in separate branches", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function place(el, flag) {
+        if (flag) {
+          return el.getBoundingClientRect().top;
+        } else {
+          return el.getBoundingClientRect().bottom;
+        }
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag getComputedStyle plus getBoundingClientRect on the same element (canonical measure-an-element idiom)", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function measure(el) {
+        const style = getComputedStyle(el);
+        const rect = el.getBoundingClientRect();
+        return rect.height - parseFloat(style.paddingTop);
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a same-method repeat when a different-method read is also present", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function measure(el) {
+        const style = getComputedStyle(el);
+        const top = el.getBoundingClientRect().top;
+        const bottom = el.getBoundingClientRect().bottom;
+        return [style, top, bottom];
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag getComputedStyle with different pseudo-element selectors (::before/::after content reads)", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function pseudo(el) {
+        const before = getComputedStyle(el, '::before').content;
+        const after = getComputedStyle(el, '::after').content;
+        return [before, after];
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reads in different switch cases (per-placement edge lookup)", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function edge(el, placement) {
+        switch (placement) {
+          case 'top':
+            return el.getBoundingClientRect().top;
+          case 'bottom':
+            return el.getBoundingClientRect().bottom;
+        }
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reads in the two arms of a ternary (axis-conditional measurement)", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function size(el, horizontal) {
+        return horizontal ? el.getBoundingClientRect().width : el.getBoundingClientRect().height;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reads in unbraced if/else branches", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function edge(el, flag) {
+        if (flag) return el.getBoundingClientRect().top;
+        else return el.getBoundingClientRect().bottom;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag re-measure after Object.assign(el.style, …) between reads (floating-ui apply-styles idiom)", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function measure(el) {
+        const before = el.getBoundingClientRect();
+        Object.assign(el.style, { height: 'auto' });
+        const after = el.getBoundingClientRect();
+        return after.height - before.height;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag re-measure after a helper call receiving the element (measure -> apply -> re-measure)", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function measure(el) {
+        const before = el.getBoundingClientRect();
+        applyCollapsedStyles(el);
+        const after = el.getBoundingClientRect();
+        return after.height - before.height;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag re-measure after an assignment whose right-hand side contains the first read", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      function collapse(el) {
+        el.style.height = el.getBoundingClientRect().height / 2 + 'px';
+        const after = el.getBoundingClientRect();
+        return after.height;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag re-measure across an await (next-frame async re-measurement)", () => {
+    const result = runRule(
+      noRepeatedLayoutReadSameElement,
+      `
+      async function measure(el) {
+        const before = el.getBoundingClientRect();
+        await new Promise(requestAnimationFrame);
+        const after = el.getBoundingClientRect();
+        return after.top - before.top;
+      }
+    `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.ts
@@ -1,0 +1,270 @@
+import { FUNCTION_LIKE_TYPES } from "../../constants/js.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Method-call layout reads that each force a synchronous style/layout
+// flush. Bare property forms (scrollTop/offsetWidth/…) are deliberately
+// excluded: they are write-invalidated and commonly live on non-DOM
+// objects, so they carry a high false-positive risk.
+const LAYOUT_READ_METHOD_NAMES = new Set(["getBoundingClientRect", "getComputedStyle"]);
+
+interface NodeWithRange {
+  start?: number;
+  end?: number;
+}
+
+const rangeStart = (node: EsTreeNode): number => (node as NodeWithRange).start ?? 0;
+const rangeEnd = (node: EsTreeNode): number => (node as NodeWithRange).end ?? 0;
+
+// Canonical source-ish key for a receiver expression, or null when the
+// receiver isn't a simple identifier / member chain (computed access,
+// call results, …) — we only group receivers we can compare exactly.
+const serializeReceiver = (node: EsTreeNode | null | undefined): string | null => {
+  if (!node) return null;
+  if (isNodeOfType(node, "Identifier")) return node.name;
+  if (isNodeOfType(node, "ThisExpression")) return "this";
+  if (isNodeOfType(node, "MemberExpression")) {
+    if (node.computed) return null;
+    const objectKey = serializeReceiver(node.object);
+    if (!objectKey) return null;
+    if (!isNodeOfType(node.property, "Identifier")) return null;
+    return `${objectKey}.${node.property.name}`;
+  }
+  return null;
+};
+
+interface LayoutRead {
+  methodName: string;
+  readSignature: string;
+  receiverKey: string;
+  regionNode: EsTreeNode;
+  callNode: EsTreeNode;
+}
+
+interface ReceiverMutation {
+  receiverKey: string;
+  end: number;
+}
+
+// The layout-read receiver, or null when the call is not a recognized
+// forced-layout read. For `el.getBoundingClientRect()` the receiver is
+// `el`; for `getComputedStyle(el)` it is the first argument.
+const layoutReadReceiver = (call: EsTreeNodeOfType<"CallExpression">): EsTreeNode | null => {
+  const callee = call.callee;
+  if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
+    if (!isNodeOfType(callee.property, "Identifier")) return null;
+    if (callee.property.name === "getBoundingClientRect") return callee.object;
+    // `window.getComputedStyle(el)` — the element is the argument.
+    if (callee.property.name === "getComputedStyle") return call.arguments?.[0] ?? null;
+    return null;
+  }
+  if (isNodeOfType(callee, "Identifier") && callee.name === "getComputedStyle") {
+    return call.arguments?.[0] ?? null;
+  }
+  return null;
+};
+
+const layoutReadMethodName = (call: EsTreeNodeOfType<"CallExpression">): string | null => {
+  const callee = call.callee;
+  if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
+    return LAYOUT_READ_METHOD_NAMES.has(callee.property.name) ? callee.property.name : null;
+  }
+  if (isNodeOfType(callee, "Identifier") && callee.name === "getComputedStyle") {
+    return "getComputedStyle";
+  }
+  return null;
+};
+
+// Distinguishes getComputedStyle(el) from getComputedStyle(el, "::before"):
+// only calls with the same pseudo-element selector return the same
+// declaration, so only those can pair. A dynamic selector is
+// incomparable, so the call is skipped entirely (null).
+const layoutReadSignature = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  methodName: string,
+): string | null => {
+  if (methodName !== "getComputedStyle") return methodName;
+  const pseudoElementArgument = call.arguments?.[1];
+  if (!pseudoElementArgument) return methodName;
+  if (isNodeOfType(pseudoElementArgument, "Literal")) {
+    return `${methodName}(${String(pseudoElementArgument.value)})`;
+  }
+  return null;
+};
+
+// Nearest enclosing block, branch arm, or the scope root — two reads
+// only "repeat" when they share the same execution path, so reads in
+// separate branches (blocks, switch cases, ternary arms, unbraced
+// if/else bodies) never group together.
+const enclosingRegion = (node: EsTreeNode, scopeRoot: EsTreeNode): EsTreeNode => {
+  let child: EsTreeNode = node;
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor && cursor !== scopeRoot) {
+    if (isNodeOfType(cursor, "BlockStatement")) return cursor;
+    if (isNodeOfType(cursor, "SwitchCase")) return cursor;
+    if (
+      (isNodeOfType(cursor, "ConditionalExpression") || isNodeOfType(cursor, "IfStatement")) &&
+      (cursor.consequent === child || cursor.alternate === child)
+    ) {
+      return child;
+    }
+    child = cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return scopeRoot;
+};
+
+// The receiver a statement mutates (invalidating any cached layout), or
+// null. Covers `el.scrollTop = 0`, `el.scrollTop++`, and any other
+// method call on the receiver (`el.focus()`, `el.scrollIntoView()`).
+const mutatedReceiverKey = (node: EsTreeNode): string | null => {
+  if (isNodeOfType(node, "AssignmentExpression")) {
+    const left = node.left;
+    if (isNodeOfType(left, "MemberExpression")) return serializeReceiver(left.object);
+    return serializeReceiver(left);
+  }
+  if (isNodeOfType(node, "UpdateExpression")) {
+    const argument = node.argument;
+    if (isNodeOfType(argument, "MemberExpression")) return serializeReceiver(argument.object);
+    return serializeReceiver(argument);
+  }
+  return null;
+};
+
+export const noRepeatedLayoutReadSameElement = defineRule({
+  id: "no-repeated-layout-read-same-element",
+  title: "Repeated layout read on the same element",
+  tags: ["test-noise"],
+  severity: "warn",
+  category: "Performance",
+  recommendation:
+    "Cache the result in a const once (`const rect = el.getBoundingClientRect()`) so the browser only computes layout a single time.",
+  create: (context: RuleContext) => {
+    const inspectScope = (scopeRoot: EsTreeNode): void => {
+      const reads: LayoutRead[] = [];
+      const mutations: ReceiverMutation[] = [];
+      const barrierEnds: number[] = [];
+
+      const visit = (node: EsTreeNode): void => {
+        if (isNodeOfType(node, "AwaitExpression")) {
+          // Any layout can change across an await, so a re-read after it
+          // is a legitimate re-measurement, not a duplicate.
+          barrierEnds.push(rangeEnd(node));
+        }
+        if (isNodeOfType(node, "CallExpression")) {
+          const methodName = layoutReadMethodName(node);
+          const readSignature = methodName ? layoutReadSignature(node, methodName) : null;
+          if (methodName && readSignature) {
+            const receiver = layoutReadReceiver(node);
+            const receiverKey = serializeReceiver(receiver);
+            if (receiverKey) {
+              reads.push({
+                methodName,
+                readSignature,
+                receiverKey,
+                regionNode: enclosingRegion(node, scopeRoot),
+                callNode: node,
+              });
+            }
+          } else if (!methodName) {
+            if (isNodeOfType(node.callee, "MemberExpression")) {
+              // A non-read method call on a receiver invalidates its layout.
+              const mutatedKey = serializeReceiver(node.callee.object);
+              if (mutatedKey)
+                mutations.push({
+                  receiverKey: mutatedKey,
+                  end: rangeEnd(node),
+                });
+            }
+            // A call receiving the element (or a sub-object like
+            // `el.style`) may mutate it — `Object.assign(el.style, …)`,
+            // `applyCollapsedStyles(el)` — so it invalidates the cache.
+            for (const argument of node.arguments ?? []) {
+              const argumentKey = serializeReceiver(argument);
+              if (argumentKey) mutations.push({ receiverKey: argumentKey, end: rangeEnd(node) });
+            }
+          }
+        }
+        const mutatedKey = mutatedReceiverKey(node);
+        if (mutatedKey) mutations.push({ receiverKey: mutatedKey, end: rangeEnd(node) });
+
+        const nodeRecord = node as unknown as Record<string, unknown>;
+        for (const key of Object.keys(nodeRecord)) {
+          if (key === "parent") continue;
+          const child = nodeRecord[key];
+          if (Array.isArray(child)) {
+            for (const item of child) {
+              if (isAstNode(item) && !FUNCTION_LIKE_TYPES.has(item.type)) visit(item);
+            }
+          } else if (isAstNode(child) && !FUNCTION_LIKE_TYPES.has(child.type)) {
+            visit(child);
+          }
+        }
+      };
+      const body = (scopeRoot as unknown as { body?: EsTreeNode | EsTreeNode[] | null }).body;
+      if (Array.isArray(body)) {
+        for (const statement of body) {
+          if (isAstNode(statement) && !FUNCTION_LIKE_TYPES.has(statement.type)) visit(statement);
+        }
+      } else if (isAstNode(body) && !FUNCTION_LIKE_TYPES.has(body.type)) {
+        visit(body);
+      }
+
+      const reportedGroups = new Set<string>();
+      for (let outer = 0; outer < reads.length; outer++) {
+        for (let inner = outer + 1; inner < reads.length; inner++) {
+          const first = reads[outer];
+          const second = reads[inner];
+          if (first.regionNode !== second.regionNode) continue;
+          if (first.receiverKey !== second.receiverKey) continue;
+          if (first.readSignature !== second.readSignature) continue;
+          const groupSignature = `${
+            first.regionNode === scopeRoot ? "root" : rangeStart(first.regionNode)
+          }::${first.receiverKey}::${first.readSignature}`;
+          if (reportedGroups.has(groupSignature)) continue;
+
+          const earlierEnd = Math.min(rangeEnd(first.callNode), rangeEnd(second.callNode));
+          const laterStart = Math.max(rangeStart(first.callNode), rangeStart(second.callNode));
+          // A mutation invalidates the cache when it writes to the receiver
+          // itself, a sub-property of it (`el.style.top = …`), or a parent
+          // of it — any overlap of the access chains. The mutation's END
+          // position orders it: an assignment whose right-hand side contains
+          // the first read still writes after that read completes.
+          const invalidates = (mutatedKey: string): boolean =>
+            mutatedKey === first.receiverKey ||
+            mutatedKey.startsWith(`${first.receiverKey}.`) ||
+            first.receiverKey.startsWith(`${mutatedKey}.`);
+          const hasInterveningMutation = mutations.some(
+            (mutation) =>
+              invalidates(mutation.receiverKey) &&
+              mutation.end >= earlierEnd &&
+              mutation.end <= laterStart,
+          );
+          if (hasInterveningMutation) continue;
+          const hasInterveningBarrier = barrierEnds.some(
+            (barrierEnd) => barrierEnd >= earlierEnd && barrierEnd <= laterStart,
+          );
+          if (hasInterveningBarrier) continue;
+
+          reportedGroups.add(groupSignature);
+          context.report({
+            node: second.callNode,
+            message: `You call ${second.methodName}() on the same element twice here, forcing a second layout reflow. Read it once into a const (const rect = el.${second.methodName}()) and reuse it.`,
+          });
+        }
+      }
+    };
+
+    const handleScope = (node: EsTreeNode): void => inspectScope(node);
+    return {
+      Program: handleScope,
+      FunctionDeclaration: handleScope,
+      FunctionExpression: handleScope,
+      ArrowFunctionExpression: handleScope,
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.ts
@@ -229,9 +229,13 @@ export const noRepeatedLayoutReadSameElement = defineRule({
           if (hasInterveningBarrier) continue;
 
           reportedGroups.add(groupSignature);
+          const cacheExample =
+            second.methodName === "getComputedStyle"
+              ? "const style = getComputedStyle(el)"
+              : "const rect = el.getBoundingClientRect()";
           context.report({
             node: second.callNode,
-            message: `You call ${second.methodName}() on the same element twice here, forcing a second layout reflow. Read it once into a const (const rect = el.${second.methodName}()) and reuse it.`,
+            message: `You call ${second.methodName}() on the same element twice here, forcing a second layout reflow. Read it once into a const (${cacheExample}) and reuse it.`,
           });
         }
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-repeated-layout-read-same-element.ts
@@ -1,10 +1,11 @@
-import { FUNCTION_LIKE_TYPES } from "../../constants/js.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { isAstNode } from "../../utils/is-ast-node.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
 
 // Method-call layout reads that each force a synchronous style/layout
 // flush. Bare property forms (scrollTop/offsetWidth/…) are deliberately
@@ -50,50 +51,53 @@ interface ReceiverMutation {
   end: number;
 }
 
-// The layout-read receiver, or null when the call is not a recognized
-// forced-layout read. For `el.getBoundingClientRect()` the receiver is
-// `el`; for `getComputedStyle(el)` it is the first argument.
-const layoutReadReceiver = (call: EsTreeNodeOfType<"CallExpression">): EsTreeNode | null => {
-  const callee = call.callee;
-  if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
-    if (!isNodeOfType(callee.property, "Identifier")) return null;
-    if (callee.property.name === "getBoundingClientRect") return callee.object;
-    // `window.getComputedStyle(el)` — the element is the argument.
-    if (callee.property.name === "getComputedStyle") return call.arguments?.[0] ?? null;
-    return null;
-  }
-  if (isNodeOfType(callee, "Identifier") && callee.name === "getComputedStyle") {
-    return call.arguments?.[0] ?? null;
-  }
-  return null;
-};
+interface LayoutReadCall {
+  methodName: string;
+  readSignature: string | null;
+  receiver: EsTreeNode | null;
+}
 
-const layoutReadMethodName = (call: EsTreeNodeOfType<"CallExpression">): string | null => {
-  const callee = call.callee;
-  if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
-    return LAYOUT_READ_METHOD_NAMES.has(callee.property.name) ? callee.property.name : null;
-  }
-  if (isNodeOfType(callee, "Identifier") && callee.name === "getComputedStyle") {
-    return "getComputedStyle";
-  }
-  return null;
-};
-
-// Distinguishes getComputedStyle(el) from getComputedStyle(el, "::before"):
-// only calls with the same pseudo-element selector return the same
-// declaration, so only those can pair. A dynamic selector is
-// incomparable, so the call is skipped entirely (null).
-const layoutReadSignature = (
+// Classifies a call as a forced-layout read, or null when it is not one
+// (the caller then treats it as a potential mutation). For
+// `el.getBoundingClientRect()` the receiver is `el`; for
+// `getComputedStyle(el)` it is the first argument. The readSignature
+// distinguishes `getComputedStyle(el)` from `getComputedStyle(el,
+// "::before")`: only calls with the same pseudo-element selector return
+// the same declaration, so only those can pair. A null readSignature
+// (dynamic selector) or null receiver (computed callee) marks the read
+// incomparable — skipped entirely, but still never a mutation.
+const classifyLayoutReadCall = (
   call: EsTreeNodeOfType<"CallExpression">,
-  methodName: string,
-): string | null => {
-  if (methodName !== "getComputedStyle") return methodName;
-  const pseudoElementArgument = call.arguments?.[1];
-  if (!pseudoElementArgument) return methodName;
-  if (isNodeOfType(pseudoElementArgument, "Literal")) {
-    return `${methodName}(${String(pseudoElementArgument.value)})`;
+): LayoutReadCall | null => {
+  const callee = call.callee;
+  let methodName: string | null = null;
+  let receiver: EsTreeNode | null = null;
+  if (
+    isNodeOfType(callee, "MemberExpression") &&
+    isNodeOfType(callee.property, "Identifier") &&
+    LAYOUT_READ_METHOD_NAMES.has(callee.property.name)
+  ) {
+    methodName = callee.property.name;
+    if (!callee.computed) {
+      receiver =
+        methodName === "getBoundingClientRect" ? callee.object : (call.arguments?.[0] ?? null);
+    }
+  } else if (isNodeOfType(callee, "Identifier") && callee.name === "getComputedStyle") {
+    methodName = "getComputedStyle";
+    receiver = call.arguments?.[0] ?? null;
   }
-  return null;
+  if (!methodName) return null;
+
+  let readSignature: string | null = methodName;
+  if (methodName === "getComputedStyle") {
+    const pseudoElementArgument = call.arguments?.[1];
+    if (pseudoElementArgument) {
+      readSignature = isNodeOfType(pseudoElementArgument, "Literal")
+        ? `${methodName}(${String(pseudoElementArgument.value)})`
+        : null;
+    }
+  }
+  return { methodName, readSignature, receiver };
 };
 
 // Nearest enclosing block, branch arm, or the scope root — two reads
@@ -122,17 +126,13 @@ const enclosingRegion = (node: EsTreeNode, scopeRoot: EsTreeNode): EsTreeNode =>
 // null. Covers `el.scrollTop = 0`, `el.scrollTop++`, and any other
 // method call on the receiver (`el.focus()`, `el.scrollIntoView()`).
 const mutatedReceiverKey = (node: EsTreeNode): string | null => {
+  let target: EsTreeNode | null = null;
   if (isNodeOfType(node, "AssignmentExpression")) {
-    const left = node.left;
-    if (isNodeOfType(left, "MemberExpression")) return serializeReceiver(left.object);
-    return serializeReceiver(left);
+    target = isNodeOfType(node.left, "MemberExpression") ? node.left.object : node.left;
+  } else if (isNodeOfType(node, "UpdateExpression")) {
+    target = isNodeOfType(node.argument, "MemberExpression") ? node.argument.object : node.argument;
   }
-  if (isNodeOfType(node, "UpdateExpression")) {
-    const argument = node.argument;
-    if (isNodeOfType(argument, "MemberExpression")) return serializeReceiver(argument.object);
-    return serializeReceiver(argument);
-  }
-  return null;
+  return serializeReceiver(target);
 };
 
 export const noRepeatedLayoutReadSameElement = defineRule({
@@ -149,36 +149,30 @@ export const noRepeatedLayoutReadSameElement = defineRule({
       const mutations: ReceiverMutation[] = [];
       const barrierEnds: number[] = [];
 
-      const visit = (node: EsTreeNode): void => {
+      const recordNode = (node: EsTreeNode): void => {
         if (isNodeOfType(node, "AwaitExpression")) {
           // Any layout can change across an await, so a re-read after it
           // is a legitimate re-measurement, not a duplicate.
           barrierEnds.push(rangeEnd(node));
         }
         if (isNodeOfType(node, "CallExpression")) {
-          const methodName = layoutReadMethodName(node);
-          const readSignature = methodName ? layoutReadSignature(node, methodName) : null;
-          if (methodName && readSignature) {
-            const receiver = layoutReadReceiver(node);
-            const receiverKey = serializeReceiver(receiver);
-            if (receiverKey) {
+          const layoutRead = classifyLayoutReadCall(node);
+          if (layoutRead) {
+            const receiverKey = serializeReceiver(layoutRead.receiver);
+            if (layoutRead.readSignature && receiverKey) {
               reads.push({
-                methodName,
-                readSignature,
+                methodName: layoutRead.methodName,
+                readSignature: layoutRead.readSignature,
                 receiverKey,
                 regionNode: enclosingRegion(node, scopeRoot),
                 callNode: node,
               });
             }
-          } else if (!methodName) {
+          } else {
             if (isNodeOfType(node.callee, "MemberExpression")) {
               // A non-read method call on a receiver invalidates its layout.
               const mutatedKey = serializeReceiver(node.callee.object);
-              if (mutatedKey)
-                mutations.push({
-                  receiverKey: mutatedKey,
-                  end: rangeEnd(node),
-                });
+              if (mutatedKey) mutations.push({ receiverKey: mutatedKey, end: rangeEnd(node) });
             }
             // A call receiving the element (or a sub-object like
             // `el.style`) may mutate it — `Object.assign(el.style, …)`,
@@ -191,27 +185,11 @@ export const noRepeatedLayoutReadSameElement = defineRule({
         }
         const mutatedKey = mutatedReceiverKey(node);
         if (mutatedKey) mutations.push({ receiverKey: mutatedKey, end: rangeEnd(node) });
-
-        const nodeRecord = node as unknown as Record<string, unknown>;
-        for (const key of Object.keys(nodeRecord)) {
-          if (key === "parent") continue;
-          const child = nodeRecord[key];
-          if (Array.isArray(child)) {
-            for (const item of child) {
-              if (isAstNode(item) && !FUNCTION_LIKE_TYPES.has(item.type)) visit(item);
-            }
-          } else if (isAstNode(child) && !FUNCTION_LIKE_TYPES.has(child.type)) {
-            visit(child);
-          }
-        }
       };
-      const body = (scopeRoot as unknown as { body?: EsTreeNode | EsTreeNode[] | null }).body;
-      if (Array.isArray(body)) {
-        for (const statement of body) {
-          if (isAstNode(statement) && !FUNCTION_LIKE_TYPES.has(statement.type)) visit(statement);
-        }
-      } else if (isAstNode(body) && !FUNCTION_LIKE_TYPES.has(body.type)) {
-        visit(body);
+      if (isFunctionLike(scopeRoot)) {
+        walkOwnFunctionScope(scopeRoot, recordNode);
+      } else {
+        walkAst(scopeRoot, (node) => (isFunctionLike(node) ? false : recordNode(node)));
       }
 
       const reportedGroups = new Set<string>();
@@ -259,12 +237,11 @@ export const noRepeatedLayoutReadSameElement = defineRule({
       }
     };
 
-    const handleScope = (node: EsTreeNode): void => inspectScope(node);
     return {
-      Program: handleScope,
-      FunctionDeclaration: handleScope,
-      FunctionExpression: handleScope,
-      ArrowFunctionExpression: handleScope,
+      Program: inspectScope,
+      FunctionDeclaration: inspectScope,
+      FunctionExpression: inspectScope,
+      ArrowFunctionExpression: inspectScope,
     };
   },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-constructed-context-values.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-constructed-context-values.ts
@@ -1,10 +1,8 @@
+import { collectContextBindings } from "../../utils/collect-context-bindings.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
-import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
-import { isAstNode } from "../../utils/is-ast-node.js";
-import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
+import { isContextProviderJsxName } from "../../utils/is-context-provider-jsx-name.js";
 import { isInsideFunctionScope } from "../../utils/is-inside-function-scope.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
@@ -12,11 +10,6 @@ import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const MESSAGE =
   "Every reader of this context redraws on each render because you build its `value` inline.";
-
-// Modules whose `createContext` export has the same identity
-// semantics as React's. Kept in sync with the list in
-// no-create-context-in-render.ts.
-const CONTEXT_MODULES = ["react", "use-context-selector", "react-tracked"];
 
 const isConstructedValue = (expression: EsTreeNode): boolean => {
   const stripped = stripParenExpression(expression);
@@ -39,85 +32,6 @@ const isConstructedValue = (expression: EsTreeNode): boolean => {
     return isConstructedValue(stripped.left) || isConstructedValue(stripped.right);
   }
   return false;
-};
-
-// True for `<XContext.Provider …>` — the legacy provider shape.
-const isProviderMemberName = (node: EsTreeNode): boolean => {
-  if (!isNodeOfType(node, "JSXMemberExpression")) return false;
-  return node.property.name === "Provider";
-};
-
-const isCreateContextCallExpression = (expression: EsTreeNode): boolean => {
-  const stripped = stripParenExpression(expression);
-  if (!isNodeOfType(stripped, "CallExpression")) return false;
-  const callee = stripped.callee;
-  if (isNodeOfType(callee, "Identifier")) {
-    for (const moduleName of CONTEXT_MODULES) {
-      const canonical = getImportedNameFromModule(callee, callee.name, moduleName);
-      if (canonical === "createContext") return true;
-    }
-    return false;
-  }
-  if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
-    const namespaceIdentifier = callee.object;
-    const propertyIdentifier = callee.property;
-    if (!isNodeOfType(namespaceIdentifier, "Identifier")) return false;
-    if (!isNodeOfType(propertyIdentifier, "Identifier")) return false;
-    if (propertyIdentifier.name !== "createContext") return false;
-    if (isCanonicalReactNamespaceName(namespaceIdentifier.name)) return true;
-    for (const moduleName of CONTEXT_MODULES) {
-      const canonical = getImportedNameFromModule(
-        namespaceIdentifier,
-        namespaceIdentifier.name,
-        moduleName,
-      );
-      if (canonical === null) continue;
-      return true;
-    }
-  }
-  return false;
-};
-
-// Collects the set of file-local identifier names that are bound to a
-// `createContext(...)` call (from `react`, `use-context-selector`, or
-// `react-tracked`). Walks only top-level declarators because that's
-// where context objects are conventionally declared; in-render
-// `createContext` is handled by `no-create-context-in-render` and
-// shouldn't be considered "the context" for this rule's purposes.
-const collectContextBindings = (programRoot: EsTreeNode): Set<string> => {
-  const bindings = new Set<string>();
-  if (!isNodeOfType(programRoot, "Program")) return bindings;
-  for (const topLevel of programRoot.body ?? []) {
-    let declaration: EsTreeNode | null = topLevel;
-    if (isNodeOfType(topLevel, "ExportNamedDeclaration") && topLevel.declaration) {
-      declaration = topLevel.declaration as EsTreeNode;
-    }
-    if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) continue;
-    for (const declarator of declaration.declarations ?? []) {
-      if (!isNodeOfType(declarator, "VariableDeclarator")) continue;
-      if (!isNodeOfType(declarator.id, "Identifier")) continue;
-      if (!declarator.init) continue;
-      if (!isAstNode(declarator.init)) continue;
-      if (!isCreateContextCallExpression(declarator.init)) continue;
-      bindings.add(declarator.id.name);
-    }
-  }
-  return bindings;
-};
-
-// True for `<MyContext …>` (React 19 shorthand) when `MyContext` is a
-// known createContext binding in this file AND the JSX identifier
-// resolves to that top-level binding (not a local shadow like a prop
-// or destructured variable with the same name).
-const isCreateContextBindingJsxName = (
-  node: EsTreeNode,
-  contextBindings: ReadonlySet<string>,
-): boolean => {
-  if (!isNodeOfType(node, "JSXIdentifier")) return false;
-  if (!contextBindings.has(node.name)) return false;
-  const binding = findVariableInitializer(node, node.name);
-  if (!binding) return false;
-  return binding.scopeOwner.type === "Program";
 };
 
 // Port of `oxc_linter::rules::react::jsx_no_constructed_context_values`.
@@ -145,14 +59,11 @@ export const jsxNoConstructedContextValues = defineRule({
     let contextBindings: ReadonlySet<string> = new Set<string>();
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
-        contextBindings = collectContextBindings(node as EsTreeNode);
+        contextBindings = collectContextBindings(node);
       },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (isTestlikeFile) return;
-        const nameNode = node.name as EsTreeNode;
-        const isLegacyProvider = isProviderMemberName(nameNode);
-        const isReact19Shorthand = isCreateContextBindingJsxName(nameNode, contextBindings);
-        if (!isLegacyProvider && !isReact19Shorthand) return;
+        if (!isContextProviderJsxName(node.name, contextBindings)) return;
         if (!isInsideFunctionScope(node)) return;
         for (const attribute of node.attributes) {
           if (!isNodeOfType(attribute, "JSXAttribute")) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.test.ts
@@ -54,6 +54,38 @@ describe("no-create-context-in-render", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags createContext through a non-canonical namespace import of a context module", () => {
+    const result = runRule(
+      noCreateContextInRender,
+      `
+      import * as Tracked from "react-tracked";
+
+      function App() {
+        const Ctx = Tracked.createContext(null);
+        return null;
+      }
+    `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags createContext through a non-canonical default import of react", () => {
+    const result = runRule(
+      noCreateContextInRender,
+      `
+      import MyReact from "react";
+
+      function App() {
+        const Ctx = MyReact.createContext(null);
+        return null;
+      }
+    `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags createContext inside a custom hook", () => {
     const result = runRule(
       noCreateContextInRender,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.ts
@@ -1,54 +1,11 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or-hook-name.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import {
-  getImportedNameFromModule,
-  isImportedFromModule,
-} from "../../utils/find-import-source-for-name.js";
-import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isCreateContextCallee } from "../../utils/is-create-context-call.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 const MESSAGE =
   "createContext() builds a new context every render, so every consumer gets cut off & resets.";
-
-// Context-providing modules whose `createContext` export has the same
-// identity-stability semantics as React's. Calling any of these inside
-// a render function disconnects every Provider/Consumer pair on the
-// next render. Add new entries here as they appear in the ecosystem.
-const CONTEXT_MODULES: ReadonlyArray<string> = ["react", "use-context-selector", "react-tracked"];
-
-const isCreateContextCallee = (callee: EsTreeNode): boolean => {
-  if (isNodeOfType(callee, "Identifier")) {
-    // Resolve through any renamed import — `getImportedNameFromModule`
-    // returns the originally-exported symbol name, so we catch both
-    // `import { createContext } from "react"` and
-    // `import { createContext as makeCtx } from "react"`. We accept
-    // any module in `CONTEXT_MODULES`.
-    for (const moduleName of CONTEXT_MODULES) {
-      const canonicalName = getImportedNameFromModule(callee, callee.name, moduleName);
-      if (canonicalName === "createContext") return true;
-    }
-    return false;
-  }
-
-  if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
-    const namespaceIdentifier = callee.object;
-    const propertyIdentifier = callee.property;
-    if (!isNodeOfType(namespaceIdentifier, "Identifier")) return false;
-    if (!isNodeOfType(propertyIdentifier, "Identifier")) return false;
-    if (propertyIdentifier.name !== "createContext") return false;
-    const namespaceName = namespaceIdentifier.name;
-    if (isCanonicalReactNamespaceName(namespaceName)) return true;
-    for (const moduleName of CONTEXT_MODULES) {
-      if (isImportedFromModule(namespaceIdentifier, namespaceName, moduleName)) return true;
-    }
-    return false;
-  }
-
-  return false;
-};
 
 // `createContext()` is identity-keyed: Provider/Consumer pairs match by
 // the exact Context object they were given. Calling it inside a render

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-context-bindings.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-context-bindings.ts
@@ -1,0 +1,28 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isAstNode } from "./is-ast-node.js";
+import { isCreateContextCall } from "./is-create-context-call.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+// Top-level `const X = createContext(...)` binding names — the
+// conventional place context objects are declared, and the shape the
+// React 19 `<X value={…}>` provider shorthand is detected against.
+// In-render `createContext` is `no-create-context-in-render`'s concern.
+export const collectContextBindings = (programRoot: EsTreeNode): Set<string> => {
+  const bindings = new Set<string>();
+  if (!isNodeOfType(programRoot, "Program")) return bindings;
+  for (const topLevel of programRoot.body ?? []) {
+    let declaration: EsTreeNode | null = topLevel;
+    if (isNodeOfType(topLevel, "ExportNamedDeclaration") && topLevel.declaration) {
+      declaration = topLevel.declaration;
+    }
+    if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) continue;
+    for (const declarator of declaration.declarations ?? []) {
+      if (!isNodeOfType(declarator, "VariableDeclarator")) continue;
+      if (!isNodeOfType(declarator.id, "Identifier")) continue;
+      if (!declarator.init || !isAstNode(declarator.init)) continue;
+      if (!isCreateContextCall(declarator.init)) continue;
+      bindings.add(declarator.id.name);
+    }
+  }
+  return bindings;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-context-provider-jsx-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-context-provider-jsx-name.ts
@@ -1,0 +1,17 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { findVariableInitializer } from "./find-variable-initializer.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+// True for the legacy `<XContext.Provider …>` member shape, or the
+// React 19 shorthand `<XContext …>` when the JSX identifier resolves to
+// a top-level createContext binding (not a local shadow like a prop or
+// destructured variable with the same name).
+export const isContextProviderJsxName = (
+  node: EsTreeNode,
+  contextBindings: ReadonlySet<string>,
+): boolean => {
+  if (isNodeOfType(node, "JSXMemberExpression")) return node.property.name === "Provider";
+  if (!isNodeOfType(node, "JSXIdentifier") || !contextBindings.has(node.name)) return false;
+  const binding = findVariableInitializer(node, node.name);
+  return binding?.scopeOwner.type === "Program";
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-create-context-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-create-context-call.ts
@@ -1,0 +1,35 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getImportedNameFromModule } from "./find-import-source-for-name.js";
+import { isCanonicalReactNamespaceName } from "./is-canonical-react-namespace-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+// Modules whose `createContext` export has React's identity semantics.
+const CONTEXT_MODULES = ["react", "use-context-selector", "react-tracked"];
+
+// True when `callee` resolves to such a `createContext`: named-imported
+// (including renamed) from a CONTEXT_MODULES entry, or accessed on the
+// canonical React namespace / a namespace imported from one of them.
+export const isCreateContextCallee = (callee: EsTreeNode): boolean => {
+  if (isNodeOfType(callee, "Identifier")) {
+    return CONTEXT_MODULES.some(
+      (moduleName) =>
+        getImportedNameFromModule(callee, callee.name, moduleName) === "createContext",
+    );
+  }
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  const namespaceIdentifier = callee.object;
+  if (!isNodeOfType(namespaceIdentifier, "Identifier")) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  if (callee.property.name !== "createContext") return false;
+  if (isCanonicalReactNamespaceName(namespaceIdentifier.name)) return true;
+  return CONTEXT_MODULES.some(
+    (moduleName) =>
+      getImportedNameFromModule(namespaceIdentifier, namespaceIdentifier.name, moduleName) !== null,
+  );
+};
+
+export const isCreateContextCall = (expression: EsTreeNode): boolean => {
+  const stripped = stripParenExpression(expression);
+  return isNodeOfType(stripped, "CallExpression") && isCreateContextCallee(stripped.callee);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-create-context-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-create-context-call.ts
@@ -1,5 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
-import { getImportedNameFromModule } from "./find-import-source-for-name.js";
+import { getImportedNameFromModule, isImportedFromModule } from "./find-import-source-for-name.js";
 import { isCanonicalReactNamespaceName } from "./is-canonical-react-namespace-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
@@ -23,9 +23,11 @@ export const isCreateContextCallee = (callee: EsTreeNode): boolean => {
   if (!isNodeOfType(callee.property, "Identifier")) return false;
   if (callee.property.name !== "createContext") return false;
   if (isCanonicalReactNamespaceName(namespaceIdentifier.name)) return true;
-  return CONTEXT_MODULES.some(
-    (moduleName) =>
-      getImportedNameFromModule(namespaceIdentifier, namespaceIdentifier.name, moduleName) !== null,
+  // `isImportedFromModule` (not `getImportedNameFromModule !== null`):
+  // namespace and default imports carry no imported name, but
+  // `Tracked.createContext()` on one is still the real createContext.
+  return CONTEXT_MODULES.some((moduleName) =>
+    isImportedFromModule(namespaceIdentifier, namespaceIdentifier.name, moduleName),
   );
 };
 


### PR DESCRIPTION
Adds three new `Performance` rules to `oxlint-plugin-react-doctor`, targeting wasted work that re-runs on every render (or every layout pass) and that existing rules deliberately don't cover.

> Stacked on the foundation PR (#1000 — package-version detection, SSR capability, shared AST utils). Retargets `main` when that merges.

## Why

This batch catches per-render/per-frame work that silently multiplies: a context `value` rebuilt every render forces every consumer of that context to redraw, an eager `new X()` in a `useState` initializer constructs (and discards, and sometimes leaks — think `new IntersectionObserver(...)`) a fresh instance on every render, and a second `getBoundingClientRect()`/`getComputedStyle()` on the same element forces the browser into a second synchronous layout reflow. The most impactful rule closes the identifier-indirection gap that `jsx-no-constructed-context-values` documents as a pass:

```tsx
// Bad — every ThemeContext consumer redraws on every App render
function App({ theme }) {
  const value = { theme };
  return <ThemeContext.Provider value={value}><Child /></ThemeContext.Provider>;
}

// Good
function App({ theme }) {
  const value = useMemo(() => ({ theme }), [theme]);
  return <ThemeContext.Provider value={value}><Child /></ThemeContext.Provider>;
}
```

## Rules

| Rule | Catches | Notable exemptions |
| --- | --- | --- |
| `context-provider-value-from-unmemoized-local-literal` | A Provider `value` (legacy `<X.Provider>` or React 19 `<X value>` shorthand) bound one hop away to a render-local object/array/function literal, rebuilt every render — the indirection form `jsx-no-constructed-context-values` deliberately passes on. Recognizes `createContext` from `react`, `use-context-selector`, and `react-tracked`. | Values from `useMemo`/`useCallback`/`useState`/`useRef` or member access; module-scope literals; destructured-prop parameter defaults (`{ config = {} }`); bindings allocated once in an outer factory/HOC closure; Providers inside `.map()`/`useMemo` callbacks where a hook can't be added; local shadows of a context name. |
| `no-eager-new-in-use-state-initializer` | `useState(new X())` — the argument is evaluated on every render and thrown away after the first. Targets user-defined class constructors, side-effecting web APIs (`IntersectionObserver`, `AbortController`, `Worker`), and containers rebuilt from call results (`new Map(items.map(...))`); also sees through ternary/logical branches. Fix: `useState(() => new X())`. | Cheap built-in containers and DOM geometry values with constant arguments (`new Set()`, `new Map()`, `new Date()`, `new DOMRect()`, …) — they cost about as much as the lazy closure; the lazy form itself; plain call initializers (owned by `rerender-lazy-state-init`) and `useRef(new X())` (owned by `rerender-lazy-ref-init`); `new` inside setter updater callbacks. |
| `no-repeated-layout-read-same-element` | Two `getBoundingClientRect()` calls (or two `getComputedStyle()` calls with the same pseudo-element selector) on the same receiver, in the same execution region of the same function scope — each read forces a synchronous layout flush. Reports once per group. Fix: cache the first read in a const. | Reads separated by an intervening mutation of the receiver (`el.style.top = …`, `el.focus()`, `Object.assign(el.style, …)`, any helper call receiving the element) or by an `await` (legit re-measurement); reads in different branches/switch cases/ternary arms; different elements; the canonical `getComputedStyle` + `getBoundingClientRect` measure pair; different pseudo-element selectors. Bare property reads (`offsetWidth`, `scrollTop`) are deliberately out of scope as too FP-prone. |

## Validation

Every rule was validated against 67 production OSS repos at pinned SHAs plus 88 reconstructed merged-PR gold solutions. Per-rule sampled hits were judged and adversarially re-verified by two independent reviewers, and the rules went through up to three FP-hardening waves — the exemption columns above (factory-closure bindings, `.map()` render loops, `await` re-measure barriers, constant-argument container seeds) are the direct output of that hardening.

| Rule | Corpus hits (pre-hardening → remaining) | Verdict |
| --- | --- | --- |
| `context-provider-value-from-unmemoized-local-literal` | 53 → 50 | clean-keep (remaining hits judged majority true-positive) |
| `no-eager-new-in-use-state-initializer` | 59 → 1 | needs-narrowing — the further narrowing (constant-argument exemption for cheap built-in/DOM-geometry constructors) ships in this PR with regression tests |
| `no-repeated-layout-read-same-element` | 9 → 3 | clean-keep (remaining hits judged majority true-positive) |

## Test plan

- [x] 65 focused `it()` cases across the three rule test suites (20 + 24 + 21), covering every exemption above with named real-world idioms
- [x] `pnpm typecheck` on `oxlint-plugin-react-doctor`
- [x] `pnpm format:check`
- [x] registry `gen:check` (generated rule registry is in sync)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint rules and internal AST utility refactors; behavior changes are limited to new warnings and slightly broader createContext detection, with heavy regression tests.
> 
> **Overview**
> Adds **three new Performance-category oxlint rules** and wires them into the generated rule registry, with a minor **changeset** for `oxlint-plugin-react-doctor`.
> 
> **`context-provider-value-from-unmemoized-local-literal`** flags Context Provider `value={identifier}` when that identifier is a render-local object/array/function (including React 19 `<Context value={…}>`), complementing **`jsx-no-constructed-context-values`** which only sees inline literals. **`no-eager-new-in-use-state-initializer`** reports `useState(new X())` that runs every render, with exemptions for cheap builtins (`Set`, `Map`, `Date`, `DOMRect`, etc.) and constant arguments. **`no-repeated-layout-read-same-element`** detects duplicate `getBoundingClientRect()` / `getComputedStyle()` on the same element in one execution region, ignoring intervening DOM mutations, `await`, and branch-separated reads.
> 
> Shared **`collectContextBindings`**, **`isContextProviderJsxName`**, and **`isCreateContextCallee`** / **`isCreateContextCall`** replace duplicated logic in **`jsx-no-constructed-context-values`** and **`no-create-context-in-render`**; the latter gains coverage for non-canonical React namespace/default imports. Each rule ships with a large focused test suite encoding corpus-driven false-positive exemptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541de010f8dc285f27bd4362b97a8e6a924334e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->