### PR TITLE
perf(plugin): memoization sweep — cache pure per-file analyses

### DIFF
--- a/.changeset/perf-sweep-memo.md
+++ b/.changeset/perf-sweep-memo.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+perf: memoization sweep — per-file/per-Program analyses stop recomputing per node and per rule (security-scan path classification cached per pattern+path, layout export scans cached per file with mtime invalidation, effect scope/reference/upstream-ref lookups memoized per analysis, the duplicated outer-scope scan converged onto getScopeForNode, zod import classification memoized per identifier, and normalizeFilename skips the no-op allocation)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-production-file-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-production-file-path.ts
@@ -5,11 +5,27 @@ import {
   TEST_CONTEXT_PATTERN,
 } from "../../../constants/security-scan.js";
 
+// Every enabled scan rule re-classifies the same relativePath (once per rule
+// per file), so the pure result is memoized. Keyed by BOTH the source-file
+// pattern (by object identity — callers pass a small fixed set of module
+// constants) and the path, since a path-only key would conflate the source /
+// script / database extension variants.
+const classificationCacheByPattern = new Map<RegExp, Map<string, boolean>>();
+
 export const isProductionFilePath = (relativePath: string, sourceFilePattern: RegExp): boolean => {
-  if (!sourceFilePattern.test(relativePath)) return false;
-  if (TEST_CONTEXT_PATTERN.test(relativePath)) return false;
-  if (BUILD_SCRIPT_CONTEXT_PATTERN.test(relativePath)) return false;
-  if (DOCUMENTATION_CONTEXT_PATTERN.test(relativePath)) return false;
-  if (GENERATED_SOURCE_CONTEXT_PATTERN.test(relativePath)) return false;
-  return true;
+  let classificationByPath = classificationCacheByPattern.get(sourceFilePattern);
+  if (!classificationByPath) {
+    classificationByPath = new Map();
+    classificationCacheByPattern.set(sourceFilePattern, classificationByPath);
+  }
+  const cached = classificationByPath.get(relativePath);
+  if (cached !== undefined) return cached;
+  const isProduction =
+    sourceFilePattern.test(relativePath) &&
+    !TEST_CONTEXT_PATTERN.test(relativePath) &&
+    !BUILD_SCRIPT_CONTEXT_PATTERN.test(relativePath) &&
+    !DOCUMENTATION_CONTEXT_PATTERN.test(relativePath) &&
+    !GENERATED_SOURCE_CONTEXT_PATTERN.test(relativePath);
+  classificationByPath.set(relativePath, isProduction);
+  return isProduction;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
@@ -69,11 +69,23 @@ const descend = (
   }
 };
 
+// The upstream-reference chain for a given (analysis, ref) is deterministic
+// and read-only for every caller, so the def-chain ascent runs once per ref.
+const upstreamRefsCache = new WeakMap<ProgramAnalysis, WeakMap<Reference, Reference[]>>();
+
 export const getUpstreamRefs = (analysis: ProgramAnalysis, ref: Reference): Reference[] => {
+  let upstreamByRef = upstreamRefsCache.get(analysis);
+  if (!upstreamByRef) {
+    upstreamByRef = new WeakMap();
+    upstreamRefsCache.set(analysis, upstreamByRef);
+  }
+  const cached = upstreamByRef.get(ref);
+  if (cached) return cached;
   const refs: Reference[] = [];
   ascend(analysis, ref, (upRef) => {
     refs.push(upRef);
   });
+  upstreamByRef.set(ref, refs);
   return refs;
 };
 
@@ -85,13 +97,30 @@ export const findDownstreamNodes = (topNode: EsTreeNode, type: string): EsTreeNo
   return nodes;
 };
 
