### PR TITLE
perf(plugin): memoize getElementType per JSX opening element across a11y rules

### DIFF
--- a/.changeset/perf-get-element-type-memo.md
+++ b/.changeset/perf-get-element-type-memo.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: memoize getElementType per JSX opening element (with a settings-identity guard) so the ~30 a11y rules resolve each element once instead of once per rule

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-element-type.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-element-type.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseFixture } from "../../test-utils/parse-fixture.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { getElementType } from "./get-element-type.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { walkAst } from "./walk-ast.js";
+
+const parseOpeningElement = (jsx: string): EsTreeNodeOfType<"JSXOpeningElement"> => {
+  const { program, errors } = parseFixture(`const rendered = ${jsx};`);
+  expect(errors).toEqual([]);
+  let openingElement: EsTreeNodeOfType<"JSXOpeningElement"> | null = null;
+  walkAst(program, (child: EsTreeNode) => {
+    if (openingElement) return false;
+    if (isNodeOfType(child, "JSXOpeningElement")) openingElement = child;
+  });
+  if (!openingElement) throw new Error("fixture has no JSX opening element");
+  return openingElement;
+};
+
+describe("getElementType", () => {
+  it("resolves intrinsic elements to their tag name", () => {
+    expect(getElementType(parseOpeningElement("<div />"), undefined)).toBe("div");
+    expect(getElementType(parseOpeningElement("<img src='x.png' />"), undefined)).toBe("img");
+  });
+
+  it("resolves custom components to their identifier name", () => {
+    expect(getElementType(parseOpeningElement("<Button />"), undefined)).toBe("Button");
+  });
+
+  it("flattens member-expression and namespaced names", () => {
+    expect(getElementType(parseOpeningElement("<Menu.Item />"), undefined)).toBe("Menu.Item");
+    expect(getElementType(parseOpeningElement("<svg:rect />"), undefined)).toBe("svg:rect");
+  });
+
+  it("returns the base name when settings carry no jsx-a11y block", () => {
+    expect(getElementType(parseOpeningElement("<Button />"), {})).toBe("Button");
+    expect(getElementType(parseOpeningElement("<Button />"), { "jsx-a11y": "bogus" })).toBe(
+      "Button",
+    );
+  });
+
+  it("maps components through settings['jsx-a11y'].components", () => {
+    const settings = { "jsx-a11y": { components: { Button: "button" } } };
+    expect(getElementType(parseOpeningElement("<Button />"), settings)).toBe("button");
+    expect(getElementType(parseOpeningElement("<Anchor />"), settings)).toBe("Anchor");
+  });
+
+  it("prefers the polymorphic prop's string value over the tag", () => {
+    const settings = { "jsx-a11y": { polymorphicPropName: "as" } };
+    expect(getElementType(parseOpeningElement("<Box as='span' />"), settings)).toBe("span");
+    expect(getElementType(parseOpeningElement("<Box AS='span' />"), settings)).toBe("span");
+  });
+
+  it("falls back past a non-string polymorphic prop value", () => {
+    const settings = {
+      "jsx-a11y": { polymorphicPropName: "as", components: { Box: "div" } },
+    };
+    expect(getElementType(parseOpeningElement("<Box as={tag} />"), settings)).toBe("div");
+    expect(getElementType(parseOpeningElement("<Box as />"), settings)).toBe("div");
+  });
+
+  it("prefers the polymorphic prop over a components mapping", () => {
+    const settings = {
+      "jsx-a11y": { polymorphicPropName: "as", components: { Box: "div" } },
+    };
+    expect(getElementType(parseOpeningElement("<Box as='nav' />"), settings)).toBe("nav");
+  });
+
+  it("returns a stable result on repeated calls with the same settings object", () => {
+    const settings = { "jsx-a11y": { components: { Button: "button" } } };
+    const openingElement = parseOpeningElement("<Button />");
+    expect(getElementType(openingElement, settings)).toBe("button");
+    expect(getElementType(openingElement, settings)).toBe("button");
+  });
+
+  it("does not leak a cached result across different settings objects for the same node", () => {
+    const openingElement = parseOpeningElement("<Button />");
+    const buttonSettings = { "jsx-a11y": { components: { Button: "button" } } };
+    const anchorSettings = { "jsx-a11y": { components: { Button: "a" } } };
+    expect(getElementType(openingElement, buttonSettings)).toBe("button");
+    expect(getElementType(openingElement, anchorSettings)).toBe("a");
+    expect(getElementType(openingElement, undefined)).toBe("Button");
+    expect(getElementType(openingElement, buttonSettings)).toBe("button");
+  });
+
+  it("does not leak a cached undefined-settings result into a mapped lookup", () => {
+    const openingElement = parseOpeningElement("<Button />");
+    expect(getElementType(openingElement, undefined)).toBe("Button");
+    expect(
+      getElementType(openingElement, { "jsx-a11y": { components: { Button: "button" } } }),
+    ).toBe("button");
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-element-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-element-type.ts
@@ -9,13 +9,25 @@ interface JsxA11ySettings {
   polymorphicPropName?: string;
 }
 
+interface ElementTypeCacheEntry {
+  settings: Readonly<Record<string, unknown>> | undefined;
+  elementType: string;
+}
+
+const EMPTY_JSX_A11Y_SETTINGS: JsxA11ySettings = Object.freeze({});
+
+const jsxA11ySettingsCache = new WeakMap<Readonly<Record<string, unknown>>, JsxA11ySettings>();
+
 const readJsxA11ySettings = (
   settings: Readonly<Record<string, unknown>> | undefined,
 ): JsxA11ySettings => {
-  if (!settings) return {};
+  if (!settings) return EMPTY_JSX_A11Y_SETTINGS;
+  const cachedSettings = jsxA11ySettingsCache.get(settings);
+  if (cachedSettings) return cachedSettings;
   const block = (settings as { ["jsx-a11y"]?: JsxA11ySettings })["jsx-a11y"];
-  if (!block || typeof block !== "object") return {};
-  return block;
+  const a11ySettings = block && typeof block === "object" ? block : EMPTY_JSX_A11Y_SETTINGS;
+  jsxA11ySettingsCache.set(settings, a11ySettings);
+  return a11ySettings;
 };
 
 const flattenJsxName = (name: EsTreeNode): string => {
@@ -30,20 +42,10 @@ const flattenJsxName = (name: EsTreeNode): string => {
   return "";
 };
 
-// Resolves a JSX opening element to the (possibly-aliased) HTML tag
-// name. Mirrors oxc_linter::utils::react::get_element_type.
-//
-// - Honors `settings["jsx-a11y"].polymorphicPropName` (defaults to
-//   none): when the element has that prop with a string-literal
-//   value, the value overrides the element's tag.
-// - Honors `settings["jsx-a11y"].components`: a mapping from
-//   component name → resolved tag (e.g. `{ Button: "button" }`).
-// - Falls back to the JSX identifier / member-expression name.
-export const getElementType = (
+const computeElementType = (
   openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
-  settings: Readonly<Record<string, unknown>> | undefined,
+  a11ySettings: JsxA11ySettings,
 ): string => {
-  const a11ySettings = readJsxA11ySettings(settings);
   const baseName = flattenJsxName(openingElement.name as EsTreeNode);
 
   if (a11ySettings.polymorphicPropName) {
@@ -61,4 +63,38 @@ export const getElementType = (
     return a11ySettings.components[baseName]!;
   }
   return baseName;
+};
+
+// Per-node memo shared by the ~30 a11y rules that resolve the same opening
+// element once per rule. Entries die with the AST via the WeakMap. The result
+// also depends on settings, so each entry carries a settings-identity guard:
+// both hosts hand every rule the same per-file settings object (oxlint parses
+// the settings JSON once per file and exposes it through the shared
+// FILE_CONTEXT prototype getter; ESLint 9 puts config.settings on the one
+// FileContext all rule contexts inherit from), so within a file the guard
+// always matches after the first rule computes it, and a different settings
+// object (next file, tests) recomputes instead of serving a stale entry.
+const elementTypeCache = new WeakMap<
+  EsTreeNodeOfType<"JSXOpeningElement">,
+  ElementTypeCacheEntry
+>();
+
+// Resolves a JSX opening element to the (possibly-aliased) HTML tag
+// name. Mirrors oxc_linter::utils::react::get_element_type.
+//
+// - Honors `settings["jsx-a11y"].polymorphicPropName` (defaults to
+//   none): when the element has that prop with a string-literal
+//   value, the value overrides the element's tag.
+// - Honors `settings["jsx-a11y"].components`: a mapping from
+//   component name → resolved tag (e.g. `{ Button: "button" }`).
+// - Falls back to the JSX identifier / member-expression name.
+export const getElementType = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  settings: Readonly<Record<string, unknown>> | undefined,
+): string => {
+  const cachedEntry = elementTypeCache.get(openingElement);
+  if (cachedEntry && cachedEntry.settings === settings) return cachedEntry.elementType;
+  const elementType = computeElementType(openingElement, readJsxA11ySettings(settings));
+  elementTypeCache.set(openingElement, { settings, elementType });
+  return elementType;
 };


### PR DESCRIPTION
## Why

~30 a11y rules call `getElementType` on the same `JSXOpeningElement` for every JSX element in every file, re-deriving the settings mapping and element resolution ~30x per element. A multi-agent perf audit confirmed the finding and its adversarial verifier endorsed exactly this design ("node with a settings-identity guard").

Before:

```
10 most JSX-dense corpus files, 30 calls per opening element × 40 reps (384,000 calls):
undefined settings:                 41.3 ms (Node)  /  9.5 ms (Bun)
components + polymorphicPropName:   74.1 ms (Node)  / 34.4 ms (Bun)
```

After:

```
undefined settings:                 27.1 ms (1.5x)  /  8.1 ms
components + polymorphicPropName:   27.4 ms (2.7x)  / 10.7 ms (3.2x)
identical checksums both sides
```

## What changed

- `getElementType` consults a module-level `WeakMap<JSXOpeningElement, { settings, elementType }>`; the hit path is one lookup plus one settings-identity compare. Entries die with the AST. A different settings object recomputes and overwrites, so nothing can cross-contaminate; `undefined` settings falls out of the identity compare naturally.
- The identity guard always hits within a file on both hosts (verified in host source): oxlint 1.66 parses the settings JSON once per file, deep-freezes it, and exposes it via the shared `FILE_CONTEXT` prototype getter all rules inherit; ESLint 9 puts `config.settings` on the one `FileContext` all rule contexts inherit from, and the eslint mirror forwards the host context by reference.
- `readJsxA11ySettings` is memoized per settings object with a shared frozen empty fallback, so even first-per-element calls skip the per-call shape re-derivation.
- New colocated test file (11 tests) pinning current behavior: intrinsic/custom/member/namespaced names, `components` mapping, polymorphic prop (string value, case-insensitive attribute, non-string fallback, precedence), missing/malformed settings blocks, and same-node cross-settings non-contamination (A→B→undefined→A).

## Test plan

- `pnpm test` in `packages/oxlint-plugin-react-doctor`: 8715 passed / 94 skipped (pristine baseline on this machine: 8704 / 94; +11 new tests, zero new failures). Note: CI does not run the plugin suite.
- Root `pnpm typecheck` and `pnpm lint` clean.
- Equivalence: `--json` scan of AdaptiveConsulting/ReactiveTraderCloud @ 4a31f016 before/after — 291 diagnostics, sorted diff empty.
- End-to-end A/B (6 interleaved dist-swap pairs): a wash on this corpus, honestly reported — the win is the 1.5–3x micro-improvement multiplied across every JSX element × the a11y rule fleet, and it unblocks the audit catalog's ~10 "rely on the getElementType memo" follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure performance memoization with identity guards and extensive tests; lint semantics should stay identical when per-file settings identity holds as documented.
> 
> **Overview**
> **`getElementType`** now caches resolved tag names per **`JSXOpeningElement`** in a module-level **`WeakMap`**, keyed with a **settings object identity** check so the ~30 a11y rules that call it on the same node reuse one result per file instead of recomputing ~30 times per element.
> 
> Resolution logic moves into **`computeElementType`**; **`readJsxA11ySettings`** is also memoized per settings object with a shared frozen empty fallback. A new **`get-element-type.test.ts`** (11 cases) locks behavior and guards against cache leakage across different settings objects.
> 
> Reported micro-benchmarks show roughly **1.5–3.2×** faster repeated lookups; diagnostic equivalence on a corpus scan is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50db113ec6b7c7ea23ffb3367f014f4b7615278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->