### PR TITLE
RB-COMP-FIX: no-render-in-render — require hook-calling helpers, exempt class methods

### DIFF
--- a/.changeset/no-render-in-render-hook-semantics.md
+++ b/.changeset/no-render-in-render-hook-semantics.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`no-render-in-render` now requires React-component semantics before firing: it only reports an inline `render*()` call when the callee resolves to a local function whose body calls hooks (a component in disguise, whose hooks get spliced into the caller's hook order). Hook-free render helpers that merely return JSX (inline call == inline JSX, nothing to lose) and class methods (`this.renderHeader()` — methods cannot call hooks) are no longer flagged.

--- a/packages/core/tests/fixtures/basic-react/src/architecture-issues.tsx
+++ b/packages/core/tests/fixtures/basic-react/src/architecture-issues.tsx
@@ -6,7 +6,10 @@ const GenericHandlerComponent = () => {
 };
 
 const RenderInRenderComponent = () => {
-  const renderItem = (item: string) => <span>{item}</span>;
+  const renderItem = (item: string) => {
+    const [isExpanded] = useState(false);
+    return <span>{isExpanded ? item : item.slice(0, 1)}</span>;
+  };
   return <div>{renderItem("hello")}</div>;
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -782,7 +782,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     forceJsx: true,
   },
   "no-render-in-render": {
-    code: "const Foo = () => <div>{renderRow()}</div>;",
+    code: "const Foo = () => {\n        const renderRow = () => {\n          const [open] = useState(false);\n          return <div>{String(open)}</div>;\n        };\n        return <div>{renderRow()}</div>;\n      };",
   },
   "no-render-prop-children": {
     code: '\n        import { Layout } from "@/components/layout";\n        const Panel = () => (\n          <Layout\n            renderHeader={() => <h1>Title</h1>}\n            renderFooter={() => <footer>Footer</footer>}\n            renderActions={() => <button>Go</button>}\n          />\n        );\n      ',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -204,6 +204,39 @@ describe("architecture/no-render-in-render — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag a hook-free helper that defines a nested hook-calling component", () => {
+    const result = run(
+      `const renderList = (items) => {
+        const Row = ({ item }) => {
+          const [open, setOpen] = useState(false);
+          return <li onClick={() => setOpen(!open)}>{item.name}</li>;
+        };
+        return <ul>{items.map((item) => <Row key={item.id} item={item} />)}</ul>;
+      };
+      export function Panel({ items }) {
+        return <div>{renderList(items)}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags when a nested NON-component closure calls hooks during the helper call", () => {
+    const result = run(
+      `const renderRows = (items) => {
+        const buildRow = (item) => {
+          const theme = useContext(ThemeContext);
+          return <li className={theme}>{item.name}</li>;
+        };
+        return <ul>{items.map(buildRow)}</ul>;
+      };
+      export function Panel({ items }) {
+        return <div>{renderRows(items)}</div>;
+      }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0].message).toContain("renderRows()");
+  });
+
   it("does not flag a render* call inside a module-scope render helper (outside any component)", () => {
     const result = run(
       `const renderIcon = (icon) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -7,8 +7,10 @@ const run = (code: string) => runRule(noRenderInRender, code, { filename: "fixtu
 // Precision audit: the rule requires React-component semantics — the
 // resolved helper's body must CALL hooks — before firing. A hook-free
 // render helper is a plain function returning JSX (inline call ==
-// inline JSX; nothing to lose), and class methods can't call hooks, so
-// both are exempt.
+// inline JSX; nothing to lose), and `this.renderX()` method calls can't
+// resolve to hook-calling locals, so both are exempt. A class
+// component's render() is still render context: a bare hook-calling
+// helper invoked there fires.
 describe("architecture/no-render-in-render — regressions", () => {
   it("flags a component-local render* helper that calls hooks", () => {
     const result = run(
@@ -86,6 +88,59 @@ describe("architecture/no-render-in-render — regressions", () => {
       }
       export function PluginDialogHost({ current }) {
         return <p>{renderMessage(current.message)}</p>;
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a hook-calling helper invoked as a bare identifier inside a class render()", () => {
+    const result = run(
+      `const renderStatus = () => {
+        const [open] = useState(false);
+        return <div>{String(open)}</div>;
+      };
+      class Panel extends React.Component {
+        render() { return <div>{renderStatus()}</div>; }
+      }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0].message).toContain("renderStatus()");
+  });
+
+  it("flags a hook-calling helper declared inside a class render() body", () => {
+    const result = run(
+      `class Panel extends Component {
+        render() {
+          const renderRow = () => {
+            const [open] = useState(false);
+            return <div>{String(open)}</div>;
+          };
+          return <div>{renderRow()}</div>;
+        }
+      }`,
+    );
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0].message).toContain("renderRow()");
+  });
+
+  it("does not flag a hook-free bare helper called inside a class render()", () => {
+    const result = run(
+      `const renderIcon = () => <span className="icon" />;
+      class Panel extends React.Component {
+        render() { return <div>{renderIcon()}</div>; }
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a hook-calling helper called inside a non-React class method", () => {
+    const result = run(
+      `const renderStatus = () => {
+        const [open] = useState(false);
+        return <div>{String(open)}</div>;
+      };
+      class TemplateBuilder {
+        build() { return <div>{renderStatus()}</div>; }
       }`,
     );
     expect(result.diagnostics).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -4,211 +4,78 @@ import { noRenderInRender } from "./no-render-in-render.js";
 
 const run = (code: string) => runRule(noRenderInRender, code, { filename: "fixture.tsx" });
 
+// Precision audit: the rule requires React-component semantics — the
+// resolved helper's body must CALL hooks — before firing. A hook-free
+// render helper is a plain function returning JSX (inline call ==
+// inline JSX; nothing to lose), and class methods can't call hooks, so
+// both are exempt.
 describe("architecture/no-render-in-render — regressions", () => {
-  it("flags a locally-declared render* helper called inline", () => {
-    const result = run(`const Foo = () => <div>{renderRow()}</div>;`);
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  it("does not flag a props.render* render-prop invocation", () => {
-    const result = run(`const Foo = (props) => <div>{props.renderProject(project)}</div>;`);
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag a this.props.render* render-prop invocation", () => {
-    const result = run(`const Foo = () => <div>{this.props.renderPanel()}</div>;`);
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag a render prop destructured from props", () => {
+  it("flags a component-local render* helper that calls hooks", () => {
     const result = run(
-      `function List(props){ const { renderItem } = props; return <div>{renderItem(1)}</div>; }`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag a render prop destructured directly in the parameter list", () => {
-    const result = run(`function List({ renderItem }){ return <div>{renderItem(1)}</div>; }`);
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  // Bugbot: the parameter carve-out is for COMPONENT props. A render* param
-  // of an ordinary nested helper is a plain local, so an inline call still
-  // remounts and must stay flagged.
-  it("still flags a render* param of a nested non-component helper", () => {
-    const result = run(
-      `const Foo = () => { const runRow = (renderRow) => <li>{renderRow()}</li>; return <ul>{runRow((x) => x)}</ul>; };`,
+      `const Foo = () => {
+        const renderRow = () => {
+          const [open] = useState(false);
+          return <div>{String(open)}</div>;
+        };
+        return <div>{renderRow()}</div>;
+      };`,
     );
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
-  // Bugbot: a render prop invoked directly on a nested prop bag roots in the
-  // parent-owned props, so it's exempt — matching its destructured form.
-  it("does not flag a render prop invoked on a nested prop bag (props.slots.renderItem())", () => {
-    const result = run(`const Foo = (props) => <div>{props.slots.renderItem(1)}</div>;`);
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  // Bugbot: the `props` carve-out must be scope-aware. A LOCAL object named
-  // `props` is not the component's props bag, so an inline render* call on it
-  // still remounts and stays flagged.
-  it("still flags a render* call on a local object named props", () => {
+  it("flags a module-scope render helper that calls hooks", () => {
     const result = run(
-      `const Foo = () => { const props = { renderRow: (x) => <li>{x}</li> }; return <ul>{props.renderRow(1)}</ul>; };`,
-    );
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  // Bugbot wave 4: a render prop destructured from a nested prop bag
-  // (`props.slots`) still roots in the parent-owned props, so it's exempt —
-  // the comment documented this but the code only matched `this.props`.
-  it("does not flag a render prop destructured from a nested prop bag", () => {
-    const result = run(
-      `function List(props){ const { renderItem } = props.slots; return <div>{renderItem(1)}</div>; }`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag a render prop destructured from this.props.slots", () => {
-    const result = run(
-      `function List(){ const { renderItem } = this.props.slots; return <div>{renderItem(1)}</div>; }`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("still flags a render prop destructured from a non-prop object", () => {
-    const result = run(
-      `function List(){ const { renderItem } = config.slots; return <div>{renderItem(1)}</div>; }`,
-    );
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  // fp-review PR 996: an earlier isStableMethodReceiver carve-out exempted
-  // every this.renderX() call, voiding the react-datepicker calendar
-  // must-detect check. Class fields (`renderX = () => …`) are per-instance,
-  // so `this.` is not a stability signal — these must fire.
-  it("flags a this.render* class-component helper method call", () => {
-    const result = run(
-      `class Chart extends React.Component {
-        renderLine(props) { return <g>{props.x}</g>; }
-        render() { return <g>{this.renderLine(this.props)}</g>; }
+      `const renderStatus = () => {
+        const [open] = useState(false);
+        return <div>{String(open)}</div>;
+      };
+      export function Panel() {
+        return <div>{renderStatus()}</div>;
       }`,
     );
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
-  it("flags inline this.renderX() class-field calls (calendar.tsx mined shape)", () => {
+  it("flags a hook-calling render helper declared as a function declaration", () => {
     const result = run(
-      `class Calendar extends Component {
-        renderCurrentMonth = (date = this.state.date) => (
-          <h2 className="react-datepicker__current-month">{date.toString()}</h2>
-        );
-        renderDefaultHeader = ({ monthDate }) => (
-          <div className="react-datepicker__header">
-            {this.renderCurrentMonth(monthDate)}
-          </div>
-        );
-        render() {
-          return <div>{this.renderAriaLiveRegion()}</div>;
-        }
+      `function renderBadge(label) {
+        const theme = useContext(ThemeContext);
+        return <span className={theme}>{label}</span>;
+      }
+      export function Panel() {
+        return <div>{renderBadge("new")}</div>;
       }`,
     );
     expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0].message).toContain("renderBadge()");
   });
 
-  it("still flags a local const render* helper called inline", () => {
+  it("does not claim a remount or state loss in the message", () => {
+    const result = run(
+      `function Page() {
+        const renderHeader = () => {
+          const [pinned] = useState(false);
+          return <h1>{String(pinned)}</h1>;
+        };
+        return <div>{renderHeader()}</div>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).not.toContain("remount");
+    expect(result.diagnostics[0].message).not.toContain("lose state");
+    expect(result.diagnostics[0].message).toContain("renderHeader()");
+  });
+
+  it("does not flag a hook-free render helper that merely returns JSX", () => {
     const result = run(
       `const UploadFileItem = (props) => {
         const renderIcon = () => <div className="icon" />;
         return <div>{renderIcon()}</div>;
       };`,
     );
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  // fp-review PR 996: the plain-alias spelling of a render prop is
-  // semantically identical to the destructured one and must stay silent.
-  it("does not flag a plain alias of a render prop (const renderItem = props.renderItem)", () => {
-    const result = run(
-      `function List(props){ const renderItem = props.renderItem; return <div>{renderItem(1)}</div>; }`,
-    );
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("does not flag a defaulted render-prop alias (props.renderItem ?? defaultRender)", () => {
-    const result = run(
-      `function List(props){ const renderItem = props.renderItem ?? defaultRender; return <div>{renderItem(1)}</div>; }`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag a conditional render-prop alias", () => {
-    const result = run(
-      `function List(props){ const renderItem = props.compact ? props.renderCompactItem : props.renderItem; return <div>{renderItem(1)}</div>; }`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag an alias of a parameter-destructured render prop", () => {
-    const result = run(
-      `function List({ renderItem }){ const renderRow = renderItem; return <div>{renderRow(1)}</div>; }`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("still flags an alias of a local render* helper", () => {
-    const result = run(
-      `function List(){ const renderIcon = () => <i />; const renderItem = renderIcon; return <div>{renderItem(1)}</div>; }`,
-    );
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  // Bugbot: the render-prop exemption is only for `props` / `this.props`. An
-  // unrelated object that happens to have a `.props` field must not hide a real
-  // inline `render*` call.
-  it("still flags an inline render* call on an arbitrary object's .props field", () => {
-    const result = run(
-      `function List(){ const renderRow = (x) => <li>{x}</li>; const cfg = { props: { renderRow } }; return <ul>{cfg.props.renderRow(1)}</ul>; }`,
-    );
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  it("does not flag a render prop called through a props-slice alias", () => {
-    const result = run(
-      `function List(props){ const slots = props.slots; return <div>{slots.renderItem(1)}</div>; }`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag a render prop called through a whole-props alias", () => {
-    const result = run(
-      `function List(props){ const p = props; return <div>{p.renderRow(1)}</div>; }`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("still flags a member render* call whose alias roots in a local object", () => {
-    const result = run(
-      `function List(){ const renderRow = (x) => <li>{x}</li>; const local = { renderRow }; const slots = local; return <ul>{slots.renderRow(1)}</ul>; }`,
-    );
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  // Verify wave: render helpers composing other render helpers at MODULE
-  // scope (lobe-ui renderItems.tsx) run outside any component render — no
-  // component identity, state, or memoization to lose.
-  it("does not flag a render* call inside a module-scope render helper", () => {
-    const result = run(
-      `const renderIcon = (icon) => <span className="icon">{icon}</span>;
-      export const renderDropdownMenuItems = (items) =>
-        items.map((item) => <li key={item.key}>{renderIcon(item.icon)}</li>);`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  // Verify wave: a module-scope hook-free formatter (bulwarkmail
-  // renderMessage) cannot close over component state; the inline call is
-  // equivalent to inline JSX.
   it("does not flag a module-scope hook-free formatter called inside a component", () => {
     const result = run(
       `function renderMessage(message) {
@@ -224,39 +91,73 @@ describe("architecture/no-render-in-render — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("still flags a module-scope render helper that calls hooks", () => {
+  it("does not flag class-component render helper methods (this.renderX())", () => {
     const result = run(
-      `const renderStatus = () => {
-        const [open] = useState(false);
-        return <div>{String(open)}</div>;
+      `class Chart extends React.Component {
+        renderLine(props) { return <g>{props.x}</g>; }
+        render() { return <g>{this.renderLine(this.props)}</g>; }
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag class-field render helpers (react-datepicker calendar shape)", () => {
+    const result = run(
+      `class Calendar extends Component {
+        renderCurrentMonth = (date = this.state.date) => (
+          <h2 className="react-datepicker__current-month">{date.toString()}</h2>
+        );
+        renderDefaultHeader = ({ monthDate }) => (
+          <div className="react-datepicker__header">
+            {this.renderCurrentMonth(monthDate)}
+          </div>
+        );
+        render() {
+          return <div>{this.renderAriaLiveRegion()}</div>;
+        }
+      }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a props.render* render-prop invocation", () => {
+    const result = run(`const Foo = (props) => <div>{props.renderProject(project)}</div>;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a render prop destructured from props", () => {
+    const result = run(
+      `function List(props){ const { renderItem } = props; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a render prop destructured directly in the parameter list", () => {
+    const result = run(`function List({ renderItem }){ return <div>{renderItem(1)}</div>; }`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a plain alias of a render prop (const renderItem = props.renderItem)", () => {
+    const result = run(
+      `function List(props){ const renderItem = props.renderItem; return <div>{renderItem(1)}</div>; }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an unresolved bare render* call", () => {
+    const result = run(`const Foo = () => <div>{renderRow()}</div>;`);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a render* call inside a module-scope render helper (outside any component)", () => {
+    const result = run(
+      `const renderIcon = (icon) => {
+        const theme = useContext(ThemeContext);
+        return <span className={theme}>{icon}</span>;
       };
-      export function Panel() {
-        return <div>{renderStatus()}</div>;
-      }`,
+      export const renderDropdownMenuItems = (items) =>
+        items.map((item) => <li key={item.key}>{renderIcon(item.icon)}</li>);`,
     );
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  it("still flags a component-local render helper called inline", () => {
-    const result = run(
-      `export function Panel({ items }) {
-        const renderRow = (item) => <li>{item.label}</li>;
-        return <ul>{items.map((item) => renderRow(item))}<li>{renderRow(items[0])}</li></ul>;
-      }`,
-    );
-    expect(result.diagnostics.length).toBeGreaterThan(0);
-  });
-
-  it("does not claim a remount or state loss for a plain render-helper call", () => {
-    const result = run(
-      `function Page() {
-        const renderHeader = () => <h1>Title</h1>;
-        return <div>{renderHeader()}</div>;
-      }`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0].message).not.toContain("remount");
-    expect(result.diagnostics[0].message).not.toContain("lose state");
-    expect(result.diagnostics[0].message).toContain("renderHeader()");
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -46,7 +46,13 @@ const functionBodyOf = (node: EsTreeNode): EsTreeNode | null => {
 const containsHookCall = (body: EsTreeNode): boolean => {
   let found = false;
   walkAst(body, (child: EsTreeNode) => {
-    if (found) return;
+    if (found) return false;
+    // A component DEFINED inside the helper owns its hooks — they run under
+    // that child's fiber when it renders, not when the helper is invoked
+    // inline — so its subtree must not make the helper itself hook-calling.
+    // Non-component nested functions stay in the walk: a closure that calls
+    // hooks and runs during the helper call still splices into the caller.
+    if (child !== body && isFunctionLike(child) && isComponentFunction(child)) return false;
     if (!isNodeOfType(child, "CallExpression")) return;
     const name = getCalleeName(child);
     if (name && isReactHookName(name)) found = true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -2,6 +2,8 @@ import { RENDER_FUNCTION_PATTERN } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
 import { isComponentFunction } from "../../utils/is-component-function.js";
+import { isEs5Component } from "../../utils/is-es5-component.js";
+import { isEs6Component } from "../../utils/is-es6-component.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -18,13 +20,16 @@ import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 // count) corrupts hook state. A hook-free render helper is just a
 // function that returns JSX — calling it inline is byte-for-byte
 // equivalent to writing the JSX in place (no identity, state, or
-// memoization exists to lose), so it is NOT flagged. Class methods
-// (`this.renderHeader()`) are exempt for the same reason: they cannot
-// call hooks, so an inline method call is plain JSX composition.
+// memoization exists to lose), so it is NOT flagged. Hook-free class
+// method calls (`this.renderHeader()`) are exempt for the same reason —
+// but a class component's render() IS render context: a bare
+// hook-calling helper invoked there still inlines hooks into a class
+// render, which is always broken.
 const isInsideComponentContext = (node: EsTreeNode): boolean => {
   let cursor: EsTreeNode | null | undefined = node.parent;
   while (cursor) {
     if (isFunctionLike(cursor) && isComponentFunction(cursor)) return true;
+    if (isEs5Component(cursor) || isEs6Component(cursor)) return true;
     cursor = cursor.parent ?? null;
   }
   return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -1,9 +1,7 @@
 import { RENDER_FUNCTION_PATTERN } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
-import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
 import { isComponentFunction } from "../../utils/is-component-function.js";
-import { isComponentParameterSymbol } from "../../utils/is-component-parameter-symbol.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -11,98 +9,21 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 
-// `({ renderItem }) => …` / `const { renderItem } = props` /
-// `const renderItem = props.renderItem`: the callee resolves to a COMPONENT
-// parameter or a name whose declaration roots in one (a render prop owned by
-// the parent). Its identity is the parent's, so calling it inline remounts
-// nothing — the same render-prop carve-out as the `props.renderX()` shape,
-// for the destructured and plain-alias spellings. A locally-declared
-// `renderRow` helper, or a parameter of an ordinary nested helper, still
-// carries the smell and stays flagged.
-const tracesToPropOrParameter = (
-  symbol: SymbolDescriptor | null,
-  scopes: ScopeAnalysis,
-  visitedSymbols: Set<SymbolDescriptor> = new Set(),
-): boolean => {
-  if (!symbol || visitedSymbols.has(symbol)) return false;
-  visitedSymbols.add(symbol);
-  if (isComponentParameterSymbol(symbol)) return true;
-  if (!isNodeOfType(symbol.declarationNode, "VariableDeclarator")) return false;
-  const source = symbol.initializer;
-  if (!source) return false;
-  return initializerRootsInProps(source, scopes, visitedSymbols);
-};
-
-// The initializer of a destructuring (`const { renderItem } = props.slots`)
-// or plain alias (`const renderItem = props.renderItem`) is parent-owned
-// when it roots in `props` / `this.props`, including the defaulted spellings
-// `props.renderItem ?? defaultRender` and
-// `cond ? props.renderItem : renderFallback` where an operand roots there.
-const initializerRootsInProps = (
-  node: EsTreeNode,
-  scopes: ScopeAnalysis,
-  visitedSymbols: Set<SymbolDescriptor> = new Set(),
-): boolean => {
-  if (isNodeOfType(node, "LogicalExpression")) {
-    return (
-      initializerRootsInProps(node.left, scopes, visitedSymbols) ||
-      initializerRootsInProps(node.right, scopes, visitedSymbols)
-    );
-  }
-  if (isNodeOfType(node, "ConditionalExpression")) {
-    return (
-      initializerRootsInProps(node.consequent, scopes, visitedSymbols) ||
-      initializerRootsInProps(node.alternate, scopes, visitedSymbols)
-    );
-  }
-  return rootsInProps(node, scopes, visitedSymbols);
-};
-
-// True when a member-expression chain bottoms out in a COMPONENT parameter
-// (`props.slots.header`, or `slots.header` where `slots` is a component
-// parameter), a `this.props` access (`this.props.slots`), or a local alias
-// whose declaration roots in one (`const slots = props.slots` then
-// `slots.renderItem()`). The root is resolved through scope, so a local
-// variable named `props` is NOT treated as the component's props bag. Also
-// gates the inline member-call receiver, so `props.slots.renderItem()` is
-// exempt for the same reason its destructured form
-// (`const { renderItem } = props.slots`) already is.
-const rootsInProps = (
-  node: EsTreeNode,
-  scopes: ScopeAnalysis,
-  visitedSymbols: Set<SymbolDescriptor> = new Set(),
-): boolean => {
-  let current: EsTreeNode = node;
-  while (isNodeOfType(current, "MemberExpression")) {
-    if (
-      isNodeOfType(current.object, "ThisExpression") &&
-      isNodeOfType(current.property, "Identifier") &&
-      current.property.name === "props"
-    ) {
-      return true;
-    }
-    current = current.object;
-  }
-  if (isNodeOfType(current, "Identifier")) {
-    return tracesToPropOrParameter(scopes.symbolFor(current), scopes, visitedSymbols);
-  }
-  return false;
-};
-
-// A render* call in a module of render HELPERS (`renderItems.tsx` composing
-// `renderIcon(Check)` inside `renderDropdownMenuItems`) happens outside any
-// component render: there is no component identity, state, or memoization to
-// lose, and extracting a component would change nothing observable. Class
-// bodies count as component context so `this.renderX()` class-field helpers
-// keep firing.
+// A `render*` call inside JSX is only a problem when the helper carries
+// REACT-COMPONENT semantics — i.e. its body calls hooks. Such a helper
+// is a component in disguise: invoking it inline splices its hooks into
+// the caller's hook order, so a conditional call (or a changed call
+// count) corrupts hook state. A hook-free render helper is just a
+// function that returns JSX — calling it inline is byte-for-byte
+// equivalent to writing the JSX in place (no identity, state, or
+// memoization exists to lose), so it is NOT flagged. Class methods
+// (`this.renderHeader()`) are exempt for the same reason: they cannot
+// call hooks, so an inline method call is plain JSX composition.
 const isInsideComponentContext = (node: EsTreeNode): boolean => {
   let cursor: EsTreeNode | null | undefined = node.parent;
   while (cursor) {
-    if (isNodeOfType(cursor, "ClassDeclaration") || isNodeOfType(cursor, "ClassExpression")) {
-      return true;
-    }
     if (isFunctionLike(cursor) && isComponentFunction(cursor)) return true;
     cursor = cursor.parent ?? null;
   }
@@ -128,11 +49,11 @@ const containsHookCall = (body: EsTreeNode): boolean => {
   return found;
 };
 
-// `renderMessage` declared at MODULE scope with no hook calls is a pure
-// formatter: it cannot close over component state, so calling it inline is
-// byte-for-byte equivalent to writing its JSX in place — nothing for an
-// extracted component to preserve.
-const isModuleScopeHookFreeHelper = (symbol: SymbolDescriptor | null): boolean => {
+// Fires only when the callee resolves to a LOCAL function whose body
+// calls hooks. Everything unresolvable — render props, parameters,
+// aliases, member calls — is a plain callable with no hook state to
+// corrupt, so it stays silent.
+const isHookCallingRenderHelper = (symbol: SymbolDescriptor | null): boolean => {
   if (!symbol) return false;
   const declaration = symbol.declarationNode;
   if (
@@ -143,8 +64,7 @@ const isModuleScopeHookFreeHelper = (symbol: SymbolDescriptor | null): boolean =
   }
   const body = functionBodyOf(declaration);
   if (!body) return false;
-  if (findEnclosingFunction(declaration) !== null) return false;
-  return !containsHookCall(body);
+  return containsHookCall(body);
 };
 
 export const noRenderInRender = defineRule({
@@ -158,28 +78,11 @@ export const noRenderInRender = defineRule({
     JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
       const expression = node.expression;
       if (!isNodeOfType(expression, "CallExpression")) return;
-
-      let calleeName: string | null = null;
-      if (isNodeOfType(expression.callee, "Identifier")) {
-        calleeName = expression.callee.name;
-      } else if (
-        isNodeOfType(expression.callee, "MemberExpression") &&
-        isNodeOfType(expression.callee.property, "Identifier")
-      ) {
-        calleeName = expression.callee.property.name;
-      }
-
-      if (!calleeName || !RENDER_FUNCTION_PATTERN.test(calleeName)) return;
-
+      if (!isNodeOfType(expression.callee, "Identifier")) return;
+      const calleeName = expression.callee.name;
+      if (!RENDER_FUNCTION_PATTERN.test(calleeName)) return;
       if (!isInsideComponentContext(node)) return;
-
-      if (isNodeOfType(expression.callee, "Identifier")) {
-        const calleeSymbol = context.scopes.symbolFor(expression.callee);
-        if (tracesToPropOrParameter(calleeSymbol, context.scopes)) return;
-        if (isModuleScopeHookFreeHelper(calleeSymbol)) return;
-      } else if (isNodeOfType(expression.callee, "MemberExpression")) {
-        if (rootsInProps(expression.callee.object, context.scopes)) return;
-      }
+      if (!isHookCallingRenderHelper(context.scopes.symbolFor(expression.callee))) return;
 
       context.report({
         node: expression,


### PR DESCRIPTION
## Why

`no-render-in-render` flagged plain functions that merely return JSX and class render helpers. Calling a hook-free helper as a function is legitimate — it inlines JSX without creating a component boundary, and React treats the result exactly like inline JSX. The failure mode the rule exists for is calling a helper that **uses hooks** as a plain function: its hook state is then attributed to the caller and resets/corrupts across renders.

Before — false positives:

```tsx
const renderBadge = (count) => <span className="badge">{count}</span>;

const Toolbar = ({ unread }) => <div>{renderBadge(unread)}</div>; // was flagged

class Legacy extends React.Component {
  renderHeader() { return <h1>{this.props.title}</h1>; } // was flagged
  render() { return <div>{this.renderHeader()}</div>; }
}
```

After: fires only when the called helper's body calls React hooks — the case that genuinely breaks state:

```tsx
const renderCounter = () => {
  const [count, setCount] = useState(0); // hooks inside a helper…
  return <button onClick={() => setCount(count + 1)}>{count}</button>;
};

const App = () => <div>{renderCounter()}</div>; // still flagged: call it as <RenderCounter />
```

## What changed

- Requires resolvable hook usage in the callee before reporting.
- Class methods are exempt (no hook semantics to corrupt).
- Regression tests rewritten: hook-free helpers and class render methods stay silent; hook-calling helpers fire.
- Changeset included.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/architecture/no-render-in-render`
- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- Full plugin suite + core e2e fixtures green locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lint behavior changes for a widely used rule—many previously reported patterns become silent, while hook-splicing edge cases remain flagged; low runtime risk but may surprise teams relying on the old warnings.
> 
> **Overview**
> **`no-render-in-render`** now reports only when an inline **`render*()`** call resolves to a **local function whose body calls React hooks** inside real component render context—treating that pattern as a component-in-disguise that corrupts hook order.
> 
> Hook-free helpers that only return JSX, **`this.renderX()`** class helpers, render props, unresolved callees, and module-scope helper composition are **no longer flagged**. Detection is limited to **identifier** callees (not member calls), with hook scanning that **ignores hooks inside nested components** but still catches **non-component closures** that call hooks during the helper. Diagnostics no longer mention remount/state loss.
> 
> Fixtures, liveness positive control, core e2e sample, and regression tests were updated to match the new semantics; patch changeset included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9daa1c94352280bdce5ded0767ce18b7bbf6dff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->