+// Reference identity is stable per analysis, so the scope + reference scan
+// runs once per identifier; `has()` distinguishes a cached null resolution
+// from a miss (same WeakMap shape as downstreamRefsCache below).
+const refByIdentifierCache = new WeakMap<ProgramAnalysis, WeakMap<EsTreeNode, Reference | null>>();
+
 export const getRef = (analysis: ProgramAnalysis, identifier: EsTreeNode): Reference | null => {
-  const scope = getScopeForNode(identifier, analysis.scopeManager);
-  if (!scope) return null;
-  for (const reference of scope.references) {
-    if (reference.identifier === identifier) return reference;
+  let refByIdentifier = refByIdentifierCache.get(analysis);
+  if (!refByIdentifier) {
+    refByIdentifier = new WeakMap();
+    refByIdentifierCache.set(analysis, refByIdentifier);
   }
-  return null;
+  if (refByIdentifier.has(identifier)) return refByIdentifier.get(identifier) ?? null;
+  let resolvedReference: Reference | null = null;
+  const scope = getScopeForNode(identifier, analysis.scopeManager);
+  if (scope) {
+    for (const reference of scope.references) {
+      if (reference.identifier === identifier) {
+        resolvedReference = reference;
+        break;
+      }
+    }
+  }
+  refByIdentifier.set(identifier, resolvedReference);
+  return resolvedReference;
 };
 
 // Memoize per (analysis, node). `analysis` is the per-Program singleton

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/get-program-analysis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/get-program-analysis.ts
@@ -90,12 +90,23 @@ export const getProgramAnalysis = (anyNode: EsTreeNode): ProgramAnalysis | null 
   return analysis;
 };
 
+// Scope membership is fixed per file, so the linear scan over
+// `manager.scopes` runs once per queried node — every rule and pass that
+// asks about the same identifier afterwards gets a WeakMap hit.
+const scopeByNodeCache = new WeakMap<ScopeManager, WeakMap<EsTreeNode, Scope | null>>();
+
 // Replicates upstream's `context.sourceCode.getScope(node)`: returns the
 // innermost scope that *contains* `node`. We find the deepest scope
 // whose `block.range` strictly contains `node.range` (or whose `block`
 // IS the node).
 export const getScopeForNode = (node: EsTreeNode, manager: ScopeManager): Scope | null => {
   if (!node.range) return null;
+  let scopeByNode = scopeByNodeCache.get(manager);
+  if (!scopeByNode) {
+    scopeByNode = new WeakMap();
+    scopeByNodeCache.set(manager, scopeByNode);
+  }
+  if (scopeByNode.has(node)) return scopeByNode.get(node) ?? null;
   let bestScope: Scope | null = null;
   let bestSize = Infinity;
   for (const scope of manager.scopes) {
@@ -112,5 +123,6 @@ export const getScopeForNode = (node: EsTreeNode, manager: ScopeManager): Scope 
       bestScope = scope;
     }
   }
+  scopeByNode.set(node, bestScope);
   return bestScope;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
@@ -1,4 +1,4 @@
-import type { Reference, Scope } from "eslint-scope";
+import type { Reference } from "eslint-scope";
 import type { EsTreeNode } from "../../../../utils/es-tree-node.js";
 import { isAstNode } from "../../../../utils/is-ast-node.js";
 import { isFunctionLike } from "../../../../utils/is-function-like.js";
@@ -12,32 +12,7 @@ import {
   resolvesToAsyncFunction,
   resolveToFunction,
 } from "./ast.js";
-import type { ProgramAnalysis } from "./get-program-analysis.js";
-
-const getOuterScopeContaining = (analysis: ProgramAnalysis, node: EsTreeNode): Scope | null => {
-  if (!node.range) return null;
-  // Find the smallest scope whose block strictly *contains* `node`
-  // (block.range fully envelops node.range). For a top-level
-  // VariableDeclarator in the module scope, this returns the
-  // module scope.
-  let best: Scope | null = null;
-  let bestSize = Infinity;
-  for (const scope of analysis.scopeManager.scopes) {
-    const block = scope.block as unknown as EsTreeNode;
-    if (!block?.range) continue;
-    if (node.range[0] < block.range[0] || node.range[1] > block.range[1]) continue;
-    const size = block.range[1] - block.range[0];
-    // `<=` so that when two scopes have identical ranges (the
-    // global + module pair always share the Program range), the
-    // later-created (i.e. inner) scope wins — module variables live
-    // there, not in the global scope.
-    if (size <= bestSize) {
-      bestSize = size;
-      best = scope;
-    }
-  }
-  return best;
-};
+import { getScopeForNode, type ProgramAnalysis } from "./get-program-analysis.js";
 
 // 1:1 port of upstream `src/util/react.js` from
 // `eslint-plugin-react-you-might-not-need-an-effect`. See `./ast.ts`
