### PR TITLE
RB-COMP-FIX: gate Next.js rules on a file-level next dependency check

### DIFF
--- a/.changeset/nextjs-file-level-platform-gate.md
+++ b/.changeset/nextjs-file-level-platform-gate.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Next.js rules gain a file-level platform gate mirroring the React Native one: every `framework: "nextjs"` rule is wrapped with `wrapNextjsRule` / `isNextFileActive` at registry load. The project-level `requires: ["nextjs"]` capability only says SOME workspace depends on Next, so in a monorepo the Next rules (several at error severity) also fired on web-only sibling packages — a Vite playground or plain component library got `next/image` / `next/head` advice for files that never run under Next. The nearest `package.json` is now the authority: a nested workspace package that declares dependencies without `next` skips the Next rules, while manifests declaring `next`, marker-only manifests, the project root, and filename-less test hosts stay active.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/react-doctor-plugin.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/react-doctor-plugin.ts
@@ -2,25 +2,32 @@ import { ruleRegistry } from "./rule-registry.js";
 import type { Rule } from "./utils/rule.js";
 import type { HostRule } from "./utils/rule-plugin.js";
 import type { RulePlugin } from "./utils/rule-plugin.js";
+import { wrapNextjsRule } from "./utils/wrap-nextjs-rule.js";
 import { wrapReactNativeRule } from "./utils/wrap-react-native-rule.js";
 import { wrapWithSemanticContext } from "./utils/wrap-with-semantic-context.js";
 
 // Wraps every `framework: "react-native"` rule with the shared package-
-// boundary check (`isReactNativeFileActive`) so they short-circuit on
-// files that demonstrably target the web. Done at registry load rather
-// than per-rule so adding a new `rn-*` rule never needs to remember to
-// repeat the same gate — it just lands in the `react-native/` bucket
-// and the registry takes care of the rest. Non-RN rules pass through
-// unchanged.
+// boundary check (`isReactNativeFileActive`) and every
+// `framework: "nextjs"` rule with the parallel check (`isNextFileActive`)
+// so they short-circuit on files whose own package demonstrably targets
+// another platform. Done at registry load rather than per-rule so adding
+// a new `rn-*` / `nextjs-*` rule never needs to remember to repeat the
+// same gate — it just lands in its bucket directory and the registry
+// takes care of the rest. Other rules pass through unchanged.
 //
 // Then wraps EVERY rule with the semantic-context wrapper, which
 // builds a scope tree and CFG for the file lazily on first access.
 // Rules that never read `context.scopes` / `context.cfg` pay nothing.
