### PR TITLE
fix(cli): scan cache no longer replays across projects at a reused path

### DIFF
--- a/.changeset/scan-cache-cross-project-replay.md
+++ b/.changeset/scan-cache-cross-project-replay.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix whole-repo scan cache replaying another project's diagnostics when a .git-less checkout sits inside an unrelated repository (e.g. a gitignored benchmark/mining clone directory reused across projects). The cache key's git identity (HEAD sha, worktree fingerprint) resolved from the enclosing repository, which cannot see the checkout's files, so two different projects materialized at the same path keyed identically. The key now requires the fingerprinted repository to actually track files under the project directory (cache off otherwise), and every cache hit re-verifies the stored payload's directory and `package.json` content hash so any future keying bug of this class degrades to a miss instead of a cross-project replay.

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -27,7 +27,9 @@ export const BASELINE_FILES_TEMP_DIR_PREFIX = "react-doctor-baseline-";
 // Bumped to 2: `CachedScanPayload` gained the required `supplyChainOverlapTimedOut`
 // (supply-chain overlap) and `deadCodeOverlapped` (dead-code overlap) fields.
 // Bumped to 3: gained the required `suppressedRuleCounts` field (suppression telemetry).
-export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 3;
+// Bumped to 4: gained the `manifestContentHash` replay guard, which every
+// `lookup` verifies — pre-bump entries without it would never hit again.
+export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 4;
 export const SCAN_RESULT_CACHE_MAX_ENTRY_COUNT = 20;
 export const SCAN_RESULT_CACHE_FILENAME = "scan-cache.json";
 // The dirty-worktree cache-key fingerprint content-hashes every path `git

--- a/packages/react-doctor/src/cli/utils/scan-result-cache.ts
+++ b/packages/react-doctor/src/cli/utils/scan-result-cache.ts
@@ -23,7 +23,7 @@ import {
   SCAN_RESULT_CACHE_MAX_HASHED_FILE_SIZE_BYTES,
   SCAN_RESULT_CACHE_SCHEMA_VERSION,
 } from "./constants.js";
-import { isRecord, runGit } from "./git-hook-shared.js";
+import { getPackageJsonPath, isRecord, runGit } from "./git-hook-shared.js";
 import type { ResolvedInspectOptions } from "../../inspect.js";
 
 export interface CachedScanPayload {
@@ -63,6 +63,14 @@ export interface CachedScanPayload {
    * suppression telemetry the fresh scan emitted.
    */
   readonly suppressedRuleCounts: ReadonlyArray<SuppressedRuleCount>;
+  /**
+   * Content hash of the project's `package.json` when the payload was stored
+   * (`null` when the project has none). Stamped by `store` and re-checked by
+   * `lookup` independently of the cache key, so any keying bug of the
+   * same-path-different-project class surfaces as a miss instead of silently
+   * replaying another project's diagnostics.
+   */
+  readonly manifestContentHash?: string | null;
 }
 
 interface PersistedScanResultCacheEntry {
@@ -282,10 +290,20 @@ const resolveDotenvFingerprint = (projectDirectory: string): ReadonlyArray<strin
   }
 };
 
-const hasHiddenTrackedFileState = (projectDirectory: string): boolean => {
+// Whether the repository git resolves for the project directory can be
+// trusted as cache-key identity. `git ls-files -v` (restricted to the project
+// directory by cwd) refutes that two ways: zero entries means the repository
+// tracks nothing here — the project directory is a gitignored or untracked
+// checkout (e.g. a .git-less clone nested inside an unrelated repository), so
+// HEAD and `git status` describe a repository that cannot see the project's
+// files and different project contents would key identically; a non-"H"
+// entry means assume-unchanged / skip-worktree bits hide tracked-file changes
+// from every fingerprint built on `git status`.
+const isGitIdentityTrustworthy = (projectDirectory: string): boolean => {
   const output = runGit(projectDirectory, ["ls-files", "-v"]);
-  if (output === null) return true;
-  return output.split("\n").some((line) => line.length > 0 && line[0] !== "H");
+  if (output === null) return false;
+  const entryLines = output.split("\n").filter((line) => line.length > 0);
+  return entryLines.length > 0 && entryLines.every((line) => line[0] === "H");
 };
 
 // Sits beside the per-file lint / sidecar / dead-code caches under the shared
@@ -354,6 +372,9 @@ const resolveProjectIdentity = (projectDirectory: string): string => {
   }
 };
 