@@ -94,7 +69,7 @@ const isReactFunctionalHOC = (
   const isWrappedSeparately = (): boolean => {
     if (!isNodeOfType(node.id, "Identifier")) return false;
     const bindingName = node.id.name;
-    const containingScope = getOuterScopeContaining(analysis, node as unknown as EsTreeNode);
+    const containingScope = getScopeForNode(node as unknown as EsTreeNode, analysis.scopeManager);
     if (!containingScope) return false;
     const variable = containingScope.variables.find((v) => v.name === bindingName);
     if (!variable) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/utils/zod-ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/utils/zod-ast.ts
@@ -28,7 +28,21 @@ export const getStaticPropertyName = (
   return null;
 };
 
+// The classification is a pure function of the identifier node within its
+// (immutable) file, and every zod rule re-queries the same identifiers —
+// memoize per node; `has()` distinguishes a cached null from a miss.
+const importInfoCache = new WeakMap<EsTreeNode, ZodImportInfo | null>();
+
 const getImportInfoForIdentifier = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+): ZodImportInfo | null => {
+  if (importInfoCache.has(identifier)) return importInfoCache.get(identifier) ?? null;
+  const importInfo = computeImportInfoForIdentifier(identifier);
+  importInfoCache.set(identifier, importInfo);
+  return importInfo;
+};
+
+const computeImportInfoForIdentifier = (
   identifier: EsTreeNodeOfType<"Identifier">,
 ): ZodImportInfo | null => {
   const binding = findVariableInitializer(identifier, identifier.name);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/does-module-export-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/does-module-export-name.ts
@@ -8,30 +8,52 @@ const NAMED_EXPORT_DECLARATION_PATTERN =
 const LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN =
   /^\s*export\s+(?:type\s+)?\{([\s\S]*?)\}(?:\s+from\s+["'][^"']+["'])?\s*;?\s*(?:(?:\/\/[^\n]*)?\s*)/gm;
 
-const doesSourceTextExportName = (sourceText: string, exportedName: string): boolean => {
+const collectSourceTextExportNames = (sourceText: string): ReadonlySet<string> => {
   const strippedSource = stripJsComments(sourceText);
-  if (exportedName === "default" && DEFAULT_EXPORT_DECLARATION_PATTERN.test(strippedSource)) {
-    return true;
+  const exportedNames = new Set<string>();
+  if (DEFAULT_EXPORT_DECLARATION_PATTERN.test(strippedSource)) {
+    exportedNames.add("default");
   }
 
   for (const match of strippedSource.matchAll(NAMED_EXPORT_DECLARATION_PATTERN)) {
-    if (match[1] === exportedName) return true;
+    if (match[1]) exportedNames.add(match[1]);
   }
 
   for (const match of strippedSource.matchAll(LOCAL_EXPORT_SPECIFIER_DECLARATION_PATTERN)) {
     const specifiersText = match[1] ?? "";
-    const exportedNames = parseExportSpecifiers(specifiersText, false).map(
-      (specifier) => specifier.exportedName,
-    );
-    if (exportedNames.includes(exportedName)) return true;
+    for (const specifier of parseExportSpecifiers(specifiersText, false)) {
+      exportedNames.add(specifier.exportedName);
+    }
   }
 
-  return false;
+  return exportedNames;
 };
+
+interface ExportNamesCacheEntry {
+  mtimeMs: number;
+  size: number;
+  exportedNames: ReadonlySet<string>;
+}
+
+// The same layout / barrel file is probed once per export name per page, so
+// the read + comment-strip + export scan is cached per file, keyed by
+// mtime/size for invalidation (mirrors `parse-source-file.ts`).
+const exportNamesCache = new Map<string, ExportNamesCacheEntry>();
 
 export const doesModuleExportName = (filePath: string, exportedName: string): boolean => {
   try {
-    return doesSourceTextExportName(fs.readFileSync(filePath, "utf8"), exportedName);
+    const fileStat = fs.statSync(filePath);
+    const cached = exportNamesCache.get(filePath);
+    if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
+      return cached.exportedNames.has(exportedName);
+    }
+    const exportedNames = collectSourceTextExportNames(fs.readFileSync(filePath, "utf8"));
+    exportNamesCache.set(filePath, {
+      mtimeMs: fileStat.mtimeMs,
+      size: fileStat.size,
+      exportedNames,
+    });
+    return exportedNames.has(exportedName);
   } catch {
     return false;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/normalize-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/normalize-filename.ts
@@ -1,1 +1,4 @@
-export const normalizeFilename = (filename: string): string => filename.replaceAll("\\", "/");
+// Already-normalized paths (the common case — helpers re-normalize each
+// other's output) skip the replaceAll allocation.
+export const normalizeFilename = (filename: string): string =>
+  filename.includes("\\") ? filename.replaceAll("\\", "/") : filename;


### PR DESCRIPTION
## Why

The remaining ~12 memoization findings from the audit: per-file facts recomputed per node or per rule. Findings: #117 #244 #257 #265 #280 #285 #323 #324 #332 #333 #345 #346 #347 #389 #403 #430 #510.

## What changed

- security-scan `is-production-file-path`: the ~22×-per-file path classification memoized via a two-level Map keyed by pattern-object identity + relativePath (identity key avoids the path-only-key footgun the audit verifier flagged).
- `does-module-export-name`: per-file export-name Set cached with mtime/size invalidation — mirrors the existing `parse-source-file.ts` sidecar precedent — so sibling pages and both metadata names reuse one read+strip+scan.
- state-and-effects semantic helpers: `getRef` memoized per (ProgramAnalysis, identifier) with a `has()` null sentinel; `getScopeForNode` per (ScopeManager, node) with the `<=` tie-break preserved; `getUpstreamRefs` per (ProgramAnalysis, Reference); `react.ts`'s duplicate `getOuterScopeContaining` deleted and converged onto the memoized helper (byte-equivalent logic).
- zod `getImportInfoForIdentifier` memoized per identifier node; `normalize-filename` gets an already-normalized fast path.
- Deliberately SKIPPED (catalog annotated): #452/#454 — `findNearestTsconfig` carries an explicit in-code invariant that the walk is deliberately uncached so long-lived processes pick up tsconfig edits and newly-added configs; caching would break that documented guarantee. #341 — the catalog itself concludes no change needed.

## Test plan

- Plugin suite: 8704 pass / 94 skip — zero deltas vs pristine main. Root typecheck + lint clean.
- Equivalence: 617-file corpus — 291 diagnostics, sorted tuples byte-identical.
- Adversarial review attacked cache staleness (mtime granularity, long-lived workers), pattern-object mutation, and the getScopeForNode convergence tie-break — no divergence found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only memoization with existing mtime invalidation for disk reads and WeakMap lifetimes tied to AST/analysis; duplicate scope logic was consolidated rather than altered.
> 
> **Overview**
> Adds **caching** across hot paths in `oxlint-plugin-react-doctor` so repeated work per file, per rule, or per AST node is not recomputed.
> 
> **Security-scan** memoizes `isProductionFilePath` in a two-level map keyed by `RegExp` identity and relative path. **Layout/barrel checks** refactor `doesModuleExportName` to build a full export-name set once per file, with **mtime/size** invalidation matching `parse-source-file.ts`.
> 
> **State-and-effects** memoizes `getScopeForNode`, `getRef`, and `getUpstreamRefs` on `ProgramAnalysis` / `ScopeManager` WeakMaps (including cached `null` via `has()`). **`react.ts`** drops the duplicate outer-scope scan and calls the shared **`getScopeForNode`**.
> 
> **Zod** caches import classification per identifier node. **`normalizeFilename`** skips `replaceAll` when the path has no backslashes.
> 
> Patch changeset only; diagnostics behavior is intended to stay equivalent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd2c7bab242268813d6e2228bd58acc3a5a49c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->