### PR TITLE
fix: diff scopes silently skip changed .ts files

### DIFF
--- a/.changeset/fix-diff-scope-ts-include-paths.md
+++ b/.changeset/fix-diff-scope-ts-include-paths.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Diff scopes no longer skip changed `.ts`/`.js` files that contain React code. `--scope files`, `--scope changed`, `--scope lines`, and `--staged` filtered explicit include paths to `.tsx`/`.jsx` only, so a changed `.ts` hook that a full scan flags was reported clean (0 diagnostics). Changed non-JSX source files are now included when their content references React (a react/preact import or a hook call). Non-React `.ts`/`.js` changes stay excluded, so diff scopes remain quiet on server and utility code.

--- a/packages/api/tests/diagnose-changed-scope.test.ts
+++ b/packages/api/tests/diagnose-changed-scope.test.ts
@@ -1,0 +1,69 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { diagnose } from "../src/index.js";
+
+// Regression fixture for the diff-scope bug where explicit include paths were
+// filtered to JSX/TSX only, silently skipping changed .ts files (hooks, utils)
+// that a full scan flags.
+const projectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rdc-changed-scope-"));
+
+fs.writeFileSync(
+  path.join(projectDirectory, "package.json"),
+  JSON.stringify({
+    name: "changed-scope-fixture",
+    private: true,
+    dependencies: { react: "^19.0.0", "react-dom": "^19.0.0" },
+  }),
+);
+fs.writeFileSync(
+  path.join(projectDirectory, "tsconfig.json"),
+  JSON.stringify({ compilerOptions: { jsx: "react-jsx", strict: true } }),
+);
+fs.mkdirSync(path.join(projectDirectory, "src"));
+fs.writeFileSync(
+  path.join(projectDirectory, "src", "use-doubled.ts"),
+  `import { useEffect, useState } from "react";
+
+export const useDoubled = (value: number) => {
+  const [doubled, setDoubled] = useState(0);
+  useEffect(() => {
+    setDoubled(value * 2);
+  }, [value]);
+  return doubled;
+};
+`,
+);
+fs.writeFileSync(
+  path.join(projectDirectory, "src", "app.tsx"),
+  `import { useDoubled } from "./use-doubled.js";
+
+export const App = () => <p>{useDoubled(21)}</p>;
+`,
+);
+
+afterAll(() => {
+  fs.rmSync(projectDirectory, { recursive: true, force: true });
+});
+
+describe("diagnose with changed-file include paths", () => {
+  it("reports diagnostics in a changed .ts file, matching the full scan", async () => {
+    const fullScan = await diagnose(projectDirectory, { deadCode: false });
+    const fullScanHookRules = fullScan.diagnostics
+      .filter((diagnostic) => diagnostic.filePath.endsWith("use-doubled.ts"))
+      .map((diagnostic) => diagnostic.rule);
+    expect(fullScanHookRules.length).toBeGreaterThan(0);
+
+    const changedScan = await diagnose(projectDirectory, {
+      deadCode: false,
+      includePaths: ["src/use-doubled.ts"],
+    });
+    const changedScanHookRules = changedScan.diagnostics
+      .filter((diagnostic) => diagnostic.filePath.endsWith("use-doubled.ts"))
+      .map((diagnostic) => diagnostic.rule);
+
+    expect(changedScanHookRules.length).toBeGreaterThan(0);
+    expect(new Set(changedScanHookRules)).toEqual(new Set(fullScanHookRules));
+  });
+});

--- a/packages/core/src/explicit-lint-include-paths.ts
+++ b/packages/core/src/explicit-lint-include-paths.ts
@@ -1,12 +1,54 @@
-import { JSX_FILE_PATTERN } from "./constants.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { JSX_FILE_PATTERN, SOURCE_FILE_PATTERN } from "./constants.js";
 import type { ProjectInfo } from "./types/index.js";
 
 export const NEXT_ENTRY_FILE_PATTERN =
   /^(?:\.\/)?(?:src\/)?(?:middleware|proxy)\.(?:tsx?|jsx?|mts|mjs)$/;
 
