### PR TITLE
feat(telemetry): classify every scan's cache temperature in the wide event

### DIFF
--- a/.changeset/telemetry-cache-temperature.md
+++ b/.changeset/telemetry-cache-temperature.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Added cache-temperature telemetry to the per-scan Sentry wide event, so cache effectiveness is queryable at a glance instead of being inferred from per-subsystem dims. `cache.temperature` classifies every scan as `turbo` (whole-repo scan-result replay — now marked by an explicit `wholeRepoCacheHit` flag on the replay path, never inferred from absent dims), `warm` (any incremental reuse across the per-file lint, sidecar, or dead-code caches), `cold` (caches on, zero reuse), or `disabled` (the global `REACT_DOCTOR_NO_CACHE` off-switch). `cache.warmth` is the numeric headline magnitude in [0, 1] — the plain mean of the known subsystem reuse fractions, skipping subsystems that never consulted a cache. The existing per-subsystem dims (`lint.cacheHitRatio`, `lint.sidecarReplayRatio`, `deadCode.cacheHit`, `deadCode.summaryCacheHits/Misses`) are unchanged. Telemetry-only: no new counters, no JSON-report or cache-schema changes.

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -14,6 +14,7 @@ import { buildRuleBlastRadii } from "./diagnostic-grouping.js";
 import { ACTION_INPUT_ENVIRONMENT_VARIABLES, detectRunnerOs } from "./is-ci-environment.js";
 import { summarizeRuleFirings } from "./record-scan-metrics.js";
 import { isValidBlockingLevel } from "./resolve-blocking-level.js";
+import { isCacheGloballyDisabled } from "./scan-result-cache.js";
 import { shouldBlockCi } from "./should-block-ci.js";
 import { toCategoryKey } from "./to-category-key.js";
 import { toSpanAttributes } from "./to-span-attributes.js";
@@ -101,6 +102,14 @@ export interface RunEventInput {
    * (100+ rules would blow up the attribute set). Omitted on the failure path.
    */
   readonly suppressedRuleCounts?: ReadonlyArray<SuppressedRuleCount>;
+  /**
+   * `true` only when this run replayed a whole-repo scan-result payload (the
+   * "turbo" path, where no lint / dead-code / score work ran). The explicit
+   * marker for `cache.temperature = "turbo"` — never inferred from the
+   * per-subsystem cache dims being null, which is also what a cache-off run
+   * looks like. Omitted on the failure path.
+   */
+  readonly wholeRepoCacheHit?: boolean;
   /** Present only when the scan threw. */
   readonly error?: unknown;
 }
