### PR TITLE
perf(plugin): index line starts once per content in security-scan locations

### DIFF
--- a/.changeset/perf-security-scan-line-index.md
+++ b/.changeset/perf-security-scan-line-index.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: replace the security scan's per-match O(content) slice+split in `getLocationAtIndex` with a memoized per-content line-start index answered by binary search

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/get-location-at-index.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/get-location-at-index.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { SourceLocation } from "./get-location-at-index.js";
+import { getLocationAtIndex } from "./get-location-at-index.js";
+
+// Reference: the previous slice+split implementation whose outputs are the
+// pinned contract (line/column are 1-based; `\r?\n` is the line separator).
+const referenceLocationAtIndex = (content: string, matchIndex: number): SourceLocation => {
+  if (matchIndex < 0) return { line: 1, column: 1 };
+  const prefix = content.slice(0, matchIndex);
+  const lines = prefix.split(/\r?\n/);
+  return {
+    line: lines.length,
+    column: (lines[lines.length - 1]?.length ?? 0) + 1,
+  };
+};
+
+describe("security-scan/utils/get-location-at-index", () => {
+  it("reports line 1 column 1 at index 0", () => {
+    expect(getLocationAtIndex("hello world", 0)).toEqual({ line: 1, column: 1 });
+  });
+
+  it("reports line 1 column 1 for a negative index", () => {
+    expect(getLocationAtIndex("hello world", -1)).toEqual({ line: 1, column: 1 });
+  });
+
+  it("reports line 1 column 1 for a NaN index", () => {
+    expect(getLocationAtIndex("ab\ncd", Number.NaN)).toEqual({ line: 1, column: 1 });
+  });
+
+  it("reports a 1-based column within the first line", () => {
+    expect(getLocationAtIndex("hello world", 6)).toEqual({ line: 1, column: 7 });
+  });
+
+  it("locates an index on a later LF line", () => {
+    expect(getLocationAtIndex("ab\ncd\nef", 4)).toEqual({ line: 2, column: 2 });
+  });
+
+  it("treats the index of a bare \\n as the end of its line", () => {
+    expect(getLocationAtIndex("ab\ncd", 2)).toEqual({ line: 1, column: 3 });
+  });
+
+  it("starts a new line right after a bare \\n", () => {
+    expect(getLocationAtIndex("ab\ncd", 3)).toEqual({ line: 2, column: 1 });
+  });
+
+  it("locates an index after a \\r\\n separator", () => {
+    expect(getLocationAtIndex("ab\r\ncd", 5)).toEqual({ line: 2, column: 2 });
+  });
+
+  it("treats the index of the \\r in \\r\\n as the end of its line", () => {
+    expect(getLocationAtIndex("ab\r\ncd", 2)).toEqual({ line: 1, column: 3 });
+  });
+
+  it("counts the \\r as a column when the index sits on the \\n of \\r\\n", () => {
+    expect(getLocationAtIndex("ab\r\ncd", 3)).toEqual({ line: 1, column: 4 });
+  });
+
+  it("starts a new line right after a \\r\\n separator", () => {
+    expect(getLocationAtIndex("ab\r\ncd", 4)).toEqual({ line: 2, column: 1 });
+  });
+
+  it("does not treat a lone \\r as a line separator", () => {
+    expect(getLocationAtIndex("ab\rcd", 4)).toEqual({ line: 1, column: 5 });
+  });
+
+  it("locates the end of content", () => {
+    expect(getLocationAtIndex("ab\ncd", 5)).toEqual({ line: 2, column: 3 });
+  });
+
+  it("locates the end of content after a trailing \\n", () => {
+    expect(getLocationAtIndex("ab\n", 3)).toEqual({ line: 2, column: 1 });
+  });
+
+  it("clamps a past-end index to the end of content", () => {
+    expect(getLocationAtIndex("ab\ncd", 50)).toEqual({ line: 2, column: 3 });
+    expect(getLocationAtIndex("hello world", 50)).toEqual({ line: 1, column: 12 });
+  });
+
+  it("handles empty content", () => {
+    expect(getLocationAtIndex("", 0)).toEqual({ line: 1, column: 1 });
+    expect(getLocationAtIndex("", 5)).toEqual({ line: 1, column: 1 });
+  });
+
+  it("handles consecutive newlines", () => {
+    expect(getLocationAtIndex("a\n\nb", 2)).toEqual({ line: 2, column: 1 });
+    expect(getLocationAtIndex("a\n\nb", 3)).toEqual({ line: 3, column: 1 });
+  });
+
+  it("handles mixed \\r\\n and \\n separators in one content", () => {
+    expect(getLocationAtIndex("a\r\nb\nc\r\nd", 8)).toEqual({ line: 4, column: 1 });
+  });
+
+  it("stays correct when queries alternate between contents", () => {
+    const firstContent = "ab\ncd\nef";
+    const secondContent = "one\r\ntwo\r\nthree";
+    expect(getLocationAtIndex(firstContent, 7)).toEqual({ line: 3, column: 2 });
+    expect(getLocationAtIndex(secondContent, 6)).toEqual({ line: 2, column: 2 });
+    expect(getLocationAtIndex(firstContent, 7)).toEqual({ line: 3, column: 2 });
+    expect(getLocationAtIndex(secondContent, 12)).toEqual({ line: 3, column: 3 });
+  });
+
+  it("matches the reference implementation on seeded pseudo-random contents", () => {
+    let seedState = 0x2f6e2b1;
+    const nextRandom = (): number => {
+      seedState = (seedState * 48271) % 0x7fffffff;
+      return seedState / 0x7fffffff;
+    };
+    const alphabet = ["a", "b", " ", "\n", "\r", "\r\n", "\t", "é", "x\ny"];
+    for (let contentRound = 0; contentRound < 60; contentRound += 1) {
+      const pieceCount = Math.floor(nextRandom() * 40);
+      let content = "";
+      for (let pieceIndex = 0; pieceIndex < pieceCount; pieceIndex += 1) {
+        content += alphabet[Math.floor(nextRandom() * alphabet.length)];
+      }
+      for (let queryRound = 0; queryRound < 25; queryRound += 1) {
+        const matchIndex = Math.floor(nextRandom() * (content.length + 3)) - 1;
+        expect(getLocationAtIndex(content, matchIndex)).toEqual(
+          referenceLocationAtIndex(content, matchIndex),
+        );
+      }
+    }
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/get-location-at-index.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/get-location-at-index.ts
@@ -3,13 +3,52 @@ export interface SourceLocation {
   readonly column: number;
 }
 
-// O(content) per call — memoizing line offsets is a tracked follow-up.
+interface ContentLineIndex {
+  readonly content: string;
+  readonly lineStartOffsets: ReadonlyArray<number>;
+}
+
+// Single-entry memo: the security scan is synchronous and processes one
+// file's content at a time (per-match exec loops query the same string
+// consecutively), so caching the last content's line index is enough and
+// stays bounded — it holds at most one content string reference.
+let lastContentLineIndex: ContentLineIndex | undefined;
+
+const buildLineStartOffsets = (content: string): number[] => {
+  const lineStartOffsets = [0];
+  for (
+    let newlineIndex = content.indexOf("\n");
+    newlineIndex !== -1;
+    newlineIndex = content.indexOf("\n", newlineIndex + 1)
+  ) {
+    lineStartOffsets.push(newlineIndex + 1);
+  }
+  return lineStartOffsets;
+};
+
+const getLineStartOffsets = (content: string): ReadonlyArray<number> => {
+  if (lastContentLineIndex?.content === content) return lastContentLineIndex.lineStartOffsets;
+  const lineStartOffsets = buildLineStartOffsets(content);
+  lastContentLineIndex = { content, lineStartOffsets };
+  return lineStartOffsets;
+};
+
 export const getLocationAtIndex = (content: string, matchIndex: number): SourceLocation => {
-  if (matchIndex < 0) return { line: 1, column: 1 };
-  const prefix = content.slice(0, matchIndex);
-  const lines = prefix.split(/\r?\n/);
+  if (Number.isNaN(matchIndex) || matchIndex < 0) return { line: 1, column: 1 };
+  const lineStartOffsets = getLineStartOffsets(content);
+  const boundedIndex = Math.min(Math.trunc(matchIndex), content.length);
+  let lowLineIndex = 0;
+  let highLineIndex = lineStartOffsets.length - 1;
+  while (lowLineIndex < highLineIndex) {
+    const midLineIndex = (lowLineIndex + highLineIndex + 1) >> 1;
+    if (lineStartOffsets[midLineIndex] <= boundedIndex) {
+      lowLineIndex = midLineIndex;
+    } else {
+      highLineIndex = midLineIndex - 1;
+    }
+  }
   return {
-    line: lines.length,
-    column: (lines[lines.length - 1]?.length ?? 0) + 1,
+    line: lowLineIndex + 1,
+    column: boundedIndex - lineStartOffsets[lowLineIndex] + 1,
   };
 };


### PR DESCRIPTION
## Why

The security scan runs synchronously on the parent process before lint and blocks the event loop (a CPU profile of a real 617-file scan measured it as the dominant parent-side cost). `getLocationAtIndex` was `content.slice(0, i).split(/\r?\n/)` — O(content) per call, called once per regex match per rule over raw file content.

Before:

```
built rule path (unsafe-json-in-html.scan, 20 largest corpus files with 30
injected sinks, 10 iters): 112.4 / 107.9 ms
pure location math (1180 real match indices × 5): 180.8 ms
```

After:

```
same rule path: 14.2 / 14.8 ms  (~7.6x, identical 5690 findings both sides)
pure location math: 2.6 ms      (68x)
non-firing path: 0.3 ms both (no regression when nothing matches)
```

## What changed

- `getLocationAtIndex` builds a line-start offset table once per content (`indexOf`-driven single pass) and answers each query with a binary search; column math reproduces the old `\r?\n` semantics byte-for-byte (including CRLF boundary indices, lone `\r`, index 0/negative/NaN, and past-end clamping).
- Single-entry `{ content, lineStartOffsets }` memo: the scan driver in core processes files strictly sequentially and the per-match exec loops pass the identical string reference, so one entry suffices and memory stays bounded at one retained content string.
- New colocated test file (20 tests): 19 cases pinning the old implementation's exact outputs plus a seeded differential test running ~1500 queries against the old algorithm inlined as reference.

## Test plan

- `pnpm test` in `packages/oxlint-plugin-react-doctor`: 8724 passed / 94 skipped (pristine baseline on this machine: 8704 / 94; +20 new tests, zero new failures). Note: CI does not run the plugin suite.
- Root `pnpm typecheck` and `pnpm lint` clean.
- Equivalence: `--json` scan of AdaptiveConsulting/ReactiveTraderCloud @ 4a31f016 before/after — 291 diagnostics byte-identical including `line`/`column`/`offset`; plus a purpose-built LF+CRLF fixture tripping `supabase-table-missing-rls` and `public-env-secret-name` — 5 location-bearing findings byte-identical.
- End-to-end A/B (6 interleaved dist-swap pairs) within noise on this corpus, as expected — it yields almost no security findings, so the e2e run proves the non-firing path doesn't regress; the micro-benchmarks above are the primary evidence.

Deliberately out of scope (follow-ups): fusing `scanByPattern`'s `test()` + `getMatchLocation`'s `search()` double pass (needs a g-flag audit across ~40 rule patterns), and converging with `deslop-js`'s private `compute-line-starts` (would add a wrong-direction cross-package dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized performance refactor in diagnostic positioning with broad equivalence tests; no auth or data-path changes.
> 
> **Overview**
> **Speeds up security-scan match → line/column mapping** by replacing per-call `slice` + `split(/\r?\n/)` (O(content) per regex match) with a one-pass line-start offset table and binary search per query.
> 
> A **single-entry memo** caches offsets for the last `content` string reference, which matches how the scan walks one file at a time with repeated lookups on the same string. Behavior stays aligned with the old algorithm: 1-based line/column, `\r?\n` line breaks (including CRLF edge cases), negative/NaN indices, and past-end clamping—plus explicit handling for `NaN` match indices.
> 
> Adds a **colocated test suite** (reference implementation + seeded differential checks) and a **patch changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd1853e065446d988b6e8c7c6bf033c842920294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->