### PR TITLE
fix: gate server-only Next.js rules under output: "export" (static export) (#976); lock #1082/#1078 FP regressions

### DIFF
--- a/.changeset/static-export-server-only-rules.md
+++ b/.changeset/static-export-server-only-rules.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+"@react-doctor/core": patch
+"oxlint-plugin-react-doctor": patch
+---
+
+Next.js `output: "export"` now gates server-only recommendations: `nextjs-no-client-side-redirect` is disabled for static export, and `no-prevent-default` no longer recommends Server Actions for forms in static-export projects. This fixes the false positives from #976 and locks in the #1082 and #1078 regressions with tests.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,6 +23,8 @@ export const DEFAULT_SHOW_WARNINGS = true;
 
 export const MILLISECONDS_PER_SECOND = 1000;
 
+export const SERVER_CAPABLE_FRAMEWORKS = new Set(["nextjs", "tanstack-start", "remix"]);
+
 // Upper bound for the `react:<major>` capability loop in
 // `buildCapabilities`, clamping an unvalidated package.json spec like
 // `"react": "20240101"` that would otherwise drive the loop to tens of

--- a/packages/core/src/project-info/detect-nextjs-static-export.ts
+++ b/packages/core/src/project-info/detect-nextjs-static-export.ts
@@ -1,0 +1,23 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { isFile } from "./utils/is-file.js";
+
+const NEXT_CONFIG_FILENAMES = [
+  "next.config.js",
+  "next.config.mjs",
+  "next.config.ts",
+  "next.config.cjs",
+];
+
+const OUTPUT_EXPORT_PATTERN = /["']?output["']?\s*:\s*["']export["']/;
+
+const hasStaticExportInConfigFile = (filePath: string): boolean => {
+  if (!isFile(filePath)) return false;
+  const content = fs.readFileSync(filePath, "utf-8");
+  return OUTPUT_EXPORT_PATTERN.test(content);
+};
+
+export const detectNextjsStaticExport = (directory: string): boolean =>
+  NEXT_CONFIG_FILENAMES.some((filename) =>
+    hasStaticExportInConfigFile(path.join(directory, filename)),
+  );

--- a/packages/core/src/project-info/discover-project.ts
+++ b/packages/core/src/project-info/discover-project.ts
@@ -5,6 +5,7 @@ import type { ProjectInfo } from "../types/index.js";
 import { isFile } from "./utils/is-file.js";
 import { countSourceFiles } from "./count-source-files.js";
 import { detectReactCompiler } from "./detect-react-compiler.js";
+import { detectNextjsStaticExport } from "./detect-nextjs-static-export.js";
 import { extractDependencyInfo } from "./extract-dependency-info.js";
 import { findDependencyInfoFromMonorepoRoot } from "./find-dependency-info-from-monorepo-root.js";
 import { findMonorepoRoot, isMonorepoRoot } from "./find-monorepo-root.js";
@@ -106,6 +107,7 @@ const discoverProjectWithoutPackageJson = (directory: string): ProjectInfo => {
     hasReactNativeWorkspace: false,
     nextjsVersion: null,
     nextjsMajorVersion: null,
+    hasNextjsStaticExport: false,
     expoVersion: null,
     shopifyFlashListVersion: null,
     shopifyFlashListMajorVersion: null,
@@ -319,6 +321,7 @@ export const discoverProject = (directory: string): ProjectInfo => {
           version: findNextjsVersion(directory, packageJson),
         })
       : null;
+  const hasNextjsStaticExport = framework === "nextjs" && detectNextjsStaticExport(directory);
   const preactVersion = getPreactVersion(packageJson);
   const isPreES2023Target = hasTypeScript && detectPreES2023Target(directory);
 
@@ -339,6 +342,7 @@ export const discoverProject = (directory: string): ProjectInfo => {
     hasReactNativeWorkspace,
     nextjsVersion,
     nextjsMajorVersion: nextjsVersion === null ? null : getLowestDependencyMajor(nextjsVersion),
+    hasNextjsStaticExport,
     expoVersion,
     shopifyFlashListVersion,
     shopifyFlashListMajorVersion:

--- a/packages/core/src/runners/oxlint/capabilities.ts
+++ b/packages/core/src/runners/oxlint/capabilities.ts
@@ -54,6 +54,7 @@ export const buildCapabilities = (project: ProjectInfo): ReadonlySet<string> => 
   if (project.nextjsMajorVersion !== null && project.nextjsMajorVersion >= 15) {
     capabilities.add("nextjs:15");
   }
+  if (project.hasNextjsStaticExport) capabilities.add("nextjs:static-export");
 
   const reactMajor = project.reactMajorVersion;
   if (reactMajor !== null) {

--- a/packages/core/src/runners/oxlint/capabilities.ts
+++ b/packages/core/src/runners/oxlint/capabilities.ts
@@ -4,6 +4,7 @@ import {
   EARLIEST_GATED_REACT_MAJOR,
   LATEST_KNOWN_PREACT_MAJOR,
   LATEST_KNOWN_REACT_MAJOR,
+  SERVER_CAPABLE_FRAMEWORKS,
 } from "../../constants.js";
 import { hasReactRuntime } from "../../utils/has-react-runtime.js";
 import {
@@ -55,6 +56,9 @@ export const buildCapabilities = (project: ProjectInfo): ReadonlySet<string> => 
     capabilities.add("nextjs:15");
   }
   if (project.hasNextjsStaticExport) capabilities.add("nextjs:static-export");
+  if (SERVER_CAPABLE_FRAMEWORKS.has(project.framework) && !project.hasNextjsStaticExport) {
+    capabilities.add("server-runtime");
+  }
 
   const reactMajor = project.reactMajorVersion;
   if (reactMajor !== null) {

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -6,8 +6,12 @@ import reactDoctorPlugin, {
 } from "oxlint-plugin-react-doctor";
 import type { OxlintRuleSeverity } from "oxlint-plugin-react-doctor";
 import type { ProjectInfo, RuleSeverityControls } from "../../types/index.js";
+import {
+  COMPILER_CLEANUP_BUCKET,
+  COMPILER_CLEANUP_RULE_KEYS,
+  SERVER_CAPABLE_FRAMEWORKS,
+} from "../../constants.js";
 import { resolveRuleSeverityOverride } from "../../resolve-rule-severity-override.js";
-import { COMPILER_CLEANUP_BUCKET, COMPILER_CLEANUP_RULE_KEYS } from "../../constants.js";
 import { buildCapabilities, shouldEnableRule } from "./capabilities.js";
 import { filterRulesToAvailable, resolveReactHooksJsPlugin } from "./plugin-resolution.js";
 import type { JsPluginEntry, ResolvedUserPlugin } from "./plugin-resolution.js";
@@ -62,6 +66,9 @@ const resolveSettingsRootDirectory = (rootDirectory: string): string => {
   if (!fs.existsSync(rootDirectory)) return rootDirectory;
   return fs.realpathSync(rootDirectory);
 };
+
+const hasServerRuntime = (project: ProjectInfo): boolean =>
+  SERVER_CAPABLE_FRAMEWORKS.has(project.framework) && !project.hasNextjsStaticExport;
 
 // The `compiler-cleanup` bucket override applies to its rule family only when
 // the user hasn't pinned that exact rule individually (a per-rule override
@@ -237,7 +244,7 @@ export const createOxlintConfig = ({
       "react-doctor": {
         framework: project.framework,
         rootDirectory: resolveSettingsRootDirectory(project.rootDirectory),
-        ...(project.hasNextjsStaticExport ? { hasNextjsStaticExport: true } : {}),
+        ...(hasServerRuntime(project) ? { hasServerRuntime: true } : {}),
         ...(project.shopifyFlashListMajorVersion !== null
           ? { shopifyFlashListMajorVersion: project.shopifyFlashListMajorVersion }
           : {}),

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -237,6 +237,7 @@ export const createOxlintConfig = ({
       "react-doctor": {
         framework: project.framework,
         rootDirectory: resolveSettingsRootDirectory(project.rootDirectory),
+        ...(project.hasNextjsStaticExport ? { hasNextjsStaticExport: true } : {}),
         ...(project.shopifyFlashListMajorVersion !== null
           ? { shopifyFlashListMajorVersion: project.shopifyFlashListMajorVersion }
           : {}),

--- a/packages/core/src/types/project-info.ts
+++ b/packages/core/src/types/project-info.ts
@@ -51,6 +51,7 @@ export interface ProjectInfo {
   hasReactNativeWorkspace: boolean;
   nextjsVersion: string | null;
   nextjsMajorVersion: number | null;
+  hasNextjsStaticExport: boolean;
   /**
    * The declared `expo` package version spec (e.g. `"~51.0.0"`), looked up
    * in the project or any of its workspace packages, or `null` when `expo`

--- a/packages/core/tests/build-capabilities.test.ts
+++ b/packages/core/tests/build-capabilities.test.ts
@@ -16,6 +16,7 @@ const baseProject: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,
@@ -218,6 +219,24 @@ describe("buildCapabilities", () => {
     });
     expect(capabilities.has("nextjs")).toBe(true);
     expect(capabilities.has("nextjs:15")).toBe(false);
+  });
+
+  it("emits `nextjs:static-export` when `hasNextjsStaticExport` is true", () => {
+    const capabilities = buildCapabilities({
+      ...baseProject,
+      framework: "nextjs",
+      hasNextjsStaticExport: true,
+    });
+    expect(capabilities.has("nextjs:static-export")).toBe(true);
+  });
+
+  it("omits `nextjs:static-export` when `hasNextjsStaticExport` is false", () => {
+    const capabilities = buildCapabilities({
+      ...baseProject,
+      framework: "nextjs",
+      hasNextjsStaticExport: false,
+    });
+    expect(capabilities.has("nextjs:static-export")).toBe(false);
   });
 
   it("omits `nextjs:15` when the Next.js version is unparseable", () => {

--- a/packages/core/tests/build-capabilities.test.ts
+++ b/packages/core/tests/build-capabilities.test.ts
@@ -221,6 +221,29 @@ describe("buildCapabilities", () => {
     expect(capabilities.has("nextjs:15")).toBe(false);
   });
 
+  it("emits `server-runtime` for server-capable frameworks that are not static-export Next.js", () => {
+    const serverRuntime = buildCapabilities({
+      ...baseProject,
+      framework: "remix",
+    });
+    expect(serverRuntime.has("server-runtime")).toBe(true);
+
+    const staticExportNextjs = buildCapabilities({
+      ...baseProject,
+      framework: "nextjs",
+      nextjsVersion: "^15.0.0",
+      nextjsMajorVersion: 15,
+      hasNextjsStaticExport: true,
+    });
+    expect(staticExportNextjs.has("server-runtime")).toBe(false);
+
+    const viteProject = buildCapabilities({
+      ...baseProject,
+      framework: "vite",
+    });
+    expect(viteProject.has("server-runtime")).toBe(false);
+  });
+
   it("emits `nextjs:static-export` when `hasNextjsStaticExport` is true", () => {
     const capabilities = buildCapabilities({
       ...baseProject,

--- a/packages/core/tests/build-json-report.test.ts
+++ b/packages/core/tests/build-json-report.test.ts
@@ -18,6 +18,7 @@ const projectInfo: ProjectInfo = {
   preactMajorVersion: null,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   hasReanimated: false,

--- a/packages/core/tests/check-expo-project.test.ts
+++ b/packages/core/tests/check-expo-project.test.ts
@@ -46,6 +46,7 @@ const buildExpoProject = (
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: true,
   expoVersion,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/check-react-native-project.test.ts
+++ b/packages/core/tests/check-react-native-project.test.ts
@@ -47,6 +47,7 @@ const buildRnProject = (
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: framework === "react-native" || framework === "expo",
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/check-react-server-components-advisory.test.ts
+++ b/packages/core/tests/check-react-server-components-advisory.test.ts
@@ -31,6 +31,7 @@ const buildProject = (
   hasTanStackQuery: false,
   nextjsVersion,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/compiler-cleanup-bucket.test.ts
+++ b/packages/core/tests/compiler-cleanup-bucket.test.ts
@@ -19,6 +19,7 @@ const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/compute-ruleset-hash.test.ts
+++ b/packages/core/tests/compute-ruleset-hash.test.ts
@@ -17,6 +17,7 @@ const makeProject = (rootDirectory: string): ProjectInfo => ({
   hasTanStackQuery: false,
   nextjsVersion: "^15.0.0",
   nextjsMajorVersion: 15,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/detect-nextjs-static-export.test.ts
+++ b/packages/core/tests/detect-nextjs-static-export.test.ts
@@ -1,0 +1,59 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { detectNextjsStaticExport } from "../src/project-info/detect-nextjs-static-export.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-detect-nextjs-static-export-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const setupProject = (caseId: string, files: Record<string, string>): string => {
+  const projectDirectory = path.join(tempRoot, caseId);
+  fs.mkdirSync(projectDirectory, { recursive: true });
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(projectDirectory, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+
+  return projectDirectory;
+};
+
+describe("detectNextjsStaticExport", () => {
+  it("detects output: 'export' in next.config.ts", () => {
+    const projectDirectory = setupProject("ts-export", {
+      "next.config.ts":
+        "import type { NextConfig } from 'next';\nconst nextConfig: NextConfig = { output: 'export' };\nexport default nextConfig;\n",
+    });
+
+    expect(detectNextjsStaticExport(projectDirectory)).toBe(true);
+  });
+
+  it('detects output: "export" in next.config.js', () => {
+    const projectDirectory = setupProject("js-export", {
+      "next.config.js": 'module.exports = { output: "export" };\n',
+    });
+
+    expect(detectNextjsStaticExport(projectDirectory)).toBe(true);
+  });
+
+  it("does not detect standalone output: 'standalone'", () => {
+    const projectDirectory = setupProject("standalone", {
+      "next.config.mjs": "export default { output: 'standalone' };\n",
+    });
+
+    expect(detectNextjsStaticExport(projectDirectory)).toBe(false);
+  });
+
+  it("does not detect when output is absent", () => {
+    const projectDirectory = setupProject("absent", {
+      "next.config.cjs": "module.exports = {};\n",
+    });
+
+    expect(detectNextjsStaticExport(projectDirectory)).toBe(false);
+  });
+});

--- a/packages/core/tests/helpers/oxlint-parse-harness.ts
+++ b/packages/core/tests/helpers/oxlint-parse-harness.ts
@@ -16,6 +16,7 @@ export const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo 
   hasTanStackQuery: false,
   nextjsVersion: "15.0.0",
   nextjsMajorVersion: 15,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/is-analyzable-project.test.ts
+++ b/packages/core/tests/is-analyzable-project.test.ts
@@ -18,6 +18,7 @@ const baseProject: ProjectInfo = {
   preactMajorVersion: null,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/oxlint-config-settings.test.ts
+++ b/packages/core/tests/oxlint-config-settings.test.ts
@@ -44,7 +44,7 @@ describe("createOxlintConfig settings", () => {
     expect(config.settings["react-doctor"].shopifyFlashListMajorVersion).toBe(2);
   });
 
-  it("forwards the Next.js static-export boolean when present", () => {
+  it("does not forward server-runtime for static-export Next.js", () => {
     const config = createOxlintConfig({
       pluginPath: "/tmp/plugin.js",
       project: buildProject({
@@ -53,19 +53,31 @@ describe("createOxlintConfig settings", () => {
       }),
     });
 
-    expect(config.settings["react-doctor"].hasNextjsStaticExport).toBe(true);
+    expect(config.settings["react-doctor"].hasServerRuntime).toBeUndefined();
   });
 
-  it("omits the Next.js static-export boolean when absent", () => {
+  it("forwards the derived server-runtime boolean for server-capable projects", () => {
     const config = createOxlintConfig({
       pluginPath: "/tmp/plugin.js",
       project: buildProject({
-        framework: "nextjs",
-        hasNextjsStaticExport: false,
+        framework: "remix",
       }),
     });
 
-    expect(config.settings["react-doctor"]).not.toHaveProperty("hasNextjsStaticExport");
+    expect(config.settings["react-doctor"].hasServerRuntime).toBe(true);
+  });
+
+  it("omits the server-runtime boolean when absent", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: buildProject({
+        framework: "vite",
+        hasNextjsStaticExport: false,
+        hasReactNativeWorkspace: false,
+      }),
+    });
+
+    expect(config.settings["react-doctor"]).not.toHaveProperty("hasServerRuntime");
   });
 
   it("omits the FlashList setting when the dependency is absent or unparseable", () => {

--- a/packages/core/tests/oxlint-config-settings.test.ts
+++ b/packages/core/tests/oxlint-config-settings.test.ts
@@ -16,6 +16,7 @@ const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: true,
   expoVersion: null,
   shopifyFlashListVersion: null,
@@ -41,6 +42,30 @@ describe("createOxlintConfig settings", () => {
     });
 
     expect(config.settings["react-doctor"].shopifyFlashListMajorVersion).toBe(2);
+  });
+
+  it("forwards the Next.js static-export boolean when present", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: buildProject({
+        framework: "nextjs",
+        hasNextjsStaticExport: true,
+      }),
+    });
+
+    expect(config.settings["react-doctor"].hasNextjsStaticExport).toBe(true);
+  });
+
+  it("omits the Next.js static-export boolean when absent", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: buildProject({
+        framework: "nextjs",
+        hasNextjsStaticExport: false,
+      }),
+    });
+
+    expect(config.settings["react-doctor"]).not.toHaveProperty("hasNextjsStaticExport");
   });
 
   it("omits the FlashList setting when the dependency is absent or unparseable", () => {

--- a/packages/core/tests/resolve-lint-include-paths.test.ts
+++ b/packages/core/tests/resolve-lint-include-paths.test.ts
@@ -21,6 +21,7 @@ const nextProject = (rootDirectory: string): ProjectInfo => ({
   hasTanStackQuery: false,
   nextjsVersion: "^16.0.0",
   nextjsMajorVersion: 16,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/run-inspect-security-scan.test.ts
+++ b/packages/core/tests/run-inspect-security-scan.test.ts
@@ -39,6 +39,7 @@ const sampleProject: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -55,6 +55,7 @@ const sampleProject: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/services/linter.test.ts
+++ b/packages/core/tests/services/linter.test.ts
@@ -20,6 +20,7 @@ const sampleProject: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/services/project.test.ts
+++ b/packages/core/tests/services/project.test.ts
@@ -20,6 +20,7 @@ const sampleProject: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/spawn-batches-cascade-bound.test.ts
+++ b/packages/core/tests/spawn-batches-cascade-bound.test.ts
@@ -67,6 +67,7 @@ const project: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/spawn-batches-serial-fallback.test.ts
+++ b/packages/core/tests/spawn-batches-serial-fallback.test.ts
@@ -65,6 +65,7 @@ const project: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/core/tests/spawn-batches.test.ts
+++ b/packages/core/tests/spawn-batches.test.ts
@@ -30,6 +30,7 @@ const project: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.regressions.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noPreventDefault } from "./no-prevent-default.js";
 
-const remixSettings = { "react-doctor": { framework: "remix" } };
-const nextjsSettings = { "react-doctor": { framework: "nextjs" } };
+const remixSettings = { "react-doctor": { framework: "remix", hasServerRuntime: true } };
+const nextjsSettings = { "react-doctor": { framework: "nextjs", hasServerRuntime: true } };
 
 describe("correctness/no-prevent-default regressions", () => {
   describe("href-less anchors (anchor-as-button, mined ant-design Dropdown trigger FP)", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -3,7 +3,10 @@ import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
-import { getReactDoctorStringSetting } from "../../utils/get-react-doctor-setting.js";
+import {
+  getReactDoctorBooleanSetting,
+  getReactDoctorStringSetting,
+} from "../../utils/get-react-doctor-setting.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -301,8 +304,14 @@ export const noPreventDefault = defineRule({
     "Use `<form action>` where your framework supports it (it works without JS), or use a `<button>` instead of an `<a>` with preventDefault.",
   create: (context: RuleContext) => {
     const framework = getReactDoctorStringSetting(context.settings, "framework");
+    const hasNextjsStaticExport = getReactDoctorBooleanSetting(
+      context.settings,
+      "hasNextjsStaticExport",
+    );
     const isServerCapableFramework =
-      framework !== undefined && SERVER_CAPABLE_FRAMEWORKS.has(framework);
+      framework !== undefined &&
+      SERVER_CAPABLE_FRAMEWORKS.has(framework) &&
+      !(framework === "nextjs" && hasNextjsStaticExport);
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -32,17 +32,6 @@ const PREVENT_DEFAULT_ELEMENTS = new Map<string, string[]>([
   ["a", ["onClick"]],
 ]);
 
-// Frameworks that ship a first-class server-mutation story tied to
-// plain `<form>` elements — Next.js Server Actions, TanStack Server
-// Functions, Remix loader/action handlers. Recommending
-// `<form action={serverAction}>` is honest progressive-enhancement
-// advice in these projects. Everywhere else (SPA bundlers, component
-// libraries, Electron shells, unknown classifications) calling
-// `preventDefault()` inside onSubmit IS the canonical controlled-form
-// pattern, so the form variant only fires when the framework is a
-// confirmed member of this set.
-const SERVER_CAPABLE_FRAMEWORKS = new Set<string>(["nextjs", "tanstack-start", "remix"]);
-
 const FORM_MESSAGE_SERVER_CAPABLE =
   "Your users can't submit this <form> without JavaScript because onSubmit calls preventDefault(), so use a server action like `<form action={serverAction}>` to make it work either way.";
 
@@ -304,14 +293,9 @@ export const noPreventDefault = defineRule({
     "Use `<form action>` where your framework supports it (it works without JS), or use a `<button>` instead of an `<a>` with preventDefault.",
   create: (context: RuleContext) => {
     const framework = getReactDoctorStringSetting(context.settings, "framework");
-    const hasNextjsStaticExport = getReactDoctorBooleanSetting(
-      context.settings,
-      "hasNextjsStaticExport",
+    const isServerCapableFramework = Boolean(
+      getReactDoctorBooleanSetting(context.settings, "hasServerRuntime"),
     );
-    const isServerCapableFramework =
-      framework !== undefined &&
-      SERVER_CAPABLE_FRAMEWORKS.has(framework) &&
-      !(framework === "nextjs" && hasNextjsStaticExport);
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-client-side-redirect.ts
@@ -173,6 +173,7 @@ export const nextjsNoClientSideRedirect = defineRule({
   title: "Client-side redirect for navigation",
   tags: ["test-noise"],
   requires: ["nextjs"],
+  disabledBy: ["nextjs:static-export"],
   severity: "warn",
   recommendation:
     "Avoid redirects inside useEffect. Use an event handler, middleware, or server-side redirect (App Router: redirect() from next/navigation; Pages Router: getServerSideProps redirect)",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
@@ -15,6 +15,20 @@ const expectPass = (code: string): void => {
 };
 
 describe("react-builtins/jsx-key — regressions", () => {
+  // Issue #1078 repro: key-before-spread stays valid even when props are spread
+  // afterward.
+  it("stays silent on the issue #1078 checkbox map repro", () =>
+    expectPass(
+      `const Checkboxes = ({className, ...rest}) => (<>{options.map((option) => (<Checkbox key={option.name} label={option.label} name={option.name} {...rest} />))}</>);`,
+    ));
+
+  // Issue #1078 repro: the radio-button variant has the same key-before-spread
+  // shape and must remain silent.
+  it("stays silent on the issue #1078 radio-button map repro", () =>
+    expectPass(
+      `const BaseRadioButtons = ({children, className, classNameLabel, isHorizontal, options, ...props}) => (<CheckboxRadioGroup>{options.map((option) => (<InputRadio key={option.value} className={classNameLabel} option={option} {...props} />))}{children}</CheckboxRadioGroup>);`,
+    ));
+
   // docs-validation 2026-07: the documented hazard (and oxc's
   // `checkKeyMustBeforeSpread`) is `key` placed AFTER a `{...spread}` —
   // key-BEFORE-spread is the documented fix shape and must never fire.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-destructure-result.regressions.test.ts
@@ -3,6 +3,17 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { queryDestructureResult } from "./query-destructure-result.js";
 
 describe("tanstack-query/query-destructure-result — regressions", () => {
+  // Issue #1082 repro: field access should not trigger the query-result
+  // whole-object subscription warning.
+  it("stays silent on the issue #1082 field-access repro", () => {
+    const { diagnostics } = runRule(
+      queryDestructureResult,
+      `import { useQuery } from '@tanstack/react-query';
+function C(){ const query = useQuery({queryKey:['x']}); return <div>{query.data}</div>; }`,
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
   it("stays silent when the result is assigned and consumed field-by-field in render", () => {
     const { diagnostics } = runRule(
       queryDestructureResult,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-react-doctor-setting.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-react-doctor-setting.ts
@@ -48,6 +48,16 @@ export const getReactDoctorNumberSetting = (
     : undefined;
 };
 
+export const getReactDoctorBooleanSetting = (
+  settings: RuleContext["settings"],
+  settingName: string,
+): boolean | undefined => {
+  const bag = readReactDoctorSettingsBag(settings);
+  if (!bag) return undefined;
+  const settingValue = readOwnPropertyValue(bag, settingName);
+  return typeof settingValue === "boolean" ? settingValue : undefined;
+};
+
 export const getReactDoctorStringArraySetting = (
   settings: RuleContext["settings"],
   settingName: string,

--- a/packages/react-doctor/tests/build-json-report.test.ts
+++ b/packages/react-doctor/tests/build-json-report.test.ts
@@ -16,6 +16,7 @@ const SAMPLE_PROJECT: ProjectInfo = {
   hasTanStackQuery: false,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -32,6 +32,7 @@ const projectInfo: ProjectInfo = {
   preactMajorVersion: null,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/build-sentry-project-context.test.ts
+++ b/packages/react-doctor/tests/build-sentry-project-context.test.ts
@@ -22,6 +22,7 @@ const projectInfo: ProjectInfo = {
   preactMajorVersion: null,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/build-sentry-scope.test.ts
+++ b/packages/react-doctor/tests/build-sentry-scope.test.ts
@@ -44,6 +44,7 @@ const projectInfo: ProjectInfo = {
   preactMajorVersion: null,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/explicit-lint-include-paths.test.ts
+++ b/packages/react-doctor/tests/explicit-lint-include-paths.test.ts
@@ -37,6 +37,7 @@ describe("computeExplicitLintIncludePaths", () => {
       hasTanStackQuery: false,
       nextjsVersion: "^16.0.0",
       nextjsMajorVersion: 16,
+      hasNextjsStaticExport: false,
       hasReactNativeWorkspace: false,
       expoVersion: null,
       shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/github-action-comment.test.ts
+++ b/packages/react-doctor/tests/github-action-comment.test.ts
@@ -31,6 +31,7 @@ const buildProject = (overrides: Partial<ProjectInfo> = {}): ProjectInfo => ({
   preactMajorVersion: null,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
+++ b/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
@@ -66,6 +66,7 @@ vi.mock("../src/inspect.js", () => ({
         hasTanStackQuery: false,
         nextjsVersion: null,
         nextjsMajorVersion: null,
+        hasNextjsStaticExport: false,
         hasReactNativeWorkspace: false,
         expoVersion: null,
         shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/regressions/_helpers.ts
+++ b/packages/react-doctor/tests/regressions/_helpers.ts
@@ -115,6 +115,7 @@ export interface CollectRuleHitsOptions {
   framework?: ProjectInfo["framework"];
   hasReactCompiler?: boolean;
   hasTanStackQuery?: boolean;
+  hasNextjsStaticExport?: boolean;
 }
 
 export interface BuildTestProjectOptions {
@@ -128,6 +129,7 @@ export interface BuildTestProjectOptions {
   tailwindVersion?: string | null;
   nextjsVersion?: string | null;
   nextjsMajorVersion?: number | null;
+  hasNextjsStaticExport?: boolean;
   shopifyFlashListVersion?: string | null;
   shopifyFlashListMajorVersion?: number | null;
 }
@@ -166,6 +168,7 @@ export const buildTestProject = (options: BuildTestProjectOptions): ProjectInfo 
     hasTanStackQuery: options.hasTanStackQuery ?? false,
     nextjsVersion,
     nextjsMajorVersion,
+    hasNextjsStaticExport: options.hasNextjsStaticExport ?? false,
     hasReactNativeWorkspace: framework === "expo" || framework === "react-native",
     expoVersion: framework === "expo" ? "~51.0.0" : null,
     shopifyFlashListVersion: options.shopifyFlashListVersion ?? null,

--- a/packages/react-doctor/tests/regressions/rn-package-scoping.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-package-scoping.test.ts
@@ -1464,6 +1464,7 @@ describe("inverted monorepo: web-rooted project with an RN workspace still loads
         ...buildTestProject({ rootDirectory: projectDir, framework: "nextjs" }),
         nextjsVersion: null,
         nextjsMajorVersion: null,
+        hasNextjsStaticExport: false,
         hasReactNativeWorkspace: true,
       },
     });

--- a/packages/react-doctor/tests/regressions/rule-messages.test.ts
+++ b/packages/react-doctor/tests/regressions/rule-messages.test.ts
@@ -12,6 +12,7 @@
  *                router type: Pages Router users should NOT be told to
  *                use `next/navigation` (which they don't have access to);
  *                App Router users SHOULD see that suggestion.
+ *   #976 — static export Next.js must not get server-action advice.
  */
 
 import * as fs from "node:fs";
@@ -138,6 +139,76 @@ export const AppGuard = () => {
     );
     expect(appIssue, "expected a diagnostic on app/guard.tsx").toBeDefined();
     expect(appIssue?.message).toContain("flashes the wrong page before redirecting");
+  });
+});
+
+describe("issue #976: Next.js static export gates server-only recommendations", () => {
+  const setupStaticExportProject = (caseId: string, outputExport: boolean): string =>
+    setupReactProject(tempRoot, caseId, {
+      packageJsonExtras: {
+        dependencies: { next: "^15.0.0", react: "^19.0.0", "react-dom": "^19.0.0" },
+      },
+      files: {
+        "next.config.ts": `import type { NextConfig } from 'next';
+const nextConfig: NextConfig = ${outputExport ? `{ output: 'export' }` : `{}`};
+export default nextConfig;
+`,
+        "src/app/guard.tsx": `"use client";
+import { useEffect } from "react";
+declare const router: { replace: (path: string) => void };
+export const AuthGuard = () => {
+  useEffect(() => {
+    router.replace("/login");
+  }, []);
+  return null;
+};
+`,
+        "src/app/form.tsx": `"use client";
+declare const mut: { mutate: () => void };
+export const ContactForm = () => {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        mut.mutate();
+      }}
+    >
+      <button type="submit">Send</button>
+    </form>
+  );
+};
+`,
+      },
+    });
+
+  it("stays silent on static-export Next.js for server-only recommendations", async () => {
+    const projectDir = setupStaticExportProject("issue-976-static-export", true);
+    const { discoverProject } = await import("@react-doctor/core");
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: discoverProject(projectDir),
+    });
+
+    expect(
+      diagnostics.filter((diagnostic) => diagnostic.rule === "nextjs-no-client-side-redirect"),
+    ).toHaveLength(0);
+    expect(
+      diagnostics.filter((diagnostic) => diagnostic.rule === "no-prevent-default"),
+    ).toHaveLength(0);
+  });
+
+  it("still flags the same code when Next.js is not static-export", async () => {
+    const projectDir = setupStaticExportProject("issue-976-non-static", false);
+    const { discoverProject } = await import("@react-doctor/core");
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDir,
+      project: discoverProject(projectDir),
+    });
+
+    expect(
+      diagnostics.some((diagnostic) => diagnostic.rule === "nextjs-no-client-side-redirect"),
+    ).toBe(true);
+    expect(diagnostics.some((diagnostic) => diagnostic.rule === "no-prevent-default")).toBe(true);
   });
 });
 

--- a/packages/react-doctor/tests/run-oxlint/nextjs.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/nextjs.test.ts
@@ -231,6 +231,7 @@ describe("runOxlint", () => {
           framework: "nextjs",
           nextjsVersion: "^14.2.0",
           nextjsMajorVersion: 14,
+          hasNextjsStaticExport: false,
         }),
       });
       const hits = diagnostics.filter(

--- a/packages/react-doctor/tests/scan-result-cache.test.ts
+++ b/packages/react-doctor/tests/scan-result-cache.test.ts
@@ -92,6 +92,7 @@ const basePayload = (
     hasTanStackQuery: false,
     nextjsVersion: null,
     nextjsMajorVersion: null,
+    hasNextjsStaticExport: false,
     hasReactNativeWorkspace: false,
     expoVersion: null,
     shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/to-json-report.test.ts
+++ b/packages/react-doctor/tests/to-json-report.test.ts
@@ -32,6 +32,7 @@ const buildDiagnoseResult = (): DiagnoseResult => ({
     hasTanStackQuery: false,
     nextjsVersion: null,
     nextjsMajorVersion: null,
+    hasNextjsStaticExport: false,
     hasReactNativeWorkspace: false,
     expoVersion: null,
     shopifyFlashListVersion: null,

--- a/packages/react-doctor/tests/with-sentry-run-span.test.ts
+++ b/packages/react-doctor/tests/with-sentry-run-span.test.ts
@@ -27,6 +27,7 @@ const projectInfo: ProjectInfo = {
   preactMajorVersion: null,
   nextjsVersion: null,
   nextjsMajorVersion: null,
+  hasNextjsStaticExport: false,
   hasReactNativeWorkspace: false,
   expoVersion: null,
   shopifyFlashListVersion: null,


### PR DESCRIPTION
## Summary

Fixes #976. Under `output: "export"` (Next.js static export) there is no server, no middleware, and no Server Actions, so rules that recommend server-side fixes are unactionable. This adds a `nextjs:static-export` capability and gates those rules — mirroring the React-Compiler (#669/#672) and pre-ES2023 (#750/#753) capability precedents.

Detection → ProjectInfo → gate:

```
detectNextjsStaticExport(dir)   // scans next.config.{js,mjs,ts,cjs} for output: "export"
  → ProjectInfo.hasNextjsStaticExport (only when framework === "nextjs")
  → buildCapabilities(): capabilities.add("nextjs:static-export")
```

Two mechanisms, because the two affected rules differ:

- **`nextjs-no-client-side-redirect`** → `disabledBy: ["nextjs:static-export"]`. Its entire recommendation set (server `redirect()`, middleware) is impossible without a server, so the rule is fully gated. This is the same capability + `disabledBy` shape used for React-Compiler gating.
- **`no-prevent-default`** → must keep running (it also flags anchors and other frameworks), so it can't be `disabledBy`. Instead the `hasNextjsStaticExport` boolean is forwarded into the `react-doctor` settings bag and read via a new `getReactDoctorBooleanSetting`; a static-export Next.js project is treated as **not** server-capable so the `<form action={serverAction}>` branch is skipped while the anchor variant is unchanged:

  ```ts
  const isServerCapableFramework =
    framework !== undefined &&
    SERVER_CAPABLE_FRAMEWORKS.has(framework) &&
    !(framework === "nextjs" && hasNextjsStaticExport);
  ```

Also locks two already-fixed false positives with the reporters' verbatim repros as regression tests, so they can't regress:

- **#1082** (`query-destructure-result`): `const query = useQuery(...); return <div>{query.data}</div>` — field access must stay silent (only whole-object spread / rest-destructuring should warn).
- **#1078** (`jsx-key`): `key` placed before a typed `{...rest}` / `{...props}` spread on a rest parameter must stay silent.

Both were verified to already produce zero diagnostics on `main`; the added tests pin that behavior.

## What changed

- New `detectNextjsStaticExport` detector + `ProjectInfo.hasNextjsStaticExport` (only set for Next.js projects).
- `buildCapabilities` adds `nextjs:static-export`; `createOxlintConfig` forwards the boolean into rule settings; new `getReactDoctorBooleanSetting` helper.
- `nextjs-no-client-side-redirect`: `disabledBy: ["nextjs:static-export"]`.
- `no-prevent-default`: static-export Next.js treated as non-server-capable (form/Server-Action recommendation skipped; anchor variant unchanged).
- Tests: detector unit tests, capability test, end-to-end regressions (static-export silences both rules; non-static-export still flags both), plus #1082/#1078 regression locks. Mechanical `ProjectInfo` fixture updates for the new field.
- Changeset (`patch`) for `react-doctor`, `@react-doctor/core`, `oxlint-plugin-react-doctor`.

## Test plan

- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — pass.
- `@react-doctor/core` (1248), `oxlint-plugin-react-doctor` (10851), `react-doctor` suites — pass. Only the known VM-only `install-agent-hooks` test fails locally (passes in CI).


Link to Devin session: https://app.devin.ai/sessions/c160968b37b54afda432efb993ebd19c
Requested by: @aidenybai

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted capability and settings gating for static-export Next.js with broad regression coverage; no auth or data-path changes.
> 
> **Overview**
> Fixes false positives for Next.js **`output: "export"`** projects (#976) by treating static export as having **no server runtime**, so recommendations that depend on middleware, server redirects, or Server Actions are not shown.
> 
> **Detection and capabilities:** A new detector reads `next.config.{js,mjs,ts,cjs}` for `output: 'export'`, sets **`ProjectInfo.hasNextjsStaticExport`**, and **`buildCapabilities`** adds **`nextjs:static-export`** while omitting **`server-runtime`** for static-export Next.js (Remix/TanStack Start still get **`server-runtime`**).
> 
> **Rule gating:** **`nextjs-no-client-side-redirect`** is fully disabled via **`disabledBy: ["nextjs:static-export"]`**. **`no-prevent-default`** still runs for anchors and other cases but skips the Server Action / `<form action>` advice when oxlint settings omit **`hasServerRuntime`** (static export and non-server frameworks). Core forwards **`hasServerRuntime: true`** only for server-capable, non–static-export projects; the plugin reads it through a new **`getReactDoctorBooleanSetting`** helper instead of inferring from framework name alone.
> 
> **Tests:** Unit tests for detection and capabilities, oxlint settings wiring, end-to-end #976 regressions, and **`jsx-key`** repro locks for #1078 (`key` before `{...rest}` stays valid).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11bb8321bfc38869edf1a3e18b3ad30d417ade22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->