### PR TITLE
perf(plugin): cache compiled glob patterns in compileGlob

### DIFF
--- a/.changeset/perf-compile-glob-cache.md
+++ b/.changeset/perf-compile-glob-cache.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: cache compiled glob RegExps in `compileGlob` so rules matching user-configured patterns per node stop recompiling the same pattern on every call

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/compile-glob.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/compile-glob.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vite-plus/test";
+import { compileGlob } from "./compile-glob.js";
+
+describe("compileGlob", () => {
+  it("anchors exact patterns", () => {
+    const regex = compileGlob("onClick");
+    expect(regex.test("onClick")).toBe(true);
+    expect(regex.test("onClickCapture")).toBe(false);
+    expect(regex.test("myOnClick")).toBe(false);
+  });
+
+  it("expands * into a wildcard at any position", () => {
+    expect(compileGlob("on*").test("onChange")).toBe(true);
+    expect(compileGlob("on*").test("change")).toBe(false);
+    expect(compileGlob("*Handler").test("clickHandler")).toBe(true);
+    expect(compileGlob("*Handler").test("handlerClick")).toBe(false);
+    expect(compileGlob("Foo*Bar").test("FooMiddleBar")).toBe(true);
+  });
+
+  it("escapes regex metacharacters in the pattern", () => {
+    expect(compileGlob("a.b").test("a.b")).toBe(true);
+    expect(compileGlob("a.b").test("axb")).toBe(false);
+    expect(compileGlob("a+b").test("a+b")).toBe(true);
+    expect(compileGlob("a+b").test("aab")).toBe(false);
+  });
+
+  it("returns the same cached instance with consistent matching across repeat calls", () => {
+    const firstCall = compileGlob("render*");
+    const secondCall = compileGlob("render*");
+    expect(secondCall).toBe(firstCall);
+    expect(firstCall.test("renderItem")).toBe(true);
+    expect(secondCall.test("renderItem")).toBe(true);
+    expect(secondCall.test("item")).toBe(false);
+    expect(compileGlob("render*").test("renderRow")).toBe(true);
+  });
+
+  it("does not cross-contaminate different patterns", () => {
+    const onPrefix = compileGlob("on*");
+    const handlerSuffix = compileGlob("*Handler");
+    expect(onPrefix).not.toBe(handlerSuffix);
+    expect(onPrefix.test("onClick")).toBe(true);
+    expect(onPrefix.test("clickHandler")).toBe(false);
+    expect(handlerSuffix.test("clickHandler")).toBe(true);
+    expect(handlerSuffix.test("onClick")).toBe(false);
+  });
+
+  it("compiles without stateful flags so cached instances are shareable", () => {
+    const regex = compileGlob("on*Capture");
+    expect(regex.flags).toBe("");
+    expect(regex.test("onClickCapture")).toBe(true);
+    expect(regex.test("onClickCapture")).toBe(true);
+    expect(regex.lastIndex).toBe(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/compile-glob.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/compile-glob.ts
@@ -12,7 +12,17 @@
  * `*Handler`), so the cheap escape-then-replace shape is enough
  * and avoids pulling picomatch into the per-file rule path.
  */
+// Unbounded by design: every call site passes user-config strings
+// (settings/forbid entries), never file-derived data, so the distinct
+// pattern set is tiny and fixed per scan. Flagless RegExps carry no
+// lastIndex state, so sharing one instance across callers is safe.
+const compiledGlobs = new Map<string, RegExp>();
+
 export const compileGlob = (pattern: string): RegExp => {
+  const cached = compiledGlobs.get(pattern);
+  if (cached) return cached;
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replaceAll("*", ".*");
-  return new RegExp(`^${escaped}$`);
+  const compiled = new RegExp(`^${escaped}$`);
+  compiledGlobs.set(pattern, compiled);
+  return compiled;
 };


### PR DESCRIPTION
## Why

`compileGlob` rebuilt a `RegExp` from the pattern string on every call, and two of its four callers invoke it per JSX node in a loop over configured pattern lists (`label-has-associated-control`'s `controlComponents` during its nested-control search, `jsx-handler-names`' `ignoreComponentNames` per `JSXAttribute`). One module-level cache fixes every caller at once (audit top-25 #17).

Before:

```
controlComponents-shaped micro-bench (4 patterns x 200k element visits):
241.0 / 240.7 ms
```

After:

```
24.2 / 25.8 ms (~10x), identical match counts (100000/100000)
```

## What changed

- Module-level `Map<string, RegExp>` keyed by the raw pattern, get-or-compile. Unbounded by design: every call site's patterns come from user config (settings / forbid entries), never from scanned file content, so the distinct set is tiny and fixed per scan — traced all four callers to confirm.
- Sharing is safe: `compileGlob` builds flagless regexes (asserted in a test) and every caller only uses `.test()`, so there is no `lastIndex` state to leak.
- Same idiom the codebase already uses locally in `jsx-pascal-case.ts` (`compiledGlobCache`); that compiler handles a richer glob dialect and keeps its own cache, deliberately not merged.
- New colocated test file (6 tests): anchoring, wildcard positions, metachar escaping, repeat-call identity, cross-pattern non-contamination, flagless/lastIndex invariant.

## Test plan

- `pnpm test` in `packages/oxlint-plugin-react-doctor`: 8710 passed / 94 skipped (pristine baseline on this machine: 8704 / 94; +6 new tests, zero new failures). Note: CI runs the plugin suite only on the Windows lane.
- Root `pnpm typecheck` and `pnpm lint` clean.
- Equivalence: `--json` scan of AdaptiveConsulting/ReactiveTraderCloud @ 4a31f016 before/after — 291 diagnostics, sorted tuple diff empty.
- End-to-end A/B: pure noise, honestly reported — the per-node callers are gated behind opt-in config the bench project doesn't set; this is cheap insurance for configured users, not a headline speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure performance memoization with identical matching semantics; scope is limited to shared glob utility used by allow/deny-list rules.
> 
> **Overview**
> **`compileGlob`** now memoizes compiled `RegExp` instances in a module-level `Map` keyed by the raw pattern string, so rules that call it repeatedly per JSX node (e.g. `label-has-associated-control`, `jsx-handler-names`) no longer rebuild the same regex on every visit.
> 
> Matching behavior is unchanged: patterns are still escaped, `*` becomes `.*`, and results stay anchored. Comments note the cache is intentionally unbounded because inputs come only from user config, and shared regexes are safe because compilation uses no flags and callers use `.test()` only.
> 
> A new **`compile-glob.test.ts`** covers anchoring, wildcards, metacharacter escaping, cache identity, pattern isolation, and the flagless/`lastIndex` invariant. A patch **changeset** records the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca377b883201c45417e822bf7582c3522f7773b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->