### PR TITLE
RD-NEW-RR-RULE: react-builtins — 1 rule

### DIFF
--- a/.changeset/rd-new-rules-react-builtins.md
+++ b/.changeset/rd-new-rules-react-builtins.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 1 new react-builtins rules, corpus-validated and FP-hardened

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -60,6 +60,7 @@ import { forbidElements } from "./rules/react-builtins/forbid-elements.js";
 import { forwardRefUsesRef } from "./rules/react-builtins/forward-ref-uses-ref.js";
 import { gitProviderUrlInjectionRisk } from "./rules/security-scan/git-provider-url-injection-risk.js";
 import { headingHasContent } from "./rules/a11y/heading-has-content.js";
+import { hookImportRenameLosesUsePrefix } from "./rules/react-builtins/hook-import-rename-loses-use-prefix.js";
 import { hookUseState } from "./rules/react-builtins/hook-use-state.js";
 import { hooksNoNanInDeps } from "./rules/state-and-effects/hooks-no-nan-in-deps.js";
 import { htmlHasLang } from "./rules/a11y/html-has-lang.js";
@@ -1018,6 +1019,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Accessibility",
       requires: [...new Set(["react", ...(headingHasContent.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/hook-import-rename-loses-use-prefix",
+    id: "hook-import-rename-loses-use-prefix",
+    source: "react-doctor",
+    originallyExternal: true,
+    rule: {
+      ...hookImportRenameLosesUsePrefix,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(hookImportRenameLosesUsePrefix.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/hook-import-rename-loses-use-prefix.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/hook-import-rename-loses-use-prefix.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { hookImportRenameLosesUsePrefix } from "./hook-import-rename-loses-use-prefix.js";
+
+describe("hook-import-rename-loses-use-prefix", () => {
+  it("flags a useQuery alias that drops the use prefix and is called", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useQuery as getProducts } from "@tanstack/react-query";
+       const Products = () => {
+         const products = getProducts();
+         return null;
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useState alias to a lowercase name that is called", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useState as state } from "react";
+       const Counter = () => {
+         const [count, setCount] = state(0);
+         return null;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags each renamed hook in a multi-specifier import when both are called", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useMemo as memoize, useCallback as cb } from "react";
+       const Widget = () => {
+         const value = memoize(() => 1, []);
+         const handler = cb(() => {}, []);
+         return null;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("flags a third-party hook rename that is called", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useFormik as formik } from "formik";
+       const Form = () => {
+         const formikBag = formik({ initialValues: {} });
+         return null;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a local-hooks-module hook rename that is called", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useDebouncedValue as debounced } from "./hooks/useDebouncedValue";
+       const Search = () => {
+         const query = debounced("", 300);
+         return null;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a digit-named hook rename that loses the use prefix (react-div-100vh's use100vh)", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { use100vh as viewportHeight } from "react-div-100vh";
+       const Panel = () => {
+         const height = viewportHeight();
+         return null;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a renamed hook called through an event-handler callback", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useEffect as runEffect } from "react";
+       const App = () => {
+         runEffect(() => {}, []);
+         return null;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an alias that keeps a valid hook name", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useQuery as useProducts } from "@tanstack/react-query";
+       const Products = () => {
+         const products = useProducts();
+         return null;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an alias with a digit after use, which react-hooks still recognises as a hook (use2FA)", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useTwoFactorAuth as use2FA } from "./hooks/use-two-factor-auth";
+       const Settings = () => {
+         const codes = use2FA();
+         return null;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the isomorphic SSR wrapper where the alias is only conditionally reassigned, never called (Radix useLayoutEffect idiom)", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useLayoutEffect as ReactUseLayoutEffect } from "react";
+       const useLayoutEffect = globalThis?.document ? ReactUseLayoutEffect : () => {};
+       export { useLayoutEffect };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a renamed hook alias that is only re-exported, never called (barrel re-export idiom)", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useStore as createStoreHook } from "./store";
+       export default createStoreHook;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a renamed hook alias only passed as an argument, never called (HOC/factory wiring idiom)", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useTheme as themeHook } from "./theme";
+       const withTheme = registerHook(themeHook);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a renamed hook import that is never referenced", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useQuery as getProducts } from "@tanstack/react-query";`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the imported name is not a hook", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { makeRequest as getProducts } from "./api";
+       const products = getProducts();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare `use` export rename, which is not a React hook name in import position (chai's use)", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { use as chaiUse } from "chai";
+       chaiUse(plugin);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a default import (no imported hook name to mismatch)", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import useQuery from "./hooks/useQuery";`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a plain named import with no rename", () => {
+    const result = runRule(hookImportRenameLosesUsePrefix, `import { useState } from "react";`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag imported names that fail /^use[A-Z0-9]/", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useless as helper } from "./util";
+       import { user as currentUser } from "./m";
+       import { used as consumed } from "./flags";
+       helper();
+       currentUser();
+       consumed();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a local reassignment of a hook (not an import specifier)", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `const useThing = something; const renamed = useThing;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a type-only hook import specifier", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { type useThing as thing } from "./hooks";`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a test-file hook alias used to wrap for mocking", () => {
+    const result = runRule(
+      hookImportRenameLosesUsePrefix,
+      `import { useTracking as baseUseTracking } from "react-tracking";
+       const tracking = baseUseTracking();`,
+      { filename: "src/Apps/Auctions/__tests__/MyBids.jest.tsx" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/hook-import-rename-loses-use-prefix.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/hook-import-rename-loses-use-prefix.ts
@@ -1,0 +1,70 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// eslint-plugin-react-hooks and the React Compiler recognise hooks by the
+// `/^use[A-Z0-9]/` naming convention on the call-site identifier (their
+// `isHookName`), so digit names like `use2FA` / `use100vh` count as hooks
+// while `useless` / `user` deliberately fail it. Bare `use` also counts as
+// a hook name for the ALIAS (linting stays on), but not for the IMPORTED
+// name — non-React `use` exports (e.g. chai's) are not hooks.
+const HOOK_NAME_PATTERN = /^use[A-Z0-9]/;
+
+const isRecognizedHookAlias = (name: string): boolean =>
+  name === "use" || HOOK_NAME_PATTERN.test(name);
+
+const isInvokedAsCallee = (identifier: EsTreeNode): boolean => {
+  const parent = identifier.parent;
+  return Boolean(parent && isNodeOfType(parent, "CallExpression") && parent.callee === identifier);
+};
+
+export const hookImportRenameLosesUsePrefix = defineRule({
+  id: "hook-import-rename-loses-use-prefix",
+  title: "Hook import alias drops the use prefix",
+  severity: "warn",
+  category: "Bugs",
+  tags: ["test-noise"],
+  recommendation:
+    "Keep the `use` prefix in the alias (e.g. `useQuery as useProducts`) or import the hook without renaming. Hook linting recognises hooks only by their `use` name at the call site, so dropping the prefix silently turns off rules-of-hooks and exhaustive-deps for it.",
+  create: (context: RuleContext) => ({
+    ImportSpecifier(node: EsTreeNodeOfType<"ImportSpecifier">) {
+      // A type-only hook import can never be called as a hook, so renaming
+      // it changes nothing downstream — skip to avoid noise.
+      if (node.importKind === "type") return;
+      const declaration = node.parent;
+      if (
+        declaration &&
+        isNodeOfType(declaration, "ImportDeclaration") &&
+        declaration.importKind === "type"
+      ) {
+        return;
+      }
+
+      const importedName = getImportedName(node);
+      if (!importedName || !HOOK_NAME_PATTERN.test(importedName)) return;
+
+      const localName = node.local.name;
+      // No rename (or the alias keeps a valid hook name) — still linted.
+      if (localName === importedName || isRecognizedHookAlias(localName)) return;
+
+      // Hook linting is only lost at call sites. An alias that is never
+      // invoked — only reassigned, re-exported, or used as a value (the
+      // Radix SSR-safe useLayoutEffect wrapper idiom) — keeps rules-of-hooks
+      // and exhaustive-deps coverage intact wherever the flow lands.
+      const aliasSymbol = context.scopes.symbolFor(node.local);
+      if (!aliasSymbol) return;
+      const isAliasInvoked = aliasSymbol.references.some((reference) =>
+        isInvokedAsCallee(reference.identifier),
+      );
+      if (!isAliasInvoked) return;
+
+      context.report({
+        node,
+        message: `Renaming the "${importedName}" hook to "${localName}" turns off rules-of-hooks and exhaustive-deps for every call of it, so keep the "use" prefix in the alias.`,
+      });
+    },
+  }),
+});


### PR DESCRIPTION
> **Stacked PR:** this branch is stacked on the foundation PR (#1000 — package-version detection + SSR capability + shared AST utils) and will be retargeted to `main` when it merges.

## Why

`eslint-plugin-react-hooks` and the React Compiler recognize hooks purely by the `/^use[A-Z0-9]/` naming convention at the call site. Renaming a hook in the import specifier so the alias drops the `use` prefix therefore silently disables rules-of-hooks and exhaustive-deps for **every call** of that hook — conditional calls, stale dependency arrays, and calls outside components all go unlinted, with no error anywhere. This batch adds one rule that catches the rename at its source, the import specifier:

```tsx
// Bad: hook linting is silently off for every getProducts() call
import { useQuery as getProducts } from "@tanstack/react-query";
const Products = () => {
  const products = getProducts(); // rules-of-hooks / exhaustive-deps blind here
  return null;
};

// Good: the alias keeps a valid hook name, linting stays on
import { useQuery as useProducts } from "@tanstack/react-query";
```

## Rules

| Rule | Catches | Notable exemptions |
| --- | --- | --- |
| `hook-import-rename-loses-use-prefix` | An `import { useX as y }` specifier where the imported name matches the hook pattern (`/^use[A-Z0-9]/`), the alias does not (and isn't bare `use`), **and** the alias is actually invoked somewhere in the file — reporting that hook linting is turned off for every call of it. | Type-only imports (specifier or declaration); aliases that keep a valid hook name (incl. digit names like `use2FA`); imported names that fail the hook pattern (`useless`, `user`); bare `use` imports (chai's `use` is not a hook); aliases that are never called — only reassigned (the Radix SSR-safe `useLayoutEffect` wrapper idiom), re-exported (barrel files), or passed as a value (HOC/factory wiring); default imports; test files (tagged `test-noise`). |

## Validation

Every rule in this batch was validated against 67 production OSS repos at pinned SHAs plus 88 reconstructed merged-PR gold solutions. Per-rule sampled hits were judged and adversarially re-verified by two independent reviewers, and the rules went through up to three FP-hardening waves.

| Rule | Pre-hardening corpus hits | Remaining hits | Verdict |
| --- | ---: | ---: | --- |
| `hook-import-rename-loses-use-prefix` | 1 | 0 | silent-precise |

The single pre-hardening hit was the isomorphic SSR-wrapper idiom (alias conditionally reassigned, never called); the invoked-as-callee scope check added in hardening eliminates it, so the rule now fires on zero corpus hits **by design** (silent-precise) — it exists to catch a genuine bug shape the corpus happens not to contain.

## Test plan

- 21 focused `it()` cases in `hook-import-rename-loses-use-prefix.test.ts` — 7 invalid shapes (React, third-party, local, digit-named hooks; multi-specifier imports) and 14 exemptions (SSR wrapper, barrel re-export, HOC wiring, type-only, bare `use`, non-hook names, test files).
- Package `typecheck`, `format:check`, and registry `gen:check` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint rule and registry entry only; no runtime or security surface changes, with FP hardening via callee checks and broad test coverage.
> 
> **Overview**
> Adds **`hook-import-rename-loses-use-prefix`**, a new react-builtins lint that warns when a hook is imported with an alias that drops the `use` prefix (e.g. `useQuery as getProducts`) and that alias is **called** in the file—because rules-of-hooks and exhaustive-deps only recognize `/^use[A-Z0-9]/` (and bare `use`) at the call site.
> 
> The rule skips type-only imports, non-hook imported names, aliases that still look like hooks (including `use2FA`), and aliases that are never invoked (SSR `useLayoutEffect` wrappers, barrel re-exports, HOC wiring). It is registered in the generated rule registry, tagged `test-noise`, and ships with a minor changeset plus 21 unit tests covering valid and exempt cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0654addd4683208899450df7eaeed7aa28fc690e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->