### PR TITLE
perf(plugin): memoize closureCaptures per scope analysis and function node

### DIFF
--- a/.changeset/perf-closure-captures-memo.md
+++ b/.changeset/perf-closure-captures-memo.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: memoize `closureCaptures` per (ScopeAnalysis, function node) so nested callbacks compute once and every calling rule reuses the result, and drop the redundant per-reference containment re-filter

--- a/packages/oxlint-plugin-react-doctor/src/plugin/semantic/closure-captures.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/semantic/closure-captures.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "@voidzero-dev/vite-plus-test";
+import { closureCaptures } from "./closure-captures.js";
+import { analyzeScopes } from "./scope-analysis.js";
+import { attachParentReferences } from "../../test-utils/attach-parent-references.js";
+import { parseFixture } from "../../test-utils/parse-fixture.js";
+import type { EsTreeNode } from "../utils/es-tree-node.js";
+import { isFunctionLike } from "../utils/is-function-like.js";
+
+const analyze = (code: string) => {
+  const parsed = parseFixture(code);
+  attachParentReferences(parsed.program);
+  return { scopes: analyzeScopes(parsed.program), program: parsed.program };
+};
+
+const findFunctionNode = (root: EsTreeNode, name: string): EsTreeNode | null => {
+  let result: EsTreeNode | null = null;
+  const visit = (node: EsTreeNode): void => {
+    if (result) return;
+    if (
+      node.type === "FunctionDeclaration" &&
+      (node as { id?: { name?: string } }).id?.name === name
+    ) {
+      result = node;
+      return;
+    }
+    if (node.type === "VariableDeclarator") {
+      const declarator = node as { id?: { name?: string }; init?: EsTreeNode };
+      if (declarator.id?.name === name && declarator.init && isFunctionLike(declarator.init)) {
+        result = declarator.init;
+        return;
+      }
+    }
+    const record = node as unknown as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      if (key === "parent") continue;
+      const child = record[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (item && typeof item === "object" && "type" in item) {
+            visit(item as EsTreeNode);
+            if (result) return;
+          }
+        }
+      } else if (child && typeof child === "object" && "type" in (child as object)) {
+        visit(child as EsTreeNode);
+      }
+    }
+  };
+  visit(root);
+  return result;
+};
+
+const capturedNames = (captures: ReadonlyArray<{ resolvedSymbol: { name: string } | null }>) =>
+  captures.map((capture) => capture.resolvedSymbol?.name).sort();
+
+describe("closureCaptures", () => {
+  it("collects references whose binding lives outside the function", () => {
+    const { scopes, program } = analyze(`
+      const useGreeting = () => {
+        const greeting = "hi";
+        const speak = () => greeting;
+        return speak;
+      };
+    `);
+    const speak = findFunctionNode(program, "speak")!;
+    expect(capturedNames(closureCaptures(speak, scopes))).toEqual(["greeting"]);
+  });
+
+  it("excludes parameters and internal locals", () => {
+    const { scopes, program } = analyze(`
+      const shout = (subject) => {
+        const punctuation = "!";
+        return subject + punctuation;
+      };
+    `);
+    const shout = findFunctionNode(program, "shout")!;
+    expect(closureCaptures(shout, scopes)).toEqual([]);
+  });
+
+  it("excludes the function's own recursive self-reference", () => {
+    const { scopes, program } = analyze(`
+      function countdown(steps) {
+        if (steps === 0) return;
+        countdown(steps - 1);
+      }
+    `);
+    const countdown = findFunctionNode(program, "countdown")!;
+    expect(closureCaptures(countdown, scopes)).toEqual([]);
+  });
+
+  it("bubbles nested-function captures up to every enclosing function", () => {
+    const { scopes, program } = analyze(`
+      const useOuter = () => {
+        const outerValue = 1;
+        const middle = () => {
+          const middleValue = 2;
+          const inner = () => outerValue + middleValue;
+          return inner;
+        };
+        return middle;
+      };
+    `);
+    const middle = findFunctionNode(program, "middle")!;
+    const inner = findFunctionNode(program, "inner")!;
+    expect(capturedNames(closureCaptures(inner, scopes))).toEqual(["middleValue", "outerValue"]);
+    expect(capturedNames(closureCaptures(middle, scopes))).toEqual(["outerValue"]);
+    const useOuter = findFunctionNode(program, "useOuter")!;
+    expect(closureCaptures(useOuter, scopes)).toEqual([]);
+  });
+
+  it("excludes globals (unresolved references)", () => {
+    const { scopes, program } = analyze(`
+      const report = () => {
+        console.log(window.location.href);
+      };
+    `);
+    const report = findFunctionNode(program, "report")!;
+    expect(closureCaptures(report, scopes)).toEqual([]);
+  });
+
+  it("returns the memoized result on repeat calls with the same analysis", () => {
+    const { scopes, program } = analyze(`
+      const useCounter = () => {
+        const step = 1;
+        const increment = (count) => count + step;
+        return increment;
+      };
+    `);
+    const increment = findFunctionNode(program, "increment")!;
+    const firstResult = closureCaptures(increment, scopes);
+    const secondResult = closureCaptures(increment, scopes);
+    expect(secondResult).toBe(firstResult);
+    expect(capturedNames(secondResult)).toEqual(["step"]);
+  });
+
+  it("computes fresh results for a different ScopeAnalysis over the same AST", () => {
+    const { scopes, program } = analyze(`
+      const useLabel = () => {
+        const label = "x";
+        const describeLabel = () => label;
+        return describeLabel;
+      };
+    `);
+    const describeLabel = findFunctionNode(program, "describeLabel")!;
+    const firstResult = closureCaptures(describeLabel, scopes);
+    const freshScopes = analyzeScopes(program);
+    const freshResult = closureCaptures(describeLabel, freshScopes);
+    expect(freshResult).not.toBe(firstResult);
+    expect(capturedNames(freshResult)).toEqual(capturedNames(firstResult));
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/semantic/closure-captures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/semantic/closure-captures.ts
@@ -2,21 +2,10 @@ import type { EsTreeNode } from "../utils/es-tree-node.js";
 import type { ReferenceDescriptor, ScopeAnalysis } from "./scope-analysis.js";
 import { isDescendantScope } from "./scope-analysis.js";
 import { TYPE_POSITION_CHILD_KEYS } from "../constants/ts-type-position-keys.js";
-import { isAstDescendant } from "../utils/is-ast-descendant.js";
 import { isAstNode } from "../utils/is-ast-node.js";
 import { isFunctionLike } from "../utils/is-function-like.js";
 
-// True if `inner` is a descendant of `outer` (or equal) in the AST
-// tree. Used to filter references inside `functionNode`.
-// Returns every reference inside `functionNode`'s body whose binding
-// lives OUTSIDE the function — i.e. the closure-captured set. Useful
-// for exhaustive-deps to compute the actual set of values a hook
-// callback closes over.
-//
-// Excludes: globals (unresolved references), references whose binding
-// is the function itself (recursive call) or its parameters /
-// internal locals.
-export const closureCaptures = (
+const computeClosureCaptures = (
   functionNode: EsTreeNode,
   scopes: ScopeAnalysis,
 ): ReadonlyArray<ReferenceDescriptor> => {
@@ -72,7 +61,44 @@ export const closureCaptures = (
   };
   visit(functionNode);
 
-  // Filter out references whose identifier is OUTSIDE functionNode in
-  // the AST (defensive — shouldn't happen given our walk).
-  return out.filter((reference) => isAstDescendant(reference.identifier, functionNode));
+  // Every collected reference's identifier IS a walked descendant of
+  // `functionNode` (`referenceFor` is keyed by the identifier node, and
+  // bubbled inner captures sit inside inner subtrees), so no
+  // containment re-check is needed here.
+  return out;
+};
+
+// Memoized per (ScopeAnalysis, function node). The walk recurses into
+// inner functions through this entry point, so nested callbacks compute
+// once and every enclosing function — and every calling rule — reuses
+// the shared frozen-by-convention array (`ReadonlyArray`, callers only
+// iterate). Keyed on the ScopeAnalysis first because the semantic-
+// context fallback can mint throwaway stub analyses for the same AST.
+const capturesByAnalysis = new WeakMap<
+  ScopeAnalysis,
+  WeakMap<EsTreeNode, ReadonlyArray<ReferenceDescriptor>>
+>();
+
+// Returns every reference inside `functionNode`'s body whose binding
+// lives OUTSIDE the function — i.e. the closure-captured set. Useful
+// for exhaustive-deps to compute the actual set of values a hook
+// callback closes over.
+//
+// Excludes: globals (unresolved references), references whose binding
+// is the function itself (recursive call) or its parameters /
+// internal locals.
+export const closureCaptures = (
+  functionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<ReferenceDescriptor> => {
+  let capturesByFunction = capturesByAnalysis.get(scopes);
+  if (!capturesByFunction) {
+    capturesByFunction = new WeakMap();
+    capturesByAnalysis.set(scopes, capturesByFunction);
+  }
+  const memoizedCaptures = capturesByFunction.get(functionNode);
+  if (memoizedCaptures) return memoizedCaptures;
+  const computedCaptures = computeClosureCaptures(functionNode, scopes);
+  capturesByFunction.set(functionNode, computedCaptures);
+  return computedCaptures;
 };


### PR DESCRIPTION
## Why

`closureCaptures` (the semantic-layer helper behind `exhaustive-deps`, `exhaustive-deps-symbol-stability`, and `prefer-module-scope-pure-function`) was unmemoized and recursive: every inner function's subtree was re-walked once per enclosing nesting level, and every calling rule repeated all of it. The CPU profile of a real 617-file scan shows the semantic layer as the largest per-file fixed cost, and a multi-agent perf audit confirmed this walker as super-linear on nested-callback-heavy React code.

Before:

```
closureCaptures on every function node of the 10 most nesting-heavy corpus files,
100 repeats (simulating the calling-rule fleet): 517–835 ms
single pass: 4.5–8.5 ms
```

After:

```
same workload: 2.3–6.3 ms  (133–318x)
single pass: 1.8–4.8 ms    (1.8–2.9x — nested functions now compute once even within one pass)
identical capture checksums in all runs
```

## What changed

- `closureCaptures` results are memoized per `(ScopeAnalysis, function node)` via chained WeakMaps; the walk's inner-function recursion routes through the memoized entry point, so nested callbacks compute once and enclosing functions reuse them. Keyed on the `ScopeAnalysis` first because `wrap-with-semantic-context.ts` can mint throwaway fallback stub analyses for the same AST.
- Dropped the final defensive `.filter(isAstDescendant(...))`: `referenceFor` is keyed by the identifier node itself, so every collected reference's identifier is by construction a walked descendant of `functionNode` (bubbled inner captures inductively so). The filter provably never removed anything.
- Sharing is safe: all three callers only iterate the `ReadonlyArray` result (audited; TS forbids mutation).
- New colocated test file (7 tests): capture collection, param/local/recursive-self/global exclusions, 3-level nested bubbling, repeat-call memo identity, and fresh-`ScopeAnalysis` independence on the same AST.

## Test plan

- `pnpm test` in `packages/oxlint-plugin-react-doctor`: 8711 passed / 94 skipped (pristine baseline on this machine: 8704 / 94; the +7 are the new tests, zero new failures). Note: CI does not run the plugin suite.
- Root `pnpm typecheck` and `pnpm lint` clean.
- Equivalence: `--json` scan of AdaptiveConsulting/ReactiveTraderCloud @ 4a31f016 (617 files) before/after — 291 diagnostics, sorted `{filePath, line, column, rule, message, severity}` diff empty.
- End-to-end A/B (6 interleaved dist-swap pairs) is noise-bound on this corpus (~1%); the micro-benchmark above is the primary evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving semantic helper optimization with equivalence validation; callers only read results and do not mutate the cached arrays.
> 
> **Overview**
> **`closureCaptures`** is now cached per **`(ScopeAnalysis, function AST node)`** using chained WeakMaps, so nested callbacks are walked once and rules like **`exhaustive-deps`**, **`exhaustive-deps-symbol-stability`**, and **`prefer-module-scope-pure-function`** reuse the same **`ReadonlyArray`** instead of repeating super-linear work.
> 
> The core walk lives in **`computeClosureCaptures`**; the exported **`closureCaptures`** wraps it with memoization and routes inner-function recursion through that entry point. The final **`isAstDescendant`** containment filter was removed as redundant given how references are collected.
> 
> A new **`closure-captures.test.ts`** covers capture semantics (outer bindings, params/locals, recursion, nested bubbling, globals), memo identity on repeat calls, and independence when **`ScopeAnalysis`** is recomputed on the same AST.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d434f060b4151b095701cfb6662474df998e69c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->