+// Matches a react/preact import (any subpath) or a hook call site. Enough to
+// recognize a .ts hook or React utility without parsing.
+const REACT_CONTENT_PATTERN =
+  /(?:from\s*|require\(\s*|import\(\s*)["'](?:react(?:-dom)?|preact)(?:["']|\/)|\buse[A-Z]\w*\s*\(/;
+
+// Imports sit at the top and hook calls appear early; capping the sniff keeps
+// a stray giant asset from being read whole.
+const REACT_CONTENT_SNIFF_BYTES = 262_144;
+
+const readFileHead = (absolutePath: string): string | null => {
+  try {
+    const fileDescriptor = fs.openSync(absolutePath, "r");
+    try {
+      const buffer = Buffer.alloc(REACT_CONTENT_SNIFF_BYTES);
+      const bytesRead = fs.readSync(fileDescriptor, buffer, 0, buffer.length, 0);
+      return buffer.toString("utf8", 0, bytesRead);
+    } finally {
+      fs.closeSync(fileDescriptor);
+    }
+  } catch {
+    return null;
+  }
+};
+
+const hasReactRelevantContent = (filePath: string, project?: ProjectInfo): boolean => {
+  const rootDirectory = project?.rootDirectory;
+  if (rootDirectory === undefined) return false;
+  const content = readFileHead(path.resolve(rootDirectory, filePath));
+  return content !== null && REACT_CONTENT_PATTERN.test(content);
+};
+
+// Explicit include paths (--scope files/changed/lines, --staged) always keep
+// JSX/TSX files and Next entry files. Other source extensions (.ts, .js, .mts,
+// .mjs) are kept only when their content references React (react/preact import
+// or a hook call): a full scan flags those files (see #151), and dropping them
+// wholesale silently skipped changed .ts hooks and React utilities — but
+// including every changed .ts/.js file would fire generic JS rules on
+// non-React server and utility code, which is exactly the review noise the
+// JSX-only filter existed to prevent.
 export const shouldIncludeExplicitLintPath = (filePath: string, project?: ProjectInfo): boolean =>
   JSX_FILE_PATTERN.test(filePath) ||
-  (project?.framework === "nextjs" && NEXT_ENTRY_FILE_PATTERN.test(filePath));
+  (project?.framework === "nextjs" && NEXT_ENTRY_FILE_PATTERN.test(filePath)) ||
+  (SOURCE_FILE_PATTERN.test(filePath) && hasReactRelevantContent(filePath, project));
 
 export const computeExplicitLintIncludePaths = (
   includePaths: string[],

--- a/packages/react-doctor/tests/explicit-lint-include-paths.test.ts
+++ b/packages/react-doctor/tests/explicit-lint-include-paths.test.ts
@@ -1,52 +1,124 @@
-import { describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import type { ProjectInfo } from "@react-doctor/core";
 import { computeExplicitLintIncludePaths } from "@react-doctor/core";
 
+let tempDirectory: string;
+
+const buildProject = (overrides?: Partial<ProjectInfo>): ProjectInfo => ({
+  rootDirectory: tempDirectory,
+  projectName: "vite-app",
+  reactVersion: "19.0.0",
+  reactMajorVersion: 19,
+  tailwindVersion: null,
+  zodVersion: null,
+  zodMajorVersion: null,
+  framework: "vite",
+  hasTypeScript: true,
+  hasReactCompiler: false,
+  hasTanStackQuery: false,
+  nextjsVersion: null,
+  nextjsMajorVersion: null,
+  hasReactNativeWorkspace: false,
+  expoVersion: null,
+  shopifyFlashListVersion: null,
+  shopifyFlashListMajorVersion: null,
+  hasReanimated: false,
+  isPreES2023Target: false,
+  preactVersion: null,
+  preactMajorVersion: null,
+  sourceFileCount: 0,
+  ...overrides,
+});
+
+const writeFixtureFile = (relativePath: string, content: string): void => {
+  const absolutePath = path.join(tempDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+};
+
 describe("computeExplicitLintIncludePaths", () => {
+  beforeEach(() => {
+    tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-explicit-includes-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  });
+
   it("returns undefined for empty include paths", () => {
     expect(computeExplicitLintIncludePaths([])).toBeUndefined();
   });
 
-  it("filters to ordinary component-bearing JSX/TSX files", () => {
-    const paths = ["src/app.tsx", "src/utils.ts", "src/Button.jsx", "src/config.js"];
-    const result = computeExplicitLintIncludePaths(paths);
+  it("keeps JSX/TSX files without reading them", () => {
+    const result = computeExplicitLintIncludePaths(
+      ["src/app.tsx", "src/Button.jsx", "README.md", "src/styles.css"],
+      buildProject(),
+    );
     expect(result).toEqual(["src/app.tsx", "src/Button.jsx"]);
   });
 
-  it("keeps Next middleware and proxy entry files in Next projects", () => {
+  it("keeps a changed .ts hook that imports react", () => {
+    writeFixtureFile(
+      "src/hooks/useColorManipulation.ts",
+      'import { useEffect, useState } from "react";\nexport const useColorManipulation = () => useState(0);\n',
+    );
+    const result = computeExplicitLintIncludePaths(
+      ["src/hooks/useColorManipulation.ts"],
+      buildProject(),
+    );
+    expect(result).toEqual(["src/hooks/useColorManipulation.ts"]);
+  });
+
+  it("keeps a changed .ts file that calls hooks without importing react directly", () => {
+    writeFixtureFile(
+      "src/hooks/use-theme.ts",
+      'import { useColorManipulation } from "./useColorManipulation.js";\nexport const useTheme = () => useColorManipulation();\n',
+    );
+    const result = computeExplicitLintIncludePaths(["src/hooks/use-theme.ts"], buildProject());
+    expect(result).toEqual(["src/hooks/use-theme.ts"]);
+  });
+
+  it("drops changed non-React .ts/.js files so diff scopes stay quiet on server and utility code", () => {
+    writeFixtureFile("src/utils.ts", "export const clamp = (n: number) => Math.min(1, n);\n");
+    writeFixtureFile("src/config.js", "module.exports = { retries: 3 };\n");
+    const result = computeExplicitLintIncludePaths(
+      ["src/utils.ts", "src/config.js"],
+      buildProject(),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("drops non-JSX paths whose content cannot be read", () => {
+    const result = computeExplicitLintIncludePaths(["src/missing.ts"], buildProject());
+    expect(result).toEqual([]);
+  });
+
+  it("drops non-JSX paths when no project is provided", () => {
+    expect(computeExplicitLintIncludePaths(["src/utils.ts"])).toEqual([]);
+  });
+
+  it("keeps Next middleware and proxy entry files in Next projects without reading them", () => {
     const paths = [
       "middleware.ts",
       "middleware.mjs",
       "src/proxy.ts",
       "src/proxy.mts",
       "src/app.tsx",
-      "src/server.ts",
       "nested/middleware.ts",
     ];
 
-    const result = computeExplicitLintIncludePaths(paths, {
-      rootDirectory: "/repo",
-      projectName: "next-app",
-      reactVersion: "19.0.0",
-      reactMajorVersion: 19,
-      tailwindVersion: null,
-      zodVersion: null,
-      zodMajorVersion: null,
-      framework: "nextjs",
-      hasTypeScript: true,
-      hasReactCompiler: false,
-      hasTanStackQuery: false,
-      nextjsVersion: "^16.0.0",
-      nextjsMajorVersion: 16,
-      hasReactNativeWorkspace: false,
-      expoVersion: null,
-      shopifyFlashListVersion: null,
-      shopifyFlashListMajorVersion: null,
-      hasReanimated: false,
-      isPreES2023Target: false,
-      preactVersion: null,
-      preactMajorVersion: null,
-      sourceFileCount: 0,
-    });
+    const result = computeExplicitLintIncludePaths(
+      paths,
+      buildProject({
+        projectName: "next-app",
+        framework: "nextjs",
+        nextjsVersion: "^16.0.0",
+        nextjsMajorVersion: 16,
+      }),
+    );
 
     expect(result).toEqual([
       "middleware.ts",
@@ -58,38 +130,10 @@ describe("computeExplicitLintIncludePaths", () => {
   });
 
   it("does not keep Next entry filenames for non-Next projects", () => {
-    const paths = ["middleware.ts", "src/proxy.mjs", "src/App.tsx"];
-    const result = computeExplicitLintIncludePaths(paths, {
-      rootDirectory: "/repo",
-      projectName: "vite-app",
-      reactVersion: "19.0.0",
-      reactMajorVersion: 19,
-      tailwindVersion: null,
-      zodVersion: null,
-      zodMajorVersion: null,
-      framework: "vite",
-      hasTypeScript: true,
-      hasReactCompiler: false,
-      hasTanStackQuery: false,
-      nextjsVersion: null,
-      nextjsMajorVersion: null,
-      hasReactNativeWorkspace: false,
-      expoVersion: null,
-      shopifyFlashListVersion: null,
-      shopifyFlashListMajorVersion: null,
-      hasReanimated: false,
-      isPreES2023Target: false,
-      preactVersion: null,
-      preactMajorVersion: null,
-      sourceFileCount: 0,
-    });
-
+    const result = computeExplicitLintIncludePaths(
+      ["middleware.ts", "src/proxy.mjs", "src/App.tsx"],
+      buildProject(),
+    );
     expect(result).toEqual(["src/App.tsx"]);
-  });
-
-  it("returns empty array when no explicitly lintable files exist", () => {
-    const paths = ["src/utils.ts", "src/config.js"];
-    const result = computeExplicitLintIncludePaths(paths);
-    expect(result).toEqual([]);
   });
 });


### PR DESCRIPTION
**TL;DR:** `--scope files`, `--scope changed`, `--scope lines`, and `--staged` drop every changed `.ts`/`.js` file before linting, so a changed React hook that a full scan flags comes back with zero diagnostics. This PR keeps changed non-JSX source files only when their content references React (a react/preact import or a hook call). Non-React `.ts`/`.js` changes stay excluded, so diff scopes stay quiet on server and utility code.

## The bug

`computeExplicitLintIncludePaths` (`packages/core/src/explicit-lint-include-paths.ts`) filters explicit include paths with `JSX_FILE_PATTERN = /\.(tsx|jsx)$/`. `run-inspect.ts` applies that filter to every diff scope. The changed-file list itself keeps `.ts` files (`filterSourceFiles`); they are dropped only at this filter, with no warning.

Before and after, in omgovich/react-colorful at `ddd22b1` with a committed change to `src/hooks/useColorManipulation.ts`:

```console
# before
$ react-doctor --scope files --base <base-ref> --json
0 diagnostics for useColorManipulation.ts

# after (matches the full scan for this file)
$ react-doctor --scope files --base <base-ref> --json
6+ diagnostics: no-derived-state, no-event-handler,
no-pass-live-state-to-parent, no-pass-data-to-parent, ...
```

## Why the filter exists, and why this fix keeps it

The JSX-only filter is the noise guard: including every changed `.ts`/`.js` file would fire generic JS rules on non-React server and utility code in PR reviews. The history shows the current state is drift rather than a consistent policy:

- The original filter (`680e7c40`) applied JSX-only filtering to **full-scan output** too.
- #151 deliberately widened the full scan to `SOURCE_FILE_PATTERN` so JS-performance and adopted rules report on plain `.ts`/`.js`. That is why full scans flag the react-colorful hook today.
- #734 extracted the diff-scope filter into its own helper, preserving the pre-#151 JSX-only semantics the full scan had already abandoned.

So full scans report `.ts` findings and diff scopes hide them, including real React footguns in hooks.

## The fix

Changed non-JSX source files are included only when their content is React-relevant:

```ts
export const shouldIncludeExplicitLintPath = (filePath: string, project?: ProjectInfo): boolean =>
  JSX_FILE_PATTERN.test(filePath) ||
  (project?.framework === "nextjs" && NEXT_ENTRY_FILE_PATTERN.test(filePath)) ||
  (SOURCE_FILE_PATTERN.test(filePath) && hasReactRelevantContent(filePath, project));
```

`hasReactRelevantContent` sniffs the first 256 KB for a react/preact import (any subpath, `import`/`require`/dynamic `import()`) or a hook call (`use[A-Z]...(`), so hook files that only compose other custom hooks still qualify. Unreadable files and non-React files stay excluded, which preserves today's behavior for them. JSX/TSX files and Next middleware/proxy entries are kept without any file read.

Behavior summary:

| Changed file | Before | After |
|---|---|---|
| `src/App.tsx` | linted | linted |
| `src/hooks/useColorManipulation.ts` (imports react) | **skipped** | linted |
| `src/hooks/use-theme.ts` (composes custom hooks) | **skipped** | linted |
| `src/server/db.ts` (no React content) | skipped | skipped (noise guard kept) |
| `middleware.ts` in a Next project | linted | linted |

## Tests

- `explicit-lint-include-paths.test.ts`: rewritten with real file fixtures: React `.ts` hook kept, hook-composing file kept, non-React `.ts`/`.js` dropped, unreadable path dropped, no-project dropped, Next entries kept without reads.
- `diagnose-changed-scope.test.ts` (new): React fixture with a `.ts` hook containing a real footgun; `diagnose` with `includePaths: ["src/use-doubled.ts"]` reports the same diagnostics as the full scan for that file. Fails at 0 diagnostics on the unfixed code.
- `run-inspect.test.ts` and `resolve-lint-include-paths.test.ts` are untouched from `main`: non-React file behavior in those flows is unchanged.

## Validation

- `pnpm test`: green except two pre-existing env-file/gitignore tests (`check-expo-project`, `check-security-scan`) that also fail on a clean checkout of `main` on this machine.
- `pnpm typecheck`: 14/14. `pnpm check`: clean (two pre-existing `no-control-regex` warnings).
- Changeset included (`react-doctor` patch).

Found while validating react-doctor against react-bench (context in millionco/react-bench#65). If you would rather have full parity with #151 (lint every changed source file, generic rules included), that is a one-line change from here; this version keeps the diff-scope noise stance intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
