### PR TITLE
fix(cli): raise runGit maxBuffer so the scan cache works on large repos

### DIFF
--- a/.changeset/perf-scan-cache-maxbuffer.md
+++ b/.changeset/perf-scan-cache-maxbuffer.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+Restore instant reruns on large repos: raise `runGit`'s output cap so the whole-repo scan-result cache works past ~15k tracked files.
+
+The cache's clean-worktree gates shell out to git through a helper that used Node's default 1 MiB `maxBuffer`. On repos with roughly 15-25k tracked files (getsentry/sentry: 20,343), `git ls-files -v` alone exceeds that, `execFileSync` throws ENOBUFS, the helper swallows it into `null`, and the gates read `null` as "hidden tracked state" — so the cache silently never stored or served a scan on exactly the repos where the instant-rerun path saves the most time. The helper now runs with an explicit 64 MiB cap, which clears monorepos with hundreds of thousands of files while still bounding a pathological child process.

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -31,6 +31,15 @@ export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 3;
 export const SCAN_RESULT_CACHE_MAX_ENTRY_COUNT = 20;
 export const CACHE_FILENAME_HASH_LENGTH_CHARS = 16;
 
+// Stdout cap for `runGit` (git-hook-shared.ts). Node's default `maxBuffer`
+// is 1 MiB, and `git ls-files -v` alone exceeds that on repos with ~15-25k
+// tracked files (getsentry/sentry: 1.25 MB) — execFileSync then throws
+// ENOBUFS, runGit swallows it into `null`, and the whole-repo scan-result
+// cache silently never stores or serves on exactly the large repos it helps
+// most. 64 MiB clears monorepos with hundreds of thousands of files while
+// still bounding a pathological child.
+export const RUN_GIT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
 export const GIT_HOOK_EXECUTABLE_MODE = 0o755;
 
 export const AGENT_HOOK_TIMEOUT_SECONDS = 120;

--- a/packages/react-doctor/src/cli/utils/git-hook-shared.ts
+++ b/packages/react-doctor/src/cli/utils/git-hook-shared.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
+import { RUN_GIT_MAX_BUFFER_BYTES } from "./constants.js";
 
 export const HOOK_FILE_NAME = "pre-commit";
 export const HOOK_RELATIVE_PATH = "hooks/pre-commit";
@@ -33,6 +34,7 @@ export const runGit = (projectRoot: string, args: ReadonlyArray<string>): string
       cwd: projectRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: RUN_GIT_MAX_BUFFER_BYTES,
     }).trim();
   } catch {
     return null;

--- a/packages/react-doctor/tests/scan-result-cache.test.ts
+++ b/packages/react-doctor/tests/scan-result-cache.test.ts
@@ -11,6 +11,7 @@ import {
   shouldStoreScanPayload,
   type CachedScanPayload,
 } from "../src/cli/utils/scan-result-cache.js";
+import { runGit } from "../src/cli/utils/git-hook-shared.js";
 import { VERSION } from "../src/cli/utils/version.js";
 import { commitAll, initGitRepo, setupReactProject } from "./regressions/_helpers.js";
 
@@ -255,6 +256,28 @@ describe("scan result cache", () => {
     });
 
     expect(cacheKey(projectDirectory, baseOptions())).toBeNull();
+  });
+
+  it("handles git output larger than Node's default maxBuffer", () => {
+    // `git ls-files -v` exceeds execFileSync's 1 MiB default on repos with
+    // ~15-25k tracked files (getsentry/sentry: 1.25 MB); the resulting ENOBUFS
+    // surfaced as `null`, which the cache gates read as hidden tracked state —
+    // silently disabling the whole-repo cache on exactly the largest repos.
+    // A shell alias emits 2 MiB through the production helper without needing
+    // a giant fixture repo.
+    const projectDirectory = setupReactProject(tempDirectory, "large-output", {
+      files: { "src/App.tsx": "export const App = () => <div />;\n" },
+    });
+    initGitRepo(projectDirectory, { commit: true });
+
+    const outputSizeChars = 2 * 1024 * 1024;
+    const nodeBinaryForShell = process.execPath.replaceAll("\\", "/");
+    const output = runGit(projectDirectory, [
+      "-c",
+      `alias.emit-large-output=!"${nodeBinaryForShell}" -e "process.stdout.write('x'.repeat(${outputSizeChars}))"`,
+      "emit-large-output",
+    ]);
+    expect(output?.length).toBe(outputSizeChars);
   });
 
   it("reuses diagnostics when rerendering with verbose enabled", async () => {


### PR DESCRIPTION
## Why

The whole-repo scan-result cache — the ~1s instant-rerun path — was silently dead on large repos. `runGit` uses `execFileSync` with Node's default 1MiB `maxBuffer`; `git ls-files -v` exceeds that past ~15–25k tracked files (getsentry/sentry: 1,249,064 bytes) → ENOBUFS → `runGit` returns `null` → `hasHiddenTrackedFileState` conservatively reads "unsafe" → the cache key is `null` → the cache never stores and never serves.

Before:

```
sentry (20,343 tracked files) rescan, clean tree, nothing changed:
full warm scan every time (~16-20s); no scan-cache.json ever written
```

After:

```
run 1: full scan, cache STORED (2.7MB entry, 4,975 diagnostics, 8,936 files)
run 2: whole-repo cache HIT — real 3.70s, rendered output byte-identical
```

## What changed

- `RUN_GIT_MAX_BUFFER_BYTES = 64MiB` constant (with a comment naming the failure mode) wired into `runGit` — covers `ls-files -v`, `status --porcelain`, and the small calls.
- Audited every `execFileSync`/`execSync`/`spawnSync` in both packages for the same class: core's `git ls-files -z` already had an explicit 50MiB buffer; `git grep -l` (reduced-motion) fails open to a filesystem walk on ENOBUFS with the same verdict; the remaining sites emit bytes-scale output. Table in the review thread if wanted.
- New test drives >1MB of output through the real `runGit` (verified red without the fix).

## Test plan

- `packages/react-doctor`: 2125 passed / 26 skipped (baseline 2124; +1 new, zero regressions); `packages/core`: 1145 passed, unchanged. Root typecheck + lint + `pnpm smoke:json-report` clean.
- End-to-end on the sentry clone above: store + 3.70s hit reproduced with the built bin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded change to git subprocess buffering in the CLI; improves cache behavior on large repos without altering scan logic or auth.
> 
> **Overview**
> Fixes the whole-repo scan-result cache being **silently disabled** on large git repos by giving `runGit` a **64 MiB** stdout cap instead of Node’s default **1 MiB**.
> 
> When `git ls-files -v` (and similar clean-worktree checks) exceeds that limit, `execFileSync` throws **ENOBUFS**, `runGit` returns **`null`**, and cache key logic treats that like unsafe/hidden tracked state—so **`buildScanResultCacheKey` stays `null`** and the cache never stores or serves on repos where instant reruns matter most.
> 
> Adds **`RUN_GIT_MAX_BUFFER_BYTES`** in `constants.ts`, passes it as **`maxBuffer`** in `git-hook-shared.ts`, documents the failure mode in a changeset, and adds a regression test that drives **>1 MiB** of git stdout through the real `runGit` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58627e49de7236a6b5b679b864e9ea4b1c1602f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->