### PR TITLE
perf(core): cache dead-code results so unchanged rescans skip the analysis

### DIFF
--- a/.changeset/perf-dead-code-cache.md
+++ b/.changeset/perf-dead-code-cache.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Rescans now skip the dead-code analysis entirely when nothing it reads has changed. The pass persists its diagnostics keyed by a fingerprint over the analyzed source tree (stat-based, so additions, deletions, and edits all invalidate), the project's manifests, tsconfigs, lockfiles, knip/entry/ignore configuration, and the analyzer version — on an unchanged-input rerun the stored result replays instead of re-walking the whole import graph, cutting several seconds off warm rescans of large repos. Only complete, successful passes are stored; `REACT_DOCTOR_NO_CACHE` (or the granular `REACT_DOCTOR_NO_DEAD_CODE_CACHE`) disables it.

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -6,6 +6,11 @@ import {
   collectDeadCodeEntryPatterns,
   collectDeadCodeIgnorePatterns,
 } from "./dead-code/collect-dead-code-patterns.js";
+import {
+  computeDeadCodeCacheKey,
+  lookupDeadCodeResultCache,
+  storeDeadCodeResultCache,
+} from "./dead-code/dead-code-result-cache.js";
 import { withDeadCodeWorkerSlot } from "./dead-code/dead-code-worker-slots.js";
 import {
   DEAD_CODE_WORKER_MAX_OLD_SPACE_MB,
@@ -14,6 +19,7 @@ import {
   TSCONFIG_FILENAMES,
 } from "./constants.js";
 import { isRecord } from "./utils/is-record.js";
+import { resolveReactDoctorCacheDir } from "./utils/resolve-react-doctor-cache-dir.js";
 import { toCanonicalPath } from "./utils/to-canonical-path.js";
 import { toRelativePath } from "./utils/to-relative-path.js";
 
@@ -57,6 +63,21 @@ interface CheckDeadCodeOptions {
    * `DEAD_CODE_WORKER_TIMEOUT_MS`.
    */
   readonly abortSignal?: AbortSignal;
+  /**
+   * Whether to consult the whole-project dead-code result cache. Defaults
+   * OFF so direct callers (and existing tests) keep their fresh-analysis
+   * semantics; the `DeadCode` service passes the `DeadCodeResultCacheEnabled`
+   * Reference here. A hit replays the stored diagnostics without spawning
+   * the analysis worker; a fresh COMPLETE pass is stored on success (a
+   * crashed, timed-out, or aborted worker rejects before the store).
+   */
+  readonly cacheEnabled?: boolean;
+  /**
+   * Reports the cache outcome (`true` = hit, `false` = miss) once per call.
+   * Not invoked when `cacheEnabled` is off, so the orchestrator's telemetry
+   * distinguishes "no cache" from a miss.
+   */
+  readonly onCacheOutcome?: (didHitCache: boolean) => void;
 }
 
 interface DeadCodeWorkerInput {
@@ -498,6 +519,32 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
 
   const entryPatterns = collectDeadCodeEntryPatterns(rootDirectory);
   const ignorePatterns = collectDeadCodeIgnorePatterns(rootDirectory);
+  const tsConfigPath = resolveTsConfigPath(rootDirectory);
+  const deslopJsModuleSpecifier =
+    options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js");
+
+  // Result cache: replay the last complete pass when nothing the analysis
+  // reads changed. The key snapshot is taken BEFORE the (long) analysis so a
+  // stored result is keyed by the tree it started from — an edit racing the
+  // analysis lands a stale key that the next run's fresh snapshot misses.
+  const cacheKey = options.cacheEnabled
+    ? computeDeadCodeCacheKey({
+        rootDirectory,
+        entryPatterns,
+        ignorePatterns,
+        tsConfigPath,
+        deslopJsModuleSpecifier,
+      })
+    : null;
+  if (cacheKey !== null) {
+    const cachedDiagnostics = lookupDeadCodeResultCache(
+      resolveReactDoctorCacheDir(rootDirectory),
+      cacheKey,
+    );
+    options.onCacheOutcome?.(cachedDiagnostics !== null);
+    if (cachedDiagnostics !== null) return [...cachedDiagnostics];
+  }
+
   // `runDeadCodeWorkerWithTimeout` owns the abort wiring: when the surrounding
   // Effect fiber is interrupted (lint failed / dead-code phase timeout / scan
   // cancelled), `Effect.tryPromise` aborts `options.abortSignal`, which its
@@ -507,9 +554,9 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
     const workerHandle = (options.createWorker ?? createDeadCodeWorker)({
       rootDirectory,
       entryPatterns,
-      tsConfigPath: resolveTsConfigPath(rootDirectory),
+      tsConfigPath,
       ignorePatterns,
-      deslopJsModuleSpecifier: options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js"),
+      deslopJsModuleSpecifier,
       parseConcurrency: options.parseConcurrency,
     });
     return runDeadCodeWorkerWithTimeout(
@@ -598,6 +645,13 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
       column: 0,
       category: DEAD_CODE_CATEGORY,
     });
+  }
+
+  // Only a COMPLETE successful pass reaches this line — a crashed, timed-out,
+  // or aborted worker rejects above — so a stored entry never replays a
+  // truncated result (mirroring `shouldStoreScanPayload`).
+  if (cacheKey !== null) {
+    storeDeadCodeResultCache(resolveReactDoctorCacheDir(rootDirectory), cacheKey, diagnostics);
   }
 
   return diagnostics;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -631,6 +631,13 @@ export const FILE_LINT_CACHE_MAX_FILE_COUNT = 50_000;
 // fallback when a project has no `node_modules` to host `.cache/react-doctor`.
 export const CACHE_FILENAME_HASH_LENGTH_CHARS = 16;
 
