### PR TITLE
fix(rules): three false-positive fixes found by deep adversarial fuzzing

### DIFF
--- a/.changeset/jsx-no-jsx-as-prop-slot-names.md
+++ b/.changeset/jsx-no-jsx-as-prop-slot-names.md
@@ -1,0 +1,12 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(react-builtins): `jsx-no-jsx-as-prop` recognises more conventional JSX
+slot props mined from the real-world corpus — the `*Avatar`, `*Text`,
+`*State`, and `*Zone` suffixes (material-ui `ListItem
+leftAvatar`/`primaryText`, supabase `ChartContent loadingState`, leemons
+`leftZone`/`rightZone`), the `config` slot, and capitalised exact forms of
+known slot names (`Footer={<PageFooter />}`). Inline JSX in these slots is the
+component's designed API, so flagging it was unactionable noise. Found by the
+fuzz FP oracle.

--- a/.changeset/no-secrets-author-name-fp.md
+++ b/.changeset/no-secrets-author-name-fp.md
@@ -1,0 +1,10 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(security): `no-secrets-in-client-code`'s variable-name heuristic no longer
+matches `auth` inside `author`/`authors`/`authority` — a component identifier
+like `TOP_PR_AUTHORS_FRONT_COMPONENT_UNIVERSAL_IDENTIFIER = "<uuid>"` is not a
+credential. The credential words that contain "author"
+(`authorization`, `authorised`) still match. Found by the fuzz FP oracle over
+the real-world corpus.

--- a/.changeset/only-export-components-nested-scope-fp.md
+++ b/.changeset/only-export-components-nested-scope-fp.md
@@ -1,0 +1,12 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(react-builtins): `only-export-components` no longer flags components
+declared inside another function — a test callback (`test("x", () => { const
+Harness = () => ... })`), a factory (`function setup() { const Row = () =>
+... }`), or an object-literal `render` method. Those are never Fast Refresh
+boundaries, so the "not exported" / "file exports nothing" messages told
+users to export values that can't be exported. The local-component walk now
+stays at module scope, matching the origin rule in
+eslint-plugin-react-refresh. Found by the fuzz FP oracle.

--- a/packages/fuzz/corpus/regressions/jsx-no-jsx-as-prop--corpus-slot-names.tsx
+++ b/packages/fuzz/corpus/regressions/jsx-no-jsx-as-prop--corpus-slot-names.tsx
@@ -1,0 +1,31 @@
+// rule: jsx-no-jsx-as-prop
+// weakness: slot-name coverage
+// source: fuzz FP hunt 2026-07 (material-ui ListItem leftAvatar/primaryText/
+// secondaryText, supabase ChartContent loadingState/disabledState, leemons
+// leftZone/rightZone, capitalised Footer slot — all conventional JSX slots)
+declare const ListItem: (props: {
+  leftAvatar?: unknown;
+  primaryText?: unknown;
+  secondaryText?: unknown;
+}) => null;
+declare const ChartContent: (props: { loadingState?: unknown; disabledState?: unknown }) => null;
+declare const FooterContainer: (props: { leftZone?: unknown; rightZone?: unknown }) => null;
+declare const StepContainer: (props: { Footer?: unknown }) => null;
+declare const Avatar: (props: { src: string }) => null;
+declare const user: { image: string; name: string; bio: string };
+
+export const SlotConsumers = () => (
+  <>
+    <ListItem
+      leftAvatar={<Avatar src={user.image} />}
+      primaryText={<b>{user.name}</b>}
+      secondaryText={<i>{user.bio}</i>}
+    />
+    <ChartContent loadingState={<span>loading</span>} disabledState={<span>disabled</span>} />
+    <FooterContainer
+      leftZone={<button type="button">back</button>}
+      rightZone={<button type="button">next</button>}
+    />
+    <StepContainer Footer={<footer>done</footer>} />
+  </>
+);

--- a/packages/fuzz/corpus/regressions/no-secrets-in-client-code--author-named-identifier.tsx
+++ b/packages/fuzz/corpus/regressions/no-secrets-in-client-code--author-named-identifier.tsx
@@ -1,0 +1,10 @@
+// rule: no-secrets-in-client-code
+// weakness: name-heuristic
+// source: fuzz FP hunt 2026-07 (twentyhq/twenty github-connector: `auth`
+// matched inside AUTHORS — a component identifier UUID is not a credential)
+export const TopPrAuthors = () => {
+  return <div>Top PR authors</div>;
+};
+
+export const TOP_PR_AUTHORS_FRONT_COMPONENT_UNIVERSAL_IDENTIFIER =
+  "a1d4f7e2-9b3c-4e8a-bf21-5d6c8a9b2e3f";

