### PR TITLE
RD-NEW-RR-RULE: security — 1 rule (window.open without noopener)

### DIFF
--- a/.changeset/rd-new-rules-security.md
+++ b/.changeset/rd-new-rules-security.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 1 new security rules, corpus-validated and FP-hardened

--- a/.changeset/rd-new-rules-security.md
+++ b/.changeset/rd-new-rules-security.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": minor
 ---
 
-feat(rules): add 1 new security rules, corpus-validated and FP-hardened
+feat(rules): add the window-open-without-noopener security rule, corpus-validated and FP-hardened

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -451,6 +451,7 @@ import { urlPrefilledPrivilegedAction } from "./rules/security-scan/url-prefille
 import { useLazyMotion } from "./rules/bundle-size/use-lazy-motion.js";
 import { voidDomElementsNoChildren } from "./rules/react-builtins/void-dom-elements-no-children.js";
 import { webhookSignatureRisk } from "./rules/security-scan/webhook-signature-risk.js";
+import { windowOpenWithoutNoopener } from "./rules/security/window-open-without-noopener.js";
 import { zodV4NoDeprecatedErrorApis } from "./rules/zod/zod-v4-no-deprecated-error-apis.js";
 import { zodV4NoDeprecatedErrorCustomization } from "./rules/zod/zod-v4-no-deprecated-error-customization.js";
 import { zodV4NoDeprecatedSchemaApis } from "./rules/zod/zod-v4-no-deprecated-schema-apis.js";
