### PR TITLE
fix: deflake superseded-scan scheduler test on slow runners

### DIFF
--- a/packages/language-server/tests/unit/scheduler.test.ts
+++ b/packages/language-server/tests/unit/scheduler.test.ts
@@ -63,10 +63,11 @@ describe("createScheduler", () => {
   it("drops a superseded in-flight scan and only reports the newest", async () => {
     const scannedReasons: string[] = [];
     const reportedReasons: string[] = [];
+    const releaseScanByReason = new Map<string, () => void>();
     const scheduler = createScheduler({
       performScan: async (request) => {
         scannedReasons.push(request.reason);
-        await delay(50);
+        await new Promise<void>((resolve) => releaseScanByReason.set(request.reason, resolve));
         return makeOutcome(request);
       },
       onResult: (outcome) => reportedReasons.push(outcome.request.reason),
@@ -75,12 +76,17 @@ describe("createScheduler", () => {
     });
 
     scheduler.enqueue(interactiveInput({ reason: "scan-a" }));
-    await delay(25);
+    await waitFor(() => scannedReasons.includes("scan-a"));
+
     scheduler.enqueue(interactiveInput({ reason: "scan-b" }));
+    await waitFor(() => scannedReasons.includes("scan-b"));
 
-    await delay(120);
+    // The superseded scan finishes first; its report must still be dropped.
+    releaseScanByReason.get("scan-a")?.();
+    releaseScanByReason.get("scan-b")?.();
+    await waitFor(() => reportedReasons.includes("scan-b"));
 
-    expect(scannedReasons).toContain("scan-a");
+    expect(scannedReasons).toEqual(["scan-a", "scan-b"]);
     expect(reportedReasons).toEqual(["scan-b"]);
     scheduler.dispose();
   });


### PR DESCRIPTION
## Summary

- Deflakes `tests/unit/scheduler.test.ts > createScheduler > drops a superseded in-flight scan and only reports the newest`, which intermittently failed on the Windows CI job (`blacksmith-8vcpu-windows-2025`, Node 22.18.0) with `expected [] to deeply equal [ 'scan-b' ]`, blocking unrelated PRs (#1093, #1094, #1100).

## Root cause

The test sequenced the whole scenario with wall-clock sleeps: enqueue `scan-a` (10ms debounce), sleep 25ms, enqueue `scan-b`, sleep 120ms, then assert. After `scan-b` is enqueued, its report needs its 10ms debounce timer plus the 50ms fake `performScan` delay to fire inside the fixed 120ms window. On a contended Windows runner (coarse timer resolution plus load), those timers fire tens of milliseconds late, so `scan-b`'s report hadn't landed when the assertion ran and `reportedReasons` was still empty. The scheduler's supersede logic itself is correct — the per-key generation counter drops the stale outcome regardless of completion order — so this is purely a test-timing flake, not a product race.

## Fix

Replace the sleep choreography with deterministic control:

- `performScan` blocks on a per-scan latch the test resolves explicitly, instead of a 50ms sleep.
- The test polls with the file's existing `waitFor` helper (generous 2s deadline) to confirm `scan-a` is actually in flight before enqueueing `scan-b`, and again for `scan-b`, then releases the latches — superseded `scan-a` first, preserving the completion order the original test exercised — and polls for `scan-b`'s report.

No fixed sleeps remain, and the property proven is unchanged (slightly stronger: exact scanned order is now asserted too).

## Test plan

- [x] `pnpm exec vp test run tests/unit/scheduler.test.ts` looped 50 times — 0 failures
- [x] Full `packages/language-server` test suite passes
- [x] `pnpm typecheck` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing refactor; scheduler production code is unchanged.
> 
> **Overview**
> **Deflakes** the `createScheduler` unit test that verifies a superseded in-flight scan is dropped and only the newest result is reported.
> 
> The test no longer relies on fixed `delay` timings that could expire before `scan-b` reported on slow Windows CI. **`performScan`** now blocks on per-reason release latches the test resolves explicitly, and **`waitFor`** waits until each scan is in flight and until `scan-b` is reported. Releasing **`scan-a`** before **`scan-b`** still exercises stale completion order while asserting the scheduler only reports **`scan-b`**. Scanned order is now asserted as **`["scan-a", "scan-b"]`** instead of only checking that **`scan-a`** ran.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dcc9a5966b73d0a322f324184c91bd404fea6ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->