### PR TITLE
perf(plugin): memoize functionContainsReactRenderOutput per function node

### DIFF
--- a/.changeset/perf-render-output-walk-cache.md
+++ b/.changeset/perf-render-output-walk-cache.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: memoize `functionContainsReactRenderOutput` per function node so the ~5 rules sharing it walk each function subtree once per file instead of once per query

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vite-plus/test";
+import { analyzeScopes } from "../semantic/scope-analysis.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import { attachParentReferences } from "./attach-parent-references.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { functionContainsReactRenderOutput } from "./function-contains-react-render-output.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { parseFixture } from "../../test-utils/parse-fixture.js";
+import { walkAst } from "./walk-ast.js";
+
+interface FunctionFixture {
+  functionNode: EsTreeNode;
+  scopes: ScopeAnalysis;
+  program: EsTreeNode;
+}
+
+const parseFunctionFixture = (code: string, functionName: string): FunctionFixture => {
+  const { program, errors } = parseFixture(code);
+  expect(errors).toEqual([]);
+  attachParentReferences(program);
+  let functionNode: EsTreeNode | null = null;
+  walkAst(program, (child) => {
+    if (functionNode) return false;
+    if (!isNodeOfType(child, "FunctionDeclaration")) return;
+    if (child.id?.name === functionName) functionNode = child;
+  });
+  if (!functionNode) throw new Error(`fixture has no function named ${functionName}`);
+  return { functionNode, scopes: analyzeScopes(program), program };
+};
+
+describe("functionContainsReactRenderOutput", () => {
+  it("detects JSX render output, stable across repeated calls", () => {
+    const { functionNode, scopes } = parseFunctionFixture(
+      `function Card() { return <div>hi</div>; }`,
+      "Card",
+    );
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(true);
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(true);
+  });
+
+  it("returns false for an uppercase factory without render output, stable across repeated calls", () => {
+    const { functionNode, scopes } = parseFunctionFixture(
+      `function CreateValidator(options: { strict?: boolean }) { return { isStrict: Boolean(options.strict) }; }`,
+      "CreateValidator",
+    );
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(false);
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(false);
+  });
+
+  it("memoizes per (functionNode, scopes): a repeat query with the same inputs skips the re-walk", () => {
+    const { functionNode, scopes, program } = parseFunctionFixture(
+      `function Card() { return <div>hi</div>; }`,
+      "Card",
+    );
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(true);
+    if (!isNodeOfType(functionNode, "FunctionDeclaration")) {
+      throw new Error("fixture function is not a FunctionDeclaration");
+    }
+    // Emptying the body makes the cache hit observable: a re-walk would now
+    // find no JSX and return false, so `true` proves the memoized answer.
+    functionNode.body.body = [];
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(true);
+    expect(functionContainsReactRenderOutput(functionNode, analyzeScopes(program))).toBe(false);
+  });
+
+  it("does not contaminate results across different scope analyses on the same node", () => {
+    const { functionNode, scopes } = parseFunctionFixture(
+      `import React from "react";
+       function Banner() { return React.createElement("div"); }`,
+      "Banner",
+    );
+    const scopesWithoutSymbols: ScopeAnalysis = {
+      rootScope: scopes.rootScope,
+      scopeFor: scopes.scopeFor,
+      ownScopeFor: scopes.ownScopeFor,
+      symbolFor: () => null,
+      referenceFor: () => null,
+      isGlobalReference: () => false,
+    };
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(true);
+    expect(functionContainsReactRenderOutput(functionNode, scopesWithoutSymbols)).toBe(false);
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(true);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
@@ -108,7 +108,27 @@ const containsRenderOutput = (
   return false;
 };
 
+interface RenderOutputCacheEntry {
+  scopes: ScopeAnalysis;
+  hasRenderOutput: boolean;
+}
+
+// The walk result is a pure function of (functionNode, scopes), and the host
+// shares one ScopeAnalysis per Program across every rule (see
+// wrap-with-semantic-context.ts), so the ~5 rules re-querying the same
+// function node collapse to one subtree walk per file. The scopes-identity
+// guard recomputes if a different analysis ever shows up for the same node
+// (the pre-capture fallback scopes, or tests building their own analysis).
+// Entries die with the AST via the WeakMap.
+const renderOutputCache = new WeakMap<EsTreeNode, RenderOutputCacheEntry>();
+
 export const functionContainsReactRenderOutput = (
   functionNode: EsTreeNode,
   scopes: ScopeAnalysis,
-): boolean => containsRenderOutput(functionNode, functionNode, scopes);
+): boolean => {
+  const cachedEntry = renderOutputCache.get(functionNode);
+  if (cachedEntry && cachedEntry.scopes === scopes) return cachedEntry.hasRenderOutput;
+  const hasRenderOutput = containsRenderOutput(functionNode, functionNode, scopes);
+  renderOutputCache.set(functionNode, { scopes, hasRenderOutput });
+  return hasRenderOutput;
+};


### PR DESCRIPTION
## Why

`functionContainsReactRenderOutput` does a full-subtree walk per call and is shared by 5 rules (`no-giant-component`, `no-many-boolean-props`, `no-call-component-as-function`, `no-create-ref-in-function-component`, `no-this-in-sfc`) — the same function nodes get re-walked once per calling rule per file. Confirmed by adversarial verification in the multi-agent perf audit (ranked #4 overall).

Before:

```
10 largest corpus .tsx files, 160 function nodes, 1600 queries/round
(5 rules x 2 call sites), fresh AST per round:
Node: 13.195 ms/round     Bun: 8.613 ms/round
```

After:

```
Node: 1.526 ms/round (8.65x)     Bun: 1.039 ms/round (8.29x)
identical result checksums in all runs
```

## What changed

- Module-level `WeakMap<functionNode, { scopes, hasRenderOutput }>` with a scopes-identity guard: all 5 callers pass exactly `(functionNode, context.scopes)`, and the host shares one `ScopeAnalysis` per Program across rules (`scopesByProgram` in `wrap-with-semantic-context.ts`), so a hit requires the same analysis and anything else (the pre-capture fallback stub, tests building their own analysis) recomputes and overwrites. Same pattern as the sanctioned `importLookupCache`.
- The walk itself is untouched (it already short-circuits on the first JSX/`createElement` and prunes at nested function/class boundaries).
- New colocated test file (4 cases): repeat-call stability for both answers, an observable memo-hit proof, and cross-input non-contamination on the same node with different scope analyses.

## Test plan

- `pnpm test` in `packages/oxlint-plugin-react-doctor`: 8708 passed / 94 skipped (pristine baseline on this machine: 8704 / 94; +4 new tests, zero new failures). Note: CI runs the plugin suite only on the Windows lane.
- Root `pnpm typecheck` and `pnpm lint` clean.
- Equivalence: `--json` scan of AdaptiveConsulting/ReactiveTraderCloud @ 4a31f016 (617 files) before/after — 291 diagnostics, sorted tuple diff empty.
- End-to-end A/B (6 interleaved dist-swap pairs): noise-bound (~0.3%), as expected for a single util on a full scan; the micro-benchmark is the primary evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure memoization of an existing pure helper with scopes-identity invalidation; no rule logic or diagnostic behavior changes beyond performance.
> 
> **Overview**
> **Memoizes** `functionContainsReactRenderOutput` so repeated checks on the same function with the same `ScopeAnalysis` skip redundant subtree walks—important because several rules (`no-giant-component`, `no-many-boolean-props`, `no-call-component-as-function`, and related SFC rules) all call it on the same nodes per file.
> 
> Implementation is a module-level `WeakMap` on the function AST node storing `{ scopes, hasRenderOutput }`, with a **reference equality** check on `scopes` so a different analysis (fallback scopes or test doubles) recomputes instead of reusing a stale answer. The underlying walk logic is unchanged.
> 
> Adds a colocated test file covering repeat-call stability, an observable cache hit (mutate body after first call), and no cross-contamination when the same node is queried with different scope analyses. Patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bcd2e88aae4a2111af62c097cb9c207b6fb7d06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->