### PR TITLE
fix: --staged silently scans nothing in monorepo subdirectories

### DIFF
--- a/.changeset/fix-staged-monorepo.md
+++ b/.changeset/fix-staged-monorepo.md
@@ -1,0 +1,10 @@
+---
+"react-doctor": patch
+"@react-doctor/core": patch
+---
+
+fix: --staged now works in monorepo subdirectories
+
+Fixed a bug where `--staged` silently scanned nothing when the project is in a subdirectory of the git repo (standard monorepo layout). The CLI would report "No issues found!" with `scannedFileCount: 0` because staged file paths were resolved incorrectly.
+
+The fix changes `git show :<path>` to `git show :./<path>` to use cwd-relative pathspecs, matching how baseline reads already work.

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -769,7 +769,7 @@ export class Git extends Context.Service<
         showStagedContent: (directory, relativePath, options) =>
           runCommand({
             command: "git",
-            args: ["show", `:${relativePath}`],
+            args: ["show", `:./${relativePath}`],
             directory,
             maxStdoutBytes: options?.maxBufferBytes,
           }).pipe(Effect.map((result) => (result.status === 0 ? result.stdout : null))),

--- a/packages/core/tests/services/staged-files.test.ts
+++ b/packages/core/tests/services/staged-files.test.ts
@@ -144,6 +144,63 @@ describe("StagedFiles.layerNode — Zip-Slip defense (path traversal)", () => {
   });
 });
 
+describe("StagedFiles.layerNode regression — monorepo subdirectory (#1064)", () => {
+  let monorepoRoot: string;
+  let tempDirectory3: string;
+
+  beforeEach(() => {
+    monorepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-staged-monorepo-"));
+    tempDirectory3 = fs.mkdtempSync(path.join(os.tmpdir(), "rd-staged-materialize-"));
+
+    const projectDir = path.join(monorepoRoot, "apps", "webui");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(projectDir, "package.json"),
+      JSON.stringify({ name: "webui", dependencies: { react: "^19.0.0" } }),
+    );
+    fs.writeFileSync(
+      path.join(projectDir, "src", "App.tsx"),
+      'export function App() { return <div>Hello</div>; }\n',
+    );
+
+    const { spawnSync } = require("node:child_process");
+    spawnSync("git", ["init"], { cwd: monorepoRoot });
+    spawnSync("git", ["config", "user.email", "test@test.com"], { cwd: monorepoRoot });
+    spawnSync("git", ["config", "user.name", "Test"], { cwd: monorepoRoot });
+    spawnSync("git", ["add", "apps/webui/package.json", "apps/webui/src/App.tsx"], {
+      cwd: monorepoRoot,
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(monorepoRoot, { recursive: true, force: true });
+    fs.rmSync(tempDirectory3, { recursive: true, force: true });
+  });
+
+  it("reads staged content from a project subdirectory using cwd-relative pathspec", async () => {
+    const projectDir = path.join(monorepoRoot, "apps", "webui");
+    const layer = StagedFiles.layerNode.pipe(Layer.provide(Git.layerNode));
+
+    const snapshot = await Effect.runPromise(
+      Effect.gen(function* () {
+        const staged = yield* StagedFiles;
+        const sourceFiles = yield* staged.discoverSourceFiles(projectDir);
+        return yield* staged.materialize({
+          directory: projectDir,
+          stagedFiles: sourceFiles,
+          tempDirectory: tempDirectory3,
+        });
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(snapshot.stagedFiles).toEqual(["src/App.tsx"]);
+    const materializedContent = fs.readFileSync(path.join(tempDirectory3, "src/App.tsx"), "utf8");
+    expect(materializedContent).toBe('export function App() { return <div>Hello</div>; }\n');
+  });
+});
+
 describe("StagedFiles.layerOf (deterministic test layer)", () => {
   it("returns the snapshot's source files unchanged", async () => {
     const layer = StagedFiles.layerOf({

--- a/packages/core/tests/services/staged-files.test.ts
+++ b/packages/core/tests/services/staged-files.test.ts
@@ -162,7 +162,7 @@ describe("StagedFiles.layerNode regression — monorepo subdirectory (#1064)", (
     );
     fs.writeFileSync(
       path.join(projectDir, "src", "App.tsx"),
-      'export function App() { return <div>Hello</div>; }\n',
+      "export function App() { return <div>Hello</div>; }\n",
     );
 
     const { spawnSync } = require("node:child_process");
@@ -197,7 +197,7 @@ describe("StagedFiles.layerNode regression — monorepo subdirectory (#1064)", (
 
     expect(snapshot.stagedFiles).toEqual(["src/App.tsx"]);
     const materializedContent = fs.readFileSync(path.join(tempDirectory3, "src/App.tsx"), "utf8");
-    expect(materializedContent).toBe('export function App() { return <div>Hello</div>; }\n');
+    expect(materializedContent).toBe("export function App() { return <div>Hello</div>; }\n");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

When the scanned project is a subdirectory of the git repo (standard monorepo layout), `--staged` silently scanned nothing because:

1. `git diff --cached --relative` returns **project-relative** paths (e.g., `src/Bad.tsx`)
2. But `git show :<path>` resolves paths relative to the **repo root**, not the cwd
3. So the file read failed silently and all files were skipped with `scannedFileCount: 0`

This is the same class of bug as #858 (PR baseline reads) — both stemmed from git's `:<path>` pathspec being repo-root-relative when the operation runs from a subdirectory.

## Fix

Changed `git show :<path>` to `git show :./<path>` in `showStagedContent`. The `./` prefix makes the pathspec cwd-relative, matching how `showRefContent` already works for baseline reads (which has a comment explaining exactly this issue).

## Scope

- **Only affects `--staged` mode** — the fix is in `Git.showStagedContent`, which is only called during staged file materialization
- **Zero impact on normal scans** — regular file discovery and content reading use different code paths
- **All tests pass**, including new regression test that validates `--staged` works from a monorepo subdirectory

## Parity

Parity check is not applicable for this fix because:
- The corpus scan doesn't use `--staged` mode (it scans all files normally)
- This fix only affects the staged file content reading path
- No rule behavior changed

## Testing

- Added integration test that creates a real monorepo structure and validates staged content is read correctly
- Manually tested with the reproduction case from the issue (works correctly now)
- All existing tests pass

Closes #1064
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98f6b234-d7d1-466c-b6e2-988bee890230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98f6b234-d7d1-466c-b6e2-988bee890230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

