### PR TITLE
perf(plugin): fused-walk sweep — one pass where several walked the same subtree

### DIFF
--- a/.changeset/perf-sweep-fused-walks.md
+++ b/.changeset/perf-sweep-fused-walks.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: fused-walk sweep — ~13 repeated subtree traversals collapse into single passes or per-node memos (async-await-in-loop's triple walk and fixpoint pre-pass, js-cache/js-index-maps loop walks, rendering-usetransition's three detectors, display-name's per-candidate program scans, per-binding setter walks in the state/effect rules, and WeakMap memos for prop-name/bound-name/effect-count analyses)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
@@ -77,76 +77,37 @@ const collectPatternIdentifiers = (pattern: EsTreeNode, target: Set<string>): vo
   }
 };
 
-const collectAssignedIdentifiers = (block: EsTreeNode): Set<string> => {
-  const assigned = new Set<string>();
-  walkAst(block, (child: EsTreeNode): boolean | void => {
-    if (isInlineFunctionExpression(child) || isNodeOfType(child, "FunctionDeclaration"))
-      return false;
-    if (isNodeOfType(child, "AssignmentExpression") && child.left) {
-      collectPatternIdentifiers(child.left, assigned);
-    }
-  });
-  return assigned;
-};
-
-const collectAwaitedArgIdentifiers = (block: EsTreeNode): Set<string> => {
-  const referenced = new Set<string>();
-  walkAst(block, (child: EsTreeNode): boolean | void => {
-    if (isInlineFunctionExpression(child) || isNodeOfType(child, "FunctionDeclaration"))
-      return false;
-    if (!isNodeOfType(child, "AwaitExpression") || !child.argument) return;
-    collectReferenceIdentifierNames(child.argument, referenced);
-  });
-  return referenced;
-};
-
 const ARRAY_MUTATION_METHOD_NAMES = new Set(["push", "unshift", "splice"]);
-
-// Arrays mutated in-place (`results.push(...)`, `acc.unshift(...)`) carry
-// state across iterations just like a reassigned variable. Collect the
-// mutated object's name so a later iteration reading from it counts as a
-// loop-carried dependency.
-const collectMutatedArrayNames = (block: EsTreeNode): Set<string> => {
-  const mutated = new Set<string>();
-  walkAst(block, (child: EsTreeNode): boolean | void => {
-    if (child !== block && isFunctionLike(child)) return false;
-    if (!isNodeOfType(child, "CallExpression")) return;
-    const callee = child.callee;
-    if (
-      isNodeOfType(callee, "MemberExpression") &&
-      !callee.computed &&
-      isNodeOfType(callee.property, "Identifier") &&
-      ARRAY_MUTATION_METHOD_NAMES.has(callee.property.name) &&
-      isNodeOfType(callee.object, "Identifier")
-    ) {
-      mutated.add(callee.object.name);
-    }
-  });
-  return mutated;
-};
 
 // Variables initialized by reading any of `names` (e.g.
 // `const prev = results[results.length - 1]`) carry the mutated array's
 // state forward, so awaiting on them is also order-dependent. Iterated to
-// a fixpoint to follow multi-step derivations.
+// a fixpoint to follow multi-step derivations. The declarators and their
+// referenced names never change between passes, so they are collected in
+// one walk and only the membership test repeats per round.
 const addDerivedBindings = (block: EsTreeNode, names: Set<string>): void => {
+  const declaratorBindings: Array<{ declaredName: string; referencedNames: Set<string> }> = [];
+  walkAst(block, (child: EsTreeNode): boolean | void => {
+    if (child !== block && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "VariableDeclarator") || !child.init) return;
+    if (!isNodeOfType(child.id, "Identifier")) return;
+    const referencedNames = new Set<string>();
+    collectReferenceIdentifierNames(child.init, referencedNames);
+    declaratorBindings.push({ declaredName: child.id.name, referencedNames });
+  });
   let didGrow = true;
   while (didGrow) {
     didGrow = false;
-    walkAst(block, (child: EsTreeNode): boolean | void => {
-      if (child !== block && isFunctionLike(child)) return false;
-      if (!isNodeOfType(child, "VariableDeclarator") || !child.init) return;
-      if (!isNodeOfType(child.id, "Identifier") || names.has(child.id.name)) return;
-      const initReferences = new Set<string>();
-      collectReferenceIdentifierNames(child.init, initReferences);
-      for (const referenced of initReferences) {
+    for (const { declaredName, referencedNames } of declaratorBindings) {
+      if (names.has(declaredName)) continue;
+      for (const referenced of referencedNames) {
         if (names.has(referenced)) {
-          names.add(child.id.name);
+          names.add(declaredName);
           didGrow = true;
           break;
         }
       }
-    });
+    }
   }
 };
 
