### PR TITLE
perf(cli): key the scan-result cache on dirty worktree content instead of bailing

### DIFF
--- a/.changeset/perf-dirty-tree-cache-key.md
+++ b/.changeset/perf-dirty-tree-cache-key.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Instant reruns now also work with uncommitted changes: the whole-repo scan-result cache no longer requires a clean worktree — it keys on the exact dirty state (every modified, staged, renamed, deleted, and untracked path plus a hash of its content), so rescanning the same work-in-progress tree hits the cache while any edit still invalidates it.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,7 @@ export * from "./utils/dedupe-diagnostics.js";
 export * from "./utils/define-config.js";
 export * from "./utils/detect-ai-training-environment.js";
 export * from "./utils/group-by.js";
+export * from "./utils/hash-file-contents.js";
 export * from "./utils/has-published-fix-recipe.js";
 export * from "./utils/is-errno-exception.js";
 export * from "./utils/is-large-minified-file.js";

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -30,6 +30,15 @@ export const BASELINE_FILES_TEMP_DIR_PREFIX = "react-doctor-baseline-";
 export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 3;
 export const SCAN_RESULT_CACHE_MAX_ENTRY_COUNT = 20;
 export const CACHE_FILENAME_HASH_LENGTH_CHARS = 16;
+// The dirty-worktree cache-key fingerprint content-hashes every path `git
+// status` reports; past this many entries the hashing could cost more than a
+// cache hit saves, so the key builder bails to null (cache off) — the same
+// worst case as the old clean-tree-only gate.
+export const SCAN_RESULT_CACHE_MAX_DIRTY_STATUS_ENTRY_COUNT = 300;
+// Dirty files larger than this are fingerprinted by `mtimeMs:size` (the same
+// stat identity `computeConfigFingerprint` trusts for config files) instead of
+// a content hash, bounding the key builder's read cost and memory.
+export const SCAN_RESULT_CACHE_MAX_HASHED_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
 // Stdout cap for `runGit` (git-hook-shared.ts). Node's default `maxBuffer`
 // is 1 MiB, and `git ls-files -v` alone exceeds that on repos with ~15-25k

