### PR TITLE
fix(ci): drop registry-url from OIDC stable publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,11 @@ jobs:
         with:
           node-version: 22.18.0
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # Do NOT set registry-url here: setup-node writes an empty
+          # //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} line that
+          # prevents npm Trusted Publishing OIDC from firing
+          # (actions/setup-node#1551). publish-dev still has it for classic
+          # token flows; stable publish is OIDC-only.
 
       - run: npm install -g npm@11
 


### PR DESCRIPTION
## Summary
- Reverts the `registry-url` addition on the stable Publish job from #1108.
- Root cause of the 0.7.3 partial publish was `IDENTITY_TOKEN_READ_ERROR` during parallel `changeset publish` (OIDC token fetch flake), not missing `registry-url`. Prior releases used the same workflow without `registry-url` and succeeded.
- `registry-url` on `setup-node` is actively harmful for Trusted Publishing: it writes an empty `_authToken` line that prevents OIDC ([actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551)).
- Keeps `workflow_dispatch` + `force_publish` so we can finish `react-doctor@0.7.3` / any remaining packages.

## Test plan
- [ ] Merge, then `gh workflow run publish.yml -f force_publish=true`
- [ ] `npm view react-doctor version` → `0.7.3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to npm auth configuration for the stable publish job; no application runtime impact.
> 
> **Overview**
> Reverts **`registry-url`** on the stable **Publish** job’s `actions/setup-node` step so npm **Trusted Publishing** can use OIDC again.
> 
> `setup-node` with `registry-url` injects an empty `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` entry, which blocks OIDC ([actions/setup-node#1551](https://github.com/actions/setup-node/issues/1551)). The workflow now documents that stable publish is OIDC-only; **`publish-dev`** still sets `registry-url` for classic token flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996dbad84688e08941acbd6f606a311df7566185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->