### PR TITLE
RD-NEW-RR-RULE: tanstack-query — 2 rules

### DIFF
--- a/.changeset/rd-new-rules-tanstack-query.md
+++ b/.changeset/rd-new-rules-tanstack-query.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 2 new tanstack-query rules, corpus-validated and FP-hardened

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -285,7 +285,9 @@ import { preferUseReducer } from "./rules/state-and-effects/prefer-use-reducer.j
 import { publicDebugArtifact } from "./rules/security-scan/public-debug-artifact.js";
 import { publicEnvSecretName } from "./rules/security-scan/public-env-secret-name.js";
 import { queryDestructureResult } from "./rules/tanstack-query/query-destructure-result.js";
+import { queryFloatingMutateAsync } from "./rules/tanstack-query/query-floating-mutate-async.js";
 import { queryMutationMissingInvalidation } from "./rules/tanstack-query/query-mutation-missing-invalidation.js";
+import { queryNoMutationInEffectAsRead } from "./rules/tanstack-query/query-no-mutation-in-effect-as-read.js";
 import { queryNoQueryInEffect } from "./rules/tanstack-query/query-no-query-in-effect.js";
 import { queryNoRestDestructuring } from "./rules/tanstack-query/query-no-rest-destructuring.js";
 import { queryNoUseQueryForMutation } from "./rules/tanstack-query/query-no-use-query-for-mutation.js";