--- a/packages/react-doctor/src/cli/utils/scan-result-cache.ts
+++ b/packages/react-doctor/src/cli/utils/scan-result-cache.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { computeConfigFingerprint, resolveLintBatchOrdering } from "@react-doctor/core";
+import {
+  computeConfigFingerprint,
+  hashFileContents,
+  resolveLintBatchOrdering,
+} from "@react-doctor/core";
 import type {
   Diagnostic,
   InspectOutput,
@@ -14,7 +18,9 @@ import type {
 } from "@react-doctor/core";
 import {
   CACHE_FILENAME_HASH_LENGTH_CHARS,
+  SCAN_RESULT_CACHE_MAX_DIRTY_STATUS_ENTRY_COUNT,
   SCAN_RESULT_CACHE_MAX_ENTRY_COUNT,
+  SCAN_RESULT_CACHE_MAX_HASHED_FILE_SIZE_BYTES,
   SCAN_RESULT_CACHE_SCHEMA_VERSION,
 } from "./constants.js";
 import { isRecord, runGit } from "./git-hook-shared.js";
@@ -135,9 +141,140 @@ const hashString = (value: string): string => crypto.createHash("sha1").update(v
 const readHeadSha = (projectDirectory: string): string | null =>
   runGit(projectDirectory, ["rev-parse", "HEAD"]);
 
-const isWorktreeClean = (projectDirectory: string): boolean => {
-  const status = runGit(projectDirectory, ["status", "--porcelain=v1", "--untracked-files=normal"]);
-  return status !== null && status.length === 0;
+interface WorktreeStatusEntry {
+  readonly statusCode: string;
+  readonly path: string;
+  readonly originPath?: string;
+}
+
+interface WorktreeDirtyEntry extends WorktreeStatusEntry {
+  readonly contentFingerprint: string;
+}
+
+const parseWorktreeStatusRecords = (statusOutput: string): WorktreeStatusEntry[] | null => {
+  const entries: WorktreeStatusEntry[] = [];
+  const tokens = statusOutput.split("\0");
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex += 1) {
+    let record = tokens[tokenIndex];
+    if (record.length === 0) continue;
+    // HACK: `runGit` trims subprocess output, which strips the leading space
+    // of the FIRST record's two-character status code (e.g. " M"). A valid
+    // porcelain v1 record always has the separator space at index 2, and X/Y
+    // are never both spaces, so a first record missing that separator lost
+    // exactly one leading space — restore it. Any later malformed record
+    // means the parse desynced: bail rather than fingerprint garbage.
+    if (record.length < 3 || record[2] !== " ") {
+      if (tokenIndex !== 0) return null;
+      record = ` ${record}`;
+    }
+    if (record.length < 4 || record[2] !== " ") return null;
+    const statusCode = record.slice(0, 2);
+    const recordPath = record.slice(3);
+    if (statusCode.includes("R") || statusCode.includes("C")) {
+      // Rename/copy records carry a second NUL-terminated field: the origin
+      // path (`XY to NUL from NUL`).
+      tokenIndex += 1;
+      const originPath: string | undefined = tokens[tokenIndex];
+      if (originPath === undefined || originPath.length === 0) return null;
+      entries.push({ statusCode, path: recordPath, originPath });
+      continue;
+    }
+    entries.push({ statusCode, path: recordPath });
+  }
+  return entries;
+};
+
+const buildDirtyPathContentFingerprint = (
+  absolutePath: string,
+  statusCode: string,
+): string | null => {
+  let stats: fs.Stats;
+  try {
+    stats = fs.lstatSync(absolutePath);
+  } catch {
+    // A deleted path has no content to hash; the status code in the entry
+    // already distinguishes a deletion from every other state at that path.
+    return statusCode.includes("D") ? "deleted" : null;
+  }
+  if (stats.isSymbolicLink()) {
+    try {
+      return `link:${fs.readlinkSync(absolutePath)}`;
+    } catch {
+      return null;
+    }
+  }
+  // A non-regular file (a dirty submodule shows as a directory) has no
+  // cheaply-hashable content — bail so the cache stays off rather than risk
+  // serving a stale payload for an unfingerprintable state.
+  if (!stats.isFile()) return null;
+  if (stats.size > SCAN_RESULT_CACHE_MAX_HASHED_FILE_SIZE_BYTES) {
+    return `stat:${stats.mtimeMs}:${stats.size}`;
+  }
+  return hashFileContents(absolutePath);
+};
+
+// Fingerprints every divergence of the worktree from HEAD as
+// (status code, path[, origin path], content fingerprint), so identical dirty
+// states key identically and any content or index change shifts the key.
+// Returns [] for a clean tree and null when the state cannot be fingerprinted
+// (git failure, oversized dirty set, unfingerprintable path) — the caller
+// treats null exactly like the old dirty-tree bail: cache off.
+const buildWorktreeFingerprint = (
+  projectDirectory: string,
+): ReadonlyArray<WorktreeDirtyEntry> | null => {
+  const statusOutput = runGit(projectDirectory, [
+    "status",
+    "--porcelain=v1",
+    "-z",
+    // `all` expands untracked directories into their contained files so each
+    // one is content-fingerprinted; the entry-count bound below caps the cost.
+    "--untracked-files=all",
+  ]);
+  if (statusOutput === null) return null;
+  if (statusOutput.length === 0) return [];
+  const statusEntries = parseWorktreeStatusRecords(statusOutput);
+  if (statusEntries === null) return null;
+  if (statusEntries.length > SCAN_RESULT_CACHE_MAX_DIRTY_STATUS_ENTRY_COUNT) return null;
+  // Porcelain paths are relative to the repository root, not the (possibly
+  // nested workspace-member) project directory.
+  const repositoryRoot = runGit(projectDirectory, ["rev-parse", "--show-toplevel"]);
+  if (repositoryRoot === null) return null;
+  const dirtyEntries: WorktreeDirtyEntry[] = [];
+  for (const statusEntry of statusEntries) {
+    const contentFingerprint = buildDirtyPathContentFingerprint(
+      path.join(repositoryRoot, statusEntry.path),
+      statusEntry.statusCode,
+    );
+    if (contentFingerprint === null) return null;
+    dirtyEntries.push({ ...statusEntry, contentFingerprint });
+  }
+  // Codepoint compare (not localeCompare) so the ordering — and therefore the
+  // key — never varies with the process locale or ICU version.
+  return dirtyEntries.sort((firstEntry, secondEntry) => {
+    const firstSortKey = `${firstEntry.path}${firstEntry.statusCode}`;
+    const secondSortKey = `${secondEntry.path}${secondEntry.statusCode}`;
+    return firstSortKey < secondSortKey ? -1 : firstSortKey > secondSortKey ? 1 : 0;
+  });
+};
+
+const DOTENV_FILE_NAME_PATTERN = /^\.env(\.|$)/;
+
+// The security scan reads dotenv files even when they're gitignored — a state
+// `git status` can never surface — so their stat identity is keyed explicitly,
+// the same coverage `computeConfigFingerprint` gives gitignored config files.
+const resolveDotenvFingerprint = (projectDirectory: string): ReadonlyArray<string> => {
+  try {
+    return fs
+      .readdirSync(projectDirectory)
+      .filter((entryName) => DOTENV_FILE_NAME_PATTERN.test(entryName))
+      .sort()
+      .map(
+        (entryName) =>
+          `${entryName}=${fileFingerprint(path.join(projectDirectory, entryName)) ?? "unreadable"}`,
+      );
+  } catch {
+    return [];
+  }
 };
 
 const hasHiddenTrackedFileState = (projectDirectory: string): boolean => {
@@ -233,8 +370,11 @@ const resolveToolchainFingerprint = (nodeBinaryPath: string | null): ReadonlyArr
 
 export const buildScanResultCacheKey = (input: ScanResultCacheKeyInput): string | null => {
   if (isScanResultCacheDisabled()) return null;
-  if (!isWorktreeClean(input.projectDirectory)) return null;
+  // Assume-unchanged / skip-worktree hide tracked-file state from `git
+  // status`, so no fingerprint built from it can see those changes.
   if (hasHiddenTrackedFileState(input.projectDirectory)) return null;
+  const worktreeFingerprint = buildWorktreeFingerprint(input.projectDirectory);
+  if (worktreeFingerprint === null) return null;
   const headSha = readHeadSha(input.projectDirectory);
   if (headSha === null) return null;
   const userConfigJson = stringifyStableJson(input.userConfig);
@@ -243,6 +383,8 @@ export const buildScanResultCacheKey = (input: ScanResultCacheKeyInput): string 
     schemaVersion: SCAN_RESULT_CACHE_SCHEMA_VERSION,
     projectIdentity: resolveProjectIdentity(input.projectDirectory),
     headSha,
+    worktreeFingerprint,
+    dotenvFingerprint: resolveDotenvFingerprint(input.projectDirectory),
     reactDoctorVersion: input.version,
     nodeVersion: process.version,
     toolchainFingerprint: resolveToolchainFingerprint(input.nodeBinaryPath),

--- a/packages/react-doctor/tests/scan-result-cache.test.ts
+++ b/packages/react-doctor/tests/scan-result-cache.test.ts
@@ -11,6 +11,7 @@ import {
   shouldStoreScanPayload,
   type CachedScanPayload,
 } from "../src/cli/utils/scan-result-cache.js";
+import { SCAN_RESULT_CACHE_MAX_DIRTY_STATUS_ENTRY_COUNT } from "../src/cli/utils/constants.js";
 import { runGit } from "../src/cli/utils/git-hook-shared.js";
 import { VERSION } from "../src/cli/utils/version.js";
 import { commitAll, initGitRepo, setupReactProject } from "./regressions/_helpers.js";
@@ -187,7 +188,10 @@ describe("scan result cache", () => {
       path.join(projectDirectory, "doctor.config.json"),
       JSON.stringify({ rules: {} }),
     );
-    expect(cacheKey(projectDirectory, options)).toBeNull();
+    // An uncommitted config no longer bails the key — the dirty-worktree
+    // fingerprint folds it in, so the key exists but differs from clean.
+    expect(cacheKey(projectDirectory, options)).not.toBeNull();
+    expect(cacheKey(projectDirectory, options)).not.toBe(originalKey);
 
     commitAll(projectDirectory, "config");
     const configCommitKey = cacheKey(projectDirectory, options);
@@ -278,6 +282,127 @@ describe("scan result cache", () => {
       "emit-large-output",
     ]);
     expect(output?.length).toBe(outputSizeChars);
+  });
+
+  describe("dirty worktree fingerprint", () => {
+    const setupCleanProject = (caseId: string): string => {
+      const projectDirectory = setupReactProject(tempDirectory, caseId, {
+        files: { "src/App.tsx": "export const App = () => <div />;\n" },
+      });
+      initGitRepo(projectDirectory, { commit: true });
+      return projectDirectory;
+    };
+
+    it("keys a clean tree identically across runs", () => {
+      const projectDirectory = setupCleanProject("clean-stable");
+      const firstKey = cacheKey(projectDirectory, baseOptions());
+      expect(firstKey).not.toBeNull();
+      expect(cacheKey(projectDirectory, baseOptions())).toBe(firstKey);
+    });
+
+    it("keys an untracked file distinctly from clean, stably across identical states", () => {
+      const projectDirectory = setupCleanProject("untracked");
+      const cleanKey = cacheKey(projectDirectory, baseOptions());
+      fs.writeFileSync(path.join(projectDirectory, "scratch.txt"), "x\n");
+      const dirtyKey = cacheKey(projectDirectory, baseOptions());
+      expect(dirtyKey).not.toBeNull();
+      expect(dirtyKey).not.toBe(cleanKey);
+      expect(cacheKey(projectDirectory, baseOptions())).toBe(dirtyKey);
+    });
+
+    it("misses when dirty content is edited, and rejoins the clean key when reverted", () => {
+      const projectDirectory = setupCleanProject("edited");
+      const cleanKey = cacheKey(projectDirectory, baseOptions());
+      const appPath = path.join(projectDirectory, "src", "App.tsx");
+      const committedSource = fs.readFileSync(appPath, "utf8");
+      fs.writeFileSync(appPath, "export const App = () => <main />;\n");
+      const firstDirtyKey = cacheKey(projectDirectory, baseOptions());
+      expect(firstDirtyKey).not.toBeNull();
+      expect(firstDirtyKey).not.toBe(cleanKey);
+      fs.writeFileSync(appPath, "export const App = () => <section />;\n");
+      const secondDirtyKey = cacheKey(projectDirectory, baseOptions());
+      expect(secondDirtyKey).not.toBe(firstDirtyKey);
+      expect(secondDirtyKey).not.toBe(cleanKey);
+      fs.writeFileSync(appPath, committedSource);
+      expect(cacheKey(projectDirectory, baseOptions())).toBe(cleanKey);
+    });
+
+    it("keys staged and unstaged states of the same content differently", () => {
+      const projectDirectory = setupCleanProject("staged");
+      fs.writeFileSync(
+        path.join(projectDirectory, "src", "App.tsx"),
+        "export const App = () => <main />;\n",
+      );
+      const unstagedKey = cacheKey(projectDirectory, baseOptions());
+      spawnSync("git", ["add", "src/App.tsx"], { cwd: projectDirectory });
+      const stagedKey = cacheKey(projectDirectory, baseOptions());
+      expect(unstagedKey).not.toBeNull();
+      expect(stagedKey).not.toBeNull();
+      expect(stagedKey).not.toBe(unstagedKey);
+    });
+
+    it("keys a deleted file distinctly from clean and from a modified one", () => {
+      const projectDirectory = setupCleanProject("deleted");
+      const cleanKey = cacheKey(projectDirectory, baseOptions());
+      const appPath = path.join(projectDirectory, "src", "App.tsx");
+      fs.writeFileSync(appPath, "export const App = () => <main />;\n");
+      const modifiedKey = cacheKey(projectDirectory, baseOptions());
+      fs.rmSync(appPath);
+      const deletedKey = cacheKey(projectDirectory, baseOptions());
+      expect(deletedKey).not.toBeNull();
+      expect(deletedKey).not.toBe(cleanKey);
+      expect(deletedKey).not.toBe(modifiedKey);
+      expect(cacheKey(projectDirectory, baseOptions())).toBe(deletedKey);
+    });
+
+    it("parses rename records (including paths with spaces) into a stable key", () => {
+      const projectDirectory = setupCleanProject("renamed");
+      const cleanKey = cacheKey(projectDirectory, baseOptions());
+      spawnSync("git", ["mv", "src/App.tsx", "src/My App.tsx"], { cwd: projectDirectory });
+      const renamedKey = cacheKey(projectDirectory, baseOptions());
+      expect(renamedKey).not.toBeNull();
+      expect(renamedKey).not.toBe(cleanKey);
+      expect(cacheKey(projectDirectory, baseOptions())).toBe(renamedKey);
+    });
+
+    it("fingerprints files inside untracked directories individually", () => {
+      const projectDirectory = setupCleanProject("untracked-dir");
+      fs.mkdirSync(path.join(projectDirectory, "notes"));
+      fs.writeFileSync(path.join(projectDirectory, "notes", "todo.txt"), "a\n");
+      const firstKey = cacheKey(projectDirectory, baseOptions());
+      expect(firstKey).not.toBeNull();
+      fs.writeFileSync(path.join(projectDirectory, "notes", "todo.txt"), "b\n");
+      expect(cacheKey(projectDirectory, baseOptions())).not.toBe(firstKey);
+    });
+
+    it("bails to null when the dirty set exceeds the entry bound", () => {
+      const projectDirectory = setupCleanProject("oversized");
+      const scratchDirectory = path.join(projectDirectory, "scratch");
+      fs.mkdirSync(scratchDirectory);
+      for (
+        let fileIndex = 0;
+        fileIndex <= SCAN_RESULT_CACHE_MAX_DIRTY_STATUS_ENTRY_COUNT;
+        fileIndex += 1
+      ) {
+        fs.writeFileSync(path.join(scratchDirectory, `file-${fileIndex}.txt`), String(fileIndex));
+      }
+      expect(cacheKey(projectDirectory, baseOptions())).toBeNull();
+    });
+
+    it("keys gitignored dotenv files the security scan reads", () => {
+      const projectDirectory = setupReactProject(tempDirectory, "dotenv", {
+        files: {
+          "src/App.tsx": "export const App = () => <div />;\n",
+          ".gitignore": ".env\n",
+          ".env": "API_KEY=first\n",
+        },
+      });
+      initGitRepo(projectDirectory, { commit: true });
+      const firstKey = cacheKey(projectDirectory, baseOptions());
+      expect(firstKey).not.toBeNull();
+      fs.writeFileSync(path.join(projectDirectory, ".env"), "API_KEY=second-value\n");
+      expect(cacheKey(projectDirectory, baseOptions())).not.toBe(firstKey);
+    });
   });
 
   it("reuses diagnostics when rerendering with verbose enabled", async () => {


### PR DESCRIPTION
## Why

The instant-rerun cache required `git status` to be perfectly empty, so it never fired during actual development — one untracked file or WIP edit and every rescan paid the full warm path (~16-20s on a large repo). Instead of refusing dirty trees, the dirty state now becomes part of the key.

Before:

```
rescan with an untracked scratch file, nothing changed since last run: 16.4s (full scan, every time)
```

After:

```
run 1 (dirty, cold): 16.4s, STORES
run 2 (identical dirty state): 3.4s — whole-repo HIT, identical output
run 3 (edit the scratch file): 9.5s — MISS, fresh scan, re-stored
run 4 (same state as 3): 1.3s — HIT
```

## What changed

- `buildScanResultCacheKey` folds a **worktree fingerprint** into the key: `git status --porcelain=v1 -z --untracked-files=all` parsed record-by-record (NUL-delimited; rename/copy two-path records handled), each dirty path keyed by (status code, path, content hash) — symlinks by target, deletions by marker, >10MB files by stat identity. Codepoint-sorted for locale independence.
- Bounded and conservative: >300 dirty entries, any git failure, parse desync, or an unfingerprintable path (dirty submodule) → key `null`, exactly today's cache-off behavior. The `ls-files -v` hidden-state bail stays (assume-unchanged/skip-worktree hide state no status fingerprint can see).
- Correctness: staged-vs-unstaged same content keys differently (status code captures the index split); a reverted file re-joins the clean key; every content divergence from HEAD is captured, so identical (HEAD, fingerprint, config, toolchain, options) ⇒ identical scan inputs. Root `.env*` files are stat-keyed explicitly since the security scan reads them even when gitignored (the one status-invisible input class; deeper gitignored artifacts remain exactly as invisible as they were to the old clean-tree gate — no new hole, documented).
- Key-shape change self-invalidates old entries via the hash; the persisted payload shape is unchanged (no schema bump).

## Test plan

- `packages/react-doctor`: 2133 passed / 26 skipped (baseline 2124; +9 new — dirty-state key stability/sensitivity, staged-vs-unstaged, rename-with-space records, untracked-directory expansion, over-threshold bail, gitignored `.env` sensitivity). Core suite green. Root typecheck + lint + vp fmt clean.
- End-to-end proof on ReactiveTraderCloud above (dirty hit 3.4s / miss on edit / re-hit 1.3s), cache-entry counts verified per run.
- Interaction with the sibling maxBuffer fix (#runGit): a pathological >1MB status output currently nulls the key (cache off — safe); with that fix merged, the 300-entry bound becomes the operative cap. Merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cache correctness now depends on git status parsing and content hashing; conservative bail paths mirror the old cache-off behavior, but a fingerprint bug could serve stale scan results.
> 
> **Overview**
> **Instant reruns now work with uncommitted changes** by folding the dirty worktree into `buildScanResultCacheKey` instead of returning `null` whenever `git status` was non-empty.
> 
> The key now includes a **worktree fingerprint** from `git status --porcelain=v1 -z` (rename/copy paths, per-path content via `hashFileContents`, symlinks/deletions/large-file stat fallbacks) plus **root `.env*` stat fingerprints** for inputs the security scan reads but git ignores. Identical WIP trees hit the cache; any edit, stage/index change, or dotenv change misses. Past **300** dirty entries or unfingerprintable paths, the key still bails to `null` (same as before). Assume-unchanged/skip-worktree hidden state keeps cache off.
> 
> `hashFileContents` is re-exported from `@react-doctor/core`; new bounds live in CLI constants. Tests cover dirty-state stability, staged vs unstaged, renames, and oversized dirty sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c5955d52d2d6707220b028154b90bc01b22fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->