### PR TITLE
RB-COMP-FIX: no-derived-state-effect — recurse into if guards

### DIFF
--- a/.changeset/derived-state-effect-if-guard.md
+++ b/.changeset/derived-state-effect-if-guard.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`no-derived-state-effect` now recurses into `if` guards: wrapping the derived-state setter in `if (cond) setX(derive(dep))` (including if/else and braceless forms) no longer silences the rule. Branches containing non-setter work, early returns, or other non-expression statements still disqualify the effect, so guarded escape-hatch effects stay unflagged.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.regressions.test.ts
@@ -118,6 +118,108 @@ describe("no-derived-state-effect — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a derived-state setter wrapped in an if guard", () => {
+    const result = runRule(
+      noDerivedStateEffect,
+      `function Todos({ todos }) {
+        const [visibleTodos, setVisibleTodos] = useState([]);
+        useEffect(() => {
+          if (todos.length > 0) {
+            setVisibleTodos(todos.filter((todo) => !todo.done));
+          }
+        }, [todos]);
+        return <List items={visibleTodos} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags guarded setters in both branches of an if/else", () => {
+    const result = runRule(
+      noDerivedStateEffect,
+      `function Greeting({ name }) {
+        const [greeting, setGreeting] = useState("");
+        useEffect(() => {
+          if (name) {
+            setGreeting("Hello " + name);
+          } else {
+            setGreeting("Hello stranger");
+          }
+        }, [name]);
+        return <span>{greeting}</span>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a braceless if-guarded setter", () => {
+    const result = runRule(
+      noDerivedStateEffect,
+      `function Field({ value }) {
+        const [draft, setDraft] = useState(value);
+        useEffect(() => {
+          if (value !== draft) setDraft(value);
+        }, [value]);
+        return <span>{draft}</span>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a guard branch does non-setter work", () => {
+    const result = runRule(
+      noDerivedStateEffect,
+      `function Todos({ todos }) {
+        const [visibleTodos, setVisibleTodos] = useState([]);
+        useEffect(() => {
+          if (todos.length > 0) {
+            analytics.track("todos-updated");
+            setVisibleTodos(todos.filter((todo) => !todo.done));
+          }
+        }, [todos]);
+        return <List items={visibleTodos} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an early-return guard (non-expression statement)", () => {
+    const result = runRule(
+      noDerivedStateEffect,
+      `function Field({ value }) {
+        const [draft, setDraft] = useState(value);
+        useEffect(() => {
+          if (!value) return;
+          setDraft(value);
+        }, [value]);
+        return <span>{draft}</span>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a guarded controlled-input mirror also written from onChange", () => {
+    const result = runRule(
+      noDerivedStateEffect,
+      `function Field({ value }) {
+        const [draft, setDraft] = useState(value);
+        useEffect(() => {
+          if (value !== draft) {
+            setDraft(value);
+          }
+        }, [value]);
+        return <input value={draft} onChange={(e) => setDraft(e.target.value)} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags member-expression dependencies like [user.name]", () => {
     const result = runRule(
       noDerivedStateEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
@@ -86,6 +86,38 @@ const collectValueIdentifierNames = (
   }
 };
 
+// Wrapping the setter in an `if` guard (`if (a !== b) setX(a)`) is still
+// derived state — recurse into IfStatement branches so the guard doesn't
+// silence the rule. Any branch statement that isn't itself an
+// ExpressionStatement or a nested IfStatement disqualifies the effect
+// (returns null), preserving the strict "contains only setState calls"
+// contract of the flattened list.
+const flattenGuardedStatements = (
+  statements: ReadonlyArray<EsTreeNode>,
+): ReadonlyArray<EsTreeNode> | null => {
+  const flattened: EsTreeNode[] = [];
+  for (const statement of statements) {
+    if (isNodeOfType(statement, "ExpressionStatement")) {
+      flattened.push(statement);
+      continue;
+    }
+    if (isNodeOfType(statement, "IfStatement")) {
+      for (const branch of [statement.consequent, statement.alternate]) {
+        if (!branch) continue;
+        const branchStatements = isNodeOfType(branch, "BlockStatement")
+          ? (branch.body ?? [])
+          : [branch];
+        const flattenedBranch = flattenGuardedStatements(branchStatements);
+        if (flattenedBranch === null) return null;
+        flattened.push(...flattenedBranch);
+      }
+      continue;
+    }
+    return null;
+  }
+  return flattened;
+};
+
 export const noDerivedStateEffect = defineRule({
   id: "no-derived-state-effect",
   title: "Derived state stored in an effect",
@@ -127,8 +159,8 @@ export const noDerivedStateEffect = defineRule({
       }
       if (sawAnyDep && allDepsAreInitialOnly) return;
 
-      const statements = getCallbackStatements(callback);
-      if (statements.length === 0) return;
+      const statements = flattenGuardedStatements(getCallbackStatements(callback));
+      if (statements === null || statements.length === 0) return;
 
       const containsOnlySetStateCalls = statements.every((statement: EsTreeNode) => {
         if (!isNodeOfType(statement, "ExpressionStatement")) return false;


### PR DESCRIPTION
## Why

`no-derived-state-effect`'s statement walk bailed on the first non-`ExpressionStatement`, so wrapping the derived-state setter in an `if` guard silenced the rule entirely — the guard didn't change the anti-pattern, just hid it.

Before (silent):

```tsx
useEffect(() => {
  if (todos.length > 0) {
    setVisibleTodos(todos.filter((todo) => !todo.done));
  }
}, [todos]);
```

After: `IfStatement` branches (if/else and braceless forms) are flattened into the setter analysis, so the guarded derivation above is flagged with the same compute-during-render guidance as the unguarded form.

Precision is preserved by keeping the disqualifiers strict: a branch containing non-setter work, an early `return`, or any other non-expression statement still exempts the whole effect — so guarded escape-hatch effects don't become new false positives:

```tsx
useEffect(() => {
  if (!value) return;      // early-return guard — still exempt
  setDraft(value);
}, [value]);
```

The controlled-input mirror exemption (state also written from an event handler) continues to apply to guarded setters.

## What changed

- New branch-flattening step (`flattenGuardedStatements`) feeding the existing only-setState analysis.
- Adversarial regression tests: guarded single-branch, if/else both-branch, braceless guard (fire); non-setter branch work, early-return guard, guarded controlled mirror (no fire).
- Changeset included.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/state-and-effects/no-derived-state-effect`
- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- Full plugin suite green locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only behavior change with targeted tests; may surface new warnings where guards previously hid derived-state effects, with no runtime or security impact.
> 
> **Overview**
> **`no-derived-state-effect`** no longer treats an `if` around the setter as a reason to skip the effect. The rule flattens `if` / `if-else` bodies (including braceless branches) into the same “only `setState` calls” check used for a flat callback, so guarded derivations like `if (todos.length) setVisibleTodos(...)` are reported like the unguarded form.
> 
> Effects whose guarded branches include **non-setter** work, **early `return`**, or other non-expression statements still **do not** fire, and the existing controlled-input mirror exemption still applies to guarded setters.
> 
> Adds **`flattenGuardedStatements`** in `no-derived-state-effect.ts` and regression tests for flag vs. silence cases; patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88bb1dd52d91d859e0d8d1b6a4d903f720c36023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->