### PR TITLE
RD-NEW-RR-RULE: state-and-effects — 17 rules for effect leaks, stale state, and async races

### DIFF
--- a/.changeset/rd-new-rules-state-and-effects.md
+++ b/.changeset/rd-new-rules-state-and-effects.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 17 new state-and-effects rules, corpus-validated and FP-hardened

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -32,6 +32,7 @@ import { autocompleteValid } from "./rules/a11y/autocomplete-valid.js";
 import { buildPipelineSecretBoundary } from "./rules/security-scan/build-pipeline-secret-boundary.js";
 import { buttonHasType } from "./rules/react-builtins/button-has-type.js";
 import { checkedRequiresOnchangeOrReadonly } from "./rules/react-builtins/checked-requires-onchange-or-readonly.js";
+import { classComponentMissingComponentWillUnmountTeardown } from "./rules/state-and-effects/class-component-missing-component-will-unmount-teardown.js";
 import { clickEventsHaveKeyEvents } from "./rules/a11y/click-events-have-key-events.js";
 import { clickjackingRedirectRisk } from "./rules/security-scan/clickjacking-redirect-risk.js";
 import { clientLocalstorageNoVersion } from "./rules/client/client-localstorage-no-version.js";
@@ -41,6 +42,7 @@ import { contextProviderValueFromUnmemoizedLocalLiteral } from "./rules/performa
 import { controlHasAssociatedLabel } from "./rules/a11y/control-has-associated-label.js";
 import { corsCookieTrustRisk } from "./rules/security-scan/cors-cookie-trust-risk.js";
 import { dangerousHtmlSink } from "./rules/security-scan/dangerous-html-sink.js";
+import { debounceNoCleanup } from "./rules/state-and-effects/debounce-no-cleanup.js";
 import { noEmDashInJsxText } from "./rules/react-ui/no-em-dash-in-jsx-text.js";
 import { noRedundantPaddingAxes } from "./rules/react-ui/no-redundant-padding-axes.js";
 import { noRedundantSizeAxes } from "./rules/react-ui/no-redundant-size-axes.js";
@@ -49,7 +51,11 @@ import { noThreePeriodEllipsis } from "./rules/react-ui/no-three-period-ellipsis
 import { noVagueButtonLabel } from "./rules/react-ui/no-vague-button-label.js";
 import { dialogHasAccessibleName } from "./rules/a11y/dialog-has-accessible-name.js";
 import { displayName } from "./rules/react-builtins/display-name.js";
+import { effectListenerCleanupReferenceMismatch } from "./rules/state-and-effects/effect-listener-cleanup-reference-mismatch.js";
 import { effectNeedsCleanup } from "./rules/state-and-effects/effect-needs-cleanup.js";
+import { effectObserverNeedsDisconnect } from "./rules/state-and-effects/effect-observer-needs-disconnect.js";
+import { effectRafLoopNeedsCancel } from "./rules/state-and-effects/effect-raf-loop-needs-cancel.js";
+import { effectRemoveListenerInlineHandler } from "./rules/state-and-effects/effect-remove-listener-inline-handler.js";
 import { exhaustiveDeps } from "./rules/react-builtins/exhaustive-deps.js";
 import { expoNoNonInlinedEnv } from "./rules/react-native/expo-no-non-inlined-env.js";
 import { firebaseClientOwnedAuthzField } from "./rules/security-scan/firebase-client-owned-authz-field.js";
@@ -120,6 +126,7 @@ import { localRpcNativeBridgeRisk } from "./rules/security-scan/local-rpc-native
 import { mcpToolCapabilityRisk } from "./rules/security-scan/mcp-tool-capability-risk.js";
 import { mdxSsrExecutionRisk } from "./rules/security-scan/mdx-ssr-execution-risk.js";
 import { mediaHasCaption } from "./rules/a11y/media-has-caption.js";
+import { mobxReactionDisposerDiscarded } from "./rules/state-and-effects/mobx-reaction-disposer-discarded.js";
 import { mouseEventsHaveKeyEvents } from "./rules/a11y/mouse-events-have-key-events.js";
 import { nextjsAsyncClientComponent } from "./rules/nextjs/nextjs-async-client-component.js";
 import { nextjsErrorBoundaryMissingUseClient } from "./rules/nextjs/nextjs-error-boundary-missing-use-client.js";
@@ -150,8 +157,10 @@ import { noAriaHiddenOnFocusable } from "./rules/a11y/no-aria-hidden-on-focusabl
 import { noArrayIndexAsKey } from "./rules/correctness/no-array-index-as-key.js";
 import { noArrayIndexKey } from "./rules/react-builtins/no-array-index-key.js";
 import { noAsyncEffectCallback } from "./rules/state-and-effects/no-async-effect-callback.js";
+import { noAsyncEventHandlerWithoutReentryGuard } from "./rules/state-and-effects/no-async-event-handler-without-reentry-guard.js";
 import { noAutofocus } from "./rules/a11y/no-autofocus.js";
 import { noBarrelImport } from "./rules/bundle-size/no-barrel-import.js";
+import { noBooleanToggleWithoutFunctionalUpdate } from "./rules/state-and-effects/no-boolean-toggle-without-functional-update.js";
 import { noCallComponentAsFunction } from "./rules/react-builtins/no-call-component-as-function.js";
 import { noCascadingSetState } from "./rules/state-and-effects/no-cascading-set-state.js";
 import { noChainStateUpdates } from "./rules/state-and-effects/no-chain-state-updates.js";
@@ -182,6 +191,7 @@ import { noEffectChain } from "./rules/state-and-effects/no-effect-chain.js";
 import { noEffectEventHandler } from "./rules/state-and-effects/no-effect-event-handler.js";
 import { noEffectEventInDeps } from "./rules/state-and-effects/no-effect-event-in-deps.js";
 import { noEffectWithFreshDeps } from "./rules/state-and-effects/no-effect-with-fresh-deps.js";
+import { noEffectWrapperDiscardsCallbackCleanupReturn } from "./rules/state-and-effects/no-effect-wrapper-discards-callback-cleanup-return.js";
 import { noEval } from "./rules/security/no-eval.js";
 import { noEventHandler } from "./rules/state-and-effects/no-event-handler.js";
 import { noEventTriggerState } from "./rules/state-and-effects/no-event-trigger-state.js";
@@ -210,12 +220,14 @@ import { noLayoutPropertyAnimation } from "./rules/performance/no-layout-propert
 import { noLayoutTransitionInline } from "./rules/design/no-layout-transition-inline.js";
 import { noLegacyClassLifecycles } from "./rules/architecture/no-legacy-class-lifecycles.js";
 import { noLegacyContextApi } from "./rules/architecture/no-legacy-context-api.js";
+import { noLoadingFlagResetOutsideFinally } from "./rules/state-and-effects/no-loading-flag-reset-outside-finally.js";
 import { noLongTransitionDuration } from "./rules/design/no-long-transition-duration.js";
 import { noManyBooleanProps } from "./rules/architecture/no-many-boolean-props.js";
 import { noMirrorPropEffect } from "./rules/state-and-effects/no-mirror-prop-effect.js";
 import { noMoment } from "./rules/bundle-size/no-moment.js";
 import { noMultiComp } from "./rules/react-builtins/no-multi-comp.js";
 import { noMutableInDeps } from "./rules/state-and-effects/no-mutable-in-deps.js";
+import { noMutateThenSetOrReturnSameReference } from "./rules/state-and-effects/no-mutate-then-set-or-return-same-reference.js";
 import { noMutatingReducerState } from "./rules/state-and-effects/no-mutating-reducer-state.js";
 import { noNamespace } from "./rules/react-builtins/no-namespace.js";
 import { noNestedComponentDefinition } from "./rules/architecture/no-nested-component-definition.js";
@@ -228,6 +240,7 @@ import { noPassLiveStateToParent } from "./rules/state-and-effects/no-pass-live-
 import { noPermanentWillChange } from "./rules/performance/no-permanent-will-change.js";
 import { noPolymorphicChildren } from "./rules/correctness/no-polymorphic-children.js";
 import { noPreventDefault } from "./rules/correctness/no-prevent-default.js";
+import { noPromiseThenSideEffectInEffectWithoutCatch } from "./rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.js";
 import { noPropCallbackInEffect } from "./rules/state-and-effects/no-prop-callback-in-effect.js";
 import { noPropTypes } from "./rules/architecture/no-prop-types.js";
 import { noPureBlackBackground } from "./rules/design/no-pure-black-background.js";
@@ -246,9 +259,12 @@ import { noScaleFromZero } from "./rules/performance/no-scale-from-zero.js";
 import { noSecretsInClientCode } from "./rules/security/no-secrets-in-client-code.js";
 import { noSelfUpdatingEffect } from "./rules/state-and-effects/no-self-updating-effect.js";
 import { noSetState } from "./rules/react-builtins/no-set-state.js";
+import { noSetStateAfterAwaitInEffect } from "./rules/state-and-effects/no-set-state-after-await-in-effect.js";
 import { noSetStateInRender } from "./rules/state-and-effects/no-set-state-in-render.js";
+import { noSideEffectInStateUpdaterFunction } from "./rules/state-and-effects/no-side-effect-in-state-updater-function.js";
 import { noSideTabBorder } from "./rules/design/no-side-tab-border.js";
 import { noSpreadAccumulatorInReduce } from "./rules/js-performance/no-spread-accumulator-in-reduce.js";
+import { noSpreadPropsOverDefaultsClobbersWithUndefined } from "./rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.js";
 import { noStaticElementInteractions } from "./rules/a11y/no-static-element-interactions.js";
 import { noStringFalseOnBooleanAttribute } from "./rules/react-builtins/no-string-false-on-boolean-attribute.js";
 import { noStringRefs } from "./rules/react-builtins/no-string-refs.js";
@@ -263,6 +279,7 @@ import { noUnknownProperty } from "./rules/react-builtins/no-unknown-property.js
 import { noUnsafe } from "./rules/react-builtins/no-unsafe.js";
 import { noUnstableNestedComponents } from "./rules/react-builtins/no-unstable-nested-components.js";
 import { noUsememoSimpleExpression } from "./rules/performance/no-usememo-simple-expression.js";
+import { noWholeObjectDepWithMemberReads } from "./rules/state-and-effects/no-whole-object-dep-with-member-reads.js";
 import { noWideLetterSpacing } from "./rules/design/no-wide-letter-spacing.js";
 import { noWillUpdateSetState } from "./rules/react-builtins/no-will-update-set-state.js";
 import { noZIndex9999 } from "./rules/design/no-z-index9999.js";
@@ -695,6 +712,23 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/class-component-missing-component-will-unmount-teardown",
+    id: "class-component-missing-component-will-unmount-teardown",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...classComponentMissingComponentWillUnmountTeardown,
+      framework: "global",
+      category: "Bugs",
+      requires: [
+        ...new Set([
+          "react",
+          ...(classComponentMissingComponentWillUnmountTeardown.requires ?? []),
+        ]),
+      ],
+    },
+  },
+  {
     key: "react-doctor/click-events-have-key-events",
     id: "click-events-have-key-events",
     source: "react-doctor",
@@ -805,6 +839,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/debounce-no-cleanup",
+    id: "debounce-no-cleanup",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...debounceNoCleanup,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(debounceNoCleanup.requires ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/design-no-em-dash-in-jsx-text",
     id: "design-no-em-dash-in-jsx-text",
     source: "react-doctor",
@@ -901,6 +947,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/effect-listener-cleanup-reference-mismatch",
+    id: "effect-listener-cleanup-reference-mismatch",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...effectListenerCleanupReferenceMismatch,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(effectListenerCleanupReferenceMismatch.requires ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/effect-needs-cleanup",
     id: "effect-needs-cleanup",
     source: "react-doctor",
@@ -910,6 +968,42 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(effectNeedsCleanup.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/effect-observer-needs-disconnect",
+    id: "effect-observer-needs-disconnect",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...effectObserverNeedsDisconnect,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(effectObserverNeedsDisconnect.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/effect-raf-loop-needs-cancel",
+    id: "effect-raf-loop-needs-cancel",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...effectRafLoopNeedsCancel,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(effectRafLoopNeedsCancel.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/effect-remove-listener-inline-handler",
+    id: "effect-remove-listener-inline-handler",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...effectRemoveListenerInlineHandler,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(effectRemoveListenerInlineHandler.requires ?? [])])],
     },
   },
   {
@@ -1736,6 +1830,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/mobx-reaction-disposer-discarded",
+    id: "mobx-reaction-disposer-discarded",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...mobxReactionDisposerDiscarded,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(mobxReactionDisposerDiscarded.requires ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/mouse-events-have-key-events",
     id: "mouse-events-have-key-events",
     source: "react-doctor",
@@ -2072,6 +2178,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-async-event-handler-without-reentry-guard",
+    id: "no-async-event-handler-without-reentry-guard",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noAsyncEventHandlerWithoutReentryGuard,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(noAsyncEventHandlerWithoutReentryGuard.requires ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/no-autofocus",
     id: "no-autofocus",
     source: "react-doctor",
@@ -2092,6 +2210,18 @@ export const reactDoctorRules = [
       ...noBarrelImport,
       framework: "global",
       category: "Performance",
+    },
+  },
+  {
+    key: "react-doctor/no-boolean-toggle-without-functional-update",
+    id: "no-boolean-toggle-without-functional-update",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noBooleanToggleWithoutFunctionalUpdate,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(noBooleanToggleWithoutFunctionalUpdate.requires ?? [])])],
     },
   },
   {
@@ -2449,6 +2579,20 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-effect-wrapper-discards-callback-cleanup-return",
+    id: "no-effect-wrapper-discards-callback-cleanup-return",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noEffectWrapperDiscardsCallbackCleanupReturn,
+      framework: "global",
+      category: "Bugs",
+      requires: [
+        ...new Set(["react", ...(noEffectWrapperDiscardsCallbackCleanupReturn.requires ?? [])]),
+      ],
+    },
+  },
+  {
     key: "react-doctor/no-eval",
     id: "no-eval",
     source: "react-doctor",
@@ -2772,6 +2916,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-loading-flag-reset-outside-finally",
+    id: "no-loading-flag-reset-outside-finally",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noLoadingFlagResetOutsideFinally,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(noLoadingFlagResetOutsideFinally.requires ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/no-long-transition-duration",
     id: "no-long-transition-duration",
     source: "react-doctor",
@@ -2838,6 +2994,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(noMutableInDeps.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-mutate-then-set-or-return-same-reference",
+    id: "no-mutate-then-set-or-return-same-reference",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noMutateThenSetOrReturnSameReference,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(noMutateThenSetOrReturnSameReference.requires ?? [])])],
     },
   },
   {
@@ -2980,6 +3148,20 @@ export const reactDoctorRules = [
       ...noPreventDefault,
       framework: "global",
       category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-promise-then-side-effect-in-effect-without-catch",
+    id: "no-promise-then-side-effect-in-effect-without-catch",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noPromiseThenSideEffectInEffectWithoutCatch,
+      framework: "global",
+      category: "Bugs",
+      requires: [
+        ...new Set(["react", ...(noPromiseThenSideEffectInEffectWithoutCatch.requires ?? [])]),
+      ],
     },
   },
   {
@@ -3191,6 +3373,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-set-state-after-await-in-effect",
+    id: "no-set-state-after-await-in-effect",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noSetStateAfterAwaitInEffect,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(noSetStateAfterAwaitInEffect.requires ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/no-set-state-in-render",
     id: "no-set-state-in-render",
     source: "react-doctor",
@@ -3200,6 +3394,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set(["react", ...(noSetStateInRender.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-side-effect-in-state-updater-function",
+    id: "no-side-effect-in-state-updater-function",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noSideEffectInStateUpdaterFunction,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(noSideEffectInStateUpdaterFunction.requires ?? [])])],
     },
   },
   {
@@ -3222,6 +3428,20 @@ export const reactDoctorRules = [
       ...noSpreadAccumulatorInReduce,
       framework: "global",
       category: "Performance",
+    },
+  },
+  {
+    key: "react-doctor/no-spread-props-over-defaults-clobbers-with-undefined",
+    id: "no-spread-props-over-defaults-clobbers-with-undefined",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noSpreadPropsOverDefaultsClobbersWithUndefined,
+      framework: "global",
+      category: "Bugs",
+      requires: [
+        ...new Set(["react", ...(noSpreadPropsOverDefaultsClobbersWithUndefined.requires ?? [])]),
+      ],
     },
   },
   {
@@ -3386,6 +3606,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Performance",
       requires: [...new Set(["react", ...(noUsememoSimpleExpression.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-whole-object-dep-with-member-reads",
+    id: "no-whole-object-dep-with-member-reads",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noWholeObjectDepWithMemberReads,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set(["react", ...(noWholeObjectDepWithMemberReads.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/class-component-missing-component-will-unmount-teardown.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/class-component-missing-component-will-unmount-teardown.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { classComponentMissingComponentWillUnmountTeardown } from "./class-component-missing-component-will-unmount-teardown.js";
+
+describe("class-component-missing-component-will-unmount-teardown", () => {
+  it("flags a componentDidMount that registers a listener on a new instance", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class Legend extends React.Component {
+        componentDidMount() {
+          this.network = new Network(this.container, data, options);
+          this.network.on("beforeDrawing", (ctx) => this.draw(ctx));
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags addEventListener in componentDidMount with no teardown", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends Component {
+        componentDidMount() {
+          window.addEventListener("resize", this.handleResize);
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags setInterval in componentDidMount unconditionally", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class Clock extends React.PureComponent {
+        componentDidMount() {
+          setInterval(() => this.tick(), 1000);
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags setTimeout whose callback calls this.setState", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          setTimeout(() => this.setState({ ready: true }), 500);
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a subscribe registration in the constructor", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        constructor(props) {
+          super(props);
+          this.store = createStore();
+          this.store.subscribe(() => this.forceUpdate());
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a setTimeout that only assigns a plain instance field", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class ProductModal extends React.Component {
+        componentDidMount() {
+          setTimeout(() => (this.readyToHide = true), 500);
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a setTimeout that only nudges focus via a ref", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          setTimeout(() => this.inputRef.current?.focus());
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the class declares componentWillUnmount", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          window.addEventListener("resize", this.handleResize);
+        }
+        componentWillUnmount() {
+          window.removeEventListener("resize", this.handleResize);
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the class uses disposeOnUnmount", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          disposeOnUnmount(this, reaction(() => this.value, () => {}));
+          window.addEventListener("resize", this.handleResize);
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a pure data-fetch mount with no resource to release", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          fetch("/api/data").then((r) => this.setState({ data: r }));
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a new instance with no listener registration", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          this.formatter = new Intl.NumberFormat("en-US");
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags window.setInterval in componentDidMount (TS number-timer-id idiom)", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class Clock extends React.Component {
+        componentDidMount() {
+          this.timer = window.setInterval(() => this.tick(), 1000);
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags addListener on a module-scope emitter (React Native Keyboard idiom)", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          this.subscription = Keyboard.addListener("keyboardDidShow", this.onShow);
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a listener on a local emitter that escapes onto this", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class Legend extends React.Component {
+        componentDidMount() {
+          const network = new Network(this.container, data, options);
+          network.on("beforeDrawing", (ctx) => this.draw(ctx));
+          this.network = network;
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a listener on an emitter constructed locally in the mount body (Algolia places idiom)", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          const autocomplete = places({ container: this.input });
+          autocomplete.on("change", (event) => this.props.onChange(event.suggestion));
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the lodash _.once function-factory idiom in a constructor", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        constructor(props) {
+          super(props);
+          this.trackFirstOpen = _.once(() => trackEvent("open"));
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a self-removing addEventListener with { once: true }", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class C extends React.Component {
+        componentDidMount() {
+          window.addEventListener("load", this.onLoad, { once: true });
+        }
+        render() { return null; }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a plain (non-React) class that registers a listener", () => {
+    const result = runRule(
+      classComponentMissingComponentWillUnmountTeardown,
+      `
+      class Store {
+        componentDidMount() {
+          this.emitter.on("change", this.handle);
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/class-component-missing-component-will-unmount-teardown.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/class-component-missing-component-will-unmount-teardown.ts
@@ -79,12 +79,6 @@ const timeoutCallbackMutatesComponent = (callback: EsTreeNode): boolean => {
   return mutates;
 };
 
-const getMemberChainBase = (node: EsTreeNode): EsTreeNode => {
-  let base = node;
-  while (isNodeOfType(base, "MemberExpression")) base = base.object;
-  return base;
-};
-
 // `addEventListener(..., { once: true })` self-removes after firing, so there
 // is usually nothing left to release on unmount.
 const isOneShotListenerOptions = (optionsArgument: EsTreeNode | undefined): boolean => {
@@ -133,7 +127,8 @@ const isMountHazard = (node: EsTreeNode, localReceiverNames: Set<string>): boole
   ) {
     const callArguments = node.arguments ?? [];
     const isFunctionFactoryOnce = methodName === "once" && callArguments.length < 2;
-    const receiverBase = getMemberChainBase(node.callee.object);
+    let receiverBase = node.callee.object;
+    while (isNodeOfType(receiverBase, "MemberExpression")) receiverBase = receiverBase.object;
     const isLocalReceiver =
       isNodeOfType(receiverBase, "Identifier") && localReceiverNames.has(receiverBase.name);
     const isSelfRemovingListener =
@@ -150,12 +145,9 @@ const isMountHazard = (node: EsTreeNode, localReceiverNames: Set<string>): boole
 };
 
 const getMemberFunctionBody = (member: EsTreeNode): EsTreeNode | null => {
-  if (!isNodeOfType(member, "MethodDefinition") && !isNodeOfType(member, "PropertyDefinition")) {
-    return null;
-  }
-  const value = member.value;
-  if (!value || !isFunctionLike(value)) return null;
-  return value.body ?? null;
+  const isRelevantMember =
+    isNodeOfType(member, "MethodDefinition") || isNodeOfType(member, "PropertyDefinition");
+  return isRelevantMember && isFunctionLike(member.value) ? (member.value.body ?? null) : null;
 };
 
 const getClassMemberName = (member: EsTreeNode): string | null => {
@@ -173,11 +165,9 @@ const getClassMemberName = (member: EsTreeNode): string | null => {
 const classUsesDisposeOnUnmount = (classNode: EsTreeNode): boolean => {
   let found = false;
   walkAst(classNode, (child: EsTreeNode) => {
-    if (found) return false;
-    if (isNodeOfType(child, "Identifier") && child.name === "disposeOnUnmount") {
-      found = true;
-      return false;
-    }
+    if (found || !(isNodeOfType(child, "Identifier") && child.name === "disposeOnUnmount")) return;
+    found = true;
+    return false;
   });
   return found;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/class-component-missing-component-will-unmount-teardown.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/class-component-missing-component-will-unmount-teardown.ts
@@ -1,0 +1,224 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { getCallMethodName } from "../../utils/get-call-method-name.js";
+import { isEs6Component } from "../../utils/is-es6-component.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const MESSAGE =
+  "This class registers a listener or timer on mount but declares no `componentWillUnmount`, so the subscription/timer keeps firing after the component unmounts; release it in `componentWillUnmount`.";
+
+// Listener-registration methods that hand back a resource which must be
+// explicitly removed on unmount. Sound: each has a matching removal API.
+const LISTENER_REGISTRATION_METHODS = new Set([
+  "on",
+  "once",
+  "subscribe",
+  "addEventListener",
+  "addListener",
+]);
+
+const GLOBAL_OBJECT_NAMES = new Set(["window", "globalThis", "global", "self"]);
+
+// Walks a function body without descending into nested functions, so a
+// hazard belongs to the mount body itself (not an event-driven callback).
+const walkMountBody = (functionBody: EsTreeNode, visit: (node: EsTreeNode) => void): void => {
+  walkAst(functionBody, (child: EsTreeNode) => {
+    if (child !== functionBody && isFunctionLike(child)) return false;
+    visit(child);
+  });
+};
+
+const getBareCalleeName = (node: EsTreeNode): string | null => {
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  return isNodeOfType(node.callee, "Identifier") ? node.callee.name : null;
+};
+
+// Timers are registered either bare (`setInterval(...)`) or via the global
+// object (`window.setInterval(...)`, the TS idiom for a `number` timer id).
+const getTimerCalleeName = (node: EsTreeNode): string | null => {
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  const bareName = getBareCalleeName(node);
+  if (bareName) return bareName;
+  if (
+    isNodeOfType(node.callee, "MemberExpression") &&
+    isNodeOfType(node.callee.object, "Identifier") &&
+    GLOBAL_OBJECT_NAMES.has(node.callee.object.name)
+  ) {
+    return getCallMethodName(node.callee);
+  }
+  return null;
+};
+
+// A `setTimeout` is a hazard only when its callback actually mutates the
+// component — `this.setState(...)`, `runInAction(...)`, or any direct
+// `this.<action>(...)` call. A one-shot field write (`this.x = true`) or a
+// ref/focus nudge (`this.inputRef.current?.focus()`) leaks nothing.
+const timeoutCallbackMutatesComponent = (callback: EsTreeNode): boolean => {
+  if (!isFunctionLike(callback)) return false;
+  const body = callback.body;
+  if (!body) return false;
+  let mutates = false;
+  walkMountBody(body, (node) => {
+    if (mutates) return;
+    if (getBareCalleeName(node) === "runInAction") {
+      mutates = true;
+      return;
+    }
+    if (
+      isNodeOfType(node, "CallExpression") &&
+      isNodeOfType(node.callee, "MemberExpression") &&
+      isNodeOfType(node.callee.object, "ThisExpression")
+    ) {
+      mutates = true;
+    }
+  });
+  return mutates;
+};
+
+const getMemberChainBase = (node: EsTreeNode): EsTreeNode => {
+  let base = node;
+  while (isNodeOfType(base, "MemberExpression")) base = base.object;
+  return base;
+};
+
+// `addEventListener(..., { once: true })` self-removes after firing, so there
+// is usually nothing left to release on unmount.
+const isOneShotListenerOptions = (optionsArgument: EsTreeNode | undefined): boolean => {
+  if (!optionsArgument || !isNodeOfType(optionsArgument, "ObjectExpression")) return false;
+  return (optionsArgument.properties ?? []).some(
+    (property: EsTreeNode) =>
+      isNodeOfType(property, "Property") &&
+      !property.computed &&
+      isNodeOfType(property.key, "Identifier") &&
+      property.key.name === "once" &&
+      isNodeOfType(property.value, "Literal") &&
+      property.value.value === true,
+  );
+};
+
+// Variables declared inside the mount body whose values never escape it
+// (never assigned onto `this` or another object): a listener registered on
+// such a locally constructed emitter dies with the component, so it needs
+// no teardown.
+const collectMountLocalReceiverNames = (mountBody: EsTreeNode): Set<string> => {
+  const declaredNames = new Set<string>();
+  const escapedNames = new Set<string>();
+  walkMountBody(mountBody, (node) => {
+    if (isNodeOfType(node, "VariableDeclarator") && isNodeOfType(node.id, "Identifier")) {
+      declaredNames.add(node.id.name);
+    }
+    if (
+      isNodeOfType(node, "AssignmentExpression") &&
+      isNodeOfType(node.left, "MemberExpression") &&
+      isNodeOfType(node.right, "Identifier")
+    ) {
+      escapedNames.add(node.right.name);
+    }
+  });
+  for (const escapedName of escapedNames) declaredNames.delete(escapedName);
+  return declaredNames;
+};
+
+const isMountHazard = (node: EsTreeNode, localReceiverNames: Set<string>): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const methodName = getCallMethodName(node.callee);
+  if (
+    methodName &&
+    LISTENER_REGISTRATION_METHODS.has(methodName) &&
+    isNodeOfType(node.callee, "MemberExpression")
+  ) {
+    const callArguments = node.arguments ?? [];
+    const isFunctionFactoryOnce = methodName === "once" && callArguments.length < 2;
+    const receiverBase = getMemberChainBase(node.callee.object);
+    const isLocalReceiver =
+      isNodeOfType(receiverBase, "Identifier") && localReceiverNames.has(receiverBase.name);
+    const isSelfRemovingListener =
+      methodName === "addEventListener" && isOneShotListenerOptions(callArguments[2]);
+    return !isFunctionFactoryOnce && !isLocalReceiver && !isSelfRemovingListener;
+  }
+
+  const timerCalleeName = getTimerCalleeName(node);
+  if (timerCalleeName === "setInterval") return true;
+  if (timerCalleeName === "setTimeout" && node.arguments?.[0]) {
+    return timeoutCallbackMutatesComponent(node.arguments[0]);
+  }
+  return false;
+};
+
+const getMemberFunctionBody = (member: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(member, "MethodDefinition") && !isNodeOfType(member, "PropertyDefinition")) {
+    return null;
+  }
+  const value = member.value;
+  if (!value || !isFunctionLike(value)) return null;
+  return value.body ?? null;
+};
+
+const getClassMemberName = (member: EsTreeNode): string | null => {
+  if (isNodeOfType(member, "MethodDefinition") && member.kind === "constructor") {
+    return "constructor";
+  }
+  if (!isNodeOfType(member, "MethodDefinition") && !isNodeOfType(member, "PropertyDefinition")) {
+    return null;
+  }
+  return isNodeOfType(member.key, "Identifier") ? member.key.name : null;
+};
+
+// MobX auto-manages teardown when `disposeOnUnmount` is used anywhere in the
+// class, so the missing `componentWillUnmount` is not a leak.
+const classUsesDisposeOnUnmount = (classNode: EsTreeNode): boolean => {
+  let found = false;
+  walkAst(classNode, (child: EsTreeNode) => {
+    if (found) return false;
+    if (isNodeOfType(child, "Identifier") && child.name === "disposeOnUnmount") {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+export const classComponentMissingComponentWillUnmountTeardown = defineRule({
+  id: "class-component-missing-component-will-unmount-teardown",
+  title: "Class component acquires a resource with no teardown",
+  severity: "warn",
+  category: "Bugs",
+  requires: ["react"],
+  recommendation:
+    "Release listeners and timers acquired in `componentDidMount`/`constructor` by adding a `componentWillUnmount` that removes them (or use MobX `disposeOnUnmount`).",
+  create: (context: RuleContext) => ({
+    ClassBody(node: EsTreeNodeOfType<"ClassBody">) {
+      const classNode = node.parent;
+      if (!classNode || !isEs6Component(classNode)) return;
+
+      const members = node.body ?? [];
+      const hasComponentWillUnmount = members.some(
+        (member) => getClassMemberName(member) === "componentWillUnmount",
+      );
+      if (hasComponentWillUnmount) return;
+      if (classUsesDisposeOnUnmount(classNode)) return;
+
+      for (const member of members) {
+        const memberName = getClassMemberName(member);
+        if (memberName !== "constructor" && memberName !== "componentDidMount") continue;
+        const body = getMemberFunctionBody(member);
+        if (!body) continue;
+
+        const localReceiverNames = collectMountLocalReceiverNames(body);
+        let hazardNode: EsTreeNode | null = null;
+        walkMountBody(body, (candidate) => {
+          if (hazardNode) return;
+          if (isMountHazard(candidate, localReceiverNames)) hazardNode = candidate;
+        });
+        if (hazardNode) {
+          context.report({ node: hazardNode, message: MESSAGE });
+          return;
+        }
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/debounce-no-cleanup.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/debounce-no-cleanup.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { debounceNoCleanup } from "./debounce-no-cleanup.js";
+
+const LODASH_DEBOUNCE_IMPORT = `import { debounce, throttle } from 'lodash';\n`;
+
+describe("debounce-no-cleanup", () => {
+  it("flags a useMemo debounce doing async work, driven from an effect, with no cancel cleanup", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          const results = await fetchResults(value);
+          setResults(results);
+        }, 500), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useRef debounce doing DOM work, driven from an effect, with no cancel cleanup", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Input() {
+        const debounced = useRef(debounce((value) => {
+          document.title = value;
+        }, 200));
+        useEffect(() => {
+          debounced.current(value);
+        }, [value]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a throttle variant doing DOM work driven from an effect", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Scroller() {
+        const measure = useMemo(() => throttle(() => {
+          window.requestAnimationFrame(update);
+        }, 100), []);
+        useEffect(() => {
+          measure();
+        }, [measure]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a namespace-imported lodash debounce doing async work driven from an effect", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `import _ from 'lodash';
+      function Search() {
+        const search = useMemo(() => _.debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the standalone lodash.debounce package import", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `import debounce from 'lodash.debounce';
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the lodash-es/debounce subpath import", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `import debounce from 'lodash-es/debounce';
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a debounced named callback resolved through a same-scope binding", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Search() {
+        const runQuery = async (value) => {
+          await fetchResults(value);
+        };
+        const search = useMemo(() => debounce(runQuery, 500), [runQuery]);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when a useEffect cleanup cancels the debounce", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        useEffect(() => () => search.cancel(), [search]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag returning the cancel method reference from an effect (lodash cancel handed off uninvoked)", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        useEffect(() => search.cancel, [search]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag passing the cancel method to react-use's useUnmount", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        useUnmount(search.cancel);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the exhaustive-deps ref-capture cleanup (alias cancelled on unmount)", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Input() {
+        const debounced = useRef(debounce((value) => {
+          document.title = value;
+        }, 200));
+        useEffect(() => {
+          debounced.current(value);
+          const fn = debounced.current;
+          return () => fn.cancel();
+        }, [value]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a custom hook that returns the debounced binding (caller owns the cleanup)", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      export function useDebouncedSearch(setQuery) {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), [setQuery]);
+        useEffect(() => {
+          search(initialQuery);
+        }, [search]);
+        return search;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a custom hook that returns the binding inside an object", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      export function useDebouncedSearch(setQuery) {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), [setQuery]);
+        useEffect(() => {
+          search(initialQuery);
+        }, [search]);
+        return { search };
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a debounced useState-setter commit (a post-unmount setter is a React 18 no-op)", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function ColorPicker() {
+        const [color, setColor] = useState('#fff');
+        const commitColor = useMemo(() => debounce(setColor, 300), []);
+        useEffect(() => {
+          commitColor(draftColor);
+        }, [draftColor, commitColor]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a debounced parent-notification prop callback (benign late callback)", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Slider({ onValueChange }) {
+        const notifyParent = useMemo(() => debounce((value) => {
+          onValueChange(value);
+        }, 200), [onValueChange]);
+        useEffect(() => {
+          notifyParent(value);
+        }, [value, notifyParent]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a debounced handler only wired to render event handlers, not an effect", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), []);
+        return <input onChange={(event) => search(event.target.value)} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an autosave-named debounce where flush, not cancel, is the correct teardown", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Editor({ doc }) {
+        const saveDraft = useMemo(() => debounce(async () => {
+          await api.putDraft(doc);
+        }, 300), [doc]);
+        useEffect(() => {
+          saveDraft();
+        }, [doc, saveDraft]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a debounced body guarded by a null ref early return (unmount-guarded work)", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function HrefPopover() {
+        const reposition = useMemo(() => debounce(() => {
+          if (!paperRef.current) return;
+          window.requestAnimationFrame(update);
+        }, 100), []);
+        useEffect(() => {
+          reposition();
+        }, [reposition]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a leading-edge-only debounce with trailing: false", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500, { trailing: false }), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-lodash custom debounce", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `import { debounce } from './my-utils';
+      function Search() {
+        const search = useMemo(() => debounce(async (value) => {
+          await fetchResults(value);
+        }, 500), []);
+        useEffect(() => {
+          search(query);
+        }, [query, search]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a module-scope debounce outside a hook", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      const search = debounce(setQuery, 500);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the debounce result is not assigned to a binding", () => {
+    const result = runRule(
+      debounceNoCleanup,
+      `${LODASH_DEBOUNCE_IMPORT}
+      function Search() {
+        useMemo(() => debounce(setQuery, 500), []);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/debounce-no-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/debounce-no-cleanup.ts
@@ -1,12 +1,15 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { subtreeReferencesIdentifierName } from "../../utils/subtree-references-identifier-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { findEnclosingFunction } from "./utils/find-enclosing-function.js";
 
 const DEBOUNCE_WRAPPER_HOOK_NAMES = new Set(["useMemo", "useCallback", "useRef"]);
 const DEBOUNCE_FACTORY_NAMES = new Set(["debounce", "throttle"]);
@@ -20,21 +23,14 @@ type FunctionEsTreeNode = EsTreeNodeOfType<
   "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration"
 >;
 
-const isFunctionNode = (node: EsTreeNode): node is FunctionEsTreeNode =>
-  isNodeOfType(node, "ArrowFunctionExpression") ||
-  isNodeOfType(node, "FunctionExpression") ||
-  isNodeOfType(node, "FunctionDeclaration");
-
 const isLodashModuleSource = (source: string | null): boolean =>
-  Boolean(
-    source &&
-    (source === "lodash" ||
-      source === "lodash-es" ||
-      source === "lodash.debounce" ||
-      source === "lodash.throttle" ||
-      source.startsWith("lodash/") ||
-      source.startsWith("lodash-es/")),
-  );
+  source !== null &&
+  (source === "lodash" ||
+    source === "lodash-es" ||
+    source === "lodash.debounce" ||
+    source === "lodash.throttle" ||
+    source.startsWith("lodash/") ||
+    source.startsWith("lodash-es/"));
 
 const isLodashDebounceCall = (callExpression: EsTreeNode): boolean => {
   if (!isNodeOfType(callExpression, "CallExpression")) return false;
@@ -96,30 +92,6 @@ const hasTrailingFalseOption = (debounceCall: EsTreeNode): boolean => {
   );
 };
 
-const subtreeReferencesAnyName = (node: EsTreeNode, names: ReadonlySet<string>): boolean => {
-  let didReference = false;
-  walkAst(node, (child: EsTreeNode) => {
-    if (didReference) return false;
-    if (isNodeOfType(child, "Identifier") && names.has(child.name)) {
-      didReference = true;
-      return false;
-    }
-  });
-  return didReference;
-};
-
-const subtreeReferencesName = (node: EsTreeNode, bindingName: string): boolean =>
-  subtreeReferencesAnyName(node, new Set([bindingName]));
-
-const findEnclosingFunction = (node: EsTreeNode): EsTreeNode | null => {
-  let cursor: EsTreeNode | null = node.parent ?? null;
-  while (cursor) {
-    if (isFunctionNode(cursor)) return cursor;
-    cursor = cursor.parent ?? null;
-  }
-  return null;
-};
-
 const collectBindingAliasNames = (searchRoot: EsTreeNode, bindingName: string): Set<string> => {
   const aliasNames = new Set([bindingName]);
   let didGrow = true;
@@ -131,7 +103,7 @@ const collectBindingAliasNames = (searchRoot: EsTreeNode, bindingName: string): 
       if (aliasNames.has(child.id.name)) return;
       const initializer = stripParenExpression(child.init);
       if (isNodeOfType(initializer, "CallExpression")) return;
-      if (subtreeReferencesAnyName(initializer, aliasNames)) {
+      if (subtreeReferencesIdentifierName(initializer, aliasNames)) {
         aliasNames.add(child.id.name);
         didGrow = true;
       }
@@ -147,7 +119,7 @@ const hasReleaseForBinding = (searchRoot: EsTreeNode, aliasNames: ReadonlySet<st
     if (!isNodeOfType(child, "MemberExpression") || child.computed) return;
     if (!isNodeOfType(child.property, "Identifier")) return;
     if (!DEBOUNCE_RELEASE_METHOD_NAMES.has(child.property.name)) return;
-    if (subtreeReferencesAnyName(child.object, aliasNames)) {
+    if (subtreeReferencesIdentifierName(child.object, aliasNames)) {
       didRelease = true;
       return false;
     }
@@ -167,7 +139,7 @@ const escapesViaReturn = (enclosingFunction: EsTreeNode, bindingName: string): b
     }
     if (
       (isNodeOfType(returned, "ObjectExpression") || isNodeOfType(returned, "ArrayExpression")) &&
-      subtreeReferencesName(returned, bindingName)
+      subtreeReferencesIdentifierName(returned, bindingName)
     ) {
       didEscape = true;
       return false;
@@ -188,11 +160,11 @@ const isInvokedInsideEffectCallback = (
     const effectArgument = child.arguments?.[0];
     if (!effectArgument) return;
     const effectCallback = stripParenExpression(effectArgument);
-    if (!isFunctionNode(effectCallback)) return;
+    if (!isFunctionLike(effectCallback)) return;
     walkAst(effectCallback, (inner: EsTreeNode) => {
       if (didInvoke) return false;
       if (!isNodeOfType(inner, "CallExpression")) return;
-      if (subtreeReferencesName(inner.callee, bindingName)) {
+      if (subtreeReferencesIdentifierName(inner.callee, bindingName)) {
         didInvoke = true;
         return false;
       }
@@ -209,7 +181,7 @@ const resolveWrappedCallbackFunction = (
   const wrappedArgument = debounceCall.arguments?.[0];
   if (!wrappedArgument) return null;
   const strippedArgument = stripParenExpression(wrappedArgument);
-  if (isFunctionNode(strippedArgument)) return strippedArgument;
+  if (isFunctionLike(strippedArgument)) return strippedArgument;
   if (!isNodeOfType(strippedArgument, "Identifier")) return null;
   const wrappedName = strippedArgument.name;
   let resolvedFunction: FunctionEsTreeNode | null = null;
@@ -226,14 +198,14 @@ const resolveWrappedCallbackFunction = (
       child.init
     ) {
       const initializer = stripParenExpression(child.init);
-      if (isFunctionNode(initializer)) {
+      if (isFunctionLike(initializer)) {
         resolvedFunction = initializer;
         return false;
       }
       if (isHookCall(initializer, "useCallback") && isNodeOfType(initializer, "CallExpression")) {
         const callbackArgument = initializer.arguments?.[0];
         const strippedCallback = callbackArgument ? stripParenExpression(callbackArgument) : null;
-        if (strippedCallback && isFunctionNode(strippedCallback)) {
+        if (strippedCallback && isFunctionLike(strippedCallback)) {
           resolvedFunction = strippedCallback;
           return false;
         }
@@ -241,14 +213,6 @@ const resolveWrappedCallbackFunction = (
     }
   });
   return resolvedFunction;
-};
-
-const isPropertyNamePosition = (node: EsTreeNode): boolean => {
-  const parent = node.parent;
-  if (isNodeOfType(parent, "MemberExpression") && !parent.computed && parent.property === node) {
-    return true;
-  }
-  return isNodeOfType(parent, "Property") && !parent.computed && parent.key === node;
 };
 
 const hasAsyncOrDomWork = (wrappedFunction: FunctionEsTreeNode): boolean => {
@@ -260,10 +224,16 @@ const hasAsyncOrDomWork = (wrappedFunction: FunctionEsTreeNode): boolean => {
       didFindWork = true;
       return false;
     }
+    const parent = child.parent;
     if (
       isNodeOfType(child, "Identifier") &&
       BROWSER_GLOBAL_NAMES.has(child.name) &&
-      !isPropertyNamePosition(child)
+      !(
+        isNodeOfType(parent, "MemberExpression") &&
+        !parent.computed &&
+        parent.property === child
+      ) &&
+      !(isNodeOfType(parent, "Property") && !parent.computed && parent.key === child)
     ) {
       didFindWork = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/debounce-no-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/debounce-no-cleanup.ts
@@ -1,0 +1,360 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const DEBOUNCE_WRAPPER_HOOK_NAMES = new Set(["useMemo", "useCallback", "useRef"]);
+const DEBOUNCE_FACTORY_NAMES = new Set(["debounce", "throttle"]);
+const DEBOUNCE_RELEASE_METHOD_NAMES = new Set(["cancel", "flush"]);
+const EFFECT_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect"]);
+const BROWSER_GLOBAL_NAMES = new Set(["document", "window"]);
+const PROMISE_CHAIN_METHOD_NAMES = new Set(["then", "catch", "finally"]);
+const SAVE_LIKE_BINDING_NAME_PATTERN = /save|persist|submit|commit|sync/i;
+
+type FunctionEsTreeNode = EsTreeNodeOfType<
+  "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration"
+>;
+
+const isFunctionNode = (node: EsTreeNode): node is FunctionEsTreeNode =>
+  isNodeOfType(node, "ArrowFunctionExpression") ||
+  isNodeOfType(node, "FunctionExpression") ||
+  isNodeOfType(node, "FunctionDeclaration");
+
+const isLodashModuleSource = (source: string | null): boolean =>
+  Boolean(
+    source &&
+    (source === "lodash" ||
+      source === "lodash-es" ||
+      source === "lodash.debounce" ||
+      source === "lodash.throttle" ||
+      source.startsWith("lodash/") ||
+      source.startsWith("lodash-es/")),
+  );
+
+const isLodashDebounceCall = (callExpression: EsTreeNode): boolean => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
+  const callee = callExpression.callee;
+  if (isNodeOfType(callee, "Identifier")) {
+    if (!DEBOUNCE_FACTORY_NAMES.has(callee.name)) return false;
+    return isLodashModuleSource(getImportSourceForName(callee, callee.name));
+  }
+  if (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier") &&
+    DEBOUNCE_FACTORY_NAMES.has(callee.property.name) &&
+    isNodeOfType(callee.object, "Identifier")
+  ) {
+    const receiverSource = getImportSourceForName(callee.object, callee.object.name);
+    return isLodashModuleSource(receiverSource);
+  }
+  return false;
+};
+
+const findDebounceCallInHookInitializer = (hookCall: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(hookCall, "CallExpression")) return null;
+  const firstArgument = hookCall.arguments?.[0];
+  if (!firstArgument) return null;
+  const strippedArgument = stripParenExpression(firstArgument);
+  if (isLodashDebounceCall(strippedArgument)) return strippedArgument;
+  if (
+    !isNodeOfType(strippedArgument, "ArrowFunctionExpression") &&
+    !isNodeOfType(strippedArgument, "FunctionExpression")
+  ) {
+    return null;
+  }
+  if (!isNodeOfType(strippedArgument.body, "BlockStatement")) {
+    const returned = stripParenExpression(strippedArgument.body);
+    return isLodashDebounceCall(returned) ? returned : null;
+  }
+  for (const statement of strippedArgument.body.body ?? []) {
+    if (isNodeOfType(statement, "ReturnStatement") && statement.argument) {
+      const returned = stripParenExpression(statement.argument);
+      if (isLodashDebounceCall(returned)) return returned;
+    }
+  }
+  return null;
+};
+
+const hasTrailingFalseOption = (debounceCall: EsTreeNode): boolean => {
+  if (!isNodeOfType(debounceCall, "CallExpression")) return false;
+  const optionsArgument = debounceCall.arguments?.[2];
+  if (!optionsArgument || !isNodeOfType(optionsArgument, "ObjectExpression")) return false;
+  return (optionsArgument.properties ?? []).some(
+    (property) =>
+      isNodeOfType(property, "Property") &&
+      !property.computed &&
+      isNodeOfType(property.key, "Identifier") &&
+      property.key.name === "trailing" &&
+      isNodeOfType(property.value, "Literal") &&
+      property.value.value === false,
+  );
+};
+
+const subtreeReferencesAnyName = (node: EsTreeNode, names: ReadonlySet<string>): boolean => {
+  let didReference = false;
+  walkAst(node, (child: EsTreeNode) => {
+    if (didReference) return false;
+    if (isNodeOfType(child, "Identifier") && names.has(child.name)) {
+      didReference = true;
+      return false;
+    }
+  });
+  return didReference;
+};
+
+const subtreeReferencesName = (node: EsTreeNode, bindingName: string): boolean =>
+  subtreeReferencesAnyName(node, new Set([bindingName]));
+
+const findEnclosingFunction = (node: EsTreeNode): EsTreeNode | null => {
+  let cursor: EsTreeNode | null = node.parent ?? null;
+  while (cursor) {
+    if (isFunctionNode(cursor)) return cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+const collectBindingAliasNames = (searchRoot: EsTreeNode, bindingName: string): Set<string> => {
+  const aliasNames = new Set([bindingName]);
+  let didGrow = true;
+  while (didGrow) {
+    didGrow = false;
+    walkAst(searchRoot, (child: EsTreeNode) => {
+      if (!isNodeOfType(child, "VariableDeclarator")) return;
+      if (!isNodeOfType(child.id, "Identifier") || !child.init) return;
+      if (aliasNames.has(child.id.name)) return;
+      const initializer = stripParenExpression(child.init);
+      if (isNodeOfType(initializer, "CallExpression")) return;
+      if (subtreeReferencesAnyName(initializer, aliasNames)) {
+        aliasNames.add(child.id.name);
+        didGrow = true;
+      }
+    });
+  }
+  return aliasNames;
+};
+
+const hasReleaseForBinding = (searchRoot: EsTreeNode, aliasNames: ReadonlySet<string>): boolean => {
+  let didRelease = false;
+  walkAst(searchRoot, (child: EsTreeNode) => {
+    if (didRelease) return false;
+    if (!isNodeOfType(child, "MemberExpression") || child.computed) return;
+    if (!isNodeOfType(child.property, "Identifier")) return;
+    if (!DEBOUNCE_RELEASE_METHOD_NAMES.has(child.property.name)) return;
+    if (subtreeReferencesAnyName(child.object, aliasNames)) {
+      didRelease = true;
+      return false;
+    }
+  });
+  return didRelease;
+};
+
+const escapesViaReturn = (enclosingFunction: EsTreeNode, bindingName: string): boolean => {
+  let didEscape = false;
+  walkAst(enclosingFunction, (child: EsTreeNode) => {
+    if (didEscape) return false;
+    if (!isNodeOfType(child, "ReturnStatement") || !child.argument) return;
+    const returned = stripParenExpression(child.argument);
+    if (isNodeOfType(returned, "Identifier") && returned.name === bindingName) {
+      didEscape = true;
+      return false;
+    }
+    if (
+      (isNodeOfType(returned, "ObjectExpression") || isNodeOfType(returned, "ArrayExpression")) &&
+      subtreeReferencesName(returned, bindingName)
+    ) {
+      didEscape = true;
+      return false;
+    }
+  });
+  return didEscape;
+};
+
+const isInvokedInsideEffectCallback = (
+  enclosingFunction: EsTreeNode,
+  bindingName: string,
+): boolean => {
+  let didInvoke = false;
+  walkAst(enclosingFunction, (child: EsTreeNode) => {
+    if (didInvoke) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (!isHookCall(child, EFFECT_HOOK_NAMES)) return;
+    const effectArgument = child.arguments?.[0];
+    if (!effectArgument) return;
+    const effectCallback = stripParenExpression(effectArgument);
+    if (!isFunctionNode(effectCallback)) return;
+    walkAst(effectCallback, (inner: EsTreeNode) => {
+      if (didInvoke) return false;
+      if (!isNodeOfType(inner, "CallExpression")) return;
+      if (subtreeReferencesName(inner.callee, bindingName)) {
+        didInvoke = true;
+        return false;
+      }
+    });
+  });
+  return didInvoke;
+};
+
+const resolveWrappedCallbackFunction = (
+  debounceCall: EsTreeNode,
+  enclosingFunction: EsTreeNode,
+): FunctionEsTreeNode | null => {
+  if (!isNodeOfType(debounceCall, "CallExpression")) return null;
+  const wrappedArgument = debounceCall.arguments?.[0];
+  if (!wrappedArgument) return null;
+  const strippedArgument = stripParenExpression(wrappedArgument);
+  if (isFunctionNode(strippedArgument)) return strippedArgument;
+  if (!isNodeOfType(strippedArgument, "Identifier")) return null;
+  const wrappedName = strippedArgument.name;
+  let resolvedFunction: FunctionEsTreeNode | null = null;
+  walkAst(enclosingFunction, (child: EsTreeNode) => {
+    if (resolvedFunction) return false;
+    if (isNodeOfType(child, "FunctionDeclaration") && child.id?.name === wrappedName) {
+      resolvedFunction = child;
+      return false;
+    }
+    if (
+      isNodeOfType(child, "VariableDeclarator") &&
+      isNodeOfType(child.id, "Identifier") &&
+      child.id.name === wrappedName &&
+      child.init
+    ) {
+      const initializer = stripParenExpression(child.init);
+      if (isFunctionNode(initializer)) {
+        resolvedFunction = initializer;
+        return false;
+      }
+      if (isHookCall(initializer, "useCallback") && isNodeOfType(initializer, "CallExpression")) {
+        const callbackArgument = initializer.arguments?.[0];
+        const strippedCallback = callbackArgument ? stripParenExpression(callbackArgument) : null;
+        if (strippedCallback && isFunctionNode(strippedCallback)) {
+          resolvedFunction = strippedCallback;
+          return false;
+        }
+      }
+    }
+  });
+  return resolvedFunction;
+};
+
+const isPropertyNamePosition = (node: EsTreeNode): boolean => {
+  const parent = node.parent;
+  if (isNodeOfType(parent, "MemberExpression") && !parent.computed && parent.property === node) {
+    return true;
+  }
+  return isNodeOfType(parent, "Property") && !parent.computed && parent.key === node;
+};
+
+const hasAsyncOrDomWork = (wrappedFunction: FunctionEsTreeNode): boolean => {
+  if (wrappedFunction.async) return true;
+  let didFindWork = false;
+  walkAst(wrappedFunction, (child: EsTreeNode) => {
+    if (didFindWork) return false;
+    if (isNodeOfType(child, "AwaitExpression")) {
+      didFindWork = true;
+      return false;
+    }
+    if (
+      isNodeOfType(child, "Identifier") &&
+      BROWSER_GLOBAL_NAMES.has(child.name) &&
+      !isPropertyNamePosition(child)
+    ) {
+      didFindWork = true;
+      return false;
+    }
+    if (isNodeOfType(child, "CallExpression")) {
+      const callee = child.callee;
+      if (isNodeOfType(callee, "Identifier") && callee.name === "fetch") {
+        didFindWork = true;
+        return false;
+      }
+      if (
+        isNodeOfType(callee, "MemberExpression") &&
+        !callee.computed &&
+        isNodeOfType(callee.property, "Identifier") &&
+        PROMISE_CHAIN_METHOD_NAMES.has(callee.property.name)
+      ) {
+        didFindWork = true;
+        return false;
+      }
+    }
+  });
+  return didFindWork;
+};
+
+const startsWithNullRefGuard = (wrappedFunction: FunctionEsTreeNode): boolean => {
+  if (!isNodeOfType(wrappedFunction.body, "BlockStatement")) return false;
+  const firstStatement = wrappedFunction.body.body?.[0];
+  if (!isNodeOfType(firstStatement, "IfStatement")) return false;
+  const consequent = firstStatement.consequent;
+  const isEarlyReturn =
+    isNodeOfType(consequent, "ReturnStatement") ||
+    (isNodeOfType(consequent, "BlockStatement") &&
+      isNodeOfType(consequent.body?.[0], "ReturnStatement"));
+  if (!isEarlyReturn) return false;
+  let didTestRefCurrent = false;
+  walkAst(firstStatement.test, (child: EsTreeNode) => {
+    if (didTestRefCurrent) return false;
+    if (
+      isNodeOfType(child, "MemberExpression") &&
+      !child.computed &&
+      isNodeOfType(child.property, "Identifier") &&
+      child.property.name === "current"
+    ) {
+      didTestRefCurrent = true;
+      return false;
+    }
+  });
+  return didTestRefCurrent;
+};
+
+export const debounceNoCleanup = defineRule({
+  id: "debounce-no-cleanup",
+  title: "Memoized debounce never cancelled on unmount",
+  severity: "warn",
+  category: "Bugs",
+  recommendation:
+    "A debounced/throttled callback holds a pending timer that still fires after unmount, so add `useEffect(() => () => debounced.cancel(), [])` to cancel the trailing invocation when the component tears down.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isHookCall(node, DEBOUNCE_WRAPPER_HOOK_NAMES)) return;
+      const debounceCall = findDebounceCallInHookInitializer(node);
+      if (!debounceCall) return;
+      if (hasTrailingFalseOption(debounceCall)) return;
+
+      const declarator = node.parent;
+      if (
+        !isNodeOfType(declarator, "VariableDeclarator") ||
+        !isNodeOfType(declarator.id, "Identifier")
+      ) {
+        return;
+      }
+      const bindingName = declarator.id.name;
+      if (SAVE_LIKE_BINDING_NAME_PATTERN.test(bindingName)) return;
+
+      const enclosingFunction = findEnclosingFunction(node);
+      if (!enclosingFunction) return;
+
+      const aliasNames = collectBindingAliasNames(enclosingFunction, bindingName);
+      if (hasReleaseForBinding(enclosingFunction, aliasNames)) return;
+      if (escapesViaReturn(enclosingFunction, bindingName)) return;
+      if (!isInvokedInsideEffectCallback(enclosingFunction, bindingName)) return;
+
+      const wrappedCallback = resolveWrappedCallbackFunction(debounceCall, enclosingFunction);
+      if (!wrappedCallback) return;
+      if (!hasAsyncOrDomWork(wrappedCallback)) return;
+      if (startsWithNullRefGuard(wrappedCallback)) return;
+
+      context.report({
+        node: debounceCall,
+        message: `\`${bindingName}\` keeps a pending debounced/throttled call that fires after unmount because nothing cancels it; return \`() => ${bindingName}.cancel()\` from a useEffect so the trailing call is dropped on teardown.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-reference-mismatch.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-reference-mismatch.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectListenerCleanupReferenceMismatch } from "./effect-listener-cleanup-reference-mismatch.js";
+
+describe("effect-listener-cleanup-reference-mismatch", () => {
+  it("flags addEventListener + removeEventListener with two distinct arrows", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        window.addEventListener('beforeunload', () => save(token));
+        return () => {
+          window.removeEventListener('beforeunload', () => save(token));
+        };
+      }, [token]);
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags distinct function expressions on both sides", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        el.addEventListener('scroll', function () { onScroll(); });
+        return () => el.removeEventListener('scroll', function () { onScroll(); });
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags EventEmitter on/off with mismatched literals", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        emitter.on('update', (d) => setData(d));
+        return () => emitter.off('update', (d) => setData(d));
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags subscribe/unsubscribe with handler-only literals", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        appEvent.subscribe((e) => handle(e));
+        return () => appEvent.unsubscribe((e) => handle(e));
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags textually-identical literals since they are still distinct references", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+        return () => document.removeEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+      }, [close]);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the same named handler on both sides", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      const onUnload = () => save(token);
+      useEffect(() => {
+        window.addEventListener('beforeunload', onUnload);
+        return () => window.removeEventListener('beforeunload', onUnload);
+      }, [token]);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a hoisted local binding used on both sides", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        const handler = (e) => onScroll(e);
+        el.addEventListener('scroll', handler);
+        return () => el.removeEventListener('scroll', handler);
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an AbortController teardown with no remove call", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        const controller = new AbortController();
+        el.addEventListener('resize', () => onResize(), { signal: controller.signal });
+        return () => controller.abort();
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an effect that never calls remove", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        window.addEventListener('online', () => sync());
+        return () => {};
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag different event strings", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        window.addEventListener('resize', () => onResize());
+        return () => window.removeEventListener('online', () => sync());
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag different targets with identical event and literal shape", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        a.addEventListener('x', () => f());
+        return () => b.removeEventListener('x', () => f());
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags the legacy MediaQueryList handler-only addListener/removeListener form", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        const mql = window.matchMedia('(min-width: 600px)');
+        mql.addListener((e) => setMatches(e.matches));
+        return () => mql.removeListener((e) => setMatches(e.matches));
+      }, []);
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags inline handlers when the event name is a shared identifier constant", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      const RESIZE = 'resize';
+      useEffect(() => {
+        window.addEventListener(RESIZE, () => onResize());
+        return () => window.removeEventListener(RESIZE, () => onResize());
+      }, []);
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags inline handlers when the event name is a shared enum-style member expression", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        emitter.on(EVENTS.UPDATE, (d) => setData(d));
+        return () => emitter.off(EVENTS.UPDATE, (d) => setData(d));
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags inline handlers when the event name is an expressionless template literal", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        window.addEventListener(\`resize\`, () => onResize());
+        return () => window.removeEventListener(\`resize\`, () => onResize());
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the MediaQueryList handler-only form with one shared named handler", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        const mql = window.matchMedia('(min-width: 600px)');
+        const onChange = (e) => setMatches(e.matches);
+        mql.addListener(onChange);
+        return () => mql.removeListener(onChange);
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a handler-only removal paired with an event-form registration", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        mql.addListener('change', (e) => setMatches(e.matches));
+        return () => mql.removeListener((e) => setMatches(e.matches));
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag different identifier event names on each side", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      const RESIZE = 'resize';
+      const ONLINE = 'online';
+      useEffect(() => {
+        window.addEventListener(RESIZE, () => onResize());
+        return () => window.removeEventListener(ONLINE, () => sync());
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag computed event name expressions it cannot compare", () => {
+    const result = runRule(
+      effectListenerCleanupReferenceMismatch,
+      `
+      useEffect(() => {
+        window.addEventListener(events[index], () => f());
+        return () => window.removeEventListener(events[index], () => f());
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-reference-mismatch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-reference-mismatch.ts
@@ -1,0 +1,233 @@
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+interface ListenerMethodPairing {
+  registerMethod: string;
+  requiresEventArgument: boolean;
+  allowsHandlerOnlyForm: boolean;
+}
+
+// Keyed by the RELEASE method name. The addEventListener/on family takes
+// `(event, handler)` (matching event argument required); the subscribe
+// family takes just `(handler)`. addListener/removeListener additionally
+// accept a handler-only form — the legacy MediaQueryList API and Chrome
+// extension events register with `addListener(handler)` alone.
+const RELEASE_METHOD_PAIRINGS = new Map<string, ListenerMethodPairing>([
+  [
+    "removeEventListener",
+    {
+      registerMethod: "addEventListener",
+      requiresEventArgument: true,
+      allowsHandlerOnlyForm: false,
+    },
+  ],
+  [
+    "removeListener",
+    {
+      registerMethod: "addListener",
+      requiresEventArgument: true,
+      allowsHandlerOnlyForm: true,
+    },
+  ],
+  [
+    "off",
+    {
+      registerMethod: "on",
+      requiresEventArgument: true,
+      allowsHandlerOnlyForm: false,
+    },
+  ],
+  [
+    "unsubscribe",
+    {
+      registerMethod: "subscribe",
+      requiresEventArgument: false,
+      allowsHandlerOnlyForm: false,
+    },
+  ],
+  [
+    "unsub",
+    {
+      registerMethod: "sub",
+      requiresEventArgument: false,
+      allowsHandlerOnlyForm: false,
+    },
+  ],
+  [
+    "unwatch",
+    {
+      registerMethod: "watch",
+      requiresEventArgument: false,
+      allowsHandlerOnlyForm: false,
+    },
+  ],
+  [
+    "unlisten",
+    {
+      registerMethod: "listen",
+      requiresEventArgument: false,
+      allowsHandlerOnlyForm: false,
+    },
+  ],
+]);
+
+const isFunctionLiteral = (node: EsTreeNode | null | undefined): boolean => {
+  if (!node) return false;
+  const stripped = stripParenExpression(node);
+  return (
+    isNodeOfType(stripped, "ArrowFunctionExpression") ||
+    isNodeOfType(stripped, "FunctionExpression")
+  );
+};
+
+// Purely syntactic reference key (node text equality, not aliasing
+// analysis) so `window`/`window`, `el`/`el`, `this.emitter`/`this.emitter`
+// match, and `a`/`b` do not. Returns null for shapes we can't compare.
+const serializeReferenceKey = (node: EsTreeNode): string | null => {
+  if (isNodeOfType(node, "Identifier")) return node.name;
+  if (isNodeOfType(node, "ThisExpression")) return "this";
+  if (isNodeOfType(node, "MemberExpression") && !node.computed) {
+    const object = serializeReferenceKey(node.object);
+    if (object === null || !isNodeOfType(node.property, "Identifier")) return null;
+    return `${object}.${node.property.name}`;
+  }
+  return null;
+};
+
+interface ListenerUsage {
+  method: string;
+  receiverKey: string;
+  eventKey: string | null;
+  usesHandlerOnlyForm: boolean;
+  handlerNode: EsTreeNode;
+}
+
+const readMemberCallMethod = (node: EsTreeNode): string | null => {
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  const callee = node.callee;
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
+  if (!isNodeOfType(callee.property, "Identifier")) return null;
+  return callee.property.name;
+};
+
+// String literals and expressionless template literals share the `literal:`
+// namespace; identifiers and constant member chains (`EVENTS.RESIZE`) get a
+// `reference:` key so they only match the identical source expression.
+const serializeEventKey = (node: EsTreeNode | null | undefined): string | null => {
+  if (!node) return null;
+  const stripped = stripParenExpression(node);
+  if (isNodeOfType(stripped, "Literal") && typeof stripped.value === "string") {
+    return `literal:${stripped.value}`;
+  }
+  if (isNodeOfType(stripped, "TemplateLiteral") && stripped.expressions.length === 0) {
+    return `literal:${stripped.quasis[0]?.value.cooked ?? ""}`;
+  }
+  const referenceKey = serializeReferenceKey(stripped);
+  return referenceKey === null ? null : `reference:${referenceKey}`;
+};
+
+const readListenerUsage = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  pairing: ListenerMethodPairing,
+  method: string,
+  receiverKey: string,
+): ListenerUsage | null => {
+  if (!pairing.requiresEventArgument) {
+    const handlerNode = call.arguments?.[0];
+    if (!isFunctionLiteral(handlerNode)) return null;
+    return { method, receiverKey, eventKey: null, usesHandlerOnlyForm: false, handlerNode };
+  }
+  const eventFormHandlerNode = call.arguments?.[1];
+  if (isFunctionLiteral(eventFormHandlerNode)) {
+    return {
+      method,
+      receiverKey,
+      eventKey: serializeEventKey(call.arguments?.[0]),
+      usesHandlerOnlyForm: false,
+      handlerNode: eventFormHandlerNode,
+    };
+  }
+  const handlerOnlyNode = call.arguments?.[0];
+  if (pairing.allowsHandlerOnlyForm && isFunctionLiteral(handlerOnlyNode)) {
+    return {
+      method,
+      receiverKey,
+      eventKey: null,
+      usesHandlerOnlyForm: true,
+      handlerNode: handlerOnlyNode,
+    };
+  }
+  return null;
+};
+
+export const effectListenerCleanupReferenceMismatch = defineRule({
+  id: "effect-listener-cleanup-reference-mismatch",
+  title: "Effect cleanup removes the wrong listener reference",
+  severity: "error",
+  category: "Bugs",
+  recommendation:
+    "Removal APIs match by reference identity, so the second inline function passed to the remove call can never equal the one you added; hoist the handler into a single named const (or useCallback) and pass that same reference to both the add and remove calls.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+      const callback = getEffectCallback(node);
+      if (!callback) return;
+
+      const registerUsages: ListenerUsage[] = [];
+      const releaseUsages: ListenerUsage[] = [];
+
+      walkAst(callback, (child: EsTreeNode) => {
+        if (!isNodeOfType(child, "CallExpression")) return;
+        const method = readMemberCallMethod(child);
+        if (!method) return;
+        const callee = child.callee;
+        if (!isNodeOfType(callee, "MemberExpression")) return;
+        const receiverKey = serializeReferenceKey(callee.object);
+        if (receiverKey === null) return;
+
+        const releasePairing = RELEASE_METHOD_PAIRINGS.get(method);
+        if (releasePairing) {
+          const usage = readListenerUsage(child, releasePairing, method, receiverKey);
+          if (usage) releaseUsages.push(usage);
+          return;
+        }
+
+        for (const [, candidatePairing] of RELEASE_METHOD_PAIRINGS) {
+          if (candidatePairing.registerMethod !== method) continue;
+          const usage = readListenerUsage(child, candidatePairing, method, receiverKey);
+          if (usage) registerUsages.push(usage);
+          return;
+        }
+      });
+
+      for (const releaseUsage of releaseUsages) {
+        const pairing = RELEASE_METHOD_PAIRINGS.get(releaseUsage.method);
+        if (!pairing) continue;
+        const hasMatchingRegister = registerUsages.some((registerUsage) => {
+          if (registerUsage.method !== pairing.registerMethod) return false;
+          if (registerUsage.receiverKey !== releaseUsage.receiverKey) return false;
+          if (registerUsage.usesHandlerOnlyForm !== releaseUsage.usesHandlerOnlyForm) {
+            return false;
+          }
+          if (!pairing.requiresEventArgument || releaseUsage.usesHandlerOnlyForm) return true;
+          return (
+            registerUsage.eventKey !== null && registerUsage.eventKey === releaseUsage.eventKey
+          );
+        });
+        if (!hasMatchingRegister) continue;
+        context.report({
+          node: releaseUsage.handlerNode,
+          message: `Your cleanup calls \`${releaseUsage.method}\` with a brand-new inline function that never equals the handler you added, so the cleanup exists but detaches nothing and the listener leaks; pass one shared named handler to both calls.`,
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-reference-mismatch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-reference-mismatch.ts
@@ -2,6 +2,7 @@ import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -79,14 +80,12 @@ const RELEASE_METHOD_PAIRINGS = new Map<string, ListenerMethodPairing>([
   ],
 ]);
 
-const isFunctionLiteral = (node: EsTreeNode | null | undefined): boolean => {
-  if (!node) return false;
-  const stripped = stripParenExpression(node);
-  return (
-    isNodeOfType(stripped, "ArrowFunctionExpression") ||
-    isNodeOfType(stripped, "FunctionExpression")
-  );
-};
+const REGISTER_METHOD_PAIRINGS = new Map<string, ListenerMethodPairing>(
+  [...RELEASE_METHOD_PAIRINGS.values()].map((pairing) => [pairing.registerMethod, pairing]),
+);
+
+const isFunctionLiteral = (node: EsTreeNode | null | undefined): boolean =>
+  Boolean(node && isInlineFunctionExpression(stripParenExpression(node)));
 
 // Purely syntactic reference key (node text equality, not aliasing
 // analysis) so `window`/`window`, `el`/`el`, `this.emitter`/`this.emitter`
@@ -109,14 +108,6 @@ interface ListenerUsage {
   usesHandlerOnlyForm: boolean;
   handlerNode: EsTreeNode;
 }
-
-const readMemberCallMethod = (node: EsTreeNode): string | null => {
-  if (!isNodeOfType(node, "CallExpression")) return null;
-  const callee = node.callee;
-  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
-  if (!isNodeOfType(callee.property, "Identifier")) return null;
-  return callee.property.name;
-};
 
 // String literals and expressionless template literals share the `literal:`
 // namespace; identifiers and constant member chains (`EVENTS.RESIZE`) get a
@@ -186,10 +177,10 @@ export const effectListenerCleanupReferenceMismatch = defineRule({
 
       walkAst(callback, (child: EsTreeNode) => {
         if (!isNodeOfType(child, "CallExpression")) return;
-        const method = readMemberCallMethod(child);
-        if (!method) return;
         const callee = child.callee;
-        if (!isNodeOfType(callee, "MemberExpression")) return;
+        if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+        if (!isNodeOfType(callee.property, "Identifier")) return;
+        const method = callee.property.name;
         const receiverKey = serializeReferenceKey(callee.object);
         if (receiverKey === null) return;
 
@@ -200,12 +191,10 @@ export const effectListenerCleanupReferenceMismatch = defineRule({
           return;
         }
 
-        for (const [, candidatePairing] of RELEASE_METHOD_PAIRINGS) {
-          if (candidatePairing.registerMethod !== method) continue;
-          const usage = readListenerUsage(child, candidatePairing, method, receiverKey);
-          if (usage) registerUsages.push(usage);
-          return;
-        }
+        const registerPairing = REGISTER_METHOD_PAIRINGS.get(method);
+        if (!registerPairing) return;
+        const usage = readListenerUsage(child, registerPairing, method, receiverKey);
+        if (usage) registerUsages.push(usage);
       });
 
       for (const releaseUsage of releaseUsages) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-observer-needs-disconnect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-observer-needs-disconnect.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectObserverNeedsDisconnect } from "./effect-observer-needs-disconnect.js";
+
+describe("effect-observer-needs-disconnect", () => {
+  it("flags a ResizeObserver observed without disconnect", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const observer = new ResizeObserver(() => measure());
+        observer.observe(el);
+      }, []);
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an IntersectionObserver without release in useLayoutEffect", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useLayoutEffect(() => {
+        const io = new IntersectionObserver((entries) => onIntersect(entries));
+        io.observe(node);
+      }, [node]);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a MutationObserver without disconnect", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const mo = new MutationObserver(cb);
+        mo.observe(target, { childList: true });
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when the cleanup return disconnects", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const observer = new ResizeObserver(() => measure());
+        observer.observe(el);
+        return () => observer.disconnect();
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the cleanup return unobserves", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const resizeObserver = new ResizeObserver(() => measure());
+        resizeObserver.observe(element);
+        return () => resizeObserver.unobserve(element);
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a one-shot observer that disconnects inside its own callback", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const io = new IntersectionObserver((entries) => {
+          if (entries[0].isIntersecting) {
+            onVisible();
+            io.disconnect();
+          }
+        });
+        io.observe(node);
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an observer created at module scope", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `const observer = new ResizeObserver(() => measure()); observer.observe(el);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an observer constructed but never observed", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const observer = new ResizeObserver(() => measure());
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a cleanup that delegates the release to a helper receiving the observer", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const observer = new ResizeObserver(handleResize);
+        observer.observe(node);
+        return () => cleanupObserver(observer);
+      }, [node]);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an observer stashed in a ref whose outer named cleanup is returned by reference", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      const stopObserving = () => observerRef.current?.disconnect();
+      useEffect(() => {
+        observerRef.current = new ResizeObserver(cb);
+        observerRef.current.observe(el);
+        return stopObserving;
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an observer pushed into a registry that disconnects it elsewhere", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const observer = new IntersectionObserver(onIntersect);
+        observer.observe(node);
+        activeObservers.push(observer);
+        return flushObservers;
+      }, [node]);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an observer aliased to another binding that releases it", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const observer = new MutationObserver(cb);
+        observer.observe(target, { childList: true });
+        const disposer = observer;
+        return () => disposer.disconnect();
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags the leaked observer when a second observer in the same effect is disconnected", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const resizeObserver = new ResizeObserver(onResize);
+        resizeObserver.observe(el);
+        const mutationObserver = new MutationObserver(onMutate);
+        mutationObserver.observe(el, { childList: true });
+        return () => resizeObserver.disconnect();
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags when the only disconnect belongs to an unrelated object like a socket", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const observer = new ResizeObserver(cb);
+        observer.observe(el);
+        const socket = connect(url);
+        return () => socket.disconnect();
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a global-qualified window.ResizeObserver observed without disconnect", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        if (!('ResizeObserver' in window)) return;
+        const observer = new window.ResizeObserver(cb);
+        observer.observe(el);
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a non-observer new expression with observe", () => {
+    const result = runRule(
+      effectObserverNeedsDisconnect,
+      `
+      useEffect(() => {
+        const thing = new Telescope(cb);
+        thing.observe(star);
+      }, []);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-observer-needs-disconnect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-observer-needs-disconnect.ts
@@ -19,38 +19,11 @@ interface TrackedObserver {
   didEscape: boolean;
 }
 
-const isObserverConstruction = (node: EsTreeNode): node is EsTreeNodeOfType<"NewExpression"> => {
-  if (!isNodeOfType(node, "NewExpression")) return false;
-  if (isNodeOfType(node.callee, "Identifier")) {
-    return EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(node.callee.name);
-  }
-  return (
-    isNodeOfType(node.callee, "MemberExpression") &&
-    !node.callee.computed &&
-    isNodeOfType(node.callee.object, "Identifier") &&
-    GLOBAL_OBJECT_NAMES.has(node.callee.object.name) &&
-    isNodeOfType(node.callee.property, "Identifier") &&
-    EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(node.callee.property.name)
-  );
-};
-
-const getLocalObserverBindingName = (
-  construction: EsTreeNodeOfType<"NewExpression">,
-): string | null => {
-  const parent = construction.parent;
-  if (!isNodeOfType(parent, "VariableDeclarator") || parent.init !== construction) return null;
-  return isNodeOfType(parent.id, "Identifier") ? parent.id.name : null;
-};
-
 const recordObserverUsage = (
   identifier: EsTreeNodeOfType<"Identifier">,
   tracked: TrackedObserver,
 ): void => {
   const parent = identifier.parent;
-  if (!parent) {
-    tracked.didEscape = true;
-    return;
-  }
   if (isNodeOfType(parent, "VariableDeclarator") && parent.id === identifier) return;
   if (
     isNodeOfType(parent, "MemberExpression") &&
@@ -101,8 +74,19 @@ export const effectObserverNeedsDisconnect = defineRule({
 
       const trackedObserversByName = new Map<string, TrackedObserver>();
       walkAst(callback, (child: EsTreeNode) => {
-        if (!isObserverConstruction(child)) return;
-        const bindingName = getLocalObserverBindingName(child);
+        if (!isNodeOfType(child, "NewExpression")) return;
+        const isObserverConstructor = isNodeOfType(child.callee, "Identifier")
+          ? EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(child.callee.name)
+          : isNodeOfType(child.callee, "MemberExpression") &&
+            !child.callee.computed &&
+            isNodeOfType(child.callee.object, "Identifier") &&
+            GLOBAL_OBJECT_NAMES.has(child.callee.object.name) &&
+            isNodeOfType(child.callee.property, "Identifier") &&
+            EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(child.callee.property.name);
+        if (!isObserverConstructor) return;
+        const declarator = child.parent;
+        if (!isNodeOfType(declarator, "VariableDeclarator") || declarator.init !== child) return;
+        const bindingName = isNodeOfType(declarator.id, "Identifier") ? declarator.id.name : null;
         if (!bindingName || trackedObserversByName.has(bindingName)) return;
         trackedObserversByName.set(bindingName, {
           construction: child,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-observer-needs-disconnect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-observer-needs-disconnect.ts
@@ -1,0 +1,132 @@
+import { EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS } from "../../constants/dom.js";
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const OBSERVER_RELEASE_METHOD_NAMES = new Set(["disconnect", "unobserve"]);
+const GLOBAL_OBJECT_NAMES = new Set(["window", "globalThis", "self"]);
+
+interface TrackedObserver {
+  construction: EsTreeNodeOfType<"NewExpression">;
+  didObserve: boolean;
+  didRelease: boolean;
+  didEscape: boolean;
+}
+
+const isObserverConstruction = (node: EsTreeNode): node is EsTreeNodeOfType<"NewExpression"> => {
+  if (!isNodeOfType(node, "NewExpression")) return false;
+  if (isNodeOfType(node.callee, "Identifier")) {
+    return EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(node.callee.name);
+  }
+  return (
+    isNodeOfType(node.callee, "MemberExpression") &&
+    !node.callee.computed &&
+    isNodeOfType(node.callee.object, "Identifier") &&
+    GLOBAL_OBJECT_NAMES.has(node.callee.object.name) &&
+    isNodeOfType(node.callee.property, "Identifier") &&
+    EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(node.callee.property.name)
+  );
+};
+
+const getLocalObserverBindingName = (
+  construction: EsTreeNodeOfType<"NewExpression">,
+): string | null => {
+  const parent = construction.parent;
+  if (!isNodeOfType(parent, "VariableDeclarator") || parent.init !== construction) return null;
+  return isNodeOfType(parent.id, "Identifier") ? parent.id.name : null;
+};
+
+const recordObserverUsage = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  tracked: TrackedObserver,
+): void => {
+  const parent = identifier.parent;
+  if (!parent) {
+    tracked.didEscape = true;
+    return;
+  }
+  if (isNodeOfType(parent, "VariableDeclarator") && parent.id === identifier) return;
+  if (
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.property === identifier &&
+    !parent.computed
+  )
+    return;
+  if (
+    isNodeOfType(parent, "Property") &&
+    parent.key === identifier &&
+    parent.value !== identifier &&
+    !parent.computed
+  ) {
+    return;
+  }
+  if (isNodeOfType(parent, "MemberExpression") && parent.object === identifier) {
+    if (parent.computed) {
+      tracked.didEscape = true;
+      return;
+    }
+    const accessedMethodName = isNodeOfType(parent.property, "Identifier")
+      ? parent.property.name
+      : null;
+    if (accessedMethodName && OBSERVER_RELEASE_METHOD_NAMES.has(accessedMethodName)) {
+      tracked.didRelease = true;
+      return;
+    }
+    const isMethodCall =
+      isNodeOfType(parent.parent, "CallExpression") && parent.parent.callee === parent;
+    if (accessedMethodName === "observe" && isMethodCall) tracked.didObserve = true;
+    return;
+  }
+  tracked.didEscape = true;
+};
+
+export const effectObserverNeedsDisconnect = defineRule({
+  id: "effect-observer-needs-disconnect",
+  title: "Observer created in an effect never disconnected",
+  severity: "error",
+  category: "Bugs",
+  recommendation:
+    "Return a cleanup function that calls `observer.disconnect()` (or `observer.unobserve(node)`) so the observer stops firing callbacks against detached nodes after unmount instead of leaking on every mount.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+      const callback = getEffectCallback(node);
+      if (!callback) return;
+
+      const trackedObserversByName = new Map<string, TrackedObserver>();
+      walkAst(callback, (child: EsTreeNode) => {
+        if (!isObserverConstruction(child)) return;
+        const bindingName = getLocalObserverBindingName(child);
+        if (!bindingName || trackedObserversByName.has(bindingName)) return;
+        trackedObserversByName.set(bindingName, {
+          construction: child,
+          didObserve: false,
+          didRelease: false,
+          didEscape: false,
+        });
+      });
+      if (trackedObserversByName.size === 0) return;
+
+      walkAst(callback, (child: EsTreeNode) => {
+        if (!isNodeOfType(child, "Identifier")) return;
+        const tracked = trackedObserversByName.get(child.name);
+        if (tracked) recordObserverUsage(child, tracked);
+      });
+
+      for (const tracked of trackedObserversByName.values()) {
+        if (!tracked.didObserve || tracked.didRelease || tracked.didEscape) continue;
+        context.report({
+          node: tracked.construction,
+          message:
+            "This observer is created and started in the effect but never disconnected, so it keeps firing against detached nodes and leaks one observer per mount; return a cleanup that calls `disconnect()` or `unobserve()`.",
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-raf-loop-needs-cancel.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-raf-loop-needs-cancel.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectRafLoopNeedsCancel } from "./effect-raf-loop-needs-cancel.js";
+
+describe("effect-raf-loop-needs-cancel", () => {
+  it("flags a named self-rescheduling loop with no cancel", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Clock() {
+        useEffect(() => {
+          let id;
+          const loop = () => {
+            tick();
+            id = requestAnimationFrame(loop);
+          };
+          id = requestAnimationFrame(loop);
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an inline self-rescheduling loop", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Clock() {
+        useEffect(() => {
+          requestAnimationFrame(function tick() {
+            update();
+            requestAnimationFrame(tick);
+          });
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a loop that cancels in cleanup", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Countdown() {
+        useEffect(() => {
+          let requestId;
+          const loop = () => {
+            render();
+            requestId = requestAnimationFrame(loop);
+          };
+          requestId = requestAnimationFrame(loop);
+          return () => cancelAnimationFrame(requestId);
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a one-shot requestAnimationFrame", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Following() {
+        useEffect(() => {
+          requestAnimationFrame(() => scrollToTop());
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when cancellation is delegated via an aliased handle in cleanup", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Clock() {
+        useEffect(() => {
+          const { cancelAnimationFrame: cancel } = window;
+          let id;
+          const loop = () => {
+            tick();
+            id = requestAnimationFrame(loop);
+          };
+          id = requestAnimationFrame(loop);
+          return () => cancel(id);
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a throttle that schedules a non-rescheduling frame", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Scroller() {
+        useEffect(() => {
+          let ticking = false;
+          const onScroll = () => {
+            if (!ticking) {
+              requestAnimationFrame(() => {
+                doWork();
+                ticking = false;
+              });
+              ticking = true;
+            }
+          };
+          window.addEventListener('scroll', onScroll);
+          return () => window.removeEventListener('scroll', onScroll);
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the one-shot double-rAF wait-for-next-paint idiom used to toggle CSS-transition classes", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function FadeIn() {
+        useEffect(() => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => setVisible(true));
+          });
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a stop-flag loop whose cleanup flips the boolean the loop checks before rescheduling", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Ticker() {
+        useEffect(() => {
+          let running = true;
+          const loop = () => {
+            if (!running) return;
+            tick();
+            requestAnimationFrame(loop);
+          };
+          requestAnimationFrame(loop);
+          return () => {
+            running = false;
+          };
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a token-ref-guarded tween loop whose cleanup bumps the ref the step checks", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Tween() {
+        const tokenRef = useRef(0);
+        useEffect(() => {
+          const token = tokenRef.current;
+          const step = () => {
+            if (tokenRef.current !== token) return;
+            advance();
+            requestAnimationFrame(step);
+          };
+          requestAnimationFrame(step);
+          return () => {
+            tokenRef.current += 1;
+          };
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the cleanup is returned as a named identifier that cancels the stored handle", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Clock() {
+        useEffect(() => {
+          const { cancelAnimationFrame: cancel } = window;
+          let id;
+          const loop = () => {
+            tick();
+            id = requestAnimationFrame(loop);
+          };
+          id = requestAnimationFrame(loop);
+          const stop = () => cancel(id);
+          return stop;
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an uncancellable loop even when an unrelated handler in the component cancels its own rAF throttle", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Chart() {
+        const scrollRaf = useRef(0);
+        const onScroll = () => {
+          cancelAnimationFrame(scrollRaf.current);
+          scrollRaf.current = requestAnimationFrame(paint);
+        };
+        useEffect(() => {
+          const loop = () => {
+            tick();
+            requestAnimationFrame(loop);
+          };
+          requestAnimationFrame(loop);
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a rAF-free effect", () => {
+    const result = runRule(
+      effectRafLoopNeedsCancel,
+      `
+      function Clock() {
+        useEffect(() => {
+          const id = setInterval(tick, 1000);
+          return () => clearInterval(id);
+        }, []);
+        return null;
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-raf-loop-needs-cancel.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-raf-loop-needs-cancel.ts
@@ -1,0 +1,287 @@
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const REQUEST_ANIMATION_FRAME_NAME = "requestAnimationFrame";
+const CANCEL_ANIMATION_FRAME_NAME = "cancelAnimationFrame";
+
+interface SelfReschedulingRafLoop {
+  rafCall: EsTreeNodeOfType<"CallExpression">;
+  scheduledFunction: EsTreeNode;
+}
+
+const isRequestAnimationFrameCall = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") && getCalleeName(node) === REQUEST_ANIMATION_FRAME_NAME;
+
+const resolveFunctionNode = (expression: EsTreeNode | null | undefined): EsTreeNode | null => {
+  if (!expression) return null;
+  const stripped = stripParenExpression(expression);
+  if (
+    isNodeOfType(stripped, "ArrowFunctionExpression") ||
+    isNodeOfType(stripped, "FunctionExpression")
+  ) {
+    return stripped;
+  }
+  if (isNodeOfType(stripped, "Identifier")) {
+    const binding = findVariableInitializer(stripped, stripped.name);
+    const initializer = binding?.initializer;
+    if (
+      initializer &&
+      (isNodeOfType(initializer, "ArrowFunctionExpression") ||
+        isNodeOfType(initializer, "FunctionExpression") ||
+        isNodeOfType(initializer, "FunctionDeclaration"))
+    ) {
+      return initializer;
+    }
+  }
+  return null;
+};
+
+const collectScheduledSelfNames = (
+  scheduledArgument: EsTreeNode,
+  scheduledFunction: EsTreeNode,
+): Set<string> => {
+  const selfNames = new Set<string>();
+  const strippedArgument = stripParenExpression(scheduledArgument);
+  if (isNodeOfType(strippedArgument, "Identifier")) {
+    selfNames.add(strippedArgument.name);
+  }
+  if (
+    (isNodeOfType(scheduledFunction, "FunctionExpression") ||
+      isNodeOfType(scheduledFunction, "FunctionDeclaration")) &&
+    scheduledFunction.id &&
+    isNodeOfType(scheduledFunction.id, "Identifier")
+  ) {
+    selfNames.add(scheduledFunction.id.name);
+  }
+  return selfNames;
+};
+
+const doesSubtreeRescheduleAnyName = (root: EsTreeNode, selfNames: Set<string>): boolean => {
+  if (selfNames.size === 0) return false;
+  let didReschedule = false;
+  walkAst(root, (child: EsTreeNode) => {
+    if (didReschedule) return false;
+    if (!isRequestAnimationFrameCall(child) || !isNodeOfType(child, "CallExpression")) return;
+    const innerArgument = child.arguments?.[0];
+    if (!innerArgument) return;
+    const strippedInner = stripParenExpression(innerArgument);
+    if (isNodeOfType(strippedInner, "Identifier") && selfNames.has(strippedInner.name)) {
+      didReschedule = true;
+      return false;
+    }
+  });
+  return didReschedule;
+};
+
+const findSelfReschedulingRafLoop = (
+  effectCallback: EsTreeNode,
+): SelfReschedulingRafLoop | null => {
+  let foundLoop: SelfReschedulingRafLoop | null = null;
+  walkAst(effectCallback, (child: EsTreeNode) => {
+    if (foundLoop) return false;
+    if (!isRequestAnimationFrameCall(child) || !isNodeOfType(child, "CallExpression")) return;
+    const scheduledArgument = child.arguments?.[0];
+    if (!scheduledArgument) return;
+    const scheduledFunction = resolveFunctionNode(scheduledArgument);
+    if (!scheduledFunction) return;
+    const selfNames = collectScheduledSelfNames(scheduledArgument, scheduledFunction);
+    if (doesSubtreeRescheduleAnyName(scheduledFunction, selfNames)) {
+      foundLoop = { rafCall: child, scheduledFunction };
+      return false;
+    }
+  });
+  return foundLoop;
+};
+
+const collectRafHandleNames = (root: EsTreeNode): Set<string> => {
+  const handleNames = new Set<string>();
+  walkAst(root, (child: EsTreeNode) => {
+    if (!isRequestAnimationFrameCall(child)) return;
+    const parent = child.parent;
+    if (
+      isNodeOfType(parent, "AssignmentExpression") &&
+      parent.right === child &&
+      isNodeOfType(parent.left, "Identifier")
+    ) {
+      handleNames.add(parent.left.name);
+    }
+    if (
+      isNodeOfType(parent, "AssignmentExpression") &&
+      parent.right === child &&
+      isNodeOfType(parent.left, "MemberExpression") &&
+      isNodeOfType(parent.left.object, "Identifier")
+    ) {
+      handleNames.add(parent.left.object.name);
+    }
+    if (
+      isNodeOfType(parent, "VariableDeclarator") &&
+      parent.init === child &&
+      isNodeOfType(parent.id, "Identifier")
+    ) {
+      handleNames.add(parent.id.name);
+    }
+  });
+  return handleNames;
+};
+
+const findCleanupReturnFunction = (effectCallback: EsTreeNode): EsTreeNode | null => {
+  if (
+    !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
+    !isNodeOfType(effectCallback, "FunctionExpression")
+  ) {
+    return null;
+  }
+  if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
+    return resolveFunctionNode(effectCallback.body);
+  }
+  for (const statement of effectCallback.body.body ?? []) {
+    if (isNodeOfType(statement, "ReturnStatement") && statement.argument) {
+      const returnedFunction = resolveFunctionNode(statement.argument);
+      if (returnedFunction) return returnedFunction;
+    }
+  }
+  return null;
+};
+
+const subtreeReferencesAnyName = (root: EsTreeNode, names: Set<string>): boolean => {
+  if (names.size === 0) return false;
+  let didReference = false;
+  walkAst(root, (child: EsTreeNode) => {
+    if (didReference) return false;
+    if (isNodeOfType(child, "Identifier") && names.has(child.name)) {
+      didReference = true;
+      return false;
+    }
+  });
+  return didReference;
+};
+
+const didCancelAnyStoredHandle = (searchRoot: EsTreeNode, handleNames: Set<string>): boolean => {
+  if (handleNames.size === 0) return false;
+  let didCancel = false;
+  walkAst(searchRoot, (child: EsTreeNode) => {
+    if (didCancel) return false;
+    if (
+      !isNodeOfType(child, "CallExpression") ||
+      getCalleeName(child) !== CANCEL_ANIMATION_FRAME_NAME
+    ) {
+      return;
+    }
+    for (const cancelArgument of child.arguments ?? []) {
+      if (subtreeReferencesAnyName(cancelArgument, handleNames)) {
+        didCancel = true;
+        return false;
+      }
+    }
+  });
+  return didCancel;
+};
+
+const collectCleanupWrittenNames = (cleanupFunction: EsTreeNode): Set<string> => {
+  const writtenNames = new Set<string>();
+  const addWriteTarget = (target: EsTreeNode | null | undefined): void => {
+    if (!target) return;
+    if (isNodeOfType(target, "Identifier")) {
+      writtenNames.add(target.name);
+      return;
+    }
+    if (isNodeOfType(target, "MemberExpression") && isNodeOfType(target.object, "Identifier")) {
+      writtenNames.add(target.object.name);
+    }
+  };
+  walkAst(cleanupFunction, (child: EsTreeNode) => {
+    if (isNodeOfType(child, "AssignmentExpression")) addWriteTarget(child.left);
+    if (isNodeOfType(child, "UpdateExpression")) addWriteTarget(child.argument);
+  });
+  return writtenNames;
+};
+
+const doesLoopGuardOnAnyName = (loopFunction: EsTreeNode, guardNames: Set<string>): boolean => {
+  if (guardNames.size === 0) return false;
+  let didFindGuard = false;
+  walkAst(loopFunction, (child: EsTreeNode) => {
+    if (didFindGuard) return false;
+    let guardTest: EsTreeNode | null = null;
+    if (
+      isNodeOfType(child, "IfStatement") ||
+      isNodeOfType(child, "ConditionalExpression") ||
+      isNodeOfType(child, "WhileStatement") ||
+      isNodeOfType(child, "DoWhileStatement")
+    ) {
+      guardTest = child.test;
+    } else if (isNodeOfType(child, "LogicalExpression")) {
+      guardTest = child.left;
+    }
+    if (guardTest && subtreeReferencesAnyName(guardTest, guardNames)) {
+      didFindGuard = true;
+      return false;
+    }
+  });
+  return didFindGuard;
+};
+
+const findEnclosingFunction = (node: EsTreeNode): EsTreeNode | null => {
+  let cursor: EsTreeNode | null = node.parent ?? null;
+  while (cursor) {
+    if (
+      isNodeOfType(cursor, "ArrowFunctionExpression") ||
+      isNodeOfType(cursor, "FunctionExpression") ||
+      isNodeOfType(cursor, "FunctionDeclaration")
+    ) {
+      return cursor;
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+export const effectRafLoopNeedsCancel = defineRule({
+  id: "effect-raf-loop-needs-cancel",
+  title: "requestAnimationFrame loop never cancelled",
+  severity: "warn",
+  category: "Bugs",
+  recommendation:
+    "Store the frame id and return a cleanup that calls `cancelAnimationFrame(id)` so the self-scheduling loop stops on unmount instead of running setState ~60x/sec against a torn-down component.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+      const callback = getEffectCallback(node);
+      if (!callback) return;
+
+      const rafLoop = findSelfReschedulingRafLoop(callback);
+      if (!rafLoop) return;
+
+      const handleNames = collectRafHandleNames(callback);
+      for (const handleName of collectRafHandleNames(rafLoop.scheduledFunction)) {
+        handleNames.add(handleName);
+      }
+
+      const enclosingComponent = findEnclosingFunction(node);
+      const cancelSearchRoot = enclosingComponent ?? callback;
+      if (didCancelAnyStoredHandle(cancelSearchRoot, handleNames)) return;
+
+      const cleanupReturnFunction = findCleanupReturnFunction(callback);
+      if (cleanupReturnFunction) {
+        if (subtreeReferencesAnyName(cleanupReturnFunction, handleNames)) return;
+        const cleanupWrittenNames = collectCleanupWrittenNames(cleanupReturnFunction);
+        if (doesLoopGuardOnAnyName(rafLoop.scheduledFunction, cleanupWrittenNames)) return;
+      }
+
+      context.report({
+        node: rafLoop.rafCall,
+        message:
+          "This requestAnimationFrame loop reschedules itself every frame but is never cancelled, so it keeps running after unmount; store the frame id and return `() => cancelAnimationFrame(id)` from the effect.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-raf-loop-needs-cancel.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-raf-loop-needs-cancel.ts
@@ -3,13 +3,16 @@ import { defineRule } from "../../utils/define-rule.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { subtreeReferencesIdentifierName } from "../../utils/subtree-references-identifier-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { findEnclosingFunction } from "./utils/find-enclosing-function.js";
 
 const REQUEST_ANIMATION_FRAME_NAME = "requestAnimationFrame";
 const CANCEL_ANIMATION_FRAME_NAME = "cancelAnimationFrame";
@@ -19,7 +22,9 @@ interface SelfReschedulingRafLoop {
   scheduledFunction: EsTreeNode;
 }
 
-const isRequestAnimationFrameCall = (node: EsTreeNode): boolean =>
+const isRequestAnimationFrameCall = (
+  node: EsTreeNode,
+): node is EsTreeNodeOfType<"CallExpression"> =>
   isNodeOfType(node, "CallExpression") && getCalleeName(node) === REQUEST_ANIMATION_FRAME_NAME;
 
 const resolveFunctionNode = (expression: EsTreeNode | null | undefined): EsTreeNode | null => {
@@ -34,12 +39,7 @@ const resolveFunctionNode = (expression: EsTreeNode | null | undefined): EsTreeN
   if (isNodeOfType(stripped, "Identifier")) {
     const binding = findVariableInitializer(stripped, stripped.name);
     const initializer = binding?.initializer;
-    if (
-      initializer &&
-      (isNodeOfType(initializer, "ArrowFunctionExpression") ||
-        isNodeOfType(initializer, "FunctionExpression") ||
-        isNodeOfType(initializer, "FunctionDeclaration"))
-    ) {
+    if (isFunctionLike(initializer)) {
       return initializer;
     }
   }
@@ -67,11 +67,10 @@ const collectScheduledSelfNames = (
 };
 
 const doesSubtreeRescheduleAnyName = (root: EsTreeNode, selfNames: Set<string>): boolean => {
-  if (selfNames.size === 0) return false;
   let didReschedule = false;
   walkAst(root, (child: EsTreeNode) => {
     if (didReschedule) return false;
-    if (!isRequestAnimationFrameCall(child) || !isNodeOfType(child, "CallExpression")) return;
+    if (!isRequestAnimationFrameCall(child)) return;
     const innerArgument = child.arguments?.[0];
     if (!innerArgument) return;
     const strippedInner = stripParenExpression(innerArgument);
@@ -89,7 +88,7 @@ const findSelfReschedulingRafLoop = (
   let foundLoop: SelfReschedulingRafLoop | null = null;
   walkAst(effectCallback, (child: EsTreeNode) => {
     if (foundLoop) return false;
-    if (!isRequestAnimationFrameCall(child) || !isNodeOfType(child, "CallExpression")) return;
+    if (!isRequestAnimationFrameCall(child)) return;
     const scheduledArgument = child.arguments?.[0];
     if (!scheduledArgument) return;
     const scheduledFunction = resolveFunctionNode(scheduledArgument);
@@ -153,21 +152,7 @@ const findCleanupReturnFunction = (effectCallback: EsTreeNode): EsTreeNode | nul
   return null;
 };
 
-const subtreeReferencesAnyName = (root: EsTreeNode, names: Set<string>): boolean => {
-  if (names.size === 0) return false;
-  let didReference = false;
-  walkAst(root, (child: EsTreeNode) => {
-    if (didReference) return false;
-    if (isNodeOfType(child, "Identifier") && names.has(child.name)) {
-      didReference = true;
-      return false;
-    }
-  });
-  return didReference;
-};
-
 const didCancelAnyStoredHandle = (searchRoot: EsTreeNode, handleNames: Set<string>): boolean => {
-  if (handleNames.size === 0) return false;
   let didCancel = false;
   walkAst(searchRoot, (child: EsTreeNode) => {
     if (didCancel) return false;
@@ -178,7 +163,7 @@ const didCancelAnyStoredHandle = (searchRoot: EsTreeNode, handleNames: Set<strin
       return;
     }
     for (const cancelArgument of child.arguments ?? []) {
-      if (subtreeReferencesAnyName(cancelArgument, handleNames)) {
+      if (subtreeReferencesIdentifierName(cancelArgument, handleNames)) {
         didCancel = true;
         return false;
       }
@@ -189,25 +174,25 @@ const didCancelAnyStoredHandle = (searchRoot: EsTreeNode, handleNames: Set<strin
 
 const collectCleanupWrittenNames = (cleanupFunction: EsTreeNode): Set<string> => {
   const writtenNames = new Set<string>();
-  const addWriteTarget = (target: EsTreeNode | null | undefined): void => {
-    if (!target) return;
-    if (isNodeOfType(target, "Identifier")) {
-      writtenNames.add(target.name);
-      return;
-    }
-    if (isNodeOfType(target, "MemberExpression") && isNodeOfType(target.object, "Identifier")) {
-      writtenNames.add(target.object.name);
-    }
-  };
   walkAst(cleanupFunction, (child: EsTreeNode) => {
-    if (isNodeOfType(child, "AssignmentExpression")) addWriteTarget(child.left);
-    if (isNodeOfType(child, "UpdateExpression")) addWriteTarget(child.argument);
+    const writeTarget = isNodeOfType(child, "AssignmentExpression")
+      ? child.left
+      : isNodeOfType(child, "UpdateExpression")
+        ? child.argument
+        : null;
+    if (isNodeOfType(writeTarget, "Identifier")) {
+      writtenNames.add(writeTarget.name);
+    } else if (
+      isNodeOfType(writeTarget, "MemberExpression") &&
+      isNodeOfType(writeTarget.object, "Identifier")
+    ) {
+      writtenNames.add(writeTarget.object.name);
+    }
   });
   return writtenNames;
 };
 
 const doesLoopGuardOnAnyName = (loopFunction: EsTreeNode, guardNames: Set<string>): boolean => {
-  if (guardNames.size === 0) return false;
   let didFindGuard = false;
   walkAst(loopFunction, (child: EsTreeNode) => {
     if (didFindGuard) return false;
@@ -222,27 +207,12 @@ const doesLoopGuardOnAnyName = (loopFunction: EsTreeNode, guardNames: Set<string
     } else if (isNodeOfType(child, "LogicalExpression")) {
       guardTest = child.left;
     }
-    if (guardTest && subtreeReferencesAnyName(guardTest, guardNames)) {
+    if (guardTest && subtreeReferencesIdentifierName(guardTest, guardNames)) {
       didFindGuard = true;
       return false;
     }
   });
   return didFindGuard;
-};
-
-const findEnclosingFunction = (node: EsTreeNode): EsTreeNode | null => {
-  let cursor: EsTreeNode | null = node.parent ?? null;
-  while (cursor) {
-    if (
-      isNodeOfType(cursor, "ArrowFunctionExpression") ||
-      isNodeOfType(cursor, "FunctionExpression") ||
-      isNodeOfType(cursor, "FunctionDeclaration")
-    ) {
-      return cursor;
-    }
-    cursor = cursor.parent ?? null;
-  }
-  return null;
 };
 
 export const effectRafLoopNeedsCancel = defineRule({
@@ -261,10 +231,10 @@ export const effectRafLoopNeedsCancel = defineRule({
       const rafLoop = findSelfReschedulingRafLoop(callback);
       if (!rafLoop) return;
 
-      const handleNames = collectRafHandleNames(callback);
-      for (const handleName of collectRafHandleNames(rafLoop.scheduledFunction)) {
-        handleNames.add(handleName);
-      }
+      const handleNames = new Set([
+        ...collectRafHandleNames(callback),
+        ...collectRafHandleNames(rafLoop.scheduledFunction),
+      ]);
 
       const enclosingComponent = findEnclosingFunction(node);
       const cancelSearchRoot = enclosingComponent ?? callback;
@@ -272,7 +242,7 @@ export const effectRafLoopNeedsCancel = defineRule({
 
       const cleanupReturnFunction = findCleanupReturnFunction(callback);
       if (cleanupReturnFunction) {
-        if (subtreeReferencesAnyName(cleanupReturnFunction, handleNames)) return;
+        if (subtreeReferencesIdentifierName(cleanupReturnFunction, handleNames)) return;
         const cleanupWrittenNames = collectCleanupWrittenNames(cleanupReturnFunction);
         if (doesLoopGuardOnAnyName(rafLoop.scheduledFunction, cleanupWrittenNames)) return;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-remove-listener-inline-handler.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-remove-listener-inline-handler.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectRemoveListenerInlineHandler } from "./effect-remove-listener-inline-handler.js";
+
+describe("effect-remove-listener-inline-handler", () => {
+  it("flags removeEventListener with an inline arrow handler", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `el.removeEventListener('scroll', () => handle());`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags removeEventListener with an inline function expression", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `window.removeEventListener('resize', function () { onResize(); });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags removeEventListener with a .bind() handler", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `node.removeEventListener('click', this.handle.bind(this));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags emitter.off with an inline arrow handler", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `emitter.off('data', (d) => process(d));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag two-arg unsubscribe since the second arg may be a completion callback", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `appEvent.unsubscribe('update', (e) => handle(e));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag mqtt-style unsubscribe with an inline ack callback", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `client.unsubscribe('presence/room', (err) => { if (err) console.error(err); });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag removeEventListener with a stable identifier handler", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `window.removeEventListener('resize', onResize);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag removeEventListener with a member-expression handler", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `el.removeEventListener('scroll', handlerRef.current);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag addEventListener with an inline arrow handler", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `window.addEventListener('resize', () => onResize(), { once: true });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag removeEventListener with a factory call result", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `el.removeEventListener('scroll', makeHandler());`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a single-arg unsubscribe idiom", () => {
+    const result = runRule(effectRemoveListenerInlineHandler, `store.unsubscribe(() => sync());`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag computed removal member access", () => {
+    const result = runRule(
+      effectRemoveListenerInlineHandler,
+      `el[removeName]('scroll', () => handle());`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-remove-listener-inline-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-remove-listener-inline-handler.ts
@@ -1,0 +1,61 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Removal verbs that deregister a listener by reference equality on the
+// handler argument. Excludes `addEventListener` on purpose — a fresh
+// literal is only a bug on the REMOVE side. Excludes `unsubscribe`
+// because APIs like MQTT.js use `unsubscribe(topic, completionCallback)`,
+// where an inline second argument is idiomatic and not a leak.
+const REFERENCE_EQUALITY_REMOVAL_METHOD_NAMES = new Set([
+  "removeEventListener",
+  "removeListener",
+  "off",
+]);
+
+const isFreshFunctionReference = (node: EsTreeNode): boolean => {
+  const handler = stripParenExpression(node);
+  if (
+    isNodeOfType(handler, "ArrowFunctionExpression") ||
+    isNodeOfType(handler, "FunctionExpression")
+  ) {
+    return true;
+  }
+  return (
+    isNodeOfType(handler, "CallExpression") &&
+    isNodeOfType(handler.callee, "MemberExpression") &&
+    !handler.callee.computed &&
+    isNodeOfType(handler.callee.property, "Identifier") &&
+    handler.callee.property.name === "bind"
+  );
+};
+
+export const effectRemoveListenerInlineHandler = defineRule({
+  id: "effect-remove-listener-inline-handler",
+  title: "removeEventListener called with a fresh inline handler",
+  severity: "error",
+  category: "Bugs",
+  recommendation:
+    "Removal APIs match the listener by reference equality, so a fresh inline arrow, function expression, or `.bind(...)` result can never equal the registered handler; hoist the handler into a named const and pass that same reference to both the add and remove calls.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const callee = node.callee;
+      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+      if (!isNodeOfType(callee.property, "Identifier")) return;
+      if (!REFERENCE_EQUALITY_REMOVAL_METHOD_NAMES.has(callee.property.name)) return;
+
+      const args = node.arguments ?? [];
+      if (args.length < 2) return;
+      const handlerArgument = args[1];
+      if (!handlerArgument || !isFreshFunctionReference(handlerArgument)) return;
+
+      context.report({
+        node: handlerArgument,
+        message: `\`${callee.property.name}\` gets a brand-new function reference here that never equals the registered listener, so the removal silently no-ops and the listener leaks; pass the same named handler to both the add and remove calls.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-remove-listener-inline-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-remove-listener-inline-handler.ts
@@ -1,4 +1,6 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
+import { isMemberProperty } from "../../utils/is-member-property.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -18,18 +20,11 @@ const REFERENCE_EQUALITY_REMOVAL_METHOD_NAMES = new Set([
 
 const isFreshFunctionReference = (node: EsTreeNode): boolean => {
   const handler = stripParenExpression(node);
-  if (
-    isNodeOfType(handler, "ArrowFunctionExpression") ||
-    isNodeOfType(handler, "FunctionExpression")
-  ) {
-    return true;
-  }
+  if (isInlineFunctionExpression(handler)) return true;
   return (
     isNodeOfType(handler, "CallExpression") &&
-    isNodeOfType(handler.callee, "MemberExpression") &&
-    !handler.callee.computed &&
-    isNodeOfType(handler.callee.property, "Identifier") &&
-    handler.callee.property.name === "bind"
+    isMemberProperty(handler.callee, "bind") &&
+    !handler.callee.computed
   );
 };
 
@@ -47,10 +42,10 @@ export const effectRemoveListenerInlineHandler = defineRule({
       if (!isNodeOfType(callee.property, "Identifier")) return;
       if (!REFERENCE_EQUALITY_REMOVAL_METHOD_NAMES.has(callee.property.name)) return;
 
-      const args = node.arguments ?? [];
+      const args = node.arguments;
       if (args.length < 2) return;
       const handlerArgument = args[1];
-      if (!handlerArgument || !isFreshFunctionReference(handlerArgument)) return;
+      if (!isFreshFunctionReference(handlerArgument)) return;
 
       context.report({
         node: handlerArgument,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/mobx-reaction-disposer-discarded.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/mobx-reaction-disposer-discarded.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { mobxReactionDisposerDiscarded } from "./mobx-reaction-disposer-discarded.js";
+
+describe("mobx-reaction-disposer-discarded", () => {
+  it("flags a bare reaction() whose disposer is discarded", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { reaction } from "mobx";
+      class Store {
+        constructor() {
+          reaction(() => this.value, (value) => Storage.local.set("v", value));
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare autorun() whose disposer is discarded", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { autorun } from "mobx";
+      class ViewState {
+        start() {
+          autorun(this.loadImages);
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a reaction imported under an alias", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { reaction as react } from "mobx";
+      react(() => this.value, () => {});
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a namespace-import mobx.autorun() whose disposer is discarded", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import * as mobx from "mobx";
+      class Store {
+        constructor() {
+          mobx.autorun(() => this.persist());
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags autorun() with a literal options object that has no signal", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { autorun } from "mobx";
+      class ViewState {
+        start() {
+          autorun(() => this.sync(), { delay: 100 });
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag autorun disposed via an AbortSignal `signal` option (MobX's documented alternative disposal)", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { autorun } from "mobx";
+      class ViewState {
+        controller = new AbortController();
+        start() {
+          autorun(() => this.sync(), { signal: this.controller.signal });
+        }
+        stop() {
+          this.controller.abort();
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag reaction disposed via a `signal` option in its third argument", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { reaction } from "mobx";
+      const controller = new AbortController();
+      reaction(() => store.value, (value) => persist(value), { signal: controller.signal });
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag autorun when the options argument is an opaque variable that may carry a signal", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { autorun } from "mobx";
+      const runOptions = buildAutorunOptions();
+      autorun(() => sync(), runOptions);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag autorun when the options object spreads unknown option bags", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { autorun } from "mobx";
+      autorun(() => sync(), { ...sharedOptions });
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag autorun() member access on a non-mobx namespace import", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import * as scheduler from "./scheduler";
+      scheduler.autorun(() => sync());
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the disposer is passed to disposeOnUnmount", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { reaction } from "mobx";
+      import { disposeOnUnmount } from "mobx-react";
+      class C {
+        componentDidMount() {
+          disposeOnUnmount(this, reaction(() => this.value, () => {}));
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the disposer is stored in a variable", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { reaction } from "mobx";
+      const dispose = reaction(() => this.value, () => {});
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the disposer is assigned to a field", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { autorun } from "mobx";
+      class C {
+        start() {
+          this.disposer = autorun(() => this.value);
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare when() call (auto-disposes after firing once)", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { when } from "mobx";
+      class C {
+        start() {
+          when(() => this.ready, () => this.run());
+        }
+      }
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag Yup schema.when() (MemberExpression callee)", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import * as yup from "yup";
+      const schema = yup.object({ a: yup.string() });
+      schema.when("b", { is: true, then: (s) => s.required() });
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag IntersectionObserver.observe (MemberExpression callee)", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      const io = new IntersectionObserver(cb);
+      io.observe(element);
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a local reaction() not imported from mobx", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      const reaction = (fn, effect) => {};
+      reaction(() => 1, () => {});
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a reaction imported from an unrelated module", () => {
+    const result = runRule(
+      mobxReactionDisposerDiscarded,
+      `
+      import { reaction } from "@storybook/test";
+      reaction(() => 1, () => {});
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/mobx-reaction-disposer-discarded.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/mobx-reaction-disposer-discarded.ts
@@ -1,0 +1,82 @@
+import { defineRule } from "../../utils/define-rule.js";
+import {
+  getImportedNameFromModule,
+  isNamespaceImportFromModule,
+} from "../../utils/find-import-source-for-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const MESSAGE =
+  "This `reaction`/`autorun` returns a disposer you throw away, so the tracked computation runs for the lifetime of the process; keep the returned disposer and call it on teardown, or pass the call to `disposeOnUnmount`.";
+
+// `when` auto-disposes after its predicate fires once, and `observe`/`intercept`
+// are rare and easily confused with unrelated APIs — so only the two genuinely
+// leak-prone MobX subscriptions are flagged.
+const LEAKING_MOBX_SUBSCRIPTIONS = new Set(["reaction", "autorun"]);
+
+const OPTIONS_ARGUMENT_INDEX: Record<string, number> = { autorun: 1, reaction: 2 };
+
+const resolveLeakingSubscriptionName = (
+  node: EsTreeNodeOfType<"CallExpression">,
+): string | null => {
+  if (isNodeOfType(node.callee, "Identifier")) {
+    const importedName = getImportedNameFromModule(node, node.callee.name, "mobx");
+    if (importedName && LEAKING_MOBX_SUBSCRIPTIONS.has(importedName)) return importedName;
+    return null;
+  }
+  // `mobx.autorun(...)` on a verified `import * as mobx from "mobx"` binding —
+  // this still excludes Yup's `schema.when(...)` and `observer.observe(...)`.
+  if (
+    isNodeOfType(node.callee, "MemberExpression") &&
+    !node.callee.computed &&
+    isNodeOfType(node.callee.object, "Identifier") &&
+    isNodeOfType(node.callee.property, "Identifier") &&
+    LEAKING_MOBX_SUBSCRIPTIONS.has(node.callee.property.name) &&
+    isNamespaceImportFromModule(node, node.callee.object.name, "mobx")
+  ) {
+    return node.callee.property.name;
+  }
+  return null;
+};
+
+const mayCarryAbortSignal = (optionsArgument: unknown): boolean => {
+  if (!optionsArgument) return false;
+  if (!isNodeOfType(optionsArgument, "ObjectExpression")) return true;
+  return optionsArgument.properties.some((property) => {
+    if (!isNodeOfType(property, "Property")) return true;
+    if (property.computed) return true;
+    if (isNodeOfType(property.key, "Identifier")) return property.key.name === "signal";
+    if (isNodeOfType(property.key, "Literal")) return property.key.value === "signal";
+    return true;
+  });
+};
+
+export const mobxReactionDisposerDiscarded = defineRule({
+  id: "mobx-reaction-disposer-discarded",
+  title: "MobX reaction disposer discarded",
+  severity: "warn",
+  category: "Bugs",
+  requires: ["mobx"],
+  recommendation:
+    "Store the disposer returned by `reaction`/`autorun` and call it on teardown, or pass the call to `disposeOnUnmount(this, ...)`.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const subscriptionName = resolveLeakingSubscriptionName(node);
+      if (!subscriptionName) return;
+
+      // The disposer is discarded only when the call is a standalone statement.
+      // `const d = reaction(...)`, `this.x = reaction(...)`, and
+      // `disposeOnUnmount(this, reaction(...))` all have non-statement parents.
+      if (!isNodeOfType(node.parent, "ExpressionStatement")) return;
+
+      // A `signal` option is MobX's documented alternative disposal mechanism,
+      // so discarding the disposer is correct there; opaque (non-literal)
+      // options may carry one, so they get the benefit of the doubt.
+      const optionsArgument = node.arguments[OPTIONS_ARGUMENT_INDEX[subscriptionName]];
+      if (mayCarryAbortSignal(optionsArgument)) return;
+
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-event-handler-without-reentry-guard.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-event-handler-without-reentry-guard.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noAsyncEventHandlerWithoutReentryGuard } from "./no-async-event-handler-without-reentry-guard.js";
+
+describe("no-async-event-handler-without-reentry-guard", () => {
+  it("flags an onSubmit handler that POSTs then sets state with no guard", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Signup() {
+        async function handleSubmit(event) {
+          event.preventDefault();
+          const res = await fetch('/api/signup', { method: 'POST', body });
+          setSubmitted(true);
+        }
+        return <form onSubmit={handleSubmit} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an onClick arrow that awaits api.post then sets state", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function List({ id, email }) {
+        const onSubscribe = async () => {
+          await api.post(\`/lists/\${id}/subscribe\`, { email });
+          setJoined(true);
+        };
+        return <button onClick={onSubscribe}>Subscribe</button>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an inline async onSubmit with a PATCH before any state flip", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `const Form = () => (
+        <form onSubmit={async () => {
+          await fetch('/api/reset', { method: 'PATCH', body });
+          setDone(true);
+        }} />
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an idempotent clipboard copy", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Terminal({ text }) {
+        const handleCopy = async () => {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+        };
+        return <button onClick={handleCopy} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the leading setLoading(true) loading-flag pattern", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function PasswordForm() {
+        async function onSubmit() {
+          setLoading(true);
+          try {
+            await fetch('/api/password', { method: 'PUT', body });
+          } finally {
+            setLoading(false);
+          }
+        }
+        return <button disabled={loading} onClick={onSubmit}>Save</button>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a leading if (busy) return guard", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Modal() {
+        async function submit() {
+          if (sending) return;
+          setSending(true);
+          await fetch('/api/x', { method: 'POST' });
+          setDone(true);
+        }
+        return <button onClick={submit} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-mutating GET read", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Feed() {
+        async function loadMore() {
+          const rows = await fetch('/api/items').then((response) => response.json());
+          setItems(rows);
+        }
+        return <button onClick={loadMore} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a synchronous (non-async) handler", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Sync() {
+        const onSubscribe = () => {
+          api.post('/x', {});
+          setJoined(true);
+        };
+        return <button onClick={onSubscribe} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when there is no post-await state setter", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Fire() {
+        async function submit() {
+          await fetch('/api/x', { method: 'POST' });
+        }
+        return <button onClick={submit} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the only post-await call is a setTimeout toast dismiss, not a state setter", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Save({ payload }) {
+        async function handleSave() {
+          await api.post('/save', payload);
+          setTimeout(closeToast, 2000);
+        }
+        return <button onClick={handleSave} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat a leading setTimeout as a loading-flag guard", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Save({ payload }) {
+        async function handleSave() {
+          setTimeout(logAttempt, 0);
+          await api.post('/save', payload);
+          setSaved(true);
+        }
+        return <button onClick={handleSave} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a fire-and-report handler whose only setter is error handling in catch", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Save({ payload }) {
+        async function handleSave() {
+          try {
+            await api.post('/save', payload);
+          } catch (error) {
+            setError(error);
+          }
+        }
+        return <button onClick={handleSave} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a try/catch-wrapped POST whose state flip follows the await in the same try block", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Save() {
+        async function handleSave() {
+          try {
+            await fetch('/api/save', { method: 'POST' });
+            setSaved(true);
+          } catch (err) {
+            setError(err);
+          }
+        }
+        return <button onClick={handleSave} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useCallback-wrapped async handler that POSTs then sets state", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Save({ payload }) {
+        const handleSave = useCallback(async () => {
+          await api.post('/save', payload);
+          setSaved(true);
+        }, [payload]);
+        return <button onClick={handleSave} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a guarded useCallback handler with a leading busy early return", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Save({ payload }) {
+        const handleSave = useCallback(async () => {
+          if (saving) return;
+          setSaving(true);
+          await api.post('/save', payload);
+          setSaved(true);
+        }, [payload, saving]);
+        return <button onClick={handleSave} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-reentry-guarded event handler such as onChange", () => {
+    const result = runRule(
+      noAsyncEventHandlerWithoutReentryGuard,
+      `function Input() {
+        async function onChangeHandler() {
+          await fetch('/api/x', { method: 'POST' });
+          setValue(true);
+        }
+        return <input onChange={onChangeHandler} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-event-handler-without-reentry-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-event-handler-without-reentry-guard.ts
@@ -1,0 +1,259 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const MESSAGE =
+  "This async handler awaits a mutating request and only flips state after the await, so a fast double-click or double Enter fires the request twice. Add a leading `if (busy) return` guard (or set a flag before the await and disable the control) to close the re-entry window.";
+
+const REENTRY_GUARDED_EVENT_HANDLER_NAMES = new Set(["onClick", "onSubmit", "onPress"]);
+const MUTATING_REQUEST_METHOD_NAMES = new Set(["post", "put", "patch", "delete", "mutate"]);
+const MUTATING_FETCH_HTTP_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const STATE_SETTER_NAME_PATTERN = /^set[A-Z]/;
+const NON_STATE_SETTER_GLOBAL_NAMES = new Set(["setTimeout", "setInterval", "setImmediate"]);
+
+const getNodeOffset = (node: EsTreeNode, edge: "start" | "end"): number | null => {
+  const offset = (node as { start?: unknown; end?: unknown })[edge];
+  if (typeof offset === "number") return offset;
+  const range = node.range;
+  return range ? range[edge === "start" ? 0 : 1] : null;
+};
+
+const isStateSetterCall = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") &&
+  isNodeOfType(node.callee, "Identifier") &&
+  STATE_SETTER_NAME_PATTERN.test(node.callee.name) &&
+  !NON_STATE_SETTER_GLOBAL_NAMES.has(node.callee.name);
+
+// Walk a statement collecting only the nodes that execute on this handler path,
+// pruning nested function bodies (a nested arrow does not run synchronously).
+const walkStatementPruningNestedFunctions = (
+  root: EsTreeNode,
+  visitor: (node: EsTreeNode) => void,
+): void => {
+  const visit = (node: EsTreeNode): void => {
+    if (node !== root && isFunctionLike(node)) return;
+    visitor(node);
+    const record = node as unknown as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      if (key === "parent") continue;
+      const child = record[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (item && typeof item === "object" && "type" in item) visit(item as EsTreeNode);
+        }
+      } else if (child && typeof child === "object" && "type" in child) {
+        visit(child as EsTreeNode);
+      }
+    }
+  };
+  visit(root);
+};
+
+const findFirstAwaitInStatement = (statement: EsTreeNode): EsTreeNode | null => {
+  let awaitNode: EsTreeNode | null = null;
+  walkStatementPruningNestedFunctions(statement, (node) => {
+    if (!awaitNode && isNodeOfType(node, "AwaitExpression")) awaitNode = node;
+  });
+  return awaitNode;
+};
+
+// A setter inside a `catch` handler or `finally` finalizer is error handling
+// or cleanup, not the success-path state flip the rule's message describes.
+const isInsideCatchOrFinally = (node: EsTreeNode, boundary: EsTreeNode): boolean => {
+  let child: EsTreeNode = node;
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor && child !== boundary) {
+    if (isNodeOfType(ancestor, "CatchClause")) return true;
+    if (isNodeOfType(ancestor, "TryStatement") && ancestor.finalizer === child) return true;
+    child = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+const statementContainsPostAwaitStateSetter = (
+  statement: EsTreeNode,
+  afterPosition?: number,
+): boolean => {
+  let found = false;
+  walkStatementPruningNestedFunctions(statement, (node) => {
+    if (found || !isStateSetterCall(node)) return;
+    if (afterPosition !== undefined) {
+      const setterStart = getNodeOffset(node, "start");
+      if (setterStart === null || setterStart <= afterPosition) return;
+    }
+    if (isInsideCatchOrFinally(node, statement)) return;
+    found = true;
+  });
+  return found;
+};
+
+// `fetch(url, { method: "POST" | "PUT" | "PATCH" | "DELETE" })`.
+const isMutatingFetchCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "fetch") return false;
+  const optionsArgument = node.arguments?.[1];
+  if (!optionsArgument || !isNodeOfType(optionsArgument, "ObjectExpression")) return false;
+  return optionsArgument.properties.some((property) => {
+    if (!isNodeOfType(property, "Property") || property.computed) return false;
+    const key = property.key;
+    const keyName = isNodeOfType(key, "Identifier")
+      ? key.name
+      : isNodeOfType(key, "Literal")
+        ? String(key.value)
+        : null;
+    if (keyName !== "method") return false;
+    const value = property.value;
+    return (
+      isNodeOfType(value, "Literal") &&
+      typeof value.value === "string" &&
+      MUTATING_FETCH_HTTP_METHODS.has(value.value.toUpperCase())
+    );
+  });
+};
+
+// A mutating network op: a mutating `fetch`, or a `.post`/`.put`/`.patch`/
+// `.delete`/`.mutate` call. Chained calls (`fetch(...).then(...)`) unwrap to
+// their base receiver so a trailing `.then`/`.json` doesn't hide the verb.
+const awaitedExpressionIsMutatingNetworkOp = (
+  expression: EsTreeNode | null | undefined,
+): boolean => {
+  if (!expression) return false;
+  const stripped = stripParenExpression(expression);
+  if (!isNodeOfType(stripped, "CallExpression")) return false;
+  if (isMutatingFetchCall(stripped)) return true;
+  const callee = stripped.callee;
+  if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
+    if (
+      isNodeOfType(callee.property, "Identifier") &&
+      MUTATING_REQUEST_METHOD_NAMES.has(callee.property.name)
+    ) {
+      return true;
+    }
+    return awaitedExpressionIsMutatingNetworkOp(callee.object as EsTreeNode);
+  }
+  return false;
+};
+
+// A synchronous in-flight guard placed BEFORE the first await:
+// `if (busy) return;` (early-return re-entry guard) or a leading `setBusy(true)`
+// (loading-flag pattern; treated conservatively as sufficient protection).
+const isLeadingReentryGuard = (statement: EsTreeNode): boolean => {
+  if (
+    isNodeOfType(statement, "ExpressionStatement") &&
+    isStateSetterCall(statement.expression as EsTreeNode)
+  ) {
+    return true;
+  }
+  if (isNodeOfType(statement, "IfStatement")) {
+    const consequent = statement.consequent;
+    if (isNodeOfType(consequent, "ReturnStatement")) return true;
+    if (
+      isNodeOfType(consequent, "BlockStatement") &&
+      consequent.body.some((inner) => isNodeOfType(inner as EsTreeNode, "ReturnStatement"))
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// `useCallback(async () => {...}, deps)` / `React.useCallback(...)` is a
+// transparent memoizing wrapper — the analyzable handler is its first argument.
+const unwrapUseCallback = (expression: EsTreeNode): EsTreeNode => {
+  const stripped = stripParenExpression(expression);
+  if (!isNodeOfType(stripped, "CallExpression")) return stripped;
+  const callee = stripped.callee;
+  const calleeName = isNodeOfType(callee, "Identifier")
+    ? callee.name
+    : isNodeOfType(callee, "MemberExpression") &&
+        !callee.computed &&
+        isNodeOfType(callee.property, "Identifier")
+      ? callee.property.name
+      : null;
+  if (calleeName !== "useCallback") return stripped;
+  const wrappedFunction = stripped.arguments[0];
+  return wrappedFunction && isFunctionLike(wrappedFunction) ? wrappedFunction : stripped;
+};
+
+const resolveHandlerFunction = (value: EsTreeNode): EsTreeNode | null => {
+  const unwrappedValue = unwrapUseCallback(value);
+  if (isInlineFunctionExpression(unwrappedValue)) return unwrappedValue;
+  if (isNodeOfType(unwrappedValue, "Identifier")) {
+    const binding = findVariableInitializer(unwrappedValue, unwrappedValue.name);
+    if (!binding?.initializer) return null;
+    const unwrappedInitializer = unwrapUseCallback(binding.initializer);
+    if (isFunctionLike(unwrappedInitializer)) return unwrappedInitializer;
+  }
+  return null;
+};
+
+// Reports when an async handler runs a mutating network op at its first await
+// and only flips state afterward, with no leading re-entry guard closing the
+// double-click / double-Enter window.
+const analyzeAsyncHandler = (context: RuleContext, functionNode: EsTreeNode): void => {
+  if (!isFunctionLike(functionNode)) return;
+  if (!(functionNode as { async?: boolean }).async) return;
+  if (!isNodeOfType(functionNode.body, "BlockStatement")) return;
+
+  let sawFirstAwait = false;
+  let mutatingAwaitNode: EsTreeNode | null = null;
+  let hasPostAwaitStateSetter = false;
+
+  for (const statement of functionNode.body.body) {
+    const currentStatement = statement as EsTreeNode;
+    if (!sawFirstAwait) {
+      if (isLeadingReentryGuard(currentStatement)) return;
+      const firstAwait = findFirstAwaitInStatement(currentStatement);
+      if (firstAwait) {
+        sawFirstAwait = true;
+        if (
+          !awaitedExpressionIsMutatingNetworkOp((firstAwait as { argument?: EsTreeNode }).argument)
+        ) {
+          return;
+        }
+        mutatingAwaitNode = firstAwait;
+        const awaitEnd = getNodeOffset(firstAwait, "end");
+        if (
+          awaitEnd !== null &&
+          statementContainsPostAwaitStateSetter(currentStatement, awaitEnd)
+        ) {
+          hasPostAwaitStateSetter = true;
+        }
+      }
+      continue;
+    }
+    if (statementContainsPostAwaitStateSetter(currentStatement)) hasPostAwaitStateSetter = true;
+  }
+
+  if (!sawFirstAwait || !mutatingAwaitNode || !hasPostAwaitStateSetter) return;
+  context.report({ node: mutatingAwaitNode, message: MESSAGE });
+};
+
+export const noAsyncEventHandlerWithoutReentryGuard = defineRule({
+  id: "no-async-event-handler-without-reentry-guard",
+  title: "Async mutating handler without re-entry guard",
+  severity: "warn",
+  recommendation:
+    "An async onClick/onSubmit/onPress handler that awaits a mutating request and sets state only afterward stays interactive across the await, so a double-click fires the write twice. Add a leading `if (busy) return` guard, or set a flag before the await and disable the control.",
+  create: (context: RuleContext) => {
+    const analyzedFunctions = new WeakSet<EsTreeNode>();
+    return {
+      JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
+        if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+        if (!REENTRY_GUARDED_EVENT_HANDLER_NAMES.has(node.name.name)) return;
+        const value = node.value;
+        if (!value || !isNodeOfType(value, "JSXExpressionContainer")) return;
+        const handlerFunction = resolveHandlerFunction(value.expression as EsTreeNode);
+        if (!handlerFunction || analyzedFunctions.has(handlerFunction)) return;
+        analyzedFunctions.add(handlerFunction);
+        analyzeAsyncHandler(context, handlerFunction);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-event-handler-without-reentry-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-event-handler-without-reentry-guard.ts
@@ -7,6 +7,7 @@ import { isInlineFunctionExpression } from "../../utils/is-inline-function-expre
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
 
 const MESSAGE =
   "This async handler awaits a mutating request and only flips state after the await, so a fast double-click or double Enter fires the request twice. Add a leading `if (busy) return` guard (or set a flag before the await and disable the control) to close the re-entry window.";
@@ -30,41 +31,15 @@ const isStateSetterCall = (node: EsTreeNode): boolean =>
   STATE_SETTER_NAME_PATTERN.test(node.callee.name) &&
   !NON_STATE_SETTER_GLOBAL_NAMES.has(node.callee.name);
 
-// Walk a statement collecting only the nodes that execute on this handler path,
-// pruning nested function bodies (a nested arrow does not run synchronously).
-const walkStatementPruningNestedFunctions = (
-  root: EsTreeNode,
-  visitor: (node: EsTreeNode) => void,
-): void => {
-  const visit = (node: EsTreeNode): void => {
-    if (node !== root && isFunctionLike(node)) return;
-    visitor(node);
-    const record = node as unknown as Record<string, unknown>;
-    for (const key of Object.keys(record)) {
-      if (key === "parent") continue;
-      const child = record[key];
-      if (Array.isArray(child)) {
-        for (const item of child) {
-          if (item && typeof item === "object" && "type" in item) visit(item as EsTreeNode);
-        }
-      } else if (child && typeof child === "object" && "type" in child) {
-        visit(child as EsTreeNode);
-      }
-    }
-  };
-  visit(root);
-};
-
 const findFirstAwaitInStatement = (statement: EsTreeNode): EsTreeNode | null => {
   let awaitNode: EsTreeNode | null = null;
-  walkStatementPruningNestedFunctions(statement, (node) => {
+  walkAst(statement, (node) => {
+    if (node !== statement && isFunctionLike(node)) return false;
     if (!awaitNode && isNodeOfType(node, "AwaitExpression")) awaitNode = node;
   });
   return awaitNode;
 };
 
-// A setter inside a `catch` handler or `finally` finalizer is error handling
-// or cleanup, not the success-path state flip the rule's message describes.
 const isInsideCatchOrFinally = (node: EsTreeNode, boundary: EsTreeNode): boolean => {
   let child: EsTreeNode = node;
   let ancestor: EsTreeNode | null | undefined = node.parent;
@@ -82,7 +57,8 @@ const statementContainsPostAwaitStateSetter = (
   afterPosition?: number,
 ): boolean => {
   let found = false;
-  walkStatementPruningNestedFunctions(statement, (node) => {
+  walkAst(statement, (node) => {
+    if (node !== statement && isFunctionLike(node)) return false;
     if (found || !isStateSetterCall(node)) return;
     if (afterPosition !== undefined) {
       const setterStart = getNodeOffset(node, "start");
@@ -94,7 +70,6 @@ const statementContainsPostAwaitStateSetter = (
   return found;
 };
 
-// `fetch(url, { method: "POST" | "PUT" | "PATCH" | "DELETE" })`.
 const isMutatingFetchCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
   if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "fetch") return false;
   const optionsArgument = node.arguments?.[1];
@@ -117,9 +92,6 @@ const isMutatingFetchCall = (node: EsTreeNodeOfType<"CallExpression">): boolean 
   });
 };
 
-// A mutating network op: a mutating `fetch`, or a `.post`/`.put`/`.patch`/
-// `.delete`/`.mutate` call. Chained calls (`fetch(...).then(...)`) unwrap to
-// their base receiver so a trailing `.then`/`.json` doesn't hide the verb.
 const awaitedExpressionIsMutatingNetworkOp = (
   expression: EsTreeNode | null | undefined,
 ): boolean => {
@@ -140,9 +112,6 @@ const awaitedExpressionIsMutatingNetworkOp = (
   return false;
 };
 
-// A synchronous in-flight guard placed BEFORE the first await:
-// `if (busy) return;` (early-return re-entry guard) or a leading `setBusy(true)`
-// (loading-flag pattern; treated conservatively as sufficient protection).
 const isLeadingReentryGuard = (statement: EsTreeNode): boolean => {
   if (
     isNodeOfType(statement, "ExpressionStatement") &&
@@ -163,8 +132,6 @@ const isLeadingReentryGuard = (statement: EsTreeNode): boolean => {
   return false;
 };
 
-// `useCallback(async () => {...}, deps)` / `React.useCallback(...)` is a
-// transparent memoizing wrapper — the analyzable handler is its first argument.
 const unwrapUseCallback = (expression: EsTreeNode): EsTreeNode => {
   const stripped = stripParenExpression(expression);
   if (!isNodeOfType(stripped, "CallExpression")) return stripped;
@@ -193,25 +160,20 @@ const resolveHandlerFunction = (value: EsTreeNode): EsTreeNode | null => {
   return null;
 };
 
-// Reports when an async handler runs a mutating network op at its first await
-// and only flips state afterward, with no leading re-entry guard closing the
-// double-click / double-Enter window.
 const analyzeAsyncHandler = (context: RuleContext, functionNode: EsTreeNode): void => {
   if (!isFunctionLike(functionNode)) return;
   if (!(functionNode as { async?: boolean }).async) return;
   if (!isNodeOfType(functionNode.body, "BlockStatement")) return;
 
-  let sawFirstAwait = false;
   let mutatingAwaitNode: EsTreeNode | null = null;
   let hasPostAwaitStateSetter = false;
 
   for (const statement of functionNode.body.body) {
     const currentStatement = statement as EsTreeNode;
-    if (!sawFirstAwait) {
+    if (!mutatingAwaitNode) {
       if (isLeadingReentryGuard(currentStatement)) return;
       const firstAwait = findFirstAwaitInStatement(currentStatement);
       if (firstAwait) {
-        sawFirstAwait = true;
         if (
           !awaitedExpressionIsMutatingNetworkOp((firstAwait as { argument?: EsTreeNode }).argument)
         ) {
@@ -231,7 +193,7 @@ const analyzeAsyncHandler = (context: RuleContext, functionNode: EsTreeNode): vo
     if (statementContainsPostAwaitStateSetter(currentStatement)) hasPostAwaitStateSetter = true;
   }
 
-  if (!sawFirstAwait || !mutatingAwaitNode || !hasPostAwaitStateSetter) return;
+  if (!mutatingAwaitNode || !hasPostAwaitStateSetter) return;
   context.report({ node: mutatingAwaitNode, message: MESSAGE });
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noBooleanToggleWithoutFunctionalUpdate } from "./no-boolean-toggle-without-functional-update.js";
+
+describe("no-boolean-toggle-without-functional-update", () => {
+  it("flags setIsOpen(!isOpen) inside a setTimeout", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [isOpen, setIsOpen] = useState(false);
+        useEffect(() => {
+          setTimeout(() => setIsOpen(!isOpen), 100);
+        }, []);
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a toggle inside a subscription callback", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [collapsed, setCollapsed] = useState(false);
+        useEffect(() => {
+          const sub = source.subscribe(() => setCollapsed(!collapsed));
+          return () => sub.unsubscribe();
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a toggle inside a promise .then handler", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [allowChatSupport, setAllowChatSupport] = useState(false);
+        const onLoad = () => {
+          load().then(() => setAllowChatSupport(!allowChatSupport));
+        };
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a synchronous onClick toggle", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const CollapsingSection = () => {
+        const [isOpen, setIsOpen] = useState(false);
+        return <button onClick={() => setIsOpen(!isOpen)} />;
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag negating a different variable", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = ({ open }) => {
+        const [sideMenuOpen, setSideMenuOpen] = useState(false);
+        useEffect(() => {
+          setTimeout(() => setSideMenuOpen(!open), 100);
+        }, [open]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a MemberExpression argument", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = ({ field }) => {
+        const [value, setValue] = useState(false);
+        useEffect(() => {
+          setTimeout(() => setValue(!field.value), 100);
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the correct functional updater form", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [isOpen, setIsOpen] = useState(false);
+        useEffect(() => {
+          setTimeout(() => setIsOpen((prev) => !prev), 100);
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the setter has no matching useState pair", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = ({ open }) => {
+        const setOpen = useStore((s) => s.setOpen);
+        useEffect(() => {
+          setTimeout(() => setOpen(!open), 100);
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a numeric negation (arithmetic rule's domain)", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [count, setCount] = useState(0);
+        useEffect(() => {
+          setTimeout(() => setCount(-count), 100);
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags setOpen(!isOpen) when the useState pair is [isOpen, setOpen]", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [isOpen, setOpen] = useState(false);
+        useEffect(() => {
+          setTimeout(() => setOpen(!isOpen), 100);
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  // Real-world idiom: a DOM event handler negating the FRESH value it just
+  // read from the event, stored in a local that shadows the state name.
+  it("does not flag when the operand is a shadowing local reading the fresh event value", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [checked, setChecked] = useState(false);
+        useEffect(() => {
+          el.addEventListener("change", (event) => {
+            const checked = event.target.checked;
+            setChecked(!checked);
+          });
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  // Real-world idiom: a subscription callback whose parameter delivers the
+  // fresh value and shadows the state name.
+  it("does not flag a callback parameter shadowing the state name", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [muted, setMuted] = useState(false);
+        useEffect(() => {
+          const sub = source.subscribe((muted) => setMuted(!muted));
+          return () => sub.unsubscribe();
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  // Real-world idiom: an effect closure runs from the committing render with
+  // fresh state, so a direct effect-body toggle never reads a stale value.
+  it("does not flag a direct effect-body toggle with the state in deps", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = ({ trigger }) => {
+        const [flipped, setFlipped] = useState(false);
+        useEffect(() => {
+          if (trigger && flipped) setFlipped(!flipped);
+        }, [trigger, flipped]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  // Real-world idiom: Storybook demo files toggle state loosely on purpose.
+  it("does not flag inside a Storybook stories file", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const Demo = () => {
+        const [isOpen, setIsOpen] = useState(false);
+        useEffect(() => {
+          setTimeout(() => setIsOpen(!isOpen), 100);
+        }, []);
+      };
+      `,
+      { filename: "toggle.stories.tsx" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a useReducer dispatch toggle", () => {
+    const result = runRule(
+      noBooleanToggleWithoutFunctionalUpdate,
+      `
+      const C = () => {
+        const [open, setOpen] = useReducer((s) => !s, false);
+        useEffect(() => {
+          setTimeout(() => setOpen(!open), 100);
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.ts
@@ -1,4 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isSetterCall } from "../../utils/is-setter-call.js";
@@ -6,6 +7,7 @@ import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { patternBindsName } from "./utils/pattern-binds-name.js";
 
 // Callees that defer execution past the current render — a toggle captured by
 // one of these closures can read stale state because the callback runs after
@@ -33,17 +35,12 @@ const DEFERRED_EXECUTION_CALLEE_NAMES: ReadonlySet<string> = new Set([
   "once",
 ]);
 
-const isFunctionLikeNode = (node: EsTreeNode): boolean =>
-  isNodeOfType(node, "ArrowFunctionExpression") ||
-  isNodeOfType(node, "FunctionExpression") ||
-  isNodeOfType(node, "FunctionDeclaration");
-
 const isInsideDeferredCallback = (node: EsTreeNode): boolean => {
   let current: EsTreeNode | null | undefined = node;
   while (current) {
     const parent: EsTreeNode | null | undefined = current.parent;
     if (!parent) return false;
-    if (isFunctionLikeNode(current) && isNodeOfType(parent, "CallExpression")) {
+    if (isFunctionLike(current) && isNodeOfType(parent, "CallExpression")) {
       const callee = parent.callee;
       let calleeName: string | null = null;
       if (isNodeOfType(callee, "Identifier")) {
@@ -57,24 +54,6 @@ const isInsideDeferredCallback = (node: EsTreeNode): boolean => {
       if (calleeName && DEFERRED_EXECUTION_CALLEE_NAMES.has(calleeName)) return true;
     }
     current = parent;
-  }
-  return false;
-};
-
-const patternBindsName = (pattern: EsTreeNode | null | undefined, name: string): boolean => {
-  if (!pattern) return false;
-  if (isNodeOfType(pattern, "Identifier")) return pattern.name === name;
-  if (isNodeOfType(pattern, "AssignmentPattern")) return patternBindsName(pattern.left, name);
-  if (isNodeOfType(pattern, "RestElement")) return patternBindsName(pattern.argument, name);
-  if (isNodeOfType(pattern, "ObjectPattern")) {
-    return (pattern.properties ?? []).some((property) =>
-      isNodeOfType(property, "Property")
-        ? patternBindsName(property.value, name)
-        : patternBindsName(property, name),
-    );
-  }
-  if (isNodeOfType(pattern, "ArrayPattern")) {
-    return (pattern.elements ?? []).some((element) => patternBindsName(element, name));
   }
   return false;
 };
@@ -118,11 +97,7 @@ const findUseStatePairedStateName = (node: EsTreeNode, setterName: string): stri
 const isStateNameShadowedAtCall = (node: EsTreeNode, stateName: string): boolean => {
   let cursor: EsTreeNode | null | undefined = node;
   while (cursor) {
-    if (
-      isNodeOfType(cursor, "ArrowFunctionExpression") ||
-      isNodeOfType(cursor, "FunctionExpression") ||
-      isNodeOfType(cursor, "FunctionDeclaration")
-    ) {
+    if (isFunctionLike(cursor)) {
       for (const param of cursor.params ?? []) {
         if (patternBindsName(param, stateName)) return true;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.ts
@@ -1,0 +1,179 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isSetterCall } from "../../utils/is-setter-call.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Callees that defer execution past the current render — a toggle captured by
+// one of these closures can read stale state because the callback runs after
+// later renders. A synchronous `onClick={() => setX(!x)}` recreates the arrow
+// (and re-reads fresh `x`) every render, so it is not a stale-read hazard.
+// Effect hooks (useEffect/useLayoutEffect/useInsertionEffect) are deliberately
+// NOT deferred: React runs the effect closure from the committing render, so a
+// direct effect-body toggle always reads the latest committed value; only
+// truly deferred calls nested inside an effect (setTimeout/subscribe/...)
+// carry the hazard, and those entries already cover them.
+const DEFERRED_EXECUTION_CALLEE_NAMES: ReadonlySet<string> = new Set([
+  "setTimeout",
+  "setInterval",
+  "setImmediate",
+  "queueMicrotask",
+  "requestAnimationFrame",
+  "requestIdleCallback",
+  "then",
+  "catch",
+  "finally",
+  "subscribe",
+  "addEventListener",
+  "addListener",
+  "on",
+  "once",
+]);
+
+const isFunctionLikeNode = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "ArrowFunctionExpression") ||
+  isNodeOfType(node, "FunctionExpression") ||
+  isNodeOfType(node, "FunctionDeclaration");
+
+const isInsideDeferredCallback = (node: EsTreeNode): boolean => {
+  let current: EsTreeNode | null | undefined = node;
+  while (current) {
+    const parent: EsTreeNode | null | undefined = current.parent;
+    if (!parent) return false;
+    if (isFunctionLikeNode(current) && isNodeOfType(parent, "CallExpression")) {
+      const callee = parent.callee;
+      let calleeName: string | null = null;
+      if (isNodeOfType(callee, "Identifier")) {
+        calleeName = callee.name;
+      } else if (
+        isNodeOfType(callee, "MemberExpression") &&
+        isNodeOfType(callee.property, "Identifier")
+      ) {
+        calleeName = callee.property.name;
+      }
+      if (calleeName && DEFERRED_EXECUTION_CALLEE_NAMES.has(calleeName)) return true;
+    }
+    current = parent;
+  }
+  return false;
+};
+
+const patternBindsName = (pattern: EsTreeNode | null | undefined, name: string): boolean => {
+  if (!pattern) return false;
+  if (isNodeOfType(pattern, "Identifier")) return pattern.name === name;
+  if (isNodeOfType(pattern, "AssignmentPattern")) return patternBindsName(pattern.left, name);
+  if (isNodeOfType(pattern, "RestElement")) return patternBindsName(pattern.argument, name);
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    return (pattern.properties ?? []).some((property) =>
+      isNodeOfType(property, "Property")
+        ? patternBindsName(property.value, name)
+        : patternBindsName(property, name),
+    );
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    return (pattern.elements ?? []).some((element) => patternBindsName(element, name));
+  }
+  return false;
+};
+
+const isUseStateDeclarator = (declarator: EsTreeNode): boolean =>
+  isNodeOfType(declarator, "VariableDeclarator") &&
+  isNodeOfType(declarator.init, "CallExpression") &&
+  isHookCall(declarator.init, "useState");
+
+// Locates the `const [state, setX] = useState(...)` declarator that binds
+// `setterName` at index 1 and returns the paired state name from index 0 —
+// so `const [isOpen, setOpen]` pairs `setOpen` with `isOpen` instead of a
+// naming-convention guess.
+const findUseStatePairedStateName = (node: EsTreeNode, setterName: string): string | null => {
+  let cursor: EsTreeNode | null | undefined = node;
+  while (cursor) {
+    if (isNodeOfType(cursor, "BlockStatement") || isNodeOfType(cursor, "Program")) {
+      for (const statement of cursor.body ?? []) {
+        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
+        for (const declarator of statement.declarations ?? []) {
+          if (!isUseStateDeclarator(declarator)) continue;
+          if (!isNodeOfType(declarator.id, "ArrayPattern")) continue;
+          const elements = declarator.id.elements ?? [];
+          const setterElement = elements.length > 1 ? elements[1] : null;
+          if (!isNodeOfType(setterElement, "Identifier") || setterElement.name !== setterName) {
+            continue;
+          }
+          const stateElement = elements[0];
+          return isNodeOfType(stateElement, "Identifier") ? stateElement.name : null;
+        }
+      }
+    }
+    cursor = cursor.parent;
+  }
+  return null;
+};
+
+// True when a binding between the setter call and the useState declaration
+// shadows the state name — a callback parameter or local const carrying the
+// FRESH value (`(checked) => setChecked(!checked)`) is not a stale state read.
+const isStateNameShadowedAtCall = (node: EsTreeNode, stateName: string): boolean => {
+  let cursor: EsTreeNode | null | undefined = node;
+  while (cursor) {
+    if (
+      isNodeOfType(cursor, "ArrowFunctionExpression") ||
+      isNodeOfType(cursor, "FunctionExpression") ||
+      isNodeOfType(cursor, "FunctionDeclaration")
+    ) {
+      for (const param of cursor.params ?? []) {
+        if (patternBindsName(param, stateName)) return true;
+      }
+    }
+    if (isNodeOfType(cursor, "BlockStatement") || isNodeOfType(cursor, "Program")) {
+      for (const statement of cursor.body ?? []) {
+        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
+        for (const declarator of statement.declarations ?? []) {
+          if (!patternBindsName(declarator.id, stateName)) continue;
+          if (isUseStateDeclarator(declarator)) return false;
+          return true;
+        }
+      }
+    }
+    cursor = cursor.parent;
+  }
+  return false;
+};
+
+export const noBooleanToggleWithoutFunctionalUpdate = defineRule({
+  id: "no-boolean-toggle-without-functional-update",
+  title: "Boolean toggle reads a stale value",
+  severity: "warn",
+  category: "Bugs",
+  tags: ["test-noise"],
+  recommendation:
+    "Toggle boolean state with the functional updater `setX(prev => !prev)` so a deferred double-toggle always reads the latest committed value.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isSetterCall(node)) return;
+      if (!node.arguments?.length) return;
+      if (!isNodeOfType(node.callee, "Identifier")) return;
+
+      const argument = node.arguments[0];
+      if (!isNodeOfType(argument, "UnaryExpression") || argument.operator !== "!") return;
+
+      // A bare Identifier only — `!field.value` / `!this.flag` (MemberExpression)
+      // and `!isValid()` (CallExpression) are out of scope.
+      const operand = stripParenExpression(argument.argument);
+      if (!isNodeOfType(operand, "Identifier")) return;
+
+      const pairedStateName = findUseStatePairedStateName(node, node.callee.name);
+      if (!pairedStateName || operand.name !== pairedStateName) return;
+      if (isStateNameShadowedAtCall(node, pairedStateName)) return;
+
+      if (!isInsideDeferredCallback(node)) return;
+
+      context.report({
+        node,
+        message: `You can lose this update because ${node.callee.name}(!${operand.name}) reads a stale value; use ${node.callee.name}(prev => !prev).`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -9,6 +9,7 @@ import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-str
 import { walkAst } from "../../utils/walk-ast.js";
 import { findTriggeredSideEffectCalleeName } from "./utils/find-triggered-side-effect-callee-name.js";
 import { hasDocumentClassListMutation } from "./utils/has-document-class-list-mutation.js";
+import { unwrapChainExpression } from "./utils/unwrap-chain-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -21,12 +22,6 @@ interface GuardExpression {
 
 const hasEventLikeNode = (node: EsTreeNode): boolean =>
   findTriggeredSideEffectCalleeName(node) !== null || hasDocumentClassListMutation(node);
-
-const unwrapChainExpression = (node: EsTreeNode | null | undefined): EsTreeNode | null => {
-  if (!node) return null;
-  if (isNodeOfType(node, "ChainExpression")) return node.expression;
-  return node;
-};
 
 const collectGuardExpressions = (
   node: EsTreeNode | null | undefined,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-wrapper-discards-callback-cleanup-return.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-wrapper-discards-callback-cleanup-return.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noEffectWrapperDiscardsCallbackCleanupReturn } from "./no-effect-wrapper-discards-callback-cleanup-return.js";
+
+describe("no-effect-wrapper-discards-callback-cleanup-return", () => {
+  it("flags a bare fn() when the param is typed EffectCallback", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (fn: EffectCallback, deps?: DependencyList) => {
+        const isMount = useRef(true);
+        useEffect(() => {
+          if (isMount.current) {
+            isMount.current = false;
+          } else {
+            fn();
+          }
+        }, deps);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare effect() when the wrapper is typed typeof useEffect", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect: typeof useEffect = (effect, deps) => {
+        const mounted = useRef(false);
+        useLayoutEffect(() => {
+          if (!mounted.current) {
+            mounted.current = true;
+            return;
+          }
+          effect();
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare call when the param returns void or a cleanup", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (effect: () => void | (() => void), deps?: DependencyList) => {
+        const mounted = useRef(false);
+        useEffect(() => {
+          if (mounted.current) {
+            effect();
+          } else {
+            mounted.current = true;
+          }
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare optional call effect?.() on an optional EffectCallback param", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (effect?: EffectCallback, deps?: DependencyList) => {
+        const mounted = useRef(false);
+        useEffect(() => {
+          if (mounted.current) {
+            effect?.();
+          } else {
+            mounted.current = true;
+          }
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a guarded bare call mounted.current && effect()", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (effect: EffectCallback, deps?: DependencyList) => {
+        const mounted = useRef(false);
+        useEffect(() => {
+          mounted.current && effect();
+          mounted.current = true;
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare call inside a statement-position ternary", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (effect: EffectCallback, deps?: DependencyList) => {
+        const mounted = useRef(false);
+        useEffect(() => {
+          mounted.current ? effect() : (mounted.current = true);
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a bare call when the EffectCallback param has a default value", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (effect: EffectCallback = () => {}, deps?: DependencyList) => {
+        const mounted = useRef(false);
+        useEffect(() => {
+          if (mounted.current) {
+            effect();
+          } else {
+            mounted.current = true;
+          }
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for a defaulted param typed plain () => void", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useEffectOnce = (effect: () => void = () => {}, deps?: DependencyList) => {
+        useEffect(() => {
+          effect();
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the optional call is already returned", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (effect?: EffectCallback, deps?: DependencyList) => {
+        const mounted = useRef(false);
+        useEffect(() => {
+          if (mounted.current) return effect?.();
+          mounted.current = true;
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the param is typed () => void", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useEffectAsync = (effect: () => void, deps?: DependencyList) => {
+        useEffect(() => {
+          effect();
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the forwarded call is already returned", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (effect: EffectCallback, deps?: DependencyList) => {
+        const mounted = useRef(false);
+        useEffect(() => {
+          if (mounted.current) return effect();
+          mounted.current = true;
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a bare call that is not a forwarded EffectCallback", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useMount = (cb) => {
+        useEffect(() => {
+          scrollTo(0, 0);
+        }, []);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the callback is forwarded directly to useEffect", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (effect: EffectCallback, deps?: DependencyList) => {
+        useEffect(effect, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the param has no resolvable type annotation", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `const useUpdateEffect = (fn, deps) => {
+        useEffect(() => {
+          fn();
+        }, deps);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet outside a custom hook", () => {
+    const result = runRule(
+      noEffectWrapperDiscardsCallbackCleanupReturn,
+      `function setup(fn: EffectCallback, deps) {
+        useEffect(() => {
+          fn();
+        }, deps);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-wrapper-discards-callback-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-wrapper-discards-callback-cleanup-return.ts
@@ -14,8 +14,6 @@ import type { RuleContext } from "../../utils/rule-context.js";
 
 const EFFECT_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect"]);
 
-// The parameter's binding Identifier, unwrapping a default-value
-// AssignmentPattern (`effect: EffectCallback = noop`), or null.
 const parameterIdentifier = (parameter: EsTreeNode): EsTreeNodeOfType<"Identifier"> | null => {
   if (isNodeOfType(parameter, "Identifier")) return parameter;
   if (isNodeOfType(parameter, "AssignmentPattern") && isNodeOfType(parameter.left, "Identifier")) {
@@ -24,7 +22,6 @@ const parameterIdentifier = (parameter: EsTreeNode): EsTreeNodeOfType<"Identifie
   return null;
 };
 
-// The actual type node behind a parameter's `: T` annotation, or null.
 const parameterTypeNode = (parameter: EsTreeNode): EsTreeNode | null => {
   const identifier = parameterIdentifier(parameter);
   if (!identifier) return null;
@@ -33,10 +30,7 @@ const parameterTypeNode = (parameter: EsTreeNode): EsTreeNode | null => {
   return (annotation.typeAnnotation as EsTreeNode | undefined) ?? null;
 };
 
-// Unwraps `(T)` parenthesized type wrappers so union members compare
-// against the semantic type. `TSParenthesizedType` is emitted by
-// oxc-parser but absent from `@typescript-eslint/types`, so it is
-// matched by its `.type` string rather than through `isNodeOfType`.
+// TSParenthesizedType is absent from @typescript-eslint/types, so match by type string.
 const unwrapParenthesizedType = (typeNode: EsTreeNode): EsTreeNode => {
   let current: EsTreeNode = typeNode;
   while ((current as { type: string }).type === "TSParenthesizedType") {
@@ -47,9 +41,6 @@ const unwrapParenthesizedType = (typeNode: EsTreeNode): EsTreeNode => {
   return current;
 };
 
-// True for a function type whose return can be a cleanup function, i.e.
-// `() => void | (() => void)`: the return type is a union that includes
-// a function type. A plain `() => void` returns false (cannot).
 const functionTypeCanReturnCleanup = (typeNode: EsTreeNode): boolean => {
   if (!isNodeOfType(typeNode, "TSFunctionType")) return false;
   const returnAnnotation = typeNode.returnType;
@@ -61,7 +52,6 @@ const functionTypeCanReturnCleanup = (typeNode: EsTreeNode): boolean => {
   );
 };
 
-// A parameter typed `EffectCallback` or `() => (void | (() => void))`.
 const parameterIsEffectCallback = (parameter: EsTreeNode): boolean => {
   const typeNode = parameterTypeNode(parameter);
   if (!typeNode) return false;
@@ -75,8 +65,6 @@ const parameterIsEffectCallback = (parameter: EsTreeNode): boolean => {
   return functionTypeCanReturnCleanup(typeNode);
 };
 
-// True when the wrapper binding is annotated `typeof useEffect` /
-// `typeof useLayoutEffect`, so its first parameter is the EffectCallback.
 const wrapperBindingIsTypedAsEffectHook = (hookFunction: EsTreeNode): boolean => {
   const declarator = hookFunction.parent;
   if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
@@ -88,8 +76,6 @@ const wrapperBindingIsTypedAsEffectHook = (hookFunction: EsTreeNode): boolean =>
   return isNodeOfType(query.exprName, "Identifier") && EFFECT_HOOK_NAMES.has(query.exprName.name);
 };
 
-// The name of the forwarded EffectCallback parameter of a custom hook,
-// or null when no parameter is a resolvable EffectCallback.
 const forwardedEffectCallbackParameterName = (hookFunction: EsTreeNode): string | null => {
   if (!isFunctionLike(hookFunction)) return null;
   const params = hookFunction.params ?? [];
@@ -98,17 +84,13 @@ const forwardedEffectCallbackParameterName = (hookFunction: EsTreeNode): string 
     return firstParam ? (parameterIdentifier(firstParam as EsTreeNode)?.name ?? null) : null;
   }
   for (const param of params) {
-    if (parameterIsEffectCallback(param as EsTreeNode)) {
-      return parameterIdentifier(param as EsTreeNode)?.name ?? null;
+    if (parameterIsEffectCallback(param)) {
+      return parameterIdentifier(param)?.name ?? null;
     }
   }
   return null;
 };
 
-// The discarded `callbackName()` call inside a statement-position
-// expression, unwrapping the shapes that still drop the cleanup:
-// `fn?.()` (ChainExpression), `guard && fn()` (LogicalExpression), and
-// `guard ? fn() : other` (ConditionalExpression).
 const discardedForwardedCallInExpression = (
   expression: EsTreeNode,
   callbackName: string,
@@ -138,9 +120,6 @@ const discardedForwardedCallInExpression = (
   return null;
 };
 
-// The bare `fn()` expression statement inside `effectBody` that invokes
-// `callbackName` without returning it, or null. Nested functions are
-// pruned; `return fn()` is a ReturnStatement and never matches.
 const findBareForwardedCall = (effectBody: EsTreeNode, callbackName: string): EsTreeNode | null => {
   let bareCall: EsTreeNode | null = null;
   walkAst(effectBody, (child) => {
@@ -172,7 +151,7 @@ export const noEffectWrapperDiscardsCallbackCleanupReturn = defineRule({
       // `useEffect(effect, deps)` forwards the callback directly (React
       // wires its return) — only inline effect bodies can drop it.
       if (!effectCallback || !isFunctionLike(effectCallback)) return;
-      const effectBody = effectCallback.body as EsTreeNode;
+      const effectBody = effectCallback.body;
       if (!isNodeOfType(effectBody, "BlockStatement")) return;
 
       const hookFunction = nearestEnclosingFunction(node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-wrapper-discards-callback-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-wrapper-discards-callback-cleanup-return.ts
@@ -1,0 +1,197 @@
+import {
+  componentOrHookDisplayNameForFunction,
+  nearestEnclosingFunction,
+} from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactHookName } from "../../utils/is-react-hook-name.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const EFFECT_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect"]);
+
+// The parameter's binding Identifier, unwrapping a default-value
+// AssignmentPattern (`effect: EffectCallback = noop`), or null.
+const parameterIdentifier = (parameter: EsTreeNode): EsTreeNodeOfType<"Identifier"> | null => {
+  if (isNodeOfType(parameter, "Identifier")) return parameter;
+  if (isNodeOfType(parameter, "AssignmentPattern") && isNodeOfType(parameter.left, "Identifier")) {
+    return parameter.left;
+  }
+  return null;
+};
+
+// The actual type node behind a parameter's `: T` annotation, or null.
+const parameterTypeNode = (parameter: EsTreeNode): EsTreeNode | null => {
+  const identifier = parameterIdentifier(parameter);
+  if (!identifier) return null;
+  const annotation = identifier.typeAnnotation;
+  if (!annotation || !isNodeOfType(annotation, "TSTypeAnnotation")) return null;
+  return (annotation.typeAnnotation as EsTreeNode | undefined) ?? null;
+};
+
+// Unwraps `(T)` parenthesized type wrappers so union members compare
+// against the semantic type. `TSParenthesizedType` is emitted by
+// oxc-parser but absent from `@typescript-eslint/types`, so it is
+// matched by its `.type` string rather than through `isNodeOfType`.
+const unwrapParenthesizedType = (typeNode: EsTreeNode): EsTreeNode => {
+  let current: EsTreeNode = typeNode;
+  while ((current as { type: string }).type === "TSParenthesizedType") {
+    const inner = (current as { typeAnnotation?: EsTreeNode }).typeAnnotation;
+    if (!inner) break;
+    current = inner;
+  }
+  return current;
+};
+
+// True for a function type whose return can be a cleanup function, i.e.
+// `() => void | (() => void)`: the return type is a union that includes
+// a function type. A plain `() => void` returns false (cannot).
+const functionTypeCanReturnCleanup = (typeNode: EsTreeNode): boolean => {
+  if (!isNodeOfType(typeNode, "TSFunctionType")) return false;
+  const returnAnnotation = typeNode.returnType;
+  if (!returnAnnotation || !isNodeOfType(returnAnnotation, "TSTypeAnnotation")) return false;
+  const returnType = returnAnnotation.typeAnnotation as EsTreeNode;
+  if (!isNodeOfType(returnType, "TSUnionType")) return false;
+  return (returnType.types ?? []).some((member) =>
+    isNodeOfType(unwrapParenthesizedType(member as EsTreeNode), "TSFunctionType"),
+  );
+};
+
+// A parameter typed `EffectCallback` or `() => (void | (() => void))`.
+const parameterIsEffectCallback = (parameter: EsTreeNode): boolean => {
+  const typeNode = parameterTypeNode(parameter);
+  if (!typeNode) return false;
+  if (
+    isNodeOfType(typeNode, "TSTypeReference") &&
+    isNodeOfType(typeNode.typeName, "Identifier") &&
+    typeNode.typeName.name === "EffectCallback"
+  ) {
+    return true;
+  }
+  return functionTypeCanReturnCleanup(typeNode);
+};
+
+// True when the wrapper binding is annotated `typeof useEffect` /
+// `typeof useLayoutEffect`, so its first parameter is the EffectCallback.
+const wrapperBindingIsTypedAsEffectHook = (hookFunction: EsTreeNode): boolean => {
+  const declarator = hookFunction.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
+  if (!isNodeOfType(declarator.id, "Identifier")) return false;
+  const annotation = declarator.id.typeAnnotation;
+  if (!annotation || !isNodeOfType(annotation, "TSTypeAnnotation")) return false;
+  const query = annotation.typeAnnotation as EsTreeNode;
+  if (!isNodeOfType(query, "TSTypeQuery")) return false;
+  return isNodeOfType(query.exprName, "Identifier") && EFFECT_HOOK_NAMES.has(query.exprName.name);
+};
+
+// The name of the forwarded EffectCallback parameter of a custom hook,
+// or null when no parameter is a resolvable EffectCallback.
+const forwardedEffectCallbackParameterName = (hookFunction: EsTreeNode): string | null => {
+  if (!isFunctionLike(hookFunction)) return null;
+  const params = hookFunction.params ?? [];
+  if (wrapperBindingIsTypedAsEffectHook(hookFunction)) {
+    const firstParam = params[0];
+    return firstParam ? (parameterIdentifier(firstParam as EsTreeNode)?.name ?? null) : null;
+  }
+  for (const param of params) {
+    if (parameterIsEffectCallback(param as EsTreeNode)) {
+      return parameterIdentifier(param as EsTreeNode)?.name ?? null;
+    }
+  }
+  return null;
+};
+
+// The discarded `callbackName()` call inside a statement-position
+// expression, unwrapping the shapes that still drop the cleanup:
+// `fn?.()` (ChainExpression), `guard && fn()` (LogicalExpression), and
+// `guard ? fn() : other` (ConditionalExpression).
+const discardedForwardedCallInExpression = (
+  expression: EsTreeNode,
+  callbackName: string,
+): EsTreeNode | null => {
+  if (isNodeOfType(expression, "ChainExpression")) {
+    return discardedForwardedCallInExpression(expression.expression, callbackName);
+  }
+  if (isNodeOfType(expression, "LogicalExpression")) {
+    return (
+      discardedForwardedCallInExpression(expression.left, callbackName) ??
+      discardedForwardedCallInExpression(expression.right, callbackName)
+    );
+  }
+  if (isNodeOfType(expression, "ConditionalExpression")) {
+    return (
+      discardedForwardedCallInExpression(expression.consequent, callbackName) ??
+      discardedForwardedCallInExpression(expression.alternate, callbackName)
+    );
+  }
+  if (
+    isNodeOfType(expression, "CallExpression") &&
+    isNodeOfType(expression.callee, "Identifier") &&
+    expression.callee.name === callbackName
+  ) {
+    return expression;
+  }
+  return null;
+};
+
+// The bare `fn()` expression statement inside `effectBody` that invokes
+// `callbackName` without returning it, or null. Nested functions are
+// pruned; `return fn()` is a ReturnStatement and never matches.
+const findBareForwardedCall = (effectBody: EsTreeNode, callbackName: string): EsTreeNode | null => {
+  let bareCall: EsTreeNode | null = null;
+  walkAst(effectBody, (child) => {
+    if (bareCall) return false;
+    if (child !== effectBody && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "ExpressionStatement")) return;
+    const forwardedCall = discardedForwardedCallInExpression(child.expression, callbackName);
+    if (forwardedCall) {
+      bareCall = forwardedCall;
+      return false;
+    }
+  });
+  return bareCall;
+};
+
+export const noEffectWrapperDiscardsCallbackCleanupReturn = defineRule({
+  id: "no-effect-wrapper-discards-callback-cleanup-return",
+  title: "Effect wrapper discards forwarded cleanup return",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "A custom effect wrapper must return its forwarded EffectCallback's result so React can run the cleanup. Calling it as a bare `fn()` instead of `return fn()` silently drops the cleanup, leaking every subscription/timer/listener it set up.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const calleeName = getCalleeName(node);
+      if (!calleeName || !EFFECT_HOOK_NAMES.has(calleeName)) return;
+
+      const effectCallback = node.arguments?.[0];
+      // `useEffect(effect, deps)` forwards the callback directly (React
+      // wires its return) — only inline effect bodies can drop it.
+      if (!effectCallback || !isFunctionLike(effectCallback)) return;
+      const effectBody = effectCallback.body as EsTreeNode;
+      if (!isNodeOfType(effectBody, "BlockStatement")) return;
+
+      const hookFunction = nearestEnclosingFunction(node);
+      if (!hookFunction) return;
+      const hookName = componentOrHookDisplayNameForFunction(hookFunction);
+      if (!hookName || !isReactHookName(hookName)) return;
+
+      const callbackName = forwardedEffectCallbackParameterName(hookFunction);
+      if (!callbackName) return;
+
+      const bareCall = findBareForwardedCall(effectBody, callbackName);
+      if (!bareCall) return;
+      context.report({
+        node: bareCall,
+        message:
+          "This forwards an EffectCallback but calls it as a bare statement, so the cleanup it returns is discarded and never runs (leaking its subscriptions/timers/listeners). Return it instead: `return " +
+          callbackName +
+          "();`.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -1,0 +1,364 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noLoadingFlagResetOutsideFinally } from "./no-loading-flag-reset-outside-finally.js";
+
+describe("no-loading-flag-reset-outside-finally", () => {
+  it("flags a trailing reset with no try/catch at all", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const load = async () => {
+        setIsLoading(true);
+        const result = await getTrashPaginated(page, perPage);
+        setItems(result.items);
+        setIsLoading(false);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when a swallowing catch makes the trailing reset run on rejection too (setError-in-catch idiom)", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `async function fetchNetworkAnalysis() {
+        setLoading(true);
+        try {
+          const data = await load(dataId);
+          setResult(data);
+        } catch (e) {
+          setError(e);
+        }
+        setLoading(false);
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a trailing reset when the catch rethrows, so rejection still skips it", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const save = async () => {
+        setSaving(true);
+        try {
+          await persist(draft);
+        } catch (e) {
+          reportError(e);
+          throw e;
+        }
+        setSaving(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a trailing reset when the catch returns early, so rejection still skips it", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const save = async () => {
+        setSaving(true);
+        try {
+          await persist(draft);
+        } catch (e) {
+          reportError(e);
+          return;
+        }
+        setSaving(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a reset inside the try body even when the catch swallows", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const load = async () => {
+        setLoading(true);
+        try {
+          const data = await fetchData();
+          setResult(data);
+          setLoading(false);
+        } catch (e) {
+          setError(e);
+        }
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a submit handler that resets only after the awaited mutation", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const onSubmit = async () => {
+        setSubmitting(true);
+        await savePlugin(values);
+        onClose();
+        setSubmitting(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the reset is mirrored in the catch", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const search = async (query) => {
+        setLoading(true);
+        try {
+          const res = await autocomplete(query);
+          setResults(res);
+          setLoading(false);
+        } catch (e) {
+          setLoading(false);
+          reportError(e);
+        }
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the reset is in a finally", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const submit = async () => {
+        setSubmitting(true);
+        try {
+          await placeBid(input);
+        } finally {
+          setSubmitting(false);
+        }
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a non-loading boolean toggle", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const toggle = async () => {
+        setOpen(true);
+        await animate();
+        setOpen(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when there is no await between set and reset", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const load = () => {
+        setLoading(true);
+        doWork();
+        setLoading(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat a nested callback reset as this scope's reset", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const load = async () => {
+        setLoading(true);
+        await fetchThings();
+        subscribe(() => {
+          setLoading(false);
+        });
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the reset happens before the await", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const load = async () => {
+        setLoading(true);
+        setLoading(false);
+        await fetchThings();
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for await Promise.allSettled, which never rejects by spec", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const loadAll = async () => {
+        setLoading(true);
+        const results = await Promise.allSettled(requests);
+        setItems(results);
+        setLoading(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for the fetch-with-fallback idiom await f().catch(() => null)", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const load = async () => {
+        setLoading(true);
+        const data = await fetchThings().catch(() => null);
+        setItems(data ?? []);
+        setLoading(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a never-rejecting result-object wrapper whose result is branch-checked", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const remove = async () => {
+        setIsDeleting(true);
+        const result = await deleteWorkspace(workspaceId);
+        if (!result.success) {
+          setError(result.message);
+        }
+        setIsDeleting(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the awaited result binding itself is truthiness-checked (if (!result) guard)", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const invite = async () => {
+        setSending(true);
+        const response = await sendInvites(emails);
+        if (!response) {
+          showError();
+        }
+        setSending(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for the destructured error-field convention (supabase-style { data, error })", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const load = async () => {
+        setLoading(true);
+        const { data, error } = await supabase.from("posts").select();
+        if (error) {
+          setError(error);
+        }
+        setItems(data);
+        setLoading(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags when the awaited result is used without any error-shape check", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const load = async () => {
+        setLoading(true);
+        const result = await getSurveyData(surveyId);
+        setSurvey(result.survey);
+        setLoading(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the truthy set and the reset sit on mutually exclusive if/else branches", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const toggle = async (next) => {
+        if (next) {
+          setLoading(true);
+          await start();
+        } else {
+          await stop();
+          setLoading(false);
+        }
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the awaited Promise.all result is result-shape-checked inside an array-method callback", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const handleConfirmBulkDelete = async () => {
+        setIsBulkDeleting(true);
+        const ids = Array.from(selectedIds);
+        const results = await Promise.all(ids.map((id) => deleteProject(id, false)));
+        const failures = results.filter((r) => !r.success);
+        setIsBulkDeleting(false);
+        if (failures.length === 0) {
+          toast.success("moved");
+        } else {
+          toast.error(failures[0]?.error);
+        }
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when a single awaited result is result-shape-checked via .some on the binding", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const submitAll = async () => {
+        setSubmitting(true);
+        const outcomes = await submitBatch(entries);
+        const didAnyFail = outcomes.some((outcome) => outcome.error);
+        setSubmitting(false);
+        if (didAnyFail) showError();
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags when the array callback checks a property outside the result shape", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const loadPhotos = async (searchValue) => {
+        setLoading(true);
+        const results = await Promise.all(requests);
+        setLoading(false);
+        const photos = results.flatMap((result) => {
+          if (result.errors) {
+            setError(result.errors[0]);
+            return [];
+          }
+          return result.response.results;
+        });
+        setPhotos(photos);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a Promise.all await whose result is consumed without any result-shape check", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const preview = async () => {
+        setFetching(true);
+        const [html, text] = await Promise.all([fetchHtml(id), fetchText(id)]);
+        setPreviews({ html, text });
+        setFetching(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an unprotected await between the set and the reset even when an earlier await gates the set", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const submit = async () => {
+        const ok = await validate(values);
+        if (!ok) return;
+        setSubmitting(true);
+        await save(values);
+        setSubmitting(false);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -1,0 +1,381 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const MESSAGE =
+  "This resets a loading/busy flag only on the success path: if the awaited call rejects the reset never runs and the flag stays stuck truthy (a spinner that never stops, a button disabled forever). Move the reset into a `finally` block, or mirror it on every catch, so it clears on rejection too.";
+
+// Setters whose truthy/falsy value models a loading/busy/pending UI flag.
+// The reset-on-success defect only matters for a flag the UI reads to show a
+// spinner or disable a control, so we gate on the setter name to stay quiet
+// on ordinary boolean toggles.
+const LOADING_FLAG_SETTER_PATTERN =
+  /(loading|busy|submitting|saving|pending|fetching|processing|uploading|spinner|disabl|refreshing|updating|inflight|working|posting|sending|deleting)/i;
+
+// Property names that mark the awaited call as a never-rejecting result-object
+// wrapper (`const result = await f(); if (result.success) ...`) — errors are
+// folded into the resolved value, so the await cannot skip the trailing reset.
+const RESULT_SHAPE_PROPERTY_NAMES = new Set(["success", "error", "ok"]);
+
+// Array methods whose callback receives each element of the awaited result,
+// so `<results>.filter((entry) => !entry.success)` is a per-element result-shape
+// check equivalent to `if (result.success)` on a single awaited binding.
+const ARRAY_CALLBACK_METHOD_NAMES = new Set([
+  "filter",
+  "map",
+  "flatMap",
+  "some",
+  "every",
+  "find",
+  "forEach",
+]);
+
+const getNodeStart = (node: EsTreeNode): number | null => {
+  const start = (node as { start?: unknown }).start;
+  return typeof start === "number" ? start : null;
+};
+
+const getNodeEnd = (node: EsTreeNode): number | null => {
+  const end = (node as { end?: unknown }).end;
+  return typeof end === "number" ? end : null;
+};
+
+// The boolean argument of a `setX(true)` / `setX(false)` call, or null when
+// the call is not a bare-identifier setter with a boolean-literal first arg.
+const getSetterBooleanValue = (
+  node: EsTreeNodeOfType<"CallExpression">,
+): { setterName: string; value: boolean } | null => {
+  if (!isNodeOfType(node.callee, "Identifier")) return null;
+  const firstArgument = node.arguments[0];
+  if (!firstArgument || !isNodeOfType(firstArgument, "Literal")) return null;
+  if (typeof firstArgument.value !== "boolean") return null;
+  return { setterName: node.callee.name, value: firstArgument.value };
+};
+
+// Where a call sits relative to the enclosing async function's try/catch:
+// inside a `finally` finalizer, inside a `catch` handler, or neither
+// ("plain" — a trailing success-path statement or a bare try body).
+const classifyResetContext = (
+  callNode: EsTreeNode,
+  functionNode: EsTreeNode,
+): "finally" | "catch" | "plain" => {
+  let child: EsTreeNode = callNode;
+  let cursor: EsTreeNode | null | undefined = callNode.parent;
+  while (cursor && cursor !== functionNode) {
+    if (isNodeOfType(cursor, "CatchClause")) return "catch";
+    if (isNodeOfType(cursor, "TryStatement") && cursor.finalizer === child) return "finally";
+    child = cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return "plain";
+};
+
+// Walks the function's own body, never descending into a nested function, so
+// awaits/setters belong to THIS async scope, not a deeper closure.
+const walkOwnScope = (functionNode: EsTreeNode, visit: (node: EsTreeNode) => void): void => {
+  if (!isFunctionLike(functionNode)) return;
+  const body = functionNode.body;
+  if (!body) return;
+  walkAst(body, (child: EsTreeNode) => {
+    if (child !== body && isFunctionLike(child)) return false;
+    visit(child);
+  });
+};
+
+const unwrapChainExpression = (expression: EsTreeNode): EsTreeNode =>
+  isNodeOfType(expression, "ChainExpression") ? expression.expression : expression;
+
+// `await Promise.allSettled(...)` never rejects by spec, and
+// `await f().catch(...)` handles rejection inline, so the await always
+// resumes and the trailing reset still runs.
+const isNeverRejectingAwaitedExpression = (
+  awaitNode: EsTreeNodeOfType<"AwaitExpression">,
+): boolean => {
+  const awaited = unwrapChainExpression(awaitNode.argument);
+  if (!isNodeOfType(awaited, "CallExpression")) return false;
+  const callee = unwrapChainExpression(awaited.callee);
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier")) return false;
+  if (callee.property.name === "catch") return true;
+  return (
+    callee.property.name === "allSettled" &&
+    isNodeOfType(callee.object, "Identifier") &&
+    callee.object.name === "Promise"
+  );
+};
+
+const isWithinIfTest = (node: EsTreeNode, functionNode: EsTreeNode): boolean => {
+  let child: EsTreeNode = node;
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor && cursor !== functionNode) {
+    if (isNodeOfType(cursor, "IfStatement")) return cursor.test === child;
+    if (isFunctionLike(cursor)) return false;
+    child = cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+// `const result = await f(...)` where the binding (or a destructured
+// success/error/ok field) is branch-checked in an `if` marks the callee as a
+// result-object wrapper that folds errors into a resolved value.
+const isResultObjectCheckedAwait = (
+  awaitNode: EsTreeNodeOfType<"AwaitExpression">,
+  checkedResultNames: ReadonlySet<string>,
+): boolean => {
+  const parent = awaitNode.parent;
+  if (!isNodeOfType(parent, "VariableDeclarator") || parent.init !== awaitNode) return false;
+  const bindingTarget = parent.id;
+  if (isNodeOfType(bindingTarget, "Identifier")) return checkedResultNames.has(bindingTarget.name);
+  if (isNodeOfType(bindingTarget, "ObjectPattern")) {
+    return bindingTarget.properties.some(
+      (property) =>
+        isNodeOfType(property, "Property") &&
+        isNodeOfType(property.key, "Identifier") &&
+        RESULT_SHAPE_PROPERTY_NAMES.has(property.key.name) &&
+        isNodeOfType(property.value, "Identifier") &&
+        checkedResultNames.has(property.value.name),
+    );
+  }
+  return false;
+};
+
+// A `throw` or `return` in the catch handler's own scope skips the statements
+// after the try, so the handler does not guarantee the trailing reset runs.
+const catchHandlerEscapes = (handler: EsTreeNode): boolean => {
+  let didFindEscape = false;
+  walkAst(handler, (child: EsTreeNode) => {
+    if (child !== handler && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "ThrowStatement") || isNodeOfType(child, "ReturnStatement")) {
+      didFindEscape = true;
+    }
+  });
+  return didFindEscape;
+};
+
+// When the await sits in a `try` whose catch swallows the error (no rethrow,
+// no return) and the reset comes after that whole try statement, the reset
+// runs on the rejection path too — it is semantically a `finally`.
+const isRejectionSwallowedBeforeReset = (
+  awaitNode: EsTreeNode,
+  functionNode: EsTreeNode,
+  resetStart: number,
+): boolean => {
+  let child: EsTreeNode = awaitNode;
+  let cursor: EsTreeNode | null | undefined = awaitNode.parent;
+  while (cursor && cursor !== functionNode) {
+    if (isNodeOfType(cursor, "TryStatement") && cursor.block === child && cursor.handler) {
+      const tryEnd = getNodeEnd(cursor);
+      if (tryEnd !== null && tryEnd < resetStart && !catchHandlerEscapes(cursor.handler)) {
+        return true;
+      }
+    }
+    child = cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+const collectIfBranches = (
+  node: EsTreeNode,
+  functionNode: EsTreeNode,
+): Map<EsTreeNode, "consequent" | "alternate"> => {
+  const branches = new Map<EsTreeNode, "consequent" | "alternate">();
+  let child: EsTreeNode = node;
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor && cursor !== functionNode) {
+    if (isNodeOfType(cursor, "IfStatement")) {
+      if (cursor.consequent === child) branches.set(cursor, "consequent");
+      else if (cursor.alternate === child) branches.set(cursor, "alternate");
+    }
+    child = cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return branches;
+};
+
+// Source-offset ordering merges mutually exclusive if/else branches; two nodes
+// on opposite branches of the same `if` never execute on the same call.
+const areOnExclusiveBranches = (
+  first: EsTreeNode,
+  second: EsTreeNode,
+  functionNode: EsTreeNode,
+): boolean => {
+  const firstBranches = collectIfBranches(first, functionNode);
+  if (firstBranches.size === 0) return false;
+  const secondBranches = collectIfBranches(second, functionNode);
+  for (const [ifNode, branch] of firstBranches) {
+    const otherBranch = secondBranches.get(ifNode);
+    if (otherBranch && otherBranch !== branch) return true;
+  }
+  return false;
+};
+
+const recordCheckedResultName = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  checkedResultNames: Set<string>,
+): void => {
+  const parent = identifier.parent;
+  if (
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.object === identifier &&
+    !parent.computed &&
+    isNodeOfType(parent.property, "Identifier") &&
+    RESULT_SHAPE_PROPERTY_NAMES.has(parent.property.name)
+  ) {
+    checkedResultNames.add(identifier.name);
+    return;
+  }
+  if (
+    isNodeOfType(parent, "IfStatement") ||
+    (isNodeOfType(parent, "UnaryExpression") && parent.operator === "!") ||
+    isNodeOfType(parent, "LogicalExpression")
+  ) {
+    checkedResultNames.add(identifier.name);
+  }
+};
+
+// `<results>.filter((entry) => !entry.success)`-style calls: a result-shape
+// field of the callback parameter is checked per element, marking the awaited
+// `<results>` binding (e.g. from `await Promise.all(...)`) as a never-rejecting
+// result-object wrapper whose errors are consumed via the resolved value.
+const getResultCheckedArrayCallbackBindingName = (
+  callNode: EsTreeNodeOfType<"CallExpression">,
+): string | null => {
+  const callee = unwrapChainExpression(callNode.callee);
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
+  if (!isNodeOfType(callee.property, "Identifier")) return null;
+  if (!ARRAY_CALLBACK_METHOD_NAMES.has(callee.property.name)) return null;
+  const calleeObject = unwrapChainExpression(callee.object);
+  if (!isNodeOfType(calleeObject, "Identifier")) return null;
+  const callback = callNode.arguments[0];
+  if (!isFunctionLike(callback)) return null;
+  const firstParameter = callback.params[0];
+  if (!firstParameter || !isNodeOfType(firstParameter, "Identifier")) return null;
+  const parameterName = firstParameter.name;
+  let didFindResultShapeCheck = false;
+  walkAst(callback.body, (child: EsTreeNode) => {
+    if (
+      isNodeOfType(child, "MemberExpression") &&
+      !child.computed &&
+      isNodeOfType(child.object, "Identifier") &&
+      child.object.name === parameterName &&
+      isNodeOfType(child.property, "Identifier") &&
+      RESULT_SHAPE_PROPERTY_NAMES.has(child.property.name)
+    ) {
+      didFindResultShapeCheck = true;
+    }
+  });
+  return didFindResultShapeCheck ? calleeObject.name : null;
+};
+
+interface SetterCall {
+  value: boolean;
+  start: number;
+  context: "finally" | "catch" | "plain";
+  node: EsTreeNode;
+}
+
+interface AwaitSite {
+  node: EsTreeNodeOfType<"AwaitExpression">;
+  start: number;
+}
+
+const analyzeFunction = (functionNode: EsTreeNode, context: RuleContext): void => {
+  const awaitSites: AwaitSite[] = [];
+  const settersByName = new Map<string, SetterCall[]>();
+  const checkedResultNames = new Set<string>();
+
+  walkOwnScope(functionNode, (node) => {
+    if (isNodeOfType(node, "AwaitExpression")) {
+      const start = getNodeStart(node);
+      if (start !== null) awaitSites.push({ node, start });
+      return;
+    }
+    if (isNodeOfType(node, "Identifier")) {
+      if (isWithinIfTest(node, functionNode)) recordCheckedResultName(node, checkedResultNames);
+      return;
+    }
+    if (!isNodeOfType(node, "CallExpression")) return;
+    const resultCheckedBindingName = getResultCheckedArrayCallbackBindingName(node);
+    if (resultCheckedBindingName) checkedResultNames.add(resultCheckedBindingName);
+    const setter = getSetterBooleanValue(node);
+    if (!setter) return;
+    if (!LOADING_FLAG_SETTER_PATTERN.test(setter.setterName)) return;
+    const start = getNodeStart(node);
+    if (start === null) return;
+    const list = settersByName.get(setter.setterName) ?? [];
+    list.push({
+      value: setter.value,
+      start,
+      context: classifyResetContext(node, functionNode),
+      node,
+    });
+    settersByName.set(setter.setterName, list);
+  });
+
+  if (awaitSites.length === 0) return;
+
+  const rejectionCanSkipReset = (awaitSite: AwaitSite, resetStart: number): boolean =>
+    !isNeverRejectingAwaitedExpression(awaitSite.node) &&
+    !isResultObjectCheckedAwait(awaitSite.node, checkedResultNames) &&
+    !isRejectionSwallowedBeforeReset(awaitSite.node, functionNode, resetStart);
+
+  for (const calls of settersByName.values()) {
+    // A reset in `finally` always runs; a reset in `catch` mirrors the reset
+    // on the rejection path. Either discharges the clear-obligation, so the
+    // flag is not stuck.
+    if (
+      calls.some((call) => !call.value && (call.context === "finally" || call.context === "catch"))
+    ) {
+      continue;
+    }
+
+    const truthySets = calls.filter((call) => call.value);
+    if (truthySets.length === 0) continue;
+    const plainResets = calls.filter((call) => !call.value && call.context === "plain");
+
+    for (const reset of plainResets) {
+      const stuckFlagAwait = awaitSites.find(
+        (awaitSite) =>
+          awaitSite.start < reset.start &&
+          rejectionCanSkipReset(awaitSite, reset.start) &&
+          truthySets.some(
+            (truthySet) =>
+              truthySet.start < awaitSite.start &&
+              !areOnExclusiveBranches(truthySet.node, reset.node, functionNode) &&
+              !areOnExclusiveBranches(truthySet.node, awaitSite.node, functionNode) &&
+              !areOnExclusiveBranches(awaitSite.node, reset.node, functionNode),
+          ),
+      );
+      if (stuckFlagAwait) {
+        context.report({ node: reset.node, message: MESSAGE });
+        return;
+      }
+    }
+  }
+};
+
+export const noLoadingFlagResetOutsideFinally = defineRule({
+  id: "no-loading-flag-reset-outside-finally",
+  title: "Loading flag reset outside finally",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "A trailing `setLoading(false)` after an `await` never runs if the awaited call rejects, so the flag stays stuck truthy; reset it in a `finally` block (or mirror the reset on every catch) so it clears on both paths.",
+  create: (context: RuleContext) => ({
+    ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
+      analyzeFunction(node as EsTreeNode, context);
+    },
+    FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
+      analyzeFunction(node as EsTreeNode, context);
+    },
+    FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+      analyzeFunction(node as EsTreeNode, context);
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -4,15 +4,13 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { unwrapChainExpression } from "./utils/unwrap-chain-expression.js";
 
 const MESSAGE =
   "This resets a loading/busy flag only on the success path: if the awaited call rejects the reset never runs and the flag stays stuck truthy (a spinner that never stops, a button disabled forever). Move the reset into a `finally` block, or mirror it on every catch, so it clears on rejection too.";
 
-// Setters whose truthy/falsy value models a loading/busy/pending UI flag.
-// The reset-on-success defect only matters for a flag the UI reads to show a
-// spinner or disable a control, so we gate on the setter name to stay quiet
-// on ordinary boolean toggles.
 const LOADING_FLAG_SETTER_PATTERN =
   /(loading|busy|submitting|saving|pending|fetching|processing|uploading|spinner|disabl|refreshing|updating|inflight|working|posting|sending|deleting)/i;
 
@@ -73,21 +71,6 @@ const classifyResetContext = (
   }
   return "plain";
 };
-
-// Walks the function's own body, never descending into a nested function, so
-// awaits/setters belong to THIS async scope, not a deeper closure.
-const walkOwnScope = (functionNode: EsTreeNode, visit: (node: EsTreeNode) => void): void => {
-  if (!isFunctionLike(functionNode)) return;
-  const body = functionNode.body;
-  if (!body) return;
-  walkAst(body, (child: EsTreeNode) => {
-    if (child !== body && isFunctionLike(child)) return false;
-    visit(child);
-  });
-};
-
-const unwrapChainExpression = (expression: EsTreeNode): EsTreeNode =>
-  isNodeOfType(expression, "ChainExpression") ? expression.expression : expression;
 
 // `await Promise.allSettled(...)` never rejects by spec, and
 // `await f().catch(...)` handles rejection inline, so the await always
@@ -290,7 +273,7 @@ const analyzeFunction = (functionNode: EsTreeNode, context: RuleContext): void =
   const settersByName = new Map<string, SetterCall[]>();
   const checkedResultNames = new Set<string>();
 
-  walkOwnScope(functionNode, (node) => {
+  walkOwnFunctionScope(functionNode, (node) => {
     if (isNodeOfType(node, "AwaitExpression")) {
       const start = getNodeStart(node);
       if (start !== null) awaitSites.push({ node, start });
@@ -320,11 +303,6 @@ const analyzeFunction = (functionNode: EsTreeNode, context: RuleContext): void =
 
   if (awaitSites.length === 0) return;
 
-  const rejectionCanSkipReset = (awaitSite: AwaitSite, resetStart: number): boolean =>
-    !isNeverRejectingAwaitedExpression(awaitSite.node) &&
-    !isResultObjectCheckedAwait(awaitSite.node, checkedResultNames) &&
-    !isRejectionSwallowedBeforeReset(awaitSite.node, functionNode, resetStart);
-
   for (const calls of settersByName.values()) {
     // A reset in `finally` always runs; a reset in `catch` mirrors the reset
     // on the rejection path. Either discharges the clear-obligation, so the
@@ -343,7 +321,9 @@ const analyzeFunction = (functionNode: EsTreeNode, context: RuleContext): void =
       const stuckFlagAwait = awaitSites.find(
         (awaitSite) =>
           awaitSite.start < reset.start &&
-          rejectionCanSkipReset(awaitSite, reset.start) &&
+          !isNeverRejectingAwaitedExpression(awaitSite.node) &&
+          !isResultObjectCheckedAwait(awaitSite.node, checkedResultNames) &&
+          !isRejectionSwallowedBeforeReset(awaitSite.node, functionNode, reset.start) &&
           truthySets.some(
             (truthySet) =>
               truthySet.start < awaitSite.start &&
@@ -369,13 +349,13 @@ export const noLoadingFlagResetOutsideFinally = defineRule({
     "A trailing `setLoading(false)` after an `await` never runs if the awaited call rejects, so the flag stays stuck truthy; reset it in a `finally` block (or mirror the reset on every catch) so it clears on both paths.",
   create: (context: RuleContext) => ({
     ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
-      analyzeFunction(node as EsTreeNode, context);
+      analyzeFunction(node, context);
     },
     FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
-      analyzeFunction(node as EsTreeNode, context);
+      analyzeFunction(node, context);
     },
     FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
-      analyzeFunction(node as EsTreeNode, context);
+      analyzeFunction(node, context);
     },
   }),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noMutateThenSetOrReturnSameReference } from "./no-mutate-then-set-or-return-same-reference.js";
+
+describe("no-mutate-then-set-or-return-same-reference", () => {
+  it("flags setX(state.add(index)) on a state Set", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Synth = () => {
+        const [sequence, setSequence] = useState(new Set([]));
+        if (value) {
+          setSequence(sequence.add(index));
+        }
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags mutate-prev-in-updater that returns the same reference", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Picker = () => {
+        const [selected, setSelected] = useState(new Set());
+        setSelected((prev) => {
+          prev.delete(id);
+          return prev;
+        });
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags mutate-then-setX(X) on a state array", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Table = () => {
+        const [rows, setRows] = useState(data);
+        rows.sort(byName);
+        setRows(rows);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the concise self-returning mutator updater", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Picker = () => {
+        const [selected, setSelected] = useState(new Set());
+        setSelected((prev) => prev.add(id));
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags splice-then-return-prev in a functional updater", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Pack = () => {
+        const [pack, setPack] = useState([]);
+        setPack((oldPack) => {
+          oldPack.splice(index, 1, newEmote);
+          return oldPack;
+        });
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for a fresh local via Array.from then mutated", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Survey = () => {
+        const [questions, setQuestions] = useState([]);
+        const newQuestions = Array.from(questions);
+        newQuestions.splice(index, 1, updated);
+        setQuestions(newQuestions);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a spread-copy then mutated", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Files = () => {
+        const [files, setFiles] = useState([]);
+        const next = [...files];
+        next.splice(i, 1);
+        setFiles(next);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a new Set(...) clone then mutated", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Synth = () => {
+        const [sequence, setSequence] = useState(new Set());
+        const clonedSet = new Set(sequence);
+        clonedSet.delete(index);
+        setSequence(clonedSet);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for react-router setSearchParams updater (not a useState setter)", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Plan = () => {
+        const [searchParams, setSearchParams] = useSearchParams();
+        setSearchParams((prev) => {
+          prev.delete("plan");
+          return prev;
+        });
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for reverse on a freshly derived local with no setter", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const useGrouped = (messages) => {
+        const groupAllMessages = groupBy(messages).reverse();
+        return groupAllMessages;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for concat which returns a new array", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const List = () => {
+        const [items, setItems] = useState([]);
+        setItems(items.concat(next));
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a member-chain in-place mutation then setX(X) (form.tags.push then setForm(form))", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Form = () => {
+        const [form, setForm] = useState({ tags: [] });
+        const addTag = (tag) => {
+          form.tags.push(tag);
+          setForm(form);
+        };
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for the fetch-then-sort-then-set idiom where a callback param shadows the state name", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Feed = () => {
+        const [posts, setPosts] = useState([]);
+        useEffect(() => {
+          fetchPosts().then((posts) => {
+            posts.sort(byDate);
+            setPosts(posts);
+          });
+        }, []);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a fresh await-ed local that shadows the state name (internxt const teams = await fetch)", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Members = () => {
+        const [teams, setTeams] = useState([]);
+        const refresh = async () => {
+          const teams = await fetchTeams();
+          teams.sort(byName);
+          setTeams(teams);
+        };
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a fresh empty local built up inside an effect that shadows the state name (AppFlowy const views = [])", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Sidebar = () => {
+        const [views, setViews] = useState([]);
+        useEffect(() => {
+          const views = [];
+          views.push(rootView);
+          setViews(views);
+        }, []);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when a JSX callback param shadows the state value handed to the setter (rsuite onShowColor)", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Palette = () => {
+        const [color, setColor] = useState(new Map());
+        return <Picker onShowColor={(color) => setColor(color.set("hue", 1))} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for dayjs date math where .add returns a new instance (antd/mantine date pickers)", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Calendar = () => {
+        const [date, setDate] = useState(dayjs());
+        const nextDay = () => setDate(date.add(1, "day"));
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for Immutable.js .set which returns a new map", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Editor = () => {
+        const [doc, setDoc] = useState(ImmutableMap());
+        const rename = (name) => setDoc(doc.set("name", name));
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a concise dayjs updater where .add returns a new instance", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Calendar = () => {
+        const [date, setDate] = useState(dayjs());
+        const nextDay = () => setDate((prev) => prev.add(1, "day"));
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags setX(state.add(x)) when a lazy initializer proves a native Set", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Synth = () => {
+        const [sequence, setSequence] = useState(() => new Set());
+        setSequence(sequence.add(index));
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the mutation lives inside a nested handler", () => {
+    const result = runRule(
+      noMutateThenSetOrReturnSameReference,
+      `const Table = () => {
+        const [rows, setRows] = useState(data);
+        const onClick = () => {
+          rows.sort(byName);
+        };
+        setRows(rows);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.ts
@@ -1,0 +1,368 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
+
+type StateCollectionKind = "array" | "map" | "set";
+
+// Hooks whose destructure gives a `[value, setValue]` pair React
+// compares by identity (`Object.is`) on the next set.
+const STATE_HOOK_NAMES = new Set(["useState", "useReducer"]);
+
+// Mutating collection methods that return the RECEIVER (same identity),
+// keyed by the collection kind whose builtin behaves that way — handing
+// their result straight to a setter defeats the bailout. Immutable APIs
+// reuse these names but return NEW instances (dayjs `.add`, Immutable.js
+// `.set`), so the receiver must be proven to hold the matching native
+// collection before the name is trusted.
+const SELF_RETURNING_MUTATOR_KINDS = new Map<string, StateCollectionKind>([
+  ["add", "set"],
+  ["set", "map"],
+  ["sort", "array"],
+  ["reverse", "array"],
+  ["fill", "array"],
+  ["copyWithin", "array"],
+]);
+
+// Every in-place mutator (return value irrelevant) — used to prove a
+// reference was mutated before it is handed back by identity.
+const IN_PLACE_MUTATOR_METHODS = new Set([
+  "push",
+  "pop",
+  "shift",
+  "unshift",
+  "splice",
+  "sort",
+  "reverse",
+  "fill",
+  "copyWithin",
+  "add",
+  "delete",
+  "set",
+  "clear",
+]);
+
+const MESSAGE =
+  "This mutates the same object React already holds and hands it back, so Object.is sees no change and skips the re-render. Copy it first (for example `[...value]` or `new Set(value)`) and update the copy.";
+
+const patternBindsName = (pattern: EsTreeNode | null | undefined, name: string): boolean => {
+  if (!pattern) return false;
+  if (isNodeOfType(pattern, "Identifier")) return pattern.name === name;
+  if (isNodeOfType(pattern, "AssignmentPattern")) return patternBindsName(pattern.left, name);
+  if (isNodeOfType(pattern, "RestElement")) return patternBindsName(pattern.argument, name);
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    return (pattern.elements ?? []).some((element) => patternBindsName(element, name));
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    return (pattern.properties ?? []).some((property) =>
+      isNodeOfType(property, "Property")
+        ? patternBindsName(property.value, name)
+        : patternBindsName(property, name),
+    );
+  }
+  return false;
+};
+
+const declarationBindsName = (
+  declaration: EsTreeNodeOfType<"VariableDeclaration">,
+  name: string,
+): boolean =>
+  (declaration.declarations ?? []).some((declarator) => patternBindsName(declarator.id, name));
+
+const isStateHookDestructureAt = (
+  declarator: EsTreeNodeOfType<"VariableDeclarator">,
+  bindingName: string,
+  destructureIndex: number,
+): boolean => {
+  if (!isNodeOfType(declarator.init, "CallExpression")) return false;
+  if (!isHookCall(declarator.init, STATE_HOOK_NAMES)) return false;
+  if (!isNodeOfType(declarator.id, "ArrayPattern")) return false;
+  const element = (declarator.id.elements ?? [])[destructureIndex];
+  return isNodeOfType(element, "Identifier") && element.name === bindingName;
+};
+
+// Resolves `bindingName` at `node` to its NEAREST binding and returns the
+// useState/useReducer declarator only when that nearest binding is the
+// hook destructure at `destructureIndex`. Any intervening re-binding — a
+// function/callback parameter, a fresh local, a catch clause, a `for`
+// head — shadows the state pair, so the reference is not React state.
+const findNearestStateHookDeclarator = (
+  node: EsTreeNode,
+  bindingName: string,
+  destructureIndex: number,
+): EsTreeNodeOfType<"VariableDeclarator"> | null => {
+  let cursor: EsTreeNode | null | undefined = node;
+  while (cursor) {
+    if (isFunctionLike(cursor)) {
+      for (const parameter of cursor.params ?? []) {
+        if (patternBindsName(parameter, bindingName)) return null;
+      }
+    }
+    if (
+      isNodeOfType(cursor, "CatchClause") &&
+      cursor.param &&
+      patternBindsName(cursor.param, bindingName)
+    ) {
+      return null;
+    }
+    if (
+      isNodeOfType(cursor, "ForStatement") &&
+      isNodeOfType(cursor.init, "VariableDeclaration") &&
+      declarationBindsName(cursor.init, bindingName)
+    ) {
+      return null;
+    }
+    if (
+      (isNodeOfType(cursor, "ForOfStatement") || isNodeOfType(cursor, "ForInStatement")) &&
+      isNodeOfType(cursor.left, "VariableDeclaration") &&
+      declarationBindsName(cursor.left, bindingName)
+    ) {
+      return null;
+    }
+    if (isNodeOfType(cursor, "BlockStatement") || isNodeOfType(cursor, "Program")) {
+      for (const statement of cursor.body ?? []) {
+        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
+        for (const declarator of statement.declarations ?? []) {
+          if (!isNodeOfType(declarator, "VariableDeclarator")) continue;
+          if (isStateHookDestructureAt(declarator, bindingName, destructureIndex)) {
+            return declarator;
+          }
+          if (patternBindsName(declarator.id, bindingName)) return null;
+        }
+      }
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+// The collection kind the hook's initial value PROVES the state holds
+// (`useState(new Set())`, `useReducer(reducer, [])`), or null when the
+// initializer is opaque (`useState(dayjs())`, `useState(props.rows)`).
+const stateInitializerCollectionKind = (
+  declarator: EsTreeNodeOfType<"VariableDeclarator">,
+): StateCollectionKind | null => {
+  if (!isNodeOfType(declarator.init, "CallExpression")) return null;
+  const hookCall = declarator.init;
+  const isReducer = getCalleeName(hookCall) === "useReducer";
+  const hookArguments = hookCall.arguments ?? [];
+  if (isReducer && hookArguments.length > 2) return null;
+  const initializerArgument = hookArguments[isReducer ? 1 : 0];
+  if (!initializerArgument) return null;
+  let initialValue = stripParenExpression(initializerArgument);
+  if (isFunctionLike(initialValue) && !isNodeOfType(initialValue.body, "BlockStatement")) {
+    initialValue = stripParenExpression(initialValue.body);
+  }
+  if (isNodeOfType(initialValue, "ArrayExpression")) return "array";
+  if (
+    isNodeOfType(initialValue, "NewExpression") &&
+    isNodeOfType(initialValue.callee, "Identifier")
+  ) {
+    const constructorName = initialValue.callee.name;
+    if (constructorName === "Set" || constructorName === "WeakSet") return "set";
+    if (constructorName === "Map" || constructorName === "WeakMap") return "map";
+    if (constructorName === "Array") return "array";
+  }
+  return null;
+};
+
+// The root identifier of a member chain (`rows.a.b` -> `rows`), or null.
+const memberChainRootIdentifier = (node: EsTreeNode): EsTreeNodeOfType<"Identifier"> | null => {
+  let current: EsTreeNode = stripParenExpression(node);
+  while (isNodeOfType(current, "MemberExpression")) {
+    current = stripParenExpression(current.object);
+  }
+  return isNodeOfType(current, "Identifier") ? current : null;
+};
+
+// The mutator name when `node` is `<name>.<selfReturningMutator>(...)`,
+// or null. Callers must still match the name against the proven state
+// collection kind before treating the result as the same reference.
+const selfReturningMutatorMethodOn = (node: EsTreeNode, name: string): string | null => {
+  const unwrapped = stripParenExpression(node);
+  if (!isNodeOfType(unwrapped, "CallExpression")) return null;
+  if (!isNodeOfType(unwrapped.callee, "MemberExpression")) return null;
+  const method = getStaticMemberPropertyName(unwrapped.callee);
+  if (!method || !SELF_RETURNING_MUTATOR_KINDS.has(method)) return null;
+  const receiver = stripParenExpression(unwrapped.callee.object);
+  if (!isNodeOfType(receiver, "Identifier") || receiver.name !== name) return null;
+  return method;
+};
+
+const isSelfReturningMutatorCallOn = (
+  node: EsTreeNode,
+  name: string,
+  stateKind: StateCollectionKind | null,
+): boolean => {
+  const method = selfReturningMutatorMethodOn(node, name);
+  return method !== null && SELF_RETURNING_MUTATOR_KINDS.get(method) === stateKind;
+};
+
+// True when some statement inside `root` mutates `name` in place: a
+// mutating method call rooted at it (`rows.sort()`, `form.tags.push()`),
+// or an index/property write to it. Nested functions are pruned so a
+// mutation inside a handler isn't attributed to the render path.
+const containsInPlaceMutationOf = (root: EsTreeNode, name: string): boolean => {
+  let mutated = false;
+  walkAst(root, (child) => {
+    if (mutated) return false;
+    if (child !== root && isFunctionLike(child)) return false;
+
+    if (isNodeOfType(child, "CallExpression") && isNodeOfType(child.callee, "MemberExpression")) {
+      const method = getStaticMemberPropertyName(child.callee);
+      if (method && IN_PLACE_MUTATOR_METHODS.has(method)) {
+        const receiverRoot = memberChainRootIdentifier(child.callee.object);
+        if (receiverRoot && receiverRoot.name === name) {
+          mutated = true;
+          return false;
+        }
+      }
+    }
+
+    if (isNodeOfType(child, "AssignmentExpression") || isNodeOfType(child, "UpdateExpression")) {
+      const target = isNodeOfType(child, "AssignmentExpression")
+        ? (child.left as EsTreeNode)
+        : (child.argument as EsTreeNode);
+      const unwrappedTarget = stripParenExpression(target);
+      if (isNodeOfType(unwrappedTarget, "MemberExpression")) {
+        const rootIdentifier = memberChainRootIdentifier(unwrappedTarget);
+        if (rootIdentifier && rootIdentifier.name === name) {
+          mutated = true;
+          return false;
+        }
+      }
+    }
+  });
+  return mutated;
+};
+
+const blockReturnsSameReference = (
+  blockBody: EsTreeNode,
+  name: string,
+  stateKind: StateCollectionKind | null,
+): boolean => {
+  let returnsSame = false;
+  walkAst(blockBody, (child) => {
+    if (returnsSame) return false;
+    if (child !== blockBody && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "ReturnStatement") && child.argument) {
+      const returned = stripParenExpression(child.argument);
+      if (isNodeOfType(returned, "Identifier") && returned.name === name) {
+        returnsSame = true;
+        return false;
+      }
+      if (isSelfReturningMutatorCallOn(returned, name, stateKind)) {
+        returnsSame = true;
+        return false;
+      }
+    }
+  });
+  return returnsSame;
+};
+
+// A functional updater `(prev) => { ...mutate prev...; return prev; }`
+// (or the concise `(prev) => prev.add(x)` on a proven native collection)
+// hands the same reference back to React.
+const isMutateThenReturnSameUpdater = (
+  updater: EsTreeNode,
+  stateKind: StateCollectionKind | null,
+): boolean => {
+  if (!isFunctionLike(updater)) return false;
+  const firstParam = updater.params?.[0];
+  const prevName = isNodeOfType(firstParam as EsTreeNode, "Identifier")
+    ? (firstParam as EsTreeNodeOfType<"Identifier">).name
+    : null;
+  if (!prevName) return false;
+
+  const body = updater.body as EsTreeNode;
+  if (!isNodeOfType(body, "BlockStatement")) {
+    return isSelfReturningMutatorCallOn(body, prevName, stateKind);
+  }
+  return (
+    containsInPlaceMutationOf(body, prevName) &&
+    blockReturnsSameReference(body, prevName, stateKind)
+  );
+};
+
+export const noMutateThenSetOrReturnSameReference = defineRule({
+  id: "no-mutate-then-set-or-return-same-reference",
+  title: "State mutated in place then set by same reference",
+  severity: "warn",
+  category: "Correctness",
+  tags: ["test-noise"],
+  recommendation:
+    "Mutating a state Set/Map/array in place and handing the same reference back to its setter defeats React's Object.is bailout, so the re-render is skipped. Copy the value first (`[...value]`, `new Set(value)`) and update the copy.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isNodeOfType(node.callee, "Identifier")) return;
+      const setterDeclarator = findNearestStateHookDeclarator(node, node.callee.name, 1);
+      if (!setterDeclarator) return;
+
+      const firstArgument = node.arguments?.[0];
+      if (!firstArgument) return;
+      const argument = stripParenExpression(firstArgument);
+
+      // Shape A: setX(state.mutator(...)) — self-returning mutator on a
+      // state value whose initializer proves the matching native
+      // collection, handed straight back.
+      if (
+        isNodeOfType(argument, "CallExpression") &&
+        isNodeOfType(argument.callee, "MemberExpression")
+      ) {
+        const method = getStaticMemberPropertyName(argument.callee);
+        const receiver = stripParenExpression(argument.callee.object);
+        if (
+          method &&
+          SELF_RETURNING_MUTATOR_KINDS.has(method) &&
+          isNodeOfType(receiver, "Identifier")
+        ) {
+          const valueDeclarator = findNearestStateHookDeclarator(receiver, receiver.name, 0);
+          if (
+            valueDeclarator &&
+            SELF_RETURNING_MUTATOR_KINDS.get(method) ===
+              stateInitializerCollectionKind(valueDeclarator)
+          ) {
+            context.report({ node, message: MESSAGE });
+            return;
+          }
+        }
+      }
+
+      // Shape B: mutate state in place, then setX(state) with the same
+      // identity.
+      if (
+        isNodeOfType(argument, "Identifier") &&
+        findNearestStateHookDeclarator(argument, argument.name, 0)
+      ) {
+        const enclosingFunction = node.parent;
+        let scope: EsTreeNode | null = node;
+        let cursor: EsTreeNode | null | undefined = enclosingFunction;
+        while (cursor) {
+          if (isFunctionLike(cursor)) {
+            scope = cursor;
+            break;
+          }
+          cursor = cursor.parent ?? null;
+        }
+        if (scope && containsInPlaceMutationOf(scope, argument.name)) {
+          context.report({ node, message: MESSAGE });
+        }
+        return;
+      }
+
+      // Shape C: setX((prev) => { mutate prev; return prev; }).
+      if (
+        isMutateThenReturnSameUpdater(argument, stateInitializerCollectionKind(setterDeclarator))
+      ) {
+        context.report({ node, message: MESSAGE });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.ts
@@ -9,6 +9,7 @@ import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
+import { patternBindsName } from "./utils/pattern-binds-name.js";
 
 type StateCollectionKind = "array" | "map" | "set";
 
@@ -52,30 +53,6 @@ const IN_PLACE_MUTATOR_METHODS = new Set([
 const MESSAGE =
   "This mutates the same object React already holds and hands it back, so Object.is sees no change and skips the re-render. Copy it first (for example `[...value]` or `new Set(value)`) and update the copy.";
 
-const patternBindsName = (pattern: EsTreeNode | null | undefined, name: string): boolean => {
-  if (!pattern) return false;
-  if (isNodeOfType(pattern, "Identifier")) return pattern.name === name;
-  if (isNodeOfType(pattern, "AssignmentPattern")) return patternBindsName(pattern.left, name);
-  if (isNodeOfType(pattern, "RestElement")) return patternBindsName(pattern.argument, name);
-  if (isNodeOfType(pattern, "ArrayPattern")) {
-    return (pattern.elements ?? []).some((element) => patternBindsName(element, name));
-  }
-  if (isNodeOfType(pattern, "ObjectPattern")) {
-    return (pattern.properties ?? []).some((property) =>
-      isNodeOfType(property, "Property")
-        ? patternBindsName(property.value, name)
-        : patternBindsName(property, name),
-    );
-  }
-  return false;
-};
-
-const declarationBindsName = (
-  declaration: EsTreeNodeOfType<"VariableDeclaration">,
-  name: string,
-): boolean =>
-  (declaration.declarations ?? []).some((declarator) => patternBindsName(declarator.id, name));
-
 const isStateHookDestructureAt = (
   declarator: EsTreeNodeOfType<"VariableDeclarator">,
   bindingName: string,
@@ -115,14 +92,18 @@ const findNearestStateHookDeclarator = (
     if (
       isNodeOfType(cursor, "ForStatement") &&
       isNodeOfType(cursor.init, "VariableDeclaration") &&
-      declarationBindsName(cursor.init, bindingName)
+      (cursor.init.declarations ?? []).some((declarator) =>
+        patternBindsName(declarator.id, bindingName),
+      )
     ) {
       return null;
     }
     if (
       (isNodeOfType(cursor, "ForOfStatement") || isNodeOfType(cursor, "ForInStatement")) &&
       isNodeOfType(cursor.left, "VariableDeclaration") &&
-      declarationBindsName(cursor.left, bindingName)
+      (cursor.left.declarations ?? []).some((declarator) =>
+        patternBindsName(declarator.id, bindingName),
+      )
     ) {
       return null;
     }
@@ -182,27 +163,20 @@ const memberChainRootIdentifier = (node: EsTreeNode): EsTreeNodeOfType<"Identifi
   return isNodeOfType(current, "Identifier") ? current : null;
 };
 
-// The mutator name when `node` is `<name>.<selfReturningMutator>(...)`,
-// or null. Callers must still match the name against the proven state
-// collection kind before treating the result as the same reference.
-const selfReturningMutatorMethodOn = (node: EsTreeNode, name: string): string | null => {
-  const unwrapped = stripParenExpression(node);
-  if (!isNodeOfType(unwrapped, "CallExpression")) return null;
-  if (!isNodeOfType(unwrapped.callee, "MemberExpression")) return null;
-  const method = getStaticMemberPropertyName(unwrapped.callee);
-  if (!method || !SELF_RETURNING_MUTATOR_KINDS.has(method)) return null;
-  const receiver = stripParenExpression(unwrapped.callee.object);
-  if (!isNodeOfType(receiver, "Identifier") || receiver.name !== name) return null;
-  return method;
-};
-
+// True when `node` is `<name>.<selfReturningMutator>(...)` and the
+// mutator matches the proven state collection kind.
 const isSelfReturningMutatorCallOn = (
   node: EsTreeNode,
   name: string,
   stateKind: StateCollectionKind | null,
 ): boolean => {
-  const method = selfReturningMutatorMethodOn(node, name);
-  return method !== null && SELF_RETURNING_MUTATOR_KINDS.get(method) === stateKind;
+  const unwrapped = stripParenExpression(node);
+  if (!isNodeOfType(unwrapped, "CallExpression")) return false;
+  if (!isNodeOfType(unwrapped.callee, "MemberExpression")) return false;
+  const method = getStaticMemberPropertyName(unwrapped.callee);
+  if (!method || SELF_RETURNING_MUTATOR_KINDS.get(method) !== stateKind) return false;
+  const receiver = stripParenExpression(unwrapped.callee.object);
+  return isNodeOfType(receiver, "Identifier") && receiver.name === name;
 };
 
 // True when some statement inside `root` mutates `name` in place: a
@@ -212,33 +186,24 @@ const isSelfReturningMutatorCallOn = (
 const containsInPlaceMutationOf = (root: EsTreeNode, name: string): boolean => {
   let mutated = false;
   walkAst(root, (child) => {
-    if (mutated) return false;
-    if (child !== root && isFunctionLike(child)) return false;
+    if (mutated || (child !== root && isFunctionLike(child))) return false;
 
+    let receiver: EsTreeNode | null = null;
     if (isNodeOfType(child, "CallExpression") && isNodeOfType(child.callee, "MemberExpression")) {
       const method = getStaticMemberPropertyName(child.callee);
-      if (method && IN_PLACE_MUTATOR_METHODS.has(method)) {
-        const receiverRoot = memberChainRootIdentifier(child.callee.object);
-        if (receiverRoot && receiverRoot.name === name) {
-          mutated = true;
-          return false;
-        }
-      }
+      if (method && IN_PLACE_MUTATOR_METHODS.has(method)) receiver = child.callee.object;
+    } else if (
+      isNodeOfType(child, "AssignmentExpression") ||
+      isNodeOfType(child, "UpdateExpression")
+    ) {
+      const target = stripParenExpression(
+        isNodeOfType(child, "AssignmentExpression")
+          ? (child.left as EsTreeNode)
+          : (child.argument as EsTreeNode),
+      );
+      if (isNodeOfType(target, "MemberExpression")) receiver = target;
     }
-
-    if (isNodeOfType(child, "AssignmentExpression") || isNodeOfType(child, "UpdateExpression")) {
-      const target = isNodeOfType(child, "AssignmentExpression")
-        ? (child.left as EsTreeNode)
-        : (child.argument as EsTreeNode);
-      const unwrappedTarget = stripParenExpression(target);
-      if (isNodeOfType(unwrappedTarget, "MemberExpression")) {
-        const rootIdentifier = memberChainRootIdentifier(unwrappedTarget);
-        if (rootIdentifier && rootIdentifier.name === name) {
-          mutated = true;
-          return false;
-        }
-      }
-    }
+    mutated = Boolean(receiver && memberChainRootIdentifier(receiver)?.name === name);
   });
   return mutated;
 };
@@ -250,19 +215,12 @@ const blockReturnsSameReference = (
 ): boolean => {
   let returnsSame = false;
   walkAst(blockBody, (child) => {
-    if (returnsSame) return false;
-    if (child !== blockBody && isFunctionLike(child)) return false;
-    if (isNodeOfType(child, "ReturnStatement") && child.argument) {
-      const returned = stripParenExpression(child.argument);
-      if (isNodeOfType(returned, "Identifier") && returned.name === name) {
-        returnsSame = true;
-        return false;
-      }
-      if (isSelfReturningMutatorCallOn(returned, name, stateKind)) {
-        returnsSame = true;
-        return false;
-      }
-    }
+    if (returnsSame || (child !== blockBody && isFunctionLike(child))) return false;
+    if (!isNodeOfType(child, "ReturnStatement") || !child.argument) return;
+    const returned = stripParenExpression(child.argument);
+    returnsSame =
+      (isNodeOfType(returned, "Identifier") && returned.name === name) ||
+      isSelfReturningMutatorCallOn(returned, name, stateKind);
   });
   return returnsSame;
 };
@@ -316,18 +274,16 @@ export const noMutateThenSetOrReturnSameReference = defineRule({
         isNodeOfType(argument, "CallExpression") &&
         isNodeOfType(argument.callee, "MemberExpression")
       ) {
-        const method = getStaticMemberPropertyName(argument.callee);
         const receiver = stripParenExpression(argument.callee.object);
-        if (
-          method &&
-          SELF_RETURNING_MUTATOR_KINDS.has(method) &&
-          isNodeOfType(receiver, "Identifier")
-        ) {
+        if (isNodeOfType(receiver, "Identifier")) {
           const valueDeclarator = findNearestStateHookDeclarator(receiver, receiver.name, 0);
           if (
             valueDeclarator &&
-            SELF_RETURNING_MUTATOR_KINDS.get(method) ===
-              stateInitializerCollectionKind(valueDeclarator)
+            isSelfReturningMutatorCallOn(
+              argument,
+              receiver.name,
+              stateInitializerCollectionKind(valueDeclarator),
+            )
           ) {
             context.report({ node, message: MESSAGE });
             return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noPromiseThenSideEffectInEffectWithoutCatch } from "./no-promise-then-side-effect-in-effect-without-catch.js";
+
+describe("no-promise-then-side-effect-in-effect-without-catch", () => {
+  it("flags an identifier chain bound to an in-file async fetch wrapper with no catch", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `const initEditor = async () => {
+        const response = await fetch("/editor");
+        return response.json();
+      };
+      useEffect(() => { const cancelable = initEditor(); cancelable.then((monaco) => { setMonaco(monaco); }); }, []);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a direct call chain resolving to an in-file async function that awaits fetch uncaught", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `async function generateThumbnail(clip) {
+        const response = await fetch(clip.url);
+        return response.blob();
+      }
+      useEffect(() => { generateThumbnail(clip).then((url) => { setThumbnail(url); }); }, [clip]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a global fetch chain with .finally but no .catch", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(src).then((info) => { setInfo(info); }).finally(() => { setLoading(false); }); }, [src]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a floating dynamic import chain that mutates a ref with no catch", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { import("./sounds/" + name).then((mod) => { bufferRef.current = mod.default; }); }, [name]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a loaders-map dynamic import wrapper (readme.so language dictionary idiom)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `const loaders = { en: () => import("./locales/en.js"), fr: () => import("./locales/fr.js") };
+      const loadDict = async (locale) => {
+        const loader = loaders[locale];
+        const mod = await loader();
+        return mod.default;
+      };
+      useEffect(() => { void loadDict(locale).then((next) => { if (!cancelled) setDict(next); }); }, [locale]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a Promise.resolve microtask defer", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { Promise.resolve().then(() => { setFocused(true); }); }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chain whose initiator is not a call", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { element.getAnimations()[0]?.finished.then(() => { setStatus('idle'); }); }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a predicate-style promise from an unresolved callee", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { isImageValid(src).then((ok) => { setStatus(ok ? 'loaded' : 'error'); }); }, [src]);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a name-heuristic initiator that is not provably rejectable (error-folding service wrapper)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { getDataFromService(url).then((response) => { setDtypes(response.dtypes); }); }, [url]);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an in-file wrapper that try/catches internally and resolves null", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `const requestLazyCaptionThumbnail = async (id) => {
+        try {
+          const response = await fetch("/thumb/" + id);
+          return response.blob();
+        } catch {
+          return null;
+        }
+      };
+      useEffect(() => { requestLazyCaptionThumbnail(id).then((blob) => { setThumbnail(blob); }); }, [id]);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the then callback null-guard-returns its argument first (resolve-null contract)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(src).then((view) => { if (!view) return; setView(view); }); }, [src]);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when every state write is guarded by the callback param (resolve-undefined contract)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(src).then((view) => { if (view) { setView(view); } }); }, [src]);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the callback reads the response's in-band error field (dtale error-folding contract)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(url).then((response) => { if (response?.error) { setError(response.error); return; } setData(response.data); }); }, [url]);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag in Storybook story files (designed fallback defaults)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(src).then((info) => { setInfo(info); }); }, [src]);`,
+      { filename: "widget.stories.tsx" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a .then whose only setter-shaped call is the global setTimeout", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(configUrl).then((config) => { setTimeout(applyConfig, config.delay); }); }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chain with a .catch handler", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(src).then((i) => setInfo(i)).catch((e) => {}); }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chain with an onRejected second argument", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(url).then((x) => setX(x), (e) => {}); }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chain wrapped in try/catch", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { try { fetch(url).then((x) => { setX(x); }); } catch (e) {} }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a .then with no state side effect", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(url).then((x) => log(x)); }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a re-read of a ref-held cached promise (creation site owns the catch)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => {
+        let cancelled = false;
+        const inFlight = inFlightRef.current.get(cacheKey);
+        void inFlight.then((exists) => { if (!cancelled) setRouteViewExists(exists); });
+        return () => { cancelled = true; };
+      }, [cacheKey]);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags an identifier initiator bound to an uncaught global fetch", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => {
+        const request = fetch(url);
+        void request.then((data) => { setDetail(data); });
+      }, [id]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a then that receives the state setter directly (fetch-json-setState idiom)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { fetch(url).then((response) => response.json()).then(setUser); }, [url]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags Promise.all of global fetches with no catch", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { Promise.all([fetch('/user'), fetch('/posts')]).then(([user, posts]) => { setUser(user); setPosts(posts); }); }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag Promise.allSettled (never rejects)", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { Promise.allSettled([fetch('/user'), fetch('/posts')]).then((results) => { setResults(results); }); }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an identifier bound to an uncaught chained fetch call", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { const parsed = fetch(url).then((response) => response.json()); parsed.then((data) => { setDetail(data); }); }, [url]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an identifier bound to a chain whose upstream already catches", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `useEffect(() => { const parsed = fetch(url).then((response) => response.json()).catch(() => null); parsed.then((data) => { setDetail(data); }); }, [url]);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chain outside an effect", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `function handler() { fetch(url).then((x) => { setX(x); }); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
@@ -1,0 +1,455 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isInsideTryStatement } from "../../utils/is-inside-try-statement.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Effect-shaped hooks incl. the common userland `useMount`; named distinctly so
+// it does not shadow the canonical two-member `EFFECT_HOOK_NAMES`.
+const EFFECT_LIKE_HOOK_NAMES = new Set(["useEffect", "useLayoutEffect", "useMount"]);
+const PROMISE_METHOD_NAMES = new Set(["then", "catch", "finally"]);
+// `Promise.allSettled` never rejects; `resolve`/`reject` are the
+// microtask-defer idiom — only these combinators propagate an input
+// rejection to the chain.
+const REJECTING_PROMISE_COMBINATOR_NAMES = new Set(["all", "race", "any"]);
+// Global timer callables that match the `/^set[A-Z]/` state-setter
+// pattern but set no React state.
+const GLOBAL_TIMER_NAMES = new Set(["setTimeout", "setInterval", "setImmediate"]);
+const IMPORT_BINDING_TYPES = new Set([
+  "ImportSpecifier",
+  "ImportDefaultSpecifier",
+  "ImportNamespaceSpecifier",
+]);
+const NULLISH_EQUALITY_OPERATORS = new Set(["==", "==="]);
+const MAX_INITIATOR_RESOLUTION_DEPTH = 3;
+
+const MESSAGE =
+  "This promise chain runs in an effect, ends in a `.then` that sets state or mutates a ref, and has no `.catch` or enclosing try/catch, so a rejection leaves the state unset and surfaces as an unhandled rejection. Add a `.catch` handler on the chain (`.finally` does not count).";
+
+type FunctionLikeNode =
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"FunctionDeclaration">;
+
+interface PromiseChainWalk {
+  root: EsTreeNode;
+  hasCatch: boolean;
+  hasRejectionHandlerArgument: boolean;
+  sawThen: boolean;
+  thenCallbacks: FunctionLikeNode[];
+  hasDirectSetterThenCallback: boolean;
+}
+
+interface ResolvedInitiator {
+  initiator: EsTreeNode;
+  hasUpstreamRejectionHandling: boolean;
+}
+
+const isReactStateSetterName = (name: string): boolean =>
+  isSetterIdentifier(name) && !GLOBAL_TIMER_NAMES.has(name);
+
+// Walks a `.then`/`.catch`/`.finally` member-call chain down to its
+// initiator, collecting which settlement methods appear and the
+// `.then` callbacks.
+const walkPromiseChain = (chainExpression: EsTreeNode): PromiseChainWalk => {
+  let cursor = stripParenExpression(chainExpression);
+  let hasCatch = false;
+  let hasRejectionHandlerArgument = false;
+  let sawThen = false;
+  let hasDirectSetterThenCallback = false;
+  const thenCallbacks: FunctionLikeNode[] = [];
+
+  while (
+    isNodeOfType(cursor, "CallExpression") &&
+    isNodeOfType(cursor.callee, "MemberExpression") &&
+    !cursor.callee.computed &&
+    isNodeOfType(cursor.callee.property, "Identifier") &&
+    PROMISE_METHOD_NAMES.has(cursor.callee.property.name)
+  ) {
+    const methodName = cursor.callee.property.name;
+    if (methodName === "catch") hasCatch = true;
+    if (methodName === "then") {
+      sawThen = true;
+      if (cursor.arguments.length >= 2) hasRejectionHandlerArgument = true;
+      const callbackArgument = cursor.arguments[0];
+      const callback = callbackArgument ? stripParenExpression(callbackArgument) : null;
+      if (callback && isFunctionLike(callback)) {
+        thenCallbacks.push(callback);
+      } else if (
+        callback &&
+        isNodeOfType(callback, "Identifier") &&
+        isReactStateSetterName(callback.name)
+      ) {
+        hasDirectSetterThenCallback = true;
+      }
+    }
+    cursor = stripParenExpression(cursor.callee.object);
+  }
+
+  return {
+    root: cursor,
+    hasCatch,
+    hasRejectionHandlerArgument,
+    sawThen,
+    thenCallbacks,
+    hasDirectSetterThenCallback,
+  };
+};
+
+// Follows an identifier initiator (`const request = fetch(url); request.then(...)`)
+// through its initializer — including an intermediate `.then` chain bound to a
+// variable — down to the root expression, remembering whether any hop along the
+// way already attached a `.catch`/onRejected handler.
+const resolveRootInitiator = (root: EsTreeNode): ResolvedInitiator => {
+  let cursor = stripParenExpression(root);
+  let hasUpstreamRejectionHandling = false;
+  const visitedBindingNames = new Set<string>();
+  while (true) {
+    const chainWalk = walkPromiseChain(cursor);
+    if (chainWalk.root !== cursor) {
+      if (chainWalk.hasCatch || chainWalk.hasRejectionHandlerArgument) {
+        hasUpstreamRejectionHandling = true;
+      }
+      cursor = stripParenExpression(chainWalk.root);
+      continue;
+    }
+    if (isNodeOfType(cursor, "Identifier") && !visitedBindingNames.has(cursor.name)) {
+      visitedBindingNames.add(cursor.name);
+      const binding = findVariableInitializer(cursor, cursor.name);
+      if (binding?.initializer && !isFunctionLike(binding.initializer)) {
+        cursor = stripParenExpression(binding.initializer);
+        continue;
+      }
+    }
+    return { initiator: cursor, hasUpstreamRejectionHandling };
+  }
+};
+
+const resolveObjectExpression = (
+  objectNode: EsTreeNode,
+): EsTreeNodeOfType<"ObjectExpression"> | null => {
+  const stripped = stripParenExpression(objectNode);
+  if (isNodeOfType(stripped, "ObjectExpression")) return stripped;
+  if (isNodeOfType(stripped, "Identifier")) {
+    const binding = findVariableInitializer(stripped, stripped.name);
+    const initializer = binding?.initializer ? stripParenExpression(binding.initializer) : null;
+    if (initializer && isNodeOfType(initializer, "ObjectExpression")) return initializer;
+  }
+  return null;
+};
+
+// A loaders-map lookup (`loaders[locale]` / `loaders.en`) whose map holds
+// function values — the dynamic-import registry idiom. Rejectable when a
+// matching entry's function is.
+const memberLookupResolvesToRejectableFunction = (
+  memberNode: EsTreeNodeOfType<"MemberExpression">,
+  remainingDepth: number,
+): boolean => {
+  const objectExpression = resolveObjectExpression(memberNode.object);
+  if (!objectExpression) return false;
+  const lookedUpName =
+    !memberNode.computed && isNodeOfType(memberNode.property, "Identifier")
+      ? memberNode.property.name
+      : null;
+  return objectExpression.properties.some((property) => {
+    if (!isNodeOfType(property, "Property")) return false;
+    if (lookedUpName !== null) {
+      const keyMatches = isNodeOfType(property.key, "Identifier")
+        ? property.key.name === lookedUpName
+        : isNodeOfType(property.key, "Literal") && property.key.value === lookedUpName;
+      if (!keyMatches) return false;
+    }
+    const value = stripParenExpression(property.value);
+    return isFunctionLike(value) && functionHasUnhandledRejectableSource(value, remainingDepth);
+  });
+};
+
+// The narrowed initiator contract: only flag when the promise's rejection is
+// provable in-file — a dynamic `import()`, a call to the global `fetch`, a
+// `Promise.all/race/any` over provable inputs, or a call resolving in-file to
+// a function that awaits/returns such a source outside any try/catch. Name
+// heuristics (`load*`, `request*`, `x.get()`, …) are gone: in mature codebases
+// those wrappers routinely catch internally and resolve null/`{error}`.
+const isProvablyRejectableExpression = (
+  expression: EsTreeNode,
+  remainingDepth: number,
+): boolean => {
+  const stripped = stripParenExpression(expression);
+  if (isNodeOfType(stripped, "ImportExpression")) return true;
+  if (isNodeOfType(stripped, "AwaitExpression")) {
+    return isProvablyRejectableExpression(stripped.argument, remainingDepth);
+  }
+  if (!isNodeOfType(stripped, "CallExpression")) return false;
+  const callee = stripParenExpression(stripped.callee);
+  if (isNodeOfType(callee, "Identifier")) {
+    const binding = findVariableInitializer(callee, callee.name);
+    const initializer = binding?.initializer ?? null;
+    if (
+      callee.name === "fetch" &&
+      (initializer === null || IMPORT_BINDING_TYPES.has(initializer.type))
+    ) {
+      return true;
+    }
+    if (initializer === null || remainingDepth <= 0) return false;
+    const strippedInitializer = stripParenExpression(initializer);
+    if (isFunctionLike(strippedInitializer)) {
+      return functionHasUnhandledRejectableSource(strippedInitializer, remainingDepth - 1);
+    }
+    if (isNodeOfType(strippedInitializer, "MemberExpression")) {
+      return memberLookupResolvesToRejectableFunction(strippedInitializer, remainingDepth - 1);
+    }
+    return false;
+  }
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  if (
+    !callee.computed &&
+    isNodeOfType(callee.object, "Identifier") &&
+    callee.object.name === "Promise" &&
+    isNodeOfType(callee.property, "Identifier")
+  ) {
+    if (!REJECTING_PROMISE_COMBINATOR_NAMES.has(callee.property.name)) return false;
+    const combinatorInput = stripped.arguments[0]
+      ? stripParenExpression(stripped.arguments[0])
+      : null;
+    if (!combinatorInput || !isNodeOfType(combinatorInput, "ArrayExpression")) return false;
+    return combinatorInput.elements.some((element) => {
+      if (!element || isNodeOfType(element, "SpreadElement")) return false;
+      const resolvedElement = resolveRootInitiator(element);
+      return (
+        !resolvedElement.hasUpstreamRejectionHandling &&
+        isProvablyRejectableExpression(resolvedElement.initiator, remainingDepth)
+      );
+    });
+  }
+  if (remainingDepth > 0) {
+    return memberLookupResolvesToRejectableFunction(callee, remainingDepth - 1);
+  }
+  return false;
+};
+
+// True when the function's own body awaits or returns a provably rejectable
+// source outside any try/catch — a try-wrapped await means the wrapper folds
+// the failure into its resolution value (`resolve null` contract) and the
+// chain cannot reject through it.
+const functionHasUnhandledRejectableSource = (
+  functionNode: FunctionLikeNode,
+  remainingDepth: number,
+): boolean => {
+  let didFindRejectableSource = false;
+  const checkCandidate = (candidate: EsTreeNode, positionNode: EsTreeNode): void => {
+    if (didFindRejectableSource) return;
+    if (isInsideTryStatement(positionNode, { boundary: functionNode })) return;
+    const chainWalk = walkPromiseChain(stripParenExpression(candidate));
+    if (chainWalk.hasCatch || chainWalk.hasRejectionHandlerArgument) return;
+    if (isProvablyRejectableExpression(chainWalk.root, remainingDepth)) {
+      didFindRejectableSource = true;
+    }
+  };
+  const body = functionNode.body;
+  if (body && !isNodeOfType(body, "BlockStatement")) {
+    checkCandidate(body, body);
+  }
+  walkOwnFunctionScope(functionNode, (child: EsTreeNode) => {
+    if (didFindRejectableSource) return false;
+    if (isNodeOfType(child, "AwaitExpression")) {
+      checkCandidate(child.argument, child);
+    }
+    if (isNodeOfType(child, "ReturnStatement") && child.argument) {
+      checkCandidate(child.argument, child);
+    }
+  });
+  return didFindRejectableSource;
+};
+
+const collectStateSideEffectNodes = (callback: EsTreeNode): EsTreeNode[] => {
+  const sideEffectNodes: EsTreeNode[] = [];
+  walkAst(callback, (child: EsTreeNode) => {
+    if (
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "Identifier") &&
+      isReactStateSetterName(child.callee.name)
+    ) {
+      sideEffectNodes.push(child);
+      return;
+    }
+    if (
+      isNodeOfType(child, "AssignmentExpression") &&
+      isNodeOfType(child.left, "MemberExpression") &&
+      isNodeOfType(child.left.property, "Identifier") &&
+      child.left.property.name === "current"
+    ) {
+      sideEffectNodes.push(child);
+    }
+  });
+  return sideEffectNodes;
+};
+
+const isNullishComparisonAgainstParam = (test: EsTreeNode, paramName: string): boolean => {
+  if (!isNodeOfType(test, "BinaryExpression")) return false;
+  if (!NULLISH_EQUALITY_OPERATORS.has(test.operator)) return false;
+  const left = stripParenExpression(test.left);
+  const right = stripParenExpression(test.right);
+  const isParamSide = (side: EsTreeNode): boolean =>
+    isNodeOfType(side, "Identifier") && side.name === paramName;
+  const isNullishSide = (side: EsTreeNode): boolean =>
+    (isNodeOfType(side, "Literal") && side.value === null) ||
+    (isNodeOfType(side, "Identifier") && side.name === "undefined");
+  return (isParamSide(left) && isNullishSide(right)) || (isNullishSide(left) && isParamSide(right));
+};
+
+const isParamNullGuardReturn = (statement: EsTreeNode, paramName: string): boolean => {
+  if (!isNodeOfType(statement, "IfStatement")) return false;
+  const test = stripParenExpression(statement.test);
+  const negatedArgument =
+    isNodeOfType(test, "UnaryExpression") && test.operator === "!"
+      ? stripParenExpression(test.argument)
+      : null;
+  const isNegatedParam =
+    negatedArgument !== null &&
+    isNodeOfType(negatedArgument, "Identifier") &&
+    negatedArgument.name === paramName;
+  if (!isNegatedParam && !isNullishComparisonAgainstParam(test, paramName)) return false;
+  const consequent = statement.consequent;
+  if (isNodeOfType(consequent, "ReturnStatement")) return true;
+  return (
+    isNodeOfType(consequent, "BlockStatement") &&
+    consequent.body.length > 0 &&
+    isNodeOfType(consequent.body[consequent.body.length - 1], "ReturnStatement")
+  );
+};
+
+const callbackReadsParamError = (callback: EsTreeNode, paramName: string): boolean => {
+  let didFindErrorRead = false;
+  walkAst(callback, (child: EsTreeNode) => {
+    if (didFindErrorRead) return false;
+    if (
+      isNodeOfType(child, "MemberExpression") &&
+      !child.computed &&
+      isNodeOfType(child.property, "Identifier") &&
+      child.property.name === "error"
+    ) {
+      const errorReadObject = stripParenExpression(child.object);
+      if (isNodeOfType(errorReadObject, "Identifier") && errorReadObject.name === paramName) {
+        didFindErrorRead = true;
+      }
+    }
+  });
+  return didFindErrorRead;
+};
+
+const hasParamGuardingIfAncestor = (
+  node: EsTreeNode,
+  callback: EsTreeNode,
+  paramName: string,
+): boolean => {
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor && ancestor !== callback) {
+    if (isNodeOfType(ancestor, "IfStatement")) {
+      let testReferencesParam = false;
+      walkAst(ancestor.test, (testChild: EsTreeNode) => {
+        if (isNodeOfType(testChild, "Identifier") && testChild.name === paramName) {
+          testReferencesParam = true;
+          return false;
+        }
+      });
+      if (testReferencesParam) return true;
+    }
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+// A callback that null/error-guards its resolved value signals the initiator's
+// resolve-null-on-failure contract (`getDataFromService`-style error folding):
+// the wrapper never rejects, so demanding a `.catch` would be dead code.
+const callbackSignalsResolveNullContract = (
+  callback: FunctionLikeNode,
+  sideEffectNodes: EsTreeNode[],
+): boolean => {
+  const firstParam = callback.params[0] ? stripParenExpression(callback.params[0]) : null;
+  if (!firstParam || !isNodeOfType(firstParam, "Identifier")) return false;
+  const paramName = firstParam.name;
+  if (callbackReadsParamError(callback, paramName)) return true;
+  const body = callback.body;
+  if (
+    body &&
+    isNodeOfType(body, "BlockStatement") &&
+    body.body.some((statement: EsTreeNode) => isParamNullGuardReturn(statement, paramName))
+  ) {
+    return true;
+  }
+  return sideEffectNodes.every((sideEffectNode) =>
+    hasParamGuardingIfAncestor(sideEffectNode, callback, paramName),
+  );
+};
+
+// Walk the effect body without descending into nested functions, so the
+// candidate chains belong to the effect scope (the `.then` callbacks are
+// nested functions and are inspected separately).
+const collectFloatingChains = (callback: EsTreeNode): EsTreeNode[] => {
+  const chains: EsTreeNode[] = [];
+  walkOwnFunctionScope(callback, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "ExpressionStatement")) return;
+    let expression = child.expression as EsTreeNode;
+    if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "void") {
+      expression = expression.argument as EsTreeNode;
+    }
+    chains.push(stripParenExpression(expression));
+  });
+  return chains;
+};
+
+// Flags a floating promise chain inside a React effect that is started by a
+// provably rejectable async source (dynamic import(), global fetch, a
+// Promise.all/race/any over such sources, or an in-file function that
+// awaits/returns one uncaught), ends in a `.then` performing a state setter or
+// ref mutation, and has no `.catch`/rejection handler and no enclosing
+// try/catch. `.finally` does not count as handling the rejection. Callbacks
+// that null/error-guard their resolved value are skipped — that shape signals
+// a wrapper with a resolve-null-on-failure contract.
+export const noPromiseThenSideEffectInEffectWithoutCatch = defineRule({
+  id: "no-promise-then-side-effect-in-effect-without-catch",
+  title: "Effect promise .then sets state with no catch",
+  severity: "warn",
+  category: "Correctness",
+  tags: ["test-noise"],
+  recommendation:
+    "An async init in an effect that sets state in `.then` but has no `.catch` leaves the component stuck and raises an unhandled rejection when it fails. Add a `.catch` on the chain (`.finally` does not handle the rejection).",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isHookCall(node as EsTreeNode, EFFECT_LIKE_HOOK_NAMES)) return;
+      const callback = getEffectCallback(node as EsTreeNode);
+      if (!isFunctionLike(callback)) return;
+
+      for (const chainExpression of collectFloatingChains(callback)) {
+        const chainWalk = walkPromiseChain(chainExpression);
+        if (!chainWalk.sawThen) continue;
+        if (chainWalk.hasCatch || chainWalk.hasRejectionHandlerArgument) continue;
+        const hasUnguardedStateSideEffect =
+          chainWalk.hasDirectSetterThenCallback ||
+          chainWalk.thenCallbacks.some((thenCallback) => {
+            const sideEffectNodes = collectStateSideEffectNodes(thenCallback);
+            if (sideEffectNodes.length === 0) return false;
+            return !callbackSignalsResolveNullContract(thenCallback, sideEffectNodes);
+          });
+        if (!hasUnguardedStateSideEffect) continue;
+        const resolved = resolveRootInitiator(chainWalk.root);
+        if (resolved.hasUpstreamRejectionHandling) continue;
+        if (!isProvablyRejectableExpression(resolved.initiator, MAX_INITIATOR_RESOLUTION_DEPTH)) {
+          continue;
+        }
+        if (isInsideTryStatement(chainExpression, { boundary: callback })) continue;
+        context.report({ node: chainExpression, message: MESSAGE });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
@@ -134,19 +134,6 @@ const resolveRootInitiator = (root: EsTreeNode): ResolvedInitiator => {
   }
 };
 
-const resolveObjectExpression = (
-  objectNode: EsTreeNode,
-): EsTreeNodeOfType<"ObjectExpression"> | null => {
-  const stripped = stripParenExpression(objectNode);
-  if (isNodeOfType(stripped, "ObjectExpression")) return stripped;
-  if (isNodeOfType(stripped, "Identifier")) {
-    const binding = findVariableInitializer(stripped, stripped.name);
-    const initializer = binding?.initializer ? stripParenExpression(binding.initializer) : null;
-    if (initializer && isNodeOfType(initializer, "ObjectExpression")) return initializer;
-  }
-  return null;
-};
-
 // A loaders-map lookup (`loaders[locale]` / `loaders.en`) whose map holds
 // function values — the dynamic-import registry idiom. Rejectable when a
 // matching entry's function is.
@@ -154,8 +141,14 @@ const memberLookupResolvesToRejectableFunction = (
   memberNode: EsTreeNodeOfType<"MemberExpression">,
   remainingDepth: number,
 ): boolean => {
-  const objectExpression = resolveObjectExpression(memberNode.object);
-  if (!objectExpression) return false;
+  const strippedObject = stripParenExpression(memberNode.object);
+  const boundInitializer = isNodeOfType(strippedObject, "Identifier")
+    ? findVariableInitializer(strippedObject, strippedObject.name)?.initializer
+    : null;
+  const objectExpression = boundInitializer
+    ? stripParenExpression(boundInitializer)
+    : strippedObject;
+  if (!isNodeOfType(objectExpression, "ObjectExpression")) return false;
   const lookedUpName =
     !memberNode.computed && isNodeOfType(memberNode.property, "Identifier")
       ? memberNode.property.name
@@ -246,7 +239,6 @@ const functionHasUnhandledRejectableSource = (
 ): boolean => {
   let didFindRejectableSource = false;
   const checkCandidate = (candidate: EsTreeNode, positionNode: EsTreeNode): void => {
-    if (didFindRejectableSource) return;
     if (isInsideTryStatement(positionNode, { boundary: functionNode })) return;
     const chainWalk = walkPromiseChain(stripParenExpression(candidate));
     if (chainWalk.hasCatch || chainWalk.hasRejectionHandlerArgument) return;
@@ -279,7 +271,6 @@ const collectStateSideEffectNodes = (callback: EsTreeNode): EsTreeNode[] => {
       isReactStateSetterName(child.callee.name)
     ) {
       sideEffectNodes.push(child);
-      return;
     }
     if (
       isNodeOfType(child, "AssignmentExpression") &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noSetStateAfterAwaitInEffect } from "./no-set-state-after-await-in-effect.js";
+
+describe("no-set-state-after-await-in-effect", () => {
+  it("flags a declared-then-called inner async function that sets state after await", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const Note = ({ id }) => {
+        const [note, setNote] = useState(null);
+        useEffect(() => {
+          const fetchData = async () => {
+            const data = await load(id);
+            setNote(data);
+          };
+          fetchData();
+        }, [id]);
+        return null;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an async IIFE that sets state after await when deps can change", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const Pricing = ({ catalogId }) => {
+        const [imports, setLocalCatalogImport] = useState([]);
+        useEffect(() => {
+          (async () => {
+            const res = await getCatalogImports(catalogId);
+            setLocalCatalogImport(res);
+          })();
+        }, [catalogId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useReducer dispatch called after await when deps can change", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const Widget = ({ query }) => {
+        const [state, dispatch] = useReducer(reducer, {});
+        useEffect(() => {
+          async function run() {
+            const data = await load(query);
+            dispatch({ type: "set", data });
+          }
+          run();
+        }, [query]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an unguarded post-await setter when the deps argument is omitted", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = () => {
+        const [user, setUser] = useState(null);
+        useEffect(() => {
+          (async () => {
+            const u = await load();
+            setUser(u);
+          })();
+        });
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a setter whose argument contains the await, like setUser(await load())", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ id }) => {
+        const [user, setUser] = useState(null);
+        useEffect(() => {
+          (async () => {
+            setUser(await load(id));
+          })();
+        }, [id]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags streaming setters inside a for await...of loop when deps can change", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ topic }) => {
+        const [chunks, setChunks] = useState([]);
+        useEffect(() => {
+          (async () => {
+            for await (const chunk of stream(topic)) {
+              setChunks((prev) => prev.concat(chunk));
+            }
+          })();
+        }, [topic]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a mount-only effect (empty deps) — the one-shot fetch idiom from TaskTrove/dtale cannot re-run out of order", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const AboutModal = () => {
+        const [version, setVersion] = useState("");
+        useEffect(() => {
+          (async () => {
+            const res = await getVersionInfo();
+            setVersion(res.version);
+          })();
+        }, []);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when every dependency is a stable-identity binding (setter/ref) — deps that never change identity cannot cause overlapping re-runs", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = () => {
+        const [user, setUser] = useState(null);
+        const storeRef = useRef(null);
+        useEffect(() => {
+          const run = async () => {
+            const u = await load();
+            setUser(u);
+          };
+          run();
+        }, [setUser, storeRef]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the effect callback is itself async (owned by another rule)", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ id }) => {
+        const [user, setUser] = useState(null);
+        useEffect(async () => {
+          const u = await load(id);
+          setUser(u);
+        }, [id]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the effect returns a cleanup function", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ userId }) => {
+        const [user, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const u = await load(userId);
+            setUser(u);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the setter is gated behind a mounted flag", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ userId }) => {
+        const [user, setUser] = useState(null);
+        useEffect(() => {
+          let isMounted = true;
+          const run = async () => {
+            const u = await load(userId);
+            if (isMounted) setUser(u);
+          };
+          run();
+        }, [userId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a setter that is not bound to useState/useReducer", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const Form = ({ fieldId }) => {
+        const { setValue } = useForm();
+        useEffect(() => {
+          const run = async () => {
+            const d = await load(fieldId);
+            setValue("x", d);
+          };
+          run();
+        }, [fieldId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a setState after await inside an event handler", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = () => {
+        const [user, setUser] = useState(null);
+        const onClick = async () => {
+          const u = await load();
+          setUser(u);
+        };
+        return <button onClick={onClick} />;
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a setter inside a deeper nested closure that is not the awaiting scope", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ topic }) => {
+        const [user, setUser] = useState(null);
+        useEffect(() => {
+          const run = async () => {
+            await ready(topic);
+            subscribe(() => {
+              setUser(current);
+            });
+          };
+          run();
+        }, [topic]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the setter runs before the await", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ id }) => {
+        const [loading, setLoading] = useState(false);
+        useEffect(() => {
+          const run = async () => {
+            setLoading(true);
+            await load(id);
+          };
+          run();
+        }, [id]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a void async IIFE whose setter after await sits in a try/catch (try/catch handles rejection, not stale re-runs)", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const About = ({ url }) => {
+        const [version, setVersion] = useState("");
+        useEffect(() => {
+          void (async () => {
+            try {
+              const res = await getDataFromService(url);
+              setVersion(res.version);
+            } catch (e) {
+              setVersion("");
+            }
+          })();
+        }, [url]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when an AbortController signal/abort guard is present", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ url }) => {
+        const [data, setData] = useState(null);
+        useEffect(() => {
+          const controller = new AbortController();
+          const run = async () => {
+            const res = await fetch(url, { signal: controller.signal });
+            setData(res);
+          };
+          run();
+        }, [url]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the only dep is an external-store action the effect just invokes (zustand useStore + useShallow destructure)", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const NotificationsView = () => {
+        const { fetchNotifications } = useStore(
+          useShallow((s) => ({ fetchNotifications: s.fetchNotifications })),
+        );
+        const [isBusy, setIsBusy] = useState(true);
+        useEffect(() => {
+          const loadNotifications = async () => {
+            setIsBusy(true);
+            try {
+              await fetchNotifications();
+            } finally {
+              setIsBusy(false);
+            }
+          };
+          void loadNotifications();
+        }, [fetchNotifications]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the dep is a store action selected directly (useUserStore((s) => s.fetchUser))", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const Profile = () => {
+        const fetchUser = useUserStore((s) => s.fetchUser);
+        const [profile, setProfile] = useState(null);
+        useEffect(() => {
+          const run = async () => {
+            const loaded = await fetchUser();
+            setProfile(loaded);
+          };
+          run();
+        }, [fetchUser]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when every dep is a module-scope const — its identity can never change between renders", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const DATA_SOURCE = "SOCRATA";
+      const Footer = () => {
+        const [lastUpdated, setLastUpdated] = useState("");
+        useEffect(() => {
+          const run = async () => {
+            const rows = await queryLastUpdated(DATA_SOURCE);
+            setLastUpdated(rows[0]);
+          };
+          run();
+        }, [DATA_SOURCE]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags when a store-selected dep is read as data, not invoked — selected state can change identity per render", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const Detail = () => {
+        const selectedId = useAppStore((s) => s.selectedId);
+        const [detail, setDetail] = useState(null);
+        useEffect(() => {
+          const run = async () => {
+            const loaded = await load(selectedId);
+            setDetail(loaded);
+          };
+          run();
+        }, [selectedId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags try/catch status-literal writes after await when deps can change — which branch lands depends on which run resolves last (VerifyEmailPage shape)", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const VerifyEmailPage = () => {
+        const { t } = useTranslation("auth");
+        const searchParams = useSearch({ strict: false });
+        const token = searchParams.token;
+        const [status, setStatus] = useState("pending");
+        useEffect(() => {
+          const verify = async () => {
+            try {
+              await apiClient.post("/auth/verification/confirm", { token });
+              setStatus("success");
+            } catch (err) {
+              setStatus("error");
+            }
+          };
+          void verify();
+        }, [token, t]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an awaited-derived setter when a mutable context dep rides alongside a module-scope const (LastUpdated shape)", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const DATA_SOURCE = "DUCKDB";
+      const LastUpdated = () => {
+        const [lastUpdated, setLastUpdated] = useState("");
+        const { conn } = useContext(DbContext);
+        useEffect(() => {
+          const getLastUpdated = async () => {
+            const rows = await conn.query("select max(createddate) from requests;");
+            setLastUpdated(rows[0]);
+          };
+          if (DATA_SOURCE !== "SOCRATA" && conn) {
+            getLastUpdated();
+          }
+        }, [conn, DATA_SOURCE]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an awaited-derived setter when a context-provided callback dep can change identity (MentionPanel shape)", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const MentionPanel = () => {
+        const { loadViews } = useEditorContext();
+        const [open] = useState(false);
+        const [views, setViews] = useState([]);
+        useEffect(() => {
+          if (!open || !loadViews) return;
+          void (async () => {
+            try {
+              const result = await loadViews();
+              setViews(result);
+            } catch (e) {
+              console.error(e);
+            }
+          })();
+        }, [loadViews, open]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a plain sync effect with no async work", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ id }) => {
+        const [title, setTitle] = useState("");
+        useEffect(() => { setTitle(document.title); }, [id]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -25,16 +25,6 @@ const EXTERNAL_STORE_HOOK_PATTERN = /^use(?:[A-Z][A-Za-z0-9]*)?Store$/;
 const CANCELLATION_GUARD_PATTERN =
   /^(?:is|has|did|was)?_?(?:mount|unmount|cancel|abort|ignore|stale|dispos|destroy|alive|signal|active)/i;
 
-const getNodeStart = (node: EsTreeNode): number | null => {
-  const start = (node as { start?: unknown }).start;
-  return typeof start === "number" ? start : null;
-};
-
-const getNodeEnd = (node: EsTreeNode): number | null => {
-  const end = (node as { end?: unknown }).end;
-  return typeof end === "number" ? end : null;
-};
-
 const getDependencyArray = (
   effectCall: EsTreeNodeOfType<"CallExpression">,
 ): EsTreeNodeOfType<"ArrayExpression"> | null => {
@@ -216,15 +206,12 @@ const referencesCancellationGuard = (asyncFunction: EsTreeNode): boolean => {
   let found = false;
   walkAst(asyncFunction, (child: EsTreeNode) => {
     if (found) return false;
-    if (isNodeOfType(child, "Identifier") && CANCELLATION_GUARD_PATTERN.test(child.name)) {
-      found = true;
-      return false;
-    }
     // A `.current` read is the ref-based mounted-guard idiom.
     if (
-      isNodeOfType(child, "MemberExpression") &&
-      isNodeOfType(child.property, "Identifier") &&
-      child.property.name === "current"
+      (isNodeOfType(child, "Identifier") && CANCELLATION_GUARD_PATTERN.test(child.name)) ||
+      (isNodeOfType(child, "MemberExpression") &&
+        isNodeOfType(child.property, "Identifier") &&
+        child.property.name === "current")
     ) {
       found = true;
       return false;
@@ -245,8 +232,8 @@ const hasPostAwaitStateSetter = (asyncFunction: EsTreeNode): boolean => {
       isNodeOfType(node, "AwaitExpression") ||
       (isNodeOfType(node, "ForOfStatement") && node.await === true);
     if (!isSuspensionPoint) return;
-    const start = getNodeStart(node);
-    if (start === null) return;
+    const start = (node as { start?: unknown }).start;
+    if (typeof start !== "number") return;
     if (earliestSuspensionStart === null || start < earliestSuspensionStart) {
       earliestSuspensionStart = start;
     }
@@ -259,8 +246,8 @@ const hasPostAwaitStateSetter = (asyncFunction: EsTreeNode): boolean => {
     if (hasLaterSetter) return;
     if (!isNodeOfType(node, "CallExpression")) return;
     if (!isStateDispatcherCall(node)) return;
-    const setterEnd = getNodeEnd(node);
-    if (setterEnd === null) return;
+    const setterEnd = (node as { end?: unknown }).end;
+    if (typeof setterEnd !== "number") return;
     if (setterEnd > firstSuspensionStart) hasLaterSetter = true;
   });
   return hasLaterSetter;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -1,0 +1,308 @@
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { functionBodyHasReturnWithValue } from "../../utils/function-body-has-return-with-value.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isHookBindingInScope } from "../../utils/is-hook-binding-in-scope.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const MESSAGE =
+  "This setter runs after `await`, so overlapping re-runs of the effect can resolve out of order and write stale state; gate it behind a cancellation/ignore flag or return a cleanup that cancels the work.";
+
+const STATE_DISPATCHER_HOOKS = new Set(["useState", "useReducer"]);
+const STABLE_IDENTITY_HOOK = "useRef";
+const EXTERNAL_STORE_HOOK_PATTERN = /^use(?:[A-Z][A-Za-z0-9]*)?Store$/;
+
+// Cancellation / mounted-guard idioms. When the awaiting scope reads any of
+// these we assume the developer already guards the post-await write, so we
+// stay quiet — false positives are worse than the occasional missed case.
+const CANCELLATION_GUARD_PATTERN =
+  /^(?:is|has|did|was)?_?(?:mount|unmount|cancel|abort|ignore|stale|dispos|destroy|alive|signal|active)/i;
+
+const getNodeStart = (node: EsTreeNode): number | null => {
+  const start = (node as { start?: unknown }).start;
+  return typeof start === "number" ? start : null;
+};
+
+const getNodeEnd = (node: EsTreeNode): number | null => {
+  const end = (node as { end?: unknown }).end;
+  return typeof end === "number" ? end : null;
+};
+
+const getDependencyArray = (
+  effectCall: EsTreeNodeOfType<"CallExpression">,
+): EsTreeNodeOfType<"ArrayExpression"> | null => {
+  const dependencyArgument = effectCall.arguments?.[1];
+  if (!dependencyArgument || !isNodeOfType(dependencyArgument, "ArrayExpression")) return null;
+  return dependencyArgument;
+};
+
+const doesBindingPatternBindName = (pattern: unknown, bindingName: string): boolean => {
+  if (isNodeOfType(pattern, "Identifier")) return pattern.name === bindingName;
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    return (pattern.properties ?? []).some((property) => {
+      if (isNodeOfType(property, "Property")) {
+        return doesBindingPatternBindName(property.value, bindingName);
+      }
+      if (isNodeOfType(property, "RestElement")) {
+        return doesBindingPatternBindName(property.argument, bindingName);
+      }
+      return false;
+    });
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    return (pattern.elements ?? []).some((element) =>
+      doesBindingPatternBindName(element, bindingName),
+    );
+  }
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    return doesBindingPatternBindName(pattern.left, bindingName);
+  }
+  if (isNodeOfType(pattern, "RestElement")) {
+    return doesBindingPatternBindName(pattern.argument, bindingName);
+  }
+  return false;
+};
+
+// External-store hooks (zustand's useStore / useXxxStore) hand back action
+// references that are stable for the store's lifetime, so a dep bound from
+// one cannot re-trigger the effect (NotificationsView-class false positive).
+const isExternalStoreHookBinding = (scopeAnchor: EsTreeNode, bindingName: string): boolean => {
+  let cursor: EsTreeNode | null | undefined = scopeAnchor;
+  while (cursor) {
+    if (isNodeOfType(cursor, "BlockStatement") || isNodeOfType(cursor, "Program")) {
+      for (const statement of cursor.body ?? []) {
+        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
+        for (const declarator of statement.declarations ?? []) {
+          if (!isNodeOfType(declarator.init, "CallExpression")) continue;
+          const storeHookCallee = declarator.init.callee;
+          if (!isNodeOfType(storeHookCallee, "Identifier")) continue;
+          if (!EXTERNAL_STORE_HOOK_PATTERN.test(storeHookCallee.name)) continue;
+          if (doesBindingPatternBindName(declarator.id, bindingName)) return true;
+        }
+      }
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+// Store hooks also select mutable data; only a dep the effect exclusively
+// INVOKES is action-shaped. Any other read (argument, member base, shorthand
+// spread) means the dep carries data whose identity can change per render.
+const isDependencyOnlyInvokedInCallback = (
+  effectCallback: EsTreeNode,
+  bindingName: string,
+): boolean => {
+  let hasNonInvocationUse = false;
+  walkAst(effectCallback, (child: EsTreeNode) => {
+    if (hasNonInvocationUse) return false;
+    if (!isNodeOfType(child, "Identifier") || child.name !== bindingName) return;
+    const parent = child.parent;
+    if (isNodeOfType(parent, "CallExpression") && parent.callee === child) return;
+    if (isNodeOfType(parent, "MemberExpression") && parent.property === child && !parent.computed) {
+      return;
+    }
+    if (
+      isNodeOfType(parent, "Property") &&
+      parent.key === child &&
+      !parent.computed &&
+      !parent.shorthand
+    ) {
+      return;
+    }
+    hasNonInvocationUse = true;
+    return false;
+  });
+  return !hasNonInvocationUse;
+};
+
+// A module-scope `const` (or import) has one identity for the module's whole
+// lifetime, so it can never re-trigger the effect. Any closer binding of the
+// same name (param, local declaration) shadows it and disqualifies the dep.
+const isModuleScopeConstBinding = (scopeAnchor: EsTreeNode, bindingName: string): boolean => {
+  let cursor: EsTreeNode | null | undefined = scopeAnchor;
+  while (cursor) {
+    if (isNodeOfType(cursor, "Program")) {
+      for (const statement of cursor.body ?? []) {
+        if (isNodeOfType(statement, "ImportDeclaration")) {
+          const bindsImportedName = (statement.specifiers ?? []).some((specifier) =>
+            doesBindingPatternBindName(specifier.local, bindingName),
+          );
+          if (bindsImportedName) return true;
+        }
+        if (isNodeOfType(statement, "VariableDeclaration") && statement.kind === "const") {
+          const bindsConstName = (statement.declarations ?? []).some((declarator) =>
+            doesBindingPatternBindName(declarator.id, bindingName),
+          );
+          if (bindsConstName) return true;
+        }
+      }
+      return false;
+    }
+    if (isFunctionLike(cursor)) {
+      const isShadowedByParam = (cursor.params ?? []).some((param) =>
+        doesBindingPatternBindName(param, bindingName),
+      );
+      if (isShadowedByParam) return false;
+    }
+    if (isNodeOfType(cursor, "BlockStatement")) {
+      for (const statement of cursor.body ?? []) {
+        if (isNodeOfType(statement, "VariableDeclaration")) {
+          const isShadowedLocally = (statement.declarations ?? []).some((declarator) =>
+            doesBindingPatternBindName(declarator.id, bindingName),
+          );
+          if (isShadowedLocally) return false;
+        }
+        if (
+          isNodeOfType(statement, "FunctionDeclaration") &&
+          isNodeOfType(statement.id, "Identifier") &&
+          statement.id.name === bindingName
+        ) {
+          return false;
+        }
+      }
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+// A mount-only effect (empty deps) or one whose deps are all stable-identity
+// bindings (useState/useReducer dispatcher, useRef box, external-store action
+// reference, module-scope const) can never have overlapping re-runs, so the
+// out-of-order stale-write hazard cannot occur.
+const hasOnlyStableIdentityDependencies = ({
+  dependencyArray,
+  effectCallback,
+}: {
+  dependencyArray: EsTreeNodeOfType<"ArrayExpression">;
+  effectCallback: EsTreeNode;
+}): boolean =>
+  (dependencyArray.elements ?? []).every((dependencyElement) => {
+    if (!isNodeOfType(dependencyElement, "Identifier")) return false;
+    return (
+      isHookBindingInScope(dependencyArray, {
+        bindingName: dependencyElement.name,
+        hookName: STATE_DISPATCHER_HOOKS,
+        destructureIndex: 1,
+      }) ||
+      isHookBindingInScope(dependencyArray, {
+        bindingName: dependencyElement.name,
+        hookName: STABLE_IDENTITY_HOOK,
+      }) ||
+      isModuleScopeConstBinding(dependencyArray, dependencyElement.name) ||
+      (isExternalStoreHookBinding(dependencyArray, dependencyElement.name) &&
+        isDependencyOnlyInvokedInCallback(effectCallback, dependencyElement.name))
+    );
+  });
+
+const isStateDispatcherCall = (callExpression: EsTreeNodeOfType<"CallExpression">): boolean => {
+  if (!isNodeOfType(callExpression.callee, "Identifier")) return false;
+  return isHookBindingInScope(callExpression, {
+    bindingName: callExpression.callee.name,
+    hookName: STATE_DISPATCHER_HOOKS,
+    destructureIndex: 1,
+  });
+};
+
+const referencesCancellationGuard = (asyncFunction: EsTreeNode): boolean => {
+  let found = false;
+  walkAst(asyncFunction, (child: EsTreeNode) => {
+    if (found) return false;
+    if (isNodeOfType(child, "Identifier") && CANCELLATION_GUARD_PATTERN.test(child.name)) {
+      found = true;
+      return false;
+    }
+    // A `.current` read is the ref-based mounted-guard idiom.
+    if (
+      isNodeOfType(child, "MemberExpression") &&
+      isNodeOfType(child.property, "Identifier") &&
+      child.property.name === "current"
+    ) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+// The awaiting async scope is a stale-write hazard when a state setter
+// finishes lexically after the first suspension point (`await` or
+// `for await...of`) in that same scope. Comparing the setter's END offset
+// also catches `setData(await load())`, where the setter call starts before
+// the await nested in its own arguments but still executes after it.
+const hasPostAwaitStateSetter = (asyncFunction: EsTreeNode): boolean => {
+  let earliestSuspensionStart: number | null = null;
+  walkOwnFunctionScope(asyncFunction, (node) => {
+    const isSuspensionPoint =
+      isNodeOfType(node, "AwaitExpression") ||
+      (isNodeOfType(node, "ForOfStatement") && node.await === true);
+    if (!isSuspensionPoint) return;
+    const start = getNodeStart(node);
+    if (start === null) return;
+    if (earliestSuspensionStart === null || start < earliestSuspensionStart) {
+      earliestSuspensionStart = start;
+    }
+  });
+  if (earliestSuspensionStart === null) return false;
+  const firstSuspensionStart = earliestSuspensionStart;
+
+  let hasLaterSetter = false;
+  walkOwnFunctionScope(asyncFunction, (node) => {
+    if (hasLaterSetter) return;
+    if (!isNodeOfType(node, "CallExpression")) return;
+    if (!isStateDispatcherCall(node)) return;
+    const setterEnd = getNodeEnd(node);
+    if (setterEnd === null) return;
+    if (setterEnd > firstSuspensionStart) hasLaterSetter = true;
+  });
+  return hasLaterSetter;
+};
+
+export const noSetStateAfterAwaitInEffect = defineRule({
+  id: "no-set-state-after-await-in-effect",
+  title: "State update after await in an effect",
+  severity: "warn",
+  category: "Bugs",
+  recommendation:
+    "In a `useEffect` whose dependencies can change, guard any setter call that runs after an `await` behind a cancellation/ignore flag, or return a cleanup that cancels the async work.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+      const callback = getEffectCallback(node);
+      if (!isFunctionLike(callback)) return;
+      // Async effect callbacks are owned by `no-async-effect-callback`.
+      if (callback.async) return;
+      const dependencyArray = getDependencyArray(node);
+      if (
+        dependencyArray &&
+        hasOnlyStableIdentityDependencies({ dependencyArray, effectCallback: callback })
+      ) {
+        return;
+      }
+      // A cleanup return is the documented fix; stay quiet when one exists.
+      if (functionBodyHasReturnWithValue(callback)) return;
+
+      const asyncFunctions: EsTreeNode[] = [];
+      walkAst(callback, (child: EsTreeNode) => {
+        if (child === callback) return;
+        if (isFunctionLike(child) && child.async) asyncFunctions.push(child);
+      });
+
+      for (const asyncFunction of asyncFunctions) {
+        if (referencesCancellationGuard(asyncFunction)) continue;
+        if (hasPostAwaitStateSetter(asyncFunction)) {
+          context.report({ node, message: MESSAGE });
+          return;
+        }
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-side-effect-in-state-updater-function.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-side-effect-in-state-updater-function.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noSideEffectInStateUpdaterFunction } from "./no-side-effect-in-state-updater-function.js";
+
+describe("no-side-effect-in-state-updater-function", () => {
+  it("flags a consumer callback inside a nested map updater", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setCurrentEvents((prev) =>
+        prev.map((event) => {
+          if (event.id !== id) return event;
+          const newEvent = { ...event, ...changes };
+          onEventUpdate?.(newEvent);
+          return newEvent;
+        }),
+      );`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an analytics call inside a block-body updater", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setSelectedRows((prev) => {
+        const next = toggleRow(prev, rowId);
+        trackAnalytics('row_selected', { rowId });
+        return next;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an on*-named callback before returning next state", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setSessions((prev) => {
+        const updated = prev.filter((s) => s.id !== sessionId);
+        onSessionsChange(updated);
+        return updated;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a logging call inside a block-body setter updater", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setDialog((prev) => {
+        const next = { ...prev, open: true };
+        logEvent('opened');
+        return next;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an &&-guarded consumer callback like the equivalent if statement", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setSessions((prev) => {
+        const updated = prev.filter((s) => s.id !== sessionId);
+        updated.length !== prev.length && onSessionsChange(updated);
+        return updated;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an analytics call inside a synchronously invoked forEach callback", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setItems((prev) => {
+        const next = [...prev];
+        next.forEach((item) => {
+          trackView(item.id);
+        });
+        return next;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a deferred dismiss handler stored on the next state (toast onDismiss idiom)", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setToasts((prev) => prev.concat({
+        id,
+        dismiss: () => {
+          onDismiss?.(id);
+          return true;
+        },
+      }));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a deferred column sorter stored in a block-body updater", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setColumns((prev) => {
+        const next = prev.map((column) => ({
+          ...column,
+          sort: () => {
+            onSort?.(column.id);
+            return column.id;
+          },
+        }));
+        return next;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a redux-thunk passed to dispatch (dispatch is not a React updater)", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `dispatch(async (dispatch, getState) => {
+        const settings = getState().settings;
+        const saved = await api.save(settings);
+        onSaved?.(saved);
+        return saved;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a pure Set builder updater", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setSelectedRows((prev) => {
+        const next = new Set(prev);
+        next.delete(rowId);
+        next.add(newId);
+        return next;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a pure array transform updater", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setItems((prev) => {
+        const next = prev.map((item) => ({ ...item, dirty: false }));
+        return next;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a pure lookup helper updater", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setState((prev) => {
+        const match = prev.find((entry) => entry.id === id);
+        return match ? applyChange(prev, match) : prev;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a nested setter alone (not a side effect)", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setState((prev) => {
+        const next = { ...prev };
+        setOther(next);
+        return next;
+      });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not misattribute a callback in a setInterval lambda to a nested setter", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `setInterval(() => {
+        setCountdown((prev) => prev - 1);
+        onClose();
+        return;
+      }, 1000);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a concise-body updater with no interleaved statement", () => {
+    const result = runRule(noSideEffectInStateUpdaterFunction, `setCount((prev) => prev + 1);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a consumer callback invoked outside the updater", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `const handle = (value) => {
+        onChange?.(value);
+        setState((prev) => {
+          const next = compute(prev, value);
+          return next;
+        });
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the callback is passed to a non-setter call", () => {
+    const result = runRule(
+      noSideEffectInStateUpdaterFunction,
+      `items.reduce((prev, item) => {
+        onChange(item);
+        return prev.concat(item);
+      }, []);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-side-effect-in-state-updater-function.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-side-effect-in-state-updater-function.ts
@@ -180,10 +180,9 @@ export const noSideEffectInStateUpdaterFunction = defineRule({
 
       // Only the "interleaved statement before a pure return" shape is
       // reportable, so some executed function must reach `return <value>`.
-      const valueReturningFunctions = new Set<EsTreeNode>();
-      for (const executedFunction of executedDuringUpdater) {
-        if (blockBodyReturnsValue(executedFunction)) valueReturningFunctions.add(executedFunction);
-      }
+      const valueReturningFunctions = new Set(
+        [...executedDuringUpdater].filter(blockBodyReturnsValue),
+      );
       if (valueReturningFunctions.size === 0) return;
 
       const hasValueReturningExecutedContext = (owner: EsTreeNode): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-side-effect-in-state-updater-function.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-side-effect-in-state-updater-function.ts
@@ -1,0 +1,218 @@
+import { defineRule } from "../../utils/define-rule.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const CONSUMER_CALLBACK_NAME_PATTERN = /^on[A-Z]/;
+const CALLBACK_NAME_PATTERN = /callback/i;
+// Analytics / logging / persistence verbs that denote a fire-and-forget
+// external side effect, not a pure state transform.
+const SIDE_EFFECT_VERB_PATTERN = /^(?:track|log|capture|analytics|persist|emit|notify)/i;
+
+// Timer setters syntactically match `/^set[A-Z]/` but are NOT React
+// state setters; excluding them stops a nested consumer callback inside a
+// `setInterval(() => ...)` lambda from being misattributed to the timer.
+const TIMER_SETTER_NAMES = new Set(["setTimeout", "setInterval", "setImmediate"]);
+
+// Pure array/set/map builders are exactly what a legitimate immutable
+// updater is made of; never treat them as an impure side effect.
+const PURE_BUILTIN_METHOD_NAMES = new Set([
+  "map",
+  "filter",
+  "find",
+  "has",
+  "delete",
+  "add",
+  "some",
+  "every",
+  "reduce",
+  "slice",
+  "concat",
+  "includes",
+]);
+
+// Only `set*`-named identifiers count: `dispatch(fn)` is never a React
+// useReducer updater (dispatch takes action objects), so a function
+// argument to `dispatch` is a redux-thunk whose whole purpose is to run
+// side effects exactly once.
+const isReactStateUpdaterCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  if (!isNodeOfType(node.callee, "Identifier")) return false;
+  const name = node.callee.name;
+  if (TIMER_SETTER_NAMES.has(name)) return false;
+  return isSetterIdentifier(name);
+};
+
+// An impure effectful call: an optional consumer callback `x?.(...)`, an
+// `on*` / `*Callback` / `callback` named call, or an analytics/persistence
+// verb. Never a React setter (a nested setter is a different concern) and
+// never a pure array/set/map builtin.
+const isImpureSideEffectCall = (call: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const calleeName = getCalleeName(call);
+  if (calleeName) {
+    if (PURE_BUILTIN_METHOD_NAMES.has(calleeName)) return false;
+    if (isSetterIdentifier(calleeName)) return false;
+  }
+  if (call.optional) return true;
+  if (!calleeName) return false;
+  return (
+    CONSUMER_CALLBACK_NAME_PATTERN.test(calleeName) ||
+    CALLBACK_NAME_PATTERN.test(calleeName) ||
+    calleeName.endsWith("Callback") ||
+    SIDE_EFFECT_VERB_PATTERN.test(calleeName)
+  );
+};
+
+const isImmediateStateUpdaterCall = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") && isReactStateUpdaterCall(node);
+
+// A block-body function whose body reaches a `return <value>`: the shape
+// where an interleaved statement side effect can hide before the pure
+// next-state is returned. Nested functions are pruned so only this
+// function's own returns count.
+const blockBodyReturnsValue = (functionNode: EsTreeNode): boolean => {
+  if (!isFunctionLike(functionNode) || !isNodeOfType(functionNode.body, "BlockStatement")) {
+    return false;
+  }
+  let returnsValue = false;
+  walkOwnFunctionScope(functionNode, (child: EsTreeNode) => {
+    if (isNodeOfType(child, "ReturnStatement") && child.argument) returnsValue = true;
+  });
+  return returnsValue;
+};
+
+const findNearestEnclosingFunction = (
+  node: EsTreeNode,
+  boundary: EsTreeNode,
+): EsTreeNode | null => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor) {
+    if (isFunctionLike(cursor)) return cursor;
+    if (cursor === boundary) return null;
+    cursor = cursor.parent;
+  }
+  return null;
+};
+
+// A nested function executes during the updater only when it is handed
+// directly to a call (`prev.map(fn)`, an IIFE); a function value merely
+// constructed and stored in the next state (a toast `dismiss` handler, a
+// column sorter) runs later on user interaction, never during a replay.
+const isDirectCallParticipant = (functionNode: EsTreeNode): boolean => {
+  const parent = functionNode.parent;
+  if (!parent || !isNodeOfType(parent, "CallExpression")) return false;
+  if (parent.callee === functionNode) return true;
+  return parent.arguments?.some((argumentNode) => argumentNode === functionNode) === true;
+};
+
+// Collects the statement's effectful calls, peeling awaits, TS wrappers,
+// and guard shapes — `cond && onChange(next);` is the same side effect as
+// `if (cond) onChange(next);`.
+const collectStatementCalls = (
+  expression: EsTreeNode,
+  calls: EsTreeNodeOfType<"CallExpression">[],
+): void => {
+  const current = stripParenExpression(expression);
+  if (isNodeOfType(current, "AwaitExpression") && current.argument) {
+    collectStatementCalls(current.argument, calls);
+    return;
+  }
+  if (isNodeOfType(current, "LogicalExpression")) {
+    collectStatementCalls(current.left, calls);
+    collectStatementCalls(current.right, calls);
+    return;
+  }
+  if (isNodeOfType(current, "ConditionalExpression")) {
+    collectStatementCalls(current.consequent, calls);
+    collectStatementCalls(current.alternate, calls);
+    return;
+  }
+  if (isNodeOfType(current, "SequenceExpression")) {
+    for (const innerExpression of current.expressions ?? []) {
+      collectStatementCalls(innerExpression, calls);
+    }
+    return;
+  }
+  if (isNodeOfType(current, "CallExpression")) calls.push(current);
+};
+
+export const noSideEffectInStateUpdaterFunction = defineRule({
+  id: "no-side-effect-in-state-updater-function",
+  title: "Side effect inside a state updater function",
+  severity: "warn",
+  category: "Correctness",
+  recommendation:
+    "React may run a state updater more than once (StrictMode double-invoke, concurrent replay), so a consumer callback, analytics, or persistence call inside it fires an unpredictable number of times. Compute the next state purely, then run the side effect outside the setter so it fires exactly once.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isReactStateUpdaterCall(node)) return;
+      const updater = node.arguments?.[0];
+      if (!updater || !isFunctionLike(updater)) return;
+
+      const walkBoundary = updater.parent ?? updater;
+
+      // Collect the functions that run synchronously during the updater —
+      // the updater itself plus nested functions handed directly to a call
+      // (`.map(...)`, an IIFE), transitively. Functions merely stored in
+      // the next state are deferred and excluded. Nested state-updater
+      // calls are pruned so their bodies are attributed to their own
+      // setter, not this one.
+      const executedDuringUpdater = new Set<EsTreeNode>();
+      walkAst(updater, (child: EsTreeNode) => {
+        if (child !== updater && isImmediateStateUpdaterCall(child)) return false;
+        if (!isFunctionLike(child)) return;
+        if (child === updater) {
+          executedDuringUpdater.add(child);
+          return;
+        }
+        if (!isDirectCallParticipant(child)) return;
+        const enclosingFunction = findNearestEnclosingFunction(child, walkBoundary);
+        if (enclosingFunction && executedDuringUpdater.has(enclosingFunction)) {
+          executedDuringUpdater.add(child);
+        }
+      });
+
+      // Only the "interleaved statement before a pure return" shape is
+      // reportable, so some executed function must reach `return <value>`.
+      const valueReturningFunctions = new Set<EsTreeNode>();
+      for (const executedFunction of executedDuringUpdater) {
+        if (blockBodyReturnsValue(executedFunction)) valueReturningFunctions.add(executedFunction);
+      }
+      if (valueReturningFunctions.size === 0) return;
+
+      const hasValueReturningExecutedContext = (owner: EsTreeNode): boolean => {
+        let cursor: EsTreeNode | null = owner;
+        while (cursor && executedDuringUpdater.has(cursor)) {
+          if (valueReturningFunctions.has(cursor)) return true;
+          if (cursor === updater) break;
+          cursor = findNearestEnclosingFunction(cursor, walkBoundary);
+        }
+        return false;
+      };
+
+      walkAst(updater, (child: EsTreeNode) => {
+        if (child !== updater && isImmediateStateUpdaterCall(child)) return false;
+        if (!isNodeOfType(child, "ExpressionStatement")) return;
+        const statementCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+        collectStatementCalls(child.expression, statementCalls);
+        const owner = findNearestEnclosingFunction(child, walkBoundary);
+        if (!owner || !executedDuringUpdater.has(owner)) return;
+        if (!hasValueReturningExecutedContext(owner)) return;
+        for (const call of statementCalls) {
+          if (!isImpureSideEffectCall(call)) continue;
+          context.report({
+            node: call,
+            message:
+              "This side-effecting call runs inside a state updater, which React may invoke more than once (StrictMode double-invoke, concurrent replay), so it fires an unpredictable number of times. Move it outside the setter after computing the next state.",
+          });
+        }
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noSpreadPropsOverDefaultsClobbersWithUndefined } from "./no-spread-props-over-defaults-clobbers-with-undefined.js";
+
+describe("no-spread-props-over-defaults-clobbers-with-undefined", () => {
+  it("flags { ...defaultProps, ...props } whose merge result feeds arithmetic", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const VictoryContainer = (props: VictoryContainerProps) => {
+        const merged = { ...defaultProps, ...props };
+        return <svg width={merged.width * 2} />;
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a component whose merged setting flows into a call argument", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `function Lightbox({ ...props }: LightboxProps) {
+        const settings = { ...defaultLightboxProps, ...props };
+        return <div style={{ width: Math.min(settings.width, 500) }} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a destructured merge key that flows into a computation", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const ReactSearchAutocomplete = (props: Props) => {
+        const { maxResults, ...rest } = { ...defaultTheme, ...props };
+        return <ul>{props.items.slice(0, maxResults * 1)}</ul>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a hook that computes with a defaults-over-options merge", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const useCarousel = (options: CarouselOptions) => {
+        const merged = { ...defaultCarouselOptions, ...options };
+        return Math.abs(merged.slideSpeed);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags spreading a static defaultProps member under props that feed a computation", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const List = (props: ListProps) => {
+        const merged = { ...List.defaultProps, ...props };
+        return <ul data-count={Math.min(merged.pageSize, 50)} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags spreading the rest of destructured props over defaults into arithmetic", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Button = ({ className, ...rest }: ButtonProps) => {
+        const merged = { ...defaultButtonProps, ...rest };
+        return <button style={{ width: merged.width - 4 }} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an optional-typed props binding that is not literally named props", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Widget = (incoming: WidgetProps) => {
+        const merged = { ...defaultProps, ...incoming };
+        return <div>{Math.round(merged.ratio)}</div>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a visible defaulted key destructured from the merge that feeds a call argument", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const DEFAULT_PROPS = { color: "grey.t07" };
+      function Divider(_props) {
+        const props = { ...DEFAULT_PROPS, ..._props };
+        const { color, testId } = props;
+        const circleColor = theme.getColor(color);
+        return <svg data-testid={testId} fill={circleColor} />;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags imported defaults whose merged key feeds arithmetic in a timer", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `import { defaultProps } from "./defaultProps";
+      export const Carousel = (userProps: CarouselProps) => {
+        const props = { ...defaultProps, ...userProps };
+        setTimeout(() => slide(), props.transition * 1000);
+        return <div />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when the only defaulted key is re-wrapped and the whole merge goes to an omit call", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const defaultProps = { groupComponent: "g" };
+      const VictoryPortal = (initialProps: VictoryPortalProps) => {
+        const props = { ...defaultProps, ...initialProps };
+        const { groupComponent } = props;
+        const standardProps = { groupComponent, standalone: false };
+        const newProps = merge(standardProps, omit(props, ["children", "groupComponent"]));
+        return <g {...newProps} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the whole merge and the visible defaults are handed to a re-defaulting hook", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const DEFAULT_PROPS = { direction: "row" };
+      function Flex(_props) {
+        const props = { ...DEFAULT_PROPS, ..._props };
+        const { children, testId } = props;
+        const wrapperCSS = useResponsivePropsCSS(props, DEFAULT_PROPS, { margin: responsiveMargin });
+        return <div css={wrapperCSS} data-testid={testId}>{children}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a destructured key that re-applies its default at the destructure", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Gauge = (props: GaugeProps) => {
+        const { width = 100 } = { ...defaultGaugeProps, ...props };
+        return <svg width={width * 2} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when only never-defaulted keys of a visible defaults literal feed computations", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const defaultProps = { groupComponent: "g" };
+      const Portal = (initialProps: PortalProps) => {
+        const props = { ...defaultProps, ...initialProps };
+        return <div>{Math.min(props.width, 500)}</div>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag the defaultProps-replacement merge that only forwards into JSX", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const VictoryContainer = (props: VictoryContainerProps) => {
+        const merged = { ...DEFAULT_PROPS, ...props };
+        return <svg {...merged} width={merged.width} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an imperative config-patch setter merging an update over defaults", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `export const setMessageGlobalConfig = (update: ConfigUpdate) => {
+        currentConfig = { ...defaultGlobalConfig, ...update };
+        applyDuration(currentConfig.duration * 1000);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a plain config/util merge outside component context", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `export const trashPagination = (opts: RequestOpts) =>
+        request({ ...defaultRequestConfig, ...opts });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a request helper co-located with a component in the same file", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const buildRequest = (opts: RequestOpts) =>
+        request({ ...defaultRequestConfig, ...opts });
+      export const Page = () => {
+        return <div />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an options merge helper in a hooks file with no JSX", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `export const useFetch = (url: string) => fetch(url);
+      const mergeRequestOptions = (options: RequestOptions) =>
+        ({ ...defaultRequestOptions, ...options });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the developer already filtered undefined keys into a local named props", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Chart = (rawProps: ChartProps) => {
+        const props = pickDefined(rawProps);
+        const merged = { ...defaultChartTheme, ...props };
+        return <svg width={merged.width * 2} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a fresh object-literal binding named props", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Icon = () => {
+        const props = { size: 16, color: "red" };
+        const merged = { ...defaultIconTheme, ...props };
+        return <svg width={merged.size * 2} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a shadowing literal merged inside a map callback", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Grid = (gridProps: GridProps) => {
+        const cells = gridProps.items.map((item) => {
+          const props = { id: item.id };
+          return { ...defaultCellTheme, ...props };
+        });
+        return <div>{cells.length}</div>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag in a test file", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const FileTokenGroup = (props: Props) => {
+        const merged = { ...defaultProps, ...props };
+        return <div style={{ width: merged.width * 2 }} />;
+      };`,
+      { filename: "file-token-group.test.tsx" },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the later operand is an object literal (single spread)", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Box = () => {
+        const merged = { ...defaults, width: 100, height: 50 };
+        return <div width={merged.width * 2} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the later operand is a fully-required inline type", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `function useMerge(required: { a: number; b: number }) {
+        const merged = { ...defaults, ...required };
+        return merged.a + merged.b;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the first operand is not a defaults identifier", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Panel = (props: Props) => {
+        const merged = { ...base, ...props };
+        return <div width={merged.width * 2} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the later spread is an inline object literal", () => {
+    const result = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `const Panel = (props: Props) => {
+        const merged = { ...defaults, ...{ width: 1 } };
+        return <div width={merged.width * 2} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.ts
@@ -14,10 +14,6 @@ import { walkAst } from "../../utils/walk-ast.js";
 const MESSAGE =
   "Spreading props after defaults copies an explicit `undefined` over a default, and this merged value feeds a computation, so the component runs without the default it declared. Strip `undefined` keys before merging or apply the default at the use site (`props.width ?? defaults.width`).";
 
-// Lowercase `default(s)Xxx` / SCREAMING `..._DEFAULT_PROPS` naming only —
-// config-flavored names (`defaultGlobalConfig`, `currentConfig`) belong to
-// imperative patch/setter merges where later-wins (including explicit
-// `undefined`) is the intended API contract, so they never fire.
 const LOWER_DEFAULTS_PREFIX_PATTERN = /^defaults?([A-Z_]|$)/;
 const SCREAMING_DEFAULTS_PATTERN = /^([A-Z0-9]+_)*DEFAULTS?(_[A-Z0-9]+)*$/;
 const CONFIG_FLAVORED_NAME_PATTERN = /config/i;
@@ -43,12 +39,6 @@ const spreadArgumentOf = (spread: EsTreeNode): EsTreeNode | null => {
   return argument ?? null;
 };
 
-// The enclosing component/hook's own parameter binding for `name`: either a
-// plain parameter identifier (`(props) =>`) or a rest binding inside a
-// destructured parameter (`({ className, ...rest }) =>`). Local bindings that
-// merely reuse the name (a filtered copy, an object literal, a shadow inside
-// a callback) are not the caller's props and cannot carry the caller's
-// explicit `undefined`.
 const propsParameterBindingForName = (
   functionNode: EsTreeNode,
   name: string,
@@ -80,9 +70,6 @@ const propsParameterBindingForName = (
 };
 
 const typeAnnotationHasOptionalMember = (typeNode: EsTreeNode): boolean => {
-  // A named type reference (`Props`) may declare optional members we can't see
-  // across files, so treat it as possibly-optional. An inline object type is
-  // fully visible: only flag when it actually has a `?` member.
   if (isNodeOfType(typeNode, "TSTypeReference")) return true;
   if (isNodeOfType(typeNode, "TSTypeLiteral")) {
     return typeNode.members.some((member) => Boolean((member as { optional?: boolean }).optional));
@@ -91,12 +78,9 @@ const typeAnnotationHasOptionalMember = (typeNode: EsTreeNode): boolean => {
 };
 
 const parameterCanCarryExplicitUndefined = (parameterBinding: EsTreeNode): boolean => {
-  const annotationWrapper = (parameterBinding as { typeAnnotation?: EsTreeNode }).typeAnnotation;
-  const annotatedType = annotationWrapper
-    ? (annotationWrapper as { typeAnnotation?: EsTreeNode }).typeAnnotation
-    : null;
-  if (!annotatedType) return true;
-  return typeAnnotationHasOptionalMember(annotatedType);
+  const annotatedType = (parameterBinding as { typeAnnotation?: { typeAnnotation?: EsTreeNode } })
+    .typeAnnotation?.typeAnnotation;
+  return !annotatedType || typeAnnotationHasOptionalMember(annotatedType);
 };
 
 const MAX_MERGE_DESTRUCTURE_DEPTH = 3;
@@ -170,11 +154,6 @@ const isComputationalConsumer = (consumer: EsTreeNode, expression: EsTreeNode): 
   return isNodeOfType(consumer, "TemplateLiteral");
 };
 
-// Climbs from a reference through member accesses (`merged.width`) to the
-// expression the merge result feeds, then asks whether that consumer is a
-// computation (arithmetic, comparison, call argument, template) where an
-// `undefined` changes behavior. Pure JSX forwarding, returns, fallbacks
-// (`merged.x ?? 1`), and object re-wraps stay quiet.
 const referenceFlowsIntoComputation = (referenceIdentifier: EsTreeNode): boolean => {
   let current: EsTreeNode = referenceIdentifier;
   let consumer: EsTreeNode | null | undefined = current.parent;
@@ -206,9 +185,6 @@ const identifierIsValueReference = (identifier: EsTreeNodeOfType<"Identifier">):
   return true;
 };
 
-// `merged.<key>` (or `merged["key"]`) where <key> is possibly defaulted and
-// the climbed consumer is a computation. Accessing a never-defaulted key
-// cannot observe the clobber, so it stays quiet.
 const memberAccessFeedsDefaultedKeyComputation = (
   memberExpression: EsTreeNodeOfType<"MemberExpression">,
   defaultedKeys: Set<string> | null,
@@ -256,11 +232,6 @@ const objectBindingFeedsDefaultedKeyComputation = (
   return didFindComputationalUse;
 };
 
-// A reference to the merged object only counts when a possibly-defaulted KEY
-// flows onward — via a member access or a destructure of that key. The bare
-// merged object handed whole to a call/new is NOT a computation: the callee
-// may re-apply the defaults (basis `useResponsivePropsCSS(props, DEFAULT_PROPS,
-// ...)`) or strip the defaulted keys (victory `Helpers.omit(props, [...])`).
 const objectReferenceFeedsDefaultedKeyComputation = (
   referenceIdentifier: EsTreeNode,
   defaultedKeys: Set<string> | null,
@@ -302,8 +273,6 @@ const destructuredDefaultedKeysFeedComputation = (
     namedKeys.add(keyName);
     if (!isPossiblyDefaultedKey(keyName, defaultedKeys)) continue;
     const valuePattern = property.value;
-    // `const { width = 100 } = merged` re-defaults at the destructure, so the
-    // clobbered key is repaired before any use.
     if (isNodeOfType(valuePattern, "AssignmentPattern")) continue;
     if (isNodeOfType(valuePattern, "Identifier")) {
       if (scalarBindingFeedsComputation(valuePattern.name, pattern, functionNode)) return true;
@@ -368,19 +337,6 @@ const mergeResultFeedsDefaultedKeyComputation = (
   return false;
 };
 
-// Flags `{ ...defaultProps, ...props }` (or `{ ...X.defaultProps, ...props }`)
-// directly inside a React component/hook whose OWN props parameter — or the
-// rest binding of its destructured parameter — is the last spread operand,
-// and only when a possibly-DEFAULTED key of the merge (a `merged.<key>`
-// member access or a key destructured from it) flows into a computation where
-// an explicit `undefined` changes behavior. When the defaults initializer is
-// a visible object literal, only its keys qualify; when it is imported or
-// otherwise opaque, any key does. The whole merged object handed to a call
-// never qualifies — callees like `useResponsivePropsCSS(props, DEFAULT_PROPS)`
-// or `omit(props, [...])` re-apply or strip the defaults. Config-patch
-// setters, helpers co-located with components, local bindings that shadow the
-// props name, pure JSX-forwarding merges, fully-required inline types, and
-// test files stay quiet.
 export const noSpreadPropsOverDefaultsClobbersWithUndefined = defineRule({
   id: "no-spread-props-over-defaults-clobbers-with-undefined",
   title: "Spread props over defaults can clobber with undefined",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.ts
@@ -1,0 +1,434 @@
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
+import {
+  componentOrHookDisplayNameForFunction,
+  nearestEnclosingFunction,
+} from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const MESSAGE =
+  "Spreading props after defaults copies an explicit `undefined` over a default, and this merged value feeds a computation, so the component runs without the default it declared. Strip `undefined` keys before merging or apply the default at the use site (`props.width ?? defaults.width`).";
+
+// Lowercase `default(s)Xxx` / SCREAMING `..._DEFAULT_PROPS` naming only —
+// config-flavored names (`defaultGlobalConfig`, `currentConfig`) belong to
+// imperative patch/setter merges where later-wins (including explicit
+// `undefined`) is the intended API contract, so they never fire.
+const LOWER_DEFAULTS_PREFIX_PATTERN = /^defaults?([A-Z_]|$)/;
+const SCREAMING_DEFAULTS_PATTERN = /^([A-Z0-9]+_)*DEFAULTS?(_[A-Z0-9]+)*$/;
+const CONFIG_FLAVORED_NAME_PATTERN = /config/i;
+
+const isDefaultsSourceName = (name: string): boolean =>
+  (LOWER_DEFAULTS_PREFIX_PATTERN.test(name) || SCREAMING_DEFAULTS_PATTERN.test(name)) &&
+  !CONFIG_FLAVORED_NAME_PATTERN.test(name);
+
+const firstSpreadIsDefaultsSource = (argument: EsTreeNode): boolean => {
+  if (isNodeOfType(argument, "Identifier")) return isDefaultsSourceName(argument.name);
+  if (
+    isNodeOfType(argument, "MemberExpression") &&
+    !argument.computed &&
+    isNodeOfType(argument.property, "Identifier")
+  ) {
+    return argument.property.name === "defaultProps";
+  }
+  return false;
+};
+
+const spreadArgumentOf = (spread: EsTreeNode): EsTreeNode | null => {
+  const argument = (spread as { argument?: EsTreeNode }).argument;
+  return argument ?? null;
+};
+
+// The enclosing component/hook's own parameter binding for `name`: either a
+// plain parameter identifier (`(props) =>`) or a rest binding inside a
+// destructured parameter (`({ className, ...rest }) =>`). Local bindings that
+// merely reuse the name (a filtered copy, an object literal, a shadow inside
+// a callback) are not the caller's props and cannot carry the caller's
+// explicit `undefined`.
+const propsParameterBindingForName = (
+  functionNode: EsTreeNode,
+  name: string,
+): EsTreeNode | null => {
+  if (
+    !isNodeOfType(functionNode, "FunctionDeclaration") &&
+    !isNodeOfType(functionNode, "FunctionExpression") &&
+    !isNodeOfType(functionNode, "ArrowFunctionExpression")
+  ) {
+    return null;
+  }
+  for (const parameter of functionNode.params ?? []) {
+    let pattern: EsTreeNode = parameter;
+    if (isNodeOfType(pattern, "AssignmentPattern")) pattern = pattern.left;
+    if (isNodeOfType(pattern, "Identifier") && pattern.name === name) return pattern;
+    if (isNodeOfType(pattern, "ObjectPattern")) {
+      for (const property of pattern.properties ?? []) {
+        if (
+          isNodeOfType(property, "RestElement") &&
+          isNodeOfType(property.argument, "Identifier") &&
+          property.argument.name === name
+        ) {
+          return property.argument;
+        }
+      }
+    }
+  }
+  return null;
+};
+
+const typeAnnotationHasOptionalMember = (typeNode: EsTreeNode): boolean => {
+  // A named type reference (`Props`) may declare optional members we can't see
+  // across files, so treat it as possibly-optional. An inline object type is
+  // fully visible: only flag when it actually has a `?` member.
+  if (isNodeOfType(typeNode, "TSTypeReference")) return true;
+  if (isNodeOfType(typeNode, "TSTypeLiteral")) {
+    return typeNode.members.some((member) => Boolean((member as { optional?: boolean }).optional));
+  }
+  return false;
+};
+
+const parameterCanCarryExplicitUndefined = (parameterBinding: EsTreeNode): boolean => {
+  const annotationWrapper = (parameterBinding as { typeAnnotation?: EsTreeNode }).typeAnnotation;
+  const annotatedType = annotationWrapper
+    ? (annotationWrapper as { typeAnnotation?: EsTreeNode }).typeAnnotation
+    : null;
+  if (!annotatedType) return true;
+  return typeAnnotationHasOptionalMember(annotatedType);
+};
+
+const MAX_MERGE_DESTRUCTURE_DEPTH = 3;
+
+const unwrapTsWrappers = (expression: EsTreeNode): EsTreeNode => {
+  let current = expression;
+  while (
+    isNodeOfType(current, "TSAsExpression") ||
+    isNodeOfType(current, "TSSatisfiesExpression") ||
+    isNodeOfType(current, "TSNonNullExpression")
+  ) {
+    current = current.expression;
+  }
+  return current;
+};
+
+const staticPropertyKeyName = (property: EsTreeNodeOfType<"Property">): string | null => {
+  if (!property.computed && isNodeOfType(property.key, "Identifier")) return property.key.name;
+  if (isNodeOfType(property.key, "Literal") && typeof property.key.value === "string") {
+    return property.key.value;
+  }
+  return null;
+};
+
+// The literal keys of the defaults object when its initializer is a visible
+// object literal in this file. `null` means the key set is unknowable (an
+// imported defaults object, an `X.defaultProps` member, a spread or computed
+// key inside the literal) — every key is then treated as possibly defaulted.
+const visibleDefaultedKeys = (defaultsSource: EsTreeNode): Set<string> | null => {
+  if (!isNodeOfType(defaultsSource, "Identifier")) return null;
+  const binding = findVariableInitializer(defaultsSource, defaultsSource.name);
+  if (!binding?.initializer) return null;
+  const initializer = unwrapTsWrappers(binding.initializer);
+  if (!isNodeOfType(initializer, "ObjectExpression")) return null;
+  const defaultedKeys = new Set<string>();
+  for (const property of initializer.properties) {
+    if (!isNodeOfType(property, "Property")) return null;
+    const keyName = staticPropertyKeyName(property);
+    if (!keyName) return null;
+    defaultedKeys.add(keyName);
+  }
+  return defaultedKeys;
+};
+
+const isPossiblyDefaultedKey = (keyName: string, defaultedKeys: Set<string> | null): boolean =>
+  defaultedKeys === null || defaultedKeys.has(keyName);
+
+const staticMemberKeyName = (
+  memberExpression: EsTreeNodeOfType<"MemberExpression">,
+): string | null => {
+  if (!memberExpression.computed && isNodeOfType(memberExpression.property, "Identifier")) {
+    return memberExpression.property.name;
+  }
+  if (
+    isNodeOfType(memberExpression.property, "Literal") &&
+    typeof memberExpression.property.value === "string"
+  ) {
+    return memberExpression.property.value;
+  }
+  return null;
+};
+
+const isComputationalConsumer = (consumer: EsTreeNode, expression: EsTreeNode): boolean => {
+  if (isNodeOfType(consumer, "BinaryExpression")) return true;
+  if (isNodeOfType(consumer, "UnaryExpression")) {
+    return consumer.operator === "-" || consumer.operator === "+" || consumer.operator === "~";
+  }
+  if (isNodeOfType(consumer, "CallExpression") || isNodeOfType(consumer, "NewExpression")) {
+    return consumer.arguments.some((callArgument) => callArgument === expression);
+  }
+  return isNodeOfType(consumer, "TemplateLiteral");
+};
+
+// Climbs from a reference through member accesses (`merged.width`) to the
+// expression the merge result feeds, then asks whether that consumer is a
+// computation (arithmetic, comparison, call argument, template) where an
+// `undefined` changes behavior. Pure JSX forwarding, returns, fallbacks
+// (`merged.x ?? 1`), and object re-wraps stay quiet.
+const referenceFlowsIntoComputation = (referenceIdentifier: EsTreeNode): boolean => {
+  let current: EsTreeNode = referenceIdentifier;
+  let consumer: EsTreeNode | null | undefined = current.parent;
+  while (
+    consumer &&
+    ((isNodeOfType(consumer, "MemberExpression") && consumer.object === current) ||
+      isNodeOfType(consumer, "ChainExpression") ||
+      isNodeOfType(consumer, "TSNonNullExpression"))
+  ) {
+    current = consumer;
+    consumer = consumer.parent;
+  }
+  return consumer ? isComputationalConsumer(consumer, current) : false;
+};
+
+const identifierIsValueReference = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const parent = identifier.parent;
+  if (!parent) return false;
+  if (
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.property === identifier &&
+    !parent.computed
+  ) {
+    return false;
+  }
+  if (isNodeOfType(parent, "Property") && parent.key === identifier && !parent.computed) {
+    return false;
+  }
+  return true;
+};
+
+// `merged.<key>` (or `merged["key"]`) where <key> is possibly defaulted and
+// the climbed consumer is a computation. Accessing a never-defaulted key
+// cannot observe the clobber, so it stays quiet.
+const memberAccessFeedsDefaultedKeyComputation = (
+  memberExpression: EsTreeNodeOfType<"MemberExpression">,
+  defaultedKeys: Set<string> | null,
+): boolean => {
+  const keyName = staticMemberKeyName(memberExpression);
+  if (!keyName || !isPossiblyDefaultedKey(keyName, defaultedKeys)) return false;
+  return referenceFlowsIntoComputation(memberExpression);
+};
+
+const scalarBindingFeedsComputation = (
+  bindingName: string,
+  bindingPattern: EsTreeNode,
+  functionNode: EsTreeNode,
+): boolean => {
+  let didFindComputationalUse = false;
+  walkAst(functionNode, (candidate: EsTreeNode) => {
+    if (didFindComputationalUse) return false;
+    if (candidate === bindingPattern) return false;
+    if (!isNodeOfType(candidate, "Identifier") || candidate.name !== bindingName) return;
+    if (!identifierIsValueReference(candidate)) return;
+    if (referenceFlowsIntoComputation(candidate)) didFindComputationalUse = true;
+  });
+  return didFindComputationalUse;
+};
+
+const objectBindingFeedsDefaultedKeyComputation = (
+  bindingName: string,
+  bindingPattern: EsTreeNode,
+  defaultedKeys: Set<string> | null,
+  functionNode: EsTreeNode,
+  depth: number,
+): boolean => {
+  let didFindComputationalUse = false;
+  walkAst(functionNode, (candidate: EsTreeNode) => {
+    if (didFindComputationalUse) return false;
+    if (candidate === bindingPattern) return false;
+    if (!isNodeOfType(candidate, "Identifier") || candidate.name !== bindingName) return;
+    if (!identifierIsValueReference(candidate)) return;
+    if (
+      objectReferenceFeedsDefaultedKeyComputation(candidate, defaultedKeys, functionNode, depth)
+    ) {
+      didFindComputationalUse = true;
+    }
+  });
+  return didFindComputationalUse;
+};
+
+// A reference to the merged object only counts when a possibly-defaulted KEY
+// flows onward — via a member access or a destructure of that key. The bare
+// merged object handed whole to a call/new is NOT a computation: the callee
+// may re-apply the defaults (basis `useResponsivePropsCSS(props, DEFAULT_PROPS,
+// ...)`) or strip the defaulted keys (victory `Helpers.omit(props, [...])`).
+const objectReferenceFeedsDefaultedKeyComputation = (
+  referenceIdentifier: EsTreeNode,
+  defaultedKeys: Set<string> | null,
+  functionNode: EsTreeNode,
+  depth: number,
+): boolean => {
+  const consumer = referenceIdentifier.parent;
+  if (!consumer) return false;
+  if (isNodeOfType(consumer, "MemberExpression") && consumer.object === referenceIdentifier) {
+    return memberAccessFeedsDefaultedKeyComputation(consumer, defaultedKeys);
+  }
+  if (
+    isNodeOfType(consumer, "VariableDeclarator") &&
+    consumer.init === referenceIdentifier &&
+    isNodeOfType(consumer.id, "ObjectPattern") &&
+    depth < MAX_MERGE_DESTRUCTURE_DEPTH
+  ) {
+    return destructuredDefaultedKeysFeedComputation(
+      consumer.id,
+      defaultedKeys,
+      functionNode,
+      depth + 1,
+    );
+  }
+  return false;
+};
+
+const destructuredDefaultedKeysFeedComputation = (
+  pattern: EsTreeNodeOfType<"ObjectPattern">,
+  defaultedKeys: Set<string> | null,
+  functionNode: EsTreeNode,
+  depth: number,
+): boolean => {
+  const namedKeys = new Set<string>();
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "Property")) continue;
+    const keyName = staticPropertyKeyName(property);
+    if (!keyName) continue;
+    namedKeys.add(keyName);
+    if (!isPossiblyDefaultedKey(keyName, defaultedKeys)) continue;
+    const valuePattern = property.value;
+    // `const { width = 100 } = merged` re-defaults at the destructure, so the
+    // clobbered key is repaired before any use.
+    if (isNodeOfType(valuePattern, "AssignmentPattern")) continue;
+    if (isNodeOfType(valuePattern, "Identifier")) {
+      if (scalarBindingFeedsComputation(valuePattern.name, pattern, functionNode)) return true;
+      continue;
+    }
+    const nestedBindingNames = new Set<string>();
+    collectPatternNames(valuePattern, nestedBindingNames);
+    for (const nestedBindingName of nestedBindingNames) {
+      if (scalarBindingFeedsComputation(nestedBindingName, pattern, functionNode)) return true;
+    }
+  }
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "RestElement")) continue;
+    if (!isNodeOfType(property.argument, "Identifier")) continue;
+    const restDefaultedKeys =
+      defaultedKeys === null
+        ? null
+        : new Set(
+            [...defaultedKeys].filter((defaultedKeyName) => !namedKeys.has(defaultedKeyName)),
+          );
+    if (restDefaultedKeys !== null && restDefaultedKeys.size === 0) continue;
+    if (
+      objectBindingFeedsDefaultedKeyComputation(
+        property.argument.name,
+        pattern,
+        restDefaultedKeys,
+        functionNode,
+        depth,
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const mergeResultFeedsDefaultedKeyComputation = (
+  objectExpression: EsTreeNode,
+  functionNode: EsTreeNode,
+  defaultedKeys: Set<string> | null,
+): boolean => {
+  const consumer = objectExpression.parent;
+  if (!consumer) return false;
+  if (isNodeOfType(consumer, "MemberExpression") && consumer.object === objectExpression) {
+    return memberAccessFeedsDefaultedKeyComputation(consumer, defaultedKeys);
+  }
+  if (!isNodeOfType(consumer, "VariableDeclarator") || consumer.init !== objectExpression) {
+    return false;
+  }
+  if (isNodeOfType(consumer.id, "Identifier")) {
+    return objectBindingFeedsDefaultedKeyComputation(
+      consumer.id.name,
+      consumer.id,
+      defaultedKeys,
+      functionNode,
+      0,
+    );
+  }
+  if (isNodeOfType(consumer.id, "ObjectPattern")) {
+    return destructuredDefaultedKeysFeedComputation(consumer.id, defaultedKeys, functionNode, 1);
+  }
+  return false;
+};
+
+// Flags `{ ...defaultProps, ...props }` (or `{ ...X.defaultProps, ...props }`)
+// directly inside a React component/hook whose OWN props parameter — or the
+// rest binding of its destructured parameter — is the last spread operand,
+// and only when a possibly-DEFAULTED key of the merge (a `merged.<key>`
+// member access or a key destructured from it) flows into a computation where
+// an explicit `undefined` changes behavior. When the defaults initializer is
+// a visible object literal, only its keys qualify; when it is imported or
+// otherwise opaque, any key does. The whole merged object handed to a call
+// never qualifies — callees like `useResponsivePropsCSS(props, DEFAULT_PROPS)`
+// or `omit(props, [...])` re-apply or strip the defaults. Config-patch
+// setters, helpers co-located with components, local bindings that shadow the
+// props name, pure JSX-forwarding merges, fully-required inline types, and
+// test files stay quiet.
+export const noSpreadPropsOverDefaultsClobbersWithUndefined = defineRule({
+  id: "no-spread-props-over-defaults-clobbers-with-undefined",
+  title: "Spread props over defaults can clobber with undefined",
+  severity: "warn",
+  tags: ["test-noise"],
+  recommendation:
+    "`{ ...defaults, ...props }` lets an explicit `undefined` on props overwrite a default, so a caller passing `prop={undefined}` breaks the computation that consumes the merge. Strip `undefined` keys before merging or apply the default at the use site (`props.x ?? defaults.x`).",
+  create: (context: RuleContext) => ({
+    ObjectExpression(node: EsTreeNodeOfType<"ObjectExpression">) {
+      const spreads = node.properties.filter((property) =>
+        isNodeOfType(property as EsTreeNode, "SpreadElement"),
+      );
+      if (spreads.length < 2) return;
+
+      const firstSpreadArgument = spreadArgumentOf(spreads[0] as EsTreeNode);
+      if (!firstSpreadArgument || !firstSpreadIsDefaultsSource(firstSpreadArgument)) return;
+
+      const lastSpreadArgument = spreadArgumentOf(spreads[spreads.length - 1] as EsTreeNode);
+      if (!lastSpreadArgument || !isNodeOfType(lastSpreadArgument, "Identifier")) return;
+
+      const enclosingFunction = nearestEnclosingFunction(node as EsTreeNode);
+      if (!enclosingFunction) return;
+      if (!componentOrHookDisplayNameForFunction(enclosingFunction)) return;
+
+      const parameterBinding = propsParameterBindingForName(
+        enclosingFunction,
+        lastSpreadArgument.name,
+      );
+      if (!parameterBinding) return;
+      const resolvedBinding = findVariableInitializer(
+        lastSpreadArgument as EsTreeNode,
+        lastSpreadArgument.name,
+      );
+      if (resolvedBinding && resolvedBinding.bindingIdentifier !== parameterBinding) return;
+      if (!parameterCanCarryExplicitUndefined(parameterBinding)) return;
+
+      const defaultedKeys = visibleDefaultedKeys(firstSpreadArgument);
+      if (
+        !mergeResultFeedsDefaultedKeyComputation(
+          node as EsTreeNode,
+          enclosingFunction,
+          defaultedKeys,
+        )
+      ) {
+        return;
+      }
+
+      context.report({ node, message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-whole-object-dep-with-member-reads.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-whole-object-dep-with-member-reads.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noWholeObjectDepWithMemberReads } from "./no-whole-object-dep-with-member-reads.js";
+
+describe("no-whole-object-dep-with-member-reads", () => {
+  it("flags a bare props dep when the callback only reads a member (EmailModal shape, useCallback)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function EmailModal(props) {
+        const handleFetched = useCallback(() => {
+          props.onEmailThreadFetched();
+        }, [emailThreadFetchingStatus, props]);
+        return handleFetched;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useMemo reading multiple members of a bare props dep", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function FullName(props) {
+        const fullName = useMemo(() => \`\${props.first} \${props.last}\`, [props]);
+        return fullName;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useImperativeHandle whose create callback only reads props members", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Field(props) {
+        useImperativeHandle(props.forwardedRef, () => ({ focus: () => props.onFocus() }), [props]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a useCallback that only destructures props members (destructure is a static member read)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const handle = useCallback(() => {
+          const { onChange } = props;
+          onChange();
+        }, [props]);
+        return handle;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a useEffect whole-props dep (root-mounted singletons keep a stable props reference, e.g. mapguide-react-layout App)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function App(props) {
+        useEffect(() => {
+          props.onInit(props.mapName);
+        }, [props]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a useLayoutEffect whole-props dep (effects are excluded like useEffect)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function App(props) {
+        useLayoutEffect(() => {
+          props.onMeasure();
+        }, [props]);
+        return null;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a destructured prop value (identity belongs to the parent, so [user] is idiomatic)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Card({ user }) {
+        const label = useMemo(() => \`\${user.first} \${user.last}\`, [user]);
+        return label;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the destructure has a rest element (rest captures the remaining object)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const handle = useCallback(() => {
+          const { onChange, ...rest } = props;
+          onChange(rest);
+        }, [props]);
+        return handle;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the destructure uses a computed key (dynamic read)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const handle = useCallback(() => {
+          const { [key]: value } = props;
+          use(value);
+        }, [props]);
+        return handle;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the object is spread (whole reference matters)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const merged = useMemo(() => ({ ...props }), [props]);
+        return merged;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the object is passed as an argument", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const handle = useCallback(() => {
+          save(props);
+        }, [props]);
+        return handle;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a member expression already listed in deps", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const value = useMemo(() => {
+          return use(props.requisition);
+        }, [props.requisition]);
+        return value;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an object built by a hook (not a component prop)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Cart() {
+        const cart = useContext(CartContext);
+        const total = useMemo(() => cart.state, [cart]);
+        return total;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a dynamic index read of props", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const value = useMemo(() => read(props[key]), [props]);
+        return value;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the callback shadows the prop name", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const handle = useCallback((props) => {
+          props.onChange();
+        }, [props]);
+        return handle;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag outside a component (lowercase function)", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function helper(props) {
+        const handle = useCallback(() => {
+          props.onChange();
+        }, [props]);
+        return handle;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when props is used bare in an equality check", () => {
+    const result = runRule(
+      noWholeObjectDepWithMemberReads,
+      `function Panel(props) {
+        const value = useMemo(() => {
+          if (props === prev) return null;
+          return read(props.value);
+        }, [props]);
+        return value;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-whole-object-dep-with-member-reads.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-whole-object-dep-with-member-reads.ts
@@ -1,0 +1,179 @@
+import { collectPatternNames } from "../../utils/collect-pattern-names.js";
+import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isUppercaseName } from "../../utils/is-uppercase-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+// Only identity-sensitive memoization hooks: a whole-`props` dep provably
+// defeats useMemo/useCallback/useImperativeHandle whenever the parent
+// re-renders, so narrowing the dep is always a win. useEffect/useLayoutEffect
+// are deliberately excluded — root-mounted / singleton components keep a
+// referentially stable props object, so "re-runs every render" is not a
+// sound claim for effects (verified false positive in the wild).
+const IDENTITY_SENSITIVE_HOOKS_WITH_DEPS = new Set([
+  "useMemo",
+  "useCallback",
+  "useImperativeHandle",
+]);
+
+// The single name whose identity is a fresh reference whenever the parent
+// re-renders: the whole props object bound to a `function C(props)`
+// identifier parameter. React allocates a new props object on each parent
+// render, so a bare `props` dep whose body only reads members is reliably
+// over-broad for memoization hooks.
+//
+// We deliberately do NOT extend this to destructured names
+// (`function C({ user }) {}`). A destructured `user` is `props.user` — its
+// identity belongs to the *parent* and is typically stable, so `[user]`
+// while reading `user.name` is idiomatic and exactly what React's own
+// exhaustive-deps rule blesses. Flagging it would both contradict
+// exhaustive-deps and assert a false "fresh object every render" premise, so
+// scoping to the whole-props identifier keeps the detector sound.
+const collectPropsObjectNames = (componentFunction: EsTreeNode): Set<string> => {
+  const propsNames = new Set<string>();
+  if (!isFunctionLike(componentFunction)) return propsNames;
+  const firstParam = componentFunction.params?.[0];
+  if (!firstParam) return propsNames;
+  if (isNodeOfType(firstParam, "Identifier")) {
+    propsNames.add(firstParam.name);
+  }
+  return propsNames;
+};
+
+interface DependencyUsage {
+  memberReadCount: number;
+  hasBareUse: boolean;
+}
+
+// A non-rest, non-computed object destructure (`const { onChange } = props`)
+// is semantically a set of static member reads. A rest element captures the
+// remaining object and a computed key is a dynamic read, so both disqualify.
+const countStaticDestructureReads = (destructurePattern: EsTreeNode): number | null => {
+  if (!isNodeOfType(destructurePattern, "ObjectPattern")) return null;
+  const properties = destructurePattern.properties ?? [];
+  if (properties.length === 0) return null;
+  for (const property of properties) {
+    if (!isNodeOfType(property, "Property")) return null;
+    if (property.computed) return null;
+  }
+  return properties.length;
+};
+
+// Classifies every reference to `dependencyName` inside the callback body:
+// a "member read" is `X.prop` / `X["prop"]` (static), anything else — bare
+// use, spread, argument, return, dynamic index — disqualifies the finding.
+const analyzeDependencyUsage = (
+  callbackBody: EsTreeNode,
+  dependencyName: string,
+): DependencyUsage => {
+  const usage: DependencyUsage = { memberReadCount: 0, hasBareUse: false };
+  walkAst(callbackBody, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "Identifier") || child.name !== dependencyName) return;
+    const parent = child.parent;
+    if (parent && isNodeOfType(parent, "MemberExpression")) {
+      // `something.X` — X is the property name of another object, not a use.
+      if (parent.property === child && !parent.computed) return;
+      if (parent.object === child) {
+        const staticMember =
+          !parent.computed ||
+          (isNodeOfType(parent.property, "Literal") &&
+            (typeof parent.property.value === "string" ||
+              typeof parent.property.value === "number"));
+        if (staticMember) {
+          usage.memberReadCount += 1;
+        } else {
+          // `X[dynamicKey]` — dynamic index; treat as an unknown use.
+          usage.hasBareUse = true;
+        }
+        return;
+      }
+    }
+    // Non-shorthand object key `{ X: value }` is a key, not a use of X.
+    if (
+      parent &&
+      isNodeOfType(parent, "Property") &&
+      parent.key === child &&
+      !parent.computed &&
+      !parent.shorthand
+    ) {
+      return;
+    }
+    if (parent && isNodeOfType(parent, "VariableDeclarator") && parent.init === child) {
+      const destructureReadCount = countStaticDestructureReads(parent.id);
+      if (destructureReadCount !== null) {
+        usage.memberReadCount += destructureReadCount;
+        return;
+      }
+    }
+    usage.hasBareUse = true;
+  });
+  return usage;
+};
+
+// Bindings the callback rebinds itself (its params) shadow the outer prop, so
+// references inside no longer point at the component prop.
+const callbackShadowsName = (callbackFunction: EsTreeNode, name: string): boolean => {
+  if (!isFunctionLike(callbackFunction)) return false;
+  const shadowed = new Set<string>();
+  for (const param of callbackFunction.params ?? []) collectPatternNames(param, shadowed);
+  return shadowed.has(name);
+};
+
+export const noWholeObjectDepWithMemberReads = defineRule({
+  id: "no-whole-object-dep-with-member-reads",
+  title: "Whole props object in deps while only members are read",
+  severity: "warn",
+  recommendation:
+    "Depend on the specific fields you read (e.g. `props.onChange`) instead of the whole `props` object. Props are a fresh object whenever the parent re-renders, so a whole-props dependency defeats the memoization.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isHookCall(node, IDENTITY_SENSITIVE_HOOKS_WITH_DEPS)) return;
+      const callbackIndex = isHookCall(node, "useImperativeHandle") ? 1 : 0;
+      const args = node.arguments ?? [];
+      if (args.length < callbackIndex + 2) return;
+
+      const callback = args[callbackIndex];
+      if (!isFunctionLike(callback)) return;
+      const depsNode = stripParenExpression(args[callbackIndex + 1]);
+      if (!isNodeOfType(depsNode, "ArrayExpression")) return;
+
+      // The props object belongs to the enclosing component function; the
+      // hook call sits directly in that component body.
+      let componentFunction: EsTreeNode | null | undefined = node.parent;
+      while (componentFunction && !isFunctionLike(componentFunction)) {
+        componentFunction = componentFunction.parent;
+      }
+      if (!componentFunction) return;
+      const displayName = componentOrHookDisplayNameForFunction(componentFunction);
+      // Restrict to components — props semantics (fresh object per render)
+      // only hold for a PascalCase component's first parameter.
+      if (!displayName || !isUppercaseName(displayName)) return;
+
+      const propsNames = collectPropsObjectNames(componentFunction);
+      if (propsNames.size === 0) return;
+
+      for (const element of depsNode.elements ?? []) {
+        if (!element) continue;
+        const dep = stripParenExpression(element);
+        if (!isNodeOfType(dep, "Identifier")) continue;
+        if (!propsNames.has(dep.name)) continue;
+        if (callbackShadowsName(callback, dep.name)) continue;
+
+        const usage = analyzeDependencyUsage(callback, dep.name);
+        if (usage.hasBareUse || usage.memberReadCount === 0) continue;
+
+        context.report({
+          node: element,
+          message: `This hook depends on the whole "${dep.name}" object but only reads its properties, so the memoization is defeated whenever the parent re-renders because "${dep.name}" is a fresh object each time; depend on the specific fields you read instead.`,
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/find-enclosing-function.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/find-enclosing-function.ts
@@ -1,0 +1,11 @@
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isFunctionLike } from "../../../utils/is-function-like.js";
+
+export const findEnclosingFunction = (node: EsTreeNode): EsTreeNode | null => {
+  let cursor: EsTreeNode | null = node.parent ?? null;
+  while (cursor) {
+    if (isFunctionLike(cursor)) return cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/pattern-binds-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/pattern-binds-name.ts
@@ -1,0 +1,8 @@
+import { collectPatternNames } from "../../../utils/collect-pattern-names.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+
+export const patternBindsName = (pattern: EsTreeNode | null | undefined, name: string): boolean => {
+  const boundNames = new Set<string>();
+  collectPatternNames(pattern ?? null, boundNames);
+  return boundNames.has(name);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/unwrap-chain-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/unwrap-chain-expression.ts
@@ -1,0 +1,5 @@
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+
+export const unwrapChainExpression = (node: EsTreeNode | null | undefined): EsTreeNode | null =>
+  isNodeOfType(node, "ChainExpression") ? node.expression : (node ?? null);


### PR DESCRIPTION
> Stacked on the foundation PR (#1000 — package-version detection, SSR capability, shared AST utils). Retargets `main` when #1000 merges.

## Why

This batch catches the runtime-bug class where React's lifecycle and async work drift apart: effects that leak listeners, observers, rAF loops, and debounced timers past unmount; state written from stale closures or out-of-order awaits; and updaters that mutate the reference React already holds so `Object.is` skips the re-render. None of these throw — they surface as ghost subscriptions, spinners stuck forever, lost toggles, and UIs that silently show the wrong data.

The batch's most impactful rule, `no-set-state-after-await-in-effect` (59 corpus hits pre-hardening), catches the classic fetch race:

```tsx
// Bad: overlapping re-runs resolve out of order — the last write wins, not the latest id
useEffect(() => {
  (async () => {
    const data = await load(id);
    setNote(data); // stale `id`'s response can land after the fresh one
  })();
}, [id]);

// Good: cancelled re-runs never commit
useEffect(() => {
  let ignore = false;
  (async () => {
    const data = await load(id);
    if (!ignore) setNote(data);
  })();
  return () => { ignore = true; };
}, [id]);
```

## Rules

| Rule | Catches | Notable exemptions |
| --- | --- | --- |
| `class-component-missing-component-will-unmount-teardown` | Class component registers a listener (`on`/`subscribe`/`addEventListener`/`addListener`) or timer on mount but declares no `componentWillUnmount` | `disposeOnUnmount`, `{ once: true }` self-removers, emitters constructed locally in the mount body, `setTimeout`s that only assign a field or nudge focus, non-React classes |
| `debounce-no-cleanup` | Lodash-style debounce/throttle binding driven from an effect with no `.cancel()` cleanup, so the trailing call fires after unmount | Cancel in cleanup or via `useUnmount`, custom hooks returning the binding (caller owns teardown), debounced `useState` setters (post-unmount no-op), parent-notify prop callbacks, `trailing: false`, autosave-flush idiom, handler-only wiring |
| `effect-listener-cleanup-reference-mismatch` | Cleanup calls `remove`/`off`/`unsubscribe` with a brand-new inline function that never equals the added handler, so the removal detaches nothing | Shared named or hoisted handler, different event strings/targets, computed event names it cannot compare, AbortController teardown, effects with no remove call |
| `effect-observer-needs-disconnect` | Resize/Intersection/MutationObserver created and `observe`d in an effect with no cleanup calling `disconnect()`/`unobserve()` | One-shot observers disconnecting in their own callback, ref-stashed observers released by a returned named cleanup, release delegated to a helper/registry/alias, module-scope observers |
| `effect-raf-loop-needs-cancel` | Self-rescheduling `requestAnimationFrame` loop in an effect that is never cancelled, so it runs after unmount | One-shot rAF (incl. double-rAF wait-for-paint), stop-flag/token-ref loops whose cleanup flips the guard the step checks, cancellation via aliased handle or named cleanup |
| `effect-remove-listener-inline-handler` | `removeEventListener`/`.off` passed an inline arrow, function expression, or `.bind()` — a reference that cannot match the registered listener | Two-arg `unsubscribe` (second arg may be a completion/ack callback), single-arg unsubscribe idiom, stable identifier or member-expression handlers, computed removal access |
| `mobx-reaction-disposer-discarded` | Bare `reaction()`/`autorun()` from mobx whose returned disposer is thrown away, so the tracked computation runs forever | Disposal via the `signal` option (incl. opaque/spread option bags that may carry one), disposer stored/assigned/passed to `disposeOnUnmount`, `when()` (auto-disposes), non-mobx bindings |
| `no-async-event-handler-without-reentry-guard` | Async `onClick`/`onSubmit`/`onPress` that awaits a mutating request (`post`/`put`/`patch`/`delete`/`mutate`) and only flips state after the await — a double-click fires it twice | Leading `if (busy) return` guard or leading loading-flag set, GET reads, idempotent work (clipboard copy), error-only setters in `catch`, other event names |
| `no-boolean-toggle-without-functional-update` | `setX(!x)` inside async closures (timeouts, subscriptions, `.then`) where `x` is a stale capture; wants `setX(prev => !prev)` | Synchronous handler toggles, shadowing locals/callback params, effect-body toggle with the state in deps, `useReducer` dispatch, Storybook files |
| `no-effect-wrapper-discards-callback-cleanup-return` | Custom hook forwards a param typed `EffectCallback`/`typeof useEffect` but calls it as a bare statement, discarding the cleanup it returns | Params typed plain `() => void`, calls already `return`ed, params with no resolvable type annotation, code outside a custom hook |
| `no-loading-flag-reset-outside-finally` | Loading/busy flag reset only on the success path after an await — a rejection leaves the spinner stuck truthy | Reset in `finally` or mirrored in a swallowing `catch`, `Promise.allSettled`, `await f().catch(() => null)` fallbacks, result-shape-checked awaits (`{ data, error }`, truthiness guards), reset before the await |
| `no-mutate-then-set-or-return-same-reference` | Mutating the array/Set/object React already holds and handing the same reference back (`setX(x)` or `return prev`), so `Object.is` skips the re-render | Fresh copies (spread/`Array.from`/`new Set`), locals shadowing the state name (fetched/derived), non-`useState` setters (`setSearchParams`), immutable APIs whose `.add`/`.set` return new instances (dayjs, Immutable.js), mutations in nested handlers |
| `no-promise-then-side-effect-in-effect-without-catch` | In-effect promise chain ending in a `.then` that sets state or mutates a ref with no `.catch`/onRejected/try-catch (`.finally` does not count) | Initiators not provably rejectable (error-folding wrappers, internal try/catch resolving null), resolve-null/undefined contracts guarded on the callback arg, in-band error-field reads, ref-held cached promises (creation site owns the catch), Storybook files |
| `no-set-state-after-await-in-effect` | State setter/dispatch after `await` in effect-launched async work when deps can change identity, so overlapping re-runs write stale state out of order | Mount-only (empty-deps) effects, all-stable deps (setters, refs, module-scope consts, store actions), effects returning a cleanup, mounted-flag or AbortController guards, setters in event handlers or deeper closures |
| `no-side-effect-in-state-updater-function` | Side-effecting call (consumer/analytics/logging callback) inside a state updater, which React may invoke more than once (StrictMode double-invoke, concurrent replay) | Callbacks merely stored on the next state (toast `onDismiss`, deferred sorter), redux-thunk dispatch (not a React updater), nested setters, callbacks invoked outside the updater |
| `no-spread-props-over-defaults-clobbers-with-undefined` | `{ ...defaults, ...props }` where an explicitly-`undefined` prop clobbers a default and the merged value feeds a computation | Merges only forwarded to JSX/omit/re-defaulting hooks, keys re-defaulted at the destructure or use site, pre-filtered `undefined` keys, non-defaults first operands, config/util merges outside component context, test files |
| `no-whole-object-dep-with-member-reads` | `useCallback`/`useMemo`/`useImperativeHandle` depending on the whole `props` object while only reading members — a fresh `props` each parent render defeats the memoization | `useEffect`/`useLayoutEffect` deps, destructured prop values, rest/computed/spread/argument/equality uses of the object, member already listed in deps, shadowed names, non-components |

## Validation

Every rule was validated against 67 production OSS repos at pinned SHAs plus 88 reconstructed merged-PR gold solutions. Per-rule sampled hits were judged and adversarially re-verified by two independent reviewers, and rules went through up to three FP-hardening waves. Verdicts: **clean-keep** = remaining hits judged majority true-positive; **needs-narrowing** = a further narrowing shipped in this PR with regression tests; **silent-precise** = zero corpus hits by design (the pattern is rare but high-severity when present).

| Rule | Pre-hardening hits | Remaining hits | Verdict |
| --- | ---: | ---: | --- |
| `no-set-state-after-await-in-effect` | 59 | 46 | needs-narrowing |
| `no-loading-flag-reset-outside-finally` | 57 | 33 | needs-narrowing |
| `no-spread-props-over-defaults-clobbers-with-undefined` | 33 | 16 | needs-narrowing |
| `no-promise-then-side-effect-in-effect-without-catch` | 30 | 2 | clean-keep |
| `no-side-effect-in-state-updater-function` | 23 | 25 | clean-keep |
| `debounce-no-cleanup` | 9 | 1 | clean-keep |
| `no-async-event-handler-without-reentry-guard` | 8 | 8 | clean-keep |
| `no-mutate-then-set-or-return-same-reference` | 8 | 3 | clean-keep |
| `effect-raf-loop-needs-cancel` | 8 | 0 | silent-precise |
| `effect-remove-listener-inline-handler` | 5 | 5 | clean-keep |
| `effect-listener-cleanup-reference-mismatch` | 4 | 4 | clean-keep |
| `class-component-missing-component-will-unmount-teardown` | 3 | 2 | clean-keep |
| `no-boolean-toggle-without-functional-update` | 2 | 0 | silent-precise |
| `no-effect-wrapper-discards-callback-cleanup-return` | 1 | 1 | clean-keep |
| `no-whole-object-dep-with-member-reads` | 1 | 0 | silent-precise |
| `effect-observer-needs-disconnect` | 0 | 0 | silent-precise |
| `mobx-reaction-disposer-discarded` | 0 | 0 | silent-precise |

The three needs-narrowing rules ship their narrowings in this PR — e.g. `no-loading-flag-reset-outside-finally` learned the never-rejecting result-object contracts (`Promise.allSettled`, `.catch(() => null)`, supabase-style `{ data, error }` checks) and `no-set-state-after-await-in-effect` learned stable-identity dep analysis (setters, refs, module-scope consts, store actions) — each with regression tests reproduced from the surviving corpus hits.

## Test plan

- 320 focused `it()` cases across the 17 rule test suites (invalid shapes plus every exemption listed above), including corpus-derived regression tests for the narrowings
- `pnpm typecheck`
- `pnpm format:check`
- registry `gen:check` (generated rule registry is in sync)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive surface area (many new diagnostics on real apps) with corpus-driven exemptions, but limited risk to runtime behavior since changes are lint-only; reviewers should watch for noisy rules on existing codebases.
> 
> **Overview**
> Adds **17 new `state-and-effects` lint rules** to `oxlint-plugin-react-doctor` (minor bump in changeset), each wired into `rule-registry.ts` as global **Bugs** (or **Correctness** for the effect-wrapper rule) with React where needed.
> 
> The rules target silent runtime issues: **effect teardown** (missing class `componentWillUnmount`, debounce `.cancel()`, observer `disconnect`, rAF `cancelAnimationFrame`, listener reference mismatches, inline handlers on `removeEventListener`), **MobX** disposers thrown away, **async races** (setState after await in effects, promise `.then` in effects without catch, loading flags reset only on success, async submit/click without re-entry guards), and **state correctness** (boolean toggles in deferred closures, mutating then re-setting the same reference, side effects inside updaters, `undefined` props clobbering defaults, whole-`props` memo deps).
> 
> Implementations are AST-heavy with broad **false-positive carve-outs** (documented in the PR description and mirrored in large per-rule test suites). **`no-effect-event-handler`** now imports shared **`unwrapChainExpression`** instead of an inline helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501b888dc505c2f11b690114fabeb630469f2aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->