### PR TITLE
perf(core): stop lint's pre-spawn burst and the scan walk from starving forked fibers

### DIFF
--- a/.changeset/secscan-overlap-starvation.md
+++ b/.changeset/secscan-overlap-starvation.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+Stop lint's pre-spawn setup from starving the overlapped security-scan and supply-chain passes.
+
+The security scan already runs on a cooperative background fiber that overlaps the lint pass, but a forked fiber only advances when the main thread yields — and lint's synchronous pre-spawn prefix (full-scan file discovery plus the per-file cache's content-hash partition over every candidate file) held the event loop until the first oxlint subprocess spawned. The overlapped passes now start immediately: the lint runner hands the loop back once before discovery and yields on the shared cooperative time budget while hashing, and the security scan's own directory walk (previously one unyielding readdir+classify burst before its first budget checkpoint) yields walk-progress markers so large trees can't stall lint subprocess draining or concurrently-scanning sibling projects. Diagnostics are byte-identical and the report order is unchanged.

--- a/packages/core/src/check-security-scan.ts
+++ b/packages/core/src/check-security-scan.ts
@@ -3,7 +3,7 @@ import type { FileScan, ScannedFile } from "oxlint-plugin-react-doctor";
 import { buildSecurityScanDiagnostic } from "./checks/security-scan/build-security-scan-diagnostic.js";
 import type { SecurityScanRuleEntry } from "./checks/security-scan/build-security-scan-diagnostic.js";
 import { collectSecurityScanFiles } from "./checks/security-scan/collect-security-scan-files.js";
-import { SECURITY_SCAN_YIELD_BUDGET_MS } from "./checks/security-scan/constants.js";
+import { COOPERATIVE_YIELD_BUDGET_MS } from "./constants.js";
 import { buildCapabilities, shouldEnableRule } from "./runners/oxlint/capabilities.js";
 import type { Diagnostic, ProjectInfo } from "./types/index.js";
 import { isPathGitIgnored } from "./utils/is-path-git-ignored.js";