@@ -3632,12 +3634,34 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/query-floating-mutate-async",
+    id: "query-floating-mutate-async",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...queryFloatingMutateAsync,
+      framework: "tanstack-query",
+      category: "Bugs",
+    },
+  },
+  {
     key: "react-doctor/query-mutation-missing-invalidation",
     id: "query-mutation-missing-invalidation",
     source: "react-doctor",
     originallyExternal: false,
     rule: {
       ...queryMutationMissingInvalidation,
+      framework: "tanstack-query",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/query-no-mutation-in-effect-as-read",
+    id: "query-no-mutation-in-effect-as-read",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...queryNoMutationInEffectAsRead,
       framework: "tanstack-query",
       category: "Bugs",
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.test.ts
@@ -206,4 +206,25 @@ describe("query-floating-mutate-async", () => {
     );
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("flags a logical left-operand mutateAsync statement", () => {
+    const result = runRule(queryFloatingMutateAsync, `mutation.mutateAsync(payload) && refetch();`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags mutateAsync discarded as a bare ternary test", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `mutation.mutateAsync(payload) ? onDone() : onFail();`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a logical left-operand assigned to a variable", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const didStart = mutation.mutateAsync(payload) && true;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { queryFloatingMutateAsync } from "./query-floating-mutate-async.js";
+
+describe("query-floating-mutate-async", () => {
+  it("flags a bare mutateAsync statement", () => {
+    const result = runRule(queryFloatingMutateAsync, `mutation.mutateAsync(payload);`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags mutateAsync as the sole statement in a useEffect block", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `useEffect(() => { mutation.mutateAsync(payload); }, [id]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a concise useEffect arrow body", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `useEffect(() => mutation.mutateAsync(payload), [id]);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a concise event-handler arrow body", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const x = <button onClick={() => mutation.mutateAsync(payload)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an awaited call", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `async function f() { await mutation.mutateAsync(payload); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a returned call", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `function f() { return mutation.mutateAsync(payload); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a voided call", () => {
+    const result = runRule(queryFloatingMutateAsync, `void mutation.mutateAsync(payload);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a chained catch", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `mutation.mutateAsync(payload).catch(handleError);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an assigned promise", () => {
+    const result = runRule(queryFloatingMutateAsync, `const p = mutation.mutateAsync(payload);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag mutateAsync args to an awaited Promise.all", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `async function f() { await Promise.all([a.mutateAsync(x), b.mutateAsync(y)]); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a concise arrow mapped into Promise.all", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `async function f() { await Promise.all(items.map((item) => mutation.mutateAsync(item))); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag refetch or invalidateQueries", () => {
+    const refetch = runRule(queryFloatingMutateAsync, `query.refetch();`);
+    expect(refetch.diagnostics).toHaveLength(0);
+    const invalidate = runRule(queryFloatingMutateAsync, `client.invalidateQueries({ queryKey });`);
+    expect(invalidate.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a computed mutateAsync member", () => {
+    const result = runRule(queryFloatingMutateAsync, `obj['mutateAsync'](payload);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an optional-chained bare mutateAsync statement", () => {
+    const result = runRule(queryFloatingMutateAsync, `ref.current?.mutateAsync(payload);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an awaited optional-chained mutateAsync", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `async function f() { await ref.current?.mutateAsync(payload); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a floating destructured mutateAsync call", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const { mutateAsync } = useMutation(opts); mutateAsync(payload);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an awaited destructured mutateAsync call", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const { mutateAsync } = useMutation(opts);
+       async function f() { await mutateAsync(payload); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare mutateAsync identifier with no useMutation destructure", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const mutateAsync = () => save(payload); mutateAsync(payload);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a mutateAsync parameter shadowing a useMutation destructure", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const { mutateAsync } = useMutation(opts);
+       const run = (mutateAsync) => { mutateAsync(payload); };
+       run(fireAndForgetCallback);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags mutateAsync followed only by a fulfillment .then", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `mutation.mutateAsync(payload).then(onSuccess);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags mutateAsync followed only by .finally", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `mutation.mutateAsync(payload).finally(stopLoading);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a two-argument .then with a rejection handler", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `mutation.mutateAsync(payload).then(onSuccess, onError);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a .then chain closed by .catch", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `mutation.mutateAsync(payload).then(onSuccess).catch(onError);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a returned .then chain", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `function f() { return mutation.mutateAsync(payload).then(onSuccess); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags both branches of a ternary concise handler body", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const x = <button onClick={() => (isNew ? create.mutateAsync(v) : update.mutateAsync(v))} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("flags a logical-guarded concise handler body", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const x = <button onClick={() => canSave && mutation.mutateAsync(v)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a ternary branch assigned to a variable", () => {
+    const result = runRule(
+      queryFloatingMutateAsync,
+      `const p = isNew ? create.mutateAsync(v) : null;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.ts
@@ -21,17 +21,21 @@ const FLOATING_CALLBACK_HOST_NAMES = new Set([
   "queueMicrotask",
 ]);
 
-// Wrappers that forward the promise unchanged while walking up from the
-// call: optional-chain containers, parens, and TS assertion nodes (oxc's
-// ESTree surfaces parens as `ParenthesizedExpression`, which is not part
-// of the TSESTree union — hence the string set, mirroring
-// `stripParenExpression`).
-const TRANSPARENT_PROMISE_WRAPPER_TYPES = new Set<string>([
+// Parents that keep the rejection unreachable while walking up from the
+// call: wrappers that forward the promise unchanged (optional-chain
+// containers, parens, and TS assertion nodes — oxc's ESTree surfaces parens
+// as `ParenthesizedExpression`, which is not part of the TSESTree union,
+// hence the string set, mirroring `stripParenExpression`), plus ternary and
+// `&&`/`||`/`??` containers, where the promise either flows through as the
+// expression value or is discarded as a bare truthiness test.
+const FLOATING_PROMISE_PARENT_TYPES = new Set<string>([
   "ChainExpression",
   "ParenthesizedExpression",
   "TSAsExpression",
   "TSSatisfiesExpression",
   "TSNonNullExpression",
+  "ConditionalExpression",
+  "LogicalExpression",
 ]);
 
 const isMutateAsyncMemberCall = (node: EsTreeNode): boolean =>
@@ -67,16 +71,8 @@ const isDiscardedArrowReturn = (arrow: EsTreeNode): boolean => {
   return false;
 };
 
-// Parents that keep the promise floating: the transparent wrappers above,
-// ternary branches, and `&&`/`||` right operands.
-const isTransparentPromiseParent = (parent: EsTreeNode, current: EsTreeNode): boolean =>
-  TRANSPARENT_PROMISE_WRAPPER_TYPES.has(parent.type) ||
-  (isNodeOfType(parent, "ConditionalExpression") &&
-    (parent.consequent === current || parent.alternate === current)) ||
-  (isNodeOfType(parent, "LogicalExpression") && parent.right === current);
-
 // True when the mutateAsync call's promise is discarded with no rejection
-// handler. Walks upward through the transparent parents and
+// handler. Walks upward through the floating parents and
 // `.then(onFulfilled)` / `.finally(...)` steps that never handle rejection,
 // then requires the outermost expression to be a bare ExpressionStatement or
 // the concise body of a discarded-return arrow. A `.catch(...)`, two-argument
@@ -86,7 +82,7 @@ const isFloatingMutateAsync = (node: EsTreeNode): boolean => {
   let current: EsTreeNode = node;
   let parent: EsTreeNode | null = current.parent ?? null;
   while (parent) {
-    if (isTransparentPromiseParent(parent, current)) {
+    if (FLOATING_PROMISE_PARENT_TYPES.has(parent.type)) {
       current = parent;
       parent = current.parent ?? null;
       continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
+import { getCallMethodName } from "../../utils/get-call-method-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
@@ -34,11 +35,7 @@ const TRANSPARENT_PROMISE_WRAPPER_TYPES = new Set<string>([
 ]);
 
 const isMutateAsyncMemberCall = (node: EsTreeNode): boolean =>
-  isNodeOfType(node, "CallExpression") &&
-  isNodeOfType(node.callee, "MemberExpression") &&
-  !node.callee.computed &&
-  isNodeOfType(node.callee.property, "Identifier") &&
-  node.callee.property.name === "mutateAsync";
+  isNodeOfType(node, "CallExpression") && getCallMethodName(node.callee) === "mutateAsync";
 
 // `const { mutateAsync } = useMutation(...)` followed by a bare
 // `mutateAsync(payload)` — the callee is a plain Identifier, so we
@@ -60,22 +57,27 @@ const isDestructuredMutateAsyncCall = (node: EsTreeNode, context: RuleContext): 
 // or returning it keeps the rejection reachable, so those stay quiet.
 const isDiscardedArrowReturn = (arrow: EsTreeNode): boolean => {
   const parent = arrow.parent;
-  if (!parent) return false;
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
   if (isNodeOfType(parent, "JSXExpressionContainer")) return true;
   if (isNodeOfType(parent, "CallExpression")) {
-    const isArgument = parent.arguments?.some((argument) => argument === arrow) ?? false;
-    if (!isArgument) return false;
+    if (!parent.arguments.some((argument) => argument === arrow)) return false;
     const hostName = getCalleeName(parent);
     return hostName !== null && FLOATING_CALLBACK_HOST_NAMES.has(hostName);
   }
   return false;
 };
 
+// Parents that keep the promise floating: the transparent wrappers above,
+// ternary branches, and `&&`/`||` right operands.
+const isTransparentPromiseParent = (parent: EsTreeNode, current: EsTreeNode): boolean =>
+  TRANSPARENT_PROMISE_WRAPPER_TYPES.has(parent.type) ||
+  (isNodeOfType(parent, "ConditionalExpression") &&
+    (parent.consequent === current || parent.alternate === current)) ||
+  (isNodeOfType(parent, "LogicalExpression") && parent.right === current);
+
 // True when the mutateAsync call's promise is discarded with no rejection
-// handler. Walks upward through wrappers that keep the promise floating —
-// ChainExpression, ternary branches, `&&`/`||` right operands, and
-// `.then(onFulfilled)` / `.finally(...)` steps that never handle rejection —
+// handler. Walks upward through the transparent parents and
+// `.then(onFulfilled)` / `.finally(...)` steps that never handle rejection,
 // then requires the outermost expression to be a bare ExpressionStatement or
 // the concise body of a discarded-return arrow. A `.catch(...)`, two-argument
 // `.then(...)`, await/return/void wrapper, assignment, or `Promise.all([...])`
@@ -84,51 +86,26 @@ const isFloatingMutateAsync = (node: EsTreeNode): boolean => {
   let current: EsTreeNode = node;
   let parent: EsTreeNode | null = current.parent ?? null;
   while (parent) {
-    if (TRANSPARENT_PROMISE_WRAPPER_TYPES.has(parent.type)) {
+    if (isTransparentPromiseParent(parent, current)) {
       current = parent;
       parent = current.parent ?? null;
       continue;
     }
-    if (
-      isNodeOfType(parent, "ConditionalExpression") &&
-      (parent.consequent === current || parent.alternate === current)
-    ) {
-      current = parent;
-      parent = current.parent ?? null;
-      continue;
-    }
-    if (isNodeOfType(parent, "LogicalExpression") && parent.right === current) {
-      current = parent;
-      parent = current.parent ?? null;
-      continue;
-    }
-    if (
-      isNodeOfType(parent, "MemberExpression") &&
-      parent.object === current &&
-      !parent.computed &&
-      isNodeOfType(parent.property, "Identifier")
-    ) {
-      const chainMethodName = parent.property.name;
+    if (isNodeOfType(parent, "MemberExpression") && parent.object === current) {
+      const chainMethodName = getCallMethodName(parent);
       if (chainMethodName === "catch") return false;
       if (chainMethodName !== "then" && chainMethodName !== "finally") break;
       const chainStepCall: EsTreeNode | null = parent.parent ?? null;
-      if (
-        !chainStepCall ||
-        !isNodeOfType(chainStepCall, "CallExpression") ||
-        chainStepCall.callee !== parent
-      ) {
+      if (!isNodeOfType(chainStepCall, "CallExpression") || chainStepCall.callee !== parent) {
         return false;
       }
-      const thenHandlesRejection =
-        chainMethodName === "then" && (chainStepCall.arguments?.length ?? 0) >= 2;
-      if (thenHandlesRejection) return false;
+      if (chainMethodName === "then" && chainStepCall.arguments.length >= 2) return false;
       current = chainStepCall;
       parent = current.parent ?? null;
       continue;
     }
     break;
   }
-  if (!parent) return false;
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
   if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === current) {
     return isDiscardedArrowReturn(parent);
@@ -139,6 +116,7 @@ const isFloatingMutateAsync = (node: EsTreeNode): boolean => {
 export const queryFloatingMutateAsync = defineRule({
   id: "query-floating-mutate-async",
   title: "Floating mutateAsync rejection",
+  tags: ["test-noise"],
   requires: ["tanstack-query"],
   severity: "warn",
   recommendation:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-floating-mutate-async.ts
@@ -1,0 +1,157 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+// Callback hosts that discard their callback's return value, so a concise
+// `() => x.mutateAsync()` body there is a fire-and-forget floating call —
+// exactly where an unhandled rejection is most acute (effects + timers).
+const FLOATING_CALLBACK_HOST_NAMES = new Set([
+  "useEffect",
+  "useLayoutEffect",
+  "useInsertionEffect",
+  "setTimeout",
+  "setInterval",
+  "setImmediate",
+  "requestAnimationFrame",
+  "requestIdleCallback",
+  "queueMicrotask",
+]);
+
+// Wrappers that forward the promise unchanged while walking up from the
+// call: optional-chain containers, parens, and TS assertion nodes (oxc's
+// ESTree surfaces parens as `ParenthesizedExpression`, which is not part
+// of the TSESTree union — hence the string set, mirroring
+// `stripParenExpression`).
+const TRANSPARENT_PROMISE_WRAPPER_TYPES = new Set<string>([
+  "ChainExpression",
+  "ParenthesizedExpression",
+  "TSAsExpression",
+  "TSSatisfiesExpression",
+  "TSNonNullExpression",
+]);
+
+const isMutateAsyncMemberCall = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") &&
+  isNodeOfType(node.callee, "MemberExpression") &&
+  !node.callee.computed &&
+  isNodeOfType(node.callee.property, "Identifier") &&
+  node.callee.property.name === "mutateAsync";
+
+// `const { mutateAsync } = useMutation(...)` followed by a bare
+// `mutateAsync(payload)` — the callee is a plain Identifier, so we
+// scope-resolve it back to its declarator and require the destructure
+// source to be a `useMutation(...)` call (wrapper hooks that may catch
+// internally stay unflagged).
+const isDestructuredMutateAsyncCall = (node: EsTreeNode, context: RuleContext): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "mutateAsync") return false;
+  const symbol = context.scopes.symbolFor(node.callee);
+  if (!symbol || !isNodeOfType(symbol.declarationNode, "VariableDeclarator")) return false;
+  return symbol.initializer !== null && getCalleeName(symbol.initializer) === "useMutation";
+};
+
+// A concise `() => x.mutateAsync()` returns the promise to its caller, so
+// it's only floating when that return value is thrown away: a bare
+// statement, a JSX event handler, or a discarding scheduler callback
+// (useEffect/setTimeout/...). Passing the arrow into `Promise.all(items.map(...))`
+// or returning it keeps the rejection reachable, so those stay quiet.
+const isDiscardedArrowReturn = (arrow: EsTreeNode): boolean => {
+  const parent = arrow.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isNodeOfType(parent, "JSXExpressionContainer")) return true;
+  if (isNodeOfType(parent, "CallExpression")) {
+    const isArgument = parent.arguments?.some((argument) => argument === arrow) ?? false;
+    if (!isArgument) return false;
+    const hostName = getCalleeName(parent);
+    return hostName !== null && FLOATING_CALLBACK_HOST_NAMES.has(hostName);
+  }
+  return false;
+};
+
+// True when the mutateAsync call's promise is discarded with no rejection
+// handler. Walks upward through wrappers that keep the promise floating —
+// ChainExpression, ternary branches, `&&`/`||` right operands, and
+// `.then(onFulfilled)` / `.finally(...)` steps that never handle rejection —
+// then requires the outermost expression to be a bare ExpressionStatement or
+// the concise body of a discarded-return arrow. A `.catch(...)`, two-argument
+// `.then(...)`, await/return/void wrapper, assignment, or `Promise.all([...])`
+// argument position stays quiet.
+const isFloatingMutateAsync = (node: EsTreeNode): boolean => {
+  let current: EsTreeNode = node;
+  let parent: EsTreeNode | null = current.parent ?? null;
+  while (parent) {
+    if (TRANSPARENT_PROMISE_WRAPPER_TYPES.has(parent.type)) {
+      current = parent;
+      parent = current.parent ?? null;
+      continue;
+    }
+    if (
+      isNodeOfType(parent, "ConditionalExpression") &&
+      (parent.consequent === current || parent.alternate === current)
+    ) {
+      current = parent;
+      parent = current.parent ?? null;
+      continue;
+    }
+    if (isNodeOfType(parent, "LogicalExpression") && parent.right === current) {
+      current = parent;
+      parent = current.parent ?? null;
+      continue;
+    }
+    if (
+      isNodeOfType(parent, "MemberExpression") &&
+      parent.object === current &&
+      !parent.computed &&
+      isNodeOfType(parent.property, "Identifier")
+    ) {
+      const chainMethodName = parent.property.name;
+      if (chainMethodName === "catch") return false;
+      if (chainMethodName !== "then" && chainMethodName !== "finally") break;
+      const chainStepCall: EsTreeNode | null = parent.parent ?? null;
+      if (
+        !chainStepCall ||
+        !isNodeOfType(chainStepCall, "CallExpression") ||
+        chainStepCall.callee !== parent
+      ) {
+        return false;
+      }
+      const thenHandlesRejection =
+        chainMethodName === "then" && (chainStepCall.arguments?.length ?? 0) >= 2;
+      if (thenHandlesRejection) return false;
+      current = chainStepCall;
+      parent = current.parent ?? null;
+      continue;
+    }
+    break;
+  }
+  if (!parent) return false;
+  if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === current) {
+    return isDiscardedArrowReturn(parent);
+  }
+  return false;
+};
+
+export const queryFloatingMutateAsync = defineRule({
+  id: "query-floating-mutate-async",
+  title: "Floating mutateAsync rejection",
+  requires: ["tanstack-query"],
+  severity: "warn",
+  recommendation:
+    "Await, return, or `.catch()` the `mutateAsync()` promise so its rejection surfaces an error instead of becoming a silent unhandled rejection.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isMutateAsyncMemberCall(node) && !isDestructuredMutateAsyncCall(node, context)) return;
+      if (!isFloatingMutateAsync(node)) return;
+      context.report({
+        node,
+        message:
+          "This `mutateAsync()` promise is never awaited or caught, so a failed mutation becomes a silent unhandled rejection — await, return, or `.catch()` it.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { queryNoMutationInEffectAsRead } from "./query-no-mutation-in-effect-as-read.js";
+
+describe("query-no-mutation-in-effect-as-read", () => {
+  it("flags a destructured data read fed from a mutate-in-effect", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutateAsync, data } = useGetMarkedAsSpamRetailers();
+         useEffect(() => { mutateAsync(ids); }, [ids]);
+         return <div>{data.retailers}</div>;
+       }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an awaited mutateAsync result captured in the effect", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutateAsync } = useMutation(opts);
+         useEffect(() => {
+           (async () => {
+             const response = await mutateAsync(params);
+             setLogs(response.logs);
+           })();
+         }, [id]);
+         return null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an aliased useMutation with data read in useMemo", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `import { useMutation as useGetLocales } from '@tanstack/react-query';
+       function C() {
+         const { mutate, data } = useGetLocales(opts);
+         useEffect(() => { mutate(payload); }, [dep]);
+         const options = useMemo(() => (data ? data.available_locales : []), [data]);
+         return options;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a fire-and-forget write that never reads data", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate } = useMutation(opts);
+         useEffect(() => { mutate(progress); }, [progress]);
+         return null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when data is read only as an acknowledgement field", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useUploadEvent(opts);
+         useEffect(() => { mutate(buildEvent()); }, [id]);
+         return data?.success ? <Done /> : <Pending />;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a then-handler that reads the response body in the effect", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutateAsync } = useMutation(opts);
+         useEffect(() => {
+           mutateAsync(params).then((response) => setLogs(response.logs));
+         }, [id]);
+         return null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a destructured awaited response body in the effect", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutateAsync } = useMutation(opts);
+         useEffect(() => {
+           (async () => {
+             const { logs } = await mutateAsync(params);
+             setLogs(logs);
+           })();
+         }, [id]);
+         return null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag the pre-optional-chaining ack guard `data && data.success`", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useUploadEvent(opts);
+         useEffect(() => { mutate(buildEvent()); }, [id]);
+         return data && data.success ? <Done /> : <Pending />;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an early-return existence guard before an ack read", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useUploadEvent(opts);
+         useEffect(() => { mutate(buildEvent()); }, [id]);
+         if (!data) return <Pending />;
+         return data.success ? <Done /> : <Failed />;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a mutate fired from a socket handler registered in the effect", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useMutation(opts);
+         useEffect(() => {
+           const onMessage = (event) => mutate(JSON.parse(event.data));
+           socket.addEventListener('message', onMessage);
+           return () => socket.removeEventListener('message', onMessage);
+         }, []);
+         return data ? <div>{data.value}</div> : null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag SWR's revalidate-style mutate alongside a data render", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `import useSWR from 'swr';
+       function C() {
+         const { data, mutate } = useSWR('/api/user', fetcher);
+         useEffect(() => { mutate(); }, [focusCount]);
+         return <div>{data.name}</div>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an awaited response destructured to ack fields only", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutateAsync } = useMutation(opts);
+         useEffect(() => {
+           (async () => {
+             const { success } = await mutateAsync(params);
+             if (!success) reportFailure();
+           })();
+         }, [id]);
+         return null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a then-handler that ignores the response", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutateAsync } = useMutation(opts);
+         useEffect(() => {
+           mutateAsync(params).then(() => setDone(true));
+         }, [id]);
+         return null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a mutate called only from a handler", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useMutation(opts);
+         const onClick = () => mutate(x);
+         return <button onClick={onClick}>{data.value}</button>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when data is consumed but the mutation never fires in an effect", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useMutation(opts);
+         return <div>{data.value}</div>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an awaited result that is never read", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutateAsync } = useMutation(opts);
+         useEffect(() => {
+           (async () => { await mutateAsync(params); })();
+         }, [id]);
+         return null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.test.ts
@@ -210,6 +210,99 @@ describe("query-no-mutation-in-effect-as-read", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("flags a mutate fired via a local helper the effect calls synchronously", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useMutation(opts);
+         useEffect(() => {
+           const run = () => { mutate(ids); };
+           run();
+         }, [ids]);
+         return <div>{data.items}</div>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a mutate fired via a function-declaration helper outside the effect", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useMutation(opts);
+         function load() { mutate(id); }
+         useEffect(() => { load(); }, [id]);
+         return <div>{data.items}</div>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a mutate inside a handler returned by a factory called in the effect", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useMutation(opts);
+         const createHandler = () => () => mutate(event);
+         useEffect(() => {
+           socket.addEventListener('message', createHandler());
+         }, []);
+         return data ? <div>{data.value}</div> : null;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a useSWR-named alias of a useMutation import", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `import { useMutation as useSWRLocales } from '@tanstack/react-query';
+       function C() {
+         const { mutate, data } = useSWRLocales(opts);
+         useEffect(() => { mutate(payload); }, [dep]);
+         return <div>{data.available_locales}</div>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a local useSWR-prefixed wrapper that exposes mutateAsync", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutateAsync, data } = useSWRLocales();
+         useEffect(() => { mutateAsync(payload); }, [dep]);
+         return <div>{data.available_locales}</div>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag useSWR re-exported through a local barrel", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `import { useSWR } from '~/lib/swr';
+       function C() {
+         const { data, mutate } = useSWR('/api/user', fetcher);
+         useEffect(() => { mutate(); }, [focusCount]);
+         return <div>{data.name}</div>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a mutate-only local useSWR-prefixed wrapper", () => {
+    const result = runRule(
+      queryNoMutationInEffectAsRead,
+      `function C() {
+         const { mutate, data } = useSWRUser();
+         useEffect(() => { mutate(); }, [focusCount]);
+         return <div>{data.name}</div>;
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag an awaited result that is never read", () => {
     const result = runRule(
       queryNoMutationInEffectAsRead,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.ts
@@ -10,7 +10,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
-import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { ScopeDescriptor, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 
 // The `mutate`/`mutateAsync` destructure keys are the near-unique TanStack
 // mutation signature, so their presence identifies a mutation result even
@@ -44,12 +44,17 @@ const findPatternPropertyBinding = (
   return null;
 };
 
+// A definitive module source wins over the name heuristic: an `swr` import
+// is exempt whatever it's called, and a `useMutation as useSWRFoo` TanStack
+// alias stays flagged. The name pattern covers what imports can't decide —
+// local SWR wrapper hooks and barrel re-exports.
 const isSwrHookResult = (init: EsTreeNodeOfType<"CallExpression">): boolean => {
   const calleeName = getCalleeName(init);
   if (!calleeName) return false;
-  if (SWR_HOOK_NAME_PATTERN.test(calleeName)) return true;
   const importSource = getImportSourceForName(init, calleeName);
-  return Boolean(importSource && SWR_MODULE_SOURCE_PATTERN.test(importSource));
+  if (importSource && SWR_MODULE_SOURCE_PATTERN.test(importSource)) return true;
+  if (importSource?.startsWith("@tanstack/")) return false;
+  return SWR_HOOK_NAME_PATTERN.test(calleeName);
 };
 
 // The destructure binding itself (`{ data }` / `{ data: rows }`) is recorded
@@ -136,16 +141,36 @@ const skipGroupingParensUpward = (node: EsTreeNode): EsTreeNode | null | undefin
   return current;
 };
 
+const getFunctionBindingIdentifier = (
+  functionNode: EsTreeNode,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  if (isNodeOfType(functionNode, "FunctionDeclaration") && functionNode.id) return functionNode.id;
+  const parent = functionNode.parent;
+  if (isNodeOfType(parent, "VariableDeclarator") && isNodeOfType(parent.id, "Identifier")) {
+    return parent.id;
+  }
+  return null;
+};
+
 // Only calls on the effect callback's own execution path count as "fired from
-// useEffect" — crossing an immediately-invoked wrapper is fine, but a handler
-// merely *registered* in the effect (socket listener, interval, observer)
-// fires per external event, not on dependency changes.
-const isInvokedFromEffectBody = (node: EsTreeNode): boolean => {
+// useEffect" — crossing an immediately-invoked wrapper or a local helper the
+// effect calls synchronously is fine, but a handler merely *registered* in
+// the effect (socket listener, interval, observer) fires per external event,
+// not on dependency changes.
+const isInvokedFromEffectBody = (
+  node: EsTreeNode,
+  context: RuleContext,
+  visitedFunctions: Set<EsTreeNode> = new Set(),
+): boolean => {
   let current = node.parent;
   while (current) {
     if (isFunctionLike(current)) {
+      if (visitedFunctions.has(current)) return false;
+      visitedFunctions.add(current);
       const enclosingCall = skipGroupingParensUpward(current);
-      if (!enclosingCall || !isNodeOfType(enclosingCall, "CallExpression")) return false;
+      if (!isNodeOfType(enclosingCall, "CallExpression")) {
+        return isHelperCalledFromEffectBody(current, context, visitedFunctions);
+      }
       if (isHookCall(enclosingCall, EFFECT_HOOK_NAMES)) {
         const effectCallback = enclosingCall.arguments[0];
         return Boolean(effectCallback) && stripGroupingParens(effectCallback) === current;
@@ -153,6 +178,40 @@ const isInvokedFromEffectBody = (node: EsTreeNode): boolean => {
       if (stripGroupingParens(enclosingCall.callee) !== current) return false;
     }
     current = current.parent;
+  }
+  return false;
+};
+
+// A helper that isn't invoked where it's defined still counts as effect-fired
+// when the effect body synchronously calls its local binding — but only
+// call-position references qualify, so a handler passed by name into a
+// registration API (`socket.addEventListener('message', onMessage)`) does not.
+// A hoisted `function` name carries two symbol records (enclosing scope +
+// own scope for recursion) and external calls land on the enclosing-scope
+// record, so resolve by walking the scope chain and matching the binding
+// identifier's node identity instead of using `symbolFor`, which returns
+// the inner record.
+const isHelperCalledFromEffectBody = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+  visitedFunctions: Set<EsTreeNode>,
+): boolean => {
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) return false;
+  let scope: ScopeDescriptor | null = context.scopes.scopeFor(functionNode);
+  while (scope) {
+    const helperSymbol = scope.symbolsByName.get(bindingIdentifier.name);
+    if (helperSymbol?.bindingIdentifier === bindingIdentifier) {
+      return helperSymbol.references.some((reference) => {
+        const callSite = reference.identifier.parent;
+        return (
+          isNodeOfType(callSite, "CallExpression") &&
+          callSite.callee === reference.identifier &&
+          isInvokedFromEffectBody(callSite, context, visitedFunctions)
+        );
+      });
+    }
+    scope = scope.parent;
   }
   return false;
 };
@@ -211,7 +270,10 @@ export const queryNoMutationInEffectAsRead = defineRule({
       if (!node.init || !isNodeOfType(node.init, "CallExpression")) return;
       const mutateBinding = findPatternPropertyBinding(node.id, isMutateKey);
       if (!mutateBinding) return;
-      if (isSwrHookResult(node.init)) return;
+      const hasMutateAsyncKey = Boolean(
+        findPatternPropertyBinding(node.id, (name) => name === "mutateAsync"),
+      );
+      if (!hasMutateAsyncKey && isSwrHookResult(node.init)) return;
       const mutateSymbol = context.scopes.symbolFor(mutateBinding);
       if (!mutateSymbol) return;
 
@@ -226,7 +288,7 @@ export const queryNoMutationInEffectAsRead = defineRule({
         ) {
           continue;
         }
-        if (!isInvokedFromEffectBody(callNode)) continue;
+        if (!isInvokedFromEffectBody(callNode, context)) continue;
         mutateCalledInEffect = true;
         if (
           awaitedResultConsumesResponse(callNode, context) ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.ts
@@ -1,0 +1,275 @@
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripGroupingParens } from "../../utils/strip-grouping-parens.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+
+// The `mutate`/`mutateAsync` destructure keys are the near-unique TanStack
+// mutation signature, so their presence identifies a mutation result even
+// through custom hooks (`useUploadEvent`, `useListAvailableLocales`) and
+// `useMutation as useGetXxx` aliases.
+const isMutateKey = (name: string): boolean => name === "mutate" || name === "mutateAsync";
+
+// Reading only an acknowledgement field off the response (a genuine write
+// confirming its result) is NOT a read-shaped query, so these never count
+// as consuming the response body.
+const ACK_FIELD_NAMES = new Set(["success", "error", "errors", "ok", "message", "status", "code"]);
+
+// SWR's `const { data, mutate } = useSWR(...)` matches the destructure keys,
+// but there `mutate` is the bound revalidate function — calling it in an
+// effect while rendering `data` is idiomatic SWR, not a mutation-as-read.
+const SWR_HOOK_NAME_PATTERN = /^useSWR/;
+const SWR_MODULE_SOURCE_PATTERN = /^swr(\/|$)/;
+
+const NULLISH_COMPARISON_OPERATORS = new Set(["==", "!=", "===", "!=="]);
+
+const findPatternPropertyBinding = (
+  pattern: EsTreeNode,
+  keyPredicate: (name: string) => boolean,
+): EsTreeNode | null => {
+  if (!isNodeOfType(pattern, "ObjectPattern")) return null;
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "Property") || property.computed) continue;
+    if (!isNodeOfType(property.key, "Identifier") || !keyPredicate(property.key.name)) continue;
+    if (isNodeOfType(property.value, "Identifier")) return property.value;
+  }
+  return null;
+};
+
+const isSwrHookResult = (init: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const calleeName = getCalleeName(init);
+  if (!calleeName) return false;
+  if (SWR_HOOK_NAME_PATTERN.test(calleeName)) return true;
+  const importSource = getImportSourceForName(init, calleeName);
+  return Boolean(importSource && SWR_MODULE_SOURCE_PATTERN.test(importSource));
+};
+
+// The destructure binding itself (`{ data }` / `{ data: rows }`) is recorded
+// as a reference by the scope analyzer, so skip the pattern position — it is
+// the declaration, not a consuming read.
+const isDestructureBindingPosition = (identifier: EsTreeNode): boolean => {
+  const parent = identifier.parent;
+  if (!parent || !isNodeOfType(parent, "Property")) return false;
+  return Boolean(parent.parent) && isNodeOfType(parent.parent as EsTreeNode, "ObjectPattern");
+};
+
+const isAckMemberRead = (identifier: EsTreeNode): boolean => {
+  const parent = identifier.parent;
+  return (
+    Boolean(parent) &&
+    isNodeOfType(parent as EsTreeNode, "MemberExpression") &&
+    (parent as EsTreeNodeOfType<"MemberExpression">).object === identifier &&
+    !(parent as EsTreeNodeOfType<"MemberExpression">).computed &&
+    isNodeOfType((parent as EsTreeNodeOfType<"MemberExpression">).property, "Identifier") &&
+    ACK_FIELD_NAMES.has(
+      ((parent as EsTreeNodeOfType<"MemberExpression">).property as EsTreeNodeOfType<"Identifier">)
+        .name,
+    )
+  );
+};
+
+const isNullishOperand = (node: EsTreeNode): boolean =>
+  (isNodeOfType(node, "Literal") && node.value === null) ||
+  (isNodeOfType(node, "Identifier") && node.name === "undefined");
+
+// A bare truthiness/nullish guard (`!data`, `data && ...`, `data ? ... : ...`,
+// `if (data)`, `Boolean(data)`, `data != null`) checks that the response
+// exists — the pre-optional-chaining spelling of `data?.x` — and does not
+// consume the response body.
+const isGuardOnlyRead = (identifier: EsTreeNode): boolean => {
+  const parent = identifier.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "!") return true;
+  if (isNodeOfType(parent, "LogicalExpression") && parent.operator === "&&") {
+    return parent.left === identifier;
+  }
+  if (isNodeOfType(parent, "ConditionalExpression")) return parent.test === identifier;
+  if (isNodeOfType(parent, "IfStatement") || isNodeOfType(parent, "WhileStatement")) {
+    return parent.test === identifier;
+  }
+  if (
+    isNodeOfType(parent, "CallExpression") &&
+    isNodeOfType(parent.callee, "Identifier") &&
+    parent.callee.name === "Boolean"
+  ) {
+    return parent.callee !== identifier;
+  }
+  if (
+    isNodeOfType(parent, "BinaryExpression") &&
+    NULLISH_COMPARISON_OPERATORS.has(parent.operator)
+  ) {
+    const otherOperand = parent.left === identifier ? parent.right : parent.left;
+    return isNullishOperand(otherOperand);
+  }
+  return false;
+};
+
+// True when the binding's response body is actually consumed — returned,
+// fed to a memo, rendered, or read field-by-field — rather than only
+// checked for existence or a success/error acknowledgement.
+const symbolHasConsumerRead = (symbol: SymbolDescriptor): boolean =>
+  symbol.references.some(
+    (reference) =>
+      reference.flag !== "write" &&
+      !isDestructureBindingPosition(reference.identifier) &&
+      !isAckMemberRead(reference.identifier) &&
+      !isGuardOnlyRead(reference.identifier),
+  );
+
+const objectPatternReadsResponseBody = (pattern: EsTreeNodeOfType<"ObjectPattern">): boolean =>
+  pattern.properties.some(
+    (property) =>
+      isNodeOfType(property, "Property") &&
+      !property.computed &&
+      isNodeOfType(property.key, "Identifier") &&
+      !ACK_FIELD_NAMES.has(property.key.name),
+  );
+
+// oxc-parser surfaces `(...)` as a `ParenthesizedExpression`, a node kind
+// outside the TSESTree union, so it is matched by string here.
+const GROUPING_PARENS_TYPE: string = "ParenthesizedExpression";
+
+const skipGroupingParensUpward = (node: EsTreeNode): EsTreeNode | null | undefined => {
+  let current = node.parent;
+  while (current && current.type === GROUPING_PARENS_TYPE) current = current.parent;
+  return current;
+};
+
+// Only calls on the effect callback's own execution path count as "fired from
+// useEffect" — crossing an immediately-invoked wrapper is fine, but a handler
+// merely *registered* in the effect (socket listener, interval, observer)
+// fires per external event, not on dependency changes.
+const isInvokedFromEffectBody = (node: EsTreeNode): boolean => {
+  let current = node.parent;
+  while (current) {
+    if (isFunctionLike(current)) {
+      const enclosingCall = skipGroupingParensUpward(current);
+      if (!enclosingCall || !isNodeOfType(enclosingCall, "CallExpression")) return false;
+      if (isHookCall(enclosingCall, EFFECT_HOOK_NAMES)) {
+        const effectCallback = enclosingCall.arguments[0];
+        return Boolean(effectCallback) && stripGroupingParens(effectCallback) === current;
+      }
+      if (stripGroupingParens(enclosingCall.callee) !== current) return false;
+    }
+    current = current.parent;
+  }
+  return false;
+};
+
+const awaitedResultConsumesResponse = (
+  callNode: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  const awaitExpression = callNode.parent;
+  if (!awaitExpression || !isNodeOfType(awaitExpression, "AwaitExpression")) return false;
+  const declarator = awaitExpression.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
+  if (isNodeOfType(declarator.id, "Identifier")) {
+    const resultSymbol = context.scopes.symbolFor(declarator.id);
+    return Boolean(resultSymbol && symbolHasConsumerRead(resultSymbol));
+  }
+  if (isNodeOfType(declarator.id, "ObjectPattern")) {
+    return objectPatternReadsResponseBody(declarator.id);
+  }
+  return false;
+};
+
+const thenHandlerConsumesResponse = (
+  callNode: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  const memberExpression = callNode.parent;
+  if (
+    !memberExpression ||
+    !isNodeOfType(memberExpression, "MemberExpression") ||
+    memberExpression.object !== callNode ||
+    memberExpression.computed ||
+    !isNodeOfType(memberExpression.property, "Identifier") ||
+    memberExpression.property.name !== "then"
+  ) {
+    return false;
+  }
+  const thenCall = memberExpression.parent;
+  if (
+    !thenCall ||
+    !isNodeOfType(thenCall, "CallExpression") ||
+    thenCall.callee !== memberExpression
+  ) {
+    return false;
+  }
+  const handlerArgument = thenCall.arguments[0];
+  if (!handlerArgument) return false;
+  const handler = stripGroupingParens(handlerArgument);
+  if (!isFunctionLike(handler)) return false;
+  const responseParam = handler.params[0];
+  if (!responseParam) return false;
+  if (isNodeOfType(responseParam, "Identifier")) {
+    const responseSymbol = context.scopes.symbolFor(responseParam);
+    return Boolean(responseSymbol && symbolHasConsumerRead(responseSymbol));
+  }
+  if (isNodeOfType(responseParam, "ObjectPattern")) {
+    return objectPatternReadsResponseBody(responseParam);
+  }
+  return false;
+};
+
+export const queryNoMutationInEffectAsRead = defineRule({
+  id: "query-no-mutation-in-effect-as-read",
+  title: "Mutation driven from an effect as a read",
+  tags: ["test-noise"],
+  requires: ["tanstack-query"],
+  severity: "warn",
+  recommendation:
+    "Use `useQuery` with a `queryKey` and `enabled` for GET-shaped reads instead of firing a mutation from `useEffect`, so the response is cached and deduplicated.",
+  create: (context: RuleContext) => ({
+    VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+      if (!node.init || !isNodeOfType(node.init, "CallExpression")) return;
+      const mutateBinding = findPatternPropertyBinding(node.id, isMutateKey);
+      if (!mutateBinding) return;
+      if (isSwrHookResult(node.init)) return;
+      const mutateSymbol = context.scopes.symbolFor(mutateBinding);
+      if (!mutateSymbol) return;
+
+      let mutateCalledInEffect = false;
+      let effectResultConsumed = false;
+      for (const reference of mutateSymbol.references) {
+        const callNode = reference.identifier.parent;
+        if (
+          !callNode ||
+          !isNodeOfType(callNode, "CallExpression") ||
+          callNode.callee !== reference.identifier
+        ) {
+          continue;
+        }
+        if (!isInvokedFromEffectBody(callNode)) continue;
+        mutateCalledInEffect = true;
+        if (
+          awaitedResultConsumesResponse(callNode, context) ||
+          thenHandlerConsumesResponse(callNode, context)
+        ) {
+          effectResultConsumed = true;
+        }
+      }
+      if (!mutateCalledInEffect) return;
+
+      const dataBinding = findPatternPropertyBinding(node.id, (name) => name === "data");
+      const dataSymbol = dataBinding ? context.scopes.symbolFor(dataBinding) : null;
+      const dataConsumed = Boolean(dataSymbol && symbolHasConsumerRead(dataSymbol));
+
+      if (!dataConsumed && !effectResultConsumed) return;
+
+      context.report({
+        node: node.init,
+        message:
+          "This mutation is fired from `useEffect` and its response is read like a query, so it loses caching and refires on every dependency change — use `useQuery` instead.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-mutation-in-effect-as-read.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
+import { getCallMethodName } from "../../utils/get-call-method-name.js";
 import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
@@ -56,22 +57,16 @@ const isSwrHookResult = (init: EsTreeNodeOfType<"CallExpression">): boolean => {
 // the declaration, not a consuming read.
 const isDestructureBindingPosition = (identifier: EsTreeNode): boolean => {
   const parent = identifier.parent;
-  if (!parent || !isNodeOfType(parent, "Property")) return false;
-  return Boolean(parent.parent) && isNodeOfType(parent.parent as EsTreeNode, "ObjectPattern");
+  return isNodeOfType(parent, "Property") && isNodeOfType(parent.parent, "ObjectPattern");
 };
 
 const isAckMemberRead = (identifier: EsTreeNode): boolean => {
   const parent = identifier.parent;
+  if (!isNodeOfType(parent, "MemberExpression") || parent.object !== identifier) return false;
   return (
-    Boolean(parent) &&
-    isNodeOfType(parent as EsTreeNode, "MemberExpression") &&
-    (parent as EsTreeNodeOfType<"MemberExpression">).object === identifier &&
-    !(parent as EsTreeNodeOfType<"MemberExpression">).computed &&
-    isNodeOfType((parent as EsTreeNodeOfType<"MemberExpression">).property, "Identifier") &&
-    ACK_FIELD_NAMES.has(
-      ((parent as EsTreeNodeOfType<"MemberExpression">).property as EsTreeNodeOfType<"Identifier">)
-        .name,
-    )
+    !parent.computed &&
+    isNodeOfType(parent.property, "Identifier") &&
+    ACK_FIELD_NAMES.has(parent.property.name)
   );
 };
 
@@ -85,7 +80,6 @@ const isNullishOperand = (node: EsTreeNode): boolean =>
 // consume the response body.
 const isGuardOnlyRead = (identifier: EsTreeNode): boolean => {
   const parent = identifier.parent;
-  if (!parent) return false;
   if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "!") return true;
   if (isNodeOfType(parent, "LogicalExpression") && parent.operator === "&&") {
     return parent.left === identifier;
@@ -163,22 +157,25 @@ const isInvokedFromEffectBody = (node: EsTreeNode): boolean => {
   return false;
 };
 
+// The response lands either in a plain binding (scope-resolve and inspect
+// its reads) or a destructure pattern (inspect the destructured keys).
+const bindingConsumesResponse = (binding: EsTreeNode, context: RuleContext): boolean => {
+  if (isNodeOfType(binding, "Identifier")) {
+    const bindingSymbol = context.scopes.symbolFor(binding);
+    return Boolean(bindingSymbol && symbolHasConsumerRead(bindingSymbol));
+  }
+  return isNodeOfType(binding, "ObjectPattern") && objectPatternReadsResponseBody(binding);
+};
+
 const awaitedResultConsumesResponse = (
   callNode: EsTreeNodeOfType<"CallExpression">,
   context: RuleContext,
 ): boolean => {
   const awaitExpression = callNode.parent;
-  if (!awaitExpression || !isNodeOfType(awaitExpression, "AwaitExpression")) return false;
+  if (!isNodeOfType(awaitExpression, "AwaitExpression")) return false;
   const declarator = awaitExpression.parent;
-  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
-  if (isNodeOfType(declarator.id, "Identifier")) {
-    const resultSymbol = context.scopes.symbolFor(declarator.id);
-    return Boolean(resultSymbol && symbolHasConsumerRead(resultSymbol));
-  }
-  if (isNodeOfType(declarator.id, "ObjectPattern")) {
-    return objectPatternReadsResponseBody(declarator.id);
-  }
-  return false;
+  if (!isNodeOfType(declarator, "VariableDeclarator")) return false;
+  return bindingConsumesResponse(declarator.id, context);
 };
 
 const thenHandlerConsumesResponse = (
@@ -186,38 +183,19 @@ const thenHandlerConsumesResponse = (
   context: RuleContext,
 ): boolean => {
   const memberExpression = callNode.parent;
-  if (
-    !memberExpression ||
-    !isNodeOfType(memberExpression, "MemberExpression") ||
-    memberExpression.object !== callNode ||
-    memberExpression.computed ||
-    !isNodeOfType(memberExpression.property, "Identifier") ||
-    memberExpression.property.name !== "then"
-  ) {
+  if (!isNodeOfType(memberExpression, "MemberExpression") || memberExpression.object !== callNode) {
     return false;
   }
+  if (getCallMethodName(memberExpression) !== "then") return false;
   const thenCall = memberExpression.parent;
-  if (
-    !thenCall ||
-    !isNodeOfType(thenCall, "CallExpression") ||
-    thenCall.callee !== memberExpression
-  ) {
+  if (!isNodeOfType(thenCall, "CallExpression") || thenCall.callee !== memberExpression) {
     return false;
   }
   const handlerArgument = thenCall.arguments[0];
   if (!handlerArgument) return false;
   const handler = stripGroupingParens(handlerArgument);
-  if (!isFunctionLike(handler)) return false;
-  const responseParam = handler.params[0];
-  if (!responseParam) return false;
-  if (isNodeOfType(responseParam, "Identifier")) {
-    const responseSymbol = context.scopes.symbolFor(responseParam);
-    return Boolean(responseSymbol && symbolHasConsumerRead(responseSymbol));
-  }
-  if (isNodeOfType(responseParam, "ObjectPattern")) {
-    return objectPatternReadsResponseBody(responseParam);
-  }
-  return false;
+  if (!isFunctionLike(handler) || !handler.params[0]) return false;
+  return bindingConsumesResponse(handler.params[0], context);
 };
 
 export const queryNoMutationInEffectAsRead = defineRule({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-call-method-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-call-method-name.ts
@@ -4,9 +4,7 @@ import { isNodeOfType } from "./is-node-of-type.js";
 /**
  * Returns the static method name of a call's callee when it's a
  * non-computed MemberExpression (`obj.method` → `"method"`), or
- * `null` otherwise. Used by `no-pass-data-to-parent` and
- * `no-pass-live-state-to-parent` to match the receiver-bound
- * method-call shape against an allow/block list.
+ * `null` otherwise.
  */
 export const getCallMethodName = (callee: EsTreeNode): string | null => {
   if (


### PR DESCRIPTION
Adds 2 new `tanstack-query` rules to `oxlint-plugin-react-doctor`, both gated behind `requires: ["tanstack-query"]` so they only run in projects that actually depend on TanStack Query.

> **Stacked PR:** this branch is stacked on the foundation PR (#1000 — package-version detection, SSR capability, and shared AST utils). It will be retargeted to `main` once #1000 merges; only the `tanstack-query` rule commits are new here.

## Why

TanStack Query mutations have two failure modes that produce runtime bugs, not just style issues: a `mutateAsync()` promise that nobody awaits or catches turns every failed mutation into a **silent unhandled rejection** (the UI acts like the write succeeded), and a mutation fired from `useEffect` whose response is rendered like query data silently loses caching/deduplication and **refires on every dependency change**. Both are invisible in review because the happy path works.

```tsx
// Bad — a failed mutation vanishes as an unhandled rejection
useEffect(() => {
  mutation.mutateAsync(payload);
}, [id]);

// Good — the rejection is reachable
useEffect(() => {
  mutation.mutateAsync(payload).catch(reportError);
}, [id]);
```

## Rules

| Rule | Catches | Notable exemptions |
| --- | --- | --- |
| `query-floating-mutate-async` | A `mutateAsync()` call whose promise is discarded with no rejection handler — a bare statement, a concise `() => x.mutateAsync()` arrow whose return value is thrown away (JSX handler, `useEffect`/timer callback), or a chain that never handles rejection (`.then(onFulfilled)`, `.finally()`); also resolves destructured `const { mutateAsync } = useMutation(...)` via scope analysis | `await`/`return`/`void`, assignment, `.catch(...)`, two-argument `.then(ok, err)`, arrows fed into `Promise.all(items.map(...))` or otherwise returned to a caller, computed members, bare `mutateAsync` identifiers not traced to a `useMutation` destructure (wrapper hooks may catch internally), shadowed parameters |
| `query-no-mutation-in-effect-as-read` | A `useMutation` result whose `mutate`/`mutateAsync` fires from a `useEffect` body **and** whose response is consumed like query data (the `data` binding rendered/memoized, or the awaited/`.then` result's body read) — a GET-shaped read that loses caching and refires per dependency change | Fire-and-forget writes that never read the response; reads of acknowledgement fields only (`success`, `error`, `ok`, `status`, …) including guard-only reads (`!data`, `data && data.success`, `data != null`); handlers merely *registered* in the effect (socket/interval callbacks); SWR's `useSWR` `mutate` (revalidate, not a mutation); mutations called only from event handlers |

## Validation

Both rules were validated against 67 production OSS repos at pinned SHAs plus 88 reconstructed merged-PR gold solutions, with sampled hits judged and adversarially re-verified by two independent reviewers, and up to three FP-hardening waves available per rule.

| Rule | Pre-hardening corpus hits | Remaining hits | Verdict |
| --- | --- | --- | --- |
| `query-floating-mutate-async` | 0 | 0 | silent-precise |
| `query-no-mutation-in-effect-as-read` | 0 | 0 | silent-precise |

Both rules landed **silent-precise**: zero corpus hits by design. The detectors are deliberately narrow — the floating-`mutateAsync` rule only fires when the promise is provably unreachable by any rejection handler, and the mutation-as-read rule requires both an effect-driven fire *and* a consumed response body — so healthy codebases stay quiet while the targeted anti-patterns are caught exactly.

## Test plan

- 43 focused rule tests (`query-floating-mutate-async.test.ts`: 27, `query-no-mutation-in-effect-as-read.test.ts`: 16) covering the invalid shapes and every exemption in the table above
- `pnpm typecheck` and `pnpm format:check` on the package
- Registry `gen:check` confirms both rules are registered and the generated registry is in sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, opt-in lint rules (`tanstack-query` capability) at warn severity with no runtime or API changes; main risk is narrow false positives on complex promise/effect patterns.
> 
> **Overview**
> Adds two **TanStack Query** lint rules to `oxlint-plugin-react-doctor`, both under `requires: ["tanstack-query"]` and registered as **Bugs** / `warn`.
> 
> **`query-floating-mutate-async`** flags `mutateAsync()` when the returned promise is effectively fire-and-forget (bare statements, discarded concise arrows in `useEffect`/timers/JSX handlers, `.then`/`.finally` without rejection handling). It resolves destructured `mutateAsync` from `useMutation` via scope analysis and leaves alone awaited/returned/voided/assigned calls, `.catch`, two-arg `.then`, and similar safe shapes.
> 
> **`query-no-mutation-in-effect-as-read`** flags `useMutation` (or mutation-shaped hooks) when `mutate`/`mutateAsync` runs on the **synchronous `useEffect` execution path** and the response is consumed like query data (`data` in render/memo, or response body from `await`/`.then`). Exemptions cover fire-and-forget writes, ack-only reads (`success`, guards), handlers only registered in the effect, and real **SWR** `mutate` revalidation.
> 
> Includes large focused test suites for both rules, a minor **changeset**, registry wiring, and a small comment trim on `get-call-method-name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40afbbed05d27bcf70ac586e0cb5dde859df0b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->