+// Whole-project dead-code result cache (`dead-code/dead-code-result-cache.ts`).
+// Replays deslop's diagnostics — skipping the analysis worker entirely — when
+// nothing the analysis reads has changed since the stored run.
+export const DEAD_CODE_CACHE_SCHEMA_VERSION = 1;
+
+export const DEAD_CODE_CACHE_FILENAME = "dead-code-cache.json";
+
 // Plugin / rule / category identity for the diagnostics the supply-chain
 // check emits. `plugin: "socket"` keeps Socket findings visually distinct
 // from the `react-doctor` lint surface in the printed list and JSON report.

--- a/packages/core/src/dead-code/dead-code-result-cache.ts
+++ b/packages/core/src/dead-code/dead-code-result-cache.ts
@@ -1,0 +1,197 @@
+import crypto from "node:crypto";
+import * as fs from "node:fs";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+import * as Schema from "effect/Schema";
+import type { Diagnostic } from "../types/index.js";
+import { DEAD_CODE_CACHE_FILENAME, DEAD_CODE_CACHE_SCHEMA_VERSION } from "../constants.js";
+import { Diagnostic as DiagnosticSchema } from "../schemas.js";
+import { atomicWriteJson } from "../utils/atomic-write-json.js";
+import { failOpenReadJson } from "../utils/fail-open-read-json.js";
+import { isRecord } from "../utils/is-record.js";
+import { walkSourceTreeFiles } from "../utils/walk-source-tree-files.js";
+
+/**
+ * Whole-project dead-code result cache. Dead-code reachability is a
+ * whole-project property, so the cache holds ONE entry: the diagnostics of the
+ * last complete, successful pass, keyed by a fingerprint over everything the
+ * analysis reads. Any input change mints a new key, which makes the stored
+ * entry unreachable — so there is nothing to gain from keeping history.
+ *
+ * The key fingerprints files by (path, mtime, size) — the same stat-based
+ * invalidation the plugin's `parse-source-file` cache uses — rather than
+ * content-hashing the whole tree, because statting ~9k files costs
+ * ~100-200 ms while hashing them costs seconds. The accepted tradeoff, shared
+ * with that precedent: an edit that preserves BOTH a file's byte size and its
+ * mtime is invisible to the fingerprint. Additions and deletions always
+ * invalidate — the sorted path list itself is part of the hash.
+ *
+ * Every operation fails open: a missing or corrupt cache degrades to a fresh
+ * analysis, never to a wrong result.
+ */
+
+interface DeadCodeCacheKeyInput {
+  /** Canonicalized project root (`checkDeadCode` realpaths it first). */
+  readonly rootDirectory: string;
+  readonly entryPatterns: ReadonlyArray<string>;
+  readonly ignorePatterns: ReadonlyArray<string>;
+  readonly tsConfigPath: string | undefined;
+  readonly deslopJsModuleSpecifier: string;
+}
+
+interface PersistedDeadCodeResultCache {
+  readonly version: number;
+  readonly key: string;
+  readonly diagnostics: ReadonlyArray<unknown>;
+}
+
+// The extensions deslop's import-graph walk parses (its DEFAULT_EXTENSIONS),
+// so an edit to any file the graph can reach changes the key.
+const ANALYZED_FILE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mts",
+  ".mjs",
+  ".cts",
+  ".cjs",
+  ".mdx",
+  ".astro",
+  ".graphql",
+  ".gql",
+  ".css",
+  ".scss",
+  ".vue",
+  ".svelte",
+]);
+
+// Non-source files deslop's entry/workspace/dependency analysis reads:
+// manifests (workspace layout, dependency declarations, knip/expo config),
+// lockfiles (the proxy for installed `node_modules` metadata — deslop reads
+// installed packages' bin/peer fields, which only change through an install
+// that rewrites the lockfile), and `.gitignore` files at every level (deslop
+// consults git's ignore state for its walk).
+const ANALYZED_MANIFEST_NAMES = new Set([
+  "package.json",
+  "knip.json",
+  "app.json",
+  "pnpm-workspace.yaml",
+  "lerna.json",
+  "pnpm-lock.yaml",
+  "package-lock.json",
+  "yarn.lock",
+  "bun.lock",
+  "bun.lockb",
+  "deno.lock",
+  ".gitignore",
+]);
+
+// tsconfig/jsconfig files anywhere in the tree — path-alias resolution reads
+// the root config, and `extends` chains reach the rest.
+const isTsConfigLikeFile = (fileName: string): boolean =>
+  (fileName.startsWith("tsconfig") || fileName.startsWith("jsconfig")) &&
+  fileName.endsWith(".json");
+
+const isFingerprintedFile = (fileName: string): boolean =>
+  ANALYZED_FILE_EXTENSIONS.has(path.extname(fileName).toLowerCase()) ||
+  ANALYZED_MANIFEST_NAMES.has(fileName) ||
+  isTsConfigLikeFile(fileName);
+
+const collectAnalyzedFileFingerprints = (rootDirectory: string): string[] => {
+  const fingerprints: string[] = [];
+  for (const { absolutePath, name } of walkSourceTreeFiles(rootDirectory)) {
+    if (!isFingerprintedFile(name)) continue;
+    try {
+      const fileStat = fs.statSync(absolutePath);
+      const relativePath = path.relative(rootDirectory, absolutePath).replace(/\\/g, "/");
+      fingerprints.push(`${relativePath}:${fileStat.mtimeMs}:${fileStat.size}`);
+    } catch {
+      // Vanished between walk and stat — same key contribution as deleted.
+    }
+  }
+  return fingerprints.sort();
+};
+
+const bundledRequire = createRequire(import.meta.url);
+
+const resolveDeslopVersion = (): string => {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(bundledRequire.resolve("deslop-js/package.json"), "utf8"),
+    );
+    return isRecord(packageJson) && typeof packageJson.version === "string"
+      ? packageJson.version
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
+};
+
+export const computeDeadCodeCacheKey = (input: DeadCodeCacheKeyInput): string =>
+  crypto
+    .createHash("sha1")
+    .update(
+      JSON.stringify({
+        schemaVersion: DEAD_CODE_CACHE_SCHEMA_VERSION,
+        deslopVersion: resolveDeslopVersion(),
+        deslopJsModuleSpecifier: input.deslopJsModuleSpecifier,
+        entryPatterns: input.entryPatterns,
+        ignorePatterns: input.ignorePatterns,
+        // Which tsconfig filename resolved (its CONTENT rides in the file
+        // fingerprints below; existence/choice is what this captures).
+        tsConfigFile:
+          input.tsConfigPath === undefined
+            ? null
+            : path.relative(input.rootDirectory, input.tsConfigPath).replace(/\\/g, "/"),
+        files: collectAnalyzedFileFingerprints(input.rootDirectory),
+      }),
+    )
+    .digest("hex");
+
+const validateDiagnostic = Schema.decodeUnknownSync(DiagnosticSchema);
+
+// Returns `null` if ANY stored entry is malformed, so a corrupt file degrades
+// to a whole-pass miss rather than a partial diagnostic set. The records were
+// serialized straight from `checkDeadCode`'s `Diagnostic[]`, so the validated
+// array replays as-is in its original (deterministic) order.
+const decodeCachedDiagnostics = (raw: ReadonlyArray<unknown>): ReadonlyArray<Diagnostic> | null => {
+  try {
+    for (const entry of raw) validateDiagnostic(entry);
+    return raw as ReadonlyArray<Diagnostic>;
+  } catch {
+    return null;
+  }
+};
+
+export const lookupDeadCodeResultCache = (
+  cacheDirectory: string,
+  cacheKey: string,
+): ReadonlyArray<Diagnostic> | null => {
+  const persisted = failOpenReadJson<PersistedDeadCodeResultCache | null>(
+    path.join(cacheDirectory, DEAD_CODE_CACHE_FILENAME),
+    null,
+  );
+  if (
+    persisted === null ||
+    !isRecord(persisted) ||
+    persisted.version !== DEAD_CODE_CACHE_SCHEMA_VERSION ||
+    persisted.key !== cacheKey ||
+    !Array.isArray(persisted.diagnostics)
+  ) {
+    return null;
+  }
+  return decodeCachedDiagnostics(persisted.diagnostics);
+};
+
+export const storeDeadCodeResultCache = (
+  cacheDirectory: string,
+  cacheKey: string,
+  diagnostics: ReadonlyArray<Diagnostic>,
+): void => {
+  atomicWriteJson(path.join(cacheDirectory, DEAD_CODE_CACHE_FILENAME), {
+    version: DEAD_CODE_CACHE_SCHEMA_VERSION,
+    key: cacheKey,
+    diagnostics,
+  });
+};

