### PR TITLE
RB-COMP-FIX: only-export-components — align with the real Fast Refresh constraint

### DIFF
--- a/.changeset/only-export-components-exports-only-model.md
+++ b/.changeset/only-export-components-exports-only-model.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`only-export-components` is re-derived against the actual react-refresh boundary constraint, which is about exports only: a module that exports a component must export only components / allowed constants. Non-exported internal components are no longer reported (react-refresh registers them fine, and "export this component" was the wrong advice for config/registry files that merely use a local component). The previously-missed real breaker is now detected: a namespace-object export that bundles components (`export const Pages = { Home, sidebarWidth: 240 }` / `export default { Home, helpers }`) fails the boundary check for the whole module and is reported.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
@@ -91,13 +91,26 @@ export const DIVERGENCES: Record<string, OxcDivergence> = {
     reason: "Intentional: default max raised from 2 → 10 to suppress idiomatic-React FPs.",
   },
   "only-export-components": {
-    // OXC defaults `allowConstantExport: false`, which flags any
-    // primitive-constant export alongside a component. We default
-    // `allowConstantExport: true` because exported constants are
-    // stable references that don't break Fast Refresh — matches the
-    // recommended config in `eslint-plugin-react-refresh`.
-    failSkips: [3, 4, 10, 14],
-    reason: "Intentional: default allowConstantExport=true to suppress shadcn-style FPs.",
+    // Two intentional divergences:
+    // (1) fail[3, 4, 10, 14] — OXC defaults `allowConstantExport: false`,
+    //     which flags any primitive-constant export alongside a
+    //     component. We default `allowConstantExport: true` because
+    //     exported constants are stable references that don't break Fast
+    //     Refresh — matches the recommended config in
+    //     `eslint-plugin-react-refresh`.
+    // (2) fail[12, 13, 21] — non-exported internal components are no
+    //     longer reported. The react-refresh boundary constraint is
+    //     about exports only (a module that exports a component must
+    //     export only components); a module whose exports carry no
+    //     component was never a refresh boundary, and "export this
+    //     component" is the wrong advice for config/registry files that
+    //     merely USE a local component (`export const tabs = [<Tab/>]`).
+    //     The real breaker — a namespace-object export bundling
+    //     components — is reported instead (not covered by OXC fixtures;
+    //     see only-export-components.regressions.test.ts).
+    failSkips: [3, 4, 10, 14, 12, 13, 21],
+    reason:
+      "Intentional: default allowConstantExport=true; exports-only Fast-Refresh model (local components unreported, namespace-object exports flagged).",
   },
   "jsx-pascal-case": {
     // OXC defaults `allowLeadingUnderscore: false`. We default to

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -318,6 +318,130 @@ describe("react-builtins/only-export-components — regressions", () => {
     expect(result.diagnostics[0].message).toContain("bundles components inside an object");
   });
 
+  // PR #1093 review: HoC results stored as object properties are
+  // components too — `{ Header: memo(() => …) }` bundles a component
+  // exactly like `{ Header: () => … }` does.
+  it("flags a namespace-object export whose component properties are HoC-wrapped", () => {
+    const hocNamespaceFile = `
+      import { memo } from "react";
+      export const Layout = { Header: memo(() => <header />), gutter: 12 };
+    `;
+    const result = runRule(onlyExportComponents, hocNamespaceFile, {
+      filename: "src/layout-parts.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("bundles components inside an object");
+  });
+
+  it("flags a default namespace-object export whose only component is HoC-wrapped", () => {
+    const hocDefaultFile = `
+      import { forwardRef } from "react";
+      export default { Body: forwardRef((props, ref) => <div ref={ref} />) };
+    `;
+    const result = runRule(onlyExportComponents, hocDefaultFile, {
+      filename: "src/body-parts.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("bundles components inside an object");
+  });
+
+  it("does not flag object properties whose calls are not HoCs", () => {
+    const factoryObjectFile = `
+      const createHeader = () => ({ height: 48 });
+      export const layout = { Header: createHeader(), gutter: 12 };
+    `;
+    const result = runRule(onlyExportComponents, factoryObjectFile, {
+      filename: "src/layout-config.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an HoC-valued property under a non-component key", () => {
+    const camelCaseKeyFile = `
+      import { memo } from "react";
+      export const registry = { headerRenderer: memo(() => <header />) };
+    `;
+    const result = runRule(onlyExportComponents, camelCaseKeyFile, {
+      filename: "src/header-registry.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  // PR #1093 review: module-scope class components must join the locals
+  // set so `export const Pages = { Home }` after `class Home extends
+  // Component` is recognized as a namespace-object bundling a component.
+  it("flags a namespace-object export referencing a local class component", () => {
+    const classNamespaceFile = `
+      import React from "react";
+      class Home extends React.Component {
+        render() {
+          return <div>Home</div>;
+        }
+      }
+      export const Pages = { Home, sidebarWidth: 240 };
+    `;
+    const result = runRule(onlyExportComponents, classNamespaceFile, {
+      filename: "src/pages-class.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("bundles components inside an object");
+  });
+
+  it("flags a default namespace-object export referencing a local class component", () => {
+    const classDefaultFile = `
+      import { Component } from "react";
+      class Home extends Component {
+        render() {
+          return <div>Home</div>;
+        }
+      }
+      export default { Home };
+    `;
+    const result = runRule(onlyExportComponents, classDefaultFile, {
+      filename: "src/pages-class-default.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("bundles components inside an object");
+  });
+
+  it("flags a namespace-object export referencing a class-expression component", () => {
+    const classExpressionFile = `
+      import React from "react";
+      const Home = class extends React.PureComponent {
+        render() {
+          return <div>Home</div>;
+        }
+      };
+      export const Pages = { Home };
+    `;
+    const result = runRule(onlyExportComponents, classExpressionFile, {
+      filename: "src/pages-class-expression.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("bundles components inside an object");
+  });
+
+  it("does not treat non-React classes as bundled components", () => {
+    const plainClassFile = `
+      class HomeStore {
+        state = {};
+      }
+      export const stores = { HomeStore };
+    `;
+    const result = runRule(onlyExportComponents, plainClassFile, {
+      filename: "src/home-stores.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a plain config-object export without components", () => {
     const plainObjectFile = `
       export const ProfileCard = () => <div>Profile</div>;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -252,14 +252,88 @@ describe("react-builtins/only-export-components — regressions", () => {
     }
   });
 
-  it("still flags module-scope local components", () => {
+  // Exports-only Fast-Refresh model: react-refresh's boundary check only
+  // looks at what a module EXPORTS. Non-exported internal components are
+  // fine; the real breaker is an export whose value is an object that
+  // bundles components with (or without) other values.
+  it("does not flag non-exported module-scope components", () => {
     const moduleScopeFile = `
       const Widget = () => <div />;
     `;
     const result = runRule(onlyExportComponents, moduleScopeFile, {
       filename: "src/widget.tsx",
     });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a config file that merely uses a local component in an exported value", () => {
+    const configFile = `
+      const Tab = () => <div />;
+      export const tabs = [<Tab />, <Tab />];
+    `;
+    const result = runRule(onlyExportComponents, configFile, {
+      filename: "src/tabs-config.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a named namespace-object export that bundles components with non-components", () => {
+    const namespaceFile = `
+      const Home = () => <div>Home</div>;
+      const About = () => <div>About</div>;
+      export const Pages = { Home, About, sidebarWidth: 240 };
+    `;
+    const result = runRule(onlyExportComponents, namespaceFile, {
+      filename: "src/pages-namespace.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("bundles components inside an object");
+  });
+
+  it("flags a default namespace-object export carrying components", () => {
+    const namespaceDefaultFile = `
+      const Home = () => <div>Home</div>;
+      const formatTitle = (title) => title.trim();
+      export default { Home, formatTitle };
+    `;
+    const result = runRule(onlyExportComponents, namespaceDefaultFile, {
+      filename: "src/pages-default.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("bundles components inside an object");
+  });
+
+  it("flags a namespace-object export with an inline PascalCase component property", () => {
+    const inlineNamespaceFile = `
+      export const Widgets = { Header: () => <header />, footerHeight: 64 };
+    `;
+    const result = runRule(onlyExportComponents, inlineNamespaceFile, {
+      filename: "src/widgets.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("bundles components inside an object");
+  });
+
+  it("does not flag a plain config-object export without components", () => {
+    const plainObjectFile = `
+      export const ProfileCard = () => <div>Profile</div>;
+      export const Home = () => <div>Home</div>;
+    `;
+    const configOnlyFile = `
+      export const theme = { primary: "#333", spacing: 8 };
+    `;
+    for (const [code, filename] of [
+      [plainObjectFile, "src/profile.tsx"],
+      [configOnlyFile, "src/theme-config.tsx"],
+    ]) {
+      const result = runRule(onlyExportComponents, code, { filename });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    }
   });
 
   it("still flags non-component exports in ordinary component files", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -203,12 +203,21 @@ const objectExpressionBundlesComponents = (
       if (state.localComponentNames.has(value.name)) return true;
       continue;
     }
-    if (
-      (isNodeOfType(value, "ArrowFunctionExpression") ||
-        isNodeOfType(value, "FunctionExpression")) &&
+    const hasComponentNamedKey =
       !property.computed &&
       isNodeOfType(property.key as EsTreeNode, "Identifier") &&
-      isReactComponentName((property.key as EsTreeNodeOfType<"Identifier">).name)
+      isReactComponentName((property.key as EsTreeNodeOfType<"Identifier">).name);
+    if (!hasComponentNamedKey) continue;
+    if (
+      isNodeOfType(value, "ArrowFunctionExpression") ||
+      isNodeOfType(value, "FunctionExpression")
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(value, "CallExpression") &&
+      isHocCallee(value.callee as EsTreeNode, state) &&
+      value.arguments.length > 0
     ) {
       return true;
     }
@@ -325,7 +334,11 @@ const collectRelevantNodes = (programRoot: EsTreeNode): RelevantNodes => {
       childType === "ExportNamedDeclaration"
     ) {
       exportNodes.push(child);
-    } else if (childType === "FunctionDeclaration" || childType === "VariableDeclarator") {
+    } else if (
+      childType === "FunctionDeclaration" ||
+      childType === "VariableDeclarator" ||
+      childType === "ClassDeclaration"
+    ) {
       componentCandidates.push(child);
     }
   });
@@ -471,10 +484,21 @@ export const onlyExportComponents = defineRule({
               localComponentNames.add(child.id.name);
             }
           }
-          if (isNodeOfType(child, "VariableDeclarator") && isNodeOfType(child.id, "Identifier")) {
+          if (isNodeOfType(child, "ClassDeclaration") && child.id) {
             if (
               isReactComponentName(child.id.name) &&
-              canBeReactFunctionComponent(child.init as EsTreeNode | null | undefined, state) &&
+              isEs6Component(child) &&
+              !isInsideFunctionScope(child)
+            ) {
+              localComponentNames.add(child.id.name);
+            }
+          }
+          if (isNodeOfType(child, "VariableDeclarator") && isNodeOfType(child.id, "Identifier")) {
+            const initializer = child.init as EsTreeNode | null | undefined;
+            if (
+              isReactComponentName(child.id.name) &&
+              (canBeReactFunctionComponent(initializer, state) ||
+                (initializer ? isEs6Component(skipTsExpression(initializer)) : false)) &&
               !isInsideFunctionScope(child)
             ) {
               localComponentNames.add(child.id.name);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -25,10 +25,8 @@ const EXPORT_ALL_MESSAGE =
   "`export *` hides what's exported, so Fast Refresh can't safely preserve component state.";
 const REACT_CONTEXT_MESSAGE =
   "This file exports a context with components, so Fast Refresh can't safely preserve component state.";
-const LOCAL_COMPONENT_MESSAGE =
-  "This component is not exported, so Fast Refresh skips it and local edits can full-reload.";
-const NO_EXPORT_MESSAGE =
-  "This file exports nothing, so Fast Refresh can't track the component and local edits can full-reload.";
+const NAMESPACE_OBJECT_MESSAGE =
+  "This export bundles components inside an object, so Fast Refresh can't track them and falls back to a full reload.";
 
 interface OnlyExportComponentsSettings {
   allowExportNames?: ReadonlyArray<string>;
@@ -75,7 +73,8 @@ type ExportType =
   | { kind: "react-component" }
   | { kind: "non-component"; reportNode: EsTreeNode }
   | { kind: "allowed" }
-  | { kind: "react-context"; reportNode: EsTreeNode };
+  | { kind: "react-context"; reportNode: EsTreeNode }
+  | { kind: "namespace-object"; reportNode: EsTreeNode };
 
 const isReactCreateContext = (initializer: EsTreeNode | null | undefined): boolean => {
   if (!initializer) return false;
@@ -117,6 +116,9 @@ interface AnalyzerState {
   customHocs: ReadonlySet<string>;
   allowExportNames: ReadonlySet<string>;
   allowConstantExport: boolean;
+  // Module-scope component binding names — used to spot a component
+  // reference smuggled inside a namespace-object export.
+  localComponentNames: ReadonlySet<string>;
 }
 
 const isReactHocName = (name: string, state: AnalyzerState): boolean => state.customHocs.has(name);
@@ -180,6 +182,36 @@ const isReactComponentInitializer = (expression: EsTreeNode, state: AnalyzerStat
     stripped.arguments.length > 0
   ) {
     return true;
+  }
+  return false;
+};
+
+// The real Fast-Refresh breaker react-refresh checks for: a module whose
+// export is a plain OBJECT that carries components among its properties
+// (`export const Pages = { Home, sidebarWidth: 240 }` / `export default
+// { Home, helpers }`). The export itself is not a component function, so
+// `isReactRefreshBoundary` rejects the whole module and every component
+// reached through the object full-reloads on edit.
+const objectExpressionBundlesComponents = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+  state: AnalyzerState,
+): boolean => {
+  for (const property of objectExpression.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) continue;
+    const value = skipTsExpression(property.value as EsTreeNode);
+    if (isNodeOfType(value, "Identifier")) {
+      if (state.localComponentNames.has(value.name)) return true;
+      continue;
+    }
+    if (
+      (isNodeOfType(value, "ArrowFunctionExpression") ||
+        isNodeOfType(value, "FunctionExpression")) &&
+      !property.computed &&
+      isNodeOfType(property.key as EsTreeNode, "Identifier") &&
+      isReactComponentName((property.key as EsTreeNodeOfType<"Identifier">).name)
+    ) {
+      return true;
+    }
   }
   return false;
 };
@@ -258,6 +290,12 @@ const classifyExport = (
         return { kind: "react-context", reportNode };
       }
       return { kind: "non-component", reportNode };
+    }
+    if (
+      isNodeOfType(stripped, "ObjectExpression") &&
+      objectExpressionBundlesComponents(stripped, state)
+    ) {
+      return { kind: "namespace-object", reportNode };
     }
     if (NOT_REACT_COMPONENT_EXPRESSION_TYPES.has(stripped.type)) {
       return { kind: "non-component", reportNode };
@@ -411,21 +449,42 @@ export const onlyExportComponents = defineRule({
   category: "Architecture",
   create: (context) => {
     const settings = resolveSettings(context.settings);
-    const state: AnalyzerState = {
-      customHocs: new Set([...DEFAULT_REACT_HOCS, ...settings.customHOCs]),
-      allowExportNames: new Set(settings.allowExportNames),
-      allowConstantExport: settings.allowConstantExport,
-    };
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
         const filename = normalizeFilename(context.filename ?? "");
         if (!isFileNameAllowed(filename, settings.checkJS)) return;
         const { exportNodes, componentCandidates } = collectRelevantNodes(node as EsTreeNode);
 
+        // Module-scope component bindings (exported or not) — a component
+        // declared inside another function is never a Fast Refresh
+        // boundary, so only top-level names participate.
+        const localComponentNames = new Set<string>();
+        const state: AnalyzerState = {
+          customHocs: new Set([...DEFAULT_REACT_HOCS, ...settings.customHOCs]),
+          allowExportNames: new Set(settings.allowExportNames),
+          allowConstantExport: settings.allowConstantExport,
+          localComponentNames,
+        };
+        for (const child of componentCandidates) {
+          if (isNodeOfType(child, "FunctionDeclaration") && child.id) {
+            if (isReactComponentName(child.id.name) && !isInsideFunctionScope(child)) {
+              localComponentNames.add(child.id.name);
+            }
+          }
+          if (isNodeOfType(child, "VariableDeclarator") && isNodeOfType(child.id, "Identifier")) {
+            if (
+              isReactComponentName(child.id.name) &&
+              canBeReactFunctionComponent(child.init as EsTreeNode | null | undefined, state) &&
+              !isInsideFunctionScope(child)
+            ) {
+              localComponentNames.add(child.id.name);
+            }
+          }
+        }
+
         const exports: ExportType[] = [];
         let hasReactExport = false;
         let hasAnyExports = false;
-        const localComponents: EsTreeNode[] = [];
         const isExportedNodeIds = new WeakSet<object>();
 
         // First pass: collect exports.
@@ -507,9 +566,17 @@ export const onlyExportComponents = defineRule({
               }
               continue;
             }
+            if (isNodeOfType(stripped, "ObjectExpression")) {
+              context.report({
+                node: stripped,
+                message: objectExpressionBundlesComponents(stripped, state)
+                  ? NAMESPACE_OBJECT_MESSAGE
+                  : ANONYMOUS_MESSAGE,
+              });
+              continue;
+            }
             if (
               isNodeOfType(stripped, "ArrowFunctionExpression") ||
-              isNodeOfType(stripped, "ObjectExpression") ||
               isNodeOfType(stripped, "Literal")
             ) {
               context.report({ node: stripped, message: ANONYMOUS_MESSAGE });
@@ -597,6 +664,13 @@ export const onlyExportComponents = defineRule({
                 entry = classifyExport(exportedName, reportNode, false, null, state);
               } else {
                 entry = { kind: "non-component", reportNode };
+                // `export { Foo as "🍌" }` still EXPORTS the component —
+                // the module is a (broken) component boundary, so the
+                // string-literal specifier must be reported as the
+                // non-component shape it is.
+                if (localName && isReactComponentName(localName)) {
+                  exports.push({ kind: "react-component" });
+                }
               }
               if (isReExportFromSource && entry.kind !== "react-component") continue;
               exports.push(entry);
@@ -609,50 +683,19 @@ export const onlyExportComponents = defineRule({
           if (entry.kind === "react-component") hasReactExport = true;
         }
 
-        // Find unexported local components — only matters if there are
-        // exports already (mixed module) or no exports at all. A
-        // declaration whose name appears in a separate `export {…}`
-        // is still LOCAL per OXC (only declarations inside an export
-        // statement count as "exported").
-        const isInsideExport = (node: EsTreeNode): boolean => {
-          let walker: EsTreeNode | null | undefined = node.parent;
-          while (walker) {
-            if (
-              isNodeOfType(walker, "ExportNamedDeclaration") ||
-              isNodeOfType(walker, "ExportDefaultDeclaration") ||
-              isNodeOfType(walker, "ExportAllDeclaration")
-            ) {
-              return true;
-            }
-            walker = walker.parent ?? null;
-          }
-          return false;
-        };
-        // A component declared inside another function (a test callback, a
-        // factory, an object-literal `render` method) is never a Fast
-        // Refresh boundary — only module-scope components are. The origin
-        // rule (eslint-plugin-react-refresh) walks top-level statements
-        // only; flagging nested declarations tells users to export values
-        // that can't be exported.
-        for (const child of componentCandidates) {
-          if (isNodeOfType(child, "FunctionDeclaration") && child.id) {
-            if (
-              isReactComponentName(child.id.name) &&
-              !isInsideExport(child as EsTreeNode) &&
-              !isInsideFunctionScope(child)
-            ) {
-              localComponents.push(child.id);
-            }
-          }
-          if (isNodeOfType(child, "VariableDeclarator") && isNodeOfType(child.id, "Identifier")) {
-            if (
-              isReactComponentName(child.id.name) &&
-              canBeReactFunctionComponent(child.init as EsTreeNode | null | undefined, state) &&
-              !isInsideExport(child as EsTreeNode) &&
-              !isInsideFunctionScope(child)
-            ) {
-              localComponents.push(child.id);
-            }
+        // The react-refresh boundary constraint is about EXPORTS only: a
+        // module that exports a component must export nothing but
+        // components / allowed constants. Non-exported internal components
+        // are fine (react-refresh registers them, and modules that don't
+        // export components were never refresh boundaries), so they are
+        // deliberately NOT reported. A namespace-object export that
+        // carries components is the real breaker — the export is an
+        // object, not a component function, so the whole module fails the
+        // boundary check — and reports regardless of what else the module
+        // exports.
+        for (const entry of exports) {
+          if (entry.kind === "namespace-object") {
+            context.report({ node: entry.reportNode, message: NAMESPACE_OBJECT_MESSAGE });
           }
         }
         if (hasAnyExports && hasReactExport) {
@@ -663,14 +706,6 @@ export const onlyExportComponents = defineRule({
             if (entry.kind === "react-context") {
               context.report({ node: entry.reportNode, message: REACT_CONTEXT_MESSAGE });
             }
-          }
-        } else if (hasAnyExports && !hasReactExport && localComponents.length > 0) {
-          for (const local of localComponents) {
-            context.report({ node: local, message: LOCAL_COMPONENT_MESSAGE });
-          }
-        } else if (!hasAnyExports && localComponents.length > 0) {
-          for (const local of localComponents) {
-            context.report({ node: local, message: NO_EXPORT_MESSAGE });
           }
         }
       },


### PR DESCRIPTION
## Why

`only-export-components` had the Fast Refresh model inverted. React Fast Refresh's actual constraint is about a module's **exports**: a module that exports a component must export only components (plus allowed constants) for hot updates to preserve state. The rule instead flagged non-exported internal helpers — which Fast Refresh never sees — and stayed silent on a real breaker: exporting a namespace object that bundles components together with non-component values.

Before — false positive (module-private helper, Fast Refresh doesn't care):

```tsx
const ListItem = ({ label }) => <li>{label}</li>; // not exported — was flagged

export const List = ({ items }) => (
  <ul>{items.map((item) => <ListItem key={item.id} label={item.label} />)}</ul>
);
```

Before — false negative (breaks Fast Refresh, was silent):

```tsx
export const Panels = {
  Header: () => <header />, // component
  DEFAULT_WIDTH: 320,       // non-component in the same export
};
```

After: the rule is derived from the exports-only model — non-exported locals are never reported, mixed component/non-component exports (including namespace objects) are.

## What changed

- Reports only on the module's export surface; internal components are exempt.
- Detects namespace-object exports mixing components and non-components.
- Keeps the allowed-constant exemptions (uppercase consts, etc.) from the Fast Refresh contract.
- Regression tests rewritten to encode the exports-only model in both directions.
- Changeset included.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/react-builtins/only-export-components`
- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- Full plugin suite green locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lint behavior changes materially (fewer FPs on locals, new diagnostics on object exports), but scope is limited to one rule with extensive regression tests.
> 
> **Overview**
> **`only-export-components`** now matches react-refresh’s **exports-only** boundary: it cares about what a module exports, not private module-scope components.
> 
> **Stops reporting** non-exported locals (including config files that export values built with a local component, e.g. `export const tabs = [<Tab />]`). The old “export this component” / “exports nothing” paths and their messages are removed.
> 
> **Starts reporting** namespace-object exports that mix components with other values—named/default, shorthand locals, inline PascalCase keys, HoC-wrapped properties, and class components—via `objectExpressionBundlesComponents` and a dedicated **bundles components inside an object** message. Plain config objects and non-HoC factory calls under component keys stay clean.
> 
> OXC fixture divergences document the exports-only skip set; regression tests cover the new behavior. Patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b47731bb1ede5b9852f0fb861cb765aed41468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->