### PR TITLE
RB-COMP-FIX: no-react19-deprecated-apis — stop calling useContext deprecated

### DIFF
--- a/.changeset/react19-usecontext-not-deprecated.md
+++ b/.changeset/react19-usecontext-not-deprecated.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+no-react19-deprecated-apis no longer flags `useContext`. React 19's `use()` is an additive alternative — `useContext` remains a fully supported, non-deprecated API, so calling it deprecated was misinformation. The rule still flags `forwardRef` (both named imports and `React.forwardRef` member access) on React 19+ projects.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.regressions.test.ts
@@ -43,7 +43,9 @@ describe("architecture/no-react19-deprecated-apis — regressions", () => {
     expect(result.diagnostics[0]?.message).toContain("forwardRef");
   });
 
-  it("reports forwardRef and useContext separately in the same file", () => {
+  // useContext is NOT deprecated in React 19 — `use()` is additive. Flagging
+  // it was reward-deciding misinformation (RD-FP-010).
+  it("does not flag useContext (not deprecated; use() is additive)", () => {
     const result = run(
       `import { forwardRef, useContext } from "react";
 const Ctx = {};
@@ -53,10 +55,8 @@ const useTheme = () => useContext(Ctx);
 const useLocale = () => useContext(Ctx);
 `,
     );
-    expect(result.diagnostics).toHaveLength(2);
-    const messages = result.diagnostics.map((diagnostic) => diagnostic.message).sort();
-    expect(messages[0]).toContain("forwardRef");
-    expect(messages[1]).toContain("useContext");
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain("forwardRef");
   });
 
   it("still flags a named forwardRef import outside components/ui/", () => {
@@ -69,15 +69,14 @@ const Input = forwardRef((props, ref) => <input ref={ref} {...props} />);
     expect(result.diagnostics[0]?.message).toContain("forwardRef");
   });
 
-  it("still flags React.useContext on a namespace import", () => {
+  it("does not flag React.useContext on a namespace import", () => {
     const result = run(
       `import * as React from "react";
 const Ctx = {};
 const useTheme = () => React.useContext(Ctx);
 `,
     );
-    expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0]?.message).toContain("useContext");
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("still flags directories that merely resemble components/ui/", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.ts
@@ -5,11 +5,15 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 
 // HACK: React 19+ deprecated `forwardRef` (refs are now regular props on
-// function components) and `useContext` (replaced by the more flexible
-// `use()`). Catches both named imports (`import { forwardRef } from "react"`)
-// AND member access on namespace/default imports (`React.forwardRef`,
-// `React.useContext` after `import React from "react"` or
-// `import * as React from "react"`).
+// function components). Catches both named imports
+// (`import { forwardRef } from "react"`) AND member access on
+// namespace/default imports (`React.forwardRef` after
+// `import React from "react"` or `import * as React from "react"`).
+//
+// `useContext` is deliberately NOT in this map: React 19's `use()` is an
+// additive alternative, and `useContext` remains a fully supported,
+// non-deprecated API — calling it deprecated was reward-deciding
+// misinformation in downstream audits.
 //
 // Stored as a Map (not a plain object) because plain-object lookups inherit
 // from `Object.prototype` — `messages["constructor"]` returns the native
@@ -20,10 +24,6 @@ const REACT_19_DEPRECATED_MESSAGES = new Map<string, string>([
   [
     "forwardRef",
     "forwardRef is dead weight in React 19, since ref is a normal prop now, so drop it & pass ref straight through.",
-  ],
-  [
-    "useContext",
-    "useContext is replaced by `use()` in React 19, which reads context inside ifs & loops too, so switch to `import { use } from 'react'`.",
   ],
 ]);
 
@@ -81,7 +81,7 @@ export const noReact19DeprecatedApis = defineRule({
   tags: ["test-noise", "migration-hint"],
   severity: "warn",
   recommendation:
-    "Pass `ref` as a normal prop on function components, since `forwardRef` isn't needed in React 19. Replace `useContext(X)` with `use(X)`. Only runs on React 19+ projects.",
+    "Pass `ref` as a normal prop on function components, since `forwardRef` isn't needed in React 19. Only runs on React 19+ projects.",
   create: (context: RuleContext): RuleVisitors => {
     if (isVendoredShadcnUiFilename(context.filename)) return {};
     return deprecatedReactImportRule.create(buildOncePerApiContext(context));


### PR DESCRIPTION
## Why

`no-react19-deprecated-apis` flagged every `useContext` call (named import and `React.useContext`) with "useContext is replaced by `use()` in React 19". That's factually wrong: React 19's `use()` is an **additive** API — `useContext` remains fully supported and non-deprecated. The rule was emitting misinformation, and audits found single `useContext` diagnostics deciding scan outcomes on projects using a perfectly current API.

## What changed

- `useContext` removed from the deprecated-API map; the rule now covers exactly what React 19 actually deprecates in this family (`forwardRef`, both as a named import and as namespace member access).
- Rule recommendation text updated to drop the `use()` migration claim.
- Regression tests flipped to assert `useContext` / `React.useContext` stay silent while `forwardRef` still fires.
- Changeset included.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/architecture/no-react19-deprecated-apis`
- `pnpm --filter react-doctor test tests/diagnose.test.ts tests/regressions/react-19-migration-rules.test.ts`
- Full plugin suite green locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4485c51d7a6ac5a642712a381a5e316eec384928. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->