--- a/packages/core/src/refs.ts
+++ b/packages/core/src/refs.ts
@@ -207,3 +207,28 @@ export class PerFileLintCacheEnabled extends Context.Reference<boolean>(
     },
   },
 ) {}
+
+/**
+ * Whether the whole-project dead-code result cache
+ * (`dead-code/dead-code-result-cache.ts`) is active. Defaults ON — a rescan
+ * whose inputs (source tree, manifests, configs, analyzer version) are
+ * unchanged replays the stored diagnostics instead of re-running the
+ * analysis worker. Opt-OUT, two knobs (matching the per-file lint cache):
+ *
+ *   - `REACT_DOCTOR_NO_CACHE` — the global off-switch.
+ *   - `REACT_DOCTOR_NO_DEAD_CODE_CACHE` — granular: bust only this cache.
+ *
+ * Tests override via `Layer.succeed(DeadCodeResultCacheEnabled, false)`.
+ */
+export class DeadCodeResultCacheEnabled extends Context.Reference<boolean>(
+  "react-doctor/DeadCodeResultCacheEnabled",
+  {
+    defaultValue: () => {
+      const noCache = process.env["REACT_DOCTOR_NO_CACHE"]?.toLowerCase() ?? "";
+      const noDeadCodeCache = process.env["REACT_DOCTOR_NO_DEAD_CODE_CACHE"]?.toLowerCase() ?? "";
+      if (CACHE_DISABLED_VALUES.has(noCache)) return false;
+      if (CACHE_DISABLED_VALUES.has(noDeadCodeCache)) return false;
+      return true;
+    },
+  },
+) {}

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -239,6 +239,16 @@ export interface InspectOutput {
   readonly lintCacheHitFileCount: number | null;
   readonly lintCacheTotalFileCount: number | null;
   /**
+   * Dead-code result cache outcome for this scan's dead-code pass: `true`
+   * when the cached result was replayed (the analysis worker never spawned),
+   * `false` on a miss (fresh analysis). `null` when the pass never consulted
+   * the cache — dead-code skipped/disabled, the cache off
+   * (`REACT_DOCTOR_NO_CACHE` / `REACT_DOCTOR_NO_DEAD_CODE_CACHE`), or the
+   * pass discarded by a lint failure. Fed to the Sentry wide event as
+   * `deadCode.cacheHit`.
+   */
+  readonly deadCodeCacheHit: boolean | null;
+  /**
    * Per-rule tallies of diagnostics the pipeline dropped because the user
    * explicitly silenced the rule (config off switches, per-path overrides,
    * inline disable comments) — see `DiagnosticPipeline.summarizeSuppressions`.
@@ -673,6 +683,9 @@ export const runInspect = <HooksR = never>(
               rootDirectory: scanDirectory,
               parseConcurrency: deadCodeParseConcurrency,
               workerTimeoutMs: deadCodeTimeout.workerTimeoutMs,
+              onCacheOutcome: (didHitCache) => {
+                deadCodeCacheHit = didHitCache;
+              },
             })
             .pipe(
               Stream.catchTag("ReactDoctorError", (error: ReactDoctorError) =>
@@ -736,6 +749,7 @@ export const runInspect = <HooksR = never>(
     // or bypassed so the wide event can tell "no cache" from "0% hit".
     let lintCacheHitFileCount: number | null = null;
     let lintCacheTotalFileCount: number | null = null;
+    let deadCodeCacheHit: boolean | null = null;
 
     const baseLintStream = linterService
       .run({
@@ -985,6 +999,9 @@ export const runInspect = <HooksR = never>(
       securityScanFailed,
       lintCacheHitFileCount,
       lintCacheTotalFileCount,
+      // Lint failure discards the dead-code pass entirely (see
+      // `deadCodeFailureState` above), so its cache outcome must not leak.
+      deadCodeCacheHit: lintFailureState.didFail ? null : deadCodeCacheHit,
       suppressedRuleCounts: transform.summarizeSuppressions(),
     };
   }).pipe(

--- a/packages/core/src/services/dead-code.ts
+++ b/packages/core/src/services/dead-code.ts
@@ -5,6 +5,7 @@ import * as Stream from "effect/Stream";
 import type { Diagnostic } from "../types/index.js";
 import { checkDeadCode } from "../check-dead-code.js";
 import { DeadCodeAnalysisFailed, ReactDoctorError } from "../errors.js";
+import { DeadCodeResultCacheEnabled } from "../refs.js";
 
 interface DeadCodeInput {
   readonly rootDirectory: string;
@@ -20,6 +21,13 @@ interface DeadCodeInput {
    * `DEAD_CODE_WORKER_TIMEOUT_MS` floor.
    */
   readonly workerTimeoutMs?: number;
+  /**
+   * Reports the dead-code result cache outcome (`true` = hit, `false` =
+   * miss). Not invoked when the cache is disabled
+   * (`DeadCodeResultCacheEnabled` off), so the orchestrator's telemetry
+   * distinguishes "no cache" from a miss.
+   */
+  readonly onCacheOutcome?: (didHitCache: boolean) => void;
 }
 
 /**
@@ -47,6 +55,7 @@ export class DeadCode extends Context.Service<
           // surfaces as a single named span in OTel traces (parent
           // of the per-call `Effect.tryPromise`).
           Effect.fn("DeadCode.run")(function* () {
+            const cacheEnabled = yield* DeadCodeResultCacheEnabled;
             return yield* Effect.tryPromise({
               // The signal is wired to fiber interruption: when the
               // orchestrator interrupts this fiber (lint failed / scan
@@ -58,6 +67,8 @@ export class DeadCode extends Context.Service<
                   parseConcurrency: input.parseConcurrency,
                   workerTimeoutMs: input.workerTimeoutMs,
                   abortSignal: signal,
+                  cacheEnabled,
+                  onCacheOutcome: input.onCacheOutcome,
                 }),
               catch: (cause) =>
                 new ReactDoctorError({ reason: new DeadCodeAnalysisFailed({ cause }) }),

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -49,6 +49,14 @@ export interface InspectResult {
   lintCacheHitFileCount?: number | null;
   lintCacheTotalFileCount?: number | null;
   /**
+   * Dead-code result cache outcome: `true` when the pass replayed a cached
+   * result (the analysis never ran), `false` on a fresh analysis. Absent when
+   * the pass never consulted the cache — dead-code skipped, the cache
+   * disabled, or a whole-repo cache replay where no analysis ran. The CLI
+   * projects it onto the Sentry wide event as `deadCode.cacheHit`.
+   */
+  deadCodeCacheHit?: boolean | null;
+  /**
    * Present only for a baseline run (`InspectOptions.baseline` set). The
    * `diagnostics` above are then the *introduced* findings only; this
    * carries the comparison totals for Codecov-style delta reporting.

--- a/packages/core/tests/dead-code-result-cache.test.ts
+++ b/packages/core/tests/dead-code-result-cache.test.ts
@@ -1,0 +1,315 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import * as Effect from "effect/Effect";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import type { Diagnostic } from "../src/types/index.js";
+import { checkDeadCode } from "../src/check-dead-code.js";
+import { computeDeadCodeCacheKey } from "../src/dead-code/dead-code-result-cache.js";
+import { DeadCodeResultCacheEnabled } from "../src/refs.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-dead-code-cache-"));
+const originalCacheDirEnv = process.env["REACT_DOCTOR_CACHE_DIR"];
+
+beforeAll(() => {
+  // The cache resolves through `REACT_DOCTOR_CACHE_DIR` first; clear it so
+  // every fixture's cache deterministically lands in its own
+  // `node_modules/.cache/react-doctor` (created by `setupProject`).
+  delete process.env["REACT_DOCTOR_CACHE_DIR"];
+});
+
+afterAll(() => {
+  if (originalCacheDirEnv === undefined) delete process.env["REACT_DOCTOR_CACHE_DIR"];
+  else process.env["REACT_DOCTOR_CACHE_DIR"] = originalCacheDirEnv;
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const setupProject = (caseId: string, files: Record<string, string>): string => {
+  const projectDirectory = path.join(tempRoot, caseId);
+  fs.mkdirSync(projectDirectory, { recursive: true });
+  // An (empty) node_modules pins `resolveReactDoctorCacheDir` to the fixture
+  // so the cache file is cleaned up with `tempRoot`.
+  fs.mkdirSync(path.join(projectDirectory, "node_modules"), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectDirectory, "package.json"),
+    JSON.stringify({ name: caseId, type: "module", dependencies: { react: "^19.0.0" } }),
+  );
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const fullPath = path.join(projectDirectory, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, contents);
+  }
+  // Match `checkDeadCode`'s canonicalized root (os.tmpdir() is a symlink into
+  // /private on macOS) so key inputs built from this path line up.
+  return fs.realpathSync(projectDirectory);
+};
+
+const cacheFilePath = (projectDirectory: string): string =>
+  path.join(projectDirectory, "node_modules", ".cache", "react-doctor", "dead-code-cache.json");
+
+const keyInput = (projectDirectory: string) => ({
+  rootDirectory: projectDirectory,
+  entryPatterns: [],
+  ignorePatterns: [],
+  tsConfigPath: undefined,
+  deslopJsModuleSpecifier: "deslop-js",
+});
+
+interface SpyWorker {
+  readonly factory: (input: unknown) => { result: Promise<unknown> };
+  readonly callCount: () => number;
+}
+
+const createSpyWorker = (unusedFilePath: string): SpyWorker => {
+  let calls = 0;
+  return {
+    factory: () => {
+      calls += 1;
+      return {
+        result: Promise.resolve({
+          unusedFiles: [{ path: unusedFilePath }],
+          unusedExports: [],
+          unusedDependencies: [],
+          circularDependencies: [],
+        }),
+      };
+    },
+    callCount: () => calls,
+  };
+};
+
+describe("computeDeadCodeCacheKey", () => {
+  it("is stable for identical inputs", () => {
+    const directory = setupProject("key-stable", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    expect(computeDeadCodeCacheKey(keyInput(directory))).toBe(
+      computeDeadCodeCacheKey(keyInput(directory)),
+    );
+  });
+
+  it("changes when a source file is touched (mtime)", () => {
+    const directory = setupProject("key-touch", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const keyBefore = computeDeadCodeCacheKey(keyInput(directory));
+    const later = new Date(Date.now() + 5_000);
+    fs.utimesSync(path.join(directory, "src", "index.ts"), later, later);
+    expect(computeDeadCodeCacheKey(keyInput(directory))).not.toBe(keyBefore);
+  });
+
+  it("changes when a source file is added", () => {
+    const directory = setupProject("key-add", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const keyBefore = computeDeadCodeCacheKey(keyInput(directory));
+    fs.writeFileSync(path.join(directory, "src", "added.ts"), "export const added = 1;\n");
+    expect(computeDeadCodeCacheKey(keyInput(directory))).not.toBe(keyBefore);
+  });
+
+  it("changes when a source file is deleted", () => {
+    const directory = setupProject("key-delete", {
+      "src/index.ts": "export const used = 1;\n",
+      "src/doomed.ts": "export const doomed = 1;\n",
+    });
+    const keyBefore = computeDeadCodeCacheKey(keyInput(directory));
+    fs.rmSync(path.join(directory, "src", "doomed.ts"));
+    expect(computeDeadCodeCacheKey(keyInput(directory))).not.toBe(keyBefore);
+  });
+
+  it("changes when a manifest (package.json) changes", () => {
+    const directory = setupProject("key-manifest", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const keyBefore = computeDeadCodeCacheKey(keyInput(directory));
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      JSON.stringify({
+        name: "key-manifest",
+        type: "module",
+        dependencies: { react: "^19.0.0", "left-pad": "^1.0.0" },
+      }),
+    );
+    expect(computeDeadCodeCacheKey(keyInput(directory))).not.toBe(keyBefore);
+  });
+
+  it("changes with entry / ignore patterns and the resolved tsconfig", () => {
+    const directory = setupProject("key-config", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const baseKey = computeDeadCodeCacheKey(keyInput(directory));
+    expect(
+      computeDeadCodeCacheKey({ ...keyInput(directory), entryPatterns: ["src/cli.ts"] }),
+    ).not.toBe(baseKey);
+    expect(
+      computeDeadCodeCacheKey({ ...keyInput(directory), ignorePatterns: ["src/generated/**"] }),
+    ).not.toBe(baseKey);
+    expect(
+      computeDeadCodeCacheKey({
+        ...keyInput(directory),
+        tsConfigPath: path.join(directory, "tsconfig.json"),
+      }),
+    ).not.toBe(baseKey);
+  });
+
+  it("ignores files the analysis never reads (scratch text files)", () => {
+    const directory = setupProject("key-scratch", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const keyBefore = computeDeadCodeCacheKey(keyInput(directory));
+    fs.writeFileSync(path.join(directory, "scratch.txt"), "not part of the graph\n");
+    expect(computeDeadCodeCacheKey(keyInput(directory))).toBe(keyBefore);
+  });
+});
+
+describe("checkDeadCode result cache", () => {
+  it("replays a stored pass without spawning the worker, and reports the outcome", async () => {
+    const directory = setupProject("hit-skips-analysis", {
+      "src/index.ts": "export const used = 1;\n",
+      "src/orphan.ts": "export const orphan = 1;\n",
+    });
+    const spyWorker = createSpyWorker(path.join(directory, "src", "orphan.ts"));
+    const cacheOutcomes: boolean[] = [];
+    const onCacheOutcome = (didHitCache: boolean): void => {
+      cacheOutcomes.push(didHitCache);
+    };
+
+    const firstRun = await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: spyWorker.factory,
+      cacheEnabled: true,
+      onCacheOutcome,
+    });
+    expect(spyWorker.callCount()).toBe(1);
+    expect(cacheOutcomes).toEqual([false]);
+    expect(fs.existsSync(cacheFilePath(directory))).toBe(true);
+
+    const secondRun = await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: spyWorker.factory,
+      cacheEnabled: true,
+      onCacheOutcome,
+    });
+    expect(spyWorker.callCount()).toBe(1);
+    expect(cacheOutcomes).toEqual([false, true]);
+    expect(secondRun).toEqual(firstRun);
+  });
+
+  it("misses after a source file changes, and re-analyzes", async () => {
+    const directory = setupProject("miss-on-change", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const spyWorker = createSpyWorker(path.join(directory, "src", "index.ts"));
+    const cacheOutcomes: boolean[] = [];
+    const onCacheOutcome = (didHitCache: boolean): void => {
+      cacheOutcomes.push(didHitCache);
+    };
+
+    await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: spyWorker.factory,
+      cacheEnabled: true,
+      onCacheOutcome,
+    });
+    const later = new Date(Date.now() + 5_000);
+    fs.utimesSync(path.join(directory, "src", "index.ts"), later, later);
+    await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: spyWorker.factory,
+      cacheEnabled: true,
+      onCacheOutcome,
+    });
+    expect(spyWorker.callCount()).toBe(2);
+    expect(cacheOutcomes).toEqual([false, false]);
+  });
+
+  it("never stores a failed pass", async () => {
+    const directory = setupProject("store-barred-on-failure", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    await expect(
+      checkDeadCode({
+        rootDirectory: directory,
+        createWorker: () => ({ result: Promise.reject(new Error("analysis crashed")) }),
+        cacheEnabled: true,
+      }),
+    ).rejects.toThrow("analysis crashed");
+    expect(fs.existsSync(cacheFilePath(directory))).toBe(false);
+
+    // The next (successful) run must be a genuine miss that re-analyzes.
+    const spyWorker = createSpyWorker(path.join(directory, "src", "index.ts"));
+    const cacheOutcomes: boolean[] = [];
+    await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: spyWorker.factory,
+      cacheEnabled: true,
+      onCacheOutcome: (didHitCache) => {
+        cacheOutcomes.push(didHitCache);
+      },
+    });
+    expect(spyWorker.callCount()).toBe(1);
+    expect(cacheOutcomes).toEqual([false]);
+  });
+
+  it("bypasses the cache entirely when disabled (default)", async () => {
+    const directory = setupProject("cache-disabled", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const spyWorker = createSpyWorker(path.join(directory, "src", "index.ts"));
+    const cacheOutcomes: boolean[] = [];
+    const runOnce = (): Promise<Diagnostic[]> =>
+      checkDeadCode({
+        rootDirectory: directory,
+        createWorker: spyWorker.factory,
+        onCacheOutcome: (didHitCache) => {
+          cacheOutcomes.push(didHitCache);
+        },
+      });
+
+    await runOnce();
+    await runOnce();
+    expect(spyWorker.callCount()).toBe(2);
+    expect(cacheOutcomes).toEqual([]);
+    expect(fs.existsSync(cacheFilePath(directory))).toBe(false);
+  });
+
+  it("ignores an existing stored entry when the cache is disabled", async () => {
+    const directory = setupProject("cache-disabled-after-store", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const spyWorker = createSpyWorker(path.join(directory, "src", "index.ts"));
+    await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: spyWorker.factory,
+      cacheEnabled: true,
+    });
+    expect(fs.existsSync(cacheFilePath(directory))).toBe(true);
+
+    await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: spyWorker.factory,
+      cacheEnabled: false,
+    });
+    expect(spyWorker.callCount()).toBe(2);
+  });
+});
+
+describe("DeadCodeResultCacheEnabled", () => {
+  // One read only: a Reference's `defaultValue` is memoized per process, so
+  // this test owns the file's single unprovided read of the ref.
+  it("defaults off when REACT_DOCTOR_NO_CACHE is set", () => {
+    const originalNoCacheEnv = process.env["REACT_DOCTOR_NO_CACHE"];
+    process.env["REACT_DOCTOR_NO_CACHE"] = "1";
+    try {
+      const enabled = Effect.runSync(
+        Effect.gen(function* () {
+          return yield* DeadCodeResultCacheEnabled;
+        }),
+      );
+      expect(enabled).toBe(false);
+    } finally {
+      if (originalNoCacheEnv === undefined) delete process.env["REACT_DOCTOR_NO_CACHE"];
+      else process.env["REACT_DOCTOR_NO_CACHE"] = originalNoCacheEnv;
+    }
+  });
+});

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -284,6 +284,9 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
     ...withNamespace("deadCode", {
       failed: input.didDeadCodeFail ?? null,
       overlapped: input.deadCodeOverlapped ?? null,
+      // Dead-code result cache outcome; `null` when the pass never consulted
+      // the cache, so "no cache" reads distinctly from a miss.
+      cacheHit: result.deadCodeCacheHit ?? null,
     }),
     ...withNamespace("supplyChain", {
       overlapTimedOut: input.supplyChainOverlapTimedOut ?? null,

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -792,6 +792,7 @@ const runInspectWithRuntime = async (
     baselineDegraded,
     lintCacheHitFileCount: output.lintCacheHitFileCount,
     lintCacheTotalFileCount: output.lintCacheTotalFileCount,
+    deadCodeCacheHit: output.deadCodeCacheHit,
   });
   recordOnboardingCompletion(options);
   return result;
@@ -815,6 +816,7 @@ interface FinalizeInput {
   scanElapsedMilliseconds: number;
   lintCacheHitFileCount: number | null;
   lintCacheTotalFileCount: number | null;
+  deadCodeCacheHit: boolean | null;
   baselineDelta: InspectResult["baselineDelta"];
 }
 
@@ -842,6 +844,13 @@ interface RenderAndRecordScanInput {
    */
   readonly lintCacheHitFileCount?: number | null;
   readonly lintCacheTotalFileCount?: number | null;