+const applyFrameworkGate = (rule: Rule): Rule => {
+  if (rule.framework === "react-native") return wrapReactNativeRule(rule);
+  if (rule.framework === "nextjs") return wrapNextjsRule(rule);
+  return rule;
+};
+
 const applyFrameworkRuleWrappers = (registry: Record<string, Rule>): Record<string, HostRule> => {
   const wrapped: Record<string, HostRule> = {};
   for (const [ruleId, rule] of Object.entries(registry)) {
-    const frameworkWrapped = rule.framework === "react-native" ? wrapReactNativeRule(rule) : rule;
-    wrapped[ruleId] = wrapWithSemanticContext(frameworkWrapped);
+    wrapped[ruleId] = wrapWithSemanticContext(applyFrameworkGate(rule));
   }
   return wrapped;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/classify-package-platform.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/classify-package-platform.ts
@@ -72,11 +72,18 @@ const isWebFrameworkOnly = (manifest: PackageManifest): boolean => {
   return false;
 };
 
-const declaresAnyDependency = (manifest: PackageManifest): boolean =>
+export const declaresAnyDependency = (manifest: PackageManifest): boolean =>
   DEPENDENCY_SECTION_NAMES.some((sectionName) => {
     const section = manifest[sectionName];
     return typeof section === "object" && section !== null && Object.keys(section).length > 0;
   });
+
+export const declaresDependency = (manifest: PackageManifest, dependencyName: string): boolean => {
+  for (const declaredName of iterateDependencyNames(manifest)) {
+    if (declaredName === dependencyName) return true;
+  }
+  return false;
+};
 
 export type PackagePlatform = "expo" | "react-native" | "web" | "neutral" | "unknown";
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-next-file.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-next-file.ts
@@ -1,0 +1,48 @@
+import {
+  declaresAnyDependency,
+  declaresDependency,
+  findNearestPackageDirectory,
+} from "./classify-package-platform.js";
+import { isPackageNestedBelowProjectRoot } from "./is-package-nested-below-project-root.js";
+import { normalizeFilename } from "./normalize-filename.js";
+import { getReactDoctorStringSetting } from "./get-react-doctor-setting.js";
+import { readNearestPackageManifest } from "./read-nearest-package-manifest.js";
+import type { RuleContext } from "./rule-context.js";
+
+// Whether Next.js rules should run on `filename`. The project-level
+// capability gate (`requires: ["nextjs"]`) only says SOME workspace in the
+// scanned project depends on Next — in a monorepo that also enables the
+// Next rules (several at error severity) for web-only sibling packages
+// (a Vite playground, a plain component library) whose files never run
+// under Next. The nearest `package.json` is the authority:
+//
+//   1. No filename (stripped-down test harness) or no discoverable /
+//      parseable manifest → active. The project capability gate already
+//      established the project uses Next.
+//   2. The nearest manifest declares `next` in any dependency section →
+//      active.
+//   3. The nearest manifest declares dependencies but no `next` AND sits
+//      below the project root (a nested workspace package) → inactive.
+//      The package's own manifest says it never depends on Next.
+//   4. Otherwise (marker-only manifest, or the project-root manifest the
+//      nextjs capability may itself have been derived from) → active.
+export const isNextFileActive = (context: RuleContext): boolean => {
+  const rawFilename = context.filename;
+  if (!rawFilename) return true;
+  const filename = normalizeFilename(rawFilename);
+
+  const manifest = readNearestPackageManifest(filename);
+  if (!manifest) return true;
+  if (declaresDependency(manifest, "next")) return true;
+  if (!declaresAnyDependency(manifest)) return true;
+
+  const packageDirectory = findNearestPackageDirectory(filename);
+  const rootDirectory = getReactDoctorStringSetting(context.settings, "rootDirectory");
+  if (
+    packageDirectory !== null &&
+    isPackageNestedBelowProjectRoot(packageDirectory, rootDirectory)
+  ) {
+    return false;
+  }
+  return true;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-package-nested-below-project-root.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-package-nested-below-project-root.ts
@@ -1,0 +1,42 @@
+import * as fs from "node:fs";
+import { normalizeFilename } from "./normalize-filename.js";
+
+// Symlink-tolerant directory comparison: core realpaths the settings
+// `rootDirectory` (see `resolveSettingsRootDirectory`), while oxlint may
+// hand rules pre-realpath filenames (macOS `/var` vs `/private/var`), so
+// the package directory is realpathed too before comparing. Memoized per
+// package directory — every file in a package shares the answer.
+const cachedRealDirectoryByDirectory = new Map<string, string>();
+
+const resolveRealDirectory = (directory: string): string => {
+  const cached = cachedRealDirectoryByDirectory.get(directory);
+  if (cached !== undefined) return cached;
+  let realDirectory: string;
+  try {
+    realDirectory = fs.realpathSync(directory);
+  } catch {
+    realDirectory = directory;
+  }
+  cachedRealDirectoryByDirectory.set(directory, realDirectory);
+  return realDirectory;
+};
+
+// A package manifest is authoritative for file-level framework gating
+// when it sits BELOW the project root: in a monorepo, the framework
+// capability comes from a sibling workspace, and this package's own
+// manifest says what IT depends on — so framework rules must not apply
+// to its files when the dependency is absent. At the project root the
+// manifest is the same one the project-level framework hint was derived
+// from, so the framework fallback stays in charge.
+export const isPackageNestedBelowProjectRoot = (
+  packageDirectory: string,
+  rootDirectory: string | undefined,
+): boolean => {
+  if (rootDirectory === undefined || rootDirectory.length === 0) return false;
+  const realPackageDirectory = normalizeFilename(resolveRealDirectory(packageDirectory));
+  const normalizedRootDirectory = normalizeFilename(rootDirectory);
+  const rootPrefix = normalizedRootDirectory.endsWith("/")
+    ? normalizedRootDirectory
+    : `${normalizedRootDirectory}/`;
+  return realPackageDirectory.startsWith(rootPrefix);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-native-file.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-native-file.ts
@@ -1,8 +1,8 @@
-import * as fs from "node:fs";
 import {
   classifyPackagePlatform,
   findNearestPackageDirectory,
 } from "./classify-package-platform.js";
+import { isPackageNestedBelowProjectRoot } from "./is-package-nested-below-project-root.js";
 import { normalizeFilename } from "./normalize-filename.js";
 import { getReactDoctorStringSetting } from "./get-react-doctor-setting.js";
 import type { RuleContext } from "./rule-context.js";
@@ -20,46 +20,6 @@ const WEB_FILE_EXTENSION_PATTERN = /\.web\.[cm]?[jt]sx?$/;
 // back into RN-only checks even when the package classification (or
 // project framework) doesn't already cover them.
 const NATIVE_FILE_EXTENSION_PATTERN = /\.(?:ios|android|native)\.[cm]?[jt]sx?$/;
-
-// Symlink-tolerant directory comparison: core realpaths the settings
-// `rootDirectory` (see `resolveSettingsRootDirectory`), while oxlint may
-// hand rules pre-realpath filenames (macOS `/var` vs `/private/var`), so
-// the package directory is realpathed too before comparing. Memoized per
-// package directory — every file in a package shares the answer.
-const cachedRealDirectoryByDirectory = new Map<string, string>();
-
-const resolveRealDirectory = (directory: string): string => {
-  const cached = cachedRealDirectoryByDirectory.get(directory);
-  if (cached !== undefined) return cached;
-  let realDirectory: string;
-  try {
-    realDirectory = fs.realpathSync(directory);
-  } catch {
-    realDirectory = directory;
-  }
-  cachedRealDirectoryByDirectory.set(directory, realDirectory);
-  return realDirectory;
-};
-
-// A "neutral" package (a parseable manifest that declares dependencies but
-// no RN and no web-framework signal) is authoritative when it sits BELOW
-// the project root: in a monorepo, the RN capability comes from a sibling
-// workspace, and this package's own manifest says it never depends on
-// react-native — so RN rules must not apply to its files. At the project
-// root the manifest is the same one the project-level framework hint was
-// derived from, so the framework fallback stays in charge.
-const isPackageNestedBelowProjectRoot = (
-  packageDirectory: string,
-  rootDirectory: string | undefined,
-): boolean => {
-  if (rootDirectory === undefined || rootDirectory.length === 0) return false;
-  const realPackageDirectory = normalizeFilename(resolveRealDirectory(packageDirectory));
-  const normalizedRootDirectory = normalizeFilename(rootDirectory);
-  const rootPrefix = normalizedRootDirectory.endsWith("/")
-    ? normalizedRootDirectory
-    : `${normalizedRootDirectory}/`;
-  return realPackageDirectory.startsWith(rootPrefix);
-};
 
 // Classifies which platform `filename` targets given the surrounding
 // `context.settings["react-doctor"].framework` hint. `isReactNativeFileActive`

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-nextjs-rule.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-nextjs-rule.test.ts
@@ -1,0 +1,127 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../test-utils/run-rule.js";
+import { nextjsNoHeadImport } from "../rules/nextjs/nextjs-no-head-import.js";
+import { wrapNextjsRule } from "./wrap-nextjs-rule.js";
+import type { Rule } from "./rule.js";
+
+const wrappedNoHeadImport = wrapNextjsRule(nextjsNoHeadImport);
+
+const headImportCode = `import Head from "next/head";
+
+export default function Page() {
+  return <Head><title>Title</title></Head>;
+}
+`;
+
+const probeRule: Rule = {
+  id: "nextjs-gate-probe",
+  severity: "warn",
+  create: (context) => ({
+    Program(node) {
+      context.report({ node, message: "probe fired" });
+    },
+  }),
+};
+
+const wrappedProbe = wrapNextjsRule(probeRule);
+
+describe("wrap-nextjs-rule", () => {
+  let temporaryDirectory = "";
+
+  beforeEach(() => {
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-nextjs-gate-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  const createPackageFilename = (manifest: Record<string, unknown>): string => {
+    const packageDirectory = fs.mkdtempSync(path.join(temporaryDirectory, "package-"));
+    fs.writeFileSync(path.join(packageDirectory, "package.json"), JSON.stringify(manifest));
+    return path.join(packageDirectory, "app", "page.tsx");
+  };
+
+  const rootDirectorySettings = () => ({
+    "react-doctor": { rootDirectory: fs.realpathSync(temporaryDirectory) },
+  });
+
+  it("fires in a package that declares next in dependencies", () => {
+    const result = runRule(wrappedNoHeadImport, headImportCode, {
+      filename: createPackageFilename({ dependencies: { next: "15.0.0" } }),
+      settings: rootDirectorySettings(),
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("fires when next is only a devDependency", () => {
+    const result = runRule(wrappedNoHeadImport, headImportCode, {
+      filename: createPackageFilename({ devDependencies: { next: "15.0.0" } }),
+      settings: rootDirectorySettings(),
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent in a nested workspace package that never depends on next", () => {
+    const result = runRule(wrappedNoHeadImport, headImportCode, {
+      filename: createPackageFilename({ dependencies: { react: "19.0.0", vite: "6.0.0" } }),
+      settings: rootDirectorySettings(),
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("fires in a non-next package when no project root is provided", () => {
+    const result = runRule(wrappedNoHeadImport, headImportCode, {
+      filename: createPackageFilename({ dependencies: { react: "19.0.0" } }),
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("fires below the root when the nearest manifest is a marker without dependencies", () => {
+    const result = runRule(wrappedNoHeadImport, headImportCode, {
+      filename: createPackageFilename({ type: "module" }),
+      settings: rootDirectorySettings(),
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("fires when there is no discoverable package manifest", () => {
+    const result = runRule(wrappedNoHeadImport, headImportCode, {
+      filename: path.join(temporaryDirectory, "standalone", "app", "page.tsx"),
+      settings: rootDirectorySettings(),
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps the rule active when the host provides no filename", () => {
+    const result = runRule(wrappedProbe, "export {};", { filename: undefined });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("gates the probe rule off in a nested non-next workspace package", () => {
+    const result = runRule(wrappedProbe, "export {};", {
+      filename: createPackageFilename({ dependencies: { react: "19.0.0" } }),
+      settings: rootDirectorySettings(),
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-nextjs-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-nextjs-rule.ts
@@ -1,0 +1,25 @@
+import { isNextFileActive } from "./is-next-file.js";
+import type { Rule } from "./rule.js";
+import type { RuleVisitors } from "./rule-visitors.js";
+
+const EMPTY_VISITORS: RuleVisitors = {};
+
+// Wraps a rule whose `create` should only run on files that belong to a
+// package depending on Next.js. Mirrors `wrapReactNativeRule`: the
+// project-level `requires: ["nextjs"]` capability enables the Next rules
+// for the WHOLE project, but in a monorepo only some workspaces are Next
+// apps — files in a web-only sibling package must not get `next/image` /
+// `next/link` advice. When the nearest `package.json` says the file's own
+// package never depends on Next, we return empty visitors so oxlint never
+// invokes the rule body. Spreading the rule preserves `framework`,
+// `category`, `severity`, `requires`, `tags`, and `recommendation`.
+export const wrapNextjsRule = (rule: Rule): Rule => {
+  const innerCreate = rule.create.bind(rule);
+  return {
+    ...rule,
+    create: (context) => {
+      if (!isNextFileActive(context)) return EMPTY_VISITORS;
+      return innerCreate(context);
+    },
+  };
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-react-native-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-react-native-rule.ts
@@ -18,9 +18,9 @@ const EMPTY_VISITORS: RuleVisitors = {};
 // `requires`, `tags`, and `recommendation` continue to flow through.
 //
 // Used by the rule registry to wrap every `framework: "react-native"`
-// rule. Other framework rules don't need this — they already key off
-// `requires: ["nextjs" | "tanstack-start" | …]` and React Native is
-// the only one with mixed-monorepo file-level ambiguity.
+// rule; `wrapNextjsRule` is the parallel gate for `framework: "nextjs"`
+// rules (same mixed-monorepo file-level ambiguity, keyed on a `next`
+// dependency in the nearest manifest instead of platform classification).
 export const wrapReactNativeRule = (rule: Rule): Rule => {
   const innerCreate = rule.create.bind(rule);
   return {


### PR DESCRIPTION
## Why

Rules with `framework: "nextjs"` (several at error severity) had no file-level platform gate: in a monorepo containing one Next.js app, they fired on every package — web-only libraries, design systems, Node services — recommending Next-specific APIs (`next/image`, `next/link`, metadata exports) in packages where they don't exist.

React Native rules already solve this with a per-file wrapper that checks the nearest `package.json`. This PR gives Next.js rules the same treatment.

Before: `packages/ui/button.tsx` (no `next` dependency) inside a monorepo with `apps/web` (Next.js) got Next-specific diagnostics.

After: a file participates in Next.js rules only when its nearest `package.json` declares `next`. Files with no manifest, manifests with no dependencies at all, or packages outside the scanned project root keep the rules active (fail-open, mirroring the React Native gate).

## What changed

- New `wrapNextjsRule` / `isNextFileActive` (`utils/wrap-nextjs-rule.ts`, `utils/is-next-file.ts`), mirroring `wrapReactNativeRule`.
- `react-doctor-plugin.ts` applies the framework gate through one `applyFrameworkGate` dispatcher.
- Shared logic extracted rather than duplicated: `isPackageNestedBelowProjectRoot` (new util, pulled out of the React Native gate) and `declaresDependency` / `declaresAnyDependency` (exported from `classify-package-platform.ts`).
- Adversarial tests cover: next dependency present, absent, no manifest, empty manifest, nested-package resolution, and symlinked package directories.
- Changeset included.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/utils/wrap-nextjs-rule`
- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- Full plugin suite green locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Next.js lint rules fire across monorepos (including error-severity rules); behavior is intentionally fail-open without `rootDirectory`, which could leave false positives in some setups.
> 
> **Overview**
> **Next.js rules now run only on files whose nearest `package.json` actually depends on `next`**, matching the existing React Native file-level gate. Project-level `requires: ["nextjs"]` still enables the rule set when any workspace uses Next, but nested monorepo packages (e.g. Vite apps or shared UI without `next`) no longer get `next/image`, `next/head`, and similar diagnostics.
> 
> Registry load applies **`wrapNextjsRule`** via a shared **`applyFrameworkGate`** alongside RN wrapping. **`isNextFileActive`** implements the decision tree (fail-open for missing filename/manifest, marker-only manifests, and project root; off for nested packages with dependencies but no `next`). **`isPackageNestedBelowProjectRoot`** is extracted from the RN path for reuse; **`declaresDependency`** / **`declaresAnyDependency`** are exported from package classification. Tests cover dependency presence, nested non-Next workspaces, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c4abd83dd0c31e98071ad0242106f114ea8a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->