### PR TITLE
RB-COMP-FIX: no-mutating-reducer-state — stop flagging immutable-collection reducers

### DIFF
--- a/.changeset/no-mutating-reducer-state-immutable-escape.md
+++ b/.changeset/no-mutating-reducer-state-immutable-escape.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`no-mutating-reducer-state` no longer flags immutable-collection reducers: `return state.set(k, v)` / `const next = state.delete(k); return next` on an Immutable.js/Mori collection returns a NEW collection and is the correct reducer shape, but was reported as an in-place mutation at error severity. Since native Map/Set can't be distinguished without type info, the escape is result-shaped — a collection `.set`/`.add`/`.delete`/`.clear` call whose result is CONSUMED (returned or assigned) matches the immutable idiom and is skipped, while a discarded-result call (`state.set(k, v); return state`) still fires (it's either a native mutation or a no-op immutable call, both bugs). Array mutators stay unconditional because consuming a native `.splice()` result is idiomatic and still mutates.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.test.ts
@@ -984,4 +984,87 @@ describe("no-mutating-reducer-state", () => {
     expect(result.parseErrors).toEqual([]);
     expect(Array.isArray(result.diagnostics)).toBe(true);
   });
+
+  it("does NOT flag `return state.set(...)` — the immutable-collection idiom", () => {
+    const result = runRule(
+      noMutatingReducerState,
+      `
+      import { useReducer } from "react";
+      import { Map } from "immutable";
+
+      function reducer(state, action) {
+        switch (action.type) {
+          case "put":
+            return state.set(action.key, action.value);
+          case "drop":
+            return state.delete(action.key);
+          default:
+            return state;
+        }
+      }
+
+      useReducer(reducer, Map());
+    `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does NOT flag a consumed collection call assigned and returned", () => {
+    const result = runRule(
+      noMutatingReducerState,
+      `
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        const next = state.set(action.key, action.value);
+        return next;
+      }
+
+      useReducer(reducer, initialImmutableState);
+    `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a discarded-result collection delete followed by returning state", () => {
+    const result = runRule(
+      noMutatingReducerState,
+      `
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        state.delete(action.key);
+        return state;
+      }
+
+      useReducer(reducer, new Map());
+    `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a consumed ARRAY mutator — native splice returns removed items and mutates", () => {
+    const result = runRule(
+      noMutatingReducerState,
+      `
+      import { useReducer } from "react";
+
+      function reducer(state, action) {
+        const removed = state.items.splice(action.index, 1);
+        return state;
+      }
+
+      useReducer(reducer, { items: [] });
+    `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -7,6 +7,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isResultDiscardedCall } from "../../utils/is-result-discarded-call.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -17,8 +18,6 @@ import { getStaticMemberPropertyName } from "./utils/static-member-property-name
 const MESSAGE = "This reducer changes state in place, so your update is silently skipped.";
 
 const SAME_REFERENCE_ARRAY_RETURN_METHODS = new Set(["copyWithin", "fill", "reverse", "sort"]);
-
-const SAME_REFERENCE_COLLECTION_RETURN_METHODS = new Set(["add", "set"]);
 
 const OBJECT_MUTATION_METHODS = new Set(["assign", "defineProperties", "defineProperty"]);
 
@@ -282,16 +281,14 @@ const canExpressionReturnOriginalReducerStateReference = (
       ) {
         return true;
       }
-      // Map#set and Set#add return the collection receiver. Only count this as
-      // a top-level same-reference return when the receiver itself is the
-      // reducer state reference, not merely a nested collection in a new wrapper.
-      if (
-        methodName &&
-        SAME_REFERENCE_COLLECTION_RETURN_METHODS.has(methodName) &&
-        isExpressionOriginalReducerStateReference(unwrappedNode.callee.object, state)
-      ) {
-        return true;
-      }
+      // `return state.set(k, v)` / `return state.add(v)` is deliberately NOT
+      // treated as a same-reference return: on an immutable-API collection
+      // (Immutable.js Map, Mori) `.set`/`.add` return a NEW collection and
+      // returning it is the CORRECT reducer shape. Distinguishing that from a
+      // native Map/Set (where the receiver comes back) needs type info the
+      // lint pipeline doesn't have, and the immutable idiom dominates
+      // return-position collection calls in reducers (see the consumed-result
+      // escape in `collectReducerStateMutationsInExpressionOrStatement`).
     }
   }
 
@@ -428,21 +425,29 @@ const collectReducerStateMutationsInExpressionOrStatement = (
     //   state.items.push(item);
     //   items.splice(index, 1);
     //   stateMap.set(key, value);
-    //
-    // Collection method names like `set` and `add` are assumed mutating
-    // when called on state-derived values. The residual false-positive
-    // risk is when state holds a custom immutable-API value whose
-    // `.set`/`.add`/`.delete` return a NEW container (Immutable.js
-    // Map, Mori, persistent collections). Distinguishing those from
-    // Map/Set requires TS type info which the lint pipeline doesn't
-    // have. In practice the discard-the-result-of-an-immutable-API
-    // pattern is itself a bug, so this rule's diagnostic still points
-    // at code that needs attention.
     if (
       !methodName ||
       (!MUTATING_ARRAY_METHODS.has(methodName) && !MUTATING_COLLECTION_METHODS.has(methodName))
     )
       return;
+    // Collection method names like `set` / `add` / `delete` are shared with
+    // immutable-API containers (Immutable.js Map, Mori) whose calls return a
+    // NEW collection instead of mutating the receiver. Distinguishing them
+    // from native Map/Set needs type info the lint pipeline doesn't have, so
+    // the escape is result-shaped: a call whose result is CONSUMED
+    // (`return state.set(k, v)`, `const next = state.set(k, v)`) matches the
+    // immutable idiom and is skipped; a discarded-result call
+    // (`state.set(k, v);`) is either a native mutation or a no-op immutable
+    // call — both worth reporting. Array mutators stay unconditional:
+    // consuming a native `.splice()` / `.push()` result is idiomatic
+    // (`const removed = items.splice(i, 1)`) and still mutates.
+    if (
+      MUTATING_COLLECTION_METHODS.has(methodName) &&
+      !MUTATING_ARRAY_METHODS.has(methodName) &&
+      !isResultDiscardedCall(unwrappedChild)
+    ) {
+      return;
+    }
     if (isExpressionRootedInMutableReducerStateSource(unwrappedChild.callee.object, state)) {
       mutations.push({ node: unwrappedChild });
     }


### PR DESCRIPTION
## Why

`no-mutating-reducer-state` flagged `return state.set(key, value)` in reducers at error severity. On an Immutable.js/Mori-style collection, `.set` / `.add` / `.delete` return a **new** collection — that reducer is the correct, canonical shape, not a mutation.

Since native `Map`/`Set` can't be distinguished from immutable collections without type information, the escape is result-shaped:

- `return state.set(k, v)` / `const next = state.delete(k); return next` — the call result is **consumed**, matching the immutable idiom → not flagged.
- `state.set(k, v); return state` — the result is **discarded**; that's either a native in-place mutation or a no-op immutable call, and both are bugs → still flagged.

Array mutators (`.push`, `.splice`, `.sort`, …) stay unconditional: consuming a native `.splice()` result is idiomatic *and* still mutates the receiver.

Before (flagged, correct code):

```tsx
const reducer = (state, action) => {
  switch (action.type) {
    case "set":
      return state.set(action.key, action.value); // Immutable.Map → new collection
  }
};
```

After: silent. The discarded-result form still fires:

```tsx
case "set":
  state.set(action.key, action.value); // mutation or no-op — bug either way
  return state;
```

## What changed

- Collection `.set`/`.add`/`.delete`/`.clear` calls whose result is consumed (returned/assigned) are exempt, reusing the existing `isResultDiscardedCall` utility.
- Discarded-result collection calls and all array mutators keep firing.
- Adversarial tests cover both directions.
- Changeset included.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/state-and-effects/no-mutating-reducer-state`
- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- Full plugin suite green locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule heuristic change with targeted tests; no runtime app or security impact. Residual risk: native `Map`/`Set` updates that return the new collection could be missed without type info.
> 
> **Overview**
> **`no-mutating-reducer-state`** no longer reports immutable-style reducers that **return** or **assign** the result of collection `.set` / `.add` / `.delete` / `.clear` (e.g. `return state.set(k, v)`), which is correct for Immutable.js/Mori but was treated like in-place native `Map`/`Set` mutation.
> 
> The rule drops treating those collection calls as “same-reference returns” on `return state.set(...)`, and instead **skips** collection-only mutator detection when the call’s result is **consumed** via **`isResultDiscardedCall`**. Discarded calls (`state.set(k, v); return state`) still diagnose; **array** mutators (`.splice`, `.push`, etc.) stay strict because using the return value does not make the receiver safe.
> 
> Tests and a patch changeset document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf491075e25d8c6334dc0b9c28add65b8f3cbbf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->