### PR TITLE
perf(plugin): set-membership sweep — replace linear scans with Sets/Maps

### DIFF
--- a/.changeset/perf-sweep-set-membership.md
+++ b/.changeset/perf-sweep-set-membership.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: set-membership sweep — ~13 linear array scans on per-element hot paths now use Sets/Maps (ARIA element-role tables become O(1) lookup maps, event-handler presence checks collapse to one lowercased-Set pass per element, a11y settings lists and tanstack order tables convert to Sets/index Maps)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/aria-element-roles.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/aria-element-roles.ts
@@ -79,20 +79,33 @@ const ELEMENT_ROLE_PAIRS: ReadonlyArray<readonly [string, string]> = [
   ["ul", "list"],
 ];
 
-// Returns all implicit roles for `tag`. Empty array if tag has none.
-export const getElementImplicitRoles = (tag: string): ReadonlyArray<string> => {
-  const out: string[] = [];
-  for (const [element, role] of ELEMENT_ROLE_PAIRS) {
-    if (element === tag && !out.includes(role)) out.push(role);
+const EMPTY_ROLE_LIST: ReadonlyArray<string> = [];
+
+const buildLookup = (
+  pairs: ReadonlyArray<readonly [string, string]>,
+  keyIndex: 0 | 1,
+): ReadonlyMap<string, ReadonlyArray<string>> => {
+  const lookup = new Map<string, string[]>();
+  for (const pair of pairs) {
+    const key = pair[keyIndex];
+    const value = pair[keyIndex === 0 ? 1 : 0];
+    const values = lookup.get(key);
+    if (!values) {
+      lookup.set(key, [value]);
+    } else if (!values.includes(value)) {
+      values.push(value);
+    }
   }
-  return out;
+  return lookup;
 };
 
+const IMPLICIT_ROLES_BY_TAG = buildLookup(ELEMENT_ROLE_PAIRS, 0);
+const TAGS_BY_ROLE = buildLookup(ELEMENT_ROLE_PAIRS, 1);
+
+// Returns all implicit roles for `tag`. Empty array if tag has none.
+export const getElementImplicitRoles = (tag: string): ReadonlyArray<string> =>
+  IMPLICIT_ROLES_BY_TAG.get(tag) ?? EMPTY_ROLE_LIST;
+
 // Reverse lookup: HTML elements that map to `role`.
-export const getTagsForRole = (role: string): ReadonlyArray<string> => {
-  const out: string[] = [];
-  for (const [element, r] of ELEMENT_ROLE_PAIRS) {
-    if (r === role && !out.includes(element)) out.push(element);
-  }
-  return out;
-};
+export const getTagsForRole = (role: string): ReadonlyArray<string> =>
+  TAGS_BY_ROLE.get(role) ?? EMPTY_ROLE_LIST;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom-property-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom-property-names.ts
@@ -694,11 +694,15 @@ export const DOM_ATTRIBUTES_TO_CAMEL: ReadonlyMap<string, string> = new Map([
 ]);
 
 // Names for which casing isn't enforced — i.e. both `charset` and
-// `charSet` (and similar) are accepted spellings.
-export const DOM_PROPERTIES_IGNORE_CASE: ReadonlyArray<string> = [
-  "charset",
-  "allowFullScreen",
-  "webkitAllowFullScreen",
-  "mozAllowFullScreen",
-  "webkitDirectory",
-];
+// `charSet` (and similar) are accepted spellings. Keyed by lowercased form
+// so a lookup is one `toLowerCase` + one `Map.get` instead of a linear scan
+// that re-lowercases the constants per call.
+export const DOM_PROPERTIES_IGNORE_CASE_BY_LOWER: ReadonlyMap<string, string> = new Map(
+  [
+    "charset",
+    "allowFullScreen",
+    "webkitAllowFullScreen",
+    "mozAllowFullScreen",
+    "webkitDirectory",
+  ].map((name) => [name.toLowerCase(), name]),
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/event-handlers.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/event-handlers.ts
@@ -30,3 +30,10 @@ export const ALL_EVENT_HANDLERS: ReadonlyArray<string> = [
   ...MOUSE_EVENT_HANDLERS,
   ...KEYBOARD_EVENT_HANDLERS,
 ];
+
+// Lowercased Set for single-pass, case-insensitive presence checks over an
+// element's attributes — one lookup per attribute instead of one full
+// attribute scan per handler name.
+export const ALL_EVENT_HANDLERS_LOWER: ReadonlySet<string> = new Set(
+  ALL_EVENT_HANDLERS.map((handlerName) => handlerName.toLowerCase()),
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/tanstack.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/tanstack.ts
@@ -18,6 +18,12 @@ export const TANSTACK_ROUTE_PROPERTY_ORDER = [
   "remountDeps",
 ];
 
+// Index of each order-sensitive route property, so membership and ordering
+// are one Map lookup instead of includes() + indexOf() linear scans.
+export const TANSTACK_ROUTE_PROPERTY_INDEX: ReadonlyMap<string, number> = new Map(
+  TANSTACK_ROUTE_PROPERTY_ORDER.map((propertyName, orderIndex) => [propertyName, orderIndex]),
+);
+
 export const TANSTACK_ROUTE_CREATION_FUNCTIONS = new Set([
   "createFileRoute",
   "createRoute",
@@ -38,6 +44,11 @@ export const TANSTACK_MIDDLEWARE_METHOD_ORDER = [
   "server",
   "handler",
 ];
+
+// Same Map-index companion for the server-fn middleware chain order.
+export const TANSTACK_MIDDLEWARE_METHOD_INDEX: ReadonlyMap<string, number> = new Map(
+  TANSTACK_MIDDLEWARE_METHOD_ORDER.map((methodName, orderIndex) => [methodName, orderIndex]),
+);
 
 export const TANSTACK_REDIRECT_FUNCTIONS = new Set(["redirect", "notFound"]);
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/autocomplete-valid.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/autocomplete-valid.ts
@@ -131,13 +131,13 @@ interface AutocompleteValidSettings {
 
 const resolveSettings = (
   settings: Readonly<Record<string, unknown>> | undefined,
-): { inputComponents: ReadonlyArray<string> } => {
+): { inputComponents: ReadonlySet<string> } => {
   const reactDoctor = settings?.["react-doctor"];
   const ruleSettings =
     typeof reactDoctor === "object" && reactDoctor !== null
       ? ((reactDoctor as { autocompleteValid?: AutocompleteValidSettings }).autocompleteValid ?? {})
       : {};
-  return { inputComponents: ruleSettings.inputComponents ?? [] };
+  return { inputComponents: new Set(ruleSettings.inputComponents ?? []) };
 };
 
 // Port of `oxc_linter::rules::jsx_a11y::autocomplete_valid`. Validates
@@ -155,7 +155,7 @@ export const autocompleteValid = defineRule({
     return {
       JSXOpeningElement: (node: EsTreeNodeOfType<"JSXOpeningElement">) => {
         const tag = getElementType(node, context.settings);
-        if (!FORM_CONTROL_TAGS.has(tag) && !settings.inputComponents.includes(tag)) return;
+        if (!FORM_CONTROL_TAGS.has(tag) && !settings.inputComponents.has(tag)) return;
         const attribute = hasJsxPropIgnoreCase(node.attributes, "autoComplete");
         if (!attribute) return;
         const value = getJsxPropStringValue(attribute);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/heading-has-content.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/heading-has-content.ts
@@ -18,14 +18,14 @@ interface HeadingHasContentSettings {
 
 const resolveSettings = (
   settings: Readonly<Record<string, unknown>> | undefined,
-): { headingTags: ReadonlyArray<string> } => {
+): { headingTags: ReadonlySet<string> } => {
   const reactDoctor = settings?.["react-doctor"];
   const ruleSettings =
     typeof reactDoctor === "object" && reactDoctor !== null
       ? ((reactDoctor as { headingHasContent?: HeadingHasContentSettings }).headingHasContent ?? {})
       : {};
   return {
-    headingTags: [...DEFAULT_HEADING_TAGS, ...(ruleSettings.components ?? [])],
+    headingTags: new Set([...DEFAULT_HEADING_TAGS, ...(ruleSettings.components ?? [])]),
   };
 };
 
@@ -44,7 +44,7 @@ export const headingHasContent = defineRule({
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         const elementType = getElementType(node, context.settings);
-        if (!settings.headingTags.includes(elementType)) return;
+        if (!settings.headingTags.has(elementType)) return;
         const parent = (node as EsTreeNode).parent;
         if (parent && isNodeOfType(parent, "JSXElement")) {
           if (objectHasAccessibleChild(parent, context.settings)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.ts
@@ -1,11 +1,13 @@
-import { ALL_EVENT_HANDLERS } from "../../constants/event-handlers.js";
+import { ALL_EVENT_HANDLERS_LOWER } from "../../constants/event-handlers.js";
 import { HTML_TAGS } from "../../constants/html-tags.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isDisabledElement } from "../../utils/is-disabled-element.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isInteractiveElement } from "../../utils/is-interactive-element.js";
@@ -65,9 +67,15 @@ export const interactiveSupportsFocus = defineRule({
         const roleAttribute = hasJsxPropIgnoreCase(node.attributes, "role");
         const role = roleAttribute ? getJsxPropStringValue(roleAttribute) : null;
         if (!role) return;
-        const hasInteractiveHandler = ALL_EVENT_HANDLERS.some((handler) =>
-          Boolean(hasJsxPropIgnoreCase(node.attributes, handler)),
-        );
+        let hasInteractiveHandler = false;
+        for (const attribute of node.attributes) {
+          if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+          const attributeName = getJsxAttributeName(attribute.name);
+          if (attributeName && ALL_EVENT_HANDLERS_LOWER.has(attributeName.toLowerCase())) {
+            hasInteractiveHandler = true;
+            break;
+          }
+        }
         if (!hasInteractiveHandler) return;
         const elementType = getElementType(node, context.settings);
         // Custom components (PascalCase, not in HTML_TAGS) encapsulate

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/label-has-associated-control.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/label-has-associated-control.ts
@@ -26,20 +26,22 @@ interface JsxA11ySettings {
   attributes?: { for?: ReadonlyArray<string> };
 }
 
-const DEFAULT_CONTROL_COMPONENTS: ReadonlyArray<string> = [
+const DEFAULT_CONTROL_COMPONENTS: ReadonlySet<string> = new Set([
   "input",
   "meter",
   "output",
   "progress",
   "select",
   "textarea",
-];
+]);
 
 const DEFAULT_LABEL_ATTRIBUTES: ReadonlyArray<string> = ["alt", "aria-label", "aria-labelledby"];
 
 const resolveSettings = (
   settings: Readonly<Record<string, unknown>> | undefined,
-): Required<LabelHasAssociatedControlSettings> & {
+): Omit<Required<LabelHasAssociatedControlSettings>, "labelComponents" | "labelAttributes"> & {
+  labelComponents: ReadonlySet<string>;
+  labelAttributes: ReadonlySet<string>;
   forAttributes: ReadonlyArray<string>;
 } => {
   const reactDoctor = settings?.["react-doctor"];
@@ -52,10 +54,14 @@ const resolveSettings = (
   const a11ySettings =
     typeof jsxA11y === "object" && jsxA11y !== null ? (jsxA11y as JsxA11ySettings) : {};
   const forAttributes = a11ySettings.attributes?.for ?? ["htmlFor"];
-  const labelComponents = ["label", ...(ruleSettings.labelComponents ?? [])].sort();
-  const labelAttributes = [
-    ...new Set([...DEFAULT_LABEL_ATTRIBUTES, ...(ruleSettings.labelAttributes ?? [])]),
-  ].sort();
+  const labelComponents: ReadonlySet<string> = new Set([
+    "label",
+    ...(ruleSettings.labelComponents ?? []),
+  ]);
+  const labelAttributes: ReadonlySet<string> = new Set([
+    ...DEFAULT_LABEL_ATTRIBUTES,
+    ...(ruleSettings.labelAttributes ?? []),
+  ]);
   return {
     labelComponents,
     labelAttributes,
@@ -75,13 +81,13 @@ const resolveSettings = (
 
 // Glob match used by OXC for `controlComponents` entries (supports `*`).
 const isControlComponent = (tagName: string, controlComponents: ReadonlyArray<string>): boolean => {
-  if (DEFAULT_CONTROL_COMPONENTS.includes(tagName)) return true;
+  if (DEFAULT_CONTROL_COMPONENTS.has(tagName)) return true;
   return controlComponents.some((pattern) => compileGlob(pattern).test(tagName));
 };
 
 interface SearchContext {
   depth: number;
-  labelAttributes: ReadonlyArray<string>;
+  labelAttributes: ReadonlySet<string>;
   controlComponents: ReadonlyArray<string>;
   settings: Readonly<Record<string, unknown>> | undefined;
 }
@@ -131,7 +137,7 @@ const searchForAccessibleLabel = (
       const attributeName = (attribute as EsTreeNodeOfType<"JSXAttribute">).name;
       if (!isNodeOfType(attributeName as EsTreeNode, "JSXIdentifier")) continue;
       const propName = getJsxAttributeName(attributeName as EsTreeNodeOfType<"JSXIdentifier">);
-      if (!propName || !searchContext.labelAttributes.includes(propName)) continue;
+      if (!propName || !searchContext.labelAttributes.has(propName)) continue;
       const attributeValue = (attribute as EsTreeNodeOfType<"JSXAttribute">).value;
       if (!attributeValue) continue;
       if (
@@ -173,7 +179,7 @@ const hasAccessibleLabel = (
     const attributeName = (attribute as EsTreeNodeOfType<"JSXAttribute">).name;
     if (!isNodeOfType(attributeName as EsTreeNode, "JSXIdentifier")) continue;
     const propName = getJsxAttributeName(attributeName as EsTreeNodeOfType<"JSXIdentifier">);
-    if (propName && searchContext.labelAttributes.includes(propName)) return true;
+    if (propName && searchContext.labelAttributes.has(propName)) return true;
   }
   for (const child of element.children) {
     if (searchForAccessibleLabel(child as EsTreeNode, 1, searchContext)) return true;
@@ -207,7 +213,7 @@ export const labelHasAssociatedControl = defineRule({
         if (isTestlikeFile) return;
         const opening = node.openingElement;
         const tagName = getElementType(opening, context.settings);
-        if (!settings.labelComponents.includes(tagName)) return;
+        if (!settings.labelComponents.has(tagName)) return;
         const hasHtmlFor = settings.forAttributes.some((attributeName) =>
           Boolean(hasJsxPropIgnoreCase(opening.attributes, attributeName)),
         );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/media-has-caption.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/media-has-caption.ts
@@ -22,9 +22,9 @@ interface MediaHasCaptionSettings {
 const resolveSettings = (
   settings: Readonly<Record<string, unknown>> | undefined,
 ): {
-  audio: ReadonlyArray<string>;
-  video: ReadonlyArray<string>;
-  track: ReadonlyArray<string>;
+  audio: ReadonlySet<string>;
+  video: ReadonlySet<string>;
+  track: ReadonlySet<string>;
 } => {
   const reactDoctor = settings?.["react-doctor"];
   const ruleSettings =
@@ -32,9 +32,9 @@ const resolveSettings = (
       ? ((reactDoctor as { mediaHasCaption?: MediaHasCaptionSettings }).mediaHasCaption ?? {})
       : {};
   return {
-    audio: [...DEFAULT_AUDIO, ...(ruleSettings.audio ?? [])],
-    video: [...DEFAULT_VIDEO, ...(ruleSettings.video ?? [])],
-    track: [...DEFAULT_TRACK, ...(ruleSettings.track ?? [])],
+    audio: new Set([...DEFAULT_AUDIO, ...(ruleSettings.audio ?? [])]),
+    video: new Set([...DEFAULT_VIDEO, ...(ruleSettings.video ?? [])]),
+    track: new Set([...DEFAULT_TRACK, ...(ruleSettings.track ?? [])]),
   };
 };
 
@@ -83,7 +83,7 @@ const trackKindMightBeCaptions = (
 // tracks (e.g. a static `kind="subtitles"`) does not satisfy the requirement.
 const childMayRenderTrack = (
   child: EsTreeNode,
-  trackTags: ReadonlyArray<string>,
+  trackTags: ReadonlySet<string>,
   settings: Readonly<Record<string, unknown>> | undefined,
 ): boolean => {
   if (!isNodeOfType(child, "JSXExpressionContainer")) return false;
@@ -104,7 +104,7 @@ const childMayRenderTrack = (
     if (rendersCaptionTrack) return false;
     if (
       isNodeOfType(inner, "JSXElement") &&
-      trackTags.includes(getElementType(inner.openingElement, settings)) &&
+      trackTags.has(getElementType(inner.openingElement, settings)) &&
       trackKindMightBeCaptions(inner.openingElement)
     ) {
       rendersCaptionTrack = true;
@@ -127,7 +127,7 @@ export const mediaHasCaption = defineRule({
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         const tag = getElementType(node, context.settings);
-        const isAudioOrVideo = settings.audio.includes(tag) || settings.video.includes(tag);
+        const isAudioOrVideo = settings.audio.has(tag) || settings.video.has(tag);
         if (!isAudioOrVideo) return;
         const mutedAttribute = hasJsxPropIgnoreCase(node.attributes, "muted");
         if (evaluateMuted(mutedAttribute) === true) return;
@@ -145,7 +145,7 @@ export const mediaHasCaption = defineRule({
           if (!isNodeOfType(child as EsTreeNode, "JSXElement")) return false;
           const opening = (child as EsTreeNodeOfType<"JSXElement">).openingElement;
           const childTag = getElementType(opening, context.settings);
-          if (!settings.track.includes(childTag)) return false;
+          if (!settings.track.has(childTag)) return false;
           const kindAttribute = hasJsxPropIgnoreCase(opening.attributes, "kind");
           if (!kindAttribute) return false;
           let kindValue = kindAttribute.value as EsTreeNode | null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
@@ -100,15 +101,13 @@ const collectRoleBranches = (expression: EsTreeNode, out: RoleExpressionBranches
 const buildMessage = (tag: string): string =>
   `Keyboard & screen reader users can't trigger this \`<${tag}>\` because it isn't interactive, so use a button or link or add an interactive role.`;
 
-// Mouse / pointer / keyboard events that imply interaction.
-const INTERACTIVE_HANDLERS: ReadonlyArray<string> = [
-  "onClick",
-  "onMouseDown",
-  "onMouseUp",
-  "onKeyDown",
-  "onKeyPress",
-  "onKeyUp",
-];
+// Mouse / pointer / keyboard events that imply interaction, keyed by
+// lowercased form for a single case-insensitive pass over the attributes.
+const INTERACTIVE_HANDLERS_LOWER: ReadonlySet<string> = new Set(
+  ["onClick", "onMouseDown", "onMouseUp", "onKeyDown", "onKeyPress", "onKeyUp"].map((handlerName) =>
+    handlerName.toLowerCase(),
+  ),
+);
 
 // Port of `oxc_linter::rules::jsx_a11y::no_noninteractive_element_interactions`.
 // Reports interactive event handlers attached to non-interactive HTML
@@ -131,9 +130,15 @@ export const noNoninteractiveElementInteractions = defineRule({
         // ARIA role, and clicking a label forwards activation to its nested
         // keyboard-accessible input.
         if (tag === "label") return;
-        const hasHandler = INTERACTIVE_HANDLERS.some((handler) =>
-          hasJsxPropIgnoreCase(node.attributes, handler),
-        );
+        let hasHandler = false;
+        for (const attribute of node.attributes) {
+          if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+          const attributeName = getJsxAttributeName(attribute.name);
+          if (attributeName && INTERACTIVE_HANDLERS_LOWER.has(attributeName.toLowerCase())) {
+            hasHandler = true;
+            break;
+          }
+        }
         if (!hasHandler) return;
         if (isHiddenFromScreenReader(node, context.settings)) return;
         const roleAttr = hasJsxPropIgnoreCase(node.attributes, "role");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-static-element-interactions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-static-element-interactions.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isAbstractRole } from "../../utils/is-abstract-role.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
@@ -70,6 +71,9 @@ export const noStaticElementInteractions = defineRule({
   category: "Accessibility",
   create: (context) => {
     const settings = resolveSettings(context.settings);
+    const handlersLower: ReadonlySet<string> = new Set(
+      settings.handlers.map((handlerName) => handlerName.toLowerCase()),
+    );
     const isTestlikeFile = isTestlikeFilename(context.filename);
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
@@ -82,9 +86,17 @@ export const noStaticElementInteractions = defineRule({
         // pass through.
         let hasNonBlockerHandler = false;
         let hasAnyHandler = false;
-        for (const handler of settings.handlers) {
-          const attribute = hasJsxPropIgnoreCase(node.attributes, handler);
-          if (!attribute) continue;
+        // Only the FIRST attribute per handler name counts (mirrors the
+        // per-handler `hasJsxPropIgnoreCase` first-match this replaces).
+        let seenHandlerNames: Set<string> | null = null;
+        for (const attribute of node.attributes) {
+          if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+          const attributeName = getJsxAttributeName(attribute.name);
+          if (!attributeName) continue;
+          const handlerNameLower = attributeName.toLowerCase();
+          if (!handlersLower.has(handlerNameLower)) continue;
+          if (seenHandlerNames?.has(handlerNameLower)) continue;
+          (seenHandlerNames ??= new Set()).add(handlerNameLower);
           if (isNullValue(attribute)) continue;
           hasAnyHandler = true;
           if (!isPureEventBlockerHandler(attribute)) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.ts
@@ -1,7 +1,7 @@
 import { isValidDomAriaProperty } from "../../constants/dom-aria-properties.js";
 import {
   DOM_ATTRIBUTES_TO_CAMEL,
-  DOM_PROPERTIES_IGNORE_CASE,
+  DOM_PROPERTIES_IGNORE_CASE_BY_LOWER,
   DOM_PROPERTY_NAMES,
   DOM_PROPERTY_NAMES_LOWER,
 } from "../../constants/dom-property-names.js";
@@ -44,12 +44,8 @@ const matchesHtmlTagConventions = (tagName: string): boolean => {
   return !tagName.includes("-");
 };
 
-const normalizeAttributeCase = (name: string): string => {
-  for (const ignoreCaseName of DOM_PROPERTIES_IGNORE_CASE) {
-    if (ignoreCaseName.toLowerCase() === name.toLowerCase()) return ignoreCaseName;
-  }
-  return name;
-};
+const normalizeAttributeCase = (name: string): string =>
+  DOM_PROPERTIES_IGNORE_CASE_BY_LOWER.get(name.toLowerCase()) ?? name;
 
 const hasUppercaseChar = (input: string): boolean => /[A-Z]/.test(input);
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -67,9 +67,11 @@ const resolveTextBoundaryName = (
   return resolveJsxElementName(openingElement);
 };
 
+const TEXT_COMPONENT_KEYWORDS: ReadonlyArray<string> = [...REACT_NATIVE_TEXT_COMPONENT_KEYWORDS];
+
 const isTextHandlingComponent = (elementName: string): boolean => {
   if (REACT_NATIVE_TEXT_COMPONENTS.has(elementName)) return true;
-  return [...REACT_NATIVE_TEXT_COMPONENT_KEYWORDS].some((keyword) => elementName.includes(keyword));
+  return TEXT_COMPONENT_KEYWORDS.some((keyword) => elementName.includes(keyword));
 };
 
 const isTransparentTextWrapper = (elementName: string | null): boolean =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-route-property-order.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-route-property-order.ts
@@ -1,4 +1,7 @@
-import { TANSTACK_ROUTE_PROPERTY_ORDER } from "../../constants/tanstack.js";
+import {
+  TANSTACK_ROUTE_PROPERTY_INDEX,
+  TANSTACK_ROUTE_PROPERTY_ORDER,
+} from "../../constants/tanstack.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { getRouteOptionsObject } from "./utils/get-route-options-object.js";
@@ -28,12 +31,12 @@ export const tanstackStartRoutePropertyOrder = defineRule({
       }
 
       const sensitiveProperties = orderedPropertyNames.filter((propertyName) =>
-        TANSTACK_ROUTE_PROPERTY_ORDER.includes(propertyName),
+        TANSTACK_ROUTE_PROPERTY_INDEX.has(propertyName),
       );
 
       let lastIndex = -1;
       for (const propertyName of sensitiveProperties) {
-        const currentIndex = TANSTACK_ROUTE_PROPERTY_ORDER.indexOf(propertyName);
+        const currentIndex = TANSTACK_ROUTE_PROPERTY_INDEX.get(propertyName) ?? -1;
         if (currentIndex < lastIndex) {
           const expectedBefore = TANSTACK_ROUTE_PROPERTY_ORDER[lastIndex];
           context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-server-fn-method-order.ts
@@ -1,5 +1,6 @@
 import {
   TANSTACK_INPUT_VALIDATOR_METHOD_NAMES,
+  TANSTACK_MIDDLEWARE_METHOD_INDEX,
   TANSTACK_MIDDLEWARE_METHOD_ORDER,
   TANSTACK_SERVER_FN_NAMES,
 } from "../../constants/tanstack.js";
@@ -53,14 +54,13 @@ export const tanstackStartServerFnMethodOrder = defineRule({
       if (methodNames[methodNames.length - 1] !== ownMethodName) return;
 
       const orderSensitiveMethods = methodNames.filter((name) =>
-        TANSTACK_MIDDLEWARE_METHOD_ORDER.includes(toMethodOrderToken(name)),
+        TANSTACK_MIDDLEWARE_METHOD_INDEX.has(toMethodOrderToken(name)),
       );
 
       let lastIndex = -1;
       for (const methodName of orderSensitiveMethods) {
-        const currentIndex = TANSTACK_MIDDLEWARE_METHOD_ORDER.indexOf(
-          toMethodOrderToken(methodName),
-        );
+        const currentIndex =
+          TANSTACK_MIDDLEWARE_METHOD_INDEX.get(toMethodOrderToken(methodName)) ?? -1;
         if (currentIndex < lastIndex) {
           const expectedBefore = TANSTACK_MIDDLEWARE_METHOD_ORDER[lastIndex];
           context.report({


### PR DESCRIPTION
## Why

~15 audit findings where per-node hot paths scan arrays with `.includes()`/`.indexOf()` or re-lowercase constants per call: ARIA role tables, DOM property case-insensitive lookups, event-handler probes, tag lists, TanStack property-order tables. Findings: #10 #17 #21 #23 #28 #36 #39 #40 #216 #372 #373 #458 #459 #460 #461.

## What changed

- `aria-element-roles`: prebuilt `IMPLICIT_ROLES_BY_TAG` / `TAGS_BY_ROLE` Maps (O(1) instead of scanning the pair table per node).
- `dom-property-names`: `DOM_PROPERTIES_IGNORE_CASE` gets a lowercased-key Map — attribute case normalization is one `toLowerCase` + `Map.get` instead of a double-lowercase linear scan per attribute.
- `event-handlers`: `ALL_EVENT_HANDLERS_LOWER` Set, lowercased once at module load.
- Handler probes (interactive-supports-focus, no-noninteractive-element-interactions, no-static-element-interactions): one pass over the element's attributes against the Set instead of a `.some()` per handler name × attributes scan — first-match and duplicate-prop semantics preserved exactly.
- Tag/component lists → Sets: autocomplete-valid, heading-has-content, media-has-caption, label-has-associated-control (settings-derived lists included).
- TanStack: `TANSTACK_ROUTE_PROPERTY_INDEX` / `TANSTACK_MIDDLEWARE_METHOD_INDEX` Maps give membership + order in one lookup.

## Test plan

- Plugin suite: 8704 pass / 94 skip — zero deltas vs pristine main. Root typecheck + lint clean.
- Equivalence: 617-file corpus — 291 diagnostics, sorted tuples byte-identical.
- Adversarial review attacked case-sensitivity, duplicate-key collapse, and first-match-vs-any-match semantics on the single-pass rewrites — no divergence found.

Note: touches `interactive-supports-focus.ts` and `rn-no-raw-text.ts`, shared with the early-exit sweep PR — whichever merges second needs a trivial rebase. The two touched tanstack files (route-property-order, server-fn-method-order) are NOT the ones in PR #1043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor targets hot-path lookups only; PR claims byte-identical diagnostics on a large corpus, with careful preservation of case-insensitivity and first-match handler semantics.
> 
> **Overview**
> **Performance-only refactor** across `oxlint-plugin-react-doctor`: linear membership and ordering checks on per-JSX-node paths now use **Sets and Maps** built at module load or rule `create()` time.
> 
> **Constants:** ARIA element↔role lookups use prebuilt `IMPLICIT_ROLES_BY_TAG` / `TAGS_BY_ROLE` maps; DOM case-insensitive props use `DOM_PROPERTIES_IGNORE_CASE_BY_LOWER`; event handlers export `ALL_EVENT_HANDLERS_LOWER`; TanStack adds `TANSTACK_ROUTE_PROPERTY_INDEX` and `TANSTACK_MIDDLEWARE_METHOD_INDEX` for order checks.
> 
> **Rules:** Several a11y rules resolve config tag/component lists as `Set`s (`autocomplete-valid`, `heading-has-content`, `media-has-caption`, `label-has-associated-control`). Handler detection in `interactive-supports-focus`, `no-noninteractive-element-interactions`, and `no-static-element-interactions` does **one attribute pass** against lowercased handler Sets (first-match / duplicate-prop behavior kept). `no-unknown-property` uses the new DOM ignore-case map. TanStack order rules use the index maps instead of `includes` + `indexOf`. `rn-no-raw-text` caches the text-keyword array once per module.
> 
> No intended diagnostic or API behavior change beyond faster lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a9ffca67a7cf3367c3dcc97ede43d4b254ac9a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->