### PR TITLE
fix(core): harden the dead-code cache key against version and input-list drift

### DIFF
--- a/.changeset/perf-dead-code-cache-key-hardening.md
+++ b/.changeset/perf-dead-code-cache-key-hardening.md
@@ -1,0 +1,6 @@
+---
+"react-doctor": patch
+"deslop-js": patch
+---
+
+Hardened the dead-code result cache key against two silent-staleness classes. The fingerprinted extension and manifest name lists are now imported from `deslop-js/analyzed-inputs` — a new dependency-free subpath export assembled from the same constants deslop's own readers consume — so a deslop upgrade that widens its walk can never under-invalidate the cache. And the key now includes `@react-doctor/core`'s own version, so upgrading react-doctor re-analyzes instead of replaying cached diagnostics shaped by an older core's post-processing. The cache schema-version constant remains for cache-format changes only.

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -13,6 +13,7 @@ import {
 } from "./dead-code/dead-code-result-cache.js";
 import { withDeadCodeWorkerSlot } from "./dead-code/dead-code-worker-slots.js";
 import {
+  CORE_PACKAGE_VERSION,
   DEAD_CODE_WORKER_MAX_OLD_SPACE_MB,
   DEAD_CODE_WORKER_TIMEOUT_MS,
   MILLISECONDS_PER_SECOND,
@@ -534,6 +535,7 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
         ignorePatterns,
         tsConfigPath,
         deslopJsModuleSpecifier,
+        coreVersion: CORE_PACKAGE_VERSION,
       })
     : null;
   if (cacheKey !== null) {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -631,6 +631,13 @@ export const FILE_LINT_CACHE_MAX_FILE_COUNT = 50_000;
 // fallback when a project has no `node_modules` to host `.cache/react-doctor`.
 export const CACHE_FILENAME_HASH_LENGTH_CHARS = 16;
 
+// This package's own version, inlined at build time (`vite.config.ts` `env`)
+// the same way the CLI inlines `VERSION`; running from source (tests, dev)
+// falls back to "0.0.0". Cache keys include it because cached diagnostics
+// carry core's POST-PROCESSING (message text, toolchain-dependency filtering),
+// so an upgrade must never replay entries shaped by an older core.
+export const CORE_PACKAGE_VERSION = process.env.REACT_DOCTOR_CORE_VERSION ?? "0.0.0";
+
 // Whole-project dead-code result cache (`dead-code/dead-code-result-cache.ts`).
 // Replays deslop's diagnostics — skipping the analysis worker entirely — when
 // nothing the analysis reads has changed since the stored run.

--- a/packages/core/src/dead-code/dead-code-result-cache.ts
+++ b/packages/core/src/dead-code/dead-code-result-cache.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import * as Schema from "effect/Schema";
+import { ANALYZED_MANIFEST_FILENAMES, DEFAULT_EXTENSIONS } from "deslop-js/analyzed-inputs";
 import type { Diagnostic } from "../types/index.js";
 import { DEAD_CODE_CACHE_FILENAME, DEAD_CODE_CACHE_SCHEMA_VERSION } from "../constants.js";
 import { Diagnostic as DiagnosticSchema } from "../schemas.js";
@@ -37,6 +38,13 @@ interface DeadCodeCacheKeyInput {
   readonly ignorePatterns: ReadonlyArray<string>;
   readonly tsConfigPath: string | undefined;
   readonly deslopJsModuleSpecifier: string;
+  /**
+   * `@react-doctor/core`'s own version (`CORE_PACKAGE_VERSION`). Cached
+   * entries store diagnostics AFTER `checkDeadCode`'s post-processing
+   * (message text, toolchain-dependency filtering), so a core upgrade must
+   * invalidate them even when the analyzed tree is unchanged.
+   */
+  readonly coreVersion: string;
 }
 
 interface PersistedDeadCodeResultCache {
@@ -45,46 +53,24 @@ interface PersistedDeadCodeResultCache {
   readonly diagnostics: ReadonlyArray<unknown>;
 }
 
-// The extensions deslop's import-graph walk parses (its DEFAULT_EXTENSIONS),
-// so an edit to any file the graph can reach changes the key.
-const ANALYZED_FILE_EXTENSIONS = new Set([
-  ".ts",
-  ".tsx",
-  ".js",
-  ".jsx",
-  ".mts",
-  ".mjs",
-  ".cts",
-  ".cjs",
-  ".mdx",
-  ".astro",
-  ".graphql",
-  ".gql",
-  ".css",
-  ".scss",
-  ".vue",
-  ".svelte",
-]);
+// The fingerprinted file sets come straight from the analyzer package
+// (`deslop-js/analyzed-inputs`): the extensions its import-graph walk parses
+// and every manifest/lockfile/.gitignore name its analysis reads. The worker
+// resolves deslop-js from the same install, so these constants are exactly
+// what the analysis will use — and a deslop version bump also rotates the key
+// via the `deslopVersion` field (belt and suspenders).
+const ANALYZED_FILE_EXTENSIONS = new Set(DEFAULT_EXTENSIONS);
 
-// Non-source files deslop's entry/workspace/dependency analysis reads:
-// manifests (workspace layout, dependency declarations, knip/expo config),
-// lockfiles (the proxy for installed `node_modules` metadata — deslop reads
-// installed packages' bin/peer fields, which only change through an install
-// that rewrites the lockfile), and `.gitignore` files at every level (deslop
-// consults git's ignore state for its walk).
+// Beyond what deslop itself reads, the dead-code PASS also depends on:
+// `knip.json` (read core-side by `collect-dead-code-patterns.ts` to derive
+// the entry/ignore patterns) and `deno.lock` (an extra proxy for installed
+// `node_modules` metadata — deslop reads installed packages' bin/peer fields,
+// which only change through an install that rewrites a lockfile).
+const CORE_SIDE_MANIFEST_NAMES = ["knip.json", "deno.lock"];
+
 const ANALYZED_MANIFEST_NAMES = new Set([
-  "package.json",
-  "knip.json",
-  "app.json",
-  "pnpm-workspace.yaml",
-  "lerna.json",
-  "pnpm-lock.yaml",
-  "package-lock.json",
-  "yarn.lock",
-  "bun.lock",
-  "bun.lockb",
-  "deno.lock",
-  ".gitignore",
+  ...ANALYZED_MANIFEST_FILENAMES,
+  ...CORE_SIDE_MANIFEST_NAMES,
 ]);
 
 // tsconfig/jsconfig files anywhere in the tree — path-alias resolution reads
@@ -134,6 +120,7 @@ export const computeDeadCodeCacheKey = (input: DeadCodeCacheKeyInput): string =>
     .update(
       JSON.stringify({
         schemaVersion: DEAD_CODE_CACHE_SCHEMA_VERSION,
+        coreVersion: input.coreVersion,
         deslopVersion: resolveDeslopVersion(),
         deslopJsModuleSpecifier: input.deslopJsModuleSpecifier,
         entryPatterns: input.entryPatterns,

--- a/packages/core/tests/dead-code-result-cache.test.ts
+++ b/packages/core/tests/dead-code-result-cache.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
 import * as Effect from "effect/Effect";
+import { ANALYZED_MANIFEST_FILENAMES, DEFAULT_EXTENSIONS } from "deslop-js/analyzed-inputs";
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import type { Diagnostic } from "../src/types/index.js";
 import { checkDeadCode } from "../src/check-dead-code.js";
@@ -53,6 +54,7 @@ const keyInput = (projectDirectory: string) => ({
   ignorePatterns: [],
   tsConfigPath: undefined,
   deslopJsModuleSpecifier: "deslop-js",
+  coreVersion: "0.0.0",
 });
 
 interface SpyWorker {
@@ -159,6 +161,86 @@ describe("computeDeadCodeCacheKey", () => {
     const keyBefore = computeDeadCodeCacheKey(keyInput(directory));
     fs.writeFileSync(path.join(directory, "scratch.txt"), "not part of the graph\n");
     expect(computeDeadCodeCacheKey(keyInput(directory))).toBe(keyBefore);
+  });
+
+  it("changes when the core package version changes", () => {
+    const directory = setupProject("key-core-version", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    expect(computeDeadCodeCacheKey({ ...keyInput(directory), coreVersion: "99.0.0" })).not.toBe(
+      computeDeadCodeCacheKey(keyInput(directory)),
+    );
+  });
+});
+
+describe("fingerprinted file sets (imported from deslop-js/analyzed-inputs)", () => {
+  it("fingerprints a file for every extension deslop's walk parses", () => {
+    const directory = setupProject("key-extension-coverage", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const keyBefore = computeDeadCodeCacheKey(keyInput(directory));
+    for (const extension of DEFAULT_EXTENSIONS) {
+      const probePath = path.join(directory, "probe", `probe${extension}`);
+      fs.mkdirSync(path.dirname(probePath), { recursive: true });
+      fs.writeFileSync(probePath, "probe\n");
+      expect(computeDeadCodeCacheKey(keyInput(directory)), extension).not.toBe(keyBefore);
+      fs.rmSync(probePath);
+    }
+  });
+
+  it("fingerprints every manifest name deslop's analysis reads", () => {
+    const directory = setupProject("key-manifest-coverage", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    const keyBefore = computeDeadCodeCacheKey(keyInput(directory));
+    for (const manifestName of ANALYZED_MANIFEST_FILENAMES) {
+      const probePath = path.join(directory, "probe", manifestName);
+      fs.mkdirSync(path.dirname(probePath), { recursive: true });
+      fs.writeFileSync(probePath, "probe\n");
+      expect(computeDeadCodeCacheKey(keyInput(directory)), manifestName).not.toBe(keyBefore);
+      fs.rmSync(probePath);
+    }
+  });
+
+  // Not a redundant copy: a NEW extension or manifest in a deslop-js upgrade
+  // widens what the cache fingerprints, so it must land here as a conscious,
+  // reviewed choice rather than silently.
+  it("matches the reviewed set snapshots", () => {
+    expect([...DEFAULT_EXTENSIONS].sort()).toEqual([
+      ".astro",
+      ".cjs",
+      ".css",
+      ".cts",
+      ".gql",
+      ".graphql",
+      ".js",
+      ".jsx",
+      ".mdx",
+      ".mjs",
+      ".mts",
+      ".scss",
+      ".svelte",
+      ".ts",
+      ".tsx",
+      ".vue",
+    ]);
+    expect([...ANALYZED_MANIFEST_FILENAMES].sort()).toEqual([
+      ".gitignore",
+      "app.json",
+      "bun.lock",
+      "bun.lockb",
+      "lerna.json",
+      "ng-package.json",
+      "nx.json",
+      "package-lock.json",
+      "package.json",
+      "pnpm-lock.yaml",
+      "pnpm-workspace.yaml",
+      "pnpm-workspace.yml",
+      "rush.json",
+      "turbo.json",
+      "yarn.lock",
+    ]);
   });
 });
 

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,4 +1,13 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite-plus";
+
+const packageRoot = path.dirname(fileURLToPath(import.meta.url));
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8")) as {
+  version: string;
+};
 
 export default defineConfig({
   pack: [
@@ -20,6 +29,9 @@ export default defineConfig({
       target: "node20",
       platform: "node",
       fixedExtension: false,
+      env: {
+        REACT_DOCTOR_CORE_VERSION: packageJson.version,
+      },
     },
   ],
   test: {

--- a/packages/deslop-js/package.json
+++ b/packages/deslop-js/package.json
@@ -47,6 +47,16 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./analyzed-inputs": {
+      "import": {
+        "types": "./dist/analyzed-inputs.d.mts",
+        "default": "./dist/analyzed-inputs.mjs"
+      },
+      "require": {
+        "types": "./dist/analyzed-inputs.d.cts",
+        "default": "./dist/analyzed-inputs.cjs"
+      }
     }
   },
   "publishConfig": {

--- a/packages/deslop-js/src/analyzed-inputs.ts
+++ b/packages/deslop-js/src/analyzed-inputs.ts
@@ -1,0 +1,7 @@
+// The canonical "what does an analysis pass read?" contract, published as the
+// `deslop-js/analyzed-inputs` subpath so external result caches (react-doctor's
+// dead-code cache) can fingerprint exactly the files a pass depends on. Kept
+// as a dedicated dependency-free entry: the package root eagerly loads
+// `typescript` and the native oxc bindings, which a fingerprinting caller must
+// never pay for.
+export { ANALYZED_MANIFEST_FILENAMES, DEFAULT_EXTENSIONS } from "./constants.js";

--- a/packages/deslop-js/src/collect/workspaces.ts
+++ b/packages/deslop-js/src/collect/workspaces.ts
@@ -1,6 +1,7 @@
 import { resolve, join, relative, dirname } from "node:path";
 import { readFileSync, existsSync, statSync } from "node:fs";
 import fg from "fast-glob";
+import { STANDALONE_PROJECT_LOCKFILES } from "../constants.js";
 import { extractReactRouterRouteModuleEntries } from "./parse.js";
 
 export interface WorkspacePackage {
@@ -69,13 +70,6 @@ export const resolveWorkspaces = (rootDir: string): WorkspaceDiscoveryResult => 
 };
 
 const IMPLICIT_SUB_PROJECT_SEARCH_DEPTH = 3;
-
-const STANDALONE_PROJECT_LOCKFILES = [
-  "package-lock.json",
-  "yarn.lock",
-  "pnpm-lock.yaml",
-  "bun.lockb",
-];
 
 const isStandaloneProject = (directory: string): boolean =>
   STANDALONE_PROJECT_LOCKFILES.some((lockfile) => existsSync(join(directory, lockfile)));

--- a/packages/deslop-js/src/constants.ts
+++ b/packages/deslop-js/src/constants.ts
@@ -17,6 +17,52 @@ export const DEFAULT_EXTENSIONS = [
   ".svelte",
 ];
 
+export const STANDALONE_PROJECT_LOCKFILES = [
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "bun.lockb",
+];
+
+export const MONOREPO_ROOT_MARKERS = [
+  "pnpm-workspace.yaml",
+  "pnpm-workspace.yml",
+  "lerna.json",
+  "nx.json",
+  "turbo.json",
+  "rush.json",
+];
+
+export const LOCKFILE_MARKERS = [
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "package-lock.json",
+  "bun.lockb",
+  "bun.lock",
+];
+
+// Every non-source file name the analysis reads, assembled from the same
+// constants the readers consume (plus the names read individually by
+// `collect/workspaces.ts`, `collect/entries.ts`,
+// `collect/expo-config-plugin-entries.ts`, and — via `git check-ignore` —
+// `utils/collect-git-ignored-paths.ts`). Exported through
+// `deslop-js/analyzed-inputs` so external result caches can fingerprint
+// exactly the files a pass depends on; extend this list whenever a reader
+// starts consuming a new manifest name.
+export const ANALYZED_MANIFEST_FILENAMES = [
+  ...new Set([
+    "package.json",
+    "pnpm-workspace.yaml",
+    "lerna.json",
+    "app.json",
+    "ng-package.json",
+    ".gitignore",
+    ...STANDALONE_PROJECT_LOCKFILES,
+    ...MONOREPO_ROOT_MARKERS,
+    ...LOCKFILE_MARKERS,
+  ]),
+];
+
 export const HIDDEN_DIRECTORY_ALLOWLIST = [
   ".storybook",
   ".vitepress",

--- a/packages/deslop-js/src/utils/find-monorepo-root.ts
+++ b/packages/deslop-js/src/utils/find-monorepo-root.ts
@@ -1,22 +1,6 @@
 import { resolve, join, dirname } from "node:path";
 import { existsSync, readFileSync } from "node:fs";
-
-const MONOREPO_ROOT_MARKERS = [
-  "pnpm-workspace.yaml",
-  "pnpm-workspace.yml",
-  "lerna.json",
-  "nx.json",
-  "turbo.json",
-  "rush.json",
-];
-
-const LOCKFILE_MARKERS = [
-  "pnpm-lock.yaml",
-  "yarn.lock",
-  "package-lock.json",
-  "bun.lockb",
-  "bun.lock",
-];
+import { LOCKFILE_MARKERS, MONOREPO_ROOT_MARKERS } from "../constants.js";
 
 const MAX_MONOREPO_WALK_DEPTH = 5;
 

--- a/packages/deslop-js/vite.config.ts
+++ b/packages/deslop-js/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite-plus";
 export default defineConfig({
   pack: [
     {
-      entry: ["./src/index.ts"],
+      entry: ["./src/index.ts", "./src/analyzed-inputs.ts"],
       format: ["cjs", "esm"],
       dts: true,
       clean: true,


### PR DESCRIPTION
## Why

Follow-up to #1053, addressing both review findings:

- **Devin (fingerprint drift):** the cache key's extension and manifest lists were hand-copied from deslop-js's behavior — a silent under-invalidation risk if the analyzer's inputs widen. Making it concrete: the copies were **already missing two inputs deslop reads today** (`ng-package.json`, whose `lib.entryFile` feeds Angular entry discovery, and `pnpm-workspace.yml`).
- **Cursor Bugbot (missing version key):** cached entries hold diagnostics *after* `checkDeadCode`'s post-processing (message text, toolchain-dependency filtering), so upgrading react-doctor with an unchanged tree could replay stale-shaped findings.

## What changed

- deslop-js (in-monorepo) now exports its canonical input lists via a new dependency-free `deslop-js/analyzed-inputs` subpath: `DEFAULT_EXTENSIONS` (already the single source its walk uses) and `ANALYZED_MANIFEST_FILENAMES` (assembled from constants its own readers now consume — the workspace/lockfile/monorepo-marker lists were consolidated into `constants.ts` so the export can't drift from usage either). A dedicated entry matters: deslop's root export top-level-imports `typescript`/`oxc-parser`/`oxc-resolver`, which the in-process cache module must never load (verified: 162-byte entry, stays external in core's and the CLI's bundles).
- The core cache module imports those lists and deletes its copies, keeping only two documented core-side extras (`knip.json`, read core-side for entry/ignore patterns; `deno.lock` as an extra installed-metadata proxy).
- `CORE_PACKAGE_VERSION` (build-time-injected from core's package.json, mirroring the CLI's `VERSION` mechanism; verified inlined as `0.6.3` in both dists) joins the cache key.
- `DEAD_CODE_CACHE_SCHEMA_VERSION` deliberately not bumped — it stays reserved for cache-format changes; both drift classes are now closed structurally.

## Test plan

- `packages/core`: 1162 passed (baseline 1158; +4 — core-version key sensitivity, per-extension and per-manifest fingerprint loops over the imported lists, and a reviewed-set snapshot so a widened deslop list lands as a conscious choice). deslop-js suite (`node --import tsx --test`): 489 passed, before and after. Root typecheck + lint + vp fmt clean.
- Functional sanity: a cache stored by an origin/main build is **missed** by this build (version-keyed re-store confirmed via key + mtime), and a fresh store→hit round-trip replays the fixture's `unused-file` finding exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to cache key composition and a dependency-free deslop subpath export; behavior on cache miss is unchanged and tests cover invalidation paths.
> 
> **Overview**
> **Hardens whole-project dead-code cache invalidation** so stale diagnostics are not replayed after react-doctor or deslop upgrades, or when analyzer input coverage grows.
> 
> The cache key now includes **`CORE_PACKAGE_VERSION`** (inlined at core build time), because stored entries reflect core post-processing (messages, toolchain filtering), not raw deslop output. **`DEAD_CODE_CACHE_SCHEMA_VERSION` is unchanged** — reserved for on-disk format changes only.
> 
> **Fingerprint extension and manifest name sets** are no longer duplicated in core: they come from a new lightweight **`deslop-js/analyzed-inputs`** export (`DEFAULT_EXTENSIONS`, `ANALYZED_MANIFEST_FILENAMES`), built from the same `constants.ts` lists deslop readers use. Core still fingerprints **`knip.json`** and **`deno.lock`** on its side. In deslop-js, workspace/lockfile/monorepo marker lists were centralized in `constants.ts` (closing prior gaps such as **`ng-package.json`** and **`pnpm-workspace.yml`** in the old copy).
> 
> Tests add core-version key sensitivity, loops over imported extension/manifest sets, and snapshot assertions so widening deslop inputs is an explicit review step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e045ff8eb7f52b19acb2ac95db1e89aabbb6c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->