### PR TITLE
perf(plugin): early-exit sweep — cheap discriminators before expensive walks

### DIFF
--- a/.changeset/perf-sweep-early-exit.md
+++ b/.changeset/perf-sweep-early-exit.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: early-exit sweep — cheap discriminators now run before walks, scope lookups, and parent climbs across ~23 rules (raw-name bails before getElementType, whole-file import gates for the zod and recycler-list rules, substring gates before regex-heavy className analysis, filename gates hoisted to Program, and first-match pruning in containsFetchCall)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react-native.ts
@@ -129,6 +129,12 @@ export const RECYCLABLE_LIST_PACKAGES: Record<string, ReadonlyArray<string>> = {
   LegendList: ["@legendapp/list"],
 };
 
+// Flat list of every recycler-owning package source, for whole-file
+// import-presence gates: a file importing none of these can never resolve a
+// recycler, so per-element resolution is skipped entirely.
+export const RECYCLABLE_LIST_PACKAGE_SOURCES: ReadonlyArray<string> =
+  Object.values(RECYCLABLE_LIST_PACKAGES).flat();
+
 // Every list-like element name: built-in RN lists plus the recycler exports.
 // A name-only set for the cheap first filter — provenance lives in the rules.
 export const REACT_NATIVE_LIST_COMPONENTS = new Set([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/alt-text.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
+import { hasJsxA11ySettings } from "../../utils/has-jsx-a11y-settings.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -200,9 +201,25 @@ export const altText = defineRule({
     const objectAliases = new Set(settings.object ?? []);
     const areaAliases = new Set(settings.area ?? []);
     const inputImageAliases = new Set(settings['input[type="image"]'] ?? []);
+    const fileHasJsxA11ySettings = hasJsxA11ySettings(context.settings);
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (!fileHasJsxA11ySettings && isNodeOfType(node.name, "JSXIdentifier")) {
+          const rawName = node.name.name;
+          if (
+            rawName !== "img" &&
+            rawName !== "object" &&
+            rawName !== "area" &&
+            rawName.toLowerCase() !== "input" &&
+            !imgAliases.has(rawName) &&
+            !objectAliases.has(rawName) &&
+            !areaAliases.has(rawName) &&
+            !inputImageAliases.has(rawName)
+          ) {
+            return;
+          }
+        }
         if (isGeneratedImageRenderContext(context, node)) return;
         const tag = getElementType(node, context.settings);
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-is-valid.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-is-valid.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
+import { hasJsxA11ySettings } from "../../utils/has-jsx-a11y-settings.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
@@ -76,8 +77,15 @@ export const anchorIsValid = defineRule({
   category: "Accessibility",
   create: (context) => {
     const settings = resolveSettings(context.settings);
+    const fileHasJsxA11ySettings = hasJsxA11ySettings(context.settings);
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (
+          !fileHasJsxA11ySettings &&
+          (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a")
+        ) {
+          return;
+        }
         const tag = getElementType(node, context.settings);
         if (tag !== "a") return;
         // First-found custom href alternative, falling back to "href".

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/img-redundant-alt.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/img-redundant-alt.ts
@@ -94,10 +94,10 @@ export const imgRedundantAlt = defineRule({
     const settings = resolveSettings(context.settings);
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (isGeneratedImageRenderContext(context, node)) return;
         const tag = getElementType(node, context.settings);
         if (!settings.components.includes(tag)) return;
         if (isHiddenFromScreenReader(node, context.settings)) return;
+        if (isGeneratedImageRenderContext(context, node)) return;
         const altAttribute = hasJsxPropIgnoreCase(node.attributes, "alt");
         if (!altAttribute) return;
         if (altValueRedundant(altAttribute, settings.words)) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.ts
@@ -59,10 +59,16 @@ export const interactiveSupportsFocus = defineRule({
     const tabbableSet = new Set(settings.tabbable);
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (node.attributes.length === 0) return;
         // A spread (`{...props}`) can carry `tabIndex`, so focus support is indeterminate.
         if (hasJsxSpreadAttribute(node.attributes)) return;
         const roleAttribute = hasJsxPropIgnoreCase(node.attributes, "role");
         const role = roleAttribute ? getJsxPropStringValue(roleAttribute) : null;
+        if (!role) return;
+        const hasInteractiveHandler = ALL_EVENT_HANDLERS.some((handler) =>
+          Boolean(hasJsxPropIgnoreCase(node.attributes, handler)),
+        );
+        if (!hasInteractiveHandler) return;
         const elementType = getElementType(node, context.settings);
         // Custom components (PascalCase, not in HTML_TAGS) encapsulate
         // their own focus behaviour — `<SegmentButton role="option" />`
@@ -71,20 +77,14 @@ export const interactiveSupportsFocus = defineRule({
         // unactionable: the user can't add tabIndex to a wrapper that
         // already handles focus correctly.
         if (!HTML_TAGS.has(elementType)) return;
-        const hasInteractiveHandler = ALL_EVENT_HANDLERS.some((handler) =>
-          Boolean(hasJsxPropIgnoreCase(node.attributes, handler)),
-        );
-        const hasTabIndex = Boolean(hasJsxPropIgnoreCase(node.attributes, "tabIndex"));
-
         if (
-          !hasInteractiveHandler ||
           isDisabledElement(node) ||
           isHiddenFromScreenReader(node, context.settings) ||
           isPresentationRole(node)
         ) {
           return;
         }
-        if (!role) return;
+        const hasTabIndex = Boolean(hasJsxPropIgnoreCase(node.attributes, "tabIndex"));
         if (
           !isInteractiveRole(role) ||
           isInteractiveElement(elementType, node) ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.ts
@@ -29,17 +29,7 @@ export const roleSupportsAriaProps = defineRule({
   category: "Accessibility",
   create: (context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      const elementType = getElementType(node, context.settings);
-      const roleAttribute = hasJsxPropIgnoreCase(node.attributes, "role");
-      const role = roleAttribute
-        ? getJsxPropStringValue(roleAttribute)
-        : getImplicitRole(node, elementType);
-      if (!role) return;
-      if (!VALID_ARIA_ROLES.has(role)) return;
-      const isImplicit = !roleAttribute;
-      const supported = ROLE_SUPPORTS_ARIA_PROPS[role];
-      if (!supported) return;
-
+      let ariaAttributes: Array<{ attribute: EsTreeNode; propName: string }> | null = null;
       for (const attribute of node.attributes) {
         if (!isNodeOfType(attribute as EsTreeNode, "JSXAttribute")) continue;
         const attributeNode = attribute as EsTreeNodeOfType<"JSXAttribute">;
@@ -51,9 +41,25 @@ export const roleSupportsAriaProps = defineRule({
         const propName = propRawName.toLowerCase();
         if (!propName.startsWith("aria-")) continue;
         if (!ARIA_PROPERTIES.has(propName)) continue;
+        (ariaAttributes ??= []).push({ attribute: attribute as EsTreeNode, propName });
+      }
+      if (!ariaAttributes) return;
+
+      const elementType = getElementType(node, context.settings);
+      const roleAttribute = hasJsxPropIgnoreCase(node.attributes, "role");
+      const role = roleAttribute
+        ? getJsxPropStringValue(roleAttribute)
+        : getImplicitRole(node, elementType);
+      if (!role) return;
+      if (!VALID_ARIA_ROLES.has(role)) return;
+      const isImplicit = !roleAttribute;
+      const supported = ROLE_SUPPORTS_ARIA_PROPS[role];
+      if (!supported) return;
+
+      for (const { attribute, propName } of ariaAttributes) {
         if (supported.has(propName)) continue;
         context.report({
-          node: attribute as EsTreeNode,
+          node: attribute,
           message: isImplicit
             ? buildMessageImplicit(role, propName, elementType)
             : buildMessageDefault(role, propName),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -99,19 +99,23 @@ export const noRenderInRender = defineRule({
 
       let calleeName: string | null = null;
       if (isNodeOfType(expression.callee, "Identifier")) {
-        if (tracesToPropOrParameter(context.scopes.symbolFor(expression.callee), context.scopes)) {
-          return;
-        }
         calleeName = expression.callee.name;
       } else if (
         isNodeOfType(expression.callee, "MemberExpression") &&
         isNodeOfType(expression.callee.property, "Identifier")
       ) {
-        if (rootsInProps(expression.callee.object, context.scopes)) return;
         calleeName = expression.callee.property.name;
       }
 
       if (!calleeName || !RENDER_FUNCTION_PATTERN.test(calleeName)) return;
+
+      if (isNodeOfType(expression.callee, "Identifier")) {
+        if (tracesToPropOrParameter(context.scopes.symbolFor(expression.callee), context.scopes)) {
+          return;
+        }
+      } else if (isNodeOfType(expression.callee, "MemberExpression")) {
+        if (rootsInProps(expression.callee.object, context.scopes)) return;
+      }
 
       context.report({
         node: expression,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
@@ -213,7 +213,6 @@ export const jsHoistIntl = defineRule({
   create: (context: RuleContext) => ({
     NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
       if (!isIntlNewExpression(node)) return;
-      if (isInsideCacheMemo(node)) return;
       // Walk up: if any enclosing function is a function/arrow, this is in
       // a function body. Module-scope `new Intl.X()` is fine; we only flag
       // when wrapped in a function (likely called per render or per item).
@@ -259,6 +258,7 @@ export const jsHoistIntl = defineRule({
         cursor = cursor.parent ?? null;
       }
       if (!inFunctionBody) return;
+      if (isInsideCacheMemo(node)) return;
 
       const className =
         isNodeOfType(node.callee, "MemberExpression") &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
@@ -226,22 +226,24 @@ export const nextjsNoSideEffectInGetHandler = defineRule({
     "GET requests can be prefetched and are open to CSRF. Move the side effect to a POST handler.",
   create: (context: RuleContext) => {
     let resolveBinding: (identifierName: string) => EsTreeNode | null = () => null;
+    let isRouteHandlerFile = false;
+    // A "mutating-sounding" route segment (cancel, delete, logout, …) is a
+    // hint, NOT proof: a read-only GET that returns a cancellation policy
+    // is safe. Require an actual side effect before reporting, and only
+    // use the segment to flavor the message.
+    let mutatingSegment: string | null = null;
 
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
         resolveBinding = buildProgramBindingLookup(node);
+        const filename = normalizeFilename(context.filename ?? "");
+        isRouteHandlerFile =
+          ROUTE_HANDLER_FILE_PATTERN.test(filename) && !CRON_ROUTE_PATTERN.test(filename);
+        mutatingSegment = isRouteHandlerFile ? extractMutatingRouteSegment(filename) : null;
       },
       ExportNamedDeclaration(node: EsTreeNodeOfType<"ExportNamedDeclaration">) {
-        const filename = normalizeFilename(context.filename ?? "");
-        if (!ROUTE_HANDLER_FILE_PATTERN.test(filename)) return;
-        if (CRON_ROUTE_PATTERN.test(filename)) return;
+        if (!isRouteHandlerFile) return;
         if (!isExportedGetHandler(node)) return;
-
-        // A "mutating-sounding" route segment (cancel, delete, logout, …) is a
-        // hint, NOT proof: a read-only GET that returns a cancellation policy
-        // is safe. Require an actual side effect before reporting, and only
-        // use the segment to flavor the message.
-        const mutatingSegment = extractMutatingRouteSegment(filename);
 
         const handlerBodies = resolveGetHandlerBodies(node, resolveBinding);
         for (const handlerBody of handlerBodies) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/prefer-stable-empty-fallback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/prefer-stable-empty-fallback.ts
@@ -108,13 +108,13 @@ export const preferStableEmptyFallback = defineRule({
         memoRegistry = buildSameFileMemoRegistry(node as EsTreeNode);
       },
       JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
-        if (!isInsideFunctionScope(node)) return;
-        if (isJsxAttributeOnIntrinsicHtmlElement(node)) return;
         if (!node.value) return;
         if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
         const innerExpression = node.value.expression;
         if (!innerExpression) return;
         if (innerExpression.type === "JSXEmptyExpression") return;
+        if (!isInsideFunctionScope(node)) return;
+        if (isJsxAttributeOnIntrinsicHtmlElement(node)) return;
 
         const parentJsxOpening = node.parent;
         const openingName =

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
@@ -8,7 +8,6 @@ import { isEs6Component } from "../../utils/is-es6-component.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
-import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 
 const buildMessage = (parentName: string | null): string => {
   let message =
@@ -277,15 +276,22 @@ const isFirstArgumentOfHocCall = (node: EsTreeNode): boolean => {
   return parent.arguments[0] === node;
 };
 
+const MAP_LIKE_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "map",
+  "forEach",
+  "filter",
+  "flatMap",
+  "reduce",
+  "reduceRight",
+]);
+
 const isReturnOfMapCallback = (node: EsTreeNode): boolean => {
   const parent = node.parent;
   if (!parent) return false;
   if (isNodeOfType(parent, "CallExpression")) {
     const callee = parent.callee;
     if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
-      return ["map", "forEach", "filter", "flatMap", "reduce", "reduceRight"].includes(
-        callee.property.name,
-      );
+      return MAP_LIKE_METHOD_NAMES.has(callee.property.name);
     }
   }
   if (
@@ -296,9 +302,7 @@ const isReturnOfMapCallback = (node: EsTreeNode): boolean => {
     if (callbackParent && isNodeOfType(callbackParent, "CallExpression")) {
       const callee = callbackParent.callee;
       if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
-        return ["map", "forEach", "filter", "flatMap", "reduce", "reduceRight"].includes(
-          callee.property.name,
-        );
+        return MAP_LIKE_METHOD_NAMES.has(callee.property.name);
       }
     }
   }
@@ -360,14 +364,14 @@ const isRenderFlowingReadReference = (identifier: EsTreeNode): boolean => {
         return (
           parent.init === valueNode &&
           isNodeOfType(parent.id, "Identifier") &&
-          isUppercaseName(parent.id.name)
+          isReactComponentName(parent.id.name)
         );
       case "AssignmentExpression": {
         const assignmentTarget = parent.left as EsTreeNode;
         return (
           parent.right === valueNode &&
           isNodeOfType(assignmentTarget, "Identifier") &&
-          isUppercaseName(assignmentTarget.name)
+          isReactComponentName(assignmentTarget.name)
         );
       }
       case "Property": {
@@ -541,7 +545,7 @@ export const noUnstableNestedComponents = defineRule({
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (isNodeOfType(node.name, "JSXIdentifier") && isUppercaseName(node.name.name)) {
+        if (isNodeOfType(node.name, "JSXIdentifier") && isReactComponentName(node.name.name)) {
           recordInstantiation(node.name as EsTreeNode, node.name.name);
           return;
         }
@@ -550,7 +554,7 @@ export const noUnstableNestedComponents = defineRule({
         }
       },
       Identifier(node: EsTreeNodeOfType<"Identifier">) {
-        if (!isUppercaseName(node.name)) return;
+        if (!isReactComponentName(node.name)) return;
         if (!isRenderFlowingReadReference(node as EsTreeNode)) return;
         recordInstantiation(node as EsTreeNode, node.name);
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.ts
@@ -1,6 +1,10 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { getReactDoctorNumberSetting } from "../../utils/get-react-doctor-setting.js";
-import { FLASH_LIST_V2_MAJOR } from "../../constants/react-native.js";
+import {
+  FLASH_LIST_V2_MAJOR,
+  RECYCLABLE_LIST_PACKAGE_SOURCES,
+} from "../../constants/react-native.js";
+import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { resolveImportedRecyclerName } from "./utils/resolve-imported-recycler-name.js";
@@ -42,48 +46,55 @@ export const rnListMissingEstimatedItemSize = defineRule({
   severity: "warn",
   recommendation:
     "Without `estimatedItemSize` the list guesses row height and can flash blank cells on fast scroll. Add `estimatedItemSize={<avg-row-height-in-px>}` so it matches your rows.",
-  create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      const localElementName = resolveJsxElementName(node);
-      if (!localElementName) return;
-      // Resolve the LOCAL JSX name back to its originally-exported
-      // symbol from one of the recycler-owning packages. This handles
-      // both plain (`import { FlashList }`) and aliased
-      // (`import { FlashList as List }; <List />`) imports — we never
-      // key off the local JSX name directly.
-      const canonicalRecyclerName = resolveImportedRecyclerName(node, localElementName);
-      if (canonicalRecyclerName === null) return;
-      if (canonicalRecyclerName === "FlashList" && isFlashListV2OrNewer(context)) return;
+  create: (context: RuleContext) => {
+    let fileImportsRecycler = false;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        fileImportsRecycler = hasImportFromModules(node, RECYCLABLE_LIST_PACKAGE_SOURCES);
+      },
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (!fileImportsRecycler) return;
+        const localElementName = resolveJsxElementName(node);
+        if (!localElementName) return;
+        // Resolve the LOCAL JSX name back to its originally-exported
+        // symbol from one of the recycler-owning packages. This handles
+        // both plain (`import { FlashList }`) and aliased
+        // (`import { FlashList as List }; <List />`) imports — we never
+        // key off the local JSX name directly.
+        const canonicalRecyclerName = resolveImportedRecyclerName(node, localElementName);
+        if (canonicalRecyclerName === null) return;
+        if (canonicalRecyclerName === "FlashList" && isFlashListV2OrNewer(context)) return;
 
-      let hasSizingHint = false;
-      let dataIsEmptyLiteral = false;
-      let hasDataProp = false;
+        let hasSizingHint = false;
+        let dataIsEmptyLiteral = false;
+        let hasDataProp = false;
 
-      for (const attribute of node.attributes ?? []) {
-        if (!isNodeOfType(attribute, "JSXAttribute")) continue;
-        if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
-        const attributeName = attribute.name.name;
-        if (SIZING_HINT_ATTRIBUTE_NAMES.has(attributeName)) hasSizingHint = true;
-        if (attributeName === "data") {
-          hasDataProp = true;
-          if (isEmptyArrayLiteral(attribute)) dataIsEmptyLiteral = true;
+        for (const attribute of node.attributes ?? []) {
+          if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+          if (!isNodeOfType(attribute.name, "JSXIdentifier")) continue;
+          const attributeName = attribute.name.name;
+          if (SIZING_HINT_ATTRIBUTE_NAMES.has(attributeName)) hasSizingHint = true;
+          if (attributeName === "data") {
+            hasDataProp = true;
+            if (isEmptyArrayLiteral(attribute)) dataIsEmptyLiteral = true;
+          }
         }
-      }
 
-      if (hasSizingHint) return;
-      // Skip placeholder lists — `<FlashList data={[]} />` is almost
-      // always a render-with-empty-data branch, not a production code
-      // path, and adding `estimatedItemSize` there is busywork.
-      if (dataIsEmptyLiteral) return;
-      // Skip JSX that doesn't even pass `data` — likely an
-      // abstract wrapper component being defined, not an instantiation
-      // with real items.
-      if (!hasDataProp) return;
+        if (hasSizingHint) return;
+        // Skip placeholder lists — `<FlashList data={[]} />` is almost
+        // always a render-with-empty-data branch, not a production code
+        // path, and adding `estimatedItemSize` there is busywork.
+        if (dataIsEmptyLiteral) return;
+        // Skip JSX that doesn't even pass `data` — likely an
+        // abstract wrapper component being defined, not an instantiation
+        // with real items.
+        if (!hasDataProp) return;
 
-      context.report({
-        node,
-        message: `Your users see blank cells flash on fast scroll when <${localElementName}> has no \`estimatedItemSize\`.`,
-      });
-    },
-  }),
+        context.report({
+          node,
+          message: `Your users see blank cells flash on fast scroll when <${localElementName}> has no \`estimatedItemSize\`.`,
+        });
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
@@ -1,4 +1,6 @@
+import { RECYCLABLE_LIST_PACKAGE_SOURCES } from "../../constants/react-native.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
 import { resolveImportedRecyclerName } from "./utils/resolve-imported-recycler-name.js";
@@ -24,48 +26,55 @@ export const rnListRecyclableWithoutTypes = defineRule({
   severity: "warn",
   recommendation:
     "When rows have different shapes, reused cells can show the wrong layout. Add `getItemType={item => item.kind}` so FlashList keeps a separate pool per row type.",
-  create: (context: RuleContext) => ({
-    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      const elementName = resolveJsxElementName(node);
-      if (!elementName) return;
-      // Resolve the LOCAL JSX name back to a recycler that was really imported
-      // from `@shopify/flash-list` / `@legendapp/list` — named, aliased, or
-      // namespace member access. A name-only match on a homegrown `FlashList`
-      // (`const FlashList = MyOwnList`) isn't a recycler.
-      if (
-        resolveImportedRecyclerName(node, elementName, {
-          allowNamespaceMemberAccess: true,
-        }) === null
-      )
-        return;
+  create: (context: RuleContext) => {
+    let fileImportsRecycler = false;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        fileImportsRecycler = hasImportFromModules(node, RECYCLABLE_LIST_PACKAGE_SOURCES);
+      },
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (!fileImportsRecycler) return;
+        const elementName = resolveJsxElementName(node);
+        if (!elementName) return;
+        // Resolve the LOCAL JSX name back to a recycler that was really imported
+        // from `@shopify/flash-list` / `@legendapp/list` — named, aliased, or
+        // namespace member access. A name-only match on a homegrown `FlashList`
+        // (`const FlashList = MyOwnList`) isn't a recycler.
+        if (
+          resolveImportedRecyclerName(node, elementName, {
+            allowNamespaceMemberAccess: true,
+          }) === null
+        )
+          return;
 
-      let hasRecycleItemsEnabled = false;
-      let hasGetItemType = false;
+        let hasRecycleItemsEnabled = false;
+        let hasGetItemType = false;
 
-      for (const attr of node.attributes ?? []) {
-        if (!isNodeOfType(attr, "JSXAttribute")) continue;
-        if (!isNodeOfType(attr.name, "JSXIdentifier")) continue;
-        if (attr.name.name === "recycleItems") {
-          if (!attr.value) {
-            hasRecycleItemsEnabled = true;
-          } else if (
-            isNodeOfType(attr.value, "JSXExpressionContainer") &&
-            isNodeOfType(attr.value.expression, "Literal")
-          ) {
-            hasRecycleItemsEnabled = attr.value.expression.value === true;
-          } else {
-            hasRecycleItemsEnabled = true;
+        for (const attr of node.attributes ?? []) {
+          if (!isNodeOfType(attr, "JSXAttribute")) continue;
+          if (!isNodeOfType(attr.name, "JSXIdentifier")) continue;
+          if (attr.name.name === "recycleItems") {
+            if (!attr.value) {
+              hasRecycleItemsEnabled = true;
+            } else if (
+              isNodeOfType(attr.value, "JSXExpressionContainer") &&
+              isNodeOfType(attr.value.expression, "Literal")
+            ) {
+              hasRecycleItemsEnabled = attr.value.expression.value === true;
+            } else {
+              hasRecycleItemsEnabled = true;
+            }
           }
+          if (attr.name.name === "getItemType") hasGetItemType = true;
         }
-        if (attr.name.name === "getItemType") hasGetItemType = true;
-      }
 
-      if (hasRecycleItemsEnabled && !hasGetItemType) {
-        context.report({
-          node,
-          message: `Your users see rows of different shapes reuse the wrong cells when <${elementName} recycleItems> has no \`getItemType\`.`,
-        });
-      }
-    },
-  }),
+        if (hasRecycleItemsEnabled && !hasGetItemType) {
+          context.report({
+            node,
+            message: `Your users see rows of different shapes reuse the wrong cells when <${elementName} recycleItems> has no \`getItemType\`.`,
+          });
+        }
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -5,6 +5,7 @@ import {
   REACT_NATIVE_TEXT_COMPONENT_KEYWORDS,
   REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS,
 } from "../../constants/react-native.js";
+import { containsJsxElement } from "../../utils/contains-jsx-element.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { isInsidePlatformOsWebBranch } from "../../utils/is-inside-platform-os-web-branch.js";
@@ -163,6 +164,9 @@ export const rnNoRawText = defineRule({
     return {
       Program(programNode: EsTreeNodeOfType<"Program">) {
         isDomComponentFile = hasDirective(programNode, "use dom");
+        // A file with no JSX never fires the JSXElement visitor, so the
+        // wrapper classification would go unread — skip the fixpoint walk.
+        if (!containsJsxElement(programNode)) return;
         const childrenForwarding = collectTextWrapperComponents(
           programNode,
           isTextHandlingComponent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-redundant-padding-axes.ts
@@ -31,6 +31,9 @@ export const noRedundantPaddingAxes = defineRule({
       }
       const classNameLiteral = getClassNameLiteral(jsxAttribute);
       if (!classNameLiteral) return;
+      // A collapsible pair needs BOTH axes present, so a class list missing
+      // either substring can never match — bail before any regex work.
+      if (!classNameLiteral.includes("px-") || !classNameLiteral.includes("py-")) return;
       // Per-breakpoint variation is a legit reason to keep the axes split.
       if (
         hasResponsivePrefix(classNameLiteral, "px") ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-redundant-size-axes.ts
@@ -29,6 +29,9 @@ export const noRedundantSizeAxes = defineRule({
       }
       const classNameLiteral = getClassNameLiteral(jsxAttribute);
       if (!classNameLiteral) return;
+      // A redundant pair needs BOTH axes present, so a class list missing
+      // either substring can never match — bail before any regex work.
+      if (!classNameLiteral.includes("w-") || !classNameLiteral.includes("h-")) return;
       if (
         hasResponsivePrefix(classNameLiteral, "w") ||
         hasResponsivePrefix(classNameLiteral, "h")

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/no-space-on-flex-children.ts
@@ -29,6 +29,8 @@ export const noSpaceOnFlexChildren = defineRule({
       }
       const classNameLiteral = getClassNameLiteral(jsxAttribute);
       if (!classNameLiteral) return;
+      // No `space-*` utility means nothing to report — bail before tokenizing.
+      if (!classNameLiteral.includes("space-")) return;
       const tokens = tokenizeClassName(classNameLiteral);
       let hasFlexOrGridLayout = false;
       for (const token of tokens) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/insecure-crypto-risk.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/insecure-crypto-risk.ts
@@ -71,6 +71,14 @@ const MATH_RANDOM_CALL_PATTERN = /Math\.random\s*\(/g;
 
 const SECURITY_CONTEXT_WINDOW_CHARS = 250;
 
+// Every detection pass below requires one of these substrings, so a file
+// without any of them can never report — bail before stripping comments and
+// running the multi-pass scan. Comment stripping only blanks characters
+// (positions preserved), so a token present in stripped content is always
+// present in the raw content too.
+const CRYPTO_SURFACE_TRIGGER_PATTERN =
+  /createHash|md5|cipher|encrypt|decrypt|crypto|signature|Math\.random/i;
+
 // File-level co-occurrence is a trap: any OAuth service mentions `token`
 // somewhere, so the context word must sit near the flagged call itself.
 const findMatchIndexNearContext = (
@@ -124,6 +132,8 @@ export const insecureCryptoRisk = defineRule({
     // The protocol marker often lives in the file name (`digest-auth.ts`),
     // not within the 250-char window around the hash call.
     if (PROTOCOL_MANDATED_HASH_CONTEXT_PATTERN.test(file.relativePath)) return [];
+
+    if (!CRYPTO_SURFACE_TRIGGER_PATTERN.test(file.content)) return [];
 
     // Match against comment-stripped content (positions preserved) — migration
     // notes and doc comments are exactly where `md5` / `DES` prose concentrates,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
@@ -36,6 +36,7 @@ export const serverCacheWithObjectLiteral = defineRule({
         cachedFunctionNames.add(node.id.name);
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (cachedFunctionNames.size === 0) return;
         if (!isNodeOfType(node.callee, "Identifier")) return;
         if (!cachedFunctionNames.has(node.callee.name)) return;
         const firstArg = node.arguments?.[0];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.ts
@@ -3,8 +3,8 @@ import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import {
-  getImportedNameFromModule,
-  isImportedFromModule,
+  getImportBindingForName,
+  getImportSourceForName,
 } from "../../utils/find-import-source-for-name.js";
 import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -21,16 +21,17 @@ const CONTEXT_MODULES: ReadonlyArray<string> = ["react", "use-context-selector",
 
 const isCreateContextCallee = (callee: EsTreeNode): boolean => {
   if (isNodeOfType(callee, "Identifier")) {
-    // Resolve through any renamed import — `getImportedNameFromModule`
-    // returns the originally-exported symbol name, so we catch both
+    // Resolve through any renamed import — the binding carries the
+    // originally-exported symbol name, so we catch both
     // `import { createContext } from "react"` and
     // `import { createContext as makeCtx } from "react"`. We accept
     // any module in `CONTEXT_MODULES`.
-    for (const moduleName of CONTEXT_MODULES) {
-      const canonicalName = getImportedNameFromModule(callee, callee.name, moduleName);
-      if (canonicalName === "createContext") return true;
-    }
-    return false;
+    const binding = getImportBindingForName(callee, callee.name);
+    return (
+      binding !== null &&
+      binding.exportedName === "createContext" &&
+      CONTEXT_MODULES.includes(binding.source)
+    );
   }
 
   if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
@@ -41,10 +42,8 @@ const isCreateContextCallee = (callee: EsTreeNode): boolean => {
     if (propertyIdentifier.name !== "createContext") return false;
     const namespaceName = namespaceIdentifier.name;
     if (isCanonicalReactNamespaceName(namespaceName)) return true;
-    for (const moduleName of CONTEXT_MODULES) {
-      if (isImportedFromModule(namespaceIdentifier, namespaceName, moduleName)) return true;
-    }
-    return false;
+    const importSource = getImportSourceForName(namespaceIdentifier, namespaceName);
+    return importSource !== null && CONTEXT_MODULES.includes(importSource);
   }
 
   return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/utils/zod-ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/utils/zod-ast.ts
@@ -6,6 +6,11 @@ import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 
 const ZOD_MODULE = "zod";
 
+// Every zod detection below bottoms out in `getImportInfoForIdentifier`,
+// which requires an import whose source is exactly `ZOD_MODULE` — so a file
+// with no such import can never report, and rules gate their visitors on it.
+export const ZOD_MODULE_SOURCES: ReadonlyArray<string> = [ZOD_MODULE];
+
 interface ZodImportInfo {
   imported: string | null;
   isDefault: boolean;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-error-apis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-error-apis.ts
@@ -1,10 +1,12 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import {
+  ZOD_MODULE_SOURCES,
   getMethodCall,
   getStaticPropertyName,
   getZodNamedImport,
@@ -70,31 +72,39 @@ export const zodV4NoDeprecatedErrorApis = defineRule({
   severity: "warn",
   recommendation:
     "Use the Zod 4 helpers instead: `z.treeifyError()`, `z.flattenError()`, `z.prettifyError()`, or read `error.issues` directly.",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (isZodErrorCreateCall(node) && isReceiverOfDeprecatedZodErrorMember(node)) return;
-      if (!isZodErrorCreateCall(node) && !isDeprecatedZodErrorMemberAccess(node.callee)) {
-        return;
-      }
-      context.report({
-        node,
-        message: ZOD_ERROR_API_MESSAGE,
-      });
-    },
-    MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
-      const parent = node.parent;
-      if (
-        parent &&
-        isNodeOfType(parent, "CallExpression") &&
-        stripParenExpression(parent.callee as EsTreeNode) === node
-      ) {
-        return;
-      }
-      if (!isDeprecatedZodErrorMemberAccess(node)) return;
-      context.report({
-        node,
-        message: ZOD_ERROR_API_MESSAGE,
-      });
-    },
-  }),
+  create: (context: RuleContext) => {
+    let fileImportsZod = false;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        fileImportsZod = hasImportFromModules(node, ZOD_MODULE_SOURCES);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!fileImportsZod) return;
+        if (isZodErrorCreateCall(node) && isReceiverOfDeprecatedZodErrorMember(node)) return;
+        if (!isZodErrorCreateCall(node) && !isDeprecatedZodErrorMemberAccess(node.callee)) {
+          return;
+        }
+        context.report({
+          node,
+          message: ZOD_ERROR_API_MESSAGE,
+        });
+      },
+      MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+        if (!fileImportsZod) return;
+        const parent = node.parent;
+        if (
+          parent &&
+          isNodeOfType(parent, "CallExpression") &&
+          stripParenExpression(parent.callee as EsTreeNode) === node
+        ) {
+          return;
+        }
+        if (!isDeprecatedZodErrorMemberAccess(node)) return;
+        context.report({
+          node,
+          message: ZOD_ERROR_API_MESSAGE,
+        });
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-schema-apis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-schema-apis.ts
@@ -1,10 +1,12 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import {
+  ZOD_MODULE_SOURCES,
   getMethodCall,
   getStaticPropertyName,
   getZodNamedImport,
@@ -169,33 +171,41 @@ export const zodV4NoDeprecatedSchemaApis = defineRule({
   severity: "warn",
   recommendation:
     "Switch to the Zod 4 versions: top-level factories like `z.enum()`, object helpers like `z.strictObject()`, the new `z.function({ input, output })` form, and explicit key/value schemas for `z.record()`.",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (
-        isCallToDeprecatedTopLevelFactory(node) ||
-        isCallToDroppedCreateFactory(node) ||
-        isSingleArgumentRecordCall(node) ||
-        isLiteralSymbolCall(node) ||
-        isDeprecatedFunctionChainCall(node) ||
-        isDirectMethodCallOnZodFactory(node, OBJECT_FACTORY, OBJECT_METHODS) ||
-        isDirectMethodCallOnZodFactory(node, NUMBER_FACTORY, NUMBER_METHODS) ||
-        isRefineSecondArgumentFunction(node)
-      ) {
-        reportSchemaMigration(context, node);
-      }
-    },
-    MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
-      const parent = node.parent;
-      if (
-        parent &&
-        isNodeOfType(parent, "CallExpression") &&
-        stripParenExpression(parent.callee as EsTreeNode) === node
-      ) {
-        return;
-      }
-      if (isDroppedEnumAliasAccess(node) || isZodNamespaceImportMemberCreate(node)) {
-        reportSchemaMigration(context, node);
-      }
-    },
-  }),
+  create: (context: RuleContext) => {
+    let fileImportsZod = false;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        fileImportsZod = hasImportFromModules(node, ZOD_MODULE_SOURCES);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!fileImportsZod) return;
+        if (
+          isCallToDeprecatedTopLevelFactory(node) ||
+          isCallToDroppedCreateFactory(node) ||
+          isSingleArgumentRecordCall(node) ||
+          isLiteralSymbolCall(node) ||
+          isDeprecatedFunctionChainCall(node) ||
+          isDirectMethodCallOnZodFactory(node, OBJECT_FACTORY, OBJECT_METHODS) ||
+          isDirectMethodCallOnZodFactory(node, NUMBER_FACTORY, NUMBER_METHODS) ||
+          isRefineSecondArgumentFunction(node)
+        ) {
+          reportSchemaMigration(context, node);
+        }
+      },
+      MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+        if (!fileImportsZod) return;
+        const parent = node.parent;
+        if (
+          parent &&
+          isNodeOfType(parent, "CallExpression") &&
+          stripParenExpression(parent.callee as EsTreeNode) === node
+        ) {
+          return;
+        }
+        if (isDroppedEnumAliasAccess(node) || isZodNamespaceImportMemberCreate(node)) {
+          reportSchemaMigration(context, node);
+        }
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-prefer-top-level-string-formats.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-prefer-top-level-string-formats.ts
@@ -1,7 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { isDirectMethodCallOnZodFactory } from "./utils/zod-ast.js";
+import { ZOD_MODULE_SOURCES, isDirectMethodCallOnZodFactory } from "./utils/zod-ast.js";
 
 const ZOD_STRING_FACTORY = new Set(["string"]);
 const STRING_FORMAT_METHODS = new Set([
@@ -36,14 +37,23 @@ export const zodV4PreferTopLevelStringFormats = defineRule({
   severity: "warn",
   recommendation:
     "Use the Zod 4 top-level format checks like `z.email()`, `z.uuid()`, or `z.ipv4()` instead of `z.string().<format>()`.",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isDirectMethodCallOnZodFactory(node, ZOD_STRING_FACTORY, STRING_FORMAT_METHODS)) return;
-      context.report({
-        node,
-        message:
-          "This `z.string().<format>()` check is deprecated in Zod 4, so it can break during the upgrade.",
-      });
-    },
-  }),
+  create: (context: RuleContext) => {
+    let fileImportsZod = false;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        fileImportsZod = hasImportFromModules(node, ZOD_MODULE_SOURCES);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!fileImportsZod) return;
+        if (!isDirectMethodCallOnZodFactory(node, ZOD_STRING_FACTORY, STRING_FORMAT_METHODS)) {
+          return;
+        }
+        context.report({
+          node,
+          message:
+            "This `z.string().<format>()` check is deprecated in Zod 4, so it can break during the upgrade.",
+        });
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/contains-fetch-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/contains-fetch-call.ts
@@ -37,6 +37,7 @@ export const containsFetchCall = (
     : null;
   let didFindFetchCall = false;
   walkAst(node, (child) => {
+    if (didFindFetchCall) return false;
     if (
       effectInvokedFunctions &&
       child !== node &&
@@ -45,7 +46,10 @@ export const containsFetchCall = (
     ) {
       return false;
     }
-    if (isFetchCall(child)) didFindFetchCall = true;
+    if (isFetchCall(child)) {
+      didFindFetchCall = true;
+      return false;
+    }
   });
   return didFindFetchCall;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-jsx-a11y-settings.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-jsx-a11y-settings.ts
@@ -1,0 +1,8 @@
+// When no `jsx-a11y` settings block exists, `getElementType` resolves to the
+// raw JSX name, so rules can bail on the raw name without the settings parse.
+export const hasJsxA11ySettings = (
+  settings: Readonly<Record<string, unknown>> | undefined,
+): boolean => {
+  const block = settings?.["jsx-a11y"];
+  return typeof block === "object" && block !== null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-create-element-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-create-element-call.ts
@@ -38,14 +38,14 @@ export const isCreateElementCall = (node: EsTreeNode): boolean => {
   if (isNodeOfType(callee, "Identifier")) return callee.name === "createElement";
 
   if (isNodeOfType(callee, "MemberExpression")) {
+    const propertyIsCreateElement = callee.computed
+      ? isNodeOfType(callee.property, "Literal") && callee.property.value === "createElement"
+      : isNodeOfType(callee.property, "Identifier") && callee.property.name === "createElement";
+    if (!propertyIsCreateElement) return false;
     // Walk the chain — `dom.window.document.createElement(...)` has
     // `document` somewhere in the object chain (not just the immediate
     // object), and that's still the DOM API.
-    if (memberChainContainsDocument(callee.object as EsTreeNode)) return false;
-    if (callee.computed) {
-      return isNodeOfType(callee.property, "Literal") && callee.property.value === "createElement";
-    }
-    return isNodeOfType(callee.property, "Identifier") && callee.property.name === "createElement";
+    return !memberChainContainsDocument(callee.object as EsTreeNode);
   }
 
   return false;


### PR DESCRIPTION
## Why

The multi-agent perf audit's largest cross-cutting theme: ~24 rules ran subtree walks, scope traces, parent climbs, or settings parses before a trivial name/type/substring check that usually fails. This sweep reorders them and adds whole-file no-op gates where a Program-level fact (no zod import, no recycler-list import, no JSX) makes the rule inert. Findings: #6 #11 #18 #19 #42 #56 #100 #121 #129 #193 #205 #206 #217 #236 #237 #238 #259 #299 #308(partial) #327 #385 #386 #387 #428.

Before / After: pure predicate reorders and gates — the reported diagnostic set is provably unchanged (every gate is an ANDed condition of the existing report path).

## What changed

- a11y: raw-name bails before `getElementType`/generated-image climbs (alt-text, anchor-is-valid, img-redundant-alt, interactive-supports-focus, role-supports-aria-props) via a new `has-jsx-a11y-settings` util (safe: without settings the alias sets are empty).
- Whole-file gates: zod rules on a literal `"zod"` import (the detectors cannot fire without one — verified), react-native list rules on recycler package imports, rn-no-raw-text on JSX presence, nextjs-no-side-effect-in-get-handler on filename at Program.
- security-scan insecure-crypto-risk: trigger-token pre-filter over raw content (conservative: the stripper only blanks characters, so stripped-content tokens are always present raw).
- Assorted: render-name pattern before scope traces (no-render-in-render), value-shape checks before parent climbs (prefer-stable-empty-fallback), `charCodeAt` uppercase check + hoisted Set (no-unstable-nested-components), first-match early exits (containsFetchCall, is-create-element-call).
- Deliberately NOT done (finding overreach, catalog annotated): #308's whole-file react-import gate would drop real diagnostics on global-React files — only the safe single-lookup half shipped.

## Test plan

- Plugin suite: 8704 pass / 94 skip — zero deltas vs pristine main. Root typecheck + lint clean.
- Equivalence: 617-file corpus scan before/after — 291 diagnostics, sorted tuples byte-identical.
- Adversarial review: an independent reviewer attacked every reorder and gate (side effects, message-choice changes, gate-excluded firing paths) — no divergence found.

Note: touches `interactive-supports-focus.ts` and `rn-no-raw-text.ts`, which the set-membership sweep PR also touches — whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are predicate reordering and conservative skip gates only; PR claims byte-identical corpus diagnostics, so behavioral risk is low aside from any missed edge case in gate logic.
> 
> **Overview**
> **Performance-only refactor** across ~23 oxlint rules: cheap checks and whole-file gates run before AST walks, scope lookups, settings parsing, and regex-heavy `className` work. Reported diagnostics are intended to stay identical (gates are conservative AND conditions on existing report paths).
> 
> **Whole-file gates at `Program`:** Zod v4 rules skip files without a `"zod"` import; FlashList/LegendList rules skip without recycler package imports (`RECYCLABLE_LIST_PACKAGE_SOURCES`); `rn-no-raw-text` skips wrapper classification when the file has no JSX; `nextjs-no-side-effect-in-get-handler` hoists route filename checks once per file.
> 
> **a11y:** New `hasJsxA11ySettings` lets `alt-text` and `anchor-is-valid` bail on raw JSX tag names before `getElementType`. Other a11y rules reorder checks (e.g. `role-supports-aria-props` collects `aria-*` first; `interactive-supports-focus` requires `role` + handlers earlier).
> 
> **Misc:** Tailwind design rules add substring guards before regex; `insecure-crypto-risk` pre-filters raw content; `containsFetchCall` and `is-create-element-call` stop after first match; assorted predicate reordering (`no-render-in-render`, `js-hoist-intl`, `prefer-stable-empty-fallback`, `no-unstable-nested-components`, `server-cache-with-object-literal`, `no-create-context-in-render` import helpers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f82a61c1e82b19bd10d23ff0e5eaf0898485292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->