### PR TITLE
RB-COMP-FIX: lock no-aria-hidden-on-focusable exemption for controls-less media

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-aria-hidden-on-focusable.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-aria-hidden-on-focusable.regressions.test.ts
@@ -125,4 +125,40 @@ describe("a11y/no-aria-hidden-on-focusable regressions", () => {
     );
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("does not flag aria-hidden on a decorative background video without controls", () => {
+    const result = runRule(
+      noAriaHiddenOnFocusable,
+      `export const Hero = ({ onError }) => (
+        <video aria-hidden="true" autoPlay muted loop playsInline onError={onError}>
+          <source src="/hero.mp4" type="video/mp4" />
+        </video>
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag aria-hidden on an autoplaying audio element without controls", () => {
+    const result = runRule(
+      noAriaHiddenOnFocusable,
+      `export const Ambience = () => <audio aria-hidden="true" autoPlay loop src="/wind.mp3" />;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags aria-hidden on a video with controls", () => {
+    const result = runRule(
+      noAriaHiddenOnFocusable,
+      `export const Player = () => <video controls aria-hidden="true" src="/clip.mp4" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags aria-hidden on a video made tabbable via tabIndex", () => {
+    const result = runRule(
+      noAriaHiddenOnFocusable,
+      `export const Player = () => <video tabIndex={0} aria-hidden="true" src="/clip.mp4" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Why

An external audit reported `no-aria-hidden-on-focusable` firing on a decorative background `<video aria-hidden="true" autoPlay muted loop>` — valid ARIA, since a `<video>` without `controls` is not focusable and hiding decorative media from assistive tech is exactly right. The report also documented a case where a graded accessibility test *required* the `aria-hidden`, making the diagnostic directly contradictory.

Investigating against current `main`: the fix already landed in the precision-sweep rework (the rule's focusability model treats `<audio>`/`<video>` as focusable only with `controls` or a non-negative `tabIndex`), so the report reflects an older release. But the media cases had **zero test coverage** — nothing prevented a regression back to the interactivity-map behavior that caused the report.

## What changed

Test-only. Four regression cases locking the media focusability contract:

- decorative `<video aria-hidden autoPlay muted loop>` (no `controls`) — silent
- autoplaying `<audio aria-hidden>` (no `controls`) — silent
- `<video controls aria-hidden>` — fires (in the tab order, hidden from AT)
- `<video tabIndex={0} aria-hidden>` — fires

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test src/plugin/rules/a11y/no-aria-hidden-on-focusable`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds regression tests; no production or lint rule logic is modified.
> 
> **Overview**
> **Test-only change.** Adds four regression cases to `no-aria-hidden-on-focusable.regressions.test.ts` so the rule’s media focusability contract stays locked: decorative `<video>` / `<audio>` with `aria-hidden` and no `controls` must **not** report, while `<video controls aria-hidden>` and `<video tabIndex={0} aria-hidden>` must still report.
> 
> No rule implementation changes in this PR—the tests document behavior that already exists on `main` and guard against regressions to treating all media as focusable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3438930028924844bc773141ed34f70a112c97f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->