@@ -156,12 +117,35 @@ const addDerivedBindings = (block: EsTreeNode, names: Set<string>): void => {
 // covers carries that flow through an in-place array mutation
 // (`results.push(await fetchNext(id, prev))` with `prev` read from
 // `results`): the awaited argument reads a binding the loop mutates.
+// Assignments, in-place array mutations, and awaited-argument reads inspect
+// disjoint node types, so one walk collects all three signal sets.
 const hasLoopCarriedDependency = (block: EsTreeNode): boolean => {
-  const carried = collectAssignedIdentifiers(block);
-  for (const name of collectMutatedArrayNames(block)) carried.add(name);
+  const carried = new Set<string>();
+  const awaitedReferences = new Set<string>();
+  walkAst(block, (child: EsTreeNode): boolean | void => {
+    if (child !== block && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "AssignmentExpression") && child.left) {
+      collectPatternIdentifiers(child.left, carried);
+      return;
+    }
+    if (isNodeOfType(child, "AwaitExpression") && child.argument) {
+      collectReferenceIdentifierNames(child.argument, awaitedReferences);
+      return;
+    }
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = child.callee;
+    if (
+      isNodeOfType(callee, "MemberExpression") &&
+      !callee.computed &&
+      isNodeOfType(callee.property, "Identifier") &&
+      ARRAY_MUTATION_METHOD_NAMES.has(callee.property.name) &&
+      isNodeOfType(callee.object, "Identifier")
+    ) {
+      carried.add(callee.object.name);
+    }
+  });
   if (carried.size === 0) return false;
   addDerivedBindings(block, carried);
-  const awaitedReferences = collectAwaitedArgIdentifiers(block);
   for (const name of carried) {
     if (awaitedReferences.has(name)) return true;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-cache-property-access.ts
@@ -78,11 +78,11 @@ export const jsCachePropertyAccess = defineRule({
         if (isNameShadowedByEnclosingFunctionParameter(writeTarget, rootName, loopBody)) return;
         writtenAccessPrefixes.add(writtenKey);
       };
+      // Write targets and read counts inspect disjoint node types, and the
+      // write-prefix set is only consulted after the walk — one pass fills both.
       walkAst(loopBody, (child: EsTreeNode) => {
         if (isNodeOfType(child, "AssignmentExpression")) recordWriteTarget(child.left);
         if (isNodeOfType(child, "UpdateExpression")) recordWriteTarget(child.argument);
-      });
-      walkAst(loopBody, (child: EsTreeNode) => {
         if (!isNodeOfType(child, "MemberExpression")) return;
         if (child.computed) return;
         // Skip if this MemberExpression is itself nested inside another (only

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
@@ -64,8 +64,15 @@ const isSingleFieldEqualityPredicate = (node: EsTreeNodeOfType<"CallExpression">
 // inside the loop body. When the `.find()` receiver roots at one of
 // these, the receiver is a different array each pass, so a single
 // pre-loop Map can't replace it — flagging it would be a false
-// positive.
-const collectLoopBoundNames = (loop: EsTreeNode, names: Set<string>): void => {
+// positive. The set is a pure function of the (immutable) loop subtree, so
+// it is memoized per loop node — nested `.find()`s under the same loops
+// reuse one walk instead of re-collecting per call site.
+const loopBoundNamesCache = new WeakMap<EsTreeNode, ReadonlySet<string>>();
+
+const getLoopBoundNames = (loop: EsTreeNode): ReadonlySet<string> => {
+  const cached = loopBoundNamesCache.get(loop);
+  if (cached) return cached;
+  const names = new Set<string>();
   if ((isNodeOfType(loop, "ForOfStatement") || isNodeOfType(loop, "ForInStatement")) && loop.left) {
     walkAst(loop.left, (child: EsTreeNode) => {
       if (isNodeOfType(child, "Identifier")) names.add(child.name);
@@ -88,6 +95,8 @@ const collectLoopBoundNames = (loop: EsTreeNode, names: Set<string>): void => {
       if (targetRoot) names.add(targetRoot);
     }
   });
+  loopBoundNamesCache.set(loop, names);
+  return names;
 };
 
 // `groups[i].links.find(...)` — the chain roots at an invariant name,
@@ -126,7 +135,9 @@ const isLoopVariantReceiver = (node: EsTreeNodeOfType<"CallExpression">): boolea
   const loopBoundNames = new Set<string>();
   let ancestor: EsTreeNode | null | undefined = node.parent;
   while (ancestor) {
-    if (LOOP_TYPES.includes(ancestor.type)) collectLoopBoundNames(ancestor, loopBoundNames);
+    if (LOOP_TYPES.includes(ancestor.type)) {
+      for (const name of getLoopBoundNames(ancestor)) loopBoundNames.add(name);
+    }
     ancestor = ancestor.parent;
   }
   if (loopBoundNames.has(receiverRoot)) return true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
@@ -61,64 +61,7 @@ const callsIdentifier = (root: EsTreeNode | null, identifierName: string): boole
   return found;
 };
 
-// True when ANY async-context function inside `componentBody` calls
-// `setterName`. An "async-context function" is `async` or has an own-
-// scope `await`. Setter calls inside non-async helpers (e.g. a sync
-// `handleTabChange` that toggles `setIsTabPending`) don't count, so a
-// sync state transition in a component that ALSO has an unrelated
-// `handleSubmit = async () => …` no longer gets suppressed.
-const setterIsCalledInAsyncContext = (
-  componentBody: EsTreeNode | null,
-  setterName: string,
-): boolean => {
-  if (!componentBody) return false;
-  let found = false;
-  walkAst(componentBody, (child: EsTreeNode) => {
-    if (found) return;
-    if (!isFunctionLike(child)) return;
-    const functionBody = (child as { body: EsTreeNode | null }).body;
-    const isAsyncContext =
-      Boolean((child as { async?: boolean }).async) || hasOwnAwait(functionBody);
-    if (!isAsyncContext) return;
-    if (callsIdentifier(functionBody, setterName)) found = true;
-  });
-  return found;
-};
-
 const PROMISE_CHAIN_METHOD_NAMES: ReadonlySet<string> = new Set(["then", "catch", "finally"]);
-
-// True when `setterName` is called inside a Promise-chain callback
-// (`loadData().then(() => setIsLoading(false))`). That flag tracks real
-// async I/O the same way an `async`/`await` setter does, so `useTransition`
-// (which only deprioritizes sync state updates, it doesn't await a promise)
-// is not a substitute.
-const setterIsCalledInPromiseChain = (
-  componentBody: EsTreeNode | null,
-  setterName: string,
-): boolean => {
-  if (!componentBody) return false;
-  let found = false;
-  walkAst(componentBody, (child: EsTreeNode) => {
-    if (found) return;
-    if (!isNodeOfType(child, "CallExpression")) return;
-    const callee = child.callee;
-    if (
-      !isNodeOfType(callee, "MemberExpression") ||
-      !isNodeOfType(callee.property, "Identifier") ||
-      !PROMISE_CHAIN_METHOD_NAMES.has(callee.property.name)
-    ) {
-      return;
-    }
-    for (const argument of child.arguments ?? []) {
-      if (!isFunctionLike(argument)) continue;
-      if (callsIdentifier(argument.body, setterName)) {
-        found = true;
-        return;
-      }
-    }
-  });
-  return found;
-};
 
 // Identifiers that, when present alongside a loading useState, strongly
 // signal async data fetching (not a transition). The rule's
@@ -138,24 +81,47 @@ const ASYNC_DATA_CALLEE_NAMES: ReadonlySet<string> = new Set([
   "axios",
 ]);
 
-const referencesAsyncDataApi = (body: EsTreeNode | null): boolean => {
-  if (!body) return false;
+// One pass over the component body computes every async-work signal the
+// caller ORs together, short-circuiting on the first hit:
+//   - `setterName` called inside an async-context function ("async" or an
+//     own-scope `await`) — a sync helper toggling the flag doesn't count.
+//   - `setterName` called inside a Promise-chain callback
+//     (`loadData().then(() => setIsLoading(false))`).
+//   - a call to a known async-data hook / global anywhere in the body.
+const hasAsyncLoadingWork = (fnBody: EsTreeNode, setterName: string | null): boolean => {
   let found = false;
-  walkAst(body, (child: EsTreeNode) => {
-    if (found) return;
+  walkAst(fnBody, (child: EsTreeNode) => {
+    if (found) return false;
     if (isNodeOfType(child, "CallExpression")) {
       const callee = child.callee;
       if (isNodeOfType(callee, "Identifier") && ASYNC_DATA_CALLEE_NAMES.has(callee.name)) {
         found = true;
-        return;
+        return false;
       }
-      if (
-        isNodeOfType(callee, "MemberExpression") &&
-        isNodeOfType(callee.property, "Identifier") &&
-        ASYNC_DATA_CALLEE_NAMES.has(callee.property.name)
-      ) {
+      if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
+        if (ASYNC_DATA_CALLEE_NAMES.has(callee.property.name)) {
+          found = true;
+          return false;
+        }
+        if (setterName !== null && PROMISE_CHAIN_METHOD_NAMES.has(callee.property.name)) {
+          for (const argument of child.arguments ?? []) {
+            if (!isFunctionLike(argument)) continue;
+            if (callsIdentifier(argument.body, setterName)) {
+              found = true;
+              return false;
+            }
+          }
+        }
+      }
+      return;
+    }
+    if (setterName !== null && isFunctionLike(child)) {
+      const functionBody = (child as { body: EsTreeNode | null }).body;
+      const isAsyncContext =
+        Boolean((child as { async?: boolean }).async) || hasOwnAwait(functionBody);
+      if (isAsyncContext && callsIdentifier(functionBody, setterName)) {
         found = true;
-        return;
+        return false;
       }
     }
   });
@@ -192,14 +158,7 @@ export const renderingUsetransitionLoading = defineRule({
       // flag is wrapping that async work) OR a call to a known
       // async-data hook / global in the component body.
       const fnBody = enclosingFunctionBody(node as EsTreeNode);
-      if (
-        fnBody &&
-        ((setterName && setterIsCalledInAsyncContext(fnBody, setterName)) ||
-          (setterName && setterIsCalledInPromiseChain(fnBody, setterName)) ||
-          referencesAsyncDataApi(fnBody))
-      ) {
-        return;
-      }
+      if (fnBody && hasAsyncLoadingWork(fnBody, setterName)) return;
 
       context.report({
         node: node.init,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/display-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/display-name.ts
@@ -58,7 +58,13 @@ const isReactVersionAtLeast = (version: string, major: number, minor: number): b
   return actualMajor > major || (actualMajor === major && actualMinor >= minor);
 };
 
+// Memoized per (immutable) subtree root — nested candidates re-query the
+// same regions from several visitors, so each subtree is walked once.
+const containsJsxCache = new WeakMap<EsTreeNode, boolean>();
+
 const containsJsx = (root: EsTreeNode): boolean => {
+  const cached = containsJsxCache.get(root);
+  if (cached !== undefined) return cached;
   let found = false;
   const visit = (node: EsTreeNode): void => {
     if (found) return;
@@ -83,6 +89,7 @@ const containsJsx = (root: EsTreeNode): boolean => {
     }
   };
   visit(root);
+  containsJsxCache.set(root, found);
   return found;
 };
 
@@ -269,39 +276,6 @@ const hasDisplayNameMember = (classNode: EsTreeNode): boolean => {
   return false;
 };
 
-// Looks for a `<ClassName>.displayName = ...` assignment ANYWHERE in
-// the program. Transpiler output and most React codebases attach
-// display names this way for non-anonymous classes/functions.
-const hasDisplayNameAssignment = (className: string, programRoot: EsTreeNode): boolean => {
-  let found = false;
-  const visit = (node: EsTreeNode): void => {
-    if (found) return;
-    if (
-      isNodeOfType(node, "AssignmentExpression") &&
-      isNodeOfType(node.left, "MemberExpression") &&
-      isNodeOfType(node.left.object, "Identifier") &&
-      node.left.object.name === className &&
-      getStaticMemberName(node.left) === "displayName"
-    ) {
-      found = true;
-      return;
-    }
-    const record = node as unknown as Record<string, unknown>;
-    for (const key of Object.keys(record)) {
-      if (key === "parent") continue;
-      const child = record[key];
-      if (Array.isArray(child)) {
-        for (const item of child) if (isAstNode(item)) visit(item);
-      } else if (isAstNode(child)) {
-        visit(child);
-      }
-      if (found) return;
-    }
-  };
-  visit(programRoot);
-  return found;
-};
-
 const memberExpressionPath = (node: EsTreeNode): ReadonlyArray<string> => {
   if (isNodeOfType(node, "Identifier")) return [node.name];
   if (!isNodeOfType(node, "MemberExpression")) return [];
@@ -310,22 +284,34 @@ const memberExpressionPath = (node: EsTreeNode): ReadonlyArray<string> => {
   return propertyName ? [...objectPath, propertyName] : objectPath;
 };
 
-const hasDisplayNameAssignmentForProperty = (
-  propertyName: string,
-  programRoot: EsTreeNode,
-): boolean => {
-  let found = false;
+interface DisplayNameAssignmentIndex {
+  // `X.displayName = …` targets where `X` is a plain identifier.
+  identifierTargets: ReadonlySet<string>;
+  // Every static path segment of every `….displayName = …` target object
+  // (`Foo.Bar.displayName = …` contributes both `Foo` and `Bar`).
+  memberPathSegments: ReadonlySet<string>;
+}
+
+// One program walk indexes every `<target>.displayName = …` assignment so
+// each candidate answers with a Set lookup instead of re-walking the file.
+const displayNameAssignmentIndexCache = new WeakMap<EsTreeNode, DisplayNameAssignmentIndex>();
+
+const getDisplayNameAssignmentIndex = (programRoot: EsTreeNode): DisplayNameAssignmentIndex => {
+  const cached = displayNameAssignmentIndexCache.get(programRoot);
+  if (cached) return cached;
+  const identifierTargets = new Set<string>();
+  const memberPathSegments = new Set<string>();
   const visit = (node: EsTreeNode): void => {
-    if (found) return;
     if (
       isNodeOfType(node, "AssignmentExpression") &&
       isNodeOfType(node.left, "MemberExpression") &&
       getStaticMemberName(node.left) === "displayName"
     ) {
-      const objectPath = memberExpressionPath(node.left.object);
-      if (objectPath.includes(propertyName)) {
-        found = true;
-        return;
+      if (isNodeOfType(node.left.object, "Identifier")) {
+        identifierTargets.add(node.left.object.name);
+      }
+      for (const segment of memberExpressionPath(node.left.object)) {
+        memberPathSegments.add(segment);
       }
     }
     const record = node as unknown as Record<string, unknown>;
@@ -337,12 +323,24 @@ const hasDisplayNameAssignmentForProperty = (
       } else if (isAstNode(child)) {
         visit(child);
       }
-      if (found) return;
     }
   };
   visit(programRoot);
-  return found;
+  const index: DisplayNameAssignmentIndex = { identifierTargets, memberPathSegments };
+  displayNameAssignmentIndexCache.set(programRoot, index);
+  return index;
 };
+
+// Looks for a `<ClassName>.displayName = ...` assignment ANYWHERE in
+// the program. Transpiler output and most React codebases attach
+// display names this way for non-anonymous classes/functions.
+const hasDisplayNameAssignment = (className: string, programRoot: EsTreeNode): boolean =>
+  getDisplayNameAssignmentIndex(programRoot).identifierTargets.has(className);
+
+const hasDisplayNameAssignmentForProperty = (
+  propertyName: string,
+  programRoot: EsTreeNode,
+): boolean => getDisplayNameAssignmentIndex(programRoot).memberPathSegments.has(propertyName);
 
 // Port of `oxc_linter::rules::react::display_name`. Reports React
 // components whose displayName is unknown to React DevTools — most

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
@@ -56,35 +56,6 @@ const collectChildComponentNames = (
   });
 };
 
-const findSameFileComponentBody = (
-  programRoot: EsTreeNode,
-  componentName: string,
-): EsTreeNode | null => {
-  let foundBody: EsTreeNode | null = null;
-  walkAst(programRoot, (node: EsTreeNode) => {
-    if (foundBody) return false;
-    if (isNodeOfType(node, "FunctionDeclaration") && node.id && node.id.name === componentName) {
-      foundBody = node.body;
-      return false;
-    }
-    if (
-      isNodeOfType(node, "VariableDeclarator") &&
-      isNodeOfType(node.id, "Identifier") &&
-      node.id.name === componentName
-    ) {
-      const initializer = node.init;
-      if (
-        isNodeOfType(initializer, "ArrowFunctionExpression") ||
-        isNodeOfType(initializer, "FunctionExpression")
-      ) {
-        foundBody = initializer.body;
-        return false;
-      }
-    }
-  });
-  return foundBody;
-};
-
 const countEffectHookCalls = (body: EsTreeNode | null): number => {
   if (!body) return 0;
   let count = 0;
@@ -92,6 +63,59 @@ const countEffectHookCalls = (body: EsTreeNode | null): number => {
     if (!isNodeOfType(child, "CallExpression")) return;
     if (isHookCall(child, EFFECT_HOOK_NAMES)) count++;
   });
+  return count;
+};
+
+interface ComponentEffectIndex {
+  // First (pre-order) same-file function body per name — the same body a
+  // fresh first-match program walk would resolve.
+  bodyByName: Map<string, EsTreeNode>;
+  // Effect-hook counts, filled lazily per queried component.
+  effectCountByName: Map<string, number>;
+}
+
+// One program walk indexes every named function body; each Activity child
+// then costs a Map lookup plus one lazily-cached body count, instead of a
+// full program walk per child name per Activity element.
+const componentEffectIndexCache = new WeakMap<EsTreeNode, ComponentEffectIndex>();
+
+const getComponentEffectIndex = (programRoot: EsTreeNode): ComponentEffectIndex => {
+  const cached = componentEffectIndexCache.get(programRoot);
+  if (cached) return cached;
+  const bodyByName = new Map<string, EsTreeNode>();
+  walkAst(programRoot, (node: EsTreeNode) => {
+    if (isNodeOfType(node, "FunctionDeclaration") && node.id && !bodyByName.has(node.id.name)) {
+      bodyByName.set(node.id.name, node.body);
+      return;
+    }
+    if (
+      isNodeOfType(node, "VariableDeclarator") &&
+      isNodeOfType(node.id, "Identifier") &&
+      !bodyByName.has(node.id.name)
+    ) {
+      const initializer = node.init;
+      if (
+        isNodeOfType(initializer, "ArrowFunctionExpression") ||
+        isNodeOfType(initializer, "FunctionExpression")
+      ) {
+        bodyByName.set(node.id.name, initializer.body);
+      }
+    }
+  });
+  const index: ComponentEffectIndex = { bodyByName, effectCountByName: new Map() };
+  componentEffectIndexCache.set(programRoot, index);
+  return index;
+};
+
+const getSameFileComponentEffectCount = (
+  programRoot: EsTreeNode,
+  componentName: string,
+): number => {
+  const index = getComponentEffectIndex(programRoot);
+  const cachedCount = index.effectCountByName.get(componentName);
+  if (cachedCount !== undefined) return cachedCount;
+  const count = countEffectHookCalls(index.bodyByName.get(componentName) ?? null);
+  index.effectCountByName.set(componentName, count);
   return count;
 };
 
@@ -192,9 +216,7 @@ export const activityWrapsEffectHeavySubtree = defineRule({
         let totalEffects = 0;
         const effectfulChildren: string[] = [];
         for (const componentName of childComponentNames) {
-          const body = findSameFileComponentBody(programRoot, componentName);
-          if (!body) continue;
-          const effectCount = countEffectHookCalls(body);
+          const effectCount = getSameFileComponentEffectCount(programRoot, componentName);
           if (effectCount === 0) continue;
           totalEffects += effectCount;
           effectfulChildren.push(`<${componentName}>`);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -63,15 +63,30 @@ const isHandlerShapedReseed = (setterCall: EsTreeNode, componentFunction: EsTree
   return hasNestedFunction;
 };
 
-// An editable draft buffer re-seeds itself from the prop inside an event
-// handler (e.g. `edit = () => setTitle(props.title)` on entering rename
-// mode) and commits via a callback — the prop stays the source of truth for
-// display, so `useState(prop)` holds intentional decoupled user-edit text,
-// not a stale mirror. The re-seed must live in a NESTED handler: a re-seed in
-// the render body is the adjust-state-during-render pattern, and a re-seed in
-// an effect (built-in or custom wrapper) or a memo is the genuine prop
-// mirror — neither is a draft.
-const isReseededDraftBuffer = (
+// True when no function boundary sits between `node` and the component —
+// i.e. the call runs during render, not inside a nested handler/callback.
+const isInRenderScope = (node: EsTreeNode, componentFunction: EsTreeNode): boolean => {
+  let cursor: EsTreeNode | null = node.parent ?? null;
+  while (cursor && cursor !== componentFunction) {
+    if (isFunctionLike(cursor)) return false;
+    cursor = cursor.parent ?? null;
+  }
+  return true;
+};
+
+// Two exemptions, one walk (they look for the same prop-derived setter call
+// and differ only in where it sits):
+//   - Draft buffer: the re-seed lives in a NESTED handler (e.g.
+//     `edit = () => setTitle(props.title)` on entering rename mode) and
+//     commits via a callback — the prop stays the source of truth, so
+//     `useState(prop)` holds intentional decoupled user-edit text, not a
+//     stale mirror. A re-seed in an effect or memo is a genuine mirror.
+//   - Adjust-during-render: the "store information from previous renders"
+//     pattern re-syncs during render (`if (prop !== prev) setPrev(prop)`), so
+//     the value is never stale. React endorses this over a mirroring effect.
+//     The render-phase call must pass a prop-derived argument: a render-phase
+//     reset to an unrelated constant leaves the stale copy and keeps the report.
+const isDraftReseedOrRenderAdjusted = (
   useStateCall: EsTreeNodeOfType<"CallExpression">,
   isPropName: IsPropNameFn,
 ): boolean => {
@@ -80,53 +95,21 @@ const isReseededDraftBuffer = (
   const componentFunction = findEnclosingFunction(useStateCall);
   if (!componentFunction) return false;
 
-  let isReseeded = false;
+  let isExempt = false;
   walkAst(componentFunction, (child) => {
-    if (isReseeded) return false;
+    if (isExempt) return false;
     if (
       isNodeOfType(child, "CallExpression") &&
       isNodeOfType(child.callee, "Identifier") &&
       child.callee.name === setterName &&
       isPropDerivedArgument(child.arguments?.[0], isPropName) &&
-      isHandlerShapedReseed(child, componentFunction)
+      (isHandlerShapedReseed(child, componentFunction) || isInRenderScope(child, componentFunction))
     ) {
-      isReseeded = true;
+      isExempt = true;
       return false;
     }
   });
-  return isReseeded;
-};
-
-// The "store information from previous renders" pattern seeds `useState`
-// from a prop and re-syncs it during render (`if (prop !== prev)
-// setPrev(prop)`), so the value is never stale — it tracks the prop every
-// render. React endorses this over a mirroring effect, so it must not be
-// reported as a stale copy. The render-phase call must pass a prop-derived
-// argument: a render-phase reset to an unrelated constant leaves the stale
-// prop copy in place and keeps the report.
-const isAdjustedDuringRender = (
-  useStateCall: EsTreeNodeOfType<"CallExpression">,
-  isPropName: IsPropNameFn,
-): boolean => {
-  const setterName = getStateSetterName(useStateCall);
-  if (!setterName) return false;
-  const componentFunction = findEnclosingFunction(useStateCall);
-  if (!componentFunction) return false;
-  let isAdjusted = false;
-  walkAst(componentFunction, (child) => {
-    if (isAdjusted) return false;
-    if (child !== componentFunction && isFunctionLike(child)) return false;
-    if (
-      isNodeOfType(child, "CallExpression") &&
-      isNodeOfType(child.callee, "Identifier") &&
-      child.callee.name === setterName &&
-      isPropDerivedArgument(child.arguments?.[0], isPropName)
-    ) {
-      isAdjusted = true;
-      return false;
-    }
-  });
-  return isAdjusted;
+  return isExempt;
 };
 
 export const noDerivedUseState = defineRule({
@@ -150,8 +133,7 @@ export const noDerivedUseState = defineRule({
           propStackTracker.isPropName(initializer.name)
         ) {
           if (isInitialOnlyPropName(initializer.name)) return;
-          if (isReseededDraftBuffer(node, propStackTracker.isPropName)) return;
-          if (isAdjustedDuringRender(node, propStackTracker.isPropName)) return;
+          if (isDraftReseedOrRenderAdjusted(node, propStackTracker.isPropName)) return;
           context.report({
             node,
             message: `Your users see a stale value when prop "${initializer.name}" changes because useState copies it once.`,
@@ -170,8 +152,7 @@ export const noDerivedUseState = defineRule({
             ) {
               return;
             }
-            if (isReseededDraftBuffer(node, propStackTracker.isPropName)) return;
-            if (isAdjustedDuringRender(node, propStackTracker.isPropName)) return;
+            if (isDraftReseedOrRenderAdjusted(node, propStackTracker.isPropName)) return;
             context.report({
               node,
               message: `Your users see a stale value when prop "${rootIdentifierName}" changes because useState copies it once.`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
@@ -92,21 +92,29 @@ const collectHandlerOnlyWriteStateNames = (
   useStateBindings: Array<{ valueName: string; setterName: string; declarator: EsTreeNode }>,
   handlerBindingNames: Set<string>,
 ): Set<string> => {
+  // One walk records, per setter name, whether any call exists and whether
+  // any of them sits outside an event handler — replacing a full body walk
+  // per useState binding.
+  const setterNames = new Set(useStateBindings.map((binding) => binding.setterName));
+  const settersWithAnyCall = new Set<string>();
+  const settersWithNonHandlerCall = new Set<string>();
+  walkAst(componentBody, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (!isNodeOfType(child.callee, "Identifier")) return;
+    const setterName = child.callee.name;
+    if (!setterNames.has(setterName)) return;
+    settersWithAnyCall.add(setterName);
+    if (settersWithNonHandlerCall.has(setterName)) return;
+    if (!isInsideEventHandler(child, handlerBindingNames)) {
+      settersWithNonHandlerCall.add(setterName);
+    }
+  });
   const handlerOnlyWriteStateNames = new Set<string>();
   for (const binding of useStateBindings) {
-    let didFindAnySetterCall = false;
-    let areAllSetterCallsInHandlers = true;
-    walkAst(componentBody, (child: EsTreeNode) => {
-      if (!areAllSetterCallsInHandlers) return false;
-      if (!isNodeOfType(child, "CallExpression")) return;
-      if (!isNodeOfType(child.callee, "Identifier")) return;
-      if (child.callee.name !== binding.setterName) return;
-      didFindAnySetterCall = true;
-      if (!isInsideEventHandler(child, handlerBindingNames)) {
-        areAllSetterCallsInHandlers = false;
-      }
-    });
-    if (didFindAnySetterCall && areAllSetterCallsInHandlers) {
+    if (
+      settersWithAnyCall.has(binding.setterName) &&
+      !settersWithNonHandlerCall.has(binding.setterName)
+    ) {
       handlerOnlyWriteStateNames.add(binding.valueName);
     }
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -169,6 +169,20 @@ export const rerenderStateOnlyInHandlers = defineRule({
         renderReachableNames.add(reachableName);
       }
 
+      // One walk records which setters are called at all, replacing a full
+      // component-body walk per binding.
+      const setterNames = new Set(bindings.map((binding) => binding.setterName));
+      const calledSetterNames = new Set<string>();
+      walkAst(componentBody, (child: EsTreeNode) => {
+        if (
+          isNodeOfType(child, "CallExpression") &&
+          isNodeOfType(child.callee, "Identifier") &&
+          setterNames.has(child.callee.name)
+        ) {
+          calledSetterNames.add(child.callee.name);
+        }
+      });
+
       for (const binding of bindings) {
         if (renderReachableNames.has(binding.valueName)) continue;
         // Underscore-only or underscore-prefixed value names signal
@@ -192,18 +206,7 @@ export const rerenderStateOnlyInHandlers = defineRule({
           continue;
         }
 
-        let setterCalled = false;
-        walkAst(componentBody, (child: EsTreeNode) => {
-          if (setterCalled) return;
-          if (
-            isNodeOfType(child, "CallExpression") &&
-            isNodeOfType(child.callee, "Identifier") &&
-            child.callee.name === binding.setterName
-          ) {
-            setterCalled = true;
-          }
-        });
-        if (!setterCalled) continue;
+        if (!calledSetterNames.has(binding.setterName)) continue;
 
         // The "store information from previous renders" pattern reads the
         // value in a render-phase guard (`if (value !== prevValue)`) and

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-controlled-prop-mirror.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-controlled-prop-mirror.ts
@@ -7,7 +7,14 @@ import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import { walkAst } from "../../../utils/walk-ast.js";
 import { isEventHandlerName } from "./event-handler-reference.js";
 
-const collectComponentPropNames = (componentFunction: EsTreeNode): Set<string> => {
+// Memoized per component function node — the prop-name set is a pure
+// function of the (immutable) subtree, and every isControlledPropMirror
+// query for the same component recomputes it otherwise.
+const componentPropNamesCache = new WeakMap<EsTreeNode, ReadonlySet<string>>();
+
+const collectComponentPropNames = (componentFunction: EsTreeNode): ReadonlySet<string> => {
+  const cached = componentPropNamesCache.get(componentFunction);
+  if (cached) return cached;
   const propNames = new Set<string>();
   if (!isFunctionLike(componentFunction)) return propNames;
   const propsObjectParamNames = new Set<string>();
@@ -28,30 +35,34 @@ const collectComponentPropNames = (componentFunction: EsTreeNode): Set<string> =
       collectPatternNames(child.id, propNames);
     }
   });
+  componentPropNamesCache.set(componentFunction, propNames);
   return propNames;
 };
 
-const declaresBindingNamed = (functionNode: EsTreeNode, bindingName: string): boolean => {
+// Own-scope bound names (params + non-nested declarators) per function node,
+// memoized so the repeated "does this nested function declare X" checks are
+// a Set lookup instead of a fresh subtree walk each time.
+const ownScopeBoundNamesCache = new WeakMap<EsTreeNode, ReadonlySet<string>>();
+
+const getOwnScopeBoundNames = (functionNode: EsTreeNode): ReadonlySet<string> => {
+  const cached = ownScopeBoundNamesCache.get(functionNode);
+  if (cached) return cached;
   const boundNames = new Set<string>();
   if (isFunctionLike(functionNode)) {
     for (const param of functionNode.params ?? []) collectPatternNames(param, boundNames);
   }
-  if (boundNames.has(bindingName)) return true;
-  let declaresName = false;
   walkAst(functionNode, (child: EsTreeNode): boolean | void => {
-    if (declaresName) return false;
     if (child !== functionNode && isFunctionLike(child)) return false;
     if (isNodeOfType(child, "VariableDeclarator")) {
-      const declaratorNames = new Set<string>();
-      collectPatternNames(child.id, declaratorNames);
-      if (declaratorNames.has(bindingName)) {
-        declaresName = true;
-        return false;
-      }
+      collectPatternNames(child.id, boundNames);
     }
   });
-  return declaresName;
+  ownScopeBoundNamesCache.set(functionNode, boundNames);
+  return boundNames;
 };
+
+const declaresBindingNamed = (functionNode: EsTreeNode, bindingName: string): boolean =>
+  getOwnScopeBoundNames(functionNode).has(bindingName);
 
 const isPropertyNamePosition = (identifier: EsTreeNode): boolean => {
   const parent = identifier.parent;


### PR DESCRIPTION
## Why

~13 audit findings where a rule walks the same subtree several times (separate collector passes, per-candidate re-walks, per-binding re-walks). Net −18 LOC. Findings: #92 #93 #94 #104 #139 #147 #148 #311 #312 #318 #336 #357 #358.

## What changed

- `async-await-in-loop`: the three loop-body collectors fused into one walk; the derived-bindings fixpoint now iterates precomputed in-memory declarator records instead of re-walking per iteration.
- `js-cache-property-access`: write + read walks fused (safe: the passes inspect disjoint node types, so order independence holds).
- `js-index-maps`: per-loop bound-name Sets memoized in a WeakMap.
- `rendering-usetransition-loading`: three async-work detectors folded into one short-circuiting pass (single report path — no message-choice dependence).
- `display-name`: `containsJsx` memoized per subtree root; a per-Program displayName-assignment index replaces per-candidate whole-Program walks.
- state-and-effects: one-walk setter classification (no-event-trigger-state), one-shot called-setter-name collection (rerender-state-only-in-handlers), union-fused exemption walk (no-derived-use-state), first-wins body index + lazy effect counts (activity-wraps-effect-heavy-subtree), per-function own-scope bound-name Sets (is-controlled-prop-mirror).
- Deliberately SKIPPED (catalog annotated): #309/#310 — a per-component setter-name set is scope-chain-sensitive (shadowing; the exact FP class from PR #1018); #320 — top-level-only iteration would drop nested-effect detection; #140/#349 — design work, not mechanical.

## Test plan

- Plugin suite: 8704 pass / 94 skip — zero deltas vs pristine main. Root typecheck + lint clean.
- Equivalence: 617-file corpus — 291 diagnostics, sorted tuples byte-identical.
- Adversarial review traced the riskiest fusion (no-derived-use-state: the two original exemption walks had different subtree-skip structures) through handler / render / effect-phase scenarios and confirmed the union is equivalent; fixpoint convergence and first-wins index semantics also attacked — no divergence found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Logic is refactored across many rules where equivalence depends on walk order, fixpoint semantics, and merged exemption checks; the PR claims byte-identical corpus diagnostics but any missed edge case would change lint output.
> 
> **Overview**
> This PR is a **performance-only** refactor across `oxlint-plugin-react-doctor`: rules that walked the same AST subtree multiple times now use **single fused passes** or **WeakMap memoization**, with a patch changeset and no intended diagnostic changes.
> 
> **JS performance rules:** `async-await-in-loop` merges loop-carried dependency collection into one walk and precomputes declarator bindings for the derived-bindings fixpoint instead of re-walking each round. `js-cache-property-access` combines write-target and read counting in one loop-body walk. `js-index-maps` caches loop-bound name sets per loop node.
> 
> **Other rules:** `rendering-usetransition-loading` replaces three async-work detectors with one short-circuiting `hasAsyncLoadingWork` pass. `display-name` memoizes `containsJsx` and builds a per-program `displayName` assignment index for O(1) lookups. State/effect rules batch setter-call classification (`no-event-trigger-state`, `rerender-state-only-in-handlers`), merge draft-buffer and render-adjust exemptions (`no-derived-use-state`), index same-file component bodies with lazy effect counts (`activity-wraps-effect-heavy-subtree`), and memoize prop/bound-name sets (`is-controlled-prop-mirror`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e280f9ea57aea86569f1f9f91df4cf60d9f011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->