### PR TITLE
perf(plugin): regex-hoist sweep — stop rebuilding RegExps per call

### DIFF
--- a/.changeset/perf-sweep-regex-hoist.md
+++ b/.changeset/perf-sweep-regex-hoist.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: regex-hoist sweep — ~8 per-call RegExp constructions move to module scope or behind cheap gates (public-env secret-name global pattern hoisted, supabase RLS enables collected in one pass instead of per-table compile+slice, dangerous-html-sink inert-target and serializer exemptions gated/lazy, design color/duration parsers get first-char and substring discriminators)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -32,12 +32,21 @@ const extractColorFromShadowLayer = (layer: string): ParsedRgb | null => {
   return null;
 };
 
+const RGB_FUNCTION_PATTERN = /rgba?\([^)]*\)/g;
+const HEX_COLOR_PATTERN = /#[0-9a-f]{3,8}\b/gi;
+const NUMERIC_TOKEN_PATTERN = /(\d+(?:\.\d+)?)(px)?/g;
+
+// The blur radius is the third numeric token (`offset-x offset-y blur`).
+const SHADOW_BLUR_TOKEN_INDEX = 2;
+
 const parseShadowLayerBlur = (layer: string): number => {
-  const withoutColors = layer.replace(/rgba?\([^)]*\)/g, "").replace(/#[0-9a-f]{3,8}\b/gi, "");
-  const numericTokens = [...withoutColors.matchAll(/(\d+(?:\.\d+)?)(px)?/g)].map((match) =>
-    parseFloat(match[1]),
-  );
-  return numericTokens.length >= 3 ? numericTokens[2] : 0;
+  const withoutColors = layer.replace(RGB_FUNCTION_PATTERN, "").replace(HEX_COLOR_PATTERN, "");
+  let tokenIndex = 0;
+  for (const match of withoutColors.matchAll(NUMERIC_TOKEN_PATTERN)) {
+    if (tokenIndex === SHADOW_BLUR_TOKEN_INDEX) return parseFloat(match[1]);
+    tokenIndex += 1;
+  }
+  return 0;
 };
 
 const hasColoredGlowShadow = (shadowValue: string): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-gray-on-colored-background.ts
