### PR TITLE
fix(ci): restore npm OIDC auth for stable publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: "Run pnpm release even with no pending changesets (finish a partial publish)"
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,12 +34,23 @@ jobs:
         with:
           node-version: 22.18.0
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - run: npm install -g npm@11
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Force publish remaining package versions
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.force_publish }}
+        env:
+          NPM_CONFIG_PROVENANCE: true
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: pnpm release
+
       - name: Create release PR or publish
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.force_publish) }}
         id: changesets
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
## Summary
- Add `registry-url: https://registry.npmjs.org` to the main Publish job's `setup-node` (publish-dev already had it). Without this, npm trusted publishing intermittently hits `ENEEDAUTH` mid-release — `deslop-*` / `oxlint-plugin-react-doctor@0.7.3` published, but `react-doctor@0.7.3` and `eslint-plugin-react-doctor@0.7.3` did not.
- Add `workflow_dispatch` with `force_publish` so we can re-run `pnpm release` after a partial publish when there are no pending changesets.

## Test plan
- [ ] Merge, then `gh workflow run publish.yml -f force_publish=true`
- [ ] Confirm `npm view react-doctor version` → `0.7.3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no application runtime behavior, though misusing force_publish could affect npm publish timing.
> 
> **Overview**
> Fixes intermittent **`ENEEDAUTH`** failures during npm trusted publishing by setting **`registry-url: https://registry.npmjs.org`** on the main **`publish`** job’s **`setup-node`** step (aligned with **`publish-dev`**).
> 
> Adds **`workflow_dispatch`** with a **`force_publish`** flag: when enabled, the workflow runs **`pnpm release`** directly (with provenance and Sentry env) and **skips** the changesets action so a partial release can be finished without pending changesets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96fa8de6a6b453f1c43cf2a08f762ae416e5f549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->