+  /**
+   * Dead-code result cache outcome for THIS scan's dead-code pass. Threaded
+   * outside `CachedScanPayload` for the same reason as the lint cache stats
+   * above: a whole-repo cache replay (where no analysis ran) correctly
+   * leaves it absent.
+   */
+  readonly deadCodeCacheHit?: boolean | null;
 }
 
 const runMaybeSilent = <A, E, R>(
@@ -887,6 +896,7 @@ const renderAndRecordScan = async (input: RenderAndRecordScanInput): Promise<Ins
     scanElapsedMilliseconds: input.payload.scanElapsedMilliseconds,
     lintCacheHitFileCount: input.lintCacheHitFileCount ?? null,
     lintCacheTotalFileCount: input.lintCacheTotalFileCount ?? null,
+    deadCodeCacheHit: input.deadCodeCacheHit ?? null,
     baselineDelta: input.payload.baselineDelta,
   };
   const result = await Effect.runPromise(
@@ -959,6 +969,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       scanElapsedMilliseconds,
       lintCacheHitFileCount,
       lintCacheTotalFileCount,
+      deadCodeCacheHit,
       baselineDelta,
     } = input;
 
@@ -986,6 +997,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       ...(lintCacheTotalFileCount !== null
         ? { lintCacheHitFileCount, lintCacheTotalFileCount }
         : {}),