@@ -17,6 +17,9 @@ const BG_COLOR_PATTERN =
 // reordered stacks (`md:hover` vs `hover:md`) share one key. A leading
 // `!` (the important modifier) is not part of the utility name.
 const splitVariantScope = (token: string): { scope: string; utility: string } => {
+  if (!token.includes(":")) {
+    return { scope: "", utility: token.startsWith("!") ? token.slice(1) : token };
+  }
   const segments = token.split(":");
   const rawUtility = segments[segments.length - 1];
   return {
@@ -44,6 +47,10 @@ export const noGrayOnColoredBackground = defineRule({
       const bgColorScopes = new Set<string>();
       for (const token of classStr.split(/\s+/)) {
         if (!token) continue;
+        // Every pattern below anchors on a `text-` / `bg-` utility, so a
+        // token containing neither substring can never match — skip the
+        // variant-scope split and the four regexes.
+        if (!token.includes("text-") && !token.includes("bg-")) continue;
         const { scope, utility } = splitVariantScope(token);
         if (TEXT_COLOR_PATTERN.test(utility)) textColorScopes.add(scope);
         if (BG_COLOR_PATTERN.test(utility)) bgColorScopes.add(scope);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-long-transition-duration.ts
@@ -28,6 +28,13 @@ const hasInfiniteIterationCount = (properties: ReadonlyArray<EsTreeNode>): boole
 const isInfiniteAnimationSegment = (segment: string): boolean =>
   segment.trim().split(/\s+/).includes("infinite");
 
+// `100ms` / `1.5s` as the WHOLE segment (transitionDuration / animationDuration
+// values). One combined pattern replaces separate ms and s matches per segment.
+const DURATION_SEGMENT_PATTERN = /^([\d.]+)(m?s)$/;
+
+// First time token inside a `transition` / `animation` shorthand segment.
+const FIRST_TIME_TOKEN_PATTERN = /(?<![a-zA-Z\d])([\d.]+)(m?s)(?![a-zA-Z\d-])/;
+
 export const noLongTransitionDuration = defineRule({
   id: "no-long-transition-duration",
   title: "Transition duration too long",
@@ -67,19 +74,13 @@ export const noLongTransitionDuration = defineRule({
         if (key === "transitionDuration" || key === "animationDuration") {
           let longestDurationPropertyMs = 0;
           for (const segment of value.split(",")) {
-            const trimmedSegment = segment.trim();
-            const msMatch = trimmedSegment.match(/^([\d.]+)ms$/);
-            const secondsMatch = trimmedSegment.match(/^([\d.]+)s$/);
-            if (msMatch)
-              longestDurationPropertyMs = Math.max(
-                longestDurationPropertyMs,
-                parseFloat(msMatch[1]),
-              );
-            else if (secondsMatch)
-              longestDurationPropertyMs = Math.max(
-                longestDurationPropertyMs,
-                parseFloat(secondsMatch[1]) * 1000,
-              );
+            const durationMatch = segment.trim().match(DURATION_SEGMENT_PATTERN);
+            if (!durationMatch) continue;
+            const segmentDurationMs =
+              durationMatch[2] === "ms"
+                ? parseFloat(durationMatch[1])
+                : parseFloat(durationMatch[1]) * 1000;
+            longestDurationPropertyMs = Math.max(longestDurationPropertyMs, segmentDurationMs);
           }
           if (longestDurationPropertyMs > 0) durationMs = longestDurationPropertyMs;
         }
@@ -88,7 +89,7 @@ export const noLongTransitionDuration = defineRule({
           let longestDurationMs = 0;
           for (const segment of value.split(",")) {
             if (key === "animation" && isInfiniteAnimationSegment(segment)) continue;
-            const firstTimeMatch = segment.match(/(?<![a-zA-Z\d])([\d.]+)(m?s)(?![a-zA-Z\d-])/);
+            const firstTimeMatch = segment.match(FIRST_TIME_TOKEN_PATTERN);
             if (!firstTimeMatch) continue;
             const segmentDurationMs =
               firstTimeMatch[2] === "ms"

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/utils/parse-color-to-rgb.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/utils/parse-color-to-rgb.ts
@@ -38,58 +38,64 @@ export const parseColorToRgb = (value: string): ParsedRgb | null => {
   // (`border-[rgb(229_231_235)]`), so normalize before matching.
   const trimmed = value.trim().toLowerCase().replace(/_/g, " ");
 
-  const hex8Match = trimmed.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})[0-9a-f]{2}$/);
-  if (hex8Match) {
-    return {
-      red: parseInt(hex8Match[1], 16),
-      green: parseInt(hex8Match[2], 16),
-      blue: parseInt(hex8Match[3], 16),
-    };
+  if (trimmed.startsWith("#")) {
+    const hex8Match = trimmed.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})[0-9a-f]{2}$/);
+    if (hex8Match) {
+      return {
+        red: parseInt(hex8Match[1], 16),
+        green: parseInt(hex8Match[2], 16),
+        blue: parseInt(hex8Match[3], 16),
+      };
+    }
+
+    const hex6Match = trimmed.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/);
+    if (hex6Match) {
+      return {
+        red: parseInt(hex6Match[1], 16),
+        green: parseInt(hex6Match[2], 16),
+        blue: parseInt(hex6Match[3], 16),
+      };
+    }
+
+    const hex4Match = trimmed.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])[0-9a-f]$/);
+    if (hex4Match) {
+      return {
+        red: parseInt(hex4Match[1] + hex4Match[1], 16),
+        green: parseInt(hex4Match[2] + hex4Match[2], 16),
+        blue: parseInt(hex4Match[3] + hex4Match[3], 16),
+      };
+    }
+
+    const hex3Match = trimmed.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/);
+    if (hex3Match) {
+      return {
+        red: parseInt(hex3Match[1] + hex3Match[1], 16),
+        green: parseInt(hex3Match[2] + hex3Match[2], 16),
+        blue: parseInt(hex3Match[3] + hex3Match[3], 16),
+      };
+    }
   }
 
-  const hex6Match = trimmed.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/);
-  if (hex6Match) {
-    return {
-      red: parseInt(hex6Match[1], 16),
-      green: parseInt(hex6Match[2], 16),
-      blue: parseInt(hex6Match[3], 16),
-    };
+  if (trimmed.includes("rgb")) {
+    const rgbMatch = trimmed.match(/rgba?\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)/);
+    if (rgbMatch) {
+      return {
+        red: parseInt(rgbMatch[1], 10),
+        green: parseInt(rgbMatch[2], 10),
+        blue: parseInt(rgbMatch[3], 10),
+      };
+    }
   }
 
-  const hex4Match = trimmed.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])[0-9a-f]$/);
-  if (hex4Match) {
-    return {
-      red: parseInt(hex4Match[1] + hex4Match[1], 16),
-      green: parseInt(hex4Match[2] + hex4Match[2], 16),
-      blue: parseInt(hex4Match[3] + hex4Match[3], 16),
-    };
-  }
-
-  const hex3Match = trimmed.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/);
-  if (hex3Match) {
-    return {
-      red: parseInt(hex3Match[1] + hex3Match[1], 16),
-      green: parseInt(hex3Match[2] + hex3Match[2], 16),
-      blue: parseInt(hex3Match[3] + hex3Match[3], 16),
-    };
-  }
-
-  const rgbMatch = trimmed.match(/rgba?\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)/);
-  if (rgbMatch) {
-    return {
-      red: parseInt(rgbMatch[1], 10),
-      green: parseInt(rgbMatch[2], 10),
-      blue: parseInt(rgbMatch[3], 10),
-    };
-  }
-
-  const hslMatch = trimmed.match(/hsla?\(\s*([\d.]+)(?:deg)?[\s,]+([\d.]+)%[\s,]+([\d.]+)%/);
-  if (hslMatch) {
-    return convertHslToRgb(
-      parseFloat(hslMatch[1]),
-      parseFloat(hslMatch[2]),
-      parseFloat(hslMatch[3]),
-    );
+  if (trimmed.includes("hsl")) {
+    const hslMatch = trimmed.match(/hsla?\(\s*([\d.]+)(?:deg)?[\s,]+([\d.]+)%[\s,]+([\d.]+)%/);
+    if (hslMatch) {
+      return convertHslToRgb(
+        parseFloat(hslMatch[1]),
+        parseFloat(hslMatch[2]),
+        parseFloat(hslMatch[3]),
+      );
+    }
   }
 
   return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -153,6 +153,12 @@ const getTemplateInterpolations = (valueTail: string): string | null => {
 // catches scratch nodes parsed across a loop (the second write in a reuse loop
 // sits far from its `createElement`).
 const isInertParseTarget = (target: string, fileContent: string): boolean => {
+  // Every inert idiom below requires one of these call names somewhere in the
+  // file — without them no pattern can match, so skip all regex builds/scans.
+  const fileHasCreateElement = fileContent.includes("createElement");
+  const fileHasIsolatedDocument = fileContent.includes("createHTMLDocument");
+  if (!fileHasCreateElement && !fileHasIsolatedDocument) return false;
+
   const escapedTarget = escapeRegExp(target);
   const rootIdentifier = target.split(".")[0] ?? target;
   const escapedRoot = escapeRegExp(rootIdentifier);
@@ -165,26 +171,31 @@ const isInertParseTarget = (target: string, fileContent: string): boolean => {
   );
   if (liveDomSourcePattern.test(fileContent)) return false;
 
-  const templateElementPattern = new RegExp(
-    `${escapedTarget}\\s*=\\s*document\\.createElement\\(\\s*["'\`]template["'\`]`,
-  );
-  if (templateElementPattern.test(fileContent)) return true;
+  if (fileHasCreateElement) {
+    const templateElementPattern = new RegExp(
+      `${escapedTarget}\\s*=\\s*document\\.createElement\\(\\s*["'\`]template["'\`]`,
+    );
+    if (templateElementPattern.test(fileContent)) return true;
 
-  // A `<style>` element's innerHTML is CSS text (the critical-CSS idiom via the
-  // DOM API, counterpart of the `<style dangerouslySetInnerHTML>` JSX exemption);
-  // a `<textarea>`'s is RCDATA — scripts never execute — which is the HTML-entity
-  // decode idiom (`textarea.innerHTML = x; return textarea.value`). Neither is
-  // executable markup.
-  const inertElementPattern = new RegExp(
-    `${escapedRoot}\\s*=\\s*[^\\n;]*\\bcreateElement\\(\\s*["'\`](?:style|textarea)["'\`]`,
-  );
-  if (inertElementPattern.test(fileContent)) return true;
+    // A `<style>` element's innerHTML is CSS text (the critical-CSS idiom via the
+    // DOM API, counterpart of the `<style dangerouslySetInnerHTML>` JSX exemption);
+    // a `<textarea>`'s is RCDATA — scripts never execute — which is the HTML-entity
+    // decode idiom (`textarea.innerHTML = x; return textarea.value`). Neither is
+    // executable markup.
+    const inertElementPattern = new RegExp(
+      `${escapedRoot}\\s*=\\s*[^\\n;]*\\bcreateElement\\(\\s*["'\`](?:style|textarea)["'\`]`,
+    );
+    if (inertElementPattern.test(fileContent)) return true;
+  }
 
-  const isolatedDocumentPattern = new RegExp(
-    `${escapedRoot}\\s*=\\s*[^\\n;]*\\bcreateHTMLDocument\\s*\\(`,
-  );
-  if (isolatedDocumentPattern.test(fileContent)) return true;
+  if (fileHasIsolatedDocument) {
+    const isolatedDocumentPattern = new RegExp(
+      `${escapedRoot}\\s*=\\s*[^\\n;]*\\bcreateHTMLDocument\\s*\\(`,
+    );
+    if (isolatedDocumentPattern.test(fileContent)) return true;
+  }
 
+  if (!fileHasCreateElement) return false;
   const createElementPattern = new RegExp(`${escapedRoot}\\s*=\\s*[^\\n;]*\\bcreateElement\\s*\\(`);
   if (!createElementPattern.test(fileContent)) return false;
 
@@ -341,20 +352,16 @@ export const dangerousHtmlSink = defineRule({
             `\\b${escapedIdentifier}\\b\\s*${SERIALIZER_ASSIGNMENT_PATTERN.source}`,
             "i",
           );
+          if (fromSerializer.test(file.content)) continue;
           const fromSanitizer = new RegExp(
             `\\b${escapedIdentifier}\\b\\s*${SANITIZED_ASSIGNMENT_PATTERN.source}`,
             "i",
           );
+          if (fromSanitizer.test(file.content)) continue;
           const fromDomContent = new RegExp(
             `\\b${escapedIdentifier}\\b\\s*${DOM_CONTENT_ASSIGNMENT_PATTERN.source}`,
           );
-          if (
-            fromSerializer.test(file.content) ||
-            fromSanitizer.test(file.content) ||
-            fromDomContent.test(file.content)
-          ) {
-            continue;
-          }
+          if (fromDomContent.test(file.content)) continue;
         }
       }
       const sinkTargetMatch = INNERHTML_TARGET_PATTERN.exec(line);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-table-missing-rls.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-table-missing-rls.ts
@@ -1,6 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { ScanFinding } from "../../utils/file-scan.js";
-import { escapeRegExp } from "./utils/escape-reg-exp.js";
 import { getLocationAtIndex } from "./utils/get-location-at-index.js";
 import { isSupabaseMigrationPath } from "./utils/is-supabase-migration-path.js";
 import { sanitizeSqlForScan } from "./utils/sanitize-sql-for-scan.js";
@@ -19,11 +18,20 @@ const CREATE_PUBLIC_TABLE_PATTERN =
 // enabled — so RLS must be checked per table rather than file-wide (a sibling
 // table enabling RLS must not vouch for this one). The enable keyword must
 // follow the table name directly so a nearby unrelated `enable` cannot match.
-const enableRlsForTablePattern = (tableName: string): RegExp =>
-  new RegExp(
-    `alter\\s+table\\s+(?:if\\s+exists\\s+)?(?:only\\s+)?(?:public\\s*\\.\\s*)?["\`]?${escapeRegExp(tableName)}["\`]?\\s+(?:force\\s+)?enable\\s+row\\s+level\\s+security`,
-    "i",
-  );
+// One global pass collects every enable's (table, index) pair, replacing a
+// per-created-table RegExp compile + tail slice.
+const ENABLE_RLS_PATTERN =
+  /alter\s+table\s+(?:if\s+exists\s+)?(?:only\s+)?(?:public\s*\.\s*)?["`]?([A-Za-z_][\w$]*)["`]?\s+(?:force\s+)?enable\s+row\s+level\s+security/gi;
+
+const collectLastEnableRlsIndexByTable = (content: string): Map<string, number> => {
+  const lastEnableIndexByTable = new Map<string, number>();
+  for (const match of content.matchAll(ENABLE_RLS_PATTERN)) {
+    const tableName = match[1];
+    if (tableName === undefined) continue;
+    lastEnableIndexByTable.set(tableName.toLowerCase(), match.index);
+  }
+  return lastEnableIndexByTable;
+};
 
 export const supabaseTableMissingRls = defineRule({
   id: "supabase-table-missing-rls",
@@ -44,6 +52,7 @@ export const supabaseTableMissingRls = defineRule({
     if (!/create\s+(?:unlogged\s+)?table/i.test(content)) return [];
 
     const findings: ScanFinding[] = [];
+    const lastEnableIndexByTable = collectLastEnableRlsIndexByTable(content);
     CREATE_PUBLIC_TABLE_PATTERN.lastIndex = 0;
     for (
       let match = CREATE_PUBLIC_TABLE_PATTERN.exec(content);
@@ -54,8 +63,9 @@ export const supabaseTableMissingRls = defineRule({
       if (tableName === undefined) continue;
       // The enable must come AFTER this `create table` — an `alter table if
       // exists <name> enable …` before it is a no-op on a not-yet-created
-      // table, so only scan from the create position onward.
-      if (enableRlsForTablePattern(tableName).test(content.slice(match.index))) continue;
+      // table, so only the latest same-name enable position matters.
+      const lastEnableIndex = lastEnableIndexByTable.get(tableName.toLowerCase());
+      if (lastEnableIndex !== undefined && lastEnableIndex >= match.index) continue;
       const location = getLocationAtIndex(content, match.index);
       findings.push({
         message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/find-suspicious-public-env-secret-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/find-suspicious-public-env-secret-name.ts
@@ -4,11 +4,18 @@ import {
 } from "../../../constants/security.js";
 import { escapeRegExp } from "./escape-reg-exp.js";
 
+// Compiled once — `matchAll` clones the regex per call, so the shared
+// constant never carries `lastIndex` state between invocations.
+const PUBLIC_ENV_SECRET_NAME_GLOBAL_PATTERN = new RegExp(
+  PUBLIC_ENV_SECRET_NAME_PATTERN.source,
+  "gi",
+);
+
 // Returns a RegExp matching the first suspicious name so callers can
 // locate the finding in the file content; `undefined` when every
 // public-prefixed env name in the content is a trusted/publishable one.
 export const findSuspiciousPublicEnvSecretNamePattern = (content: string): RegExp | undefined => {
-  for (const match of content.matchAll(new RegExp(PUBLIC_ENV_SECRET_NAME_PATTERN.source, "gi"))) {
+  for (const match of content.matchAll(PUBLIC_ENV_SECRET_NAME_GLOBAL_PATTERN)) {
     const value = match[0] ?? "";
     if (!TRUSTED_PUBLIC_SECRET_NAME_PATTERN.test(value)) {
       return new RegExp(escapeRegExp(value));


### PR DESCRIPTION
## Why

~12 audit findings where RegExps are constructed inside per-node/per-file paths, or regex batteries run without a cheap substring gate. Findings: #73 #74 #76 #77 #83 #248 #264 #270 #271 #281 #295 #518 #519. (compileGlob #27/#158/#396 and has-responsive-prefix #235 already shipped as PR #1044 and are untouched here.)

## What changed

- security-scan `find-suspicious-public-env-secret-name`: one hoisted global pattern consumed via `matchAll` (clone-safe — no shared `lastIndex`; no other call site uses `.test`/`.exec` on it).
- `supabase-table-missing-rls`: per-created-table `new RegExp(escapeRegExp(name))` + tail-slice search replaced by ONE global enable-RLS collection pass keeping the max index per lowercased table name. Predicate proven identical: "any enable at index ≥ create" ⟺ "max enable index ≥ create"; capture charsets of the create and enable patterns are byte-identical (`[A-Za-z_][\w$]*`); both old (`/i` on the escaped name) and new (lowercased keys) are case-insensitive.
- `dangerous-html-sink`: inert-parse-target regexes built lazily behind `createElement`/`createHTMLDocument` includes-gates; serializer/sanitizer exemption regexes short-circuit sequentially.
- design tokens: fused duration pattern (no-long-transition-duration), hoisted regexes + third-numeric-token early stop (no-dark-mode-glow), token gates + variant-free fast path (no-gray-on-colored-background), `#`/`rgb`/`hsl` first-char gates in parse-color-to-rgb (unanchored fall-through preserved).

## Test plan

- Plugin suite: 8704 pass / 94 skip — zero deltas vs pristine main. Root typecheck + lint clean.
- Equivalence: 617-file corpus — 291 diagnostics, sorted tuples byte-identical.
- Adversarial review raised one blocking claim (enable-before-create ordering on the supabase rewrite); it was refuted mechanically — the new max-index predicate reports exactly when the old tail-slice search did, enable-before-create included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-scan logic (Supabase RLS ordering, HTML-sink exemptions) where subtle regex predicate changes could alter findings; PR claims byte-identical corpus diagnostics but migration edge cases warrant careful review.
> 
> **Overview**
> This is a **performance-only** refactor across several oxlint-plugin-react-doctor rules: RegExps move to module scope or run only after cheap substring gates, without intended diagnostic changes.
> 
> **Security-scan:** `find-suspicious-public-env-secret-name` hoists the global public-env secret name pattern instead of `new RegExp(...)` on every scan. **`supabase-table-missing-rls`** replaces per-table `new RegExp(escapeRegExp(name))` plus tail-slice search with one `ENABLE_RLS_PATTERN` pass that records the latest enable index per lowercased table; creates still require an enable at or after the create index. **`dangerous-html-sink`** gates inert-parse-target regex work on `createElement` / `createHTMLDocument` presence and short-circuits serializer/sanitizer/DOM-content exemption checks sequentially.
> 
> **Design rules:** **`no-dark-mode-glow`** hoists shadow color-stripping regexes and stops blur parsing at the third numeric token. **`no-long-transition-duration`** uses a single fused duration pattern and a hoisted shorthand time-token pattern. **`no-gray-on-colored-background`** skips tokens without `text-`/`bg-` and avoids variant splitting when there is no `:`. **`parse-color-to-rgb`** branches on `#` / `rgb` / `hsl` before running the corresponding matchers.
> 
> A patch **changeset** documents the plugin release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2a72073e53a63d4e6d2f044fd9be6bccd7bcaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->