### PR TITLE
RB-COMP-FIX: effect-needs-cleanup — observers, sockets, and retained-function coverage

### DIFF
--- a/.changeset/effect-needs-cleanup-observers-retained.md
+++ b/.changeset/effect-needs-cleanup-observers-retained.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+`effect-needs-cleanup` covers more leak shapes. Resource detection now includes DOM observers (`ResizeObserver` / `MutationObserver` / `IntersectionObserver` / `PerformanceObserver` — via their `.observe(...)` registration, released by `.disconnect()` / `.unobserve()`) and connections (`new WebSocket(...)` / `new EventSource(...)`, released by `.close()`; returning the socket handle itself is not cleanup). Cleanup analysis also runs on functions retained across renders (`useCallback` callbacks and component-scope handlers) with a stricter firing policy: a discarded `setInterval` id (unclearable), a discarded socket construction, or a discarded subscribe/observe registration in a file with no release-shaped call anywhere. One-shot `setTimeout` in handlers, `{ once: true }` / `{ signal }` listeners, captured handles, and functions that release their own resources stay unflagged.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
@@ -40,6 +40,21 @@ export const TIMER_CALLEE_NAMES_REQUIRING_CLEANUP = new Set(["setInterval", "set
 
 export const TIMER_CLEANUP_CALLEE_NAMES = new Set(["clearInterval", "clearTimeout"]);
 
+// Connection-opening constructors. Connecting starts at construction
+// time, so an instance created without a later `.close()` keeps the
+// connection (and its message handlers) alive after unmount.
+export const SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP = new Set(["WebSocket", "EventSource"]);
+
+// DOM observer constructors whose `.observe(...)` registration keeps
+// firing until `.disconnect()` / `.unobserve()`.
+export const OBSERVER_CONSTRUCTOR_NAMES = new Set([
+  "ResizeObserver",
+  "MutationObserver",
+  "IntersectionObserver",
+  "PerformanceObserver",
+  "ReportingObserver",
+]);
+
 // Globals whose values mutate outside the React data flow. Listing
 // them as deps doesn't trigger a re-run when they change because
 // React compares deps with `Object.is` during render — and the read

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
@@ -43,7 +43,12 @@ export const TIMER_CLEANUP_CALLEE_NAMES = new Set(["clearInterval", "clearTimeou
 // Connection-opening constructors. Connecting starts at construction
 // time, so an instance created without a later `.close()` keeps the
 // connection (and its message handlers) alive after unmount.
-export const SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP = new Set(["WebSocket", "EventSource"]);
+export const SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP = new Set([
+  "WebSocket",
+  "EventSource",
+  "BroadcastChannel",
+  "RTCPeerConnection",
+]);
 
 // Globals whose values mutate outside the React data flow. Listing
 // them as deps doesn't trigger a re-run when they change because

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
@@ -45,16 +45,6 @@ export const TIMER_CLEANUP_CALLEE_NAMES = new Set(["clearInterval", "clearTimeou
 // connection (and its message handlers) alive after unmount.
 export const SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP = new Set(["WebSocket", "EventSource"]);
 
-// DOM observer constructors whose `.observe(...)` registration keeps
-// firing until `.disconnect()` / `.unobserve()`.
-export const OBSERVER_CONSTRUCTOR_NAMES = new Set([
-  "ResizeObserver",
-  "MutationObserver",
-  "IntersectionObserver",
-  "PerformanceObserver",
-  "ReportingObserver",
-]);
-
 // Globals whose values mutate outside the React data flow. Listing
 // them as deps doesn't trigger a re-run when they change because
 // React compares deps with `Object.is` during render — and the read

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -181,6 +181,11 @@ export const GLOBAL_RELEASE_METHOD_NAMES = new Set([
   "unlisten",
   "unsub",
   "abort",
+  // Observer (`ResizeObserver` et al.) and connection (`WebSocket` /
+  // `EventSource`) release verbs.
+  "disconnect",
+  "unobserve",
+  "close",
 ]);
 
 export const BOUND_RESOURCE_RELEASE_METHOD_NAMES = new Set([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -166,6 +166,254 @@ export const Listener = () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("flags a ResizeObserver observed in an effect without disconnect", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Measurer = () => {
+  const elementRef = useRef(null);
+  useEffect(() => {
+    const observer = new ResizeObserver(() => update());
+    observer.observe(elementRef.current);
+  }, []);
+  return <div ref={elementRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("observe");
+  });
+
+  it("does not flag an observer whose cleanup calls disconnect", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Measurer = () => {
+  const elementRef = useRef(null);
+  useEffect(() => {
+    const observer = new IntersectionObserver(() => update());
+    observer.observe(elementRef.current);
+    return () => observer.disconnect();
+  }, []);
+  return <div ref={elementRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a MutationObserver cleaned up via unobserve", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const DomWatcher = ({ target }) => {
+  useEffect(() => {
+    const observer = new MutationObserver(() => update());
+    observer.observe(target, { childList: true });
+    return () => observer.unobserve(target);
+  }, [target]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a WebSocket opened in an effect without close", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const LiveFeed = ({ url }) => {
+  useEffect(() => {
+    const socket = new WebSocket(url);
+    socket.onmessage = (event) => update(event.data);
+  }, [url]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("WebSocket");
+    expect(result.diagnostics[0].message).toContain("connection");
+  });
+
+  it("flags returning the WebSocket handle itself as cleanup (closes nothing)", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const LiveFeed = ({ url }) => {
+  useEffect(() => {
+    const socket = new WebSocket(url);
+    return socket;
+  }, [url]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an EventSource closed in cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const ServerEvents = ({ url }) => {
+  useEffect(() => {
+    const source = new EventSource(url);
+    source.onmessage = (event) => update(event.data);
+    return () => source.close();
+  }, [url]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a discarded setInterval inside a useCallback (unclearable)", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback } from "react";
+export const Poller = () => {
+  const startPolling = useCallback(() => {
+    setInterval(() => poll(), 1000);
+  }, []);
+  return <button onClick={startPolling}>start</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("setInterval");
+  });
+
+  it("does not flag a setInterval in useCallback whose id is captured", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Poller = () => {
+  const intervalRef = useRef(null);
+  const startPolling = useCallback(() => {
+    intervalRef.current = setInterval(() => poll(), 1000);
+  }, []);
+  const stopPolling = useCallback(() => {
+    clearInterval(intervalRef.current);
+  }, []);
+  return <button onClick={startPolling} onBlur={stopPolling}>start</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a one-shot setTimeout in a component-scope handler", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useState } from "react";
+export const Toast = () => {
+  const [visible, setVisible] = useState(false);
+  const showToast = () => {
+    setVisible(true);
+    setTimeout(() => setVisible(false), 3000);
+  };
+  return <button onClick={showToast}>show</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a discarded setInterval inside a component-scope handler", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const Ticker = () => {
+  const startTicking = () => {
+    setInterval(() => tick(), 1000);
+  };
+  return <button onClick={startTicking}>tick</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an addEventListener in a handler when the file has no release call at all", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const KeyTracker = () => {
+  const armListener = () => {
+    window.addEventListener("keydown", (event) => track(event.key));
+  };
+  return <button onClick={armListener}>arm</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("addEventListener");
+  });
+
+  it("does not flag a handler subscription when another function releases it", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const KeyTracker = () => {
+  const onKeyDown = (event) => track(event.key);
+  const armListener = () => {
+    window.addEventListener("keydown", onKeyDown);
+  };
+  const disarmListener = () => {
+    window.removeEventListener("keydown", onKeyDown);
+  };
+  return <button onClick={armListener} onBlur={disarmListener}>arm</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a `{ once: true }` listener registered in a handler", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const OneShot = () => {
+  const armListener = () => {
+    window.addEventListener("pointerup", () => finish(), { once: true });
+  };
+  return <button onPointerDown={armListener}>press</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a handler that manages its own release (toggle shape)", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const Toggle = ({ emitter, handler }) => {
+  const retarget = () => {
+    emitter.off("change", handler);
+    emitter.on("change", handler);
+  };
+  return <button onClick={retarget}>retarget</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a captured subscription disposer in a useCallback", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const StoreBridge = ({ store }) => {
+  const unsubscribeRef = useRef(null);
+  const connect = useCallback(() => {
+    unsubscribeRef.current = store.subscribe(() => sync());
+  }, [store]);
+  return <button onClick={connect}>connect</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("still flags an HTTP `server.listen(port)` whose returned server is returned from the effect", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -253,6 +253,40 @@ export const LiveFeed = ({ url }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a BroadcastChannel opened in an effect without close", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const TabSync = ({ channelName }) => {
+  useEffect(() => {
+    const channel = new BroadcastChannel(channelName);
+    channel.onmessage = (event) => applyRemoteChange(event.data);
+  }, [channelName]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("BroadcastChannel");
+  });
+
+  it("does not flag an RTCPeerConnection closed in cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Call = ({ config }) => {
+  useEffect(() => {
+    const peerConnection = new RTCPeerConnection(config);
+    peerConnection.ontrack = (event) => attachStream(event.streams[0]);
+    return () => peerConnection.close();
+  }, [config]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag an EventSource closed in cleanup", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -448,6 +448,172 @@ export const StoreBridge = ({ store }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("flags a `{ once: false }` listener registered in a handler", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const KeyTracker = () => {
+  const armListener = () => {
+    window.addEventListener("keydown", (event) => track(event.key), { once: false });
+  };
+  return <button onClick={armListener}>arm</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("addEventListener");
+  });
+
+  it("flags a listener whose `once` option is a variable (may be false)", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const KeyTracker = ({ shouldFireOnce }) => {
+  const armListener = () => {
+    window.addEventListener("keydown", (event) => track(event.key), { once: shouldFireOnce });
+  };
+  return <button onClick={armListener}>arm</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a listener released through an abort `{ signal }` option", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const KeyTracker = ({ controller }) => {
+  const armListener = () => {
+    window.addEventListener("keydown", (event) => track(event.key), { signal: controller.signal });
+  };
+  return <button onClick={armListener}>arm</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a handler listener even when the same handler closes an unrelated resource", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const Recorder = ({ stream }) => {
+  const armListener = () => {
+    stream.close();
+    window.addEventListener("keydown", (event) => track(event.key));
+  };
+  return <button onClick={armListener}>arm</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("addEventListener");
+  });
+
+  it("flags a discarded setInterval even when the same handler closes a connection", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const Reconnector = ({ socket }) => {
+  const restart = () => {
+    socket.close();
+    setInterval(() => tick(), 1000);
+  };
+  return <button onClick={restart}>restart</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("setInterval");
+  });
+
+  it("does not flag a discarded setInterval in a handler that also clears an interval", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const Ticker = ({ tickIdRef }) => {
+  const restart = () => {
+    clearInterval(tickIdRef.current);
+    setInterval(() => tick(), 1000);
+  };
+  return <button onClick={restart}>restart</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a WebSocket constructed as a concise useCallback body", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback } from "react";
+export const LiveFeed = ({ url }) => {
+  const connect = useCallback(() => new WebSocket(url), [url]);
+  return <button onClick={connect}>connect</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("WebSocket");
+  });
+
+  it("flags an EventSource constructed as a concise component-scope handler body", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const ServerEvents = ({ url }) => {
+  const connect = () => new EventSource(url);
+  return <button onClick={connect}>connect</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("EventSource");
+  });
+
+  it("does not flag a concise-body socket whose handle is stored in a ref", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const LiveFeed = ({ url }) => {
+  const socketRef = useRef(null);
+  const connect = useCallback(() => (socketRef.current = new WebSocket(url)), [url]);
+  return <button onClick={connect}>connect</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not attribute a setInterval inside a nested inner callback to the retained handler", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback } from "react";
+export const Chart = ({ node }) => {
+  const draw = useCallback(() => {
+    render(node, {
+      onFrame: () => {
+        setInterval(() => tick(), 1000);
+      },
+    });
+  }, [node]);
+  return <button onClick={draw}>draw</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a direct leak in a handler that also defines a nested inner function", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `export const Poller = () => {
+  const startPolling = () => {
+    const format = (value) => String(value);
+    setInterval(() => poll(format), 1000);
+  };
+  return <button onClick={startPolling}>start</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("setInterval");
+  });
+
   it("still flags an HTTP `server.listen(port)` whose returned server is returned from the effect", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -17,11 +17,11 @@ import {
   isSubscribeLikeCallExpression,
 } from "./utils/is-subscribe-like-call-expression.js";
 import {
-  containsReleaseLikeCall,
   isCleanupFunctionLike,
   isCleanupReturn,
   isReleaseLikeCall,
 } from "./utils/is-cleanup-return.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -271,24 +271,29 @@ const effectHasCleanupReturn = (
 // scope — leaks exactly like one created in an effect, but no effect
 // cleanup return can ever release it. The firing policy here is much
 // stricter than the effect policy to stay precise:
-//   - `setInterval` with a DISCARDED id: unclearable, always a leak.
-//   - a discarded `new WebSocket(...)` / `new EventSource(...)`:
-//     the connection opens at construction and the handle is gone.
+//   - `setInterval` with a DISCARDED id: a leak unless the same handler
+//     also clears an interval (start/stop pairs manage their own ids).
+//   - a discarded `new WebSocket(...)` / `new EventSource(...)`: the
+//     connection opens at construction and the handle is gone, unless
+//     the same handler also closes a connection (reconnect shape).
 //   - a discarded subscribe/observe registration, but only when the
-//     whole file contains no release-shaped call at all (a matching
-//     `removeEventListener` / `disconnect` / `unsubscribe` elsewhere
-//     means the component manages the lifecycle across functions).
+//     whole file contains no PAIRED release for that registration verb
+//     (a `removeEventListener` elsewhere means the component manages a
+//     listener's lifecycle across functions; an unrelated
+//     `stream.close()` releases no listener and must not hide one).
+// Nested functions are separate scopes: a leak inside an inner callback
+// or a nested `useEffect` belongs to that function's own analysis, not
+// to the retained handler that happens to enclose it.
 // `setTimeout` is deliberately exempt on this path: a one-shot timer
 // in a handler (debounce, toast dismiss) is idiomatic, self-clearing
 // fire-and-forget.
 
 const EMPTY_NAME_SET: ReadonlySet<string> = new Set();
 
-const isDiscardedConstruction = (node: EsTreeNode): boolean =>
-  isNodeOfType(node.parent, "ExpressionStatement");
-
 // `addEventListener(name, handler, { once: true })` self-releases and
 // `{ signal }` delegates release to an AbortController — neither leaks.
+// `once` must be literally `true`: `{ once: false }` — or a value that
+// may be false — keeps the listener registered.
 const hasSelfReleasingListenerOptions = (node: EsTreeNode): boolean =>
   isNodeOfType(node, "CallExpression") &&
   (node.arguments ?? []).some(
@@ -298,48 +303,123 @@ const hasSelfReleasingListenerOptions = (node: EsTreeNode): boolean =>
         (property) =>
           isNodeOfType(property, "Property") &&
           isNodeOfType(property.key, "Identifier") &&
-          (property.key.name === "once" || property.key.name === "signal"),
+          (property.key.name === "signal" ||
+            (property.key.name === "once" &&
+              isNodeOfType(property.value, "Literal") &&
+              property.value.value === true)),
       ),
   );
 
-const fileReleaseScanCache = new WeakMap<EsTreeNode, boolean>();
+// A release call only counts against a leak when its verb can plausibly
+// release that resource. `on` pairs with `.on(name, null)` (d3-style
+// removal), which `isReleaseLikeCall` already recognizes.
+const PAIRED_RELEASE_VERB_NAMES_BY_REGISTRATION_VERB: ReadonlyMap<
+  string,
+  ReadonlySet<string>
+> = new Map([
+  ["addEventListener", new Set(["removeEventListener", "abort"])],
+  ["addListener", new Set(["removeListener", "off", "abort"])],
+  ["on", new Set(["off", "removeListener", "on"])],
+  ["subscribe", new Set(["unsubscribe", "unsub"])],
+  ["sub", new Set(["unsub", "unsubscribe"])],
+  ["watch", new Set(["unwatch", "close"])],
+  ["listen", new Set(["unlisten", "close"])],
+  [OBSERVER_REGISTRATION_METHOD_NAME, new Set(["disconnect", "unobserve"])],
+]);
 
-const fileContainsReleaseLikeCall = (anyNode: EsTreeNode): boolean => {
-  let programNode: EsTreeNode = anyNode;
-  while (programNode.parent) programNode = programNode.parent;
-  const cached = fileReleaseScanCache.get(programNode);
-  if (cached !== undefined) return cached;
-  let didFindRelease = false;
-  walkAst(programNode, (child: EsTreeNode) => {
-    if (didFindRelease) return false;
-    if (isReleaseLikeCall(child, EMPTY_NAME_SET, EMPTY_NAME_SET)) {
-      didFindRelease = true;
+// Whole-lifecycle verbs that release any resource kind.
+const UNIVERSAL_RELEASE_VERB_NAMES: ReadonlySet<string> = new Set([
+  "cleanup",
+  "dispose",
+  "destroy",
+  "teardown",
+]);
+
+const SOCKET_RELEASE_VERB_NAMES: ReadonlySet<string> = new Set(["close"]);
+
+const INTERVAL_RELEASE_VERB_NAMES: ReadonlySet<string> = new Set(["clearInterval"]);
+
+const getReleaseVerbName = (node: EsTreeNode): string | null => {
+  if (!isReleaseLikeCall(node, EMPTY_NAME_SET, EMPTY_NAME_SET)) return null;
+  const callNode = isNodeOfType(node, "ChainExpression") ? node.expression : node;
+  if (!isNodeOfType(callNode, "CallExpression")) return null;
+  const callee = isNodeOfType(callNode.callee, "ChainExpression")
+    ? callNode.callee.expression
+    : callNode.callee;
+  if (isNodeOfType(callee, "Identifier")) return callee.name;
+  if (isNodeOfType(callee, "MemberExpression") && isNodeOfType(callee.property, "Identifier")) {
+    return callee.property.name;
+  }
+  return null;
+};
+
+const matchesPairedReleaseVerb = (
+  releaseVerbName: string,
+  pairedVerbNames: ReadonlySet<string>,
+): boolean =>
+  pairedVerbNames.has(releaseVerbName) || UNIVERSAL_RELEASE_VERB_NAMES.has(releaseVerbName);
+
+const bodyContainsPairedReleaseCall = (
+  body: EsTreeNode,
+  pairedVerbNames: ReadonlySet<string>,
+): boolean => {
+  let didFindPairedRelease = false;
+  walkAst(body, (child: EsTreeNode) => {
+    if (didFindPairedRelease) return false;
+    if (child !== body && isFunctionLike(child)) return false;
+    const releaseVerbName = getReleaseVerbName(child);
+    if (releaseVerbName !== null && matchesPairedReleaseVerb(releaseVerbName, pairedVerbNames)) {
+      didFindPairedRelease = true;
       return false;
     }
   });
-  fileReleaseScanCache.set(programNode, didFindRelease);
-  return didFindRelease;
+  return didFindPairedRelease;
+};
+
+const fileReleaseVerbNamesCache = new WeakMap<EsTreeNode, ReadonlySet<string>>();
+
+const collectFileReleaseVerbNames = (anyNode: EsTreeNode): ReadonlySet<string> => {
+  let programNode: EsTreeNode = anyNode;
+  while (programNode.parent) programNode = programNode.parent;
+  const cached = fileReleaseVerbNamesCache.get(programNode);
+  if (cached) return cached;
+  const releaseVerbNames = new Set<string>();
+  walkAst(programNode, (child: EsTreeNode) => {
+    const releaseVerbName = getReleaseVerbName(child);
+    if (releaseVerbName !== null) releaseVerbNames.add(releaseVerbName);
+  });
+  fileReleaseVerbNamesCache.set(programNode, releaseVerbNames);
+  return releaseVerbNames;
+};
+
+const fileContainsPairedReleaseCall = (
+  registrationCall: EsTreeNode,
+  registrationVerbName: string,
+): boolean => {
+  const fileReleaseVerbNames = collectFileReleaseVerbNames(registrationCall);
+  const pairedVerbNames = PAIRED_RELEASE_VERB_NAMES_BY_REGISTRATION_VERB.get(registrationVerbName);
+  if (!pairedVerbNames) return fileReleaseVerbNames.size > 0;
+  for (const releaseVerbName of fileReleaseVerbNames) {
+    if (matchesPairedReleaseVerb(releaseVerbName, pairedVerbNames)) return true;
+  }
+  return false;
 };
 
 const findRetainedFunctionLeak = (retainedFunction: EsTreeNode): SubscribeLikeUsage | null => {
-  if (
-    !isNodeOfType(retainedFunction, "ArrowFunctionExpression") &&
-    !isNodeOfType(retainedFunction, "FunctionExpression") &&
-    !isNodeOfType(retainedFunction, "FunctionDeclaration")
-  ) {
-    return null;
-  }
+  if (!isFunctionLike(retainedFunction)) return null;
   const body = retainedFunction.body;
   if (!body) return null;
-  // A function that also releases something manages its own resource
-  // lifecycle (toggle handlers, start/stop pairs) — leave it alone.
-  if (containsReleaseLikeCall(body, EMPTY_NAME_SET, EMPTY_NAME_SET)) return null;
 
   let leak: SubscribeLikeUsage | null = null;
   walkAst(body, (child: EsTreeNode) => {
     if (leak !== null) return false;
+    if (isFunctionLike(child)) return false;
 
-    if (isSocketConstruction(child) && isDiscardedConstruction(child)) {
+    if (
+      isSocketConstruction(child) &&
+      isResultDiscardedCall(child) &&
+      !bodyContainsPairedReleaseCall(body, SOCKET_RELEASE_VERB_NAMES)
+    ) {
       leak = {
         kind: "socket",
         node: child,
@@ -353,24 +433,25 @@ const findRetainedFunctionLeak = (retainedFunction: EsTreeNode): SubscribeLikeUs
     if (
       isNodeOfType(child.callee, "Identifier") &&
       child.callee.name === "setInterval" &&
-      isResultDiscardedCall(child)
+      isResultDiscardedCall(child) &&
+      !bodyContainsPairedReleaseCall(body, INTERVAL_RELEASE_VERB_NAMES)
     ) {
       leak = { kind: "timer", node: child, resourceName: "setInterval" };
       return false;
     }
 
-    if (
-      isSubscribeOrObserveCall(child) &&
-      isResultDiscardedCall(child) &&
-      !hasSelfReleasingListenerOptions(child) &&
-      !fileContainsReleaseLikeCall(child)
-    ) {
-      const propertyName =
+    if (isSubscribeOrObserveCall(child) && isResultDiscardedCall(child)) {
+      const registrationVerbName =
         isNodeOfType(child.callee, "MemberExpression") &&
         isNodeOfType(child.callee.property, "Identifier")
           ? child.callee.property.name
           : "subscribe";
-      leak = { kind: "subscribe", node: child, resourceName: propertyName };
+      if (
+        !hasSelfReleasingListenerOptions(child) &&
+        !fileContainsPairedReleaseCall(child, registrationVerbName)
+      ) {
+        leak = { kind: "subscribe", node: child, resourceName: registrationVerbName };
+      }
       return false;
     }
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -1,8 +1,13 @@
-import { TIMER_CALLEE_NAMES_REQUIRING_CLEANUP } from "../../constants/dom.js";
+import {
+  SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP,
+  TIMER_CALLEE_NAMES_REQUIRING_CLEANUP,
+} from "../../constants/dom.js";
 import { EFFECT_HOOK_NAMES, SUBSCRIPTION_METHOD_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or-hook-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { isResultDiscardedCall } from "../../utils/is-result-discarded-call.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blocks.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -11,15 +16,47 @@ import {
   isCleanupReturningSubscribeLikeCallExpression,
   isSubscribeLikeCallExpression,
 } from "./utils/is-subscribe-like-call-expression.js";
-import { isCleanupFunctionLike, isCleanupReturn } from "./utils/is-cleanup-return.js";
+import {
+  containsReleaseLikeCall,
+  isCleanupFunctionLike,
+  isCleanupReturn,
+  isReleaseLikeCall,
+} from "./utils/is-cleanup-return.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
+// `observer.observe(el)` is the registration moment for ResizeObserver /
+// MutationObserver / IntersectionObserver et al. — subscription-shaped,
+// but not in `SUBSCRIPTION_METHOD_NAMES` (other consumers of that set
+// treat subscriptions as store-like).
+const OBSERVER_REGISTRATION_METHOD_NAME = "observe";
+
 interface SubscribeLikeUsage {
-  kind: "subscribe" | "timer";
+  kind: "subscribe" | "timer" | "socket";
   node: EsTreeNode;
   resourceName: string;
 }
+
+const RESOURCE_NOUN_BY_KIND = {
+  subscribe: "subscription",
+  timer: "timer",
+  socket: "connection",
+} as const;
+
+const isSocketConstruction = (node: EsTreeNode): node is EsTreeNodeOfType<"NewExpression"> =>
+  isNodeOfType(node, "NewExpression") &&
+  isNodeOfType(node.callee, "Identifier") &&
+  SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP.has(node.callee.name);
+
+const isSubscribeOrObserveCall = (node: EsTreeNode): boolean => {
+  if (isSubscribeLikeCallExpression(node)) return true;
+  return (
+    isNodeOfType(node, "CallExpression") &&
+    isNodeOfType(node.callee, "MemberExpression") &&
+    isNodeOfType(node.callee.property, "Identifier") &&
+    node.callee.property.name === OBSERVER_REGISTRATION_METHOD_NAME
+  );
+};
 
 const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => {
   const usages: SubscribeLikeUsage[] = [];
@@ -40,6 +77,16 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
 
   walkAst(callback, (child: EsTreeNode) => {
     if (child === cleanupArgument && !isSubscribeLikeCallExpression(child)) return false;
+
+    if (isSocketConstruction(child)) {
+      usages.push({
+        kind: "socket",
+        node: child,
+        resourceName: isNodeOfType(child.callee, "Identifier") ? child.callee.name : "WebSocket",
+      });
+      return;
+    }
+
     if (!isNodeOfType(child, "CallExpression")) return;
 
     if (
@@ -57,7 +104,8 @@ const findSubscribeLikeUsages = (callback: EsTreeNode): SubscribeLikeUsage[] => 
     if (
       isNodeOfType(child.callee, "MemberExpression") &&
       isNodeOfType(child.callee.property, "Identifier") &&
-      SUBSCRIPTION_METHOD_NAMES.has(child.callee.property.name)
+      (SUBSCRIPTION_METHOD_NAMES.has(child.callee.property.name) ||
+        child.callee.property.name === OBSERVER_REGISTRATION_METHOD_NAME)
     ) {
       usages.push({
         kind: "subscribe",
@@ -96,7 +144,14 @@ const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => 
       const bindingName = declarator.id.name;
       bindings.effectScopeVariableNames.add(bindingName);
       const init = declarator.init;
-      if (!init || !isNodeOfType(init, "CallExpression")) continue;
+      if (!init) continue;
+      // A socket handle is not a cleanup function — returning it from
+      // the effect closes nothing (cleanup is `.close()`).
+      if (isSocketConstruction(init)) {
+        bindings.subscriptionNames.add(bindingName);
+        continue;
+      }
+      if (!isNodeOfType(init, "CallExpression")) continue;
       if (isSubscribeLikeCallExpression(init)) {
         bindings.subscriptionNames.add(bindingName);
         if (isCleanupReturningSubscribeLikeCallExpression(init)) {
@@ -209,30 +264,185 @@ const effectHasCleanupReturn = (
   return didFindCleanupReturn;
 };
 
+// ---- Retained-function analysis (useCallback / component-scope handlers) ----
+//
+// A resource created inside a function that survives past the current
+// call — a `useCallback` callback or a handler declared in component
+// scope — leaks exactly like one created in an effect, but no effect
+// cleanup return can ever release it. The firing policy here is much
+// stricter than the effect policy to stay precise:
+//   - `setInterval` with a DISCARDED id: unclearable, always a leak.
+//   - a discarded `new WebSocket(...)` / `new EventSource(...)`:
+//     the connection opens at construction and the handle is gone.
+//   - a discarded subscribe/observe registration, but only when the
+//     whole file contains no release-shaped call at all (a matching
+//     `removeEventListener` / `disconnect` / `unsubscribe` elsewhere
+//     means the component manages the lifecycle across functions).
+// `setTimeout` is deliberately exempt on this path: a one-shot timer
+// in a handler (debounce, toast dismiss) is idiomatic, self-clearing
+// fire-and-forget.
+
+const EMPTY_NAME_SET: ReadonlySet<string> = new Set();
+
+const isDiscardedConstruction = (node: EsTreeNode): boolean =>
+  isNodeOfType(node.parent, "ExpressionStatement");
+
+// `addEventListener(name, handler, { once: true })` self-releases and
+// `{ signal }` delegates release to an AbortController — neither leaks.
+const hasSelfReleasingListenerOptions = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") &&
+  (node.arguments ?? []).some(
+    (argument) =>
+      isNodeOfType(argument, "ObjectExpression") &&
+      (argument.properties ?? []).some(
+        (property) =>
+          isNodeOfType(property, "Property") &&
+          isNodeOfType(property.key, "Identifier") &&
+          (property.key.name === "once" || property.key.name === "signal"),
+      ),
+  );
+
+const fileReleaseScanCache = new WeakMap<EsTreeNode, boolean>();
+
+const fileContainsReleaseLikeCall = (anyNode: EsTreeNode): boolean => {
+  let programNode: EsTreeNode = anyNode;
+  while (programNode.parent) programNode = programNode.parent;
+  const cached = fileReleaseScanCache.get(programNode);
+  if (cached !== undefined) return cached;
+  let didFindRelease = false;
+  walkAst(programNode, (child: EsTreeNode) => {
+    if (didFindRelease) return false;
+    if (isReleaseLikeCall(child, EMPTY_NAME_SET, EMPTY_NAME_SET)) {
+      didFindRelease = true;
+      return false;
+    }
+  });
+  fileReleaseScanCache.set(programNode, didFindRelease);
+  return didFindRelease;
+};
+
+const findRetainedFunctionLeak = (retainedFunction: EsTreeNode): SubscribeLikeUsage | null => {
+  if (
+    !isNodeOfType(retainedFunction, "ArrowFunctionExpression") &&
+    !isNodeOfType(retainedFunction, "FunctionExpression") &&
+    !isNodeOfType(retainedFunction, "FunctionDeclaration")
+  ) {
+    return null;
+  }
+  const body = retainedFunction.body;
+  if (!body) return null;
+  // A function that also releases something manages its own resource
+  // lifecycle (toggle handlers, start/stop pairs) — leave it alone.
+  if (containsReleaseLikeCall(body, EMPTY_NAME_SET, EMPTY_NAME_SET)) return null;
+
+  let leak: SubscribeLikeUsage | null = null;
+  walkAst(body, (child: EsTreeNode) => {
+    if (leak !== null) return false;
+
+    if (isSocketConstruction(child) && isDiscardedConstruction(child)) {
+      leak = {
+        kind: "socket",
+        node: child,
+        resourceName: isNodeOfType(child.callee, "Identifier") ? child.callee.name : "WebSocket",
+      };
+      return false;
+    }
+
+    if (!isNodeOfType(child, "CallExpression")) return;
+
+    if (
+      isNodeOfType(child.callee, "Identifier") &&
+      child.callee.name === "setInterval" &&
+      isResultDiscardedCall(child)
+    ) {
+      leak = { kind: "timer", node: child, resourceName: "setInterval" };
+      return false;
+    }
+
+    if (
+      isSubscribeOrObserveCall(child) &&
+      isResultDiscardedCall(child) &&
+      !hasSelfReleasingListenerOptions(child) &&
+      !fileContainsReleaseLikeCall(child)
+    ) {
+      const propertyName =
+        isNodeOfType(child.callee, "MemberExpression") &&
+        isNodeOfType(child.callee.property, "Identifier")
+          ? child.callee.property.name
+          : "subscribe";
+      leak = { kind: "subscribe", node: child, resourceName: propertyName };
+      return false;
+    }
+  });
+  return leak;
+};
+
+const isRetainedComponentScopeFunction = (functionNode: EsTreeNode): boolean => {
+  if (isNodeOfType(functionNode, "FunctionDeclaration")) {
+    return enclosingComponentOrHookName(functionNode) !== null;
+  }
+  if (
+    !isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(functionNode, "FunctionExpression")
+  ) {
+    return false;
+  }
+  // Only named component-scope bindings (`const onScroll = () => {...}`);
+  // inline callback arguments are attributed to whatever consumes them.
+  if (!isNodeOfType(functionNode.parent, "VariableDeclarator")) return false;
+  return enclosingComponentOrHookName(functionNode) !== null;
+};
+
 export const effectNeedsCleanup = defineRule({
   id: "effect-needs-cleanup",
   title: "Effect subscription or timer never cleaned up",
   severity: "error",
   tags: ["test-noise"],
   recommendation:
-    "Return a cleanup function that stops the subscription or timer: `return () => target.removeEventListener(name, handler)` for listeners, `return () => clearInterval(id)` or `clearTimeout(id)` for timers, or `return unsubscribe` if the subscribe call already gave you one.",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
-      const callback = getEffectCallback(node);
-      if (!callback) return;
-
-      const usages = findSubscribeLikeUsages(callback);
-      if (usages.length === 0) return;
-
-      if (effectHasCleanupReturn(callback, usages)) return;
-
-      const firstUsage = usages[0];
-      const resourceKind = firstUsage.kind === "timer" ? "timer" : "subscription";
+    "Return a cleanup function that stops the subscription or timer: `return () => target.removeEventListener(name, handler)` for listeners, `return () => clearInterval(id)` or `clearTimeout(id)` for timers, `return () => observer.disconnect()` for observers, `return () => socket.close()` for connections, or `return unsubscribe` if the subscribe call already gave you one.",
+  create: (context: RuleContext) => {
+    const reportRetainedLeak = (retainedFunction: EsTreeNode): void => {
+      const leak = findRetainedFunctionLeak(retainedFunction);
+      if (!leak) return;
+      const resourceNoun = RESOURCE_NOUN_BY_KIND[leak.kind];
       context.report({
-        node,
-        message: `\`${firstUsage.resourceName}\` creates a ${resourceKind} in useEffect without returning cleanup. Return a cleanup function so it does not leak after unmount.`,
+        node: leak.node,
+        message: `\`${leak.resourceName}\` creates a ${resourceNoun} in a function that outlives the render, with no cleanup path. Store the handle and release it, or move this into a useEffect that returns cleanup, so it does not leak after unmount.`,
       });
-    },
-  }),
+    };
+
+    return {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (isHookCall(node, "useCallback")) {
+          const retainedCallback = getEffectCallback(node);
+          if (retainedCallback) reportRetainedLeak(retainedCallback);
+          return;
+        }
+        if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+        const callback = getEffectCallback(node);
+        if (!callback) return;
+
+        const usages = findSubscribeLikeUsages(callback);
+        if (usages.length === 0) return;
+
+        if (effectHasCleanupReturn(callback, usages)) return;
+
+        const firstUsage = usages[0];
+        const resourceNoun = RESOURCE_NOUN_BY_KIND[firstUsage.kind];
+        context.report({
+          node,
+          message: `\`${firstUsage.resourceName}\` creates a ${resourceNoun} in useEffect without returning cleanup. Return a cleanup function so it does not leak after unmount.`,
+        });
+      },
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+        if (isRetainedComponentScopeFunction(node)) reportRetainedLeak(node);
+      },
+      ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
+        if (isRetainedComponentScopeFunction(node)) reportRetainedLeak(node);
+      },
+      FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
+        if (isRetainedComponentScopeFunction(node)) reportRetainedLeak(node);
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-cleanup-return.ts
@@ -78,7 +78,7 @@ const isNoOpInlineHandlerRemoval = (
   );
 };
 
-const isReleaseLikeCall = (
+export const isReleaseLikeCall = (
   node: EsTreeNode,
   knownCleanupFunctionNames: ReadonlySet<string>,
   knownBoundSubscriptionNames: ReadonlySet<string>,
@@ -131,7 +131,7 @@ const isIteratorCallbackArgument = (node: EsTreeNode): boolean => {
   );
 };
 
-const containsReleaseLikeCall = (
+export const containsReleaseLikeCall = (
   node: EsTreeNode,
   knownCleanupFunctionNames: ReadonlySet<string>,
   knownBoundSubscriptionNames: ReadonlySet<string>,


### PR DESCRIPTION
## Why

`effect-needs-cleanup` was name-driven and useEffect-scoped, which left two big leak classes invisible:

1. **Missing resources.** DOM observers (`ResizeObserver`, `MutationObserver`, `IntersectionObserver`, `PerformanceObserver`) and connections (`new WebSocket(...)`, `new EventSource(...)`) weren't in the resource vocabulary, so an effect that registers an observer or opens a socket with no cleanup was never flagged.
2. **Missing scopes.** Only effect callbacks were analyzed. A `setInterval` or subscription created inside a `useCallback` or a component-scope handler leaks exactly the same way — and no effect cleanup return can ever release it.

Before (all silent):

```tsx
useEffect(() => {
  const observer = new ResizeObserver(update);
  observer.observe(elementRef.current);          // no disconnect
}, []);

useEffect(() => {
  const socket = new WebSocket(url);             // no close
  socket.onmessage = handleMessage;
}, [url]);

const startPolling = useCallback(() => {
  setInterval(poll, 1000);                       // id discarded — unclearable
}, []);
```

After: all three fire. Cleanup shapes are recognized (`observer.disconnect()` / `.unobserve()`, `socket.close()`), and returning the socket handle itself is correctly rejected as cleanup (closing happens via `.close()`, not by returning the object).

The retained-function path uses a deliberately stricter policy to stay precise: it fires only on a discarded `setInterval` id, a discarded socket construction, or a discarded subscribe/observe registration in a file with **no** release-shaped call anywhere. One-shot `setTimeout` in handlers (debounce, toast), `{ once: true }` / `{ signal }` listeners, captured handles, and functions that release their own resources are all exempt.

## What changed

- Observer registration (`.observe`) and socket constructions join `findSubscribeLikeUsages`; `disconnect` / `unobserve` / `close` join the release vocabulary.
- Retained-function analysis for `useCallback` callbacks and named component-scope functions, with the strict firing policy above and a cached whole-file release scan.
- Diagnostic nouns are kind-aware (timer / subscription / connection); the recommendation text covers the new cleanup shapes.
- 15 new adversarial regression tests covering both directions for every new shape.
- Changeset included.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/state-and-effects/effect-needs-cleanup`
- `pnpm --filter oxlint-plugin-react-doctor typecheck`
- Full plugin suite (10,900+ tests) green locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands a lint rule with whole-file release scanning and new retained-function visitors, which may add false positives on legitimate handler patterns despite strict exemptions; effect-path behavior is mostly additive with broad test coverage.
> 
> **Overview**
> **`effect-needs-cleanup`** now flags more leak patterns in `useEffect` / `useLayoutEffect` and extends analysis to functions that survive re-renders (`useCallback` and named component-scope handlers).
> 
> In effects, the rule treats **observer `.observe(...)`** and **`new WebSocket` / `EventSource` / `BroadcastChannel` / `RTCPeerConnection`** as resources needing cleanup (`disconnect` / `unobserve` / `close`). Returning a socket handle alone is **not** accepted as cleanup.
> 
> For **retained functions**, reporting uses a stricter policy: discarded **`setInterval`** ids, discarded socket constructions, and discarded subscribe/observe calls when the file has no **paired** release verb (with exemptions for one-shot **`setTimeout`**, **`{ once: true }`** / **`{ signal }`** listeners, captured handles, same-handler **`clearInterval`**, and nested inner callbacks). Diagnostics use kind-specific nouns (timer / subscription / connection).
> 
> Constants and **`isReleaseLikeCall`** exports were updated; a large regression suite documents the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8fc36501d8bd4e3c4d789e18a5e816434322f3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->