### PR TITLE
RB-COMP-FIX: severity re-categorizations — align rule families at warn

### DIFF
--- a/.changeset/adjust-state-on-prop-change-warn.md
+++ b/.changeset/adjust-state-on-prop-change-warn.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`no-adjust-state-on-prop-change` is demoted from error to warn. It was the lone error-severity member of the derived-state family (`no-derived-state-effect` et al. are all warn), co-fires with them on the same effect, and shares their main false-positive failure mode (flagging non-derivable interactive/env/draft/handshake state). It now matches the family until precision improves.

--- a/.changeset/jsx-element-type-warn.md
+++ b/.changeset/jsx-element-type-warn.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`no-jsx-element-type` is demoted from error to warn. It fires on `JSX.Element` return-type annotations — a type-hygiene preference, not a runtime bug — so it must not block a scan at error severity.

--- a/.changeset/nested-component-severity-unified.md
+++ b/.changeset/nested-component-severity-unified.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`no-nested-component-definition` is demoted from error to warn, unifying it with `no-unstable-nested-components` — the same defect class (a component defined inside another component's render) was reported at two different severities depending on which rule caught it.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.regressions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noNestedComponentDefinition } from "./no-nested-component-definition.js";
+import { noUnstableNestedComponents } from "../react-builtins/no-unstable-nested-components.js";
 
 const run = (code: string) =>
   runRule(noNestedComponentDefinition, code, { filename: "fixture.tsx" });
@@ -9,6 +10,11 @@ const messagesOf = (result: { diagnostics: Array<{ message: string }> }) =>
   result.diagnostics.map((diagnostic) => diagnostic.message);
 
 describe("architecture/no-nested-component-definition — regressions", () => {
+  it("shares one severity with no-unstable-nested-components (same defect class)", () => {
+    expect(noNestedComponentDefinition.severity).toBe("warn");
+    expect(noNestedComponentDefinition.severity).toBe(noUnstableNestedComponents.severity);
+  });
+
   it("flags a nested component that is rendered as JSX", () => {
     const result = run(`
       const Parent = () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-nested-component-definition.ts
@@ -29,7 +29,10 @@ export const noNestedComponentDefinition = defineRule({
   id: "no-nested-component-definition",
   title: "Component defined inside another component",
   tags: ["test-noise", "react-jsx-only"],
-  severity: "error",
+  // Aligned with `no-unstable-nested-components` (react-builtins), which
+  // reports the same defect class: the two co-fire on the same nested
+  // component, and one blocking while the other warns was incoherent.
+  severity: "warn",
   category: "Correctness",
   recommendation:
     "Move it to module scope or a separate file so React does not recreate the component and erase its state on every parent render.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-jsx-element-type.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-jsx-element-type.test.ts
@@ -3,6 +3,10 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noJsxElementType } from "./no-jsx-element-type.js";
 
 describe("no-jsx-element-type", () => {
+  it("ships at warn severity — a type-hygiene preference, not a runtime bug", () => {
+    expect(noJsxElementType.severity).toBe("warn");
+  });
+
   it("flags function declaration with JSX.Element return type", () => {
     const result = runRule(
       noJsxElementType,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-jsx-element-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-jsx-element-type.ts
@@ -43,7 +43,10 @@ const extractReturnTypeAnnotation = (
 export const noJsxElementType = defineRule({
   id: "no-jsx-element-type",
   title: "No JSX.Element",
-  severity: "error",
+  // A `JSX.Element` return-type annotation is a type-hygiene preference
+  // (too narrow for what components legitimately return), not a runtime
+  // bug — it must not block a scan at error severity.
+  severity: "warn",
   recommendation:
     "Replace `JSX.Element` with `React.ReactNode`. `JSX.Element` is too narrow: it excludes `null`, strings, numbers, and fragments that components commonly return.",
   create: (context: RuleContext) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect/SOURCE.md
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect/SOURCE.md
@@ -71,14 +71,16 @@ builds one lazily per `Program` with `eslint-scope` in
   upstream invalid cases this flips ("From props via callback setter"
   in `no-derived-state.json`, "Value-less useState" in `syntax.json`)
   are marked `todo: true` in the parity fixtures.
-- **`no-adjust-state-on-prop-change` severity + message** — upstream
-  ships this rule as `type: "suggestion"` with softened "Avoid …
-  Instead …" copy. We promote it to `severity: "error"` (the pattern
-  always causes an extra render with a stale UI between the two
-  commits — there is no benign instance) and rewrite the message in
-  the authoritative "what's wrong → why → fix" shape used by the rest
-  of the error-level effect rules in this folder. Detector behavior
-  is unchanged; only the diagnostic copy and severity diverge.
+- **`no-adjust-state-on-prop-change` message** — upstream ships this
+  rule as `type: "suggestion"` with softened "Avoid … Instead …" copy.
+  We rewrite the message in the authoritative "what's wrong → why →
+  fix" shape used by the error-level effect rules in this folder.
+  Detector behavior is unchanged; only the diagnostic copy diverges.
+  Severity is `warn`, matching the rest of the derived-state family
+  (the rule co-fires with `no-derived-state` et al. on the same effect
+  and shares their false-positive mode on non-derivable interactive /
+  env / draft / handshake state; it was briefly promoted to `error`
+  before the corpus audit demoted it back).
 - **Externally-driven / non-render-knowable state suppression** — the
   whole "you might not need an effect" premise assumes a `useState`
   value is written from a React event handler, so the work can be

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
@@ -3,6 +3,10 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noAdjustStateOnPropChange } from "./no-adjust-state-on-prop-change.js";
 
 describe("no-adjust-state-on-prop-change — regressions", () => {
+  it("ships at warn severity, matching the derived-state family", () => {
+    expect(noAdjustStateOnPropChange.severity).toBe("warn");
+  });
+
   it("flags constant resets in a transition effect with a setTimeout sibling (lobe-ui FloatingSheet)", () => {
     const result = runRule(
       noAdjustStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
@@ -321,13 +321,19 @@ const isObjectUrlLifecycleEffect = (effectFn: EsTreeNode): boolean => {
 };
 
 // Detector logic is a port of upstream `src/rules/no-adjust-state-on-prop-change.js`
-// (severity and message intentionally diverge — see SOURCE.md).
+// (message intentionally diverges — see SOURCE.md).
 // Note: upstream does NOT skip on cleanup return.
+//
+// Severity matches the rest of the derived-state family (`no-derived-state`
+// et al., all `warn`): this rule co-fires with them on the same effect and
+// shares their dominant false-positive mode (flagging interactive / env /
+// draft / handshake state that is NOT derivable during render), so it must
+// not be the lone blocking member until that precision is fixed.
 
 export const noAdjustStateOnPropChange = defineRule({
   id: "no-adjust-state-on-prop-change",
   title: "State synced to a prop inside an effect",
-  severity: "error",
+  severity: "warn",
   tags: ["test-noise"],
   recommendation:
     "Adjust the state inline during render with a `prev`-prop comparison (`if (prop !== prevProp) { setPrevProp(prop); setX(...); }`), or refactor to remove the duplicated state. Routing the adjustment through a useEffect forces an extra render with a stale UI between the two commits. See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes",

--- a/packages/react-doctor/tests/e2e/terminal-visuals.test.ts
+++ b/packages/react-doctor/tests/e2e/terminal-visuals.test.ts
@@ -585,16 +585,18 @@ describe.skipIf(!hasBuiltCli)("built CLI subprocess visual smoke", () => {
   let fixtureDirectory: string;
 
   beforeAll(() => {
+    // A conditional hook call — `rules-of-hooks` fires at error severity,
+    // which is what drives the top-errors block below.
     fixtureDirectory = setupReactProject(tempRoot, "subprocess-fixture", {
       files: {
         "src/counter.tsx": [
-          "import { useState, useEffect } from 'react';",
+          "import { useState } from 'react';",
           "export const Counter = ({ value }: { value: number }) => {",
-          "  const [count, setCount] = useState(0);",
-          "  useEffect(() => {",
-          "    setCount(0);",
-          "  }, [value]);",
-          "  return <span>{count}</span>;",
+          "  if (value > 0) {",
+          "    const [count] = useState(value);",
+          "    return <span>{count}</span>;",
+          "  }",
+          "  return <span>0</span>;",
           "};",
           "",
         ].join("\n"),
@@ -612,10 +614,10 @@ describe.skipIf(!hasBuiltCli)("built CLI subprocess visual smoke", () => {
     expect(stdout).toContain("React Doctor");
     expect(stdout).toContain("error you should fix");
     // The top-error headline shows the rule's human title (not the id).
-    expect(stdout).toContain("State synced to a prop inside an effect");
+    expect(stdout).toContain("Hook called conditionally");
     // The inline code frame is rendered from the actual fixture file.
-    expect(stdout).toContain("src/counter.tsx:5");
-    expect(stdout).toContain("setCount(0)");
+    expect(stdout).toContain("src/counter.tsx:4");
+    expect(stdout).toContain("useState(value)");
   }, 60_000);
 
   it("renders the structured visual region without overflowing a 120-column terminal", async () => {

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -520,14 +520,15 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
       project: buildTestProject({ rootDirectory: "/tmp/test" }),
     });
 
-    // `no-adjust-state-on-prop-change` is intentionally promoted to
-    // `error` — the pattern always causes an extra render with a stale
-    // UI between commits, there is no benign instance. See SOURCE.md.
+    // The whole derived-state family ships at `warn` — including
+    // `no-adjust-state-on-prop-change`, which was briefly promoted to
+    // `error` before the corpus audit demoted it back to match the
+    // family it co-fires with. See SOURCE.md.
     const portedRuleSeverity: Record<string, "warn" | "error"> = {
       "no-derived-state": "warn",
       "no-chain-state-updates": "warn",
       "no-event-handler": "warn",
-      "no-adjust-state-on-prop-change": "error",
+      "no-adjust-state-on-prop-change": "warn",
       "no-reset-all-state-on-prop-change": "warn",
       "no-pass-live-state-to-parent": "warn",
       "no-pass-data-to-parent": "warn",

--- a/packages/react-doctor/tests/run-oxlint/architecture.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/architecture.test.ts
@@ -33,7 +33,8 @@ describe("runOxlint", () => {
       "no-nested-component-definition": {
         fixture: "architecture-issues.tsx",
         ruleSource: "rules/architecture.ts",
-        severity: "error",
+        // Aligned with `no-unstable-nested-components` (same defect class).
+        severity: "warning",
       },
       "no-many-boolean-props": {
         fixture: "new-rules.tsx",


### PR DESCRIPTION
## Why

Three rules reported at error severity while their siblings — same defect class, same failure modes — reported at warn. Error severity blocks scans, so the inconsistency meant the same underlying issue either blocked CI or didn't depending on which rule happened to catch it.

1. **`no-adjust-state-on-prop-change`** was the lone error member of the derived-state family (`no-derived-state-effect` et al. are all warn). It co-fires with them on the same effect and shares their main false-positive mode: flagging interactive/env/draft/handshake state that isn't actually derivable. Now warn, matching the family.
2. **`no-jsx-element-type`** fires on `JSX.Element` return-type annotations — a type-hygiene preference, not a runtime bug. A style preference must not block a scan. Now warn.
3. **`no-nested-component-definition`** (error) and `no-unstable-nested-components` (warn) report the same defect at two severities. Unified at warn.

## What changed

- `severity: "warn"` for the three rules, with severity assertions added to their regression tests (including a cross-rule assertion keeping the two nested-component rules in lockstep).
- Downstream test expectations updated (`scan-resilience`, `run-oxlint/architecture`).
- The terminal-visuals e2e sources its error-level diagnostic from a `rules-of-hooks` violation instead of the demoted rule, so the "errors you should fix" section is still exercised.
- Rule-source docs updated; one changeset per demotion.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test`
- `pnpm --filter react-doctor test` (terminal visuals, scan resilience, architecture expectations)
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Severity-only changes in the linter plugin with no detector logic changes; risk is limited to CI no longer failing on these findings unless users override severity.
> 
> **Overview**
> Three **oxlint-plugin-react-doctor** rules move from **`error` to `warn`** so scans are not blocked for issues that match sibling rules or are style-only.
> 
> **`no-adjust-state-on-prop-change`** joins the rest of the derived-state family at warn (it was the only error in that set and often fires alongside them). **`no-jsx-element-type`** is warn because it targets `JSX.Element` return types, not runtime bugs. **`no-nested-component-definition`** is warn to match **`no-unstable-nested-components`** for the same nested-in-render pattern.
> 
> Tests now assert these severities (including lockstep severity for the two nested-component rules). **`scan-resilience`** and **`run-oxlint/architecture`** expectations are updated. The built-CLI terminal e2e uses a conditional **`rules-of-hooks`** violation instead of the demoted adjust-state rule so the top-errors UI still gets an error-level finding. **`SOURCE.md`** and patch changesets document the demotions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d8f6116c0d7482f51e615ec90484409e75cbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->