### PR TITLE
RB-COMP-FIX: rerender-lazy-ref/state-init — exempt trivial empty-container constructors

### DIFF
--- a/.changeset/lazy-ref-init-trivial-containers.md
+++ b/.changeset/lazy-ref-init-trivial-containers.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`rerender-lazy-ref-init` no longer flags trivial empty-container constructors — `useRef(new Set())` / `new Map()` / `new WeakSet()` / `new WeakMap()` / `new AbortController()` cost about as much as the already-exempt coercion helpers, so recommending the lazy null-check ceremony for them was net-negative. The exemption list is now the shared `TRIVIAL_CONSTRUCTOR_NAMES` constant consumed by both `rerender-lazy-ref-init` and `rerender-lazy-state-init` (which also gains `WeakRef`). User-defined class constructors (`useRef(new HeavyModel(config))`) still fire.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -53,6 +53,26 @@ export const TRIVIAL_INITIALIZER_NAMES = new Set([
   "parseFloat",
 ]);
 
+// Constructing these built-ins costs about as much as calling the
+// trivial coercion functions — `useState(new Date())` / `useRef(new
+// Map())` are idiomatic cheap initial values, not the expensive-model
+// construction the lazy-init rules target. Recommending the lazy-init
+// pattern for an empty container is net-negative ceremony. Shared by
+// `rerender-lazy-state-init` and `rerender-lazy-ref-init`.
+export const TRIVIAL_CONSTRUCTOR_NAMES: ReadonlySet<string> = new Set([
+  "Date",
+  "Map",
+  "Set",
+  "WeakMap",
+  "WeakSet",
+  "WeakRef",
+  "RegExp",
+  "Error",
+  "URL",
+  "URLSearchParams",
+  "AbortController",
+]);
+
 // Used by `noDerivedStateEffect` to decide whether a derived-state
 // expression is "expensive enough" to recommend `useMemo` over plain
 // inline computation. Coercion / parsing / boundary helpers are cheap

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.test.ts
@@ -88,46 +88,56 @@ describe("rerender-lazy-ref-init", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("flags useRef with `new AbortController()` (allocation discarded after first render)", () => {
+  it("does NOT flag trivial empty-container constructors (lazy-init is net-negative for them)", () => {
     const result = runRule(
       rerenderLazyRefInit,
       `
       import { useRef } from "react";
 
       function Component() {
-        const ref = useRef(new AbortController());
+        const cache = useRef(new Map());
+        const seen = useRef(new Set());
+        const weakSeen = useRef(new WeakSet());
+        const weakById = useRef(new WeakMap());
+        const controller = useRef(new AbortController());
+      }
+    `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does NOT flag `new Set(props.items)` — the exemption is name-based, construction stays cheap relative to the lazy-ref ceremony", () => {
+    const result = runRule(
+      rerenderLazyRefInit,
+      `
+      import { useRef } from "react";
+
+      function Component({ items }) {
+        const seen = useRef(new Set(items));
+      }
+    `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a user-defined class constructor", () => {
+    const result = runRule(
+      rerenderLazyRefInit,
+      `
+      import { useRef } from "react";
+      import { HeavyModel } from "./model";
+
+      function Component({ config }) {
+        const model = useRef(new HeavyModel(config));
       }
     `,
     );
 
     expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0].message).toContain("new AbortController()");
-  });
-
-  it("flags useRef with a `new Map()` / `new Set()` initializer", () => {
-    const mapResult = runRule(
-      rerenderLazyRefInit,
-      `
-      import { useRef } from "react";
-
-      function Component() {
-        const cache = useRef(new Map());
-      }
-    `,
-    );
-    const setResult = runRule(
-      rerenderLazyRefInit,
-      `
-      import { useRef } from "react";
-
-      function Component() {
-        const seen = useRef(new Set());
-      }
-    `,
-    );
-
-    expect(mapResult.diagnostics).toHaveLength(1);
-    expect(setResult.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new HeavyModel()");
   });
 
   it("does NOT flag useRef capturing another hook's value", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.ts
@@ -1,4 +1,4 @@
-import { TRIVIAL_INITIALIZER_NAMES } from "../../constants/react.js";
+import { TRIVIAL_CONSTRUCTOR_NAMES, TRIVIAL_INITIALIZER_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
@@ -23,9 +23,12 @@ import type { RuleContext } from "../../utils/rule-context.js";
 //   - `useRef(new Callee())`     — `new` expression (the class case)
 //
 // Both allocate fresh per render and lose the allocation immediately
-// after the first render. The `new AbortController()` / `new Map()` /
-// `new Set()` patterns are the most common production occurrences of
-// this bug and are exactly what the rule should catch.
+// after the first render — but only EXPENSIVE construction is worth the
+// lazy-init ceremony. Empty-container built-ins (`new Set()`,
+// `new Map()`, `new AbortController()`, …) cost about as much as the
+// trivial coercion helpers, so recommending the null-check pattern for
+// them is net-negative; they're exempt via TRIVIAL_CONSTRUCTOR_NAMES
+// (shared with `rerender-lazy-state-init`).
 //
 // LIMITATIONS:
 //   - Doesn't try to follow identifier bindings (`const init = expensiveCall();
@@ -62,6 +65,7 @@ export const rerenderLazyRefInit = defineRule({
         : (memberPropertyName ?? "fn");
 
       if (TRIVIAL_INITIALIZER_NAMES.has(calleeName)) return;
+      if (isNewCall && TRIVIAL_CONSTRUCTOR_NAMES.has(calleeName)) return;
 
       // `useRef(useId())` / `useRef(useContext(Ctx))` captures another
       // hook's value. The result is already stable per the rules of

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.regressions.test.ts
@@ -148,6 +148,21 @@ describe("rerender-lazy-state-init — regressions", () => {
           const [when, setWhen] = useState(new Date());
           const [seen, setSeen] = useState(new Set());
           const [byId, setById] = useState(new Map());
+          const [weakSeen, setWeakSeen] = useState(new WeakSet());
+          const [weakById, setWeakById] = useState(new WeakMap());
+          const [controller, setController] = useState(new AbortController());
+          return null;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent on an already-lazy empty-container initializer", () => {
+      const result = runRule(
+        rerenderLazyStateInit,
+        `function C() {
+          const [byId, setById] = useState(() => new Map());
           return null;
         }`,
       );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
@@ -1,4 +1,4 @@
-import { TRIVIAL_INITIALIZER_NAMES } from "../../constants/react.js";
+import { TRIVIAL_CONSTRUCTOR_NAMES, TRIVIAL_INITIALIZER_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
@@ -31,23 +31,6 @@ const TRIVIAL_DATE_GETTER_NAMES: ReadonlySet<string> = new Set([
   "getUTCSeconds",
   "getUTCMilliseconds",
   "valueOf",
-]);
-
-// Constructing these built-ins costs about as much as calling the
-// trivial coercion functions — `useState(new Date())` / `useState(new
-// Map())` are idiomatic cheap initial states, not the expensive-model
-// construction this rule targets.
-const TRIVIAL_CONSTRUCTOR_NAMES: ReadonlySet<string> = new Set([
-  "Date",
-  "Map",
-  "Set",
-  "WeakMap",
-  "WeakSet",
-  "RegExp",
-  "Error",
-  "URL",
-  "URLSearchParams",
-  "AbortController",
 ]);
 
 const EAGER_CALL_RESOLUTION_DEPTH_LIMIT = 4;


### PR DESCRIPTION
## Why

`rerender-lazy-ref-init` and `rerender-lazy-state-init` flagged cheap empty-container constructors like `useRef(new Set())` and `useState(new Map())`, recommending a lazy-init wrapper that costs more than it saves — allocating an empty `Set`/`Map` is as cheap as the arrow function the rule would have you write.

Before (flagged):

```tsx
const seenIds = useRef(new Set());
const [cache, setCache] = useState(new Map());
```

After: exempt. Constructions of user-defined classes and member-expression callees still fire:

```tsx
// still flagged: real work on every render
const [index, setIndex] = useState(buildSearchIndex(rows));
const parser = useRef(new ExpensiveParser(grammar));
```

## What changed

- `Map`, `Set`, `WeakMap`, `WeakSet`, `WeakRef`, `Date`, `RegExp`, `Error`, and `AbortController` form a shared `TRIVIAL_CONSTRUCTOR_NAMES` exemption in `constants/react.ts`, consumed by both `rerender-lazy-ref-init` and `rerender-lazy-state-init` for `new`-call initializers.
- Regression tests cover both directions (trivial built-in constructors exempt; user-defined constructors and function-call initializers still fire).
- Changeset included.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/state-and-effects/rerender-lazy`
- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- Full plugin suite green locally.