+      ...(deadCodeCacheHit !== null ? { deadCodeCacheHit } : {}),
       ...(baselineDelta ? { baselineDelta } : {}),
     });
 


### PR DESCRIPTION
## Why

Dead-code analysis re-derives the whole import graph from scratch on every scan — measured at **~9s of a ~19.8s warm rescan** on getsentry/sentry (8,899 TS/TSX files), the single largest uncached component. The whole-repo scan cache covers the nothing-changed case, but any miss (dirty tree today, any config/flag difference) pays the full pass again.

Before:

```
warm rescan, dirty tree, nothing dead-code reads changed: ~26.8s
```

After:

```
same rescan: ~17.8s — dead-code cache HIT, worker never spawns (~9.0s saved)
touch one .tsx: MISS → fresh analysis → re-stored (correct invalidation)
```

## What changed

- New single-entry result cache (`dead-code-result-cache.ts`): dead-code reachability is a whole-project property, so one entry keyed by a fingerprint over everything the analysis reads — sorted (path, mtime, size) stats of all deslop-parsed extensions, the manifests it consults (package.json/knip/expo/workspace files, all lockfiles as the node_modules proxy, `.gitignore` at every level), tsconfig/jsconfig anywhere (extends chains), resolved entry/ignore patterns, and the deslop-js version + schema constant. Additions/deletions invalidate via the hashed path list; the mtime+size blind spot is the documented `parse-source-file` precedent.
- A hit replays diagnostics without spawning the 8GB analysis worker or taking a worker slot; only complete successful passes store (crash/timeout/abort reject before the store — the `shouldStoreScanPayload` philosophy). Reads are schema-validated and fail open.
- Off by default at the `checkDeadCode` API level (direct callers/tests keep fresh semantics); the `DeadCode` service enables it via a new `DeadCodeResultCacheEnabled` Reference, disabled by `REACT_DOCTOR_NO_CACHE` or granular `REACT_DOCTOR_NO_DEAD_CODE_CACHE`.
- Telemetry mirrors the `lintCacheHitRatio` precedent exactly: `deadCode.cacheHit` threaded outside `CachedScanPayload` (null on whole-repo hits and when no cache ran) — no scan-cache schema bump.
- `DeadCodeOverlap` semantics untouched.