@@ -103,6 +103,7 @@ export const checkSecurityScan = (
   const session = createSecurityScanSession(rootDirectory, options);
   if (session === null) return [];
   for (const file of collectSecurityScanFiles(rootDirectory)) {
+    if (file === null) continue;
     for (const _ruleStep of session.scanFileByRule(file)) {
       // Sync driver: exhaust the per-rule steps without yielding.
     }
@@ -112,12 +113,13 @@ export const checkSecurityScan = (
 
 // Cooperative variant: identical output to `checkSecurityScan`, but hands the
 // event loop back whenever a scan slice has held it for
-// `SECURITY_SCAN_YIELD_BUDGET_MS`, checked between every (file, rule) step, so
-// a caller that forks it (the orchestrator) can overlap its CPU with other
-// async work. A time budget rather than a file interval: lint's child
-// processes are spawned and drained from main-thread continuations, so any
-// long stall idles the whole worker pool — and one large minified bundle
-// could previously stall for its entire rule set.
+// `COOPERATIVE_YIELD_BUDGET_MS`, checked between every walk step and every
+// (file, rule) step, so a caller that forks it (the orchestrator) can overlap
+// its CPU with other async work. A time budget rather than a file interval:
+// lint's child processes are spawned and drained from main-thread
+// continuations, so any long stall idles the whole worker pool — and one
+// large minified bundle could previously stall for its entire rule set (as
+// could a large tree's whole directory walk, before the walk markers).
 export const checkSecurityScanCooperative = async (
   rootDirectory: string,
   options: CheckSecurityScanOptions = {},
@@ -126,8 +128,15 @@ export const checkSecurityScanCooperative = async (
   if (session === null) return [];
   let sliceStartedAt = performance.now();
   for (const file of collectSecurityScanFiles(rootDirectory)) {
+    if (file === null) {
+      if (performance.now() - sliceStartedAt >= COOPERATIVE_YIELD_BUDGET_MS) {
+        await yieldToEventLoop();
+        sliceStartedAt = performance.now();
+      }
+      continue;
+    }
     for (const _ruleStep of session.scanFileByRule(file)) {
-      if (performance.now() - sliceStartedAt >= SECURITY_SCAN_YIELD_BUDGET_MS) {
+      if (performance.now() - sliceStartedAt >= COOPERATIVE_YIELD_BUDGET_MS) {
         await yieldToEventLoop();
         sliceStartedAt = performance.now();
       }

--- a/packages/core/src/checks/security-scan/collect-security-scan-files.ts
+++ b/packages/core/src/checks/security-scan/collect-security-scan-files.ts
@@ -62,9 +62,15 @@ const readScannedFile = (candidate: SecurityScanCandidate): ScannedFile | null =
 // lazily, one file per iteration (capped at SECURITY_SCAN_MAX_FILES
 // successful reads per bucket), so a caller that streams findings never
 // holds more than one file's content at a time.
+//
+// `null` is a walk-progress marker, yielded once per directory processed: the
+// path-collection phase runs BEFORE any file can be yielded (the buckets need
+// the whole tree), so without markers a large tree's readdir + classify pass
+// would be one unyielding burst — the cooperative driver uses them as budget
+// checkpoints. Drivers that don't pace themselves just skip them.
 export function* collectSecurityScanFiles(
   rootDirectory: string,
-): Generator<ScannedFile, void, void> {
+): Generator<ScannedFile | null, void, void> {
   const priorityCandidates: SecurityScanCandidate[] = [];
   const artifactCandidates: SecurityScanCandidate[] = [];
   const otherCandidates: SecurityScanCandidate[] = [];
@@ -99,6 +105,7 @@ export function* collectSecurityScanFiles(
         isGeneratedBundleByName: classification.isGeneratedBundleByName,
       });
     }
+    yield null;
   }
 
   for (const candidates of [priorityCandidates, artifactCandidates, otherCandidates]) {

--- a/packages/core/src/checks/security-scan/constants.ts
+++ b/packages/core/src/checks/security-scan/constants.ts
@@ -3,12 +3,6 @@ export const SECURITY_SCAN_MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
 export const SECURITY_SCAN_MAX_BUNDLE_FILE_SIZE_BYTES = 8 * 1024 * 1024;
 export const SECURITY_SCAN_MAX_DIRECTORY_DEPTH = 8;
 
-// Longest synchronous burst the cooperative scan may hold the event loop
-// before yielding, checked between every (file, rule) step. The overlapping
-// lint pass spawns and drains its child processes from main-thread
-// continuations, so bursts beyond ~a frame idle the whole worker pool.
-export const SECURITY_SCAN_YIELD_BUDGET_MS = 12;
-
 export const SKIPPED_DIRECTORY_NAMES = new Set([
   ".git",
   ".turbo",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -306,6 +306,13 @@ export const OXLINT_OUTPUT_MAX_BYTES = 50 * 1024 * 1024;
 // binding is markedly slower than on a developer laptop.
 export const OXLINT_SPAWN_TIMEOUT_MS = 60_000;
 
+// Longest synchronous burst a cooperative main-thread pass (the security
+// scan's walk / file / rule steps, lint's pre-spawn cache hashing) may hold
+// the event loop before handing it back. Lint child processes are spawned and
+// drained from main-thread continuations, so bursts beyond ~a frame idle the
+// whole worker pool — and starve concurrently-scanning sibling projects.
+export const COOPERATIVE_YIELD_BUDGET_MS = 12;
+
 // Directory name appended to os.tmpdir() to form the shared base for the V8
 // compile cache. Matches the base Node's own module.enableCompileCache() uses,
 // so the bin (parent) and the spawned oxlint batches (children) share one tree.

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { CROSS_FILE_RULE_IDS } from "oxlint-plugin-react-doctor";
 import type { Diagnostic, ProjectInfo, ReactDoctorConfig } from "./types/index.js";
 import { batchIncludePaths } from "./batch-include-paths.js";
+import { COOPERATIVE_YIELD_BUDGET_MS } from "./constants.js";
 import { buildRuleSeverityControls } from "./build-rule-severity-controls.js";
 import { canOxlintExtendConfig } from "./can-oxlint-extend-config.js";
 import { collectIgnorePatterns } from "./collect-ignore-patterns.js";
@@ -27,6 +28,7 @@ import { hashFileContents } from "./utils/hash-file-contents.js";
 import { listSourceFilesWithSize } from "./utils/list-source-files.js";
 import { planLintBatches } from "./utils/plan-lint-batches.js";
 import { resolveReactDoctorCacheDir } from "./utils/resolve-react-doctor-cache-dir.js";
+import { yieldToEventLoop } from "./utils/yield-to-event-loop.js";
 
 interface RunOxlintOptions {
   rootDirectory: string;
@@ -333,6 +335,13 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     // diagnostics. Materializing the file list ahead of time and
     // feeding it through the batch planner keeps each spawn under
     // the timeout and recovers the diagnostics we were dropping.
+    // Hand the event loop back once before the synchronous discovery walk +
+    // cache-hash burst below. The orchestrator forked the security-scan and
+    // supply-chain fibers just before lint, but a forked fiber only runs when
+    // the current one suspends — this is their first chance to start (fire the
+    // Socket.dev requests, begin the scan walk) instead of stalling until the
+    // first oxlint spawn.
+    await yieldToEventLoop();
     // Only a full scan pays the walk — diff / staged scans pass
     // explicit paths.
     const sizedScanFiles =
@@ -441,10 +450,14 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       const cache = createFileLintCache(resolveReactDoctorCacheDir(rootDirectory), rulesetHash);
 
       // Partition candidates by content hash. An unreadable file (no hash) is
-      // treated as a miss and re-linted.
+      // treated as a miss and re-linted. Hashing reads every candidate's whole
+      // content, so the loop yields on the cooperative time budget — otherwise
+      // this pre-spawn burst starves the forked security-scan / supply-chain
+      // fibers (and sibling projects) until the first oxlint spawn.
       const cacheKeyByFile = new Map<string, string>();
       const missFiles: string[] = [];
       const replayedDiagnostics: Diagnostic[] = [];
+      let hashSliceStartedAt = performance.now();
       for (const candidateFile of candidateFiles) {
         const contentHash = hashFileContents(path.resolve(rootDirectory, candidateFile));
         if (contentHash === null) {
@@ -456,6 +469,10 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         const cachedDiagnostics = cache.lookup(cacheKey);
         if (cachedDiagnostics === null) missFiles.push(candidateFile);
         else replayedDiagnostics.push(...cachedDiagnostics);
+        if (performance.now() - hashSliceStartedAt >= COOPERATIVE_YIELD_BUDGET_MS) {
+          await yieldToEventLoop();
+          hashSliceStartedAt = performance.now();
+        }
       }
       const cacheHitFileCount = candidateFiles.length - missFiles.length;
 

--- a/packages/core/tests/check-security-scan.test.ts
+++ b/packages/core/tests/check-security-scan.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
-import { checkSecurityScan } from "@react-doctor/core";
+import { checkSecurityScan, checkSecurityScanCooperative } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
 import { REACT_DOCTOR_RULES } from "oxlint-plugin-react-doctor";
 
@@ -233,6 +233,17 @@ describe("checkSecurityScan", () => {
 
     it("stays quiet on a hardened app with scoped rules and public-only browser config", () => {
       expect(checkSecurityScan(path.join(FIXTURES_DIRECTORY, "safe-hardened-app"))).toEqual([]);
+    });
+  });
+
+  describe("cooperative driver", () => {
+    it("produces the same diagnostics, in the same order, as the sync driver", async () => {
+      const fixtureDirectory = path.join(FIXTURES_DIRECTORY, "eva-mintlify-docs-platform");
+      const syncDiagnostics = checkSecurityScan(fixtureDirectory);
+      expect(syncDiagnostics.length).toBeGreaterThan(0);
+      await expect(checkSecurityScanCooperative(fixtureDirectory)).resolves.toEqual(
+        syncDiagnostics,
+      );
     });
   });
 


### PR DESCRIPTION
## Why

PR #941 already forks the security scan (and supply chain) to overlap with lint — but a forked Effect fiber only runs when the current fiber suspends, and two synchronous bursts still serialized everything: lint's pre-spawn prefix (discovery walk + the per-file-cache hash loop, which reads every candidate's content with zero awaits before the first spawn) and the security scan's own directory-walk phase (the bucket collection completes before the first file yields). Verified audit findings #485/#491.

Before:

```
parent event-loop max stall (perf_hooks.monitorEventLoopDelay):
warm scans 116ms, cold 61ms — forked fibers (Socket.dev kick-off, scan walk)
cannot start until the first oxlint spawn
```

After:

```
warm 64ms (−45%), cold 50ms
wall-clock neutral on single projects — by ceiling measurement, PR #941 already
recovered ~90%+ of the scan's hideable cost there (residual ≈0.03–0.13s of ~1.8s)
```

## What changed

- `run-oxlint.ts`: one `yieldToEventLoop()` before the synchronous discovery burst (the forked fibers' first chance to run), plus 12ms budget-checked yields inside the cache hash-partition loop.
- `collect-security-scan-files.ts`: the walk yields `null` progress markers once per directory; the cooperative driver budget-checks on them, the sync (test-only) driver skips them. File set and order untouched.
- Yield budget consolidated as `COOPERATIVE_YIELD_BUDGET_MS` in core constants (was security-scan-local).
- Worker thread deliberately rejected: real/user ratio shows lint children saturate the cores while the parent waits, so the scan's CPU rides otherwise-idle parent time; a thread would add a duplicate plugin module load, IPC, and a new failure taxonomy for ≲0.1s.

The stall bound is what multi-project workspace scans (sibling git/network starvation) and supply-chain kick-off latency actually feel; those weren't benchable on this single-project corpus and should scale with tree size.

## Test plan

- `packages/core`: 1139 pass (baseline 1138; +1 new test pinning cooperative-driver output ≡ sync driver on a multi-finding fixture). `packages/react-doctor`: 2124 pass / 26 skip. Root typecheck + lint clean. (Baseline needs the documented `GIT_CONFIG_GLOBAL=/dev/null` + `XDG_CONFIG_HOME` env-trap neutralization.)
- Equivalence: 291 diagnostics on the 617-file corpus — raw JSON array order AND content byte-identical; 3 consecutive runs byte-identical to each other; `REACT_DOCTOR_PARALLEL=1` and single-file scans clean.
- Error semantics unchanged: the scan fiber still fails open into `securityScanFailedRef` (pinned by the existing EMFILE-mock test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scheduling-only changes with byte-identical diagnostics pinned by tests; no rule or security logic changes.
> 
> **Overview**
> Forked **security-scan** and **supply-chain** fibers only run when the main thread yields; lint’s synchronous **pre-spawn** work (full-scan discovery and per-file cache hashing) and the security scan’s **directory walk** could block them until the first oxlint spawn.
> 
> **Lint** (`run-oxlint.ts`) now calls `yieldToEventLoop()` once before discovery, and yields every **12ms** (`COOPERATIVE_YIELD_BUDGET_MS`) while hashing candidates for the file lint cache. **Security scan** file collection yields `null` walk-progress markers per directory; the cooperative driver treats those as budget checkpoints (sync driver skips them). The yield constant moves from security-scan-local to shared **`COOPERATIVE_YIELD_BUDGET_MS`** in core constants.
> 
> Diagnostics and report order stay the same; a test asserts cooperative output matches the sync driver on a multi-finding fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e84191bc03bfffe1ed1c0ab8502d315f71076c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->