@@ -109,6 +118,76 @@ const readEnvBoolean = (name: string): boolean | null => {
   const value = process.env[name];
   if (value === undefined) return null;
   return value.toLowerCase() === "true" || value === "1";
+};
+
+// Reuse fraction of one cache subsystem; `null` (an absent signal, not 0%)
+// when the subsystem never consulted its cache this run.
+const ratioOf = (
+  numerator: number | null | undefined,
+  denominator: number | null | undefined,
+): number | null =>
+  denominator != null && denominator > 0 ? (numerator ?? 0) / denominator : null;
+
+// The dead-code pass's reuse fraction: a whole-result replay is total reuse;
+// a fresh analysis reuses whatever fraction of its file summaries the
+// incremental store served; a consulted-but-missed result cache with no
+// summary stats is zero reuse. `null` when the pass never consulted a cache.
+const resolveDeadCodeReuseRatio = (result: InspectResult): number | null => {
+  if (result.deadCodeCacheHit === true) return 1;
+  const summaryTotal =
+    (result.deadCodeSummaryCacheHits ?? 0) + (result.deadCodeSummaryCacheMisses ?? 0);
+  if (summaryTotal > 0) return (result.deadCodeSummaryCacheHits ?? 0) / summaryTotal;
+  return result.deadCodeCacheHit === false ? 0 : null;
+};
+
+/**
+ * One queryable cache temperature per scan, derived from the whole stack:
+ *
+ *   - `"turbo"`    — whole-repo scan-result replay (the explicit
+ *                    `wholeRepoCacheHit` flag from the CLI's cachedPayload
+ *                    branch; no scan work ran).
+ *   - `"warm"`     — any incremental reuse: per-file lint hits, sidecar
+ *                    replays, a dead-code whole-result hit, or dead-code
+ *                    summary-cache hits.
+ *   - `"disabled"` — zero reuse because the global `REACT_DOCTOR_NO_CACHE`
+ *                    off-switch is on. Granular per-cache opt-outs
+ *                    (`REACT_DOCTOR_NO_FILE_CACHE`, …) still read warm/cold,
+ *                    since the other subsystems stay live.
+ *   - `"cold"`     — caches on, zero reuse (first scan / everything changed).
+ *
+ * `cache.warmth` is the headline reuse magnitude in [0, 1]: the plain mean of
+ * the subsystem reuse fractions known this run (lint hit ratio, sidecar
+ * replay ratio, dead-code reuse), skipping subsystems that never consulted a
+ * cache; `1` on turbo, dropped when nothing consulted any cache. Deliberately
+ * unweighted — the per-subsystem dims stay the precise signal; warmth is the
+ * p50/p90-able summary. Emitted only on the success path.
+ */
+const buildCacheAttributes = (input: RunEventInput): RunEventAttributes => {
+  if (input.result === undefined) return {};
+  if (input.wholeRepoCacheHit) {
+    return withNamespace("cache", { wholeRepoHit: true, temperature: "turbo", warmth: 1 });
+  }
+  const result = input.result;
+  const subsystemReuseRatios = [
+    ratioOf(result.lintCacheHitFileCount, result.lintCacheTotalFileCount),
+    ratioOf(result.lintSidecarReplayedFileCount, result.lintSidecarTotalFileCount),
+    resolveDeadCodeReuseRatio(result),
+  ];
+  let knownSubsystemCount = 0;
+  let reuseRatioSum = 0;
+  for (const reuseRatio of subsystemReuseRatios) {
+    if (reuseRatio === null) continue;
+    knownSubsystemCount += 1;
+    reuseRatioSum += reuseRatio;
+  }
+  const warmth = knownSubsystemCount > 0 ? reuseRatioSum / knownSubsystemCount : null;
+  const temperature =
+    warmth !== null && warmth > 0 ? "warm" : isCacheGloballyDisabled() ? "disabled" : "cold";
+  return withNamespace("cache", {
+    wholeRepoHit: input.wholeRepoCacheHit ?? null,
+    temperature,
+    warmth,
+  });
 };
 
 // How the official action's `version` input was pinned, derived from the
@@ -276,18 +355,15 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
       // from a 0% hit rate (`toSpanAttributes` drops the nulls).
       cacheHitFiles: result.lintCacheHitFileCount ?? null,
       cacheTotalFiles: result.lintCacheTotalFileCount ?? null,
-      cacheHitRatio:
-        result.lintCacheTotalFileCount != null && result.lintCacheTotalFileCount > 0
-          ? (result.lintCacheHitFileCount ?? 0) / result.lintCacheTotalFileCount
-          : null,
+      cacheHitRatio: ratioOf(result.lintCacheHitFileCount, result.lintCacheTotalFileCount),
       // Sidecar lint cache outcome — same shape as the per-file cache dims;
       // all `null` when the sidecar cache was off/bypassed.
       sidecarReplayedFiles: result.lintSidecarReplayedFileCount ?? null,
       sidecarTotalFiles: result.lintSidecarTotalFileCount ?? null,