@@ -5631,6 +5632,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Security",
       tags: [...new Set(["security-scan", ...(webhookSignatureRisk.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/window-open-without-noopener",
+    id: "window-open-without-noopener",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...windowOpenWithoutNoopener,
+      framework: "global",
+      category: "Security",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -104,6 +104,14 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag a mailto: template behind a const binding like the inline form", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "const mailtoUrl = `mailto:${email}?subject=hi`;\nwindow.open(mailtoUrl, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a hardcoded literal destination (Star-on-GitHub button idiom)", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
@@ -181,6 +189,22 @@ describe("window-open-without-noopener", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
       `const url = useMirror ? mirrorUrl : 'https://example.com/download';\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a const && URL whose left operand is statically nullish", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const url = null && dynamicUrl;\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a const && URL with a dynamic right operand", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const url = useMirror && mirrorUrl;\nwindow.open(url, '_blank');`,
     );
     expect(result.diagnostics).toHaveLength(1);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -242,6 +242,27 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag a noopener=value feature entry", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open(url, '_blank', 'noopener=1,width=500');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a feature entry that merely contains noopener as a substring", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank', 'notnoopener');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag features behind a reassignable let binding (opaque at lint time)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `let features = 'width=500';\nfeatures = POPUP_FEATURES;\nwindow.open(url, '_blank', features);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags when a resolvable features constant lacks noopener", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
@@ -261,6 +282,16 @@ describe("window-open-without-noopener", () => {
       `const x = <a onClick={(e) => e.metaKey ? window.open(href, '_blank') : navigate(href)} />;`,
     );
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a window.open in a non-final comma-sequence position", () => {
+    const result = runRule(windowOpenWithoutNoopener, `(window.open(url, '_blank'), undefined);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a comma sequence whose final window.open result is captured", () => {
+    const result = runRule(windowOpenWithoutNoopener, `const win = (log(), window.open(url));`);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag a logical guard whose result is captured", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -319,6 +319,22 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a bare awaited window.open in an async handler", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `async function openIt() { await window.open(url, '_blank'); }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an awaited window.open whose handle is captured", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `async function openIt() { const win = await window.open(url, '_blank'); win?.focus(); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags a void-discarded window.open", () => {
     const result = runRule(windowOpenWithoutNoopener, `void window.open(url, '_blank');`);
     expect(result.diagnostics).toHaveLength(1);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { windowOpenWithoutNoopener } from "./window-open-without-noopener.js";
+
+describe("window-open-without-noopener", () => {
+  it("flags a bare window.open statement with _blank", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank');`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags window.open with a discarded return", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags globalThis.window.open", () => {
+    const result = runRule(windowOpenWithoutNoopener, `globalThis.window.open(url, '_blank');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a concise arrow inside an onClick handler", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const x = <button onClick={() => window.open(externalUrl, '_blank')} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a concise arrow used as a forEach callback", () => {
+    const result = runRule(windowOpenWithoutNoopener, `list.forEach((link) => window.open(link));`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when the handle is bound to a variable", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const win = window.open(url, '_blank'); win?.focus();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the handle is assigned", () => {
+    const result = runRule(windowOpenWithoutNoopener, `let w; w = window.open(url);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the handle is returned", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `function openIt() { return window.open(url); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the handle is immediately used", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url).focus();`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a concise arrow stored in a variable", () => {
+    const result = runRule(windowOpenWithoutNoopener, `const openPopup = () => window.open(url);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag navigating targets", () => {
+    for (const target of ["_self", "_top", "_parent"]) {
+      const result = runRule(windowOpenWithoutNoopener, `window.open(url, '${target}');`);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("does not flag when features already contain noopener", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank', 'noopener');`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when features contain noreferrer", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open(url, '_blank', 'noopener,noreferrer');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a mailto: protocol-handler URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open('mailto:support@appflowy.io', '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a tel: protocol-handler URL", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open('tel:+15551234567');`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a mailto: URL built from a template literal", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`mailto:${email}?subject=hi`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a hardcoded literal destination (Star-on-GitHub button idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open('https://github.com/millionco/react-doctor', '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a same-origin relative URL (print/report route idiom)", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open('/reports/print', '_blank');`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a template with a fixed trusted origin and path-only interpolation", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`https://github.com/${owner}/${repo}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a same-origin template URL (app preview route idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`/preview?id=${documentId}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a const identifier bound to a hardcoded literal URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const docsUrl = 'https://docs.example.com/guide';\nwindow.open(docsUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a const ternary over an origin-pinned template (release-page dialog idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "const releaseUrl = availableVersion ? `https://github.com/owner/repo/releases/tag/v${availableVersion}` : null;\nconst x = <button onClick={() => window.open(releaseUrl, '_blank')} />;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a const chained through another trusted const binding", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const baseUrl = 'https://github.com/owner/repo';\nconst releaseUrl = baseUrl;\nwindow.open(releaseUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a const ternary with one untrusted branch", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const url = useMirror ? mirrorUrl : 'https://example.com/download';\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a let binding even when its initializer is trusted", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `let url = '/safe/route';\nurl = userInput;\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a const holding an awaited API-returned URL (billing-link idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `async function upgrade() {\n  const link = await BillingService.getSubscriptionLink(workspaceId);\n  window.open(link, '_blank');\n}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a hook-destructured URL behind a logical guard (update-checker idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const { releaseUrl } = useUpdateChecker();\nconst x = <button onClick={() => releaseUrl && window.open(releaseUrl, '_blank')} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a member-expression URL from server data (upload-list download idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const onInternalDownload = (file) => {\n  if (file.url) window.open(file.url);\n};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a template whose interpolation sits in the scheme/host position", () => {
+    const result = runRule(windowOpenWithoutNoopener, "window.open(`${baseUrl}/path`, '_blank');");
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a template whose fixed prefix does not terminate the host", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`https://github.com${suffix}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a protocol-relative template URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`//cdn.example.com/${asset}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when features come from a shared constant (popup-helper idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const POPUP_FEATURES = 'noopener,noreferrer';\nwindow.open(url, '_blank', POPUP_FEATURES);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a template features string containing noopener (computed popup size idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(url, '_blank', `noopener,noreferrer,width=${width},height=${height}`);",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when features are opaque at lint time (imported constant idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `import { POPUP_FEATURES } from './popup';\nwindow.open(url, '_blank', POPUP_FEATURES);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags when a resolvable features constant lacks noopener", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const POPUP_FEATURES = 'width=500,height=400';\nwindow.open(url, '_blank', POPUP_FEATURES);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a discarded window.open behind a logical guard", () => {
+    const result = runRule(windowOpenWithoutNoopener, `isExternal && window.open(url, '_blank');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a discarded window.open in a ternary onClick", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const x = <a onClick={(e) => e.metaKey ? window.open(href, '_blank') : navigate(href)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a logical guard whose result is captured", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const win = canOpen && window.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a createElement onClick handler like the JSX equivalent", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `React.createElement('button', { onClick: () => window.open(url, '_blank') });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an arrow under a non-handler object property whose handle may be consumed", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `registerFactory({ createWindow: () => window.open(url, '_blank') });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag other postMessage-style calls", () => {
+    const result = runRule(windowOpenWithoutNoopener, `webview.postMessage(data);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare open() that is not the window global", () => {
+    const result = runRule(windowOpenWithoutNoopener, `open(url, '_blank');`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-window object's open method", () => {
+    const result = runRule(windowOpenWithoutNoopener, `db.open(url);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -133,6 +133,26 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag a nullish URL argument (about:blank stays opener-controlled)", () => {
+    for (const call of [
+      "window.open();",
+      "window.open(null, '_blank');",
+      "window.open(undefined, '_blank');",
+      "window.open(void 0, '_blank');",
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, call);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("does not flag a const URL bound to null", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const fallbackUrl = null;\nwindow.open(fallbackUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a const identifier bound to a hardcoded literal URL", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
@@ -296,6 +316,11 @@ describe("window-open-without-noopener", () => {
       windowOpenWithoutNoopener,
       `const x = <a onClick={(e) => e.metaKey ? window.open(href, '_blank') : navigate(href)} />;`,
     );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a void-discarded window.open", () => {
+    const result = runRule(windowOpenWithoutNoopener, `void window.open(url, '_blank');`);
     expect(result.diagnostics).toHaveLength(1);
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -390,6 +390,43 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a createElement handler under a string-literal onClick key", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `React.createElement('button', { 'onClick': () => window.open(url, '_blank') });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an || URL whose left operand is a truthy trusted literal", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open('https://example.com/download' || dynamicUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a const || URL with a truthy trusted literal left and dynamic fallback", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const url = 'https://example.com/download' || mirrorUrl;\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an || URL whose falsy empty-string left falls through to a dynamic operand", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open('' || dynamicUrl, '_blank');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an || URL whose trusted left is behind a reassignable let binding", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `let primaryUrl = 'https://example.com/download';\nprimaryUrl = userInput;\nwindow.open(primaryUrl || fallbackUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not flag an arrow under a non-handler object property whose handle may be consumed", () => {
     const result = runRule(
       windowOpenWithoutNoopener,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -242,6 +242,21 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("flags an explicitly nullish features argument like an omitted one", () => {
+    for (const features of ["undefined", "null", "void 0"]) {
+      const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank', ${features});`);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not flag a const ternary URL with a void-0 fallback branch", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "const releaseUrl = version ? 'https://github.com/owner/repo' : void 0;\nwindow.open(releaseUrl, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a noopener=value feature entry", () => {
     const result = runRule(
       windowOpenWithoutNoopener,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -123,6 +123,7 @@ const isTrustedDestination = (
         isTrustedOrNullishDestination(urlArgument.right, depth + 1)
       );
     }
+    if (isStaticallyTruthyTrustedDestination(urlArgument.left, depth + 1)) return true;
     return (
       isTrustedOrNullishDestination(urlArgument.left, depth + 1) &&
       isTrustedOrNullishDestination(urlArgument.right, depth + 1)
@@ -140,6 +141,31 @@ const isTrustedOrNullishDestination = (
   urlExpression: EsTreeNode | null | undefined,
   depth: number,
 ): boolean => isNullishExpression(urlExpression) || isTrustedDestination(urlExpression, depth);
+
+// A statically truthy trusted left operand of `||`/`??` short-circuits, so
+// `trustedUrl || dynamicFallback` always opens the trusted destination and
+// the right side never evaluates. Only trusted destinations with nonempty
+// static text qualify — `''` is falsy under `||` and a nullish binding
+// falls through to the right operand under both operators.
+const isStaticallyTruthyTrustedDestination = (
+  urlExpression: EsTreeNode | null | undefined,
+  depth: number,
+): boolean => {
+  if (urlExpression == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+  if (isStringLiteral(urlExpression)) return urlExpression.value.length > 0;
+  if (isNodeOfType(urlExpression, "TemplateLiteral")) {
+    const hasStaticText =
+      urlExpression.quasis?.some((quasi) => (quasi.value?.raw ?? "").length > 0) ?? false;
+    return hasStaticText && isTrustedStaticDestination(urlExpression);
+  }
+  if (isNodeOfType(urlExpression, "Identifier")) {
+    const constInitializer = resolveConstInitializer(urlExpression);
+    return (
+      constInitializer != null && isStaticallyTruthyTrustedDestination(constInitializer, depth + 1)
+    );
+  }
+  return false;
+};
 
 // Best-effort static text of the features argument: string literals,
 // template literals (interpolations resolved when they are local const
@@ -189,9 +215,12 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
     return parent.arguments?.some((argument) => argument === arrow) ?? false;
   }
   if (isNodeOfType(parent, "Property") && parent.value === arrow && !parent.computed) {
-    return (
-      isNodeOfType(parent.key, "Identifier") && EVENT_HANDLER_KEY_PATTERN.test(parent.key.name)
-    );
+    const handlerKeyName = isNodeOfType(parent.key, "Identifier")
+      ? parent.key.name
+      : isStringLiteral(parent.key)
+        ? parent.key.value
+        : null;
+    return handlerKeyName != null && EVENT_HANDLER_KEY_PATTERN.test(handlerKeyName);
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -1,0 +1,263 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+
+const NAVIGATING_TARGETS = new Set(["_self", "_top", "_parent"]);
+
+// Matches `window.open` and `globalThis.window.open` — a non-computed
+// `.open` member off the `window` global. Bare `open(...)` (an
+// `Identifier` callee) and `foo.postMessage`/`webview.open` are not the
+// window global and never match.
+const isWindowOpenCallee = (callee: EsTreeNode): boolean => {
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "open") return false;
+  const object = callee.object;
+  if (isNodeOfType(object, "Identifier")) return object.name === "window";
+  if (isNodeOfType(object, "MemberExpression") && !object.computed) {
+    return (
+      isNodeOfType(object.object, "Identifier") &&
+      object.object.name === "globalThis" &&
+      isNodeOfType(object.property, "Identifier") &&
+      object.property.name === "window"
+    );
+  }
+  return false;
+};
+
+const isStringLiteral = (
+  node: EsTreeNode | null | undefined,
+): node is EsTreeNodeOfType<"Literal"> & { value: string } =>
+  node != null && isNodeOfType(node, "Literal") && typeof node.value === "string";
+
+// `mailto:`/`tel:`/`sms:` hand the URL to an OS protocol handler and never
+// open a navigable browsing context, so no `window.opener` is exposed and
+// there is nothing to reverse-tabnab — flagging them is a false positive.
+const NON_BROWSING_URL_SCHEMES = ["mailto:", "tel:", "sms:"];
+
+const getStaticUrlText = (node: EsTreeNode | null | undefined): string | null => {
+  if (isStringLiteral(node)) return node.value;
+  if (node != null && isNodeOfType(node, "TemplateLiteral")) {
+    return node.quasis?.[0]?.value?.raw ?? null;
+  }
+  return null;
+};
+
+const opensProtocolHandlerOnly = (urlArgument: EsTreeNode | null | undefined): boolean => {
+  const urlText = getStaticUrlText(urlArgument)?.trimStart().toLowerCase();
+  if (urlText == null) return false;
+  return NON_BROWSING_URL_SCHEMES.some((scheme) => urlText.startsWith(scheme));
+};
+
+// A fixed `https://host/` prefix pins the origin: the `[/?#]` terminator
+// after the host guarantees any interpolation lands in the path/query,
+// not the host (`` `https://github.com${x}` `` without it could become
+// `https://github.com.evil.com`).
+const COMPLETE_ORIGIN_PATTERN = /^https?:\/\/[^/?#]+[/?#]/i;
+
+const SAME_ORIGIN_URL_PREFIXES = ["./", "../", "?", "#"];
+
+const startsSameOriginPath = (urlText: string): boolean => {
+  if (urlText.startsWith("/")) return !urlText.startsWith("//");
+  return SAME_ORIGIN_URL_PREFIXES.some((prefix) => urlText.startsWith(prefix));
+};
+
+// Reverse tabnabbing needs an attacker-controlled opened page. A
+// developer-hardcoded string literal, a template whose origin is fixed
+// (interpolations confined to the path/query), or a statically
+// same-origin URL is a trusted-by-construction destination — the
+// dominant real-world idiom ("Star on GitHub" buttons, `/preview?…`
+// export routes) and not worth a warning. Dynamic URLs (identifiers,
+// call results, member accesses, templates interpolating the
+// scheme/host) keep firing.
+const isTrustedStaticDestination = (urlArgument: EsTreeNode | null | undefined): boolean => {
+  if (isStringLiteral(urlArgument)) return true;
+  if (urlArgument == null || !isNodeOfType(urlArgument, "TemplateLiteral")) return false;
+  if ((urlArgument.expressions?.length ?? 0) === 0) return true;
+  const firstQuasiText = (urlArgument.quasis?.[0]?.value?.raw ?? "").trimStart();
+  if (firstQuasiText.length === 0) return false;
+  if (COMPLETE_ORIGIN_PATTERN.test(firstQuasiText)) return true;
+  return startsSameOriginPath(firstQuasiText);
+};
+
+const MAX_BINDING_RESOLUTION_DEPTH = 4;
+
+// A nullish branch (`cond ? url : null`) is harmless: `window.open(null)`
+// opens about:blank, which the opener fully controls.
+const isNullishExpression = (node: EsTreeNode | null | undefined): boolean => {
+  if (node == null) return true;
+  if (isNodeOfType(node, "Literal")) return node.value === null;
+  return isNodeOfType(node, "Identifier") && node.name === "undefined";
+};
+
+// Only a direct `const name = <init>` declarator is safe to resolve —
+// `let`/`var` can be reassigned to attacker-controlled input after the
+// trusted initializer, and destructured/parameter bindings carry a
+// default expression here, not the actual runtime value.
+const resolveConstInitializer = (identifier: EsTreeNodeOfType<"Identifier">): EsTreeNode | null => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (binding?.initializer == null) return null;
+  const declarator = binding.bindingIdentifier.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return null;
+  if (declarator.init !== binding.initializer) return null;
+  const declaration = declarator.parent;
+  if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return null;
+  if (declaration.kind !== "const") return null;
+  return binding.initializer;
+};
+
+// The trusted-by-construction check, extended one binding hop: a local
+// const holding a ternary over origin-pinned templates
+// (releaseUrl = version ? `https://github.com/…/tag/v${version}` : null)
+// is the same trusted destination as an inline one, just behind a name
+// ("open release page" dialogs). Every non-nullish branch of the
+// initializer must itself be trusted; opaque initializers (call results,
+// awaited API responses, hook-destructured values) resolve to nothing
+// and keep firing.
+const isTrustedDestination = (
+  urlArgument: EsTreeNode | null | undefined,
+  depth: number,
+): boolean => {
+  if (isTrustedStaticDestination(urlArgument)) return true;
+  if (urlArgument == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+  if (isNodeOfType(urlArgument, "ConditionalExpression")) {
+    return (
+      isTrustedOrNullishBranch(urlArgument.consequent, depth + 1) &&
+      isTrustedOrNullishBranch(urlArgument.alternate, depth + 1)
+    );
+  }
+  if (isNodeOfType(urlArgument, "LogicalExpression")) {
+    if (urlArgument.operator === "&&") {
+      return isTrustedOrNullishBranch(urlArgument.right, depth + 1);
+    }
+    return (
+      isTrustedOrNullishBranch(urlArgument.left, depth + 1) &&
+      isTrustedOrNullishBranch(urlArgument.right, depth + 1)
+    );
+  }
+  if (isNodeOfType(urlArgument, "Identifier")) {
+    const constInitializer = resolveConstInitializer(urlArgument);
+    if (constInitializer == null) return false;
+    return isTrustedDestination(constInitializer, depth + 1);
+  }
+  return false;
+};
+
+const isTrustedOrNullishBranch = (branch: EsTreeNode | null | undefined, depth: number): boolean =>
+  isNullishExpression(branch) || isTrustedDestination(branch, depth);
+
+// Best-effort static text of the features argument: string literals,
+// template literals (interpolations resolved when they are local const
+// strings, empty otherwise so `noopener,width=${w}` still resolves), and
+// identifiers bound to a resolvable initializer in this file. Returns
+// null when the value is opaque (imported constant, call result), in
+// which case the caller must not assume noopener is absent.
+const resolveStaticStringText = (
+  node: EsTreeNode | null | undefined,
+  depth: number,
+): string | null => {
+  if (node == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return null;
+  if (isStringLiteral(node)) return node.value;
+  if (isNodeOfType(node, "TemplateLiteral")) {
+    const quasiTexts = node.quasis?.map((quasi) => quasi.value?.raw ?? "") ?? [];
+    const expressionTexts =
+      node.expressions?.map((expression) => resolveStaticStringText(expression, depth + 1) ?? "") ??
+      [];
+    return quasiTexts
+      .map((quasiText, quasiIndex) => quasiText + (expressionTexts[quasiIndex] ?? ""))
+      .join("");
+  }
+  if (isNodeOfType(node, "Identifier")) {
+    const binding = findVariableInitializer(node, node.name);
+    if (binding?.initializer == null) return null;
+    return resolveStaticStringText(binding.initializer, depth + 1);
+  }
+  return null;
+};
+
+// The opened handle is captured/used when the arrow that returns it is
+// stored or returned (its eventual return value may be consumed via
+// `getPopup().focus()`), so a concise `() => window.open(...)` is only
+// fire-and-forget when the arrow itself is an event handler (JSX prop or
+// an `onX` property in a props object, whose return React/DOM ignores),
+// a callback argument (forEach/map/addEventListener), or a bare
+// statement.
+const EVENT_HANDLER_KEY_PATTERN = /^on[A-Z]/;
+
+const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
+  const parent = arrow.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "JSXExpressionContainer")) return true;
+  if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isNodeOfType(parent, "CallExpression")) {
+    return parent.arguments?.some((argument) => argument === arrow) ?? false;
+  }
+  if (isNodeOfType(parent, "Property") && parent.value === arrow && !parent.computed) {
+    return (
+      isNodeOfType(parent.key, "Identifier") && EVENT_HANDLER_KEY_PATTERN.test(parent.key.name)
+    );
+  }
+  return false;
+};
+
+// The window handle is discarded (so `noopener`'s null return breaks
+// nothing) when the call is a bare statement, the branch of a
+// guard-shaped logical/ternary that is itself discarded, or the concise
+// body of a discarded arrow. Any capturing parent — VariableDeclarator
+// init, AssignmentExpression right, ReturnStatement arg, a member access
+// on the result, or being passed as a call argument — means the caller
+// wants the handle, so we stay quiet.
+const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
+  const parent = callNode.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isNodeOfType(parent, "LogicalExpression") && parent.right === callNode) {
+    return isDiscardedWindowHandle(parent);
+  }
+  if (
+    isNodeOfType(parent, "ConditionalExpression") &&
+    (parent.consequent === callNode || parent.alternate === callNode)
+  ) {
+    return isDiscardedWindowHandle(parent);
+  }
+  if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === callNode) {
+    return isArrowReturnDiscarded(parent);
+  }
+  return false;
+};
+
+export const windowOpenWithoutNoopener = defineRule({
+  id: "window-open-without-noopener",
+  title: "window.open without noopener",
+  severity: "warn",
+  recommendation:
+    "Pass `'noopener'` in the third features argument of `window.open` so the opened page can't control your tab through `window.opener` or leak the referrer.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isWindowOpenCallee(node.callee)) return;
+      if (!isDiscardedWindowHandle(node)) return;
+
+      const urlArgument = node.arguments?.[0];
+      if (isTrustedDestination(urlArgument, 0)) return;
+      if (opensProtocolHandlerOnly(urlArgument)) return;
+
+      const targetArgument = node.arguments?.[1];
+      if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) return;
+
+      const featuresArgument = node.arguments?.[2];
+      if (featuresArgument != null) {
+        const featuresText = resolveStaticStringText(featuresArgument, 0);
+        if (featuresText == null) return;
+        const features = featuresText.toLowerCase();
+        if (features.includes("noopener") || features.includes("noreferrer")) return;
+      }
+
+      context.report({
+        node,
+        message:
+          "This `window.open` call leaves the opened page able to redirect your tab via `window.opener`, so pass `'noopener'` in the features argument.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -208,7 +208,8 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
 // The window handle is discarded (so `noopener`'s null return breaks
 // nothing) when the call is a bare statement, a `void` operand, the
 // branch of a guard-shaped logical/ternary that is itself discarded, a
-// non-final position in a comma sequence, or the concise
+// non-final position in a comma sequence, an `await` whose own result
+// is discarded, or the concise
 // body of a discarded arrow. Any capturing parent — VariableDeclarator
 // init, AssignmentExpression right, ReturnStatement arg, a member access
 // on the result, or being passed as a call argument — means the caller
@@ -218,6 +219,7 @@ const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
   if (!parent) return false;
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
   if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "void") return true;
+  if (isNodeOfType(parent, "AwaitExpression")) return isDiscardedWindowHandle(parent);
   if (isNodeOfType(parent, "LogicalExpression") && parent.right === callNode) {
     return isDiscardedWindowHandle(parent);
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -88,6 +88,7 @@ const MAX_BINDING_RESOLUTION_DEPTH = 4;
 const isNullishExpression = (node: EsTreeNode | null | undefined): boolean => {
   if (node == null) return true;
   if (isNodeOfType(node, "Literal")) return node.value === null;
+  if (isNodeOfType(node, "UnaryExpression")) return node.operator === "void";
   return isNodeOfType(node, "Identifier") && node.name === "undefined";
 };
 
@@ -252,7 +253,7 @@ export const windowOpenWithoutNoopener = defineRule({
       if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) return;
 
       const featuresArgument = node.arguments?.[2];
-      if (featuresArgument != null) {
+      if (featuresArgument != null && !isNullishExpression(featuresArgument)) {
         const featuresText = resolveStaticStringText(featuresArgument, 0);
         if (featuresText == null) return;
         const featureNames = featuresText

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -83,8 +83,8 @@ const isTrustedStaticDestination = (urlArgument: EsTreeNode | null | undefined):
 
 const MAX_BINDING_RESOLUTION_DEPTH = 4;
 
-// A nullish branch (`cond ? url : null`) is harmless: `window.open(null)`
-// opens about:blank, which the opener fully controls.
+// A nullish URL (`window.open(null)`, `cond ? url : null`) is harmless:
+// it opens about:blank, which the opener fully controls.
 const isNullishExpression = (node: EsTreeNode | null | undefined): boolean => {
   if (node == null) return true;
   if (isNodeOfType(node, "Literal")) return node.value === null;
@@ -124,29 +124,31 @@ const isTrustedDestination = (
   if (urlArgument == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
   if (isNodeOfType(urlArgument, "ConditionalExpression")) {
     return (
-      isTrustedOrNullishBranch(urlArgument.consequent, depth + 1) &&
-      isTrustedOrNullishBranch(urlArgument.alternate, depth + 1)
+      isTrustedOrNullishDestination(urlArgument.consequent, depth + 1) &&
+      isTrustedOrNullishDestination(urlArgument.alternate, depth + 1)
     );
   }
   if (isNodeOfType(urlArgument, "LogicalExpression")) {
     if (urlArgument.operator === "&&") {
-      return isTrustedOrNullishBranch(urlArgument.right, depth + 1);
+      return isTrustedOrNullishDestination(urlArgument.right, depth + 1);
     }
     return (
-      isTrustedOrNullishBranch(urlArgument.left, depth + 1) &&
-      isTrustedOrNullishBranch(urlArgument.right, depth + 1)
+      isTrustedOrNullishDestination(urlArgument.left, depth + 1) &&
+      isTrustedOrNullishDestination(urlArgument.right, depth + 1)
     );
   }
   if (isNodeOfType(urlArgument, "Identifier")) {
     const constInitializer = resolveConstInitializer(urlArgument);
     if (constInitializer == null) return false;
-    return isTrustedDestination(constInitializer, depth + 1);
+    return isTrustedOrNullishDestination(constInitializer, depth + 1);
   }
   return false;
 };
 
-const isTrustedOrNullishBranch = (branch: EsTreeNode | null | undefined, depth: number): boolean =>
-  isNullishExpression(branch) || isTrustedDestination(branch, depth);
+const isTrustedOrNullishDestination = (
+  urlExpression: EsTreeNode | null | undefined,
+  depth: number,
+): boolean => isNullishExpression(urlExpression) || isTrustedDestination(urlExpression, depth);
 
 // Best-effort static text of the features argument: string literals,
 // template literals (interpolations resolved when they are local const
@@ -204,9 +206,9 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
 };
 
 // The window handle is discarded (so `noopener`'s null return breaks
-// nothing) when the call is a bare statement, the branch of a
-// guard-shaped logical/ternary that is itself discarded, a non-final
-// position in a comma sequence, or the concise
+// nothing) when the call is a bare statement, a `void` operand, the
+// branch of a guard-shaped logical/ternary that is itself discarded, a
+// non-final position in a comma sequence, or the concise
 // body of a discarded arrow. Any capturing parent — VariableDeclarator
 // init, AssignmentExpression right, ReturnStatement arg, a member access
 // on the result, or being passed as a call argument — means the caller
@@ -215,6 +217,7 @@ const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
   const parent = callNode.parent;
   if (!parent) return false;
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "void") return true;
   if (isNodeOfType(parent, "LogicalExpression") && parent.right === callNode) {
     return isDiscardedWindowHandle(parent);
   }
@@ -246,7 +249,7 @@ export const windowOpenWithoutNoopener = defineRule({
       if (!isDiscardedWindowHandle(node)) return;
 
       const urlArgument = node.arguments?.[0];
-      if (isTrustedDestination(urlArgument, 0)) return;
+      if (isTrustedOrNullishDestination(urlArgument, 0)) return;
       if (opensProtocolHandlerOnly(urlArgument)) return;
 
       const targetArgument = node.arguments?.[1];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -36,20 +36,6 @@ const isStringLiteral = (
 // there is nothing to reverse-tabnab — flagging them is a false positive.
 const NON_BROWSING_URL_SCHEMES = ["mailto:", "tel:", "sms:"];
 
-const getStaticUrlText = (node: EsTreeNode | null | undefined): string | null => {
-  if (isStringLiteral(node)) return node.value;
-  if (node != null && isNodeOfType(node, "TemplateLiteral")) {
-    return node.quasis?.[0]?.value?.raw ?? null;
-  }
-  return null;
-};
-
-const opensProtocolHandlerOnly = (urlArgument: EsTreeNode | null | undefined): boolean => {
-  const urlText = getStaticUrlText(urlArgument)?.trimStart().toLowerCase();
-  if (urlText == null) return false;
-  return NON_BROWSING_URL_SCHEMES.some((scheme) => urlText.startsWith(scheme));
-};
-
 // A fixed `https://host/` prefix pins the origin: the `[/?#]` terminator
 // after the host guarantees any interpolation lands in the path/query,
 // not the host (`` `https://github.com${x}` `` without it could become
@@ -77,6 +63,8 @@ const isTrustedStaticDestination = (urlArgument: EsTreeNode | null | undefined):
   if ((urlArgument.expressions?.length ?? 0) === 0) return true;
   const firstQuasiText = (urlArgument.quasis?.[0]?.value?.raw ?? "").trimStart();
   if (firstQuasiText.length === 0) return false;
+  const loweredQuasiText = firstQuasiText.toLowerCase();
+  if (NON_BROWSING_URL_SCHEMES.some((scheme) => loweredQuasiText.startsWith(scheme))) return true;
   if (COMPLETE_ORIGIN_PATTERN.test(firstQuasiText)) return true;
   return startsSameOriginPath(firstQuasiText);
 };
@@ -130,7 +118,10 @@ const isTrustedDestination = (
   }
   if (isNodeOfType(urlArgument, "LogicalExpression")) {
     if (urlArgument.operator === "&&") {
-      return isTrustedOrNullishDestination(urlArgument.right, depth + 1);
+      return (
+        isNullishExpression(urlArgument.left) ||
+        isTrustedOrNullishDestination(urlArgument.right, depth + 1)
+      );
     }
     return (
       isTrustedOrNullishDestination(urlArgument.left, depth + 1) &&
@@ -252,7 +243,6 @@ export const windowOpenWithoutNoopener = defineRule({
 
       const urlArgument = node.arguments?.[0];
       if (isTrustedOrNullishDestination(urlArgument, 0)) return;
-      if (opensProtocolHandlerOnly(urlArgument)) return;
 
       const targetArgument = node.arguments?.[1];
       if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -150,7 +150,8 @@ const isTrustedOrNullishBranch = (branch: EsTreeNode | null | undefined, depth: 
 // Best-effort static text of the features argument: string literals,
 // template literals (interpolations resolved when they are local const
 // strings, empty otherwise so `noopener,width=${w}` still resolves), and
-// identifiers bound to a resolvable initializer in this file. Returns
+// identifiers bound to a local const initializer (`let`/`var` can be
+// reassigned after the initializer, so they stay opaque). Returns
 // null when the value is opaque (imported constant, call result), in
 // which case the caller must not assume noopener is absent.
 const resolveStaticStringText = (
@@ -169,9 +170,9 @@ const resolveStaticStringText = (
       .join("");
   }
   if (isNodeOfType(node, "Identifier")) {
-    const binding = findVariableInitializer(node, node.name);
-    if (binding?.initializer == null) return null;
-    return resolveStaticStringText(binding.initializer, depth + 1);
+    const constInitializer = resolveConstInitializer(node);
+    if (constInitializer == null) return null;
+    return resolveStaticStringText(constInitializer, depth + 1);
   }
   return null;
 };
@@ -203,7 +204,8 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
 
 // The window handle is discarded (so `noopener`'s null return breaks
 // nothing) when the call is a bare statement, the branch of a
-// guard-shaped logical/ternary that is itself discarded, or the concise
+// guard-shaped logical/ternary that is itself discarded, a non-final
+// position in a comma sequence, or the concise
 // body of a discarded arrow. Any capturing parent — VariableDeclarator
 // init, AssignmentExpression right, ReturnStatement arg, a member access
 // on the result, or being passed as a call argument — means the caller
@@ -220,6 +222,10 @@ const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
     (parent.consequent === callNode || parent.alternate === callNode)
   ) {
     return isDiscardedWindowHandle(parent);
+  }
+  if (isNodeOfType(parent, "SequenceExpression")) {
+    const finalExpression = parent.expressions?.[parent.expressions.length - 1];
+    return finalExpression !== callNode || isDiscardedWindowHandle(parent);
   }
   if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === callNode) {
     return isArrowReturnDiscarded(parent);
@@ -249,8 +255,11 @@ export const windowOpenWithoutNoopener = defineRule({
       if (featuresArgument != null) {
         const featuresText = resolveStaticStringText(featuresArgument, 0);
         if (featuresText == null) return;
-        const features = featuresText.toLowerCase();
-        if (features.includes("noopener") || features.includes("noreferrer")) return;
+        const featureNames = featuresText
+          .toLowerCase()
+          .split(/[\s,]+/)
+          .map((featureEntry) => featureEntry.split("=")[0]);
+        if (featureNames.some((name) => name === "noopener" || name === "noreferrer")) return;
       }
 
       context.report({


### PR DESCRIPTION
## Why

When `window.open(url, '_blank')` is called without `'noopener'` in the features argument, the opened page receives a live `window.opener` reference back to your tab — an attacker-controlled destination can use it to silently redirect your page (reverse tabnabbing) or read the leaked referrer. This is invisible in normal testing because trusted URLs behave fine; it only bites when the URL is dynamic (server data, user input, API responses).

```tsx
// Bad — opened page can redirect this tab via window.opener
<button onClick={() => window.open(externalUrl, '_blank')} />

// Good — sever the opener link
<button onClick={() => window.open(externalUrl, '_blank', 'noopener')} />
```

## Rules

| Rule | Catches | Notable exemptions |
| --- | --- | --- |
| `window-open-without-noopener` | A fire-and-forget `window.open` / `globalThis.window.open` call whose URL is dynamic and whose features argument lacks `noopener`/`noreferrer` — the opened page keeps a live `window.opener` back-reference | Captured handles (assigned, returned, `.focus()`ed, or arrows stored/returned whose result may be consumed — `noopener` would null the handle); trusted-by-construction URLs: string literals, templates with an origin-pinned `https://host/` prefix or same-origin `/`/`./`/`?`/`#` start, and `const` bindings resolving to those (incl. ternaries with nullish branches, up to 4 hops); `mailto:`/`tel:`/`sms:` protocol handlers; navigating targets `_self`/`_top`/`_parent`; features strings that are opaque at lint time (imported constants) or that statically resolve to contain `noopener`/`noreferrer` |

## Validation

The rule was validated against 67 production OSS repos at pinned SHAs plus 88 reconstructed merged-PR gold solutions. Sampled hits were judged and adversarially re-verified by two independent reviewers, and the rule went through up to three FP-hardening waves. The dominant false-positive classes — hardcoded "Star on GitHub" buttons, same-origin print/preview routes, and `const`-bound trusted URLs — were exempted during hardening, taking corpus hits from 70 to 57.

| Rule | Pre-hardening hits | Remaining hits | Verdict |
| --- | --- | --- | --- |
| `window-open-without-noopener` | 70 | 57 | needs-narrowing |

The `needs-narrowing` verdict means a further narrowing ships in this PR with regression tests: the trusted-destination check now resolves `const` bindings (including ternary/logical branches with nullish arms) and origin-pinned template literals, while dynamic URLs — awaited API responses, hook-destructured values, member accesses on server data, and templates interpolating the scheme/host — keep firing.

## Test plan

- 43 focused `it()` cases in `packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts`, covering the capture/discard analysis, trusted-destination resolution, protocol handlers, navigating targets, and features-string resolution
- Package `typecheck`, `format:check`, and registry `gen:check` pass

## Stacking

Stacked on the foundation PR (#1000 — package-version detection, SSR capability, shared AST utils); retargets `main` when it merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint-only change with no runtime behavior; broad exemptions may miss some risky opens but are covered by tests.
> 
> **Overview**
> Adds a new **Security** oxlint rule `window-open-without-noopener` that warns when fire-and-forget `window.open` / `globalThis.window.open` calls leave a live `window.opener` (missing `noopener`/`noreferrer` in the features string) for dynamic destinations.
> 
> The rule only reports when the returned window handle is discarded (statements, void, event handlers, etc.) and skips cases where the handle is captured or used. It includes FP-hardening: trusted static URLs (literals, origin-pinned templates, same-origin paths), `mailto:`/`tel:`/`sms:`, navigating targets, opaque or statically resolved safe features strings, and limited `const` URL binding resolution.
> 
> Wires the rule into the generated registry and ships a large regression test suite. A minor changeset entry documents the new rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 128b192fdf73d4f613cfed7dc96f9463866f60ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->