## Test plan

- `packages/core`: 1158 passed (baseline 1145; +13 new — key stability/sensitivity for touch/add/delete/manifest/tsconfig/config, hit-skips-worker spy, store-barred-on-failure, NO_CACHE bypass); `packages/react-doctor`: 2124 / 26 unchanged. Root typecheck + lint + smoke:json-report clean.
- Sentry e2e: run1 cold stores; run2 warm hits (cache-file mtime proof) with sorted diagnostic tuples identical to run1 (all 262 dead-code findings replayed exactly); run3 after touching one source file misses and re-stores.
- Deliberately not covered (documented): CI fresh checkouts (mtimes reset), same-size-same-mtime edits, node_modules surgery that skips the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only caching with fail-open reads, schema validation, stat-based invalidation, and no storage on failed passes; wrong replays are unlikely and env vars allow disabling.
> 
> **Overview**
> **Warm rescans can skip dead-code analysis** when nothing the pass reads has changed. A new single-entry on-disk cache stores the last **complete** dead-code diagnostic set, keyed by a fingerprint of the analyzed source tree (path/mtime/size stats), manifests, lockfiles, tsconfigs, knip/entry/ignore config, and `deslop-js` version. A **hit** returns cached diagnostics **without** spawning the heavy analysis worker; a **miss** runs analysis and persists the result only on success (crashes/timeouts/aborts never write).
> 
> Caching is **on by default** for normal scans via `DeadCodeResultCacheEnabled`, with opt-out through `REACT_DOCTOR_NO_CACHE` or `REACT_DOCTOR_NO_DEAD_CODE_CACHE`. Direct `checkDeadCode` callers still default cache **off** so tests keep fresh semantics. Telemetry adds **`deadCode.cacheHit`** (and `InspectResult.deadCodeCacheHit`), aligned with the lint cache pattern; lint failure clears the dead-code cache signal so outcomes do not leak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7416843ff792c57c79596c2e47c9ea5692c853c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->