### PR TITLE
RB-COMP-FIX: rescue oxlint OOM-dropped files with a serial replay

### DIFF
--- a/.changeset/oxlint-oom-rescue-pass.md
+++ b/.changeset/oxlint-oom-rescue-pass.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Rescue oxlint OOM-dropped files with a serial replay instead of reporting a partial scan. When a parallel lint pass drops files because oxlint's native binding SIGABRT'd under memory pressure (oxc's fixed-size allocator panics when N concurrent oxlint processes compete for memory on very large packages), those files are now replayed once, serially, one single-file batch each — the memory pressure is usually a function of sibling processes, not the file itself, so the replay typically completes the scan. Only files that still fail alone stay dropped and reported.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -335,6 +335,15 @@ export const OXLINT_SPLIT_TOTAL_BUDGET_MS = 180_000;
 // even if the budget clock is somehow not advancing.
 export const OXLINT_SPLIT_MAX_DEPTH = 8;
 
+// Wall-clock cap on the serial OOM rescue pass (replaying OOM-dropped
+// files one at a time after the parallel pass). The rescue is unbounded
+// by batch count — each file that STILL fails re-waits a spawn timeout —
+// so without a cap a large OOM-dropped set could eat the whole
+// LINT_PHASE_TIMEOUT_MS and convert a partial scan into a total lint
+// failure. 60 s rescues dozens of healthy files while at most one
+// still-pathological file can burn the budget.
+export const OXLINT_OOM_RESCUE_BUDGET_MS = 60_000;
+
 // Effect-side cap on the dead-code phase. Sits ABOVE the in-worker
 // DEAD_CODE_WORKER_TIMEOUT_MS (= 120 s) as a runtime-independent
 // backstop: if the worker's own timer is wedged (or the worker never

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -335,6 +335,18 @@ export const OXLINT_SPLIT_TOTAL_BUDGET_MS = 180_000;
 // even if the budget clock is somehow not advancing.
 export const OXLINT_SPLIT_MAX_DEPTH = 8;
 
+// Exit codes that mean the oxlint child ABORTED rather than exited. Windows
+// has no POSIX signals, so an aborting child (oxlint's native binding
+// panicking under memory pressure, or Node's own `process.abort()`) reports
+// `signal: null` plus one of these exit codes instead of the SIGABRT a POSIX
+// parent would see: Node normalizes its aborts to 134 (`ExitCode::kAbort` —
+// which is also the POSIX 128+SIGABRT convention), and a Rust / `__fastfail`
+// abort exits with NTSTATUS STATUS_STACK_BUFFER_OVERRUN (0xC0000409).
+// `spawnOxlint` folds these into the same `OxlintBatchExceeded
+// { kind: "oom" }` class as a SIGABRT so the binary-split retry and the OOM
+// rescue pass work on Windows too.
+export const ABORT_EXIT_CODES: ReadonlySet<number> = new Set([134, 0xc0000409]);
+
 // Wall-clock cap on the serial OOM rescue pass (replaying OOM-dropped
 // files one at a time after the parallel pass). The rescue is unbounded
 // by batch count — each file that STILL fails re-waits a spawn timeout —

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -1,6 +1,7 @@
 import {
   MILLISECONDS_PER_SECOND,
   MIN_SCAN_CONCURRENCY,
+  OXLINT_OOM_RESCUE_BUDGET_MS,
   OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT,
   OXLINT_SPLIT_MAX_DEPTH,
   OXLINT_SPLIT_TOTAL_BUDGET_MS,
@@ -96,6 +97,13 @@ interface BatchPassOutcome {
   readonly oomDroppedFiles: string[];
   readonly deadlineSkippedFiles: string[];
   readonly firstDropReason: string | null;
+  /**
+   * First drop reason among NON-OOM drops. After a rescue clears the OOM
+   * drops, the surviving dropped files were dropped for other reasons
+   * (timeouts, output caps) — attributing them to the rescued OOM would
+   * point users at a failure class that no longer applies.
+   */
+  readonly firstNonOomDropReason: string | null;
 }
 
 /**
@@ -145,8 +153,12 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
   // `inspect({ concurrency })` that skips the CLI's resolver — is bounded by
   // the [MIN, HARD_MAX] worker ceiling and can't oversubscribe oxlint processes.
   const requestedConcurrency = resolveScanConcurrency(input.concurrency ?? MIN_SCAN_CONCURRENCY);
+  // The OOM rescue pass installs its own (shorter) deadline here so a serial
+  // replay of many still-failing files can't eat the whole lint-phase budget.
+  let rescueDeadlineEpochMs: number | undefined;
   const isPastDeadline = (): boolean =>
-    deadlineEpochMs !== undefined && remainingDeadlineBudgetMs(deadlineEpochMs) === 0;
+    (deadlineEpochMs !== undefined && remainingDeadlineBudgetMs(deadlineEpochMs) === 0) ||
+    (rescueDeadlineEpochMs !== undefined && remainingDeadlineBudgetMs(rescueDeadlineEpochMs) === 0);
 
   // One full pass over the given batches at `concurrency` workers. All
   // mutable state (diagnostics, dropped-file bookkeeping, progress counters,
@@ -180,6 +192,7 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     // every invocation in a sandbox runtime), so surfacing one example
     // is enough to diagnose.
     let firstDropReason: string | null = null;
+    let firstNonOomDropReason: string | null = null;
 
     // Per-top-level-batch state threaded through the binary-split recursion
     // (which awaits its two halves sequentially, so this is race-free even
@@ -231,18 +244,18 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
           // or the cumulative split budget / depth cap is exhausted — drop the
           // remaining files, record why, and let the scan continue.
           droppedFiles.push(...batch);
-          if (error.reason._tag === "OxlintBatchExceeded" && error.reason.kind === "oom") {
-            oomDroppedFiles.push(...batch);
+          const isOomDrop =
+            error.reason._tag === "OxlintBatchExceeded" && error.reason.kind === "oom";
+          if (isOomDrop) oomDroppedFiles.push(...batch);
+          let limitHint = "";
+          if (isDepthCapReached) {
+            limitHint = ` (split depth cap of ${splitMaxDepth} levels reached)`;
+          } else if (isBudgetElapsed) {
+            limitHint = ` (split budget of ${splitTotalBudgetMs / MILLISECONDS_PER_SECOND}s exhausted at depth ${depth})`;
           }
-          if (firstDropReason === null) {
-            let limitHint = "";
-            if (isDepthCapReached) {
-              limitHint = ` (split depth cap of ${splitMaxDepth} levels reached)`;
-            } else if (isBudgetElapsed) {
-              limitHint = ` (split budget of ${splitTotalBudgetMs / MILLISECONDS_PER_SECOND}s exhausted at depth ${depth})`;
-            }
-            firstDropReason = batch.length > 1 ? `${error.message}${limitHint}` : error.message;
-          }
+          const dropReason = batch.length > 1 ? `${error.message}${limitHint}` : error.message;
+          firstDropReason ??= dropReason;
+          if (!isOomDrop) firstNonOomDropReason ??= dropReason;
           return [];
         }
         const splitIndex = Math.ceil(batch.length / 2);
@@ -308,6 +321,7 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
       oomDroppedFiles,
       deadlineSkippedFiles,
       firstDropReason,
+      firstNonOomDropReason,
     };
   };
 
@@ -340,19 +354,38 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     !isPastDeadline()
   ) {
     const rescueBatches = outcome.oomDroppedFiles.map((filePath) => [filePath]);
-    const rescueOutcome = await runBatchPass(MIN_SCAN_CONCURRENCY, rescueBatches, undefined);
-    diagnostics.push(...rescueOutcome.diagnostics);
-    const rescuedFiles = new Set(outcome.oomDroppedFiles);
-    for (const stillFailingFile of [
-      ...rescueOutcome.droppedFiles,
-      ...rescueOutcome.deadlineSkippedFiles,
-    ]) {
-      rescuedFiles.delete(stillFailingFile);
+    rescueDeadlineEpochMs = Date.now() + OXLINT_OOM_RESCUE_BUDGET_MS;
+    // The rescue is strictly best-effort: it replays files that already
+    // crashed oxlint once, so a second, non-splittable failure mode
+    // (spawn error, garbled output) is realistic. Falling back to the
+    // completed main-pass outcome preserves the pre-rescue worst case —
+    // partial results plus a warning — instead of discarding the scan.
+    let rescueOutcome: BatchPassOutcome | null = null;
+    try {
+      rescueOutcome = await runBatchPass(MIN_SCAN_CONCURRENCY, rescueBatches, undefined);
+    } catch {
+      rescueOutcome = null;
+    } finally {
+      rescueDeadlineEpochMs = undefined;
     }
-    droppedFiles = droppedFiles.filter((filePath) => !rescuedFiles.has(filePath));
-    if (droppedFiles.length === 0) firstDropReason = null;
-    else if (rescueOutcome.firstDropReason !== null) {
-      firstDropReason = rescueOutcome.firstDropReason;
+    if (rescueOutcome !== null) {
+      diagnostics.push(...rescueOutcome.diagnostics);
+      const rescuedFiles = new Set(outcome.oomDroppedFiles);
+      for (const stillFailingFile of [
+        ...rescueOutcome.droppedFiles,
+        ...rescueOutcome.deadlineSkippedFiles,
+      ]) {
+        rescuedFiles.delete(stillFailingFile);
+      }
+      droppedFiles = droppedFiles.filter((filePath) => !rescuedFiles.has(filePath));
+      // Reattribute the "first failure" hint: once the OOM drops are rescued,
+      // pointing the report at the (cleared) OOM would name a failure class
+      // that no longer applies to any remaining dropped file.
+      if (droppedFiles.length === 0) firstDropReason = null;
+      else {
+        firstDropReason =
+          rescueOutcome.firstDropReason ?? outcome.firstNonOomDropReason ?? firstDropReason;
+      }
     }
   }
 

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -89,6 +89,15 @@ export interface SpawnLintBatchesInput {
   readonly concurrency?: number;
 }
 
+interface BatchPassOutcome {
+  readonly diagnostics: Diagnostic[];
+  readonly droppedFiles: string[];
+  /** Subset of `droppedFiles` whose failing error was the OOM kind. */
+  readonly oomDroppedFiles: string[];
+  readonly deadlineSkippedFiles: string[];
+  readonly firstDropReason: string | null;
+}
+
 /**
  * Runs every prebuilt file batch through oxlint, with binary-split
  * retry on the splittable error classes (timeout / output-too-large /
@@ -97,12 +106,19 @@ export interface SpawnLintBatchesInput {
  * (surfaced via `onPartialFailure`) so JSON-mode consumers see WHICH
  * files were skipped instead of silently losing them.
  *
- * Parallel runs (concurrency > 1) get one extra safety net: if the pass
- * fails with a resource-exhaustion error that's exclusive to running
- * many oxlint subprocesses at once (EAGAIN / EMFILE / ENFILE / ENOMEM —
- * see `isParallelismRelatedSpawnError`), the whole pass replays once
- * with a single worker. That's the only failure a serial replay can
- * clear, so every other error class is left to propagate.
+ * Parallel runs (concurrency > 1) get two extra safety nets:
+ * - If the pass fails with a resource-exhaustion error that's exclusive
+ *   to running many oxlint subprocesses at once (EAGAIN / EMFILE /
+ *   ENFILE / ENOMEM — see `isParallelismRelatedSpawnError`), the whole
+ *   pass replays once with a single worker. That's the only failure a
+ *   serial replay can clear, so every other error class is left to
+ *   propagate.
+ * - Files dropped because oxlint's native binding SIGABRT'd under
+ *   memory pressure (`OxlintBatchExceeded { kind: "oom" }`) get one
+ *   serial single-file-batch rescue pass: the OOM is usually a function
+ *   of N concurrent oxlint allocator arenas, not the file itself, so a
+ *   lone process with the machine to itself typically clears it —
+ *   turning a partial scan into a complete (if slower) one.
  *
  * Errors that aren't splittable and aren't parallelism-related (oxlint
  * config crash, JS plugin resolution failure, etc.) propagate to the
@@ -129,14 +145,20 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
   // `inspect({ concurrency })` that skips the CLI's resolver — is bounded by
   // the [MIN, HARD_MAX] worker ceiling and can't oversubscribe oxlint processes.
   const requestedConcurrency = resolveScanConcurrency(input.concurrency ?? MIN_SCAN_CONCURRENCY);
-  const totalFileCount = fileBatches.reduce((sum, batch) => sum + batch.length, 0);
+  const isPastDeadline = (): boolean =>
+    deadlineEpochMs !== undefined && remainingDeadlineBudgetMs(deadlineEpochMs) === 0;
 
-  // One full pass over every batch at `concurrency` workers. All mutable
-  // state (diagnostics, dropped-file bookkeeping, progress counters, the
-  // progress timer) is scoped here so the serial fallback below can replay
-  // the pass from a clean slate instead of inheriting half-populated state
-  // from a parallel attempt that died mid-flight.
-  const runBatchPass = async (concurrency: number): Promise<Diagnostic[]> => {
+  // One full pass over the given batches at `concurrency` workers. All
+  // mutable state (diagnostics, dropped-file bookkeeping, progress counters,
+  // the progress timer) is scoped here so the serial fallback and the OOM
+  // rescue below replay from a clean slate instead of inheriting
+  // half-populated state from an attempt that died mid-flight.
+  const runBatchPass = async (
+    concurrency: number,
+    passBatches: ReadonlyArray<string[]>,
+    passOnFileProgress: SpawnLintBatchesInput["onFileProgress"],
+  ): Promise<BatchPassOutcome> => {
+    const totalFileCount = passBatches.reduce((sum, batch) => sum + batch.length, 0);
     const allDiagnostics: Diagnostic[] = [];
     // HACK: tracks files whose smallest splittable batch (down to a
     // single file) still failed with a splittable error — surfaced via
@@ -147,11 +169,10 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     // ones (e.g. one file × one quadratic JS-plugin rule, originally
     // hit on supabase/studio's `apps/studio/pages/...` bucket).
     const droppedFiles: string[] = [];
+    const oomDroppedFiles: string[] = [];
     // Batches that never spawned because `deadlineEpochMs` passed — reported
     // apart from `droppedFiles` (budget exhaustion, not pathological files).
     const deadlineSkippedFiles: string[] = [];
-    const isPastDeadline = (): boolean =>
-      deadlineEpochMs !== undefined && remainingDeadlineBudgetMs(deadlineEpochMs) === 0;
     // HACK: keep the first splittable error message we saw so
     // `onPartialFailure` can report WHY each batch failed instead of
     // misleadingly always blaming the per-batch budget. Same root cause
@@ -210,6 +231,9 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
           // or the cumulative split budget / depth cap is exhausted — drop the
           // remaining files, record why, and let the scan continue.
           droppedFiles.push(...batch);
+          if (error.reason._tag === "OxlintBatchExceeded" && error.reason.kind === "oom") {
+            oomDroppedFiles.push(...batch);
+          }
           if (firstDropReason === null) {
             let limitHint = "";
             if (isDepthCapReached) {
@@ -238,19 +262,19 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     let scannedFileCount = 0;
     let displayedFileCount = 0;
     const progressTimer =
-      onFileProgress && totalFileCount > 1
+      passOnFileProgress && totalFileCount > 1
         ? setInterval(() => {
             const ceiling = Math.min(startedFileCount, totalFileCount - 1);
             if (displayedFileCount < ceiling) {
               displayedFileCount += 1;
-              onFileProgress(displayedFileCount, totalFileCount);
+              passOnFileProgress(displayedFileCount, totalFileCount);
             }
           }, PROGRESS_TICK_INTERVAL_MS)
         : null;
     progressTimer?.unref?.();
 
     try {
-      const batchResults = await mapWithConcurrency(fileBatches, concurrency, async (batch) => {
+      const batchResults = await mapWithConcurrency(passBatches, concurrency, async (batch) => {
         if (isPastDeadline()) {
           deadlineSkippedFiles.push(...batch);
           return [];
@@ -264,12 +288,12 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
         // A split retry can deadline-skip part of the batch, so count only the
         // files actually linted — not the whole batch — as scanned.
         scannedFileCount += batch.length - batchState.deadlineSkippedFileCount;
-        if (onFileProgress) {
+        if (passOnFileProgress) {
           displayedFileCount = Math.min(
             Math.max(displayedFileCount, scannedFileCount),
             totalFileCount,
           );
-          onFileProgress(displayedFileCount, totalFileCount);
+          passOnFileProgress(displayedFileCount, totalFileCount);
         }
         return batchDiagnostics;
       });
@@ -278,46 +302,85 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
       if (progressTimer !== null) clearInterval(progressTimer);
     }
 
-    // Report skipped files once per completed pass. A pass that throws (e.g.
-    // the parallel attempt below hitting EAGAIN) exits before this point, so
-    // only the winning pass surfaces its skips.
-    const reportSkippedFiles = (
-      skippedFiles: string[],
-      buildMessage: (fileListPreview: string) => string,
-    ): void => {
-      if (skippedFiles.length === 0 || !onPartialFailure) return;
-      const previewFiles = skippedFiles.slice(0, OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT).join(", ");
-      const remainderHint =
-        skippedFiles.length > OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT
-          ? `, +${skippedFiles.length - OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT} more`
-          : "";
-      onPartialFailure(buildMessage(`${previewFiles}${remainderHint}`));
-    };
-    const reasonHint = firstDropReason ? ` — first failure: ${firstDropReason}` : "";
-    reportSkippedFiles(
+    return {
+      diagnostics: allDiagnostics,
       droppedFiles,
-      (fileListPreview) =>
-        `${droppedFiles.length} file(s) failed to lint and were skipped (${fileListPreview})${reasonHint}`,
-    );
-    reportSkippedFiles(
+      oomDroppedFiles,
       deadlineSkippedFiles,
-      (fileListPreview) =>
-        `${deadlineSkippedFiles.length} file(s) skipped — max scan duration reached before they were linted (${fileListPreview})`,
-    );
-    return allDiagnostics;
+      firstDropReason,
+    };
   };
 
   // Parallel runs get one serial retry, but only for the parallelism-exclusive
   // resource exhaustion a single worker can clear. Any other error — or a run
   // that was already serial — would recur, so it propagates.
-  let diagnostics: Diagnostic[];
+  let outcome: BatchPassOutcome;
+  let effectiveConcurrency = requestedConcurrency;
   try {
-    diagnostics = await runBatchPass(requestedConcurrency);
+    outcome = await runBatchPass(requestedConcurrency, fileBatches, onFileProgress);
   } catch (error) {
     if (requestedConcurrency <= MIN_SCAN_CONCURRENCY || !isParallelismRelatedSpawnError(error)) {
       throw error;
     }
-    diagnostics = await runBatchPass(MIN_SCAN_CONCURRENCY);
+    effectiveConcurrency = MIN_SCAN_CONCURRENCY;
+    outcome = await runBatchPass(MIN_SCAN_CONCURRENCY, fileBatches, onFileProgress);
   }
+
+  let { droppedFiles, firstDropReason } = outcome;
+  const diagnostics = outcome.diagnostics;
+  // OOM rescue: a SIGABRT in oxlint's fixed-size allocator is usually caused
+  // by N sibling oxlint processes competing for memory, not by the files
+  // themselves. Replay just the OOM-dropped files serially, one single-file
+  // batch each (progress reporting stays with the main pass), and keep only
+  // the files that STILL fail as dropped. Deadline pressure skips the rescue —
+  // those files are already recorded as dropped.
+  if (
+    outcome.oomDroppedFiles.length > 0 &&
+    effectiveConcurrency > MIN_SCAN_CONCURRENCY &&
+    !isPastDeadline()
+  ) {
+    const rescueBatches = outcome.oomDroppedFiles.map((filePath) => [filePath]);
+    const rescueOutcome = await runBatchPass(MIN_SCAN_CONCURRENCY, rescueBatches, undefined);
+    diagnostics.push(...rescueOutcome.diagnostics);
+    const rescuedFiles = new Set(outcome.oomDroppedFiles);
+    for (const stillFailingFile of [
+      ...rescueOutcome.droppedFiles,
+      ...rescueOutcome.deadlineSkippedFiles,
+    ]) {
+      rescuedFiles.delete(stillFailingFile);
+    }
+    droppedFiles = droppedFiles.filter((filePath) => !rescuedFiles.has(filePath));
+    if (droppedFiles.length === 0) firstDropReason = null;
+    else if (rescueOutcome.firstDropReason !== null) {
+      firstDropReason = rescueOutcome.firstDropReason;
+    }
+  }
+
+  // Report skipped files once, after any rescue, so a fully rescued scan is
+  // NOT reported partial (a partial report causes downstream consumers to
+  // refuse the whole scan).
+  const reportSkippedFiles = (
+    skippedFiles: ReadonlyArray<string>,
+    buildMessage: (fileListPreview: string) => string,
+  ): void => {
+    if (skippedFiles.length === 0 || !onPartialFailure) return;
+    const previewFiles = skippedFiles.slice(0, OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT).join(", ");
+    const remainderHint =
+      skippedFiles.length > OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT
+        ? `, +${skippedFiles.length - OXLINT_PARTIAL_FAILURE_PREVIEW_COUNT} more`
+        : "";
+    onPartialFailure(buildMessage(`${previewFiles}${remainderHint}`));
+  };
+  const reasonHint = firstDropReason ? ` — first failure: ${firstDropReason}` : "";
+  reportSkippedFiles(
+    droppedFiles,
+    (fileListPreview) =>
+      `${droppedFiles.length} file(s) failed to lint and were skipped (${fileListPreview})${reasonHint}`,
+  );
+  reportSkippedFiles(
+    outcome.deadlineSkippedFiles,
+    (fileListPreview) =>
+      `${outcome.deadlineSkippedFiles.length} file(s) skipped — max scan duration reached before they were linted (${fileListPreview})`,
+  );
   return dedupeDiagnostics(diagnostics);
 };

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -353,39 +353,45 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     effectiveConcurrency > MIN_SCAN_CONCURRENCY &&
     !isPastDeadline()
   ) {
-    const rescueBatches = outcome.oomDroppedFiles.map((filePath) => [filePath]);
     rescueDeadlineEpochMs = Date.now() + OXLINT_OOM_RESCUE_BUDGET_MS;
-    // The rescue is strictly best-effort: it replays files that already
-    // crashed oxlint once, so a second, non-splittable failure mode
-    // (spawn error, garbled output) is realistic. Falling back to the
-    // completed main-pass outcome preserves the pre-rescue worst case —
-    // partial results plus a warning — instead of discarding the scan.
-    let rescueOutcome: BatchPassOutcome | null = null;
-    try {
-      rescueOutcome = await runBatchPass(MIN_SCAN_CONCURRENCY, rescueBatches, undefined);
-    } catch {
-      rescueOutcome = null;
-    } finally {
-      rescueDeadlineEpochMs = undefined;
+    // The rescue is strictly additive: it replays files that already crashed
+    // oxlint once, so a second, non-splittable failure mode (spawn error,
+    // garbled output) is realistic. Each file replays in its own single-file
+    // pass with its own recovery, so one file's rescue failure leaves just
+    // that file dropped (with its reason) while the completed main pass AND
+    // every rescue that already succeeded are kept — a rescue can only ever
+    // improve on the pre-rescue outcome of partial results plus a warning.
+    const rescuedFiles = new Set<string>();
+    let firstRescueFailureReason: string | null = null;
+    for (const oomDroppedFile of outcome.oomDroppedFiles) {
+      if (isPastDeadline()) break;
+      try {
+        const rescueOutcome = await runBatchPass(
+          MIN_SCAN_CONCURRENCY,
+          [[oomDroppedFile]],
+          undefined,
+        );
+        diagnostics.push(...rescueOutcome.diagnostics);
+        const didFileStillFail =
+          rescueOutcome.droppedFiles.length > 0 || rescueOutcome.deadlineSkippedFiles.length > 0;
+        if (didFileStillFail) {
+          firstRescueFailureReason ??= rescueOutcome.firstDropReason;
+        } else {
+          rescuedFiles.add(oomDroppedFile);
+        }
+      } catch (error) {
+        firstRescueFailureReason ??= error instanceof Error ? error.message : String(error);
+      }
     }
-    if (rescueOutcome !== null) {
-      diagnostics.push(...rescueOutcome.diagnostics);
-      const rescuedFiles = new Set(outcome.oomDroppedFiles);
-      for (const stillFailingFile of [
-        ...rescueOutcome.droppedFiles,
-        ...rescueOutcome.deadlineSkippedFiles,
-      ]) {
-        rescuedFiles.delete(stillFailingFile);
-      }
-      droppedFiles = droppedFiles.filter((filePath) => !rescuedFiles.has(filePath));
-      // Reattribute the "first failure" hint: once the OOM drops are rescued,
-      // pointing the report at the (cleared) OOM would name a failure class
-      // that no longer applies to any remaining dropped file.
-      if (droppedFiles.length === 0) firstDropReason = null;
-      else {
-        firstDropReason =
-          rescueOutcome.firstDropReason ?? outcome.firstNonOomDropReason ?? firstDropReason;
-      }
+    rescueDeadlineEpochMs = undefined;
+    droppedFiles = droppedFiles.filter((filePath) => !rescuedFiles.has(filePath));
+    // Reattribute the "first failure" hint: once the OOM drops are rescued,
+    // pointing the report at the (cleared) OOM would name a failure class
+    // that no longer applies to any remaining dropped file.
+    if (droppedFiles.length === 0) firstDropReason = null;
+    else {
+      firstDropReason =
+        firstRescueFailureReason ?? outcome.firstNonOomDropReason ?? firstDropReason;
     }
   }
 

--- a/packages/core/src/runners/oxlint/spawn-oxlint.ts
+++ b/packages/core/src/runners/oxlint/spawn-oxlint.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import {
+  ABORT_EXIT_CODES,
   MILLISECONDS_PER_SECOND,
   OXLINT_OUTPUT_MAX_BYTES,
   OXLINT_SPAWN_TIMEOUT_MS as DEFAULT_OXLINT_SPAWN_TIMEOUT_MS,
@@ -18,7 +19,9 @@ const SANITIZED_ENV: NodeJS.ProcessEnv = buildOxlintChildEnv(process.env);
  * - `OxlintBatchExceeded { kind: "output-too-large" }` — stdout+stderr
  *   crossed `OXLINT_OUTPUT_MAX_BYTES`.
  * - `OxlintBatchExceeded { kind: "oom" | "killed" }` — child exited
- *   on a signal (SIGABRT → OOM, others → generic kill).
+ *   on a signal (SIGABRT → OOM, others → generic kill), or with one
+ *   of the abort exit codes Windows reports instead of a signal
+ *   (`ABORT_EXIT_CODES` → OOM).
  * - `OxlintSpawnFailed { cause }` — `spawn` itself errored, or the
  *   child exited successfully but printed only stderr.
  *
@@ -122,7 +125,7 @@ export const spawnOxlint = (
       clearAbortListener();
       reject(new ReactDoctorError({ reason: new OxlintSpawnFailed({ cause: error }) }));
     });
-    child.on("close", (_code, signal) => {
+    child.on("close", (code, signal) => {
       clearTimeout(timeoutHandle);
       clearAbortListener();
       if (didKillForSize) {
@@ -136,10 +139,17 @@ export const spawnOxlint = (
         );
         return;
       }
-      if (signal) {
+      // Windows has no POSIX signals: an aborting child (the native binding
+      // panicking under memory pressure) reports `signal: null` plus a
+      // well-known abort exit code, so those exits are folded into the same
+      // OOM class a POSIX SIGABRT produces.
+      const isAbortExitCode = code !== null && ABORT_EXIT_CODES.has(code);
+      if (signal || isAbortExitCode) {
         const stderrOutput = Buffer.concat(stderrBuffers).toString("utf-8").trim();
-        const isOom = signal === "SIGABRT";
-        const detailParts: string[] = [`killed by ${signal}`];
+        const isOom = signal === "SIGABRT" || isAbortExitCode;
+        const detailParts: string[] = [
+          signal ? `killed by ${signal}` : `aborted with exit code ${code}`,
+        ];
         if (isOom) detailParts.push("try scanning fewer files with --diff");
         if (stderrOutput) detailParts.push(stderrOutput);
         reject(

--- a/packages/core/tests/spawn-batches-oom-rescue.test.ts
+++ b/packages/core/tests/spawn-batches-oom-rescue.test.ts
@@ -98,7 +98,7 @@ const buildPoisonedRescueScript = (abortAllOnce = false): string =>
     "const markerPathFor = (file) => path.join(markerDirectory, encodeURIComponent(file));",
     'const isPoison = (file) => file.includes("poison");',
     "const unattempted = files.filter(",
-    `  (file) => (${JSON.stringify(abortAllOnce)} || isPoison(file)) && !fs.existsSync(markerPathFor(file)),`,
+    `  (file) => (${abortAllOnce ? "true" : "false"} || isPoison(file)) && !fs.existsSync(markerPathFor(file)),`,
     ");",
     "if (unattempted.length > 0) {",
     '  for (const file of unattempted) fs.writeFileSync(markerPathFor(file), "");',

--- a/packages/core/tests/spawn-batches-oom-rescue.test.ts
+++ b/packages/core/tests/spawn-batches-oom-rescue.test.ts
@@ -7,9 +7,13 @@
  * OOM clears on the replay and the scan completes instead of reporting a
  * partial result; a file that STILL aborts alone stays dropped and reported.
  *
- * The oxlint binary is stood in for by a `node -e` stub that SIGABRTs itself
- * on each file's first attempt (tracked via per-file marker files) and emits
- * one diagnostic per file on later attempts.
+ * The oxlint binary is stood in for by a `node -e` stub that aborts itself
+ * via `process.abort()` on each file's first attempt (tracked via per-file
+ * marker files) and emits one diagnostic per file on later attempts.
+ * `process.abort()` raises a real SIGABRT on POSIX; on Windows — which has
+ * no POSIX signals, so a self-aborting child can never surface a signal to
+ * its parent — Node normalizes it to exit code 134 (`ExitCode::kAbort`),
+ * which `spawnOxlint` folds into the same OOM class via `ABORT_EXIT_CODES`.
  */
 
 import * as fs from "node:fs";
@@ -52,10 +56,10 @@ afterEach(() => {
   fs.rmSync(markerDirectory, { recursive: true, force: true });
 });
 
-// SIGABRTs on each file's FIRST attempt (per-file marker), then emits one
+// Aborts on each file's FIRST attempt (per-file marker), then emits one
 // oxlint-format diagnostic per file — modeling a concurrency-driven OOM that
 // clears once the process runs alone.
-const buildAbortOnceScript = (): string =>
+const buildAbortOnceScript = (abortStatement = "process.abort();"): string =>
   [
     'const fs = require("fs");',
     'const path = require("path");',
@@ -65,7 +69,7 @@ const buildAbortOnceScript = (): string =>
     "const unattempted = files.filter((file) => !fs.existsSync(markerPathFor(file)));",
     "if (unattempted.length > 0) {",
     '  for (const file of unattempted) fs.writeFileSync(markerPathFor(file), "");',
-    '  process.kill(process.pid, "SIGABRT");',
+    `  ${abortStatement}`,
     "}",
     "const diagnostics = files.map((filename) => ({",
     '  message: "Array index used as a key",',
@@ -79,12 +83,13 @@ const buildAbortOnceScript = (): string =>
     "process.stdout.write(JSON.stringify({ diagnostics, number_of_files: files.length, number_of_rules: 1 }));",
   ].join("\n");
 
-const ALWAYS_ABORT_SCRIPT = 'process.kill(process.pid, "SIGABRT");';
+const ALWAYS_ABORT_SCRIPT = "process.abort();";
 
-// "poison.tsx" SIGABRTs on its first attempt (so it enters the rescue), then
-// prints non-JSON stdout — a non-splittable `OxlintOutputUnparseable` that
-// makes the rescue pass itself reject. Every other file lints normally.
-const buildPoisonedRescueScript = (): string =>
+// "poison" files abort on their first attempt (so they enter the rescue),
+// then print non-JSON stdout — a non-splittable `OxlintOutputUnparseable`
+// that makes their rescue replay reject. Every other file aborts once when
+// `abortAllOnce` is set (so it enters the rescue too), then lints normally.
+const buildPoisonedRescueScript = (abortAllOnce = false): string =>
   [
     'const fs = require("fs");',
     'const path = require("path");',
@@ -92,12 +97,12 @@ const buildPoisonedRescueScript = (): string =>
     "const files = process.argv.slice(1);",
     "const markerPathFor = (file) => path.join(markerDirectory, encodeURIComponent(file));",
     'const isPoison = (file) => file.includes("poison");',
-    "const unattemptedPoison = files.filter(",
-    "  (file) => isPoison(file) && !fs.existsSync(markerPathFor(file)),",
+    "const unattempted = files.filter(",
+    `  (file) => (${JSON.stringify(abortAllOnce)} || isPoison(file)) && !fs.existsSync(markerPathFor(file)),`,
     ");",
-    "if (unattemptedPoison.length > 0) {",
-    '  for (const file of unattemptedPoison) fs.writeFileSync(markerPathFor(file), "");',
-    '  process.kill(process.pid, "SIGABRT");',
+    "if (unattempted.length > 0) {",
+    '  for (const file of unattempted) fs.writeFileSync(markerPathFor(file), "");',
+    "  process.abort();",
     "}",
     "if (files.some(isPoison)) {",
     '  process.stdout.write("oxlint panicked: definitely not json");',
@@ -182,6 +187,52 @@ describe("spawnLintBatches — OOM rescue pass", () => {
     expect(partialFailures).toHaveLength(1);
     expect(partialFailures[0]).toContain("1 file(s) failed to lint");
     expect(partialFailures[0]).toContain("src/poison.tsx");
+  });
+
+  it("keeps rescues that already succeeded when a later rescue fails", async () => {
+    const partialFailures: string[] = [];
+
+    const diagnostics = await spawnLintBatches({
+      baseArgs: ["-e", buildPoisonedRescueScript(true)],
+      fileBatches: [["src/a.tsx"], ["src/b.tsx"], ["src/poison.tsx"]],
+      rootDirectory: process.cwd(),
+      nodeBinaryPath: process.execPath,
+      project,
+      concurrency: 2,
+      onPartialFailure: (reason) => partialFailures.push(reason),
+    });
+
+    // Every file OOMs once, so all three enter the serial rescue. The
+    // poisoned file's replay dies on unparseable stdout (a non-splittable
+    // error) — that failure must be isolated to the one file: the rescues
+    // of a.tsx / b.tsx that succeeded around it keep their diagnostics and
+    // leave the dropped list, instead of the whole rescue rejecting and
+    // discarding them.
+    expect(diagnostics.map((diagnostic) => diagnostic.filePath).sort()).toEqual([
+      "src/a.tsx",
+      "src/b.tsx",
+    ]);
+    expect(partialFailures).toHaveLength(1);
+    expect(partialFailures[0]).toContain("1 file(s) failed to lint");
+    expect(partialFailures[0]).toContain("src/poison.tsx");
+    expect(partialFailures[0]).toContain("Failed to parse oxlint output");
+  });
+
+  it("rescues an abort surfaced as a bare exit code (the Windows shape)", async () => {
+    const partialFailures: string[] = [];
+
+    // Windows never reports a signal for a self-aborting child — only exit
+    // code 134 (`ExitCode::kAbort`). Exit that way explicitly so the
+    // `ABORT_EXIT_CODES` detection branch is exercised on every platform.
+    const diagnostics = await runBatches(buildAbortOnceScript("process.exit(134);"), 2, (reason) =>
+      partialFailures.push(reason),
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.filePath).sort()).toEqual([
+      "src/a.tsx",
+      "src/b.tsx",
+    ]);
+    expect(partialFailures).toEqual([]);
   });
 
   it("does not rescue on an already-serial run (nothing to de-contend)", async () => {

--- a/packages/core/tests/spawn-batches-oom-rescue.test.ts
+++ b/packages/core/tests/spawn-batches-oom-rescue.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Covers the OOM rescue pass in `spawnLintBatches`: files dropped because
+ * oxlint's native binding SIGABRT'd under memory pressure (the
+ * `OxlintBatchExceeded { kind: "oom" }` class — oxc's fixed-size allocator
+ * panics when N concurrent oxlint processes compete for memory) are replayed
+ * once, serially, one single-file batch each. A transient, concurrency-driven
+ * OOM clears on the replay and the scan completes instead of reporting a
+ * partial result; a file that STILL aborts alone stays dropped and reported.
+ *
+ * The oxlint binary is stood in for by a `node -e` stub that SIGABRTs itself
+ * on each file's first attempt (tracked via per-file marker files) and emits
+ * one diagnostic per file on later attempts.
+ */
+
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import type { ProjectInfo } from "@react-doctor/core";
+import { spawnLintBatches } from "../src/runners/oxlint/spawn-batches.js";
+
+const project: ProjectInfo = {
+  rootDirectory: "/tmp/app",
+  projectName: "app",
+  reactVersion: "19.2.0",
+  reactMajorVersion: 19,
+  tailwindVersion: null,
+  framework: "unknown",
+  hasTypeScript: true,
+  hasReactCompiler: false,
+  hasTanStackQuery: false,
+  nextjsVersion: null,
+  nextjsMajorVersion: null,
+  hasReactNativeWorkspace: false,
+  expoVersion: null,
+  shopifyFlashListVersion: null,
+  shopifyFlashListMajorVersion: null,
+  hasReanimated: false,
+  isPreES2023Target: false,
+  preactVersion: null,
+  preactMajorVersion: null,
+  sourceFileCount: 2,
+};
+
+let markerDirectory: string;
+
+beforeEach(() => {
+  markerDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-oom-rescue-"));
+});
+
+afterEach(() => {
+  fs.rmSync(markerDirectory, { recursive: true, force: true });
+});
+
+// SIGABRTs on each file's FIRST attempt (per-file marker), then emits one
+// oxlint-format diagnostic per file — modeling a concurrency-driven OOM that
+// clears once the process runs alone.
+const buildAbortOnceScript = (): string =>
+  [
+    'const fs = require("fs");',
+    'const path = require("path");',
+    `const markerDirectory = ${JSON.stringify(markerDirectory)};`,
+    "const files = process.argv.slice(1);",
+    "const markerPathFor = (file) => path.join(markerDirectory, encodeURIComponent(file));",
+    "const unattempted = files.filter((file) => !fs.existsSync(markerPathFor(file)));",
+    "if (unattempted.length > 0) {",
+    '  for (const file of unattempted) fs.writeFileSync(markerPathFor(file), "");',
+    '  process.kill(process.pid, "SIGABRT");',
+    "}",
+    "const diagnostics = files.map((filename) => ({",
+    '  message: "Array index used as a key",',
+    '  code: "react-doctor(no-array-index-as-key)",',
+    '  severity: "warning",',
+    '  causes: [], url: "", help: "",',
+    "  filename,",
+    '  labels: [{ label: "", span: { offset: 0, length: 1, line: 1, column: 1 } }],',
+    "  related: [],",
+    "}));",
+    "process.stdout.write(JSON.stringify({ diagnostics, number_of_files: files.length, number_of_rules: 1 }));",
+  ].join("\n");
+
+const ALWAYS_ABORT_SCRIPT = 'process.kill(process.pid, "SIGABRT");';
+
+const runBatches = (
+  script: string,
+  concurrency: number,
+  onPartialFailure?: (reason: string) => void,
+) =>
+  spawnLintBatches({
+    baseArgs: ["-e", script],
+    fileBatches: [["src/a.tsx"], ["src/b.tsx"]],
+    rootDirectory: process.cwd(),
+    nodeBinaryPath: process.execPath,
+    project,
+    concurrency,
+    onPartialFailure,
+  });
+
+describe("spawnLintBatches — OOM rescue pass", () => {
+  it("rescues files whose OOM was concurrency-driven and reports no partial failure", async () => {
+    const partialFailures: string[] = [];
+
+    const diagnostics = await runBatches(buildAbortOnceScript(), 2, (reason) =>
+      partialFailures.push(reason),
+    );
+
+    expect(diagnostics.map((diagnostic) => diagnostic.filePath).sort()).toEqual([
+      "src/a.tsx",
+      "src/b.tsx",
+    ]);
+    expect(partialFailures).toEqual([]);
+  });
+
+  it("keeps files dropped when they still abort alone, and reports the OOM", async () => {
+    const partialFailures: string[] = [];
+
+    const diagnostics = await runBatches(ALWAYS_ABORT_SCRIPT, 2, (reason) =>
+      partialFailures.push(reason),
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(partialFailures).toHaveLength(1);
+    expect(partialFailures[0]).toContain("2 file(s) failed to lint");
+    expect(partialFailures[0]).toContain("ran out of memory");
+  });
+
+  it("does not rescue on an already-serial run (nothing to de-contend)", async () => {
+    const partialFailures: string[] = [];
+
+    const diagnostics = await runBatches(buildAbortOnceScript(), 1, (reason) =>
+      partialFailures.push(reason),
+    );
+
+    // Serial run: each file's single attempt aborts and stays dropped — the
+    // rescue only exists to remove sibling-process memory pressure.
+    expect(diagnostics).toEqual([]);
+    expect(partialFailures).toHaveLength(1);
+    expect(partialFailures[0]).toContain("2 file(s) failed to lint");
+  });
+});

--- a/packages/core/tests/spawn-batches-oom-rescue.test.ts
+++ b/packages/core/tests/spawn-batches-oom-rescue.test.ts
@@ -81,6 +81,40 @@ const buildAbortOnceScript = (): string =>
 
 const ALWAYS_ABORT_SCRIPT = 'process.kill(process.pid, "SIGABRT");';
 
+// "poison.tsx" SIGABRTs on its first attempt (so it enters the rescue), then
+// prints non-JSON stdout — a non-splittable `OxlintOutputUnparseable` that
+// makes the rescue pass itself reject. Every other file lints normally.
+const buildPoisonedRescueScript = (): string =>
+  [
+    'const fs = require("fs");',
+    'const path = require("path");',
+    `const markerDirectory = ${JSON.stringify(markerDirectory)};`,
+    "const files = process.argv.slice(1);",
+    "const markerPathFor = (file) => path.join(markerDirectory, encodeURIComponent(file));",
+    'const isPoison = (file) => file.includes("poison");',
+    "const unattemptedPoison = files.filter(",
+    "  (file) => isPoison(file) && !fs.existsSync(markerPathFor(file)),",
+    ");",
+    "if (unattemptedPoison.length > 0) {",
+    '  for (const file of unattemptedPoison) fs.writeFileSync(markerPathFor(file), "");',
+    '  process.kill(process.pid, "SIGABRT");',
+    "}",
+    "if (files.some(isPoison)) {",
+    '  process.stdout.write("oxlint panicked: definitely not json");',
+    "  process.exit(0);",
+    "}",
+    "const diagnostics = files.map((filename) => ({",
+    '  message: "Array index used as a key",',
+    '  code: "react-doctor(no-array-index-as-key)",',
+    '  severity: "warning",',
+    '  causes: [], url: "", help: "",',
+    "  filename,",
+    '  labels: [{ label: "", span: { offset: 0, length: 1, line: 1, column: 1 } }],',
+    "  related: [],",
+    "}));",
+    "process.stdout.write(JSON.stringify({ diagnostics, number_of_files: files.length, number_of_rules: 1 }));",
+  ].join("\n");
+
 const runBatches = (
   script: string,
   concurrency: number,
@@ -122,6 +156,32 @@ describe("spawnLintBatches — OOM rescue pass", () => {
     expect(partialFailures).toHaveLength(1);
     expect(partialFailures[0]).toContain("2 file(s) failed to lint");
     expect(partialFailures[0]).toContain("ran out of memory");
+  });
+
+  it("falls back to the completed main pass when the rescue itself rejects", async () => {
+    const partialFailures: string[] = [];
+
+    const diagnostics = await spawnLintBatches({
+      baseArgs: ["-e", buildPoisonedRescueScript()],
+      fileBatches: [["src/one.tsx"], ["src/two.tsx"], ["src/poison.tsx"]],
+      rootDirectory: process.cwd(),
+      nodeBinaryPath: process.execPath,
+      project,
+      concurrency: 2,
+      onPartialFailure: (reason) => partialFailures.push(reason),
+    });
+
+    // The rescue replay of poison.tsx dies on unparseable stdout (a
+    // non-splittable error). The main pass already completed — its
+    // diagnostics must survive and the poisoned file stays reported as
+    // dropped, instead of the whole scan rejecting.
+    expect(diagnostics.map((diagnostic) => diagnostic.filePath).sort()).toEqual([
+      "src/one.tsx",
+      "src/two.tsx",
+    ]);
+    expect(partialFailures).toHaveLength(1);
+    expect(partialFailures[0]).toContain("1 file(s) failed to lint");
+    expect(partialFailures[0]).toContain("src/poison.tsx");
   });
 
   it("does not rescue on an already-serial run (nothing to de-contend)", async () => {


### PR DESCRIPTION
## Why

On very large packages, oxlint's native binding can SIGABRT under memory pressure (oxc's fixed-size allocator panics when N concurrent oxlint subprocesses compete for memory). The binary-split cascade retries, but when the OOM recurs at every split level the files are dropped and the scan is reported **partial** — and downstream consumers that refuse partial scans then discard the entire result. Observed repeatedly on large real-world repos (hundred-plus files skipped per scan).

The key observation: the OOM is usually a function of *sibling* oxlint processes, not the file being linted. A lone process with the machine to itself typically parses the same files fine.

## What changed

- After a parallel pass completes, files dropped with the OOM kind (`OxlintBatchExceeded { kind: "oom" }`) are replayed once, serially, one single-file batch each. Diagnostics from the rescue merge into the result; only files that STILL fail alone stay dropped and reported.
- A fully rescued scan reports no partial failure at all — reporting now happens once, after the rescue, instead of per-pass.
- The rescue is skipped when the run was already serial (no sibling pressure to remove) or the `--max-duration` deadline has passed.
- `runBatchPass` now returns a structured outcome (diagnostics + drop bookkeeping) instead of reporting internally; behavior of the existing EAGAIN/EMFILE serial fallback, deadline skips, and split cascade is unchanged.

## Test plan

- New suite `spawn-batches-oom-rescue.test.ts`: a stub binary that SIGABRTs on each file's first attempt is fully rescued with no partial failure; an always-aborting stub stays dropped and reports the OOM; an already-serial run does not rescue.
- Existing `spawn-batches*` suites (progress-timer leak, concurrency fan-out, LPT invariance, deadline handling, serial fallback) green.
- `pnpm --filter @react-doctor/core test` (1258 tests) and `pnpm --filter @react-doctor/core typecheck` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lint orchestration (`spawnLintBatches` / `spawnOxlint`) and partial-failure timing, which affects large-repo scan completeness and JSON consumers; behavior is heavily tested and rescue is additive-only.
> 
> **Overview**
> **Parallel oxlint scans** that drop files because the native binding aborts under memory pressure (`OxlintBatchExceeded { kind: "oom" }`) now get a **serial OOM rescue**: each OOM-dropped file is replayed once as its own single-file batch. Diagnostics from successful replays merge into the result; only files that still fail alone stay dropped. A fully rescued run emits **no** partial-failure warning—`onPartialFailure` runs once after rescue, not mid-pass—so consumers that reject partial scans can keep the full result.
> 
> Rescue runs only when concurrency was above 1 (no sibling pressure to remove), the main deadline has not expired, and there is a dedicated **60s** rescue budget (`OXLINT_OOM_RESCUE_BUDGET_MS`). Per-file rescue failures are isolated: successful rescues and the main pass are retained; one bad replay does not reject the whole scan.
> 
> **`spawnOxlint`** treats Windows abort exit codes **134** and **0xC0000409** like POSIX `SIGABRT` for the OOM class (`ABORT_EXIT_CODES`), so split/retry and rescue behave on Windows.
> 
> **`runBatchPass`** now returns structured drop bookkeeping (`BatchPassOutcome`) instead of reporting partial failures internally; existing EAGAIN/EMFILE serial fallback and binary-split behavior are unchanged.
> 
> New tests in `spawn-batches-oom-rescue.test.ts` cover rescue success, persistent OOM, poisoned rescue replays, Windows-shaped exit 134, and no rescue on serial runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17bd5f5f1722b74fd9b420cfcf6baf51c694d244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->