+const resolveManifestContentHash = (projectDirectory: string): string | null =>
+  hashFileContents(getPackageJsonPath(projectDirectory));
+
 const fileFingerprint = (filePath: string): string | null => {
   try {
     const stat = fs.statSync(filePath);
@@ -391,9 +412,7 @@ const resolveToolchainFingerprint = (nodeBinaryPath: string | null): ReadonlyArr
 
 export const buildScanResultCacheKey = (input: ScanResultCacheKeyInput): string | null => {
   if (isCacheGloballyDisabled()) return null;
-  // Assume-unchanged / skip-worktree hide tracked-file state from `git
-  // status`, so no fingerprint built from it can see those changes.
-  if (hasHiddenTrackedFileState(input.projectDirectory)) return null;
+  if (!isGitIdentityTrustworthy(input.projectDirectory)) return null;
   const worktreeFingerprint = buildWorktreeFingerprint(input.projectDirectory);
   if (worktreeFingerprint === null) return null;
   const headSha = readHeadSha(input.projectDirectory);
@@ -466,9 +485,24 @@ export const createScanResultCache = (projectDirectory: string): ScanResultCache
   };
 
   return {
-    lookup: (key) => entries.get(key)?.payload ?? null,
+    lookup: (key) => {
+      const payload = entries.get(key)?.payload;
+      if (payload === undefined) return null;
+      // Replay guard, independent of the key: a served payload must describe
+      // THIS project — same directory identity and same manifest content as
+      // when it was stored — so a keying bug degrades to a miss, never to
+      // another project's diagnostics.
+      const describesThisProject =
+        resolveProjectIdentity(payload.directory) === resolveProjectIdentity(projectDirectory) &&
+        (payload.manifestContentHash ?? null) === resolveManifestContentHash(projectDirectory);
+      return describesThisProject ? payload : null;
+    },
     store: (key, payload) => {
-      entries.set(key, { key, createdAtMs: Date.now(), payload });
+      entries.set(key, {
+        key,
+        createdAtMs: Date.now(),
+        payload: { ...payload, manifestContentHash: resolveManifestContentHash(projectDirectory) },
+      });
       persist();
     },
   };

--- a/packages/react-doctor/tests/scan-result-cache.test.ts
+++ b/packages/react-doctor/tests/scan-result-cache.test.ts
@@ -306,6 +306,74 @@ describe("scan result cache", () => {
     expect(cacheKey(projectDirectory, baseOptions())).toBeNull();
   });
 
+  it("does not cache a .git-less checkout git resolves to an enclosing repository", () => {
+    // The mining/benchmark layout: an enclosing "runner" repo gitignores a
+    // clones/ directory into which different projects are materialized at the
+    // same path with .git stripped. Every git probe from the clone resolves
+    // the runner repo — whose HEAD and worktree state cannot see the clone's
+    // contents — so without the tracking-state gate two different projects at
+    // this path key identically and replay each other's diagnostics.
+    const runnerDirectory = path.join(tempDirectory, "runner");
+    fs.mkdirSync(runnerDirectory, { recursive: true });
+    fs.writeFileSync(path.join(runnerDirectory, ".gitignore"), "clones/\n");
+    initGitRepo(runnerDirectory, { commit: true });
+    const projectDirectory = setupReactProject(runnerDirectory, "clones/app", {
+      files: { "src/App.tsx": "export const App = () => <div />;\n" },
+    });
+
+    expect(cacheKey(projectDirectory, baseOptions())).toBeNull();
+  });
+
+  it("still caches a tracked workspace-member subdirectory", () => {
+    const repositoryDirectory = path.join(tempDirectory, "workspace");
+    fs.mkdirSync(repositoryDirectory, { recursive: true });
+    const projectDirectory = setupReactProject(repositoryDirectory, "packages/app", {
+      files: { "src/App.tsx": "export const App = () => <div />;\n" },
+    });
+    initGitRepo(repositoryDirectory, { commit: true });
+
+    expect(cacheKey(projectDirectory, baseOptions())).not.toBeNull();
+  });
+
+  describe("replay verification", () => {
+    it("misses when the manifest content changed since the payload was stored", () => {
+      const projectDirectory = setupReactProject(tempDirectory, "manifest-drift", {
+        files: { "src/App.tsx": "export const App = () => <div />;\n" },
+      });
+      initGitRepo(projectDirectory, { commit: true });
+      const key = cacheKey(projectDirectory, baseOptions());
+      expect(key).not.toBeNull();
+      if (key === null) return;
+      createScanResultCache(projectDirectory).store(key, basePayload(projectDirectory));
+      expect(createScanResultCache(projectDirectory).lookup(key)).not.toBeNull();
+
+      // A different project materialized at the same path (same cache key by
+      // hypothesis of a keying bug) must read as a miss, not a replay.
+      fs.writeFileSync(
+        path.join(projectDirectory, "package.json"),
+        JSON.stringify({ name: "different-project", dependencies: { react: "^19.0.0" } }),
+      );
+      expect(createScanResultCache(projectDirectory).lookup(key)).toBeNull();
+    });
+
+    it("misses when the stored payload describes another directory", () => {
+      const projectDirectory = setupReactProject(tempDirectory, "directory-drift", {
+        files: { "src/App.tsx": "export const App = () => <div />;\n" },
+      });
+      initGitRepo(projectDirectory, { commit: true });
+      const key = cacheKey(projectDirectory, baseOptions());
+      expect(key).not.toBeNull();
+      if (key === null) return;
+      const cache = createScanResultCache(projectDirectory);
+      cache.store(
+        key,
+        basePayload(projectDirectory, { directory: path.join(tempDirectory, "elsewhere") }),
+      );
+
+      expect(cache.lookup(key)).toBeNull();
+    });
+  });
+
   it("handles git output larger than Node's default maxBuffer", () => {
     // `git ls-files -v` exceeds execFileSync's 1 MiB default on repos with
     // ~15-25k tracked files (getsentry/sentry: 1.25 MB); the resulting ENOBUFS


### PR DESCRIPTION
## Why

React-bench/mining pipelines observed one repo's diagnostics appearing in another repo's report ("even with per-task fixed dirs" — worked around with fresh `TMPDIR` per invocation and `pkill react-doctor`). Root cause: a `.git`-less checkout nested inside an unrelated repository (a gitignored clone dir reused across projects) resolves every cache-key git probe — `rev-parse HEAD`, `status`, `ls-files` — against the **enclosing** repo, which cannot see the checkout's files. Two different projects materialized at the same path therefore compute the same whole-repo scan-cache key, and the second scan replays the first project's diagnostics from the shared tmpdir cache.

Reproduced on 0.5.7, 0.6.1, and main (repro: runner repo gitignoring `clones/`; scan repo X there, `rm -rf`, scan repo Y at the same path — Y's report carries X's findings while its `directory` field points at the intended clone):

Before:

```
[X] diagnostic files: ['src/x-marker.jsx']
[Y] diagnostic files: ['src/x-marker.jsx']   <- repo Y replays repo X's finding
```

After:

```
[X] diagnostic files: ['src/x-marker.jsx']
[Y] diagnostic files: []                     <- cache off for the blind layout; Y scans fresh
```

Notes on the window: `configFingerprint` includes the project's own `package.json`, so the collision needs matching manifests — trivially true for parent/child commits of one repo and for scaffold twins. 0.5.7/0.6.1 fingerprinted configs by mtime+size (collides under mtime-preserving materialization: tar, `rsync -a`); #1060's content hashing widened the window to any re-clone. Lint findings leak when the `ls-files` discovery call fails (spawn flakiness under parallel harness load) and the filesystem-walk fallback lints files the cache key never sees.

## What changed

- `buildScanResultCacheKey` bails to no-cache unless the repository git resolves for the project directory actually tracks files under it (`isGitIdentityTrustworthy`, folding in the existing assume-unchanged/skip-worktree gate — one `git ls-files -v` probe, no extra subprocess).
- Replay verification, independent of the key: `store` stamps the payload with a content hash of the project's `package.json` (`manifestContentHash`); `lookup` re-checks that hash and the payload's directory identity against the current state, so any future keying bug of this class degrades to a miss instead of a cross-project replay.
- `SCAN_RESULT_CACHE_SCHEMA_VERSION` 3 → 4 (new persisted field; pre-bump entries are dropped).

## Test plan

- `vp test tests/scan-result-cache.test.ts` — 23 passed (4 new: gitignored-clone key is null, tracked workspace-member subdir still keys, lookup rejects manifest drift and directory drift).
- End-to-end repro harness re-run against the built CLI: contaminated pre-fix, clean post-fix; healthy-repo caching intact.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scan caching correctness for git edge cases (gitignored paths disable cache; failed `git ls-files` now disables rather than allowing cache), but behavior for normal tracked repos is preserved with added replay checks.
> 
> **Overview**
> Fixes **cross-project diagnostic replay** when the whole-repo scan cache keys off an enclosing git repo that does not track the project directory (e.g. a `.git`-less clone in a gitignored `clones/` dir reused for different repos).
> 
> **Cache key:** `buildScanResultCacheKey` now bails unless `isGitIdentityTrustworthy` passes—`git ls-files -v` from the project cwd must list tracked files and none may be assume-unchanged/skip-worktree (replacing the old “any non-H line disables cache” helper with stricter “must have tracked files here”). Gitignored nested checkouts get **no cache key**; normal monorepo subpackages still key as before.
> 
> **Replay guard:** On `store`, payloads get `manifestContentHash` from `package.json`; on `lookup`, hits are rejected unless the stored `directory` and manifest hash still match the current project—so a key collision degrades to a miss, not another project’s diagnostics. `SCAN_RESULT_CACHE_SCHEMA_VERSION` bumps to **4** (older on-disk entries dropped).
> 
> Tests cover the runner/clones layout, workspace subdirs, and manifest/directory drift on lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 579a6b24788aeaab81c4b67f7d8b1c8ad011767e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->