### PR TITLE
fix(config): category severities no longer force-enable opt-out rules

### DIFF
--- a/.changeset/category-severity-no-opt-in.md
+++ b/.changeset/category-severity-no-opt-in.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix category-level severities silently force-enabling opt-out rules. A config that only re-stamps category severities (e.g. `categories: { "Maintainability": "warn" }`) no longer activates `defaultEnabled: false` rules such as `forbid-component-props`, `react-in-jsx-scope`, `no-danger`, or `design-no-redundant-size-axes` in that category — enabling an opt-out rule now requires pinning the rule itself (or a legacy alias key) to `"warn"`/`"error"` under `rules`, matching the documented contract. Category severities still re-stamp the severity of already-enabled rules, and `react-doctor rules` now previews the same behavior.

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -159,15 +159,21 @@ export const createOxlintConfig = ({
     if (rule.framework !== "global" && !rule.requires) continue;
     if (!shouldEnableRule(rule.requires, rule.tags, capabilities, ignoredTags, rule.disabledBy))
       continue;
+    // `defaultEnabled: false` opts a rule out of the default config —
+    // it ships in the plugin but only activates when the user pins the
+    // rule itself (or an alias) to `"warn"` / `"error"` in `rules`. A
+    // broad `categories` bump re-stamps the severity of already-enabled
+    // rules and is not a deliberate opt-in (same principle as the
+    // app-only gate in build-diagnostic-pipeline).
+    const explicitRuleOverride = resolveRuleSeverityOverride(
+      { ruleKey: registryEntry.key },
+      severityControls,
+    );
+    if (rule.defaultEnabled === false && explicitRuleOverride === undefined) continue;
     const explicitSeverity = resolveRuleSeverityOverride(
       { ruleKey: registryEntry.key, category: rule.category },
       severityControls,
     );
-    // `defaultEnabled: false` opts a rule out of the default config —
-    // it ships in the plugin but only activates when a user explicitly
-    // turns it on via `severityControls`. Users can still get the rule
-    // by setting its severity to `"warn"` or `"error"` in config.
-    if (rule.defaultEnabled === false && explicitSeverity === undefined) continue;
     const severity =
       explicitSeverity ??
       resolveCompilerCleanupBucketSeverity(registryEntry.key, severityControls) ??

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -427,6 +427,10 @@ export interface ReactDoctorConfig {
    * { "categories": { "Maintainability": "off", "Performance": "warn" } }
    * ```
    *
+   * A category severity re-stamps rules that are already enabled; it
+   * never activates opt-out (`defaultEnabled: false`) rules — pin the
+   * rule itself under `rules` to opt in.
+   *
    * To silence a whole tag-defined rule family (e.g. `"design"`,
    * `"test-noise"`, `"migration-hint"`) that doesn't align with a
    * single category, use `ignore.tags` instead.

--- a/packages/core/tests/oxlint-config-settings.test.ts
+++ b/packages/core/tests/oxlint-config-settings.test.ts
@@ -28,6 +28,8 @@ const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
   ...overrides,
 });
 
+const viteWebProject = buildProject({ framework: "vite", hasReactNativeWorkspace: false });
+
 describe("createOxlintConfig settings", () => {
   it("forwards the detected @shopify/flash-list major version", () => {
     const config = createOxlintConfig({
@@ -53,7 +55,7 @@ describe("createOxlintConfig settings", () => {
   it("never registers security scan rules (they run as a core environment check)", () => {
     const config = createOxlintConfig({
       pluginPath: "/tmp/plugin.js",
-      project: buildProject({ framework: "vite", hasReactNativeWorkspace: false }),
+      project: viteWebProject,
     });
 
     expect(config.rules).not.toHaveProperty("react-doctor/artifact-secret-leak");
@@ -63,7 +65,7 @@ describe("createOxlintConfig settings", () => {
   it("excludes security scan rules even when severity controls opt them in", () => {
     const config = createOxlintConfig({
       pluginPath: "/tmp/plugin.js",
-      project: buildProject({ framework: "vite", hasReactNativeWorkspace: false }),
+      project: viteWebProject,
       severityControls: {
         rules: {
           "react-doctor/artifact-secret-leak": "error",
@@ -91,6 +93,55 @@ describe("createOxlintConfig settings", () => {
     expect(Object.keys(config.rules).some((ruleKey) => ruleKey.startsWith("react-hooks-js/"))).toBe(
       true,
     );
+  });
+
+  it("keeps opt-out (defaultEnabled: false) rules off by default", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: viteWebProject,
+    });
+
+    expect(config.rules).not.toHaveProperty("react-doctor/forbid-component-props");
+  });
+
+  it("does not let a category-level severity flip an opt-out rule on", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: viteWebProject,
+      severityControls: { categories: { Maintainability: "warn" } },
+    });
+
+    expect(config.rules).not.toHaveProperty("react-doctor/forbid-component-props");
+  });
+
+  it("category-level severity still re-stamps already-enabled rules", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: viteWebProject,
+      severityControls: { categories: { Maintainability: "error" } },
+    });
+
+    expect(config.rules["react-doctor/no-multi-comp"]).toBe("error");
+  });
+
+  it("a per-rule severity opts an opt-out rule in", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: viteWebProject,
+      severityControls: { rules: { "react-doctor/forbid-component-props": "warn" } },
+    });
+
+    expect(config.rules["react-doctor/forbid-component-props"]).toBe("warn");
+  });
+
+  it("a legacy alias severity opts an opt-out rule in", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: viteWebProject,
+      severityControls: { rules: { "react/forbid-component-props": "warn" } },
+    });
+
+    expect(config.rules["react-doctor/forbid-component-props"]).toBe("warn");
   });
 
   it("drops the react-hooks-js plugin + compiler rules under disableReactHooksJsPlugin (the load-failure fallback)", () => {

--- a/packages/react-doctor/src/cli/utils/resolve-effective-rule-severity.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-effective-rule-severity.ts
@@ -38,6 +38,11 @@ export const resolveEffectiveRuleSeverity = (
     if (override !== undefined) return { value: override, source: "rule" };
   }
 
+  // Category and bucket bumps re-stamp the severity of already-enabled
+  // rules; they never flip a `defaultEnabled: false` rule on (mirrors
+  // `createOxlintConfig`).
+  if (!entry.defaultEnabled) return { value: "off", source: "default" };
+
   const categoryOverride = config?.categories?.[entry.category];
   if (categoryOverride !== undefined) return { value: categoryOverride, source: "category" };
 

--- a/packages/react-doctor/tests/rule-config-units.test.ts
+++ b/packages/react-doctor/tests/rule-config-units.test.ts
@@ -116,7 +116,12 @@ describe("resolveEffectiveRuleSeverity", () => {
   });
 
   it("uses a category override when no rule override exists", () => {
-    const result = resolveEffectiveRuleSeverity({ categories: { [entry.category]: "off" } }, entry);
+    const defaultOnEntry = catalog.find((candidate) => candidate.defaultEnabled);
+    if (!defaultOnEntry) throw new Error("Expected at least one default-enabled rule");
+    const result = resolveEffectiveRuleSeverity(
+      { categories: { [defaultOnEntry.category]: "off" } },
+      defaultOnEntry,
+    );
     expect(result).toEqual({ value: "off", source: "category" });
   });
 
@@ -142,6 +147,26 @@ describe("resolveEffectiveRuleSeverity", () => {
     if (!optInEntry) throw new Error("Expected at least one default-disabled rule");
     const result = resolveEffectiveRuleSeverity(null, optInEntry);
     expect(result).toEqual({ value: "off", source: "default" });
+  });
+
+  it("keeps an opt-out rule off when only a category severity matches (never a silent opt-in)", () => {
+    const optInEntry = catalog.find((candidate) => !candidate.defaultEnabled);
+    if (!optInEntry) throw new Error("Expected at least one default-disabled rule");
+    const result = resolveEffectiveRuleSeverity(
+      { categories: { [optInEntry.category]: "warn" } },
+      optInEntry,
+    );
+    expect(result).toEqual({ value: "off", source: "default" });
+  });
+
+  it("lets a rule-level severity opt an opt-out rule in", () => {
+    const optInEntry = catalog.find((candidate) => !candidate.defaultEnabled);
+    if (!optInEntry) throw new Error("Expected at least one default-disabled rule");
+    const result = resolveEffectiveRuleSeverity(
+      { rules: { [optInEntry.key]: "warn" } },
+      optInEntry,
+    );
+    expect(result).toEqual({ value: "warn", source: "rule" });
   });
 
   it("applies a compiler-cleanup bucket override below rules and categories", () => {

--- a/packages/website/public/schema/config.json
+++ b/packages/website/public/schema/config.json
@@ -172,7 +172,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/RuleSeverityOverride"
           },
-          "description": "Per-category severity map. Mirrors oxlint's top-level `categories` field, but keyed by React Doctor's five user-facing buckets: `\"Security\"`, `\"Bugs\"`, `\"Performance\"`, `\"Accessibility\"`, `\"Maintainability\"`.\n\n```json { \"categories\": { \"Maintainability\": \"off\", \"Performance\": \"warn\" } } ```\n\nTo silence a whole tag-defined rule family (e.g. `\"design\"`, `\"test-noise\"`, `\"migration-hint\"`) that doesn't align with a single category, use `ignore.tags` instead."
+          "description": "Per-category severity map. Mirrors oxlint's top-level `categories` field, but keyed by React Doctor's five user-facing buckets: `\"Security\"`, `\"Bugs\"`, `\"Performance\"`, `\"Accessibility\"`, `\"Maintainability\"`.\n\n```json { \"categories\": { \"Maintainability\": \"off\", \"Performance\": \"warn\" } } ```\n\nA category severity re-stamps rules that are already enabled; it never activates opt-out (`defaultEnabled: false`) rules — pin the rule itself under `rules` to opt in.\n\nTo silence a whole tag-defined rule family (e.g. `\"design\"`, `\"test-noise\"`, `\"migration-hint\"`) that doesn't align with a single category, use `ignore.tags` instead."
         },
         "buckets": {
           "$ref": "#/definitions/SeverityBuckets",


### PR DESCRIPTION
## Why

A config that only re-stamps category severities — e.g. `categories: { "Maintainability": "warn" }` — silently activated every `defaultEnabled: false` rule in those categories, because the opt-out guard in `createOxlintConfig` accepted the category fallback from `resolveRuleSeverityOverride` as an explicit enable. Rule fire-rate telemetry traced the two highest per-scan intensity outliers in production to exactly this: `forbid-component-props` (avg **871** findings/scan, p90 2,965) and `react-in-jsx-scope` (avg **2,514**/scan), plus `design-no-redundant-size-axes`. Users are visibly being burned — two unrelated OSS repos carry hand-written `"react-doctor/react-in-jsx-scope": "off"` overrides for a rule they never enabled.

Before (real repo, `Anchal789/Org-Drive` — config sets category severities only, never names either rule):

```
forbid-component-props        5 findings   (flags <Image className=...>, the Tailwind pattern the rule is off-by-default to avoid)
design-no-redundant-size-axes 4 findings
total                         13 diagnostics
```

After:

```
forbid-component-props        0
design-no-redundant-size-axes 0
total                         4 diagnostics (the legitimately-enabled rules, severities still re-stamped by categories)
```

## What changed

- `createOxlintConfig` (`packages/core/src/runners/oxlint/config.ts`): the `defaultEnabled: false` guard now requires a **rule-level** severity (per-rule key or legacy alias) — resolved with the same no-category lookup the app-only gate in `build-diagnostic-pipeline` already uses. Category severities still re-stamp already-enabled rules.
- `react-doctor rules` preview (`resolve-effective-rule-severity.ts`) mirrors the same semantics so the catalog matches scan behavior.
- `categories` docstring + regenerated config schema state the contract explicitly.
- Tests: 5 new core cases + 2 new CLI cases; migrated one existing CLI test that asserted the old semantics through `no-danger` (itself an opt-out rule); consolidated a repeated test fixture literal.
- Changeset: `react-doctor` patch.

For configs that never touch `categories`, scan output is byte-identical — the change can only remove force-enabled rules, never add any.

## Test plan

- `packages/core`: full `pnpm test` suite green; `tests/oxlint-config-settings.test.ts` covers category-can't-enable / category-still-restamps / rule-key-enables / alias-enables / off-by-default
- `packages/react-doctor`: full `pnpm test` suite green (2,041 passed)
- `turbo typecheck` + `vp fmt` clean
- Empirical: re-scanned the cloned Org-Drive repo with the built CLI — 13 → 4 diagnostics, no new rules appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which lint rules run for real-world configs that set category severities without per-rule pins; impact is limited to removing unintended rule activations, not adding new ones.
> 
> **Overview**
> Fixes a bug where **`categories`** severities (e.g. `Maintainability: "warn"`) were treated as explicit opt-in for **`defaultEnabled: false`** rules, so scans could flood with rules like `forbid-component-props` and `react-in-jsx-scope` even when those rules were never named under **`rules`**.
> 
> **`createOxlintConfig`** now gates opt-out rules on a **rule-only** severity lookup (canonical key or legacy alias); category bumps still **re-stamp** severities for rules that are already on. **`react-doctor rules`** uses the same logic via **`resolveEffectiveRuleSeverity`**, and docs/schema state that category maps never activate opt-out rules.
> 
> Configs that only touch **`categories`** may see **fewer** diagnostics; explicit **`rules`** entries (or aliases) are still required to turn opt-out rules on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c89ea3f344a0d5a5d97bbdbdf1a8c9690953a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->