-      sidecarReplayRatio:
-        result.lintSidecarTotalFileCount != null && result.lintSidecarTotalFileCount > 0
-          ? (result.lintSidecarReplayedFileCount ?? 0) / result.lintSidecarTotalFileCount
-          : null,
+      sidecarReplayRatio: ratioOf(
+        result.lintSidecarReplayedFileCount,
+        result.lintSidecarTotalFileCount,
+      ),
     }),
     ...withNamespace("deadCode", {
       failed: input.didDeadCodeFail ?? null,
@@ -386,7 +462,7 @@ const buildScanAttributes = (input: RunEventInput): RunEventAttributes => {
  * Projects a scan into the namespaced attribute set for its root span — the
  * canonical per-scan "wide event". Every attribute carries a dotted namespace
  * that groups it by concept (`scan.*` config, `action.*` CI knobs, `outcome.*`
- * verdict, `diag.*` findings, `score.*`, `lint.*`, `deadCode.*`,
+ * verdict, `diag.*` findings, `score.*`, `lint.*`, `deadCode.*`, `cache.*`,
  * `supplyChain.*`, `timing.*`, `migration.*`, `baseline.*`) so the attributes
  * tree up in Sentry's attribute browser and stay filter-/group-/aggregate-able
  * in the Spans dataset. Pure and exported so the projection (outcome
@@ -404,6 +480,7 @@ export const buildRunEventAttributes = (
     ...buildScanAttributes(input),
     ...buildActionAttributes(),
     ...buildOutcomeAttributes(input),
+    ...buildCacheAttributes(input),
   });
 
 /**

--- a/packages/react-doctor/src/cli/utils/scan-result-cache.ts
+++ b/packages/react-doctor/src/cli/utils/scan-result-cache.ts
@@ -330,7 +330,16 @@ const writePersistedCache = (cacheFilePath: string, cache: PersistedScanResultCa
   }
 };
 
-const isScanResultCacheDisabled = (): boolean =>
+/**
+ * The global cache off-switch (`REACT_DOCTOR_NO_CACHE`), which disables every
+ * cache subsystem: this whole-repo scan cache plus core's per-file lint,
+ * sidecar, and dead-code caches (their `Context.Reference` defaults read the
+ * same variable). Exported for the wide event's `cache.temperature`
+ * derivation, which reports `"disabled"` instead of `"cold"` when the switch
+ * is on. Granular knobs (`REACT_DOCTOR_NO_FILE_CACHE`, …) are deliberately
+ * not consulted — they leave the other subsystems live.
+ */
+export const isCacheGloballyDisabled = (): boolean =>
   CACHE_DISABLED_VALUES.has(process.env.REACT_DOCTOR_NO_CACHE?.toLowerCase() ?? "");
 
 const resolveProjectIdentity = (projectDirectory: string): string => {
@@ -369,7 +378,7 @@ const resolveToolchainFingerprint = (nodeBinaryPath: string | null): ReadonlyArr
 };
 
 export const buildScanResultCacheKey = (input: ScanResultCacheKeyInput): string | null => {
-  if (isScanResultCacheDisabled()) return null;
+  if (isCacheGloballyDisabled()) return null;
   // Assume-unchanged / skip-worktree hide tracked-file state from `git
   // status`, so no fingerprint built from it can see those changes.
   if (hasHiddenTrackedFileState(input.projectDirectory)) return null;

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -570,6 +570,7 @@ const runInspectWithRuntime = async (
       rootSentrySpan,
       scanMode: cachedPayload.baselineDelta ? "baseline" : isDiffMode ? "diff" : "full",
       baselineDegraded,
+      wholeRepoCacheHit: true,
     });
     recordOnboardingCompletion(options);
     return result;
@@ -790,6 +791,7 @@ const runInspectWithRuntime = async (
     rootSentrySpan,
     scanMode: baselineDelta ? "baseline" : isDiffMode ? "diff" : "full",
     baselineDegraded,
+    wholeRepoCacheHit: false,
     lintCacheHitFileCount: output.lintCacheHitFileCount,
     lintCacheTotalFileCount: output.lintCacheTotalFileCount,
     lintSidecarReplayedFileCount: output.lintSidecarReplayedFileCount,
@@ -844,6 +846,14 @@ interface RenderAndRecordScanInput {
   readonly rootSentrySpan: SentryRootSpan;
   readonly scanMode: "full" | "diff" | "baseline";
   readonly baselineDegraded: boolean;
+  /**
+   * `true` only on the whole-repo scan-result replay path (the exact-key
+   * `cachedPayload` branch, where no lint / dead-code / score work ran).
+   * Required so both call sites state it explicitly — the wide event's
+   * `cache.temperature = "turbo"` derives from this flag, never from the
+   * execution dims below happening to be null.
+   */
+  readonly wholeRepoCacheHit: boolean;
   /**
    * Per-file lint cache outcome for THIS scan's lint pass. Threaded outside
    * `CachedScanPayload` on purpose — it's telemetry about the lint that ran in
@@ -960,6 +970,7 @@ const renderAndRecordScan = async (input: RenderAndRecordScanInput): Promise<Ins
     result,
     mode: input.scanMode,
     gateExempt: input.baselineDegraded,
+    wholeRepoCacheHit: input.wholeRepoCacheHit,
     didLintFail: input.payload.didLintFail,
     lintFailureReasonKind: input.payload.lintFailureReasonKind,
     lintPartialFailureCount: input.payload.lintPartialFailures.length,

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -12,6 +12,7 @@ const ENV_VARS = [
   "GITHUB_EVENT_PATH",
   "RUNNER_OS",
   "REACT_DOCTOR_GITHUB_ACTION",
+  "REACT_DOCTOR_NO_CACHE",
   ...Object.values(ACTION_INPUT_ENVIRONMENT_VARIABLES),
 ] as const;
 
@@ -393,6 +394,127 @@ describe("buildRunEventAttributes", () => {
     // Absent tallies (e.g. the failure path) read as "unknown", not zero.
     const withoutTallies = buildRunEventAttributes(baseInput({ result: buildResult() }));
     expect(withoutTallies["diag.suppressed"]).toBeUndefined();
+  });
+
+  it("marks a whole-repo replay turbo with full warmth and no subsystem dims", () => {
+    // The cachedPayload branch passes the explicit flag and none of the
+    // execution dims (no lint / dead-code ran), so the subsystem dims stay
+    // absent while the temperature is still unambiguous.
+    const attributes = buildRunEventAttributes(
+      baseInput({ result: buildResult(), wholeRepoCacheHit: true }),
+    );
+    expect(attributes["cache.temperature"]).toBe("turbo");
+    expect(attributes["cache.warmth"]).toBe(1);
+    expect(attributes["cache.wholeRepoHit"]).toBe(true);
+    expect(attributes["lint.cacheHitRatio"]).toBeUndefined();
+    expect(attributes["lint.sidecarReplayRatio"]).toBeUndefined();
+    expect(attributes["deadCode.cacheHit"]).toBeUndefined();
+    expect(attributes["deadCode.summaryCacheHits"]).toBeUndefined();
+  });
+
+  it("marks a fresh scan with zero reuse cold, with warmth 0", () => {
+    const attributes = buildRunEventAttributes(
+      baseInput({
+        result: buildResult({ lintCacheHitFileCount: 0, lintCacheTotalFileCount: 40 }),
+        wholeRepoCacheHit: false,
+      }),
+    );
+    expect(attributes["cache.temperature"]).toBe("cold");
+    expect(attributes["cache.warmth"]).toBe(0);
+    expect(attributes["cache.wholeRepoHit"]).toBe(false);
+    expect(attributes["lint.cacheHitRatio"]).toBe(0);
+  });
+
+  it("marks a REACT_DOCTOR_NO_CACHE run disabled, not cold, and drops warmth", () => {
+    process.env.REACT_DOCTOR_NO_CACHE = "1";
+    const attributes = buildRunEventAttributes(
+      baseInput({ result: buildResult(), wholeRepoCacheHit: false }),
+    );
+    expect(attributes["cache.temperature"]).toBe("disabled");
+    expect(attributes["cache.warmth"]).toBeUndefined();
+
+    process.env.REACT_DOCTOR_NO_CACHE = "true";
+    expect(
+      buildRunEventAttributes(baseInput({ result: buildResult(), wholeRepoCacheHit: false }))[
+        "cache.temperature"
+      ],
+    ).toBe("disabled");
+  });
+
+  it("marks a run warm when any single subsystem reused work", () => {
+    const warmScenarios: Array<{ overrides: Partial<InspectResult>; expectedWarmth: number }> = [
+      {
+        overrides: { lintCacheHitFileCount: 30, lintCacheTotalFileCount: 100 },
+        expectedWarmth: 0.3,
+      },
+      {
+        overrides: { lintSidecarReplayedFileCount: 5, lintSidecarTotalFileCount: 10 },
+        expectedWarmth: 0.5,
+      },
+      { overrides: { deadCodeCacheHit: true }, expectedWarmth: 1 },
+      {
+        overrides: { deadCodeSummaryCacheHits: 8, deadCodeSummaryCacheMisses: 2 },
+        expectedWarmth: 0.8,
+      },
+    ];
+    for (const { overrides, expectedWarmth } of warmScenarios) {
+      const attributes = buildRunEventAttributes(
+        baseInput({ result: buildResult(overrides), wholeRepoCacheHit: false }),
+      );
+      expect(attributes["cache.temperature"]).toBe("warm");
+      expect(attributes["cache.warmth"]).toBeCloseTo(expectedWarmth, 10);
+    }
+  });
+
+  it("computes warmth as the mean of the known subsystem ratios, skipping absent ones", () => {
+    // Sidecar dims absent -> skipped, not counted as 0: (0.5 + 0.8) / 2.
+    const attributes = buildRunEventAttributes(
+      baseInput({
+        result: buildResult({
+          lintCacheHitFileCount: 50,
+          lintCacheTotalFileCount: 100,
+          deadCodeSummaryCacheHits: 8,
+          deadCodeSummaryCacheMisses: 2,
+        }),
+        wholeRepoCacheHit: false,
+      }),
+    );
+    expect(attributes["cache.temperature"]).toBe("warm");
+    expect(attributes["cache.warmth"]).toBeCloseTo(0.65, 10);
+  });
+
+  it("counts a consulted-but-missed dead-code result cache as zero reuse", () => {
+    // deadCodeCacheHit false with no summary stats means the analysis ran
+    // fully fresh: (1.0 + 0) / 2, still warm because lint reused everything.
+    const attributes = buildRunEventAttributes(
+      baseInput({
+        result: buildResult({
+          lintCacheHitFileCount: 100,
+          lintCacheTotalFileCount: 100,
+          deadCodeCacheHit: false,
+        }),
+        wholeRepoCacheHit: false,
+      }),
+    );
+    expect(attributes["cache.temperature"]).toBe("warm");
+    expect(attributes["cache.warmth"]).toBeCloseTo(0.5, 10);
+  });
+
+  it("reads the legacy no-dims shape as cold and drops warmth and the flag", () => {
+    // No wholeRepoCacheHit flag and no subsystem dims (a caller predating the
+    // fields): nothing was reused, so the temperature still reads cold, while
+    // the magnitude and the flag stay absent rather than asserted.
+    const attributes = buildRunEventAttributes(baseInput({ result: buildResult() }));
+    expect(attributes["cache.temperature"]).toBe("cold");
+    expect(attributes["cache.warmth"]).toBeUndefined();
+    expect(attributes["cache.wholeRepoHit"]).toBeUndefined();
+  });
+
+  it("emits no cache dims on the failure path", () => {
+    const attributes = buildRunEventAttributes(baseInput({ error: new Error("boom") }));
+    expect(attributes["cache.temperature"]).toBeUndefined();
+    expect(attributes["cache.warmth"]).toBeUndefined();
+    expect(attributes["cache.wholeRepoHit"]).toBeUndefined();
   });
 
   it("captures config shape and drops null/undefined-valued attributes", () => {


### PR DESCRIPTION
## Why

The cache stack now has five layers, each with its own telemetry dim — but no single queryable answer to "was this run cold, incremental, or a full replay, and how warm was it?" This adds that classification so Sentry can segment scan latency by cache temperature and watch the incremental caches' real-world hit rates.

## What changed

- `cache.temperature` (string dim): `"turbo"` — whole-repo payload replay, driven by an explicit `wholeRepoCacheHit` flag passed from the cachedPayload branch (never inferred from nulls); `"warm"` — any incremental reuse (lint cache hits, sidecar replays, dead-code result hit, or summary hits); `"disabled"` — zero reuse with `REACT_DOCTOR_NO_CACHE` set (reuses the cache modules' own global-disable check, so it can never mislabel a real hit); `"cold"` — caches on, zero reuse.
- `cache.warmth` (number 0–1): unweighted mean of the available subsystem reuse fractions (lint hit ratio, sidecar replay ratio, dead-code: 1 for a whole-result hit else summary hit fraction), skipping null subsystems; 1 on turbo; dropped when nothing consulted a cache. The per-subsystem dims remain the precise drill-down.
- `cache.wholeRepoHit` (boolean dim), and `ratioOf` de-duplicates the two pre-existing inline ratio computations.
- Nothing added to `CachedScanPayload`, no schema bump, no new counters (wide-event home per repo conventions).

## Test plan

- +8 derivation-matrix tests (turbo / cold / disabled with both env spellings / warm via each subsystem individually / warmth mean-with-null-skipping arithmetic / consulted-miss-as-zero / legacy shape / failure path): react-doctor 2151 passed / 26 skipped. Root typecheck + lint clean.
- Functional proof captured **on the wire** via a local Sentry envelope receiver (post-`scrubSentryEvent`, confirming the new fields survive scrubbing): cold → `(cold, 0)`; warm after one new file → `(warm, 0.9989 = mean(619/620, 619/619, 619/620))`; unchanged rerun → `(turbo, 1)` at 85ms; `REACT_DOCTOR_NO_CACHE=1` → `(disabled, absent)`.
- Query recipe: Trace Explorer / Spans — group by `cache.temperature` for the adoption mix; `p50(timing.elapsedMs)` per temperature for the latency payoff (not `timing.scanMs`, which turbo replays from the payload); `p90(cache.warmth)` filtered to warm for reuse depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes to span attributes and explicit flags at existing `renderAndRecordScan` call sites; scan behavior and cache storage are unchanged.
> 
> **Overview**
> Adds **cache-temperature telemetry** to the per-scan Sentry wide event so adoption and latency can be segmented without inferring from scattered lint/dead-code cache dims.
> 
> **`cache.*` on the success path:** `cache.temperature` is `turbo` (whole-repo scan-result replay), `warm` (any incremental reuse), `cold` (caches on, zero reuse), or `disabled` when `REACT_DOCTOR_NO_CACHE` is set. `cache.warmth` is the unweighted mean of known subsystem reuse fractions (lint, sidecar, dead-code); `1` on turbo. `cache.wholeRepoHit` mirrors the new explicit flag. Existing `lint.*` / `deadCode.*` cache dims are unchanged; lint/sidecar ratios now go through a shared `ratioOf` helper.
> 
> **Wiring:** `inspect` passes `wholeRepoCacheHit: true` on the cached-payload branch and `false` on fresh scans so `turbo` is never guessed from missing subsystem stats. `isCacheGloballyDisabled` is exported from `scan-result-cache` for the disabled-vs-cold distinction.
> 
> **Tests:** Eight new cases in `build-run-event.test.ts` cover the derivation matrix and failure-path omission. Telemetry-only — no cache schema or report changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9037a34083d074681b59fabd3457f4929d7a1ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->