### PR TITLE
feat(oxlint-plugin): no-stale-timer-ref — flag cleared timer refs left holding stale ids

### DIFF
--- a/.changeset/no-stale-timer-ref-new-rule.md
+++ b/.changeset/no-stale-timer-ref-new-rule.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+New rule `no-stale-timer-ref` (State & Effects, warn): flags `clearTimeout(ref.current)` / `clearInterval(ref.current)` on a `useRef`-held timer id that is never reset afterwards, in components that read `ref.current` truthiness as a "timer pending" signal. Clearing cancels the callback but leaves the old id in the ref, so pending guards keep treating a cancelled timer as live — re-arming dismissed work or skipping future scheduling. The clear-then-null and clear-then-re-arm (debounce) shapes, bare `if (ref.current) clearTimeout(ref.current)` guard idioms, and effect-cleanup returns stay unflagged.

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -96,6 +96,8 @@ export const HANDLER_SNIPPET_POOL = [
   `const handleReset = () => { const next = { ...values }; next.title = ""; setValues(next); };`,
   `const handleMutate = () => { values.title = "changed"; setValues(values); };`,
   `const handleAsyncToggle = () => { setTimeout(() => setIsOpen(!isOpen), 100); };`,
+  `const timerRef = useRef(null); const handleSchedule = () => { if (timerRef.current) return; timerRef.current = setTimeout(() => { timerRef.current = null; handle(); }, 300); }; const handleCancel = () => { if (timerRef.current) { clearTimeout(timerRef.current); } };`,
+  `const timerRef = useRef(null); const handleQueue = () => { clearTimeout(timerRef.current); timerRef.current = setTimeout(handle, 250); }; const handleFlush = () => { clearTimeout(timerRef.current); timerRef.current = null; handle(); };`,
   `const handleBatch = async () => { for (const item of items) { await api.post(url, item); } };`,
   `const handleBatch = async () => { await Promise.all(items.map((item) => api.post(url, item))); };`,
   `const handleSequence = async () => { const first = await fetch(url); const second = await fetch(url); handle(first, second); };`,

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -30,6 +30,7 @@ const AUDITED_RULE_IDS = [
   "no-nested-component-definition",
   "no-react19-deprecated-apis",
   "no-render-in-render",
+  "no-stale-timer-ref",
   "no-usememo-simple-expression",
   "only-export-components",
   "prefer-use-sync-external-store",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -819,6 +819,9 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "no-side-tab-border": {
     code: 'const C = () => <div className="border-l-4 border-[#ff0000]" />;',
   },
+  "no-stale-timer-ref": {
+    code: 'import { useRef } from "react";\nexport const useDelayedCallback = (callback) => {\n  const timerRef = useRef(null);\n  const schedule = () => {\n    if (timerRef.current) return;\n    timerRef.current = setTimeout(callback, 100);\n  };\n  const cancel = () => {\n    clearTimeout(timerRef.current);\n  };\n  return { schedule, cancel };\n};',
+  },
   "no-static-element-interactions": {
     code: "export const A = ({ onClick }) => <div role={'wat'} onClick={onClick} />;",
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -245,6 +245,7 @@ import { noSelfUpdatingEffect } from "./rules/state-and-effects/no-self-updating
 import { noSetState } from "./rules/react-builtins/no-set-state.js";
 import { noSetStateInRender } from "./rules/state-and-effects/no-set-state-in-render.js";
 import { noSideTabBorder } from "./rules/design/no-side-tab-border.js";
+import { noStaleTimerRef } from "./rules/state-and-effects/no-stale-timer-ref.js";
 import { noStaticElementInteractions } from "./rules/a11y/no-static-element-interactions.js";
 import { noStringFalseOnBooleanAttribute } from "./rules/react-builtins/no-string-false-on-boolean-attribute.js";
 import { noStringRefs } from "./rules/react-builtins/no-string-refs.js";
@@ -3194,6 +3195,18 @@ export const reactDoctorRules = [
       ...noSideTabBorder,
       framework: "global",
       category: "Maintainability",
+    },
+  },
+  {
+    key: "react-doctor/no-stale-timer-ref",
+    id: "no-stale-timer-ref",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noStaleTimerRef,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set<Capability>(["react", ...(noStaleTimerRef.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -6,6 +6,7 @@ import { EFFECT_HOOK_NAMES, SUBSCRIPTION_METHOD_NAMES } from "../../constants/re
 import { defineRule } from "../../utils/define-rule.js";
 import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or-hook-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isResultDiscardedCall } from "../../utils/is-result-discarded-call.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -219,11 +220,6 @@ const collectCleanupBindings = (effectCallback: EsTreeNode): CleanupBindings => 
   });
 
   return bindings;
-};
-
-const getRangeStart = (node: EsTreeNode): number | null => {
-  const rangeStart = node.range?.[0];
-  return typeof rangeStart === "number" ? rangeStart : null;
 };
 
 // A resource registered and then released SYNCHRONOUSLY later in the same

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.test.ts
@@ -1,0 +1,394 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noStaleTimerRef } from "./no-stale-timer-ref.js";
+
+describe("no-stale-timer-ref", () => {
+  it("flags a hide handler that clears without resetting when an effect reads the ref as pending", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useEffect, useRef } from "react";
+      const Tooltip = ({ delayShow }) => {
+        const showTimerRef = useRef(null);
+        const scheduleShow = (delay) => {
+          showTimerRef.current = setTimeout(() => {
+            showTimerRef.current = null;
+            show();
+          }, delay);
+        };
+        const handleHide = () => {
+          if (showTimerRef.current) {
+            clearTimeout(showTimerRef.current);
+          }
+        };
+        useEffect(() => {
+          if (showTimerRef.current) {
+            scheduleShow(delayShow);
+          }
+        }, [delayShow]);
+        return <button onMouseLeave={handleHide}>anchor</button>;
+      };
+      `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("showTimerRef.current");
+    expect(result.diagnostics[0].message).toContain("= null");
+  });
+
+  it("flags a cancel function in a custom hook when scheduling early-returns on the truthy ref", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const useDelayedCallback = (callback) => {
+        const timerRef = useRef(null);
+        const schedule = () => {
+          if (timerRef.current) return;
+          timerRef.current = setTimeout(callback, 100);
+        };
+        const cancel = () => {
+          clearTimeout(timerRef.current);
+        };
+        return { schedule, cancel };
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags `window.clearTimeout` when the ref feeds a ternary pending display", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const SaveIndicator = ({ save }) => {
+        const timerRef = useRef(null);
+        const statusLabel = timerRef.current ? "saving soon" : "idle";
+        const start = () => {
+          timerRef.current = window.setTimeout(save, 500);
+        };
+        const stop = () => {
+          window.clearTimeout(timerRef.current);
+        };
+        return <span onClick={stop} onFocus={start}>{statusLabel}</span>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags `clearInterval` when a `!ref.current` guard gates re-scheduling", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useEffect, useRef } from "react";
+      const Poller = ({ poll }) => {
+        const intervalRef = useRef(null);
+        useEffect(() => {
+          if (!intervalRef.current) {
+            intervalRef.current = setInterval(poll, 1000);
+          }
+        });
+        const pause = () => {
+          clearInterval(intervalRef.current);
+        };
+        return <button onClick={pause}>pause</button>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags through a TS non-null assertion on the cleared ref", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Comp = () => {
+        const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+        const isArmed = timerRef.current !== null;
+        const arm = () => {
+          timerRef.current = setTimeout(fire, 10);
+        };
+        const disarm = () => {
+          clearTimeout(timerRef.current!);
+        };
+        return <input readOnly value={String(isArmed)} onFocus={arm} onBlur={disarm} />;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags every clear site that leaves the id behind", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Comp = () => {
+        const timerRef = useRef(null);
+        const schedule = () => {
+          if (timerRef.current) return;
+          timerRef.current = setTimeout(fire, 10);
+        };
+        const cancelFromHeader = () => {
+          clearTimeout(timerRef.current);
+        };
+        const cancelFromFooter = () => {
+          clearTimeout(timerRef.current);
+        };
+        return <div onMouseDown={cancelFromHeader} onMouseUp={cancelFromFooter} onClick={schedule} />;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("stays quiet when the clear is followed by a null reset", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useEffect, useRef } from "react";
+      const Tooltip = ({ delayShow }) => {
+        const showTimerRef = useRef(null);
+        const handleHide = () => {
+          if (showTimerRef.current) {
+            clearTimeout(showTimerRef.current);
+            showTimerRef.current = null;
+          }
+        };
+        useEffect(() => {
+          if (showTimerRef.current) {
+            reschedule(delayShow);
+          }
+        }, [delayShow]);
+        return <button onMouseLeave={handleHide}>anchor</button>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on the debounce shape that clears then immediately re-arms", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Search = ({ onQuery }) => {
+        const debounceRef = useRef(null);
+        const isDebouncing = debounceRef.current != null;
+        const handleChange = (event) => {
+          clearTimeout(debounceRef.current);
+          debounceRef.current = setTimeout(() => onQuery(event.target.value), 300);
+        };
+        return <input onChange={handleChange} data-busy={isDebouncing} />;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the only conditional reads are the clear-guard idiom", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Toast = ({ dismiss }) => {
+        const timerRef = useRef(null);
+        const arm = () => {
+          timerRef.current = setTimeout(dismiss, 3000);
+        };
+        const disarm = () => {
+          if (timerRef.current) {
+            clearTimeout(timerRef.current);
+          }
+        };
+        return <div onMouseEnter={disarm} onMouseLeave={arm} />;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the guard idiom is spelled as a logical AND", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Comp = ({ fire }) => {
+        const timerRef = useRef(null);
+        const arm = () => {
+          timerRef.current = setTimeout(fire, 10);
+        };
+        const disarm = () => {
+          timerRef.current && clearTimeout(timerRef.current);
+        };
+        return <div onFocus={arm} onBlur={disarm} />;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a clear inside an effect cleanup return (v1 non-goal)", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useEffect, useRef } from "react";
+      const Comp = ({ tick, delay }) => {
+        const timerRef = useRef(null);
+        const isPending = timerRef.current ? "yes" : "no";
+        useEffect(() => {
+          timerRef.current = setTimeout(tick, delay);
+          return () => {
+            clearTimeout(timerRef.current);
+          };
+        }, [tick, delay]);
+        return <span>{isPending}</span>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a named cleanup function returned from the effect", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useEffect, useRef } from "react";
+      const Comp = ({ tick }) => {
+        const timerRef = useRef(null);
+        const isPending = timerRef.current ? "yes" : "no";
+        useEffect(() => {
+          timerRef.current = setTimeout(tick, 100);
+          const cancelPendingTick = () => {
+            clearTimeout(timerRef.current);
+          };
+          return cancelPendingTick;
+        }, [tick]);
+        return <span>{isPending}</span>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the binding is not a useRef ref", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      const Comp = ({ fire }) => {
+        const timerBox = { current: null };
+        const armed = timerBox.current ? "armed" : "idle";
+        timerBox.current = setTimeout(fire, 10);
+        clearTimeout(timerBox.current);
+        return <span>{armed}</span>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the ref never holds a locally scheduled timer", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Comp = ({ externalTimerId }) => {
+        const idRef = useRef(externalTimerId);
+        const hasHandle = idRef.current ? "yes" : "no";
+        const stop = () => {
+          clearTimeout(idRef.current);
+        };
+        return <button onClick={stop}>{hasHandle}</button>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when `clearTimeout` is a locally shadowed binding", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      import { clearTimeout } from "./custom-scheduler";
+      const Comp = ({ fire }) => {
+        const timerRef = useRef(null);
+        const pending = timerRef.current ? 1 : 0;
+        const arm = () => {
+          timerRef.current = setTimeout(fire, 10);
+        };
+        const disarm = () => {
+          clearTimeout(timerRef.current);
+        };
+        return <div onFocus={arm} onBlur={disarm}>{pending}</div>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the timer id is cleared through a local alias (v1 non-goal)", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Comp = ({ fire }) => {
+        const timerRef = useRef(null);
+        const pending = timerRef.current ? 1 : 0;
+        const arm = () => {
+          timerRef.current = setTimeout(fire, 10);
+        };
+        const disarm = () => {
+          const id = timerRef.current;
+          if (id) {
+            clearTimeout(id);
+          }
+        };
+        return <div onFocus={arm} onBlur={disarm}>{pending}</div>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the ref is only read non-conditionally", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Comp = ({ fire }) => {
+        const timerRef = useRef(null);
+        const arm = () => {
+          timerRef.current = setTimeout(fire, 10);
+        };
+        const disarm = () => {
+          clearTimeout(timerRef.current);
+          console.log("cleared", timerRef.current);
+        };
+        return <div onFocus={arm} onBlur={disarm} />;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.test.ts
@@ -370,6 +370,51 @@ describe("no-stale-timer-ref", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays quiet when a shadowing parameter reuses the ref name", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Comp = ({ fire }) => {
+        const timerRef = useRef(null);
+        const pending = timerRef.current ? 1 : 0;
+        const arm = () => {
+          timerRef.current = setTimeout(fire, 10);
+        };
+        const disarm = (timerRef) => {
+          clearTimeout(timerRef.current);
+        };
+        return <div onFocus={arm} onBlur={disarm}>{pending}</div>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when a local non-ref binding shadows the useRef name", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useRef } from "react";
+      const Comp = ({ fire, getTimerBox }) => {
+        const timerRef = useRef(null);
+        const pending = timerRef.current ? 1 : 0;
+        const arm = () => {
+          timerRef.current = setTimeout(fire, 10);
+        };
+        const disarm = () => {
+          const timerRef = getTimerBox();
+          clearTimeout(timerRef.current);
+        };
+        return <div onFocus={arm} onBlur={disarm}>{pending}</div>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("stays quiet when the ref is only read non-conditionally", () => {
     const result = runRule(
       noStaleTimerRef,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.test.ts
@@ -286,6 +286,29 @@ describe("no-stale-timer-ref", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays quiet for a component-level cleanup function returned from the effect", () => {
+    const result = runRule(
+      noStaleTimerRef,
+      `
+      import { useEffect, useRef } from "react";
+      const Comp = ({ tick, delay }) => {
+        const timerRef = useRef(null);
+        const isPending = timerRef.current ? "yes" : "no";
+        const stop = () => {
+          clearTimeout(timerRef.current);
+        };
+        useEffect(() => {
+          timerRef.current = setTimeout(tick, delay);
+          return stop;
+        }, [tick, delay]);
+        return <span>{isPending}</span>;
+      };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("stays quiet when the binding is not a useRef ref", () => {
     const result = runRule(
       noStaleTimerRef,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.ts
@@ -7,6 +7,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { getFunctionBindingName } from "../../utils/get-function-binding-name.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
@@ -225,6 +226,19 @@ const isEffectCallbackFunction = (functionNode: EsTreeNode): boolean => {
   return isHookCall(parent, EFFECT_HOOK_NAMES) && getEffectCallback(parent) === functionNode;
 };
 
+const doesEffectCallbackReturnName = (effectCallback: EsTreeNode, name: string): boolean => {
+  if (!isFunctionLike(effectCallback)) return false;
+  let isReturnedByName = false;
+  walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
+    if (isReturnedByName || !isNodeOfType(child, "ReturnStatement") || !child.argument) return;
+    const returned = stripParenExpression(child.argument);
+    if (isNodeOfType(returned, "Identifier") && returned.name === name) {
+      isReturnedByName = true;
+    }
+  });
+  return isReturnedByName;
+};
+
 const isFunctionReturnedFromEffectCallback = (
   functionNode: EsTreeNode,
   effectCallback: EsTreeNode,
@@ -234,29 +248,40 @@ const isFunctionReturnedFromEffectCallback = (
   if (effectCallback.body === functionNode) return true;
   // `const stop = () => clearTimeout(...); return stop;` — the cleanup bound
   // to a local first. Missing this shape would flag a cleanup clear.
-  if (
-    isNodeOfType(functionNode.parent, "VariableDeclarator") &&
-    isNodeOfType(functionNode.parent.id, "Identifier")
-  ) {
-    const cleanupBindingName = functionNode.parent.id.name;
-    let isReturnedByName = false;
-    walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
-      if (isReturnedByName || !isNodeOfType(child, "ReturnStatement") || !child.argument) return;
-      const returned = stripParenExpression(child.argument);
-      if (isNodeOfType(returned, "Identifier") && returned.name === cleanupBindingName) {
-        isReturnedByName = true;
-      }
-    });
-    return isReturnedByName;
-  }
-  return false;
+  const cleanupBindingName = getFunctionBindingName(functionNode);
+  return (
+    cleanupBindingName !== null && doesEffectCallbackReturnName(effectCallback, cleanupBindingName)
+  );
+};
+
+// `const stop = () => clearTimeout(...);` declared in the component body and
+// handed to an effect via `return stop` — the cleanup lives OUTSIDE the
+// effect callback, so the nesting walk in `isInsideEffectCleanupReturn`
+// cannot link the two; match it by binding name against every effect in the
+// component/hook scope instead.
+const isReturnedFromAnyEffectInScope = (
+  functionNode: EsTreeNode,
+  ownerScope: EsTreeNode,
+): boolean => {
+  const cleanupBindingName = getFunctionBindingName(functionNode);
+  if (cleanupBindingName === null) return false;
+  let isReturnedFromEffect = false;
+  walkAst(ownerScope, (child: EsTreeNode) => {
+    if (isReturnedFromEffect) return false;
+    if (!isNodeOfType(child, "CallExpression") || !isHookCall(child, EFFECT_HOOK_NAMES)) return;
+    const effectCallback = getEffectCallback(child);
+    if (effectCallback && doesEffectCallbackReturnName(effectCallback, cleanupBindingName)) {
+      isReturnedFromEffect = true;
+    }
+  });
+  return isReturnedFromEffect;
 };
 
 // Clears inside an effect's cleanup return are a v1 non-goal: the stale
 // window there is unmount / StrictMode remount, and the re-run path
 // immediately re-arms the ref in the effect body, so flagging the ubiquitous
 // `return () => clearTimeout(ref.current)` idiom would be mostly noise.
-const isInsideEffectCleanupReturn = (node: EsTreeNode): boolean => {
+const isInsideEffectCleanupReturn = (node: EsTreeNode, ownerScope: EsTreeNode): boolean => {
   let functionNode = findEnclosingFunction(node);
   while (functionNode) {
     const outerFunction = findEnclosingFunction(functionNode);
@@ -267,6 +292,7 @@ const isInsideEffectCleanupReturn = (node: EsTreeNode): boolean => {
     ) {
       return true;
     }
+    if (isReturnedFromAnyEffectInScope(functionNode, ownerScope)) return true;
     functionNode = outerFunction;
   }
   return false;
@@ -320,7 +346,7 @@ export const noStaleTimerRef = defineRule({
       const usageFacts = collectTimerRefUsageFacts(refBinding.scopeOwner, refName);
       if (!usageFacts.holdsScheduledTimerId || !usageFacts.hasPendingSignalRead) return;
 
-      if (isInsideEffectCleanupReturn(node)) return;
+      if (isInsideEffectCleanupReturn(node, refBinding.scopeOwner)) return;
       if (hasRefCurrentReassignmentAfterClear(node, refName)) return;
 
       context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.ts
@@ -1,0 +1,364 @@
+import {
+  TIMER_CALLEE_NAMES_REQUIRING_CLEANUP,
+  TIMER_CLEANUP_CALLEE_NAMES,
+} from "../../constants/dom.js";
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isNullishExpression } from "../../utils/is-nullish-expression.js";
+import {
+  stripParenExpression,
+  TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
+} from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blocks.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const GLOBAL_TIMER_RECEIVER_NAMES = new Set(["window", "globalThis", "self"]);
+const NULLISH_COMPARISON_OPERATORS = new Set(["==", "===", "!=", "!=="]);
+
+// `clearTimeout(...)` / `window.setTimeout(...)` — the timer built-in a call
+// invokes, or null when the callee is neither a bare global identifier nor a
+// member call through a global receiver.
+const getGlobalTimerCalleeName = (node: EsTreeNode): string | null => {
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  const callee = stripParenExpression(node.callee);
+  if (isNodeOfType(callee, "Identifier")) return callee.name;
+  if (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier")
+  ) {
+    const receiver = stripParenExpression(callee.object);
+    if (isNodeOfType(receiver, "Identifier") && GLOBAL_TIMER_RECEIVER_NAMES.has(receiver.name)) {
+      return callee.property.name;
+    }
+  }
+  return null;
+};
+
+const isRefCurrentMemberOf = (node: EsTreeNode, refName: string): boolean => {
+  if (!isNodeOfType(node, "MemberExpression") || node.computed) return false;
+  if (!isNodeOfType(node.property, "Identifier") || node.property.name !== "current") return false;
+  const receiver = stripParenExpression(node.object);
+  return isNodeOfType(receiver, "Identifier") && receiver.name === refName;
+};
+
+const isClearCallOnRef = (node: EsTreeNode, refName: string): boolean => {
+  const calleeName = getGlobalTimerCalleeName(node);
+  if (calleeName === null || !TIMER_CLEANUP_CALLEE_NAMES.has(calleeName)) return false;
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const clearedArgument = node.arguments?.[0];
+  return (
+    Boolean(clearedArgument) && isRefCurrentMemberOf(stripParenExpression(clearedArgument), refName)
+  );
+};
+
+const isNullishResetExpression = (node: EsTreeNode): boolean =>
+  isNullishExpression(stripParenExpression(node));
+
+const isAssignmentToRefCurrent = (
+  node: EsTreeNode,
+  refName: string,
+): node is EsTreeNodeOfType<"AssignmentExpression"> =>
+  isNodeOfType(node, "AssignmentExpression") &&
+  node.operator === "=" &&
+  isRefCurrentMemberOf(node.left, refName);
+
+// `if (ref.current) { clearTimeout(ref.current); ref.current = null; }` —
+// the standard clear-guard idiom. Its truthiness read exists only to avoid a
+// redundant clear (or to lazily reset), so it does NOT treat the ref as a
+// pending flag. Anything else in the consequent (calls, returns, setState,
+// re-arming a timer) means the guard gates real behavior on pending-ness.
+const isClearGuardIfIdiom = (
+  ifStatement: EsTreeNodeOfType<"IfStatement">,
+  refName: string,
+): boolean => {
+  if (ifStatement.alternate) return false;
+  const consequent = ifStatement.consequent;
+  const statements = isNodeOfType(consequent, "BlockStatement")
+    ? (consequent.body ?? [])
+    : [consequent];
+  return statements.every((statement) => {
+    if (!isNodeOfType(statement, "ExpressionStatement")) return false;
+    const expression = stripParenExpression(statement.expression);
+    if (isClearCallOnRef(expression, refName)) return true;
+    return (
+      isAssignmentToRefCurrent(expression, refName) && isNullishResetExpression(expression.right)
+    );
+  });
+};
+
+interface RefCurrentConditionClimb {
+  conditionRoot: EsTreeNode;
+  logicalAncestors: EsTreeNodeOfType<"LogicalExpression">[];
+  didPassBooleanProjection: boolean;
+}
+
+// Climbs from a `ref.current` read through the expression layers that merely
+// project it to a boolean (`!x`, `x !== null`, `a && x`, parens/TS wrappers)
+// to the outermost expression whose position decides how the read is used.
+const climbBooleanProjection = (refCurrentMember: EsTreeNode): RefCurrentConditionClimb => {
+  let cursor: EsTreeNode = refCurrentMember;
+  const logicalAncestors: EsTreeNodeOfType<"LogicalExpression">[] = [];
+  let didPassBooleanProjection = false;
+  while (cursor.parent) {
+    const parent = cursor.parent;
+    if (TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(parent.type)) {
+      cursor = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "!") {
+      didPassBooleanProjection = true;
+      cursor = parent;
+      continue;
+    }
+    if (
+      isNodeOfType(parent, "BinaryExpression") &&
+      NULLISH_COMPARISON_OPERATORS.has(parent.operator) &&
+      isNullishResetExpression(parent.left === cursor ? parent.right : parent.left)
+    ) {
+      didPassBooleanProjection = true;
+      cursor = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "LogicalExpression")) {
+      logicalAncestors.push(parent);
+      cursor = parent;
+      continue;
+    }
+    break;
+  }
+  return { conditionRoot: cursor, logicalAncestors, didPassBooleanProjection };
+};
+
+// `ref.current && clearTimeout(ref.current)` — the guard idiom in expression
+// form: the read sits in the left of an `&&` whose right side only clears.
+const isLogicalClearGuardIdiom = (
+  logicalAncestors: ReadonlyArray<EsTreeNodeOfType<"LogicalExpression">>,
+  refName: string,
+): boolean =>
+  logicalAncestors.some(
+    (logical) =>
+      logical.operator === "&&" && isClearCallOnRef(stripParenExpression(logical.right), refName),
+  );
+
+const isPendingSignalRead = (refCurrentMember: EsTreeNode, refName: string): boolean => {
+  const { conditionRoot, logicalAncestors, didPassBooleanProjection } =
+    climbBooleanProjection(refCurrentMember);
+  const conditionParent = conditionRoot.parent;
+  if (isNodeOfType(conditionParent, "IfStatement") && conditionParent.test === conditionRoot) {
+    return !isClearGuardIfIdiom(conditionParent, refName);
+  }
+  if (
+    (isNodeOfType(conditionParent, "ConditionalExpression") ||
+      isNodeOfType(conditionParent, "WhileStatement") ||
+      isNodeOfType(conditionParent, "DoWhileStatement") ||
+      isNodeOfType(conditionParent, "ForStatement")) &&
+    conditionParent.test === conditionRoot
+  ) {
+    return true;
+  }
+  if (logicalAncestors.length > 0) {
+    return !isLogicalClearGuardIdiom(logicalAncestors, refName);
+  }
+  // `const armed = !ref.current` / `return ref.current !== null` — the
+  // boolean projection escapes into a value, which is still pending
+  // semantics even without an enclosing conditional.
+  return didPassBooleanProjection;
+};
+
+// The function (or Program) whose body declares `const refName = useRef(...)`
+// — the component/hook scope every read and write of the ref lives in. Null
+// when the name is not a useRef binding visible from `referenceNode`.
+const findTimerRefOwnerScope = (referenceNode: EsTreeNode, refName: string): EsTreeNode | null => {
+  let cursor: EsTreeNode | null | undefined = referenceNode;
+  while (cursor) {
+    if (isNodeOfType(cursor, "BlockStatement") || isNodeOfType(cursor, "Program")) {
+      for (const statement of cursor.body ?? []) {
+        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
+        for (const declarator of statement.declarations ?? []) {
+          if (!isNodeOfType(declarator.id, "Identifier") || declarator.id.name !== refName)
+            continue;
+          if (!declarator.init || !isHookCall(declarator.init, "useRef")) continue;
+          if (isNodeOfType(cursor, "Program")) return cursor;
+          return findEnclosingFunction(declarator) ?? cursor;
+        }
+      }
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+interface TimerRefUsageFacts {
+  holdsScheduledTimerId: boolean;
+  hasPendingSignalRead: boolean;
+}
+
+const collectTimerRefUsageFacts = (ownerScope: EsTreeNode, refName: string): TimerRefUsageFacts => {
+  const facts: TimerRefUsageFacts = {
+    holdsScheduledTimerId: false,
+    hasPendingSignalRead: false,
+  };
+  walkAst(ownerScope, (child: EsTreeNode) => {
+    if (isAssignmentToRefCurrent(child, refName)) {
+      const assignedCalleeName = getGlobalTimerCalleeName(stripParenExpression(child.right));
+      if (
+        assignedCalleeName !== null &&
+        TIMER_CALLEE_NAMES_REQUIRING_CLEANUP.has(assignedCalleeName)
+      ) {
+        facts.holdsScheduledTimerId = true;
+      }
+      return;
+    }
+    if (isRefCurrentMemberOf(child, refName) && isPendingSignalRead(child, refName)) {
+      facts.hasPendingSignalRead = true;
+    }
+  });
+  return facts;
+};
+
+const isEffectCallbackFunction = (functionNode: EsTreeNode): boolean => {
+  const parent = functionNode.parent;
+  if (!parent || !isNodeOfType(parent, "CallExpression")) return false;
+  return isHookCall(parent, EFFECT_HOOK_NAMES) && getEffectCallback(parent) === functionNode;
+};
+
+const isFunctionReturnedFromEffectCallback = (
+  functionNode: EsTreeNode,
+  effectCallback: EsTreeNode,
+): boolean => {
+  if (isNodeOfType(functionNode.parent, "ReturnStatement")) return true;
+  if (
+    (isNodeOfType(effectCallback, "ArrowFunctionExpression") ||
+      isNodeOfType(effectCallback, "FunctionExpression")) &&
+    effectCallback.body === functionNode
+  ) {
+    return true;
+  }
+  // `const stop = () => clearTimeout(...); return stop;` — the cleanup bound
+  // to a local first. Missing this shape would flag a cleanup clear.
+  if (
+    isNodeOfType(functionNode.parent, "VariableDeclarator") &&
+    isNodeOfType(functionNode.parent.id, "Identifier")
+  ) {
+    const cleanupBindingName = functionNode.parent.id.name;
+    let isReturnedByName = false;
+    walkInsideStatementBlocks(
+      (effectCallback as { body?: EsTreeNode }).body ?? effectCallback,
+      (child: EsTreeNode) => {
+        if (isReturnedByName || !isNodeOfType(child, "ReturnStatement") || !child.argument) return;
+        const returned = stripParenExpression(child.argument);
+        if (isNodeOfType(returned, "Identifier") && returned.name === cleanupBindingName) {
+          isReturnedByName = true;
+        }
+      },
+    );
+    return isReturnedByName;
+  }
+  return false;
+};
+
+// Clears inside an effect's cleanup return are a v1 non-goal: the stale
+// window there is unmount / StrictMode remount, and the re-run path
+// immediately re-arms the ref in the effect body, so flagging the ubiquitous
+// `return () => clearTimeout(ref.current)` idiom would be mostly noise.
+const isInsideEffectCleanupReturn = (node: EsTreeNode): boolean => {
+  let functionNode = findEnclosingFunction(node);
+  while (functionNode) {
+    const outerFunction = findEnclosingFunction(functionNode);
+    if (
+      outerFunction &&
+      isEffectCallbackFunction(outerFunction) &&
+      isFunctionReturnedFromEffectCallback(functionNode, outerFunction)
+    ) {
+      return true;
+    }
+    functionNode = outerFunction;
+  }
+  return false;
+};
+
+const getRangeStart = (node: EsTreeNode): number | null => {
+  const rangeStart = node.range?.[0];
+  return typeof rangeStart === "number" ? rangeStart : null;
+};
+
+// Any `ref.current = ...` (null, undefined, or a re-armed timer) lexically
+// after the clear in the same function ends the stale window — the debounce
+// `clearTimeout(ref.current); ref.current = setTimeout(...)` shape is fine.
+const hasRefCurrentReassignmentAfterClear = (clearCall: EsTreeNode, refName: string): boolean => {
+  const enclosingFunction = findEnclosingFunction(clearCall);
+  if (!enclosingFunction) return false;
+  const functionBody = (enclosingFunction as { body?: EsTreeNode }).body;
+  if (!functionBody || !isNodeOfType(functionBody, "BlockStatement")) return false;
+  const clearStart = getRangeStart(clearCall);
+  if (clearStart === null) return false;
+  let didFindLaterReassignment = false;
+  walkInsideStatementBlocks(functionBody, (child: EsTreeNode) => {
+    if (didFindLaterReassignment) return;
+    if (!isAssignmentToRefCurrent(child, refName)) return;
+    const assignmentStart = getRangeStart(child);
+    if (assignmentStart !== null && assignmentStart > clearStart) {
+      didFindLaterReassignment = true;
+    }
+  });
+  return didFindLaterReassignment;
+};
+
+const isShadowedTimerGlobal = (clearCall: EsTreeNodeOfType<"CallExpression">): boolean => {
+  const callee = stripParenExpression(clearCall.callee);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  return findVariableInitializer(callee, callee.name) !== null;
+};
+
+export const noStaleTimerRef = defineRule({
+  id: "no-stale-timer-ref",
+  title: "Cleared timer ref keeps the stale id",
+  severity: "warn",
+  recommendation:
+    "Reset the ref right after clearing (`clearTimeout(ref.current); ref.current = null`) so truthiness checks on the ref keep meaning \u201Ctimer still pending\u201D.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const clearCalleeName = getGlobalTimerCalleeName(node);
+      if (clearCalleeName === null || !TIMER_CLEANUP_CALLEE_NAMES.has(clearCalleeName)) return;
+      if (isShadowedTimerGlobal(node)) return;
+
+      const clearedArgument = node.arguments?.[0];
+      if (!clearedArgument) return;
+      const clearedExpression = stripParenExpression(clearedArgument);
+      if (
+        !isNodeOfType(clearedExpression, "MemberExpression") ||
+        clearedExpression.computed ||
+        !isNodeOfType(clearedExpression.property, "Identifier") ||
+        clearedExpression.property.name !== "current"
+      ) {
+        return;
+      }
+      const refReceiver = stripParenExpression(clearedExpression.object);
+      if (!isNodeOfType(refReceiver, "Identifier")) return;
+      const refName = refReceiver.name;
+
+      const ownerScope = findTimerRefOwnerScope(node, refName);
+      if (!ownerScope) return;
+
+      const usageFacts = collectTimerRefUsageFacts(ownerScope, refName);
+      if (!usageFacts.holdsScheduledTimerId || !usageFacts.hasPendingSignalRead) return;
+
+      if (isInsideEffectCleanupReturn(node)) return;
+      if (hasRefCurrentReassignmentAfterClear(node, refName)) return;
+
+      context.report({
+        node,
+        message: `\`${clearCalleeName}(${refName}.current)\` cancels the timer but leaves the old id in \`${refName}.current\`, and this component reads \`${refName}.current\` as a \u201Ctimer pending\u201D signal — assign \`${refName}.current = null\` right after clearing so a cancelled timer does not look pending.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.ts
@@ -7,6 +7,8 @@ import { defineRule } from "../../utils/define-rule.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNullishExpression } from "../../utils/is-nullish-expression.js";
@@ -43,22 +45,37 @@ const getGlobalTimerCalleeName = (node: EsTreeNode): string | null => {
   return null;
 };
 
-const isRefCurrentMemberOf = (node: EsTreeNode, refName: string): boolean => {
-  if (!isNodeOfType(node, "MemberExpression") || node.computed) return false;
-  if (!isNodeOfType(node.property, "Identifier") || node.property.name !== "current") return false;
+// `<name>.current` (non-computed, identifier receiver) — the receiver name,
+// or null for any other shape.
+const getRefCurrentReceiverName = (node: EsTreeNode): string | null => {
+  if (!isNodeOfType(node, "MemberExpression") || node.computed) return null;
+  if (!isNodeOfType(node.property, "Identifier") || node.property.name !== "current") return null;
   const receiver = stripParenExpression(node.object);
-  return isNodeOfType(receiver, "Identifier") && receiver.name === refName;
+  return isNodeOfType(receiver, "Identifier") ? receiver.name : null;
 };
 
-const isClearCallOnRef = (node: EsTreeNode, refName: string): boolean => {
-  const calleeName = getGlobalTimerCalleeName(node);
-  if (calleeName === null || !TIMER_CLEANUP_CALLEE_NAMES.has(calleeName)) return false;
-  if (!isNodeOfType(node, "CallExpression")) return false;
+const isRefCurrentMemberOf = (node: EsTreeNode, refName: string): boolean =>
+  getRefCurrentReceiverName(node) === refName;
+
+interface ClearCallOnTimerRef {
+  clearCalleeName: string;
+  refName: string;
+}
+
+// `clearTimeout(ref.current)` / `window.clearInterval(ref.current)` — the
+// clear built-in and the ref it clears, or null for any other call shape.
+const parseClearCallOnTimerRef = (node: EsTreeNode): ClearCallOnTimerRef | null => {
+  const clearCalleeName = getGlobalTimerCalleeName(node);
+  if (clearCalleeName === null || !TIMER_CLEANUP_CALLEE_NAMES.has(clearCalleeName)) return null;
+  if (!isNodeOfType(node, "CallExpression")) return null;
   const clearedArgument = node.arguments?.[0];
-  return (
-    Boolean(clearedArgument) && isRefCurrentMemberOf(stripParenExpression(clearedArgument), refName)
-  );
+  if (!clearedArgument) return null;
+  const refName = getRefCurrentReceiverName(stripParenExpression(clearedArgument));
+  return refName === null ? null : { clearCalleeName, refName };
 };
+
+const isClearCallOnRef = (node: EsTreeNode, refName: string): boolean =>
+  parseClearCallOnTimerRef(node)?.refName === refName;
 
 const isNullishResetExpression = (node: EsTreeNode): boolean =>
   isNullishExpression(stripParenExpression(node));
@@ -174,29 +191,6 @@ const isPendingSignalRead = (refCurrentMember: EsTreeNode, refName: string): boo
   return didPassBooleanProjection;
 };
 
-// The function (or Program) whose body declares `const refName = useRef(...)`
-// — the component/hook scope every read and write of the ref lives in. Null
-// when the name is not a useRef binding visible from `referenceNode`.
-const findTimerRefOwnerScope = (referenceNode: EsTreeNode, refName: string): EsTreeNode | null => {
-  let cursor: EsTreeNode | null | undefined = referenceNode;
-  while (cursor) {
-    if (isNodeOfType(cursor, "BlockStatement") || isNodeOfType(cursor, "Program")) {
-      for (const statement of cursor.body ?? []) {
-        if (!isNodeOfType(statement, "VariableDeclaration")) continue;
-        for (const declarator of statement.declarations ?? []) {
-          if (!isNodeOfType(declarator.id, "Identifier") || declarator.id.name !== refName)
-            continue;
-          if (!declarator.init || !isHookCall(declarator.init, "useRef")) continue;
-          if (isNodeOfType(cursor, "Program")) return cursor;
-          return findEnclosingFunction(declarator) ?? cursor;
-        }
-      }
-    }
-    cursor = cursor.parent ?? null;
-  }
-  return null;
-};
-
 interface TimerRefUsageFacts {
   holdsScheduledTimerId: boolean;
   hasPendingSignalRead: boolean;
@@ -235,14 +229,9 @@ const isFunctionReturnedFromEffectCallback = (
   functionNode: EsTreeNode,
   effectCallback: EsTreeNode,
 ): boolean => {
+  if (!isFunctionLike(effectCallback)) return false;
   if (isNodeOfType(functionNode.parent, "ReturnStatement")) return true;
-  if (
-    (isNodeOfType(effectCallback, "ArrowFunctionExpression") ||
-      isNodeOfType(effectCallback, "FunctionExpression")) &&
-    effectCallback.body === functionNode
-  ) {
-    return true;
-  }
+  if (effectCallback.body === functionNode) return true;
   // `const stop = () => clearTimeout(...); return stop;` — the cleanup bound
   // to a local first. Missing this shape would flag a cleanup clear.
   if (
@@ -251,16 +240,13 @@ const isFunctionReturnedFromEffectCallback = (
   ) {
     const cleanupBindingName = functionNode.parent.id.name;
     let isReturnedByName = false;
-    walkInsideStatementBlocks(
-      (effectCallback as { body?: EsTreeNode }).body ?? effectCallback,
-      (child: EsTreeNode) => {
-        if (isReturnedByName || !isNodeOfType(child, "ReturnStatement") || !child.argument) return;
-        const returned = stripParenExpression(child.argument);
-        if (isNodeOfType(returned, "Identifier") && returned.name === cleanupBindingName) {
-          isReturnedByName = true;
-        }
-      },
-    );
+    walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
+      if (isReturnedByName || !isNodeOfType(child, "ReturnStatement") || !child.argument) return;
+      const returned = stripParenExpression(child.argument);
+      if (isNodeOfType(returned, "Identifier") && returned.name === cleanupBindingName) {
+        isReturnedByName = true;
+      }
+    });
     return isReturnedByName;
   }
   return false;
@@ -286,23 +272,17 @@ const isInsideEffectCleanupReturn = (node: EsTreeNode): boolean => {
   return false;
 };
 
-const getRangeStart = (node: EsTreeNode): number | null => {
-  const rangeStart = node.range?.[0];
-  return typeof rangeStart === "number" ? rangeStart : null;
-};
-
 // Any `ref.current = ...` (null, undefined, or a re-armed timer) lexically
 // after the clear in the same function ends the stale window — the debounce
 // `clearTimeout(ref.current); ref.current = setTimeout(...)` shape is fine.
 const hasRefCurrentReassignmentAfterClear = (clearCall: EsTreeNode, refName: string): boolean => {
   const enclosingFunction = findEnclosingFunction(clearCall);
-  if (!enclosingFunction) return false;
-  const functionBody = (enclosingFunction as { body?: EsTreeNode }).body;
-  if (!functionBody || !isNodeOfType(functionBody, "BlockStatement")) return false;
+  if (!isFunctionLike(enclosingFunction)) return false;
+  if (!isNodeOfType(enclosingFunction.body, "BlockStatement")) return false;
   const clearStart = getRangeStart(clearCall);
   if (clearStart === null) return false;
   let didFindLaterReassignment = false;
-  walkInsideStatementBlocks(functionBody, (child: EsTreeNode) => {
+  walkInsideStatementBlocks(enclosingFunction.body, (child: EsTreeNode) => {
     if (didFindLaterReassignment) return;
     if (!isAssignmentToRefCurrent(child, refName)) return;
     const assignmentStart = getRangeStart(child);
@@ -327,29 +307,17 @@ export const noStaleTimerRef = defineRule({
     "Reset the ref right after clearing (`clearTimeout(ref.current); ref.current = null`) so truthiness checks on the ref keep meaning \u201Ctimer still pending\u201D.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      const clearCalleeName = getGlobalTimerCalleeName(node);
-      if (clearCalleeName === null || !TIMER_CLEANUP_CALLEE_NAMES.has(clearCalleeName)) return;
+      const clearCall = parseClearCallOnTimerRef(node);
+      if (!clearCall) return;
       if (isShadowedTimerGlobal(node)) return;
+      const { clearCalleeName, refName } = clearCall;
 
-      const clearedArgument = node.arguments?.[0];
-      if (!clearedArgument) return;
-      const clearedExpression = stripParenExpression(clearedArgument);
-      if (
-        !isNodeOfType(clearedExpression, "MemberExpression") ||
-        clearedExpression.computed ||
-        !isNodeOfType(clearedExpression.property, "Identifier") ||
-        clearedExpression.property.name !== "current"
-      ) {
-        return;
-      }
-      const refReceiver = stripParenExpression(clearedExpression.object);
-      if (!isNodeOfType(refReceiver, "Identifier")) return;
-      const refName = refReceiver.name;
+      // Closest-scope binding resolution — a shadowing parameter or local
+      // re-declaration of the name wins over an outer `useRef` binding.
+      const refBinding = findVariableInitializer(node, refName);
+      if (!refBinding?.initializer || !isHookCall(refBinding.initializer, "useRef")) return;
 
-      const ownerScope = findTimerRefOwnerScope(node, refName);
-      if (!ownerScope) return;
-
-      const usageFacts = collectTimerRefUsageFacts(ownerScope, refName);
+      const usageFacts = collectTimerRefUsageFacts(refBinding.scopeOwner, refName);
       if (!usageFacts.holdsScheduledTimerId || !usageFacts.hasPendingSignalRead) return;
 
       if (isInsideEffectCleanupReturn(node)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-range-start.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-range-start.ts
@@ -1,0 +1,6 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+
+export const getRangeStart = (node: EsTreeNode): number | null => {
+  const rangeStart = node.range?.[0];
+  return typeof rangeStart === "number" ? rangeStart : null;
+};


### PR DESCRIPTION
## Why

Catches cleared timer refs left holding stale ids.

`clearTimeout(ref.current)` cancels the callback but leaves the old id in the ref, so any code that reads `ref.current` truthiness as a "timer pending" signal keeps treating a cancelled timer as live — re-arming dismissed work or skipping future scheduling. This is the exact bug family behind react-tooltip's "tooltip reappears after hide when `delayShow` changes" (ReactTooltip/react-tooltip#1205), and it shows up constantly in agent-generated React code.

Before:

```tsx
const handleHide = () => {
  if (showTimerRef.current) {
    clearTimeout(showTimerRef.current)
  }
}

useEffect(() => {
  if (activeAnchor && showTimerRef.current) {
    scheduleShow(delayShow) // re-arms a show the user already dismissed
  }
}, [delayShow])
```

After:

```tsx
const handleHide = () => {
  if (showTimerRef.current) {
    clearTimeout(showTimerRef.current)
    showTimerRef.current = null
  }
}
```

## What changed

- Added `no-stale-timer-ref` (State & Effects, `warn`).
- Detects `clearTimeout`/`clearInterval` (bare or via `window`/`globalThis`/`self`) called on `ref.current` of a `useRef` binding.
- Reports only when, in the same component/hook scope, the ref also holds a scheduled timer id (`ref.current = setTimeout/setInterval(...)`) **and** `ref.current` is read as a "timer pending" signal (if/while/ternary tests, `&&`/`||` operands, `!x` / `x !== null` boolean projections) **and** the clear is never followed by a `ref.current = ...` reassignment in the same function.
- Allows: clear-then-null, clear-then-re-arm (debounce), the bare clear-guard idiom (`if (ref.current) clearTimeout(ref.current)` and `ref.current && clearTimeout(ref.current)`), effect-cleanup returns (including a named cleanup bound to a local and returned), aliased ids (`const t = ref.current; clearTimeout(t)`), shadowed timer globals, and non-`useRef` receivers.
- Adds an adversarial test suite (invalid + valid + v1 non-goal cases) and a liveness fixture; regenerates the rule registry (391 → 392).

## Eval results

| Check                 | Result                                                                 |
| --------------------- | ---------------------------------------------------------------------- |
| Repos scanned         | 86 distinct repos                                                      |
| RootDir scans         | 600                                                                    |
| Target rule           | `no-stale-timer-ref`                                                   |
| Diagnostics           | 0 across the OSS corpus                                                |
| False positives found | 0                                                                      |
| Positive control      | 4 true-positive hits on `ReactTooltip/react-tooltip@d23da63e` via the built CLI; 0 after the canonical fix |
| Output artifact       | `react-doctor-evals/.evals/-Users-aidenybai-Developer-react-doctor-2.jsonl` (local) |

The corpus zero was validated against a live positive control: the built CLI fires the rule 4 times on the react-tooltip component that motivated it (all four un-nulled clears of the show-delay timer) and goes quiet once each clear is followed by `ref.current = null`.

## Test plan

- Focused rule tests: `nr test -- no-stale-timer-ref` in `packages/oxlint-plugin-react-doctor` (20 passing, incl. shadowing and component-level-cleanup regression tests)
- Full plugin suite incl. liveness: `nr test` in `packages/oxlint-plugin-react-doctor`
- `nr typecheck` for the plugin package
- `pnpm format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint-only change with extensive tests; no runtime or security surface beyond new static analysis warnings.
> 
> **Overview**
> Adds **`no-stale-timer-ref`** (`warn`, State & Effects / Bugs): warns when `clearTimeout` / `clearInterval` on a `useRef` timer id leaves a stale id while the same scope treats `ref.current` truthiness as “timer pending.”
> 
> Detection is AST-based (scheduled timer on the ref, pending-signal reads, no later `ref.current = …` in that function). **Exemptions** include clear-then-null, debounce re-arm, standard clear-guard idioms, and effect cleanup returns.
> 
> Also extracts shared **`getRangeStart`** (used by `effect-needs-cleanup` and the new rule), registers the rule, adds liveness + fuzz snippets, verdict-robustness coverage, and a large adversarial test suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b857797156e233bb1fc150a930e94603bc58b8e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