--- a/packages/fuzz/corpus/regressions/only-export-components--component-in-function-scope.tsx
+++ b/packages/fuzz/corpus/regressions/only-export-components--component-in-function-scope.tsx
@@ -1,0 +1,19 @@
+// rule: only-export-components
+// weakness: control-flow
+// source: fuzz FP hunt 2026-07 (components declared inside test callbacks /
+// factories are not Fast Refresh boundaries; the local-component walk must
+// stay at module scope like eslint-plugin-react-refresh's)
+declare const test: (name: string, run: () => void) => void;
+declare const render: (element: unknown) => void;
+
+test("renders the harness", () => {
+  const Harness = () => <div>harness</div>;
+  render(<Harness />);
+});
+
+function setup() {
+  const Row = () => <span>row</span>;
+  return Row;
+}
+
+export const config = setup();

--- a/packages/fuzz/vite.config.ts
+++ b/packages/fuzz/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vite-plus";
 
 export default defineConfig({
   test: {
+    // Corpus checkouts under tmp/ carry their own *.spec.ts / *.test.ts
+    // files; without this include they'd be globbed into our run.
+    include: ["tests/**/*.test.ts"],
     testTimeout: 60_000,
   },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/security.ts
@@ -246,7 +246,13 @@ export const SECRET_CONTEXTUAL_PLACEHOLDER_VALUE_PATTERNS = [
 export const SECRET_PLACEHOLDER_CONTEXT_PATTERN =
   /(?:placeholder|example|sample|dummy|masked|redacted|mask)/i;
 
-export const SECRET_VARIABLE_PATTERN = /(?:api_?key|secret|token|password|credential|auth)/i;
+// `auth(?!or(?!i[sz]))` keeps `auth` / `oauth` / `authorization` /
+// `authorised` matching while exempting `author` / `authors` /
+// `authority` — the person-who-writes words are the single biggest
+// source of name-heuristic false positives (e.g.
+// `TOP_PR_AUTHORS_COMPONENT_IDENTIFIER`).
+export const SECRET_VARIABLE_PATTERN =
+  /(?:api_?key|secret|token|password|credential|auth(?!or(?!i[sz])))/i;
 
 export const SECRET_TOOLING_FILE_PATTERN = /(?:^|\/)[^/]+\.config\.[cm]?[jt]s$/;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.regressions.test.ts
@@ -72,6 +72,30 @@ describe("react-builtins/jsx-no-jsx-as-prop regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  // Fuzz FP hunt (corpus census 2026-07): material-ui `ListItem
+  // leftAvatar/primaryText/secondaryText`, supabase `ChartContent
+  // loadingState/disabledState`, leemons `leftZone/rightZone`, and the
+  // capitalised exact slot `Footer={<PageFooter />}` — all conventional
+  // JSX slots the suffix/name tables missed.
+  it("does not flag corpus-mined slot props (Avatar/Text/State/Zone suffixes, capitalised Footer)", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      const View = () => (
+        <>
+          <ListItem leftAvatar={<Avatar src={user.image} />} primaryText={<b>{user.name}</b>} secondaryText={<i>{user.bio}</i>} />
+          <ChartContent loadingState={<ChartLoadingState />} disabledState={<ChartDisabledState />} />
+          <FooterContainer leftZone={<BackButton />} rightZone={<NextButton />} />
+          <StepContainer Footer={<PageFooter />} />
+          <AuthenticationMethodCard config={<ToggleSwitch value={enabled} />} />
+        </>
+      );
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // Mined ant-design FP (.dumi/pages/index/components/PreviewPane/Components.tsx:376):
   // antd Spin's lowercase `indicator` — the case-sensitive `Indicator` suffix
   // never matched it, so it needs the explicit slot-name entry.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.ts
@@ -96,6 +96,7 @@ const KNOWN_SLOT_PROP_NAMES: ReadonlySet<string> = new Set([
   "leftContent",
   "rightContent",
   // Generic JSX-receiving slots (corpus-derived)
+  "config",
   "value",
   "currentValue",
   "form",
@@ -255,6 +256,13 @@ const SLOT_PROP_SUFFIXES: ReadonlyArray<string> = [
   "Panel",
   "Overlay",
   "Shape",
+  // material-ui `ListItem leftAvatar/rightAvatar` + `primaryText/
+  // secondaryText`, supabase `loadingState/disabledState/emptyState`,
+  // leemons `leftZone/rightZone` — corpus-derived slot conventions.
+  "Avatar",
+  "Text",
+  "State",
+  "Zone",
   // Slot-replacement / customization suffixes
   "Override",
   "Overrides",
@@ -275,6 +283,11 @@ const SLOT_PROP_SUFFIXES: ReadonlyArray<string> = [
 
 const isSlotPropName = (propName: string): boolean => {
   if (KNOWN_SLOT_PROP_NAMES.has(propName)) return true;
+  // Capitalised exact form of a known slot (`Footer={<PageFooter />}`,
+  // `Header={...}`) — design systems that treat the slot as a
+  // component-shaped prop capitalise the same conventional names.
+  const decapitalized = propName.charAt(0).toLowerCase() + propName.slice(1);
+  if (decapitalized !== propName && KNOWN_SLOT_PROP_NAMES.has(decapitalized)) return true;
   for (const suffix of SLOT_PROP_SUFFIXES) {
     if (propName.length > suffix.length && propName.endsWith(suffix)) return true;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -217,6 +217,51 @@ describe("react-builtins/only-export-components — regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  // Fuzz FP hunt: components declared inside another function — a test
+  // callback, a factory, or an object-literal `render` method — are never
+  // Fast Refresh boundaries, so neither the "not exported" nor the
+  // "exports nothing" message applies to them.
+  it("ignores components declared inside function scopes", () => {
+    const testCallbackFile = `
+      declare const test: (name: string, run: () => void) => void;
+      declare const render: (element: unknown) => void;
+      test("renders", () => {
+        const Harness = () => <div />;
+        render(<Harness />);
+      });
+    `;
+    const factoryFile = `
+      function setup() {
+        const Row = () => <tr />;
+        return Row;
+      }
+      export const config = setup();
+    `;
+    const renderMethodFile = `
+      const meta = { render: () => { const Demo = () => <div />; return <Demo />; } };
+      export default meta;
+    `;
+    for (const [code, filename] of [
+      [testCallbackFile, "src/harness.tsx"],
+      [factoryFile, "src/setup-table.tsx"],
+      [renderMethodFile, "src/demo-meta.tsx"],
+    ]) {
+      const result = runRule(onlyExportComponents, code, { filename });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("still flags module-scope local components", () => {
+    const moduleScopeFile = `
+      const Widget = () => <div />;
+    `;
+    const result = runRule(onlyExportComponents, moduleScopeFile, {
+      filename: "src/widget.tsx",
+    });
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags non-component exports in ordinary component files", () => {
     const mixedFile = `
       export const formatProfile = (profile) => profile.name.trim();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -627,7 +627,7 @@ export const onlyExportComponents = defineRule({
             if (
               isReactComponentName(child.id.name) &&
               !isInsideExport(child as EsTreeNode) &&
-              !isInsideFunctionScope(child as EsTreeNode)
+              !isInsideFunctionScope(child)
             ) {
               localComponents.push(child.id);
             }
@@ -637,7 +637,7 @@ export const onlyExportComponents = defineRule({
               isReactComponentName(child.id.name) &&
               canBeReactFunctionComponent(child.init as EsTreeNode | null | undefined, state) &&
               !isInsideExport(child as EsTreeNode) &&
-              !isInsideFunctionScope(child as EsTreeNode)
+              !isInsideFunctionScope(child)
             ) {
               localComponents.push(child.id);
             }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { isEs6Component } from "../../utils/is-es6-component.js";
+import { isInsideFunctionScope } from "../../utils/is-inside-function-scope.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import {
@@ -615,9 +616,19 @@ export const onlyExportComponents = defineRule({
           }
           return false;
         };
+        // A component declared inside another function (a test callback, a
+        // factory, an object-literal `render` method) is never a Fast
+        // Refresh boundary — only module-scope components are. The origin
+        // rule (eslint-plugin-react-refresh) walks top-level statements
+        // only; flagging nested declarations tells users to export values
+        // that can't be exported.
         for (const child of componentCandidates) {
           if (isNodeOfType(child, "FunctionDeclaration") && child.id) {
-            if (isReactComponentName(child.id.name) && !isInsideExport(child as EsTreeNode)) {
+            if (
+              isReactComponentName(child.id.name) &&
+              !isInsideExport(child as EsTreeNode) &&
+              !isInsideFunctionScope(child as EsTreeNode)
+            ) {
               localComponents.push(child.id);
             }
           }
@@ -625,7 +636,8 @@ export const onlyExportComponents = defineRule({
             if (
               isReactComponentName(child.id.name) &&
               canBeReactFunctionComponent(child.init as EsTreeNode | null | undefined, state) &&
-              !isInsideExport(child as EsTreeNode)
+              !isInsideExport(child as EsTreeNode) &&
+              !isInsideFunctionScope(child as EsTreeNode)
             ) {
               localComponents.push(child.id);
             }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.regressions.test.ts
@@ -40,4 +40,29 @@ describe("security/no-secrets-in-client-code — regressions", () => {
         .length,
     ).toBeGreaterThan(0);
   });
+
+  // Fuzz FP hunt (corpus census 2026-07): `auth` matching inside
+  // `author(s)` — a component identifier named
+  // `TOP_PR_AUTHORS_..._IDENTIFIER` holding a UUID is not a credential.
+  it("stays silent on author-named variables (auth inside author)", () => {
+    expect(
+      runClient(
+        `export const TOP_PR_AUTHORS_FRONT_COMPONENT_UNIVERSAL_IDENTIFIER = "a1d4f7e2-9b3c-4e8a-bf21-5d6c8a9b2e3f";`,
+      ),
+    ).toHaveLength(0);
+    expect(
+      runClient(`export const coAuthorsListJson = "jane;john;maria;pedro;li;omar;zoe";`),
+    ).toHaveLength(0);
+  });
+
+  // …while authorization/authorised (the credential words containing
+  // "author") still match the name heuristic.
+  it("still flags authorization/authorised-named values", () => {
+    expect(
+      runClient(`const authorizationValue = "Bearer 9f8e7d6c5b4a39281706f5e4d3c2b1a0";`).length,
+    ).toBeGreaterThan(0);
+    expect(
+      runClient(`const authorisedSigningValue = "9f8e7d6c5b4a39281706f5e4d3c2b1a0abcdef";`).length,
+    ).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary

Deep fuzzing pass over all 389 rules (strict slow-oracle runs at multiple seeds, metamorphic invariants, the real-world OSS corpus, the react-bench dense corpus, plus a per-hit census triage of the noisiest rules over 400 corpus files). Three confirmed false-positive classes, each fixed with a corpus regression seed and regression tests:

- **`only-export-components`**: components declared inside another function — a test callback (`test("x", () => { const Harness = () => … })`), a factory, or an object-literal `render` method — were flagged as "not exported" / "file exports nothing". They are never Fast Refresh boundaries, so the advice was impossible to follow. The local-component walk now stays at module scope, matching the origin rule in `eslint-plugin-react-refresh` (reuses the shared `isInsideFunctionScope` util).
- **`no-secrets-in-client-code`**: the variable-name heuristic matched `auth` inside `AUTHORS` — e.g. twentyhq/twenty's public `TOP_PR_AUTHORS_FRONT_COMPONENT_UNIVERSAL_IDENTIFIER = "<uuid>"` was reported as a hardcoded secret. The pattern now exempts `author`/`authors`/`authority` while keeping `authorization`/`authorised`/`oauth` matching.
- **`jsx-no-jsx-as-prop`**: corpus-mined slot conventions were still flagged — material-ui `ListItem leftAvatar`/`primaryText`/`secondaryText`, supabase `ChartContent loadingState`/`disabledState`, leemons `leftZone`/`rightZone`, `config`, and capitalised exact slots (`Footer={<PageFooter />}`). Added the `*Avatar`/`*Text`/`*State`/`*Zone` suffixes, the `config` slot name, and a capitalised-exact-match fallback to the slot table.

Also scopes `packages/fuzz`'s vitest `include` to `tests/**/*.test.ts` so synced corpus checkouts' own spec files are never globbed into a run.

Fuzz health after the fixes: corpus-backed run (120 iterations × 389 rules, invariants on) fully green; the transient "slow rule" findings from overlapping runs were confirmed to be CPU-contention artifacts (each reproducer runs in 10–25 ms standalone and each flagged rule passes a 400-iteration strict re-run on an idle machine). FP hunt over the 42 regression seeds: 0 regressions.

## Test plan

- [x] `pnpm test` — 2124 passed
- [x] `pnpm typecheck` — 15/15 packages
- [x] `pnpm lint` — only pre-existing warnings in untouched files
- [x] `pnpm format`
- [x] `pnpm fuzz` with corpus + invariants — 389/389 green
- [x] `bun scripts/hunt-false-positives.ts` — 0 regressions on 42 seeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Heuristic-only relaxations and test harness config; security rule still flags authorization-related names and real credentials.
> 
> **Overview**
> Addresses three **false-positive classes** found via adversarial fuzzing over the real-world corpus, each with regression tests and fuzz corpus seeds.
> 
> **`only-export-components`** now skips React components declared **inside another function** (test callbacks, factories, nested `render` methods) by gating the local-component walk with `isInsideFunctionScope`, aligning with `eslint-plugin-react-refresh` module-scope behavior.
> 
> **`no-secrets-in-client-code`** tightens **`SECRET_VARIABLE_PATTERN`** so `auth` no longer matches inside `author` / `authors` / `authority`, while **`authorization`** / **`authorised`** still trigger the name heuristic.
> 
> **`jsx-no-jsx-as-prop`** expands slot detection: adds **`config`**, suffixes **`Avatar` / `Text` / `State` / `Zone`**, and treats **capitalised** prop names as slots when they match a known lowercase slot (e.g. `Footer={...}`).
> 
> **`packages/fuzz`** Vitest **`include`** is limited to `tests/**/*.test.ts` so corpus checkouts under `tmp/` do not pollute test runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447868f7ae15b961deb2c4a3c88f4671871c0655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->