### PR TITLE
fix(core): --staged now works in monorepo subdirectories (git show :./<path>)

### DIFF
--- a/.changeset/staged-monorepo-subdir-pathspec.md
+++ b/.changeset/staged-monorepo-subdir-pathspec.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Fix `--staged` silently scanning nothing when the project is a subdirectory of the git repo (the standard monorepo layout, e.g. `apps/webui`). Staged paths are collected project-relative (`git diff --cached --relative`), but the staged-content read used a bare `git show :<path>` index pathspec, which git resolves against the repo root — so in a subproject every read missed, the file was silently skipped, and the scan "passed" with `scannedFileCount: 0` (particularly dangerous in a pre-commit hook). The index read now uses the cwd-relative `git show :./<path>` form, matching how baseline `<ref>:<path>` reads were already resolved.

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -769,7 +769,14 @@ export class Git extends Context.Service<
         showStagedContent: (directory, relativePath, options) =>
           runCommand({
             command: "git",
-            args: ["show", `:${relativePath}`],
+            // The `./` prefix is required for the same reason as `showRefContent`
+            // below: git reads a bare `:<path>` index pathspec relative to the
+            // REPO ROOT, but `relativePath` is relative to `directory` (the
+            // scanned project, which may be a monorepo subproject). `:./` makes
+            // git resolve it against the cwd, so a subproject's staged content is
+            // read correctly instead of silently missing (the whole file set
+            // would otherwise be skipped and `--staged` scans nothing).
+            args: ["show", `:./${relativePath}`],
             directory,
             maxStdoutBytes: options?.maxBufferBytes,
           }).pipe(Effect.map((result) => (result.status === 0 ? result.stdout : null))),

--- a/packages/core/tests/regressions/issue-1064-staged-subdir-path.test.ts
+++ b/packages/core/tests/regressions/issue-1064-staged-subdir-path.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as Effect from "effect/Effect";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { Git } from "@react-doctor/core";
+
+/**
+ * Regression for #1064: `--staged` silently scanned nothing when the project
+ * is a subdirectory of the git repo (the standard monorepo layout). Staged
+ * paths are collected with `git diff --cached --relative` (project-relative,
+ * e.g. `src/Bad.tsx`), but the content read used a bare `git show :<path>`
+ * index pathspec — which git resolves against the REPO ROOT, not the cwd. In a
+ * subproject that misses (`fatal: path 'apps/webui/src/Bad.tsx' is in the
+ * index, but not 'src/Bad.tsx'`), the non-zero exit folds to `null`, and
+ * `materializeSourceTree` skips the file with no warning, so every staged file
+ * is dropped and the gate "passes" with `scannedFileCount: 0`.
+ *
+ * The fix prefixes the pathspec with `./` (`git show :./<path>`) so git
+ * resolves it relative to the scanned project — the same treatment
+ * `showRefContent` already applies to the `<ref>:<path>` baseline reads.
+ *
+ * Uses `Git.layerNode` (production layer) against a real repo whose project
+ * lives in `apps/webui/`; staging (`git add`) populates the index, so the read
+ * needs no commit (and thus no `commit.gpgsign` TTY prompt).
+ */
+const runNode = <Value>(program: Effect.Effect<Value, unknown, Git>): Promise<Value> =>
+  Effect.runPromise(program.pipe(Effect.provide(Git.layerNode)));
+
+const subdirectoryRepository = (() => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-1064-"));
+  const projectDirectory = path.join(repoRoot, "apps", "webui");
+  fs.mkdirSync(path.join(projectDirectory, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectDirectory, "src", "Bad.tsx"),
+    "export const Bad = () => <div>bad</div>;\n",
+  );
+  const runGit = (args: ReadonlyArray<string>): void => {
+    execFileSync("git", [...args], { cwd: repoRoot, stdio: "ignore" });
+  };
+  runGit(["init"]);
+  runGit(["add", "apps/webui/src/Bad.tsx"]);
+  return { repoRoot, projectDirectory };
+})();
+
+afterAll(() => fs.rmSync(subdirectoryRepository.repoRoot, { recursive: true, force: true }));
+
+describe("issue #1064: staged content reads from a project subdirectory", () => {
+  it("reads a staged file whose path is relative to the scanned subproject", async () => {
+    const content = await runNode(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.showStagedContent(subdirectoryRepository.projectDirectory, "src/Bad.tsx");
+      }),
+    );
+    // Before the fix this was `null` (bare `:src/Bad.tsx` missed against the
+    // repo root), silently dropping every staged file in a monorepo subproject.
+    expect(content).toBe("export const Bad = () => <div>bad</div>;\n");
+  });
+
+  it("still returns null for a path genuinely absent from the index", async () => {
+    const content = await runNode(
+      Effect.gen(function* () {
+        const git = yield* Git;
+        return yield* git.showStagedContent(
+          subdirectoryRepository.projectDirectory,
+          "src/Missing.tsx",
+        );
+      }),
+    );
+    expect(content).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #1064.

## Problem

`react-doctor --staged` silently scanned **nothing** when the scanned project is a subdirectory of the git repo (the standard monorepo layout, e.g. `apps/webui`). The CLI printed `Scanning N staged files…` then `No issues found!`, and the JSON report showed `summary.affectedFileCount: 0`. In a pre-commit hook this means the gate **passes without checking anything**.

## Root cause

Two git invocations disagreed about what paths are relative to:

1. Staged paths are collected with `git diff --cached --relative` from the project dir → **project-relative** (`src/Bad.tsx`).
2. `showStagedContent` read each with a bare `git show :<path>` index pathspec — but git resolves `:<path>` relative to the **repo root**, not the cwd. In a subproject that fails:
   ```
   fatal: path 'apps/webui/src/Bad.tsx' is in the index, but not 'src/Bad.tsx'
   ```
   The non-zero exit folds to `null`, and `materializeSourceTree` silently skips the file — so every staged file is dropped.

The sibling `showRefContent` (the `<ref>:<path>` baseline read) was **already fixed** for this identical class of bug with the `./` prefix; the staged path just never got the same treatment.

## Fix

`git show :<path>` → `git show :./<path>`. The `./` prefix makes git resolve the pathspec against the cwd (the scanned project) instead of the repo root. Fully backward-compatible — both forms are identical when the project *is* the repo root.

## Verification

- **End-to-end CLI repro** (exact steps from the issue, against the built bin): `--staged` now reports the `no-danger-with-children` finding; `summary.affectedFileCount` / `totalDiagnosticCount` go **0 → 1**.
- **New regression test** `packages/core/tests/regressions/issue-1064-staged-subdir-path.test.ts` (real `Git.layerNode` against a subdirectory repo) — **proven to fail without the fix, pass with it**; also asserts genuinely-absent index paths still return `null`.
- Full `@react-doctor/core` suite green (1185/1185), typecheck ✓, format ✓.

## Notes

- Supersedes #1065 (independent Cursor-agent PR that landed the identical `:./` fix) — this adds an explanatory comment guarding against a future "simplify" reintroducing the bug, plus the regression test and changeset.
- The related silent-skip in `materializeSourceTree` is intentionally left as-is: it's shared with the baseline path, where a `null` read (a file added by the PR, absent at the base ref) is legitimate and must not warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches staged-scan git I/O used by pre-commit flows; the change is small and aligned with existing ref reads, with a dedicated regression test.
> 
> **Overview**
> Fixes **`--staged`** silently scanning **zero files** when the scanned project is a **monorepo subdirectory** (e.g. `apps/webui`), which could let pre-commit hooks pass without running checks.
> 
> **`showStagedContent`** now runs `git show :./<path>` instead of `git show :<path>`, so the index pathspec is resolved from the project **cwd**—matching project-relative paths from `git diff --cached --relative` and the existing **`showRefContent`** `./` prefix for baseline reads. Inline comments document why bare `:<path>` resolves from the repo root.
> 
> Adds a **regression test** (`issue-1064-staged-subdir-path.test.ts`) using real `Git.layerNode` against a subproject repo, plus a **patch changeset** for `@react-doctor/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee1b04688ec133fd784c1db07ae9b1ec6c47712d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->