### PR TITLE
perf(plugin): gate route-scoped rules at create() instead of per node

### DIFF
--- a/.changeset/perf-tanstack-in-project-dir-hoist.md
+++ b/.changeset/perf-tanstack-in-project-dir-hoist.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf(rules): hoist per-file directory classification out of per-node visitors — the TanStack Start and Next.js rules that called `isInProjectDirectory` (or tested the root-route filename pattern) on every JSX element / call expression now compute it once in `create()` and skip non-matching files entirely

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.regressions.test.ts
@@ -132,4 +132,19 @@ export default function Page() {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("stays silent outside page, layout, and pages files", () => {
+    const result = runRule(
+      nextjsNoClientFetchForServerData,
+      `"use client";
+import { useEffect } from "react";
+export function Widget() {
+  useEffect(() => { fetch("/api/data"); }, []);
+  return null;
+}`,
+      { filename: "components/widget.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-client-fetch-for-server-data.ts
@@ -8,6 +8,7 @@ import { hasDirective } from "../../utils/has-directive.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isInProjectDirectory } from "../../utils/is-in-project-directory.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 export const nextjsNoClientFetchForServerData = defineRule({
@@ -18,7 +19,12 @@ export const nextjsNoClientFetchForServerData = defineRule({
   severity: "warn",
   recommendation:
     "Remove 'use client' and fetch directly in the Server Component. No API round-trip, and secrets stay on the server.",
-  create: (context: RuleContext) => {
+  create: (context: RuleContext): RuleVisitors => {
+    const filename = normalizeFilename(context.filename ?? "");
+    const isPageOrLayoutFile =
+      PAGE_OR_LAYOUT_FILE_PATTERN.test(filename) || isInProjectDirectory(context, "pages");
+    if (!isPageOrLayoutFile) return {};
+
     let fileHasUseClient = false;
 
     return {
@@ -31,17 +37,11 @@ export const nextjsNoClientFetchForServerData = defineRule({
         const callback = getEffectCallback(node);
         if (!callback || !containsFetchCall(callback, { stopAtFunctionBoundary: true })) return;
 
-        const filename = normalizeFilename(context.filename ?? "");
-        const isPageOrLayoutFile =
-          PAGE_OR_LAYOUT_FILE_PATTERN.test(filename) || isInProjectDirectory(context, "pages");
-
-        if (isPageOrLayoutFile) {
-          context.report({
-            node,
-            message:
-              "useEffect + fetch in a page/layout makes your users wait through an extra round trip & loading spinner.",
-          });
-        }
+        context.report({
+          node,
+          message:
+            "useEffect + fetch in a page/layout makes your users wait through an extra round trip & loading spinner.",
+        });
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-head-content.ts
@@ -1,8 +1,8 @@
 import { TANSTACK_ROOT_ROUTE_FILE_PATTERN } from "../../constants/tanstack.js";
 import { defineRule } from "../../utils/define-rule.js";
-import { normalizeFilename } from "../../utils/normalize-filename.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -72,7 +72,11 @@ export const tanstackStartMissingHeadContent = defineRule({
   severity: "warn",
   recommendation:
     "Add `<HeadContent />` inside `<head>` in your __root route. Without it, route `head()` meta tags are dropped.",
-  create: (context: RuleContext) => {
+  create: (context: RuleContext): RuleVisitors => {
+    // The pattern anchors on the separator-free `__root.<ext>` basename, so
+    // testing the raw filename equals testing the backslash-normalized one.
+    if (!TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(context.filename ?? "")) return {};
+
     let hasHeadContentElement = false;
     let hasDocumentHeadElement = false;
     let hasCustomHeadChildElement = false;
@@ -140,10 +144,6 @@ export const tanstackStartMissingHeadContent = defineRule({
 
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
-        const filename = context.filename ?? "";
-        const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
-        if (!isRootRouteFile) return;
-
         const statements = node.body ?? [];
         // Pre-scan top-level imports before JSX visits so late import
         // declarations do not make alias detection source-order dependent.
@@ -160,22 +160,12 @@ export const tanstackStartMissingHeadContent = defineRule({
         }
       },
       ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
-        const filename = context.filename ?? "";
-        const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
-        if (!isRootRouteFile) return;
         collectImportBindings(node);
       },
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
-        const filename = context.filename ?? "";
-        const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
-        if (!isRootRouteFile) return;
         collectVariableAlias(node);
       },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        const filename = normalizeFilename(context.filename ?? "");
-        const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
-        if (!isRootRouteFile) return;
-
         if (isNodeOfType(node.name, "JSXIdentifier")) {
           if (node.name.name === DOCUMENT_HEAD_ELEMENT_NAME) {
             hasDocumentHeadElement = true;
@@ -208,10 +198,6 @@ export const tanstackStartMissingHeadContent = defineRule({
         }
       },
       "Program:exit"(programNode: EsTreeNode) {
-        const filename = normalizeFilename(context.filename ?? "");
-        const isRootRouteFile = TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(filename);
-        if (!isRootRouteFile) return;
-
         if (hasDocumentHeadElement && !hasHeadContentElement && !hasCustomHeadChildElement) {
           context.report({
             node: programNode,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.regressions.test.ts
@@ -51,4 +51,13 @@ describe("tanstack-start/tanstack-start-no-anchor-element — regressions", () =
     );
     expect(diagnostics.length).toBeGreaterThan(0);
   });
+
+  it("stays silent outside the routes directory", () => {
+    const { diagnostics } = runRule(
+      tanstackStartNoAnchorElement,
+      `const C = () => <a href="/dashboard">Go</a>;`,
+      { filename: "src/components/nav.tsx" },
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { isInProjectDirectory } from "../../utils/is-in-project-directory.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -29,48 +30,49 @@ export const tanstackStartNoAnchorElement = defineRule({
   severity: "warn",
   recommendation:
     "Use `Link` from `@tanstack/react-router` so internal navigation keeps client state, preloading, and typed routes.",
-  create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isInProjectDirectory(context, "routes")) return;
+  create: (context: RuleContext): RuleVisitors => {
+    if (!isInProjectDirectory(context, "routes")) return {};
+    return {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a") return;
 
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a") return;
+        const attributes = node.attributes ?? [];
+        const hrefAttribute = findJsxAttribute(attributes, "href");
+        if (!hrefAttribute?.value) return;
 
-      const attributes = node.attributes ?? [];
-      const hrefAttribute = findJsxAttribute(attributes, "href");
-      if (!hrefAttribute?.value) return;
+        let hrefValue: string | number | bigint | boolean | RegExp | null = null;
+        if (isNodeOfType(hrefAttribute.value, "Literal")) {
+          hrefValue = hrefAttribute.value.value;
+        } else if (
+          isNodeOfType(hrefAttribute.value, "JSXExpressionContainer") &&
+          isNodeOfType(hrefAttribute.value.expression, "Literal")
+        ) {
+          hrefValue = hrefAttribute.value.expression.value;
+        }
 
-      let hrefValue: string | number | bigint | boolean | RegExp | null = null;
-      if (isNodeOfType(hrefAttribute.value, "Literal")) {
-        hrefValue = hrefAttribute.value.value;
-      } else if (
-        isNodeOfType(hrefAttribute.value, "JSXExpressionContainer") &&
-        isNodeOfType(hrefAttribute.value.expression, "Literal")
-      ) {
-        hrefValue = hrefAttribute.value.expression.value;
-      }
+        if (typeof hrefValue !== "string" || !hrefValue.startsWith("/")) return;
 
-      if (typeof hrefValue !== "string" || !hrefValue.startsWith("/")) return;
+        // A protocol-relative URL (`//cdn.example.com/...`) is an EXTERNAL link
+        // that merely starts with "/".
+        if (hrefValue.startsWith("//")) return;
 
-      // A protocol-relative URL (`//cdn.example.com/...`) is an EXTERNAL link
-      // that merely starts with "/".
-      if (hrefValue.startsWith("//")) return;
+        // Non-route paths can't be a router Link: API endpoints/exports and
+        // static assets with a file extension (`/resume.pdf`, `/sitemap.xml`).
+        const pathname = hrefValue.split(/[?#]/)[0] ?? hrefValue;
+        if (pathname.startsWith("/api/")) return;
+        if (/\.[a-z0-9]{1,8}$/i.test(pathname)) return;
 
-      // Non-route paths can't be a router Link: API endpoints/exports and
-      // static assets with a file extension (`/resume.pdf`, `/sitemap.xml`).
-      const pathname = hrefValue.split(/[?#]/)[0] ?? hrefValue;
-      if (pathname.startsWith("/api/")) return;
-      if (/\.[a-z0-9]{1,8}$/i.test(pathname)) return;
+        // A `download` link or a new-tab link must stay a real <a>; a Link
+        // can't trigger a browser download or open in a new tab the same way.
+        if (findJsxAttribute(attributes, "download")) return;
+        if (getAttributeStringValue(findJsxAttribute(attributes, "target")) === "_blank") return;
 
-      // A `download` link or a new-tab link must stay a real <a>; a Link
-      // can't trigger a browser download or open in a new tab the same way.
-      if (findJsxAttribute(attributes, "download")) return;
-      if (getAttributeStringValue(findJsxAttribute(attributes, "target")) === "_blank") return;
-
-      context.report({
-        node,
-        message:
-          "Plain <a> reloads the whole page for internal navigation, so TanStack Router loses client state and preloading.",
-      });
-    },
-  }),
+        context.report({
+          node,
+          message:
+            "Plain <a> reloads the whole page for internal navigation, so TanStack Router loses client state and preloading.",
+        });
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-navigate-in-render.ts
@@ -14,6 +14,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import { isInProjectDirectory } from "../../utils/is-in-project-directory.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -33,7 +34,9 @@ export const tanstackStartNoNavigateInRender = defineRule({
   severity: "warn",
   recommendation:
     "Use `throw redirect({ to: '/path' })` in `beforeLoad` or `loader`. navigate() during render causes hydration issues.",
-  create: (context: RuleContext) => {
+  create: (context: RuleContext): RuleVisitors => {
+    if (!isInProjectDirectory(context, "routes")) return {};
+
     // HACK: only callbacks that React calls LATER are safe scopes for
     // navigate() — useEffect / useLayoutEffect (post-commit), useCallback
     // / useMemo (cached, fired by event handlers later), JSX `onXxx`
@@ -45,7 +48,6 @@ export const tanstackStartNoNavigateInRender = defineRule({
     // they must NOT be treated as deferred — they're still render-time
     // side effects. A pure function-depth counter would skip them and
     // miss real bugs; the explicit allow-list is the correct boundary.
-    const isRouteFile = isInProjectDirectory(context, "routes");
     let deferredCallbackDepth = 0;
     let eventHandlerDepth = 0;
 
@@ -191,8 +193,6 @@ export const tanstackStartNoNavigateInRender = defineRule({
 
     return {
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (!isRouteFile) return;
-
         if (isDeferredHookCall(node)) deferredCallbackDepth++;
 
         if (deferredCallbackDepth > 0 || eventHandlerDepth > 0) return;
@@ -211,47 +211,38 @@ export const tanstackStartNoNavigateInRender = defineRule({
         }
       },
       "CallExpression:exit"(node: EsTreeNode) {
-        if (!isRouteFile) return;
         if (isDeferredHookCall(node)) {
           deferredCallbackDepth = Math.max(0, deferredCallbackDepth - 1);
         }
       },
       JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
-        if (!isRouteFile) return;
         if (isEventHandlerAttribute(node)) eventHandlerDepth++;
       },
       "JSXAttribute:exit"(node: EsTreeNode) {
-        if (!isRouteFile) return;
         if (isEventHandlerAttribute(node)) {
           eventHandlerDepth = Math.max(0, eventHandlerDepth - 1);
         }
       },
       Property(node: EsTreeNodeOfType<"Property">) {
-        if (!isRouteFile) return;
         if (isEventHandlerProperty(node)) eventHandlerDepth++;
       },
       "Property:exit"(node: EsTreeNode) {
-        if (!isRouteFile) return;
         if (isEventHandlerProperty(node)) {
           eventHandlerDepth = Math.max(0, eventHandlerDepth - 1);
         }
       },
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
-        if (!isRouteFile) return;
         if (isHandlerNamedVariableDeclarator(node)) eventHandlerDepth++;
       },
       "VariableDeclarator:exit"(node: EsTreeNode) {
-        if (!isRouteFile) return;
         if (isHandlerNamedVariableDeclarator(node)) {
           eventHandlerDepth = Math.max(0, eventHandlerDepth - 1);
         }
       },
       FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
-        if (!isRouteFile) return;
         if (isHandlerNamedFunctionDeclaration(node)) eventHandlerDepth++;
       },
       "FunctionDeclaration:exit"(node: EsTreeNode) {
-        if (!isRouteFile) return;
         if (isHandlerNamedFunctionDeclaration(node)) {
           eventHandlerDepth = Math.max(0, eventHandlerDepth - 1);
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.regressions.test.ts
@@ -49,4 +49,13 @@ describe("tanstack-start/tanstack-start-no-useeffect-fetch — regressions", () 
     );
     expect(diagnostics).toHaveLength(0);
   });
+
+  it("stays silent outside the routes directory", () => {
+    const { diagnostics } = runRule(
+      tanstackStartNoUseEffectFetch,
+      `function Nav() { useEffect(() => { fetch(url).then(setData); }, []); return null; }`,
+      { filename: "src/components/nav.tsx" },
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-use-effect-fetch.ts
@@ -7,6 +7,7 @@ import { isInProjectDirectory } from "../../utils/is-in-project-directory.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -18,42 +19,43 @@ export const tanstackStartNoUseEffectFetch = defineRule({
   severity: "warn",
   recommendation:
     "Fetch data in the route `loader` instead. The router loads it before rendering and avoids waterfalls.",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isInProjectDirectory(context, "routes")) return;
+  create: (context: RuleContext): RuleVisitors => {
+    if (!isInProjectDirectory(context, "routes")) return {};
+    return {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
 
-      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+        const callback = node.arguments?.[0];
+        if (!callback) return;
 
-      const callback = node.arguments?.[0];
-      if (!callback) return;
-
-      let hasFetchCall = false;
-      const effectInvokedFunctions = collectEffectInvokedFunctions(callback);
-      walkAst(callback, (child: EsTreeNode) => {
-        if (hasFetchCall) return false;
-        // Skip nested handlers (addEventListener / setInterval) — a fetch
-        // there fires on an external event, not as a render-time data fetch
-        // the route loader could replace — but keep walking into functions
-        // the effect body itself invokes (IIFEs, called local functions,
-        // promise-chain callbacks): those ARE the render-time fetch.
-        if (child !== callback && isFunctionLike(child) && !effectInvokedFunctions.has(child))
-          return false;
-        if (
-          isNodeOfType(child, "CallExpression") &&
-          isNodeOfType(child.callee, "Identifier") &&
-          child.callee.name === "fetch"
-        ) {
-          hasFetchCall = true;
-        }
-      });
-
-      if (hasFetchCall) {
-        context.report({
-          node,
-          message:
-            "fetch() inside useEffect makes your users wait through a loading spinner after render.",
+        let hasFetchCall = false;
+        const effectInvokedFunctions = collectEffectInvokedFunctions(callback);
+        walkAst(callback, (child: EsTreeNode) => {
+          if (hasFetchCall) return false;
+          // Skip nested handlers (addEventListener / setInterval) — a fetch
+          // there fires on an external event, not as a render-time data fetch
+          // the route loader could replace — but keep walking into functions
+          // the effect body itself invokes (IIFEs, called local functions,
+          // promise-chain callbacks): those ARE the render-time fetch.
+          if (child !== callback && isFunctionLike(child) && !effectInvokedFunctions.has(child))
+            return false;
+          if (
+            isNodeOfType(child, "CallExpression") &&
+            isNodeOfType(child.callee, "Identifier") &&
+            child.callee.name === "fetch"
+          ) {
+            hasFetchCall = true;
+          }
         });
-      }
-    },
-  }),
+
+        if (hasFetchCall) {
+          context.report({
+            node,
+            message:
+              "fetch() inside useEffect makes your users wait through a loading spinner after render.",
+          });
+        }
+      },
+    };
+  },
 });


### PR DESCRIPTION
## Why

Five rules re-classified the file path — a per-file constant — on every matching AST node: `tanstack-start-no-anchor-element` (per `JSXOpeningElement`), `tanstack-start-no-use-effect-fetch` (per `CallExpression`), `tanstack-start-missing-head-content` (the `__root`-route regex in 5 separate visitors), `nextjs-no-client-fetch-for-server-data` (page/layout check per effect call, after an expensive `containsFetchCall` walk), and `tanstack-start-no-navigate-in-render` (a cached boolean re-tested in 10 visitors). Audit findings #365/#366/#367 (adversarially verified, high confidence).

Before:

```
if (!isInProjectDirectory(context, "routes")) return;  // inside every visitor call
```

After:

```
create: (context) => {
  if (!isInProjectDirectory(context, "routes")) return {};  // once per file
  return { ...visitors };
}
```

## What changed

- All five rules compute their file gate once in `create()` and register **no visitors** when the file can never match — strictly stronger than caching the boolean, since the host then skips these rules entirely on non-matching files. The pattern already ships in this codebase (`skipNonProductionFiles` wraps every test-noise rule and reads `context.filename` at `create()` time on both hosts).
- `missing-head-content` also drops a raw-vs-normalized filename inconsistency between its visitors: the `__root.<ext>` pattern is separator-free, so the verdict is provably identical either way.
- Reports are unchanged everywhere: every gate was a pure ANDed predicate on the report path.
- Deliberately untouched: `server-hoist-static-io` and `nextjs-no-head-import`, whose calls are already gated behind rarely-true conditions — hoisting would pessimize their common case.
- 3 new negative regression tests pin "non-route file → silent" for the gated rules.

## Test plan

- `pnpm test` in `packages/oxlint-plugin-react-doctor`: 8707 passed / 94 skipped (pristine baseline on this machine: 8704 / 94; +3 new tests, zero new failures). Note: CI runs the plugin suite only on the Windows lane.
- Root `pnpm typecheck` and `pnpm lint` clean (the explicit `RuleVisitors` return annotations follow the existing `no-inline-exhaustive-style` pattern).
- Equivalence on three targets, sorted tuple diff empty on each: the 617-file corpus (291 = 291), a synthetic TanStack fixture (13 = 13, `src/components/` correctly silent), and a synthetic Next.js fixture (6 = 6).
- Micro-bench: 1.2–1.5x on the touched visitor paths; the real win is that the host's merged visitor dispatch skips these rules entirely on non-matching files, which the standalone harness understates. Honest framing: sub-millisecond absolute wins, trivial-effort zero-risk sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only performance change with equivalence checks and new negative tests; reporting logic on in-scope files is unchanged.
> 
> **Overview**
> **Five** Next.js and TanStack Start lint rules now decide whether a file is in scope **once** in `create()` via `isInProjectDirectory`, page/layout patterns, or the `__root` route regex. Non-matching files get **`return {}`**, so the linter never registers per-node visitors on them instead of re-checking the path on every JSX or `CallExpression`.
> 
> For **`nextjs-no-client-fetch-for-server-data`**, the page/layout gate runs before `containsFetchCall` walks effect bodies. **`tanstack-start-missing-head-content`** drops repeated filename checks across five visitors and uses a single `__root` pattern test (raw vs normalized filename is equivalent for that pattern).
> 
> **Three** regression tests assert silence outside `routes` / page-layout paths. A patch **changeset** documents the plugin release. Diagnostic behavior on in-scope files is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84edbe47b0c5dcbedacddc1269bf17e18802f068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->