### PR TITLE
RB_792026: detect effect listener cleanup mismatches

### DIFF
--- a/.changeset/clean-listeners-match.md
+++ b/.changeset/clean-listeners-match.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Add the `effect-listener-cleanup-mismatch` rule for ineffective EventTarget cleanup callbacks and capture flags.

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--bound-abort.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--bound-abort.tsx
@@ -1,0 +1,17 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: wrapper-transparency
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const controller = new AbortController();
+    const abortListener = controller.abort.bind(controller);
+    window.addEventListener("resize", () => undefined, { signal: controller.signal });
+    return () => {
+      window.removeEventListener("resize", () => undefined);
+      abortListener();
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--const-computed-method.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--const-computed-method.tsx
@@ -1,0 +1,17 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: dynamic-computed
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const handleResize = () => undefined;
+    const removalMethod = "removeEventListener";
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window[removalMethod]("resize", handleResize);
+      window.removeEventListener("resize", () => undefined);
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--destructured-method.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--destructured-method.tsx
@@ -1,0 +1,17 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: wrapper-transparency
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const handleResize = () => undefined;
+    const { removeEventListener } = window;
+    window.addEventListener("resize", handleResize);
+    return () => {
+      removeEventListener.call(window, "resize", handleResize);
+      window.removeEventListener("resize", () => undefined);
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--equivalent-targets.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--equivalent-targets.tsx
@@ -1,0 +1,18 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: alias-guard
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const targets = { first: window, second: window };
+    const handleResize = () => undefined;
+    targets.first.addEventListener("resize", handleResize);
+    targets.second.addEventListener("resize", handleResize);
+    return () => {
+      targets.first.removeEventListener("resize", () => undefined);
+      targets.second.removeEventListener("resize", handleResize);
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--exhaustive-branches.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--exhaustive-branches.tsx
@@ -1,0 +1,20 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: control-flow
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = (isEnabled: boolean) => {
+  useEffect(() => {
+    const handleResize = () => undefined;
+    window.addEventListener("resize", handleResize);
+    return () => {
+      if (isEnabled) {
+        window.removeEventListener("resize", handleResize);
+      } else {
+        window.removeEventListener("resize", handleResize);
+      }
+      window.removeEventListener("resize", () => undefined);
+    };
+  }, [isEnabled]);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--finally-abort.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--finally-abort.tsx
@@ -1,0 +1,22 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: control-flow
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+const releaseLayout = (): void => {};
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const controller = new AbortController();
+    window.addEventListener("resize", () => undefined, { signal: controller.signal });
+    return () => {
+      window.removeEventListener("resize", () => undefined);
+      try {
+        releaseLayout();
+      } finally {
+        controller.abort();
+      }
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--finally-removal.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--finally-removal.tsx
@@ -1,0 +1,22 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: control-flow
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+const releaseLayout = (): void => {};
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const handleResize = () => undefined;
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", () => undefined);
+      try {
+        releaseLayout();
+      } finally {
+        window.removeEventListener("resize", handleResize);
+      }
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--guarded-abort.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--guarded-abort.tsx
@@ -1,0 +1,17 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: control-flow
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    window.addEventListener("resize", () => undefined, { signal });
+    return () => {
+      window.removeEventListener("resize", () => undefined);
+      if (!signal.aborted) controller.abort();
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--inherited-capture.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--inherited-capture.tsx
@@ -1,0 +1,15 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: other
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const handleResize = () => undefined;
+    window.addEventListener("resize", handleResize, {
+      __proto__: { capture: true },
+    });
+    return () => window.removeEventListener("resize", handleResize, true);
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--local-cleanup-helper.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--local-cleanup-helper.tsx
@@ -1,0 +1,17 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: wrapper-transparency
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const controller = new AbortController();
+    const abortListener = () => controller.abort();
+    window.addEventListener("resize", () => undefined, { signal: controller.signal });
+    return () => {
+      window.removeEventListener("resize", () => undefined);
+      abortListener();
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--mixed-exhaustive-cancellation.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--mixed-exhaustive-cancellation.tsx
@@ -1,0 +1,21 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: control-flow
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = (shouldAbort: boolean) => {
+  useEffect(() => {
+    const controller = new AbortController();
+    const handleResize = () => undefined;
+    window.addEventListener("resize", handleResize, { signal: controller.signal });
+    return () => {
+      if (shouldAbort) {
+        controller.abort();
+      } else {
+        window.removeEventListener("resize", handleResize);
+      }
+      window.removeEventListener("resize", () => undefined);
+    };
+  }, [shouldAbort]);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--non-empty-loop.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--non-empty-loop.tsx
@@ -1,0 +1,18 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: control-flow
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const handleResize = () => undefined;
+    window.addEventListener("resize", handleResize);
+    return () => {
+      for (const cleanupListener of [handleResize]) {
+        window.removeEventListener("resize", cleanupListener);
+      }
+      window.removeEventListener("resize", () => undefined);
+    };
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--returned-cleanup-helper.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--returned-cleanup-helper.tsx
@@ -1,0 +1,18 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: wrapper-transparency
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = () => {
+  useEffect(() => {
+    const handleResize = () => undefined;
+    const removeListener = () => window.removeEventListener("resize", handleResize);
+    const cleanup = () => {
+      removeListener();
+      window.removeEventListener("resize", () => undefined);
+    };
+    window.addEventListener("resize", handleResize);
+    return cleanup;
+  }, []);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--setup-exhaustive-abort.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--setup-exhaustive-abort.tsx
@@ -1,0 +1,18 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: control-flow
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useResizeListener = (shouldAbort: boolean) => {
+  useEffect(() => {
+    const controller = new AbortController();
+    window.addEventListener("resize", () => undefined, { signal: controller.signal });
+    if (shouldAbort) {
+      controller.abort();
+    } else {
+      controller.abort();
+    }
+    return () => window.removeEventListener("resize", () => undefined);
+  }, [shouldAbort]);
+};

--- a/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--target-snapshot.tsx
+++ b/packages/fuzz/corpus/regressions/effect-listener-cleanup-mismatch--target-snapshot.tsx
@@ -1,0 +1,19 @@
+// rule: effect-listener-cleanup-mismatch
+// weakness: alias-guard
+// source: PR #1110 FP fuzzing
+
+import { useEffect } from "react";
+
+export const useChangeListener = () => {
+  useEffect(() => {
+    const holder = { current: new EventTarget() };
+    const originalTarget = holder.current;
+    const handleChange = () => undefined;
+    holder.current.addEventListener("change", handleChange);
+    holder.current = new EventTarget();
+    return () => {
+      originalTarget.removeEventListener("change", handleChange);
+      holder.current.removeEventListener("change", () => undefined);
+    };
+  }, []);
+};

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -18,6 +18,7 @@ import { buildVerdictPreservingVariants } from "../src/verdict-preserving-varian
 const AUDITED_RULE_IDS = [
   "anchor-is-valid",
   "aria-role",
+  "effect-listener-cleanup-mismatch",
   "effect-needs-cleanup",
   "interactive-supports-focus",
   "no-adjust-state-on-prop-change",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -168,6 +168,9 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     settings: { "react-doctor": { displayName: { ignoreTranspilerName: true } } },
     forceJsx: true,
   },
+  "effect-listener-cleanup-mismatch": {
+    code: 'import { useEffect } from "react";\nexport const Listener = () => {\n  useEffect(() => {\n    window.addEventListener("resize", () => resize());\n    return () => window.removeEventListener("resize", () => resize());\n  }, []);\n  return null;\n};',
+  },
   "effect-needs-cleanup": {
     code: 'import { useEffect } from "react";\nexport const WatchForm = ({ form }) => {\n  useEffect(() => form.watch((value) => {\n    console.log(value);\n  }), [form]);\n  return null;\n};',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -49,6 +49,7 @@ import { noThreePeriodEllipsis } from "./rules/react-ui/no-three-period-ellipsis
 import { noVagueButtonLabel } from "./rules/react-ui/no-vague-button-label.js";
 import { dialogHasAccessibleName } from "./rules/a11y/dialog-has-accessible-name.js";
 import { displayName } from "./rules/react-builtins/display-name.js";
+import { effectListenerCleanupMismatch } from "./rules/state-and-effects/effect-listener-cleanup-mismatch.js";
 import { effectNeedsCleanup } from "./rules/state-and-effects/effect-needs-cleanup.js";
 import { exhaustiveDeps } from "./rules/react-builtins/exhaustive-deps.js";
 import { expoNoNonInlinedEnv } from "./rules/react-native/expo-no-non-inlined-env.js";
@@ -888,6 +889,20 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Maintainability",
       requires: [...new Set<Capability>(["react", ...(displayName.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/effect-listener-cleanup-mismatch",
+    id: "effect-listener-cleanup-mismatch",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...effectListenerCleanupMismatch,
+      framework: "global",
+      category: "Bugs",
+      requires: [
+        ...new Set<Capability>(["react", ...(effectListenerCleanupMismatch.requires ?? [])]),
+      ],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch-control-flow.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch-control-flow.test.ts
@@ -52,10 +52,23 @@ describe("effect-listener-cleanup-mismatch canonical cleanup shape", () => {
       }, [shouldListen]);`,
       expectedCount: 0,
     },
+    {
+      name: "a final cleanup-body return expression",
+      code: `useEffect(() => {
+        document.addEventListener("mousedown", (event) => { return handle(event); });
+        return () => {
+          return (document.removeEventListener(
+            "mousedown",
+            (event) => { return handle(event); },
+          ));
+        };
+      }, []);`,
+      expectedCount: 1,
+    },
   ];
 
   for (const testCase of testCases) {
-    it(`stays quiet for ${testCase.name}`, () => {
+    it(`handles ${testCase.name}`, () => {
       expectDiagnosticCount(testCase.code, testCase.expectedCount);
     });
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch-control-flow.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch-control-flow.test.ts
@@ -108,14 +108,14 @@ describe("effect-listener-cleanup-mismatch computed methods", () => {
       expectedCount: 0,
     },
     {
-      name: "dynamic computed removal method",
+      name: "const-computed removal mismatch",
       code: `useEffect(() => {
         const handleResize = () => resize();
         const removalMethod = "removeEventListener";
         window.addEventListener("resize", handleResize);
         return () => window[removalMethod]("resize", () => resize());
       }, []);`,
-      expectedCount: 0,
+      expectedCount: 1,
     },
   ];
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch-control-flow.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch-control-flow.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectListenerCleanupMismatch } from "./effect-listener-cleanup-mismatch.js";
+
+interface ListenerControlFlowTestCase {
+  code: string;
+  expectedCount: number;
+  name: string;
+}
+
+const expectDiagnosticCount = (code: string, expectedCount: number): void => {
+  const result = runRule(
+    effectListenerCleanupMismatch,
+    `import { useEffect } from "react";\n${code}`,
+  );
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedCount);
+};
+
+describe("effect-listener-cleanup-mismatch canonical cleanup shape", () => {
+  const testCases: ListenerControlFlowTestCase[] = [
+    {
+      name: "cleanup returned before a later registration",
+      code: `useEffect(() => {
+        const firstListener = () => firstResize();
+        window.addEventListener("resize", firstListener);
+        return () => window.removeEventListener("resize", () => firstResize());
+        window.addEventListener("scroll", () => scroll());
+      }, []);`,
+      expectedCount: 0,
+    },
+    {
+      name: "cleanup returned from a nested conditional",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        if (shouldCleanup) {
+          return () => window.removeEventListener("resize", () => resize());
+        }
+        continueSetup();
+      }, [shouldCleanup]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "mutually exclusive setup registrations",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        if (shouldListen) {
+          window.addEventListener("resize", handleResize);
+        }
+        return () => window.removeEventListener("resize", () => resize());
+      }, [shouldListen]);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of testCases) {
+    it(`stays quiet for ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+});
+
+describe("effect-listener-cleanup-mismatch computed methods", () => {
+  const testCases: ListenerControlFlowTestCase[] = [
+    {
+      name: "computed string removal mismatch",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => window["removeEventListener"]("resize", () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "computed string valid removal",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => window["removeEventListener"]("resize", handleResize);
+      }, []);`,
+      expectedCount: 0,
+    },
+    {
+      name: "computed string abort with an aliased signal",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        const signal = controller.signal;
+        window.addEventListener("resize", () => resize(), { signal });
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          controller["abort"]();
+        };
+      }, []);`,
+      expectedCount: 0,
+    },
+    {
+      name: "dynamic computed removal method",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        const removalMethod = "removeEventListener";
+        window.addEventListener("resize", handleResize);
+        return () => window[removalMethod]("resize", () => resize());
+      }, []);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of testCases) {
+    it(`handles ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch-false-positives.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch-false-positives.test.ts
@@ -1,0 +1,638 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectListenerCleanupMismatch } from "./effect-listener-cleanup-mismatch.js";
+
+const expectDiagnosticCount = (code: string, expectedCount: number): void => {
+  const result = runRule(
+    effectListenerCleanupMismatch,
+    `import { useEffect } from "react";\n${code}`,
+  );
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedCount);
+};
+
+const expectNoDiagnostics = (code: string): void => expectDiagnosticCount(code, 0);
+
+describe("effect-listener-cleanup-mismatch false-positive regressions", () => {
+  const setupAbortCases = [
+    {
+      name: "a controller aborted before registration",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        controller.abort();
+        window.addEventListener("resize", () => resize(), { signal: controller.signal });
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+    },
+    {
+      name: "a controller aborted after registration",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        window.addEventListener("resize", () => resize(), { signal: controller.signal });
+        controller.abort();
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+    },
+    {
+      name: "a controller guarded and aborted during setup",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        if (!controller.signal.aborted) controller.abort();
+        window.addEventListener("resize", () => resize(), { signal: controller.signal });
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+    },
+  ];
+
+  for (const testCase of setupAbortCases) {
+    it(`stays quiet for ${testCase.name}`, () => {
+      expectNoDiagnostics(testCase.code);
+    });
+  }
+
+  const guaranteedCleanupCases = [
+    {
+      name: "an abort in a literal-true branch",
+      cleanup: `if (true) controller.abort();`,
+    },
+    {
+      name: "an abort in the left side of a logical expression",
+      cleanup: `(controller.abort(), shouldFinish) && finish();`,
+    },
+    {
+      name: "an abort in a conditional test",
+      cleanup: `(controller.abort(), shouldFinish) ? finish() : fallback();`,
+    },
+    {
+      name: "an abort in an if test",
+      cleanup: `if ((controller.abort(), shouldFinish)) finish();`,
+    },
+    {
+      name: "an abort in a finally block",
+      cleanup: `try {
+        finish();
+      } finally {
+        controller.abort();
+      }`,
+    },
+    {
+      name: "an idempotent guarded abort",
+      cleanup: `if (!controller.signal.aborted) controller.abort();`,
+    },
+    {
+      name: "an idempotent binary-comparison abort guard",
+      cleanup: `if (controller.signal.aborted === false) controller.abort();`,
+    },
+    {
+      name: "an idempotent logical abort guard",
+      cleanup: `controller.signal.aborted || controller.abort();`,
+    },
+  ];
+
+  for (const testCase of guaranteedCleanupCases) {
+    it(`stays quiet for ${testCase.name}`, () => {
+      expectNoDiagnostics(`useEffect(() => {
+        const controller = new AbortController();
+        window.addEventListener("resize", () => resize(), { signal: controller.signal });
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          ${testCase.cleanup}
+        };
+      }, [shouldFinish]);`);
+    });
+  }
+
+  const guaranteedRemovalCases = [
+    {
+      name: "a matching removal in a literal-true branch",
+      cleanup: `if (true) window.removeEventListener("resize", handleResize);`,
+    },
+    {
+      name: "a matching removal in a finally block",
+      cleanup: `try {
+        finish();
+      } finally {
+        window.removeEventListener("resize", handleResize);
+      }`,
+    },
+  ];
+
+  for (const testCase of guaranteedRemovalCases) {
+    it(`stays quiet for ${testCase.name}`, () => {
+      expectNoDiagnostics(`useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          ${testCase.cleanup}
+        };
+      }, []);`);
+    });
+  }
+
+  it("stays quiet when a local helper aborts the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const controller = new AbortController();
+      const abortListener = () => controller.abort();
+      window.addEventListener("resize", () => resize(), { signal: controller.signal });
+      return () => {
+        window.removeEventListener("resize", () => resize());
+        abortListener();
+      };
+    }, []);`);
+  });
+
+  it("stays quiet when a signal alias guards the abort", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const controller = new AbortController();
+      const signal = controller.signal;
+      window.addEventListener("resize", () => resize(), { signal });
+      return () => {
+        window.removeEventListener("resize", () => resize());
+        if (!signal.aborted) controller.abort();
+      };
+    }, []);`);
+  });
+
+  it("stays quiet when a local helper removes the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      const removeListener = () => window.removeEventListener("resize", handleResize);
+      window.addEventListener("resize", handleResize);
+      return () => {
+        window.removeEventListener("resize", () => resize());
+        removeListener();
+      };
+    }, []);`);
+  });
+
+  it("stays quiet when a bound abort method aborts the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const controller = new AbortController();
+      const abortListener = controller.abort.bind(controller);
+      window.addEventListener("resize", () => resize(), { signal: controller.signal });
+      return () => {
+        window.removeEventListener("resize", () => resize());
+        abortListener();
+      };
+    }, []);`);
+  });
+
+  const deferredHelperCases = [
+    {
+      name: "an async helper",
+      helper: `const abortLater = async () => {
+        await waitForCleanup();
+        controller.abort();
+      };`,
+      call: `void abortLater();`,
+    },
+    {
+      name: "a generator helper",
+      helper: `function* abortLater() {
+        controller.abort();
+      }`,
+      call: `abortLater();`,
+    },
+  ];
+
+  for (const testCase of deferredHelperCases) {
+    it(`does not treat ${testCase.name} as synchronous cleanup`, () => {
+      expectDiagnosticCount(
+        `useEffect(() => {
+          const controller = new AbortController();
+          ${testCase.helper}
+          window.addEventListener("resize", () => resize(), { signal: controller.signal });
+          return () => {
+            window.removeEventListener("resize", () => resize());
+            ${testCase.call}
+          };
+        }, []);`,
+        1,
+      );
+    });
+  }
+
+  it("stays quiet when exhaustive branches remove the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      window.addEventListener("resize", handleResize);
+      return () => {
+        if (isEnabled) {
+          window.removeEventListener("resize", handleResize);
+        } else {
+          window.removeEventListener("resize", handleResize);
+        }
+        window.removeEventListener("resize", () => resize());
+      };
+    }, [isEnabled]);`);
+  });
+
+  it("stays quiet when exhaustive branches use equivalent cancellation mechanisms", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const controller = new AbortController();
+      const handleResize = () => resize();
+      window.addEventListener("resize", handleResize, {
+        signal: controller.signal,
+      });
+      return () => {
+        if (shouldAbort) {
+          controller.abort();
+        } else {
+          window.removeEventListener("resize", handleResize);
+        }
+        window.removeEventListener("resize", () => resize());
+      };
+    }, [shouldAbort]);`);
+  });
+
+  it("stays quiet when exhaustive setup branches abort the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const controller = new AbortController();
+      window.addEventListener("resize", () => resize(), {
+        signal: controller.signal,
+      });
+      if (shouldAbort) {
+        controller.abort();
+      } else {
+        controller.abort();
+      }
+      return () => window.removeEventListener("resize", () => resize());
+    }, [shouldAbort]);`);
+  });
+
+  it("stays quiet when a guaranteed non-empty loop removes the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      window.addEventListener("resize", handleResize);
+      return () => {
+        for (const cleanupListener of [handleResize]) {
+          window.removeEventListener("resize", cleanupListener);
+        }
+        window.removeEventListener("resize", () => resize());
+      };
+    }, []);`);
+  });
+
+  it("still reports when an empty loop cannot remove the registration", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          for (const cleanupListener of []) {
+            window.removeEventListener("resize", cleanupListener);
+          }
+          window.removeEventListener("resize", () => resize());
+        };
+      }, []);`,
+      1,
+    );
+  });
+
+  it("stays quiet when a returned cleanup alias calls a removal helper", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      const removeListener = () => window.removeEventListener("resize", handleResize);
+      const cleanup = () => {
+        removeListener();
+        window.removeEventListener("resize", () => resize());
+      };
+      window.addEventListener("resize", handleResize);
+      return cleanup;
+    }, []);`);
+  });
+
+  it("stays quiet when another static target path removes the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const targets = { first: window, second: window };
+      const handleResize = () => resize();
+      targets.first.addEventListener("resize", handleResize);
+      targets.second.addEventListener("resize", handleResize);
+      return () => {
+        targets.first.removeEventListener("resize", () => resize());
+        targets.second.removeEventListener("resize", handleResize);
+      };
+    }, []);`);
+  });
+
+  it("stays quiet when a stable target snapshot removes the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const holder = { current: new EventTarget() };
+      const originalTarget = holder.current;
+      const handleChange = () => change();
+      holder.current.addEventListener("change", handleChange);
+      holder.current = new EventTarget();
+      return () => {
+        originalTarget.removeEventListener("change", handleChange);
+        holder.current.removeEventListener("change", () => change());
+      };
+    }, []);`);
+  });
+
+  it("does not treat different global targets as aliases", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          document.removeEventListener("resize", handleResize);
+        };
+      }, []);`,
+      1,
+    );
+  });
+
+  it("stays quiet when a const-computed method removes the registration", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      const removalMethod = "removeEventListener";
+      window.addEventListener("resize", handleResize);
+      return () => {
+        window[removalMethod]("resize", handleResize);
+        window.removeEventListener("resize", () => resize());
+      };
+    }, []);`);
+  });
+
+  it("stays quiet when a destructured method removes the registration with its receiver", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      const { removeEventListener } = window;
+      window.addEventListener("resize", handleResize);
+      return () => {
+        removeEventListener.call(window, "resize", handleResize);
+        window.removeEventListener("resize", () => resize());
+      };
+    }, []);`);
+  });
+
+  it("does not trust a mutable destructured removal method", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const handleResize = () => resize();
+        let { removeEventListener } = window;
+        removeEventListener = () => {};
+        window.addEventListener("resize", handleResize);
+        return () => {
+          removeEventListener.call(window, "resize", handleResize);
+          window.removeEventListener("resize", () => resize());
+        };
+      }, []);`,
+      1,
+    );
+  });
+
+  it("stays quiet when a once listener is synchronously consumed", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const target = new EventTarget();
+      target.addEventListener("change", () => {}, { once: true });
+      target.dispatchEvent(new Event("change"));
+      return () => target.removeEventListener("change", () => change());
+    }, []);`);
+  });
+
+  it("still reports a once listener that is not synchronously consumed", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize, { once: true });
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      1,
+    );
+  });
+
+  it("does not treat an overwritten once option as true", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const target = new EventTarget();
+        const handleChange = () => change();
+        target.addEventListener("change", handleChange, {
+          once: true,
+          once: false,
+        });
+        target.dispatchEvent(new Event("change"));
+        return () => target.removeEventListener("change", () => change());
+      }, []);`,
+      1,
+    );
+  });
+
+  it("does not assume an untracked blocker lets a once listener run", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const target = new EventTarget();
+        const blockers = [(event) => event.stopImmediatePropagation()];
+        const handleChange = () => change();
+        target.addEventListener("change", blockers[0]);
+        target.addEventListener("change", handleChange, { once: true });
+        target.dispatchEvent(new Event("change"));
+        return () => target.removeEventListener("change", () => change());
+      }, []);`,
+      1,
+    );
+  });
+
+  it("does not assume an indirectly re-registering once listener was consumed", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const target = new EventTarget();
+        const registerAgain = () => {
+          target.addEventListener("change", handleChange, { once: true });
+        };
+        const handleChange = () => registerAgain();
+        target.addEventListener("change", handleChange, { once: true });
+        target.dispatchEvent(new Event("change"));
+        return () => target.removeEventListener("change", () => {});
+      }, []);`,
+      1,
+    );
+  });
+
+  it("does not let an unrelated loop exit hide a mismatch", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          for (;;) break;
+        };
+      }, []);`,
+      1,
+    );
+  });
+
+  it("does not inline an overridable cleanup parameter default", () => {
+    expectDiagnosticCount(
+      `const controller = new AbortController();
+      const useResize = (cleanup = () => controller.abort()) => {
+        useEffect(() => {
+          window.addEventListener("resize", () => resize(), {
+            signal: controller.signal,
+          });
+          return () => {
+            window.removeEventListener("resize", () => resize());
+            cleanup();
+          };
+        }, [cleanup]);
+      };`,
+      1,
+    );
+  });
+
+  it("does not treat a setup removal before registration as cleanup", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const handleResize = () => resize();
+        window.removeEventListener("resize", handleResize);
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      1,
+    );
+  });
+
+  it("does not let an unrelated setup abort suppress a mismatch", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        externalController.abort();
+        const controller = new AbortController();
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize, {
+          signal: controller.signal,
+        });
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      1,
+    );
+  });
+
+  it("stays quiet for equivalent global target paths", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleClick = () => click();
+      window.document.addEventListener("click", handleClick);
+      return () => {
+        window.document.removeEventListener("click", () => click());
+        document.removeEventListener("click", handleClick);
+      };
+    }, []);`);
+  });
+
+  it("stays quiet for the recursive window global path", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      window.window.addEventListener("resize", handleResize);
+      return () => {
+        window.window.removeEventListener("resize", () => resize());
+        window.removeEventListener("resize", handleResize);
+      };
+    }, []);`);
+  });
+
+  it("does not treat distinct fresh targets as aliases", () => {
+    expectDiagnosticCount(
+      `useEffect(() => {
+        const firstTarget = new EventTarget();
+        const secondTarget = new EventTarget();
+        const handleChange = () => change();
+        firstTarget.addEventListener("change", handleChange);
+        return () => {
+          firstTarget.removeEventListener("change", () => change());
+          secondTarget.removeEventListener("change", handleChange);
+        };
+      }, []);`,
+      1,
+    );
+  });
+
+  it("stays quiet when a guaranteed loop removes before breaking", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      window.addEventListener("resize", handleResize);
+      return () => {
+        for (const value of [1]) {
+          window.removeEventListener("resize", handleResize);
+          break;
+        }
+        window.removeEventListener("resize", () => resize());
+      };
+    }, []);`);
+  });
+
+  it("stays quiet when a guaranteed nested branch removes before breaking", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      window.addEventListener("resize", handleResize);
+      return () => {
+        for (const value of [1]) {
+          if (true) {
+            window.removeEventListener("resize", handleResize);
+            break;
+          }
+        }
+        window.removeEventListener("resize", () => resize());
+      };
+    }, []);`);
+  });
+
+  it("stays quiet when exhaustive branches contain unknown matching removals", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const callbacks = { resize: () => resize() };
+      window.addEventListener("resize", callbacks.resize);
+      return () => {
+        if (isEnabled) {
+          window.removeEventListener("resize", callbacks.resize);
+        } else {
+          window.removeEventListener("resize", callbacks.resize);
+        }
+        window.removeEventListener("resize", () => resize());
+      };
+    }, [isEnabled]);`);
+  });
+
+  it("stays quiet when exhaustive branches mix known and unknown matching removals", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      const callbacks = { resize: handleResize };
+      window.addEventListener("resize", handleResize);
+      return () => {
+        if (isEnabled) {
+          window.removeEventListener("resize", handleResize);
+        } else {
+          window.removeEventListener("resize", callbacks.resize);
+        }
+        window.removeEventListener("resize", () => resize());
+      };
+    }, [isEnabled]);`);
+  });
+
+  it("stays quiet for a local non-DOM EventTarget-like implementation", () => {
+    expectNoDiagnostics(`class TopicBus {
+      listeners = new Map();
+      addEventListener(eventName, listener) {
+        this.listeners.set(eventName, listener);
+      }
+      removeEventListener(eventName) {
+        this.listeners.delete(eventName);
+      }
+    }
+    const bus = new TopicBus();
+    useEffect(() => {
+      bus.addEventListener("change", () => change(), true);
+      return () => bus.removeEventListener("change", () => change(), false);
+    }, []);`);
+  });
+
+  it("stays quiet when capture is inherited through an object literal prototype", () => {
+    expectNoDiagnostics(`useEffect(() => {
+      const handleResize = () => resize();
+      window.addEventListener("resize", handleResize, {
+        __proto__: { capture: true },
+      });
+      return () => window.removeEventListener("resize", handleResize, true);
+    }, []);`);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch.test.ts
@@ -1,0 +1,995 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectListenerCleanupMismatch } from "./effect-listener-cleanup-mismatch.js";
+
+interface ListenerRuleTestCase {
+  code: string;
+  expectedCount: number;
+  name: string;
+  reactImport?: string;
+}
+
+const DEFAULT_REACT_IMPORT =
+  'import { useEffect, useInsertionEffect, useLayoutEffect, useRef } from "react";';
+
+const runListenerRule = (code: string, reactImport = DEFAULT_REACT_IMPORT) =>
+  runRule(effectListenerCleanupMismatch, `${reactImport}\n${code}`);
+
+const expectDiagnosticCount = (
+  code: string,
+  expectedCount: number,
+  reactImport = DEFAULT_REACT_IMPORT,
+): void => {
+  const result = runListenerRule(code, reactImport);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedCount);
+};
+
+describe("effect-listener-cleanup-mismatch", () => {
+  const reactApiCallCases: ListenerRuleTestCase[] = [
+    {
+      name: "renamed useInsertionEffect imports",
+      reactImport: 'import { useInsertionEffect as useListenerInsertionEffect } from "react";',
+      code: `useListenerInsertionEffect(() => {
+        window.addEventListener("resize", () => resize());
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "default React effect receivers",
+      reactImport: 'import ReactClient from "react";',
+      code: `ReactClient.useEffect(() => {
+        window.addEventListener("resize", () => resize());
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "namespace React effect receivers",
+      reactImport: 'import * as ReactClient from "react";',
+      code: `ReactClient.useLayoutEffect(() => {
+        window.addEventListener("resize", () => resize());
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "shadowed useInsertionEffect imports",
+      code: `const run = () => {
+        const useInsertionEffect = (callback) => callback();
+        useInsertionEffect(() => {
+          window.addEventListener("resize", () => resize());
+          return () => window.removeEventListener("resize", () => resize());
+        }, []);
+      };`,
+      expectedCount: 0,
+    },
+    {
+      name: "unbound useInsertionEffect calls",
+      reactImport: "",
+      code: `useInsertionEffect(() => {
+        window.addEventListener("resize", () => resize());
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of reactApiCallCases) {
+    it(`handles ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount, testCase.reactImport);
+    });
+  }
+
+  it("reports handlers re-declared inside cleanup", () => {
+    const result = runListenerRule(`
+      const CoreUiShape = () => {
+        useEffect(() => {
+          const handleMouseUp = () => finishResize();
+          window.addEventListener("mouseup", handleMouseUp);
+          return () => {
+            const handleMouseUp = () => finishResize();
+            window.removeEventListener("mouseup", handleMouseUp);
+          };
+        }, []);
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("different callback binding");
+  });
+
+  it("reports same-name function declarations re-declared inside cleanup", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          function handleMouseMove() {
+            continueResize();
+          }
+          window.addEventListener("mousemove", handleMouseMove);
+          return () => {
+            function handleMouseMove() {
+              continueResize();
+            }
+            window.removeEventListener("mousemove", handleMouseMove);
+          };
+        }, []);
+      `,
+      1,
+    );
+  });
+
+  it("reports the CoreUI ref.current cleanup mismatch", () => {
+    const result = runListenerRule(`
+      const Carousel = () => {
+        const carouselItemRef = useRef<HTMLDivElement>(null);
+        useEffect(() => {
+          const handleTouchStart = () => beginSwipe();
+          (carouselItemRef.current as HTMLDivElement)?.addEventListener(
+            "touchstart",
+            handleTouchStart,
+            true,
+          );
+          return () => {
+            const handleTouchStart = () => beginSwipe();
+            carouselItemRef.current?.removeEventListener("touchstart", handleTouchStart);
+          };
+        }, []);
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("different callback binding");
+    expect(result.diagnostics[0].message).toContain("capture false");
+    expect(result.diagnostics[0].message).toContain("capture true");
+  });
+
+  it("reports capture true removed with omitted capture", () => {
+    const result = runListenerRule(`
+      useEffect(() => {
+        const handleClick = () => close();
+        document.addEventListener("click", handleClick, true);
+        return () => document.removeEventListener("click", handleClick);
+      }, []);
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("capture");
+    expect(result.diagnostics[0].message).toContain("true");
+    expect(result.diagnostics[0].message).toContain("false");
+  });
+
+  it("accepts equivalent true and capture true options", () => {
+    expectDiagnosticCount(
+      `
+        useLayoutEffect(() => {
+          const handleFocus = () => focus();
+          window.addEventListener("focus", handleFocus, true);
+          return () => window.removeEventListener("focus", handleFocus, { capture: true });
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("accepts omitted, false, and capture false as equivalent", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const first = () => firstAction();
+          const second = () => secondAction();
+          window.addEventListener("first", first);
+          window.addEventListener("second", second, { capture: false });
+          return () => {
+            window.removeEventListener("first", first, false);
+            window.removeEventListener("second", second);
+          };
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("reports a useInsertionEffect callback mismatch", () => {
+    expectDiagnosticCount(
+      `
+        useInsertionEffect(() => {
+          window.addEventListener("resize", () => resize());
+          return () => window.removeEventListener("resize", () => resize());
+        }, []);
+      `,
+      1,
+    );
+  });
+
+  it("accepts a valid useInsertionEffect cleanup", () => {
+    expectDiagnosticCount(
+      `
+        useInsertionEffect(() => {
+          const handleResize = () => resize();
+          window.addEventListener("resize", handleResize);
+          return () => window.removeEventListener("resize", handleResize);
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("accepts an immutable callback alias chain", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          const listener = handleResize;
+          const cleanupListener = listener;
+          window.addEventListener("resize", handleResize);
+          return () => window.removeEventListener("resize", cleanupListener);
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("distinguishes same-name shadowed callback bindings", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const listener = () => start();
+          window.addEventListener("resize", listener);
+          return () => {
+            const listener = () => stop();
+            window.removeEventListener("resize", listener);
+          };
+        }, []);
+      `,
+      1,
+    );
+  });
+
+  it("reports fresh inline functions", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          window.addEventListener("resize", () => resize());
+          return () => window.removeEventListener("resize", () => resize());
+        }, []);
+      `,
+      1,
+    );
+  });
+
+  const staticEventNameCases: ListenerRuleTestCase[] = [
+    {
+      name: "direct const event names",
+      code: `useEffect(() => {
+        const eventName = "resize";
+        window.addEventListener(eventName, () => resize());
+        return () => window.removeEventListener(eventName, () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "const alias event names",
+      code: `useEffect(() => {
+        const sourceEventName = "resize";
+        const eventName = sourceEventName;
+        window.addEventListener(eventName, () => resize());
+        return () => window.removeEventListener(sourceEventName, () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "static template event names",
+      code: `useEffect(() => {
+        window.addEventListener(\`resize\`, () => resize());
+        return () => window.removeEventListener(\`resize\`, () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "destructured-default event names",
+      code: `useEffect(() => {
+        const { eventName = "resize" } = options;
+        window.addEventListener(eventName, () => resize());
+        return () => window.removeEventListener(eventName, () => resize());
+      }, [options]);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of staticEventNameCases) {
+    it(`handles ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  const staticOptionKeyCases: ListenerRuleTestCase[] = [
+    {
+      name: "quoted capture keys",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize, { "capture": true });
+        return () => window.removeEventListener("resize", handleResize);
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "computed string capture keys",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize, { ["capture"]: true });
+        return () => window.removeEventListener("resize", handleResize);
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "dynamic computed capture keys",
+      code: `useEffect(() => {
+        const added = () => addedAction();
+        const removed = () => removedAction();
+        window.addEventListener("resize", added, { [captureKey]: true });
+        return () => window.removeEventListener("resize", removed);
+      }, [captureKey]);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of staticOptionKeyCases) {
+    it(`handles ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  it("ignores passive and once differences", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleWheel = () => wheel();
+          window.addEventListener("wheel", handleWheel, { passive: true, once: true });
+          return () => window.removeEventListener("wheel", handleWheel, {
+            passive: false,
+            once: false,
+          });
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("stays quiet for dynamic and spread capture options", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const added = () => addedAction();
+          const removed = () => removedAction();
+          window.addEventListener("click", added, options);
+          window.addEventListener("keydown", added, { ...options, capture: true });
+          return () => {
+            window.removeEventListener("click", removed);
+            window.removeEventListener("keydown", removed, true);
+          };
+        }, [options]);
+      `,
+      0,
+    );
+  });
+
+  it("stays quiet when the same local AbortController is aborted", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const controller = new AbortController();
+          window.addEventListener("resize", () => resize(), { signal: controller.signal });
+          return () => {
+            window.removeEventListener("resize", () => resize());
+            controller.abort();
+          };
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("reports a direct local signal when its controller is not aborted", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const controller = new AbortController();
+          window.addEventListener("resize", () => resize(), { signal: controller.signal });
+          return () => window.removeEventListener("resize", () => resize());
+        }, []);
+      `,
+      1,
+    );
+  });
+
+  const unhandledSignalBindingCases: ListenerRuleTestCase[] = [
+    {
+      name: "a direct signal alias",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        const signal = controller.signal;
+        window.addEventListener("resize", () => resize(), { signal });
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "a destructured signal alias",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        const { signal } = controller;
+        window.addEventListener("resize", () => resize(), { signal });
+        return () => window.removeEventListener("resize", () => resize());
+      }, []);`,
+      expectedCount: 1,
+    },
+  ];
+
+  for (const testCase of unhandledSignalBindingCases) {
+    it(`reports an unhandled listener using ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  const abortControllerAliasCases: ListenerRuleTestCase[] = [
+    {
+      name: "signal and abort aliases",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        const signalController = controller;
+        const cleanupController = signalController;
+        window.addEventListener("resize", () => resize(), {
+          signal: signalController.signal,
+        });
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          cleanupController.abort();
+        };
+      }, []);`,
+      expectedCount: 0,
+    },
+    {
+      name: "computed signal option keys through an alias",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        const controllerAlias = controller;
+        window.addEventListener("resize", () => resize(), {
+          ["signal"]: controllerAlias.signal,
+        });
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          controller.abort();
+        };
+      }, []);`,
+      expectedCount: 0,
+    },
+    {
+      name: "a direct signal binding",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        const signal = controller.signal;
+        window.addEventListener("resize", () => resize(), { signal });
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          controller.abort();
+        };
+      }, []);`,
+      expectedCount: 0,
+    },
+    {
+      name: "a destructured signal binding",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        const { signal } = controller;
+        window.addEventListener("resize", () => resize(), { signal });
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          controller.abort();
+        };
+      }, []);`,
+      expectedCount: 0,
+    },
+    {
+      name: "an unresolved signal binding",
+      code: `useEffect(() => {
+        window.addEventListener("resize", () => resize(), { signal: externalSignal });
+        return () => window.removeEventListener("resize", () => resize());
+      }, [externalSignal]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "a signal from a destructured-default controller",
+      code: `useEffect(() => {
+        const { controller = new AbortController() } = options;
+        window.addEventListener("resize", () => resize(), { signal: controller.signal });
+        return () => window.removeEventListener("resize", () => resize());
+      }, [options]);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of abortControllerAliasCases) {
+    it(`handles ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  const pathAmbiguousCleanupCases: ListenerRuleTestCase[] = [
+    {
+      name: "a conditional AbortController abort",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        window.addEventListener("resize", () => resize(), { signal: controller.signal });
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          if (shouldAbort) controller.abort();
+        };
+      }, [shouldAbort]);`,
+      expectedCount: 1,
+    },
+    {
+      name: "an unreachable AbortController abort",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        window.addEventListener("resize", () => resize(), { signal: controller.signal });
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          if (false) controller.abort();
+        };
+      }, []);`,
+      expectedCount: 1,
+    },
+    {
+      name: "a conditional valid removal beside an unconditional mismatch",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          if (shouldRemoveCorrectly) {
+            window.removeEventListener("resize", handleResize);
+          }
+        };
+      }, [shouldRemoveCorrectly]);`,
+      expectedCount: 1,
+    },
+  ];
+
+  for (const testCase of pathAmbiguousCleanupCases) {
+    it(`reports despite ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  const concisePathAmbiguousCleanupCases: ListenerRuleTestCase[] = [
+    {
+      name: "a concise ternary choosing valid or wrong removal",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => shouldRemoveCorrectly
+          ? window.removeEventListener("resize", handleResize)
+          : window.removeEventListener("resize", () => resize());
+      }, [shouldRemoveCorrectly]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "a concise short-circuit conditional abort",
+      code: `useEffect(() => {
+        const controller = new AbortController();
+        window.addEventListener("resize", () => resize(), { signal: controller.signal });
+        return () => shouldAbort && controller.abort();
+      }, [shouldAbort]);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of concisePathAmbiguousCleanupCases) {
+    it(`stays quiet for ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  const earlyExitCleanupCases: ListenerRuleTestCase[] = [
+    {
+      name: "an early return before a mismatched removal",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          if (shouldReturnEarly) return;
+          window.removeEventListener("resize", () => resize());
+        };
+      }, [shouldReturnEarly]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "a conditional throw before a mismatched removal",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          if (shouldThrow) throw new Error("cleanup failed");
+          window.removeEventListener("resize", () => resize());
+        };
+      }, [shouldThrow]);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of earlyExitCleanupCases) {
+    it(`stays quiet for ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  it("ignores early exits inside nested cleanup functions", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          window.addEventListener("resize", handleResize);
+          return () => {
+            const nested = () => {
+              if (shouldReturnEarly) return;
+              throw new Error("nested failure");
+            };
+            consume(nested);
+            window.removeEventListener("resize", () => resize());
+          };
+        }, [shouldReturnEarly]);
+      `,
+      1,
+    );
+  });
+
+  it("does not let a different AbortController suppress the mismatch", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const registrationController = new AbortController();
+          const cleanupController = new AbortController();
+          window.addEventListener("resize", () => resize(), {
+            signal: registrationController.signal,
+          });
+          return () => {
+            window.removeEventListener("resize", () => resize());
+            cleanupController.abort();
+          };
+        }, []);
+      `,
+      1,
+    );
+  });
+
+  it("lets a valid matching removal win over an extra invalid removal", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          window.addEventListener("resize", handleResize);
+          return () => {
+            window.removeEventListener("resize", () => resize());
+            window.removeEventListener("resize", handleResize);
+          };
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  const unknownRemovalCases: ListenerRuleTestCase[] = [
+    {
+      name: "an unknown callback beside a provable mismatch",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          window.removeEventListener("resize", callbacks[currentIndex]);
+        };
+      }, [callbacks, currentIndex]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "unknown capture options beside a provable mismatch",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize, true);
+        return () => {
+          window.removeEventListener("resize", handleResize);
+          window.removeEventListener("resize", handleResize, removalOptions);
+        };
+      }, [removalOptions]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "an unknown event beside a provable mismatch",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        return () => {
+          window.removeEventListener("resize", () => resize());
+          window.removeEventListener(cleanupEventName, handleResize);
+        };
+      }, [cleanupEventName]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "an unknown abort receiver beside a provable mismatch",
+      code: `const useListener = (cleanupController) => {
+        useEffect(() => {
+          const controller = new AbortController();
+          window.addEventListener("resize", () => resize(), { signal: controller.signal });
+          return () => {
+            window.removeEventListener("resize", () => resize());
+            cleanupController.abort();
+          };
+        }, [cleanupController]);
+      };`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of unknownRemovalCases) {
+    it(`suppresses for ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  const ambiguousCleanupCases: ListenerRuleTestCase[] = [
+    {
+      name: "conditional valid and invalid cleanup alternatives",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        if (useAlternateCleanup) {
+          return () => window.removeEventListener("resize", () => resize());
+        }
+        return () => window.removeEventListener("resize", handleResize);
+      }, [useAlternateCleanup]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "multiple invalid cleanup alternatives",
+      code: `useEffect(() => {
+        const handleResize = () => resize();
+        window.addEventListener("resize", handleResize);
+        if (useAlternateCleanup) {
+          return () => window.removeEventListener("resize", () => firstResize());
+        }
+        return () => window.removeEventListener("resize", () => secondResize());
+      }, [useAlternateCleanup]);`,
+      expectedCount: 0,
+    },
+    {
+      name: "a resolved and unknown cleanup alternative",
+      code: `const useListener = (providedCleanup) => {
+        useEffect(() => {
+          const handleResize = () => resize();
+          window.addEventListener("resize", handleResize);
+          if (useProvidedCleanup) return providedCleanup;
+          return () => window.removeEventListener("resize", () => resize());
+        }, [providedCleanup, useProvidedCleanup]);
+      };`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of ambiguousCleanupCases) {
+    it(`stays quiet for ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  const duplicateRegistrationCases: ListenerRuleTestCase[] = [
+    {
+      name: "one valid removal for two same-event registrations",
+      code: `useEffect(() => {
+        const firstListener = () => firstResize();
+        const secondListener = () => secondResize();
+        window.addEventListener("resize", firstListener);
+        window.addEventListener("resize", secondListener);
+        return () => window.removeEventListener("resize", secondListener);
+      }, []);`,
+      expectedCount: 0,
+    },
+    {
+      name: "an invalid removal for two same-event registrations",
+      code: `useEffect(() => {
+        const firstListener = () => firstResize();
+        const secondListener = () => secondResize();
+        window.addEventListener("resize", firstListener);
+        window.addEventListener("resize", secondListener);
+        return () => window.removeEventListener("resize", () => cleanupResize());
+      }, []);`,
+      expectedCount: 0,
+    },
+  ];
+
+  for (const testCase of duplicateRegistrationCases) {
+    it(`stays quiet for ${testCase.name}`, () => {
+      expectDiagnosticCount(testCase.code, testCase.expectedCount);
+    });
+  }
+
+  it("pairs multiple registrations independently", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          const handleScroll = () => scroll();
+          window.addEventListener("resize", handleResize);
+          window.addEventListener("scroll", handleScroll, true);
+          return () => {
+            window.removeEventListener("resize", handleResize);
+            window.removeEventListener("scroll", handleScroll);
+          };
+        }, []);
+      `,
+      1,
+    );
+  });
+
+  it("stays quiet for a different target", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          firstTarget.addEventListener("resize", handleResize);
+          return () => secondTarget.removeEventListener("resize", () => resize());
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("stays quiet for different member target roots and properties", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          firstRef.current.addEventListener("resize", handleResize);
+          return () => {
+            secondRef.current.removeEventListener("resize", () => resize());
+            firstRef.previous.removeEventListener("resize", () => resize());
+          };
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("stays quiet for dynamic computed targets", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          targetRef[propertyName].addEventListener("resize", handleResize);
+          return () => targetRef[propertyName].removeEventListener("resize", () => resize());
+        }, [propertyName]);
+      `,
+      0,
+    );
+  });
+
+  it("stays quiet for a different event", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          window.addEventListener("resize", handleResize);
+          return () => window.removeEventListener("scroll", () => resize());
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("does not treat a nested setup function as cleanup", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          window.addEventListener("resize", () => resize());
+          const unrelated = () => {
+            window.removeEventListener("resize", () => resize());
+          };
+          schedule(unrelated);
+          return () => cancel();
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("does not treat a nested cleanup callback removal as direct cleanup", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          window.addEventListener("resize", () => resize());
+          return () => {
+            queueMicrotask(() => {
+              window.removeEventListener("resize", () => resize());
+            });
+          };
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("supports a returned immutable cleanup binding", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const added = () => addedAction();
+          const removed = () => removedAction();
+          window.addEventListener("resize", added);
+          const cleanup = () => window.removeEventListener("resize", removed);
+          return cleanup;
+        }, []);
+      `,
+      1,
+    );
+  });
+
+  it("stays quiet for dynamic callback expressions", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          window.addEventListener("resize", callbacks[currentIndex]);
+          return () => window.removeEventListener("resize", callbacks[nextIndex]);
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("stays quiet for dynamic events", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          window.addEventListener(events[currentIndex], () => start());
+          return () => window.removeEventListener(events[currentIndex], () => stop());
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("accepts matching callback and capture on the same ref.current chain", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          const handleResize = () => resize();
+          targetRef.current?.addEventListener("resize", handleResize, { capture: true });
+          return () => {
+            (targetRef.current as HTMLElement)?.removeEventListener(
+              "resize",
+              handleResize,
+              true,
+            );
+          };
+        }, []);
+      `,
+      0,
+    );
+  });
+
+  it("does not report EventEmitter on and off calls", () => {
+    expectDiagnosticCount(
+      `
+        useEffect(() => {
+          emitter.on("change", () => start());
+          return () => emitter.off("change", () => stop());
+        }, []);
+      `,
+      0,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch.ts
@@ -1,0 +1,617 @@
+import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+interface CallbackIdentity {
+  readonly node: EsTreeNode;
+  readonly isConcreteFunction: boolean;
+}
+
+interface ListenerCandidate {
+  readonly node: EsTreeNodeOfType<"CallExpression">;
+  readonly targetKey: string;
+  readonly eventName: string;
+  readonly callbackIdentity: CallbackIdentity | null;
+  readonly capture: boolean | null;
+}
+
+interface ListenerRegistration {
+  readonly node: EsTreeNodeOfType<"CallExpression">;
+  readonly targetKey: string;
+  readonly eventName: string;
+  readonly callbackIdentity: CallbackIdentity;
+  readonly capture: boolean;
+  readonly abortControllerSymbolId: number | null;
+  readonly hasUnknownCancellation: boolean;
+}
+
+interface ListenerAnalysis {
+  readonly registrations: ListenerRegistration[];
+  readonly removals: ListenerCandidate[];
+  readonly abortedControllerSymbolIds: ReadonlySet<number>;
+  readonly hasUnknownAbortCall: boolean;
+  readonly hasUnknownRemovalCall: boolean;
+}
+
+interface ListenerMismatch {
+  readonly removalNode: EsTreeNodeOfType<"CallExpression">;
+  readonly removalCapture: boolean;
+  readonly callbackComparison: "different" | "same";
+}
+
+interface CleanupAnalysis {
+  readonly removals: ListenerCandidate[];
+  readonly abortedControllerSymbolIds: ReadonlySet<number>;
+  readonly hasUnknownAbortCall: boolean;
+  readonly hasUnknownRemovalCall: boolean;
+}
+
+interface EffectListenerInputs {
+  readonly registrations: ListenerRegistration[];
+  readonly cleanupBodies: EsTreeNode[];
+  readonly hasCanonicalCleanupReturn: boolean;
+  readonly returnStatementCount: number;
+}
+
+interface RegistrationCancellation {
+  readonly abortControllerSymbolId: number | null;
+  readonly hasUnknownCancellation: boolean;
+}
+
+const LISTENER_EFFECT_HOOK_NAMES = new Set([...EFFECT_HOOK_NAMES, "useInsertionEffect"]);
+
+const PATH_AMBIGUOUS_ANCESTOR_TYPES: ReadonlySet<string> = new Set([
+  "CatchClause",
+  "ConditionalExpression",
+  "DoWhileStatement",
+  "ForInStatement",
+  "ForOfStatement",
+  "ForStatement",
+  "IfStatement",
+  "LogicalExpression",
+  "SwitchCase",
+  "SwitchStatement",
+  "TryStatement",
+  "WhileStatement",
+]);
+
+const isPathAmbiguousCall = (node: EsTreeNode, bodyNode: EsTreeNode): boolean => {
+  if (PATH_AMBIGUOUS_ANCESTOR_TYPES.has(bodyNode.type)) return true;
+  let currentNode: EsTreeNode | null | undefined = node;
+  while (currentNode?.parent && currentNode.parent !== bodyNode) {
+    currentNode = currentNode.parent;
+    if (PATH_AMBIGUOUS_ANCESTOR_TYPES.has(currentNode.type)) return true;
+  }
+  return false;
+};
+
+const hasOnlyReadReferences = (symbol: SymbolDescriptor): boolean =>
+  symbol.references.every((reference) => reference.flag === "read");
+
+const isStableSymbol = (symbol: SymbolDescriptor): boolean =>
+  symbol.kind === "const" ||
+  symbol.kind === "import" ||
+  ((symbol.kind === "function" || symbol.kind === "parameter") && hasOnlyReadReferences(symbol));
+
+const isPlainConstSymbol = (symbol: SymbolDescriptor): boolean =>
+  symbol.kind === "const" &&
+  isNodeOfType(symbol.declarationNode, "VariableDeclarator") &&
+  isNodeOfType(symbol.declarationNode.id, "Identifier") &&
+  symbol.declarationNode.id === symbol.bindingIdentifier;
+
+const resolveAliasedSymbol = (
+  identifier: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds: Set<number>,
+): SymbolDescriptor | null => {
+  if (!isNodeOfType(identifier, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(identifier);
+  if (!symbol || !isStableSymbol(symbol) || visitedSymbolIds.has(symbol.id)) return null;
+  if (symbol.kind === "const" && !isPlainConstSymbol(symbol)) return null;
+  visitedSymbolIds.add(symbol.id);
+  const initializer = symbol.initializer ? stripParenExpression(symbol.initializer) : null;
+  if (symbol.kind === "const" && isNodeOfType(initializer, "Identifier")) {
+    const resolvedAlias = resolveAliasedSymbol(initializer, context, visitedSymbolIds);
+    if (resolvedAlias) return resolvedAlias;
+  }
+  return symbol;
+};
+
+const resolveCallbackIdentity = (
+  callbackNode: EsTreeNode | null | undefined,
+  context: RuleContext,
+): CallbackIdentity | null => {
+  if (!callbackNode) return null;
+  const unwrappedCallback = stripParenExpression(callbackNode);
+  if (isFunctionLike(unwrappedCallback)) {
+    return { node: unwrappedCallback, isConcreteFunction: true };
+  }
+  if (!isNodeOfType(unwrappedCallback, "Identifier")) return null;
+
+  const symbol = resolveAliasedSymbol(unwrappedCallback, context, new Set());
+  if (!symbol) return null;
+  const initializer = symbol.initializer ? stripParenExpression(symbol.initializer) : null;
+  if (initializer && isFunctionLike(initializer)) {
+    return { node: initializer, isConcreteFunction: true };
+  }
+  return { node: symbol.bindingIdentifier, isConcreteFunction: false };
+};
+
+const compareCallbackIdentities = (
+  registrationIdentity: CallbackIdentity,
+  removalIdentity: CallbackIdentity,
+): "same" | "different" | "unknown" => {
+  if (registrationIdentity.node === removalIdentity.node) return "same";
+  if (registrationIdentity.isConcreteFunction && removalIdentity.isConcreteFunction) {
+    return "different";
+  }
+  return "unknown";
+};
+
+const resolveTargetKey = (targetNode: EsTreeNode, context: RuleContext): string | null => {
+  const unwrappedTarget = stripParenExpression(targetNode);
+  if (isNodeOfType(unwrappedTarget, "Identifier")) {
+    const symbol = resolveAliasedSymbol(unwrappedTarget, context, new Set());
+    if (symbol) return `symbol:${symbol.id}`;
+    if (context.scopes.isGlobalReference(unwrappedTarget)) {
+      return `global:${unwrappedTarget.name}`;
+    }
+    return null;
+  }
+  if (
+    isNodeOfType(unwrappedTarget, "MemberExpression") &&
+    !unwrappedTarget.computed &&
+    isNodeOfType(unwrappedTarget.property, "Identifier")
+  ) {
+    const objectKey = resolveTargetKey(unwrappedTarget.object, context);
+    return objectKey === null ? null : `${objectKey}.${unwrappedTarget.property.name}`;
+  }
+  return null;
+};
+
+const resolveStaticEventName = (
+  eventNode: EsTreeNode | null | undefined,
+  context: RuleContext,
+  visitedSymbolIds: Set<number> = new Set(),
+): string | null => {
+  if (!eventNode) return null;
+  const unwrappedEvent = stripParenExpression(eventNode);
+  if (isNodeOfType(unwrappedEvent, "Literal") && typeof unwrappedEvent.value === "string") {
+    return unwrappedEvent.value;
+  }
+  if (isNodeOfType(unwrappedEvent, "TemplateLiteral") && unwrappedEvent.expressions.length === 0) {
+    return unwrappedEvent.quasis[0]?.value.cooked ?? "";
+  }
+  if (!isNodeOfType(unwrappedEvent, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(unwrappedEvent);
+  if (
+    !symbol ||
+    !isPlainConstSymbol(symbol) ||
+    !symbol.initializer ||
+    visitedSymbolIds.has(symbol.id)
+  ) {
+    return null;
+  }
+  visitedSymbolIds.add(symbol.id);
+  return resolveStaticEventName(symbol.initializer, context, visitedSymbolIds);
+};
+
+const resolveCapture = (optionsNode: EsTreeNode | null | undefined): boolean | null => {
+  if (!optionsNode) return false;
+  const unwrappedOptions = stripParenExpression(optionsNode);
+  if (isNodeOfType(unwrappedOptions, "Literal")) {
+    return typeof unwrappedOptions.value === "boolean" ? unwrappedOptions.value : null;
+  }
+  if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) return null;
+
+  let capture = false;
+  for (const property of unwrappedOptions.properties) {
+    if (!isNodeOfType(property, "Property")) return null;
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (propertyName === null) return null;
+    if (propertyName !== "capture") continue;
+    const propertyValue = stripParenExpression(property.value);
+    if (!isNodeOfType(propertyValue, "Literal") || typeof propertyValue.value !== "boolean") {
+      return null;
+    }
+    capture = propertyValue.value;
+  }
+  return capture;
+};
+
+const resolveLocalAbortControllerSymbolId = (
+  controllerNode: EsTreeNode,
+  context: RuleContext,
+): number | null => {
+  const unwrappedController = stripParenExpression(controllerNode);
+  if (!isNodeOfType(unwrappedController, "Identifier")) return null;
+  const controllerSymbol = resolveAliasedSymbol(unwrappedController, context, new Set());
+  if (!controllerSymbol || controllerSymbol.kind !== "const" || !controllerSymbol.initializer) {
+    return null;
+  }
+  const initializer = stripParenExpression(controllerSymbol.initializer);
+  if (
+    !isNodeOfType(initializer, "NewExpression") ||
+    !isNodeOfType(initializer.callee, "Identifier") ||
+    initializer.callee.name !== "AbortController" ||
+    !context.scopes.isGlobalReference(initializer.callee)
+  ) {
+    return null;
+  }
+  return controllerSymbol.id;
+};
+
+const readDirectMemberReceiver = (
+  memberNode: EsTreeNode | null | undefined,
+  memberName: string,
+): EsTreeNode | null => {
+  if (!memberNode) return null;
+  const unwrappedMember = stripParenExpression(memberNode);
+  if (
+    !isNodeOfType(unwrappedMember, "MemberExpression") ||
+    getStaticMemberPropertyName(unwrappedMember) !== memberName
+  ) {
+    return null;
+  }
+  return unwrappedMember.object;
+};
+
+const isSignalObjectPatternBinding = (
+  patternNode: EsTreeNode,
+  bindingIdentifier: EsTreeNode,
+): boolean => {
+  if (!isNodeOfType(patternNode, "ObjectPattern")) return false;
+  return patternNode.properties.some((property) => {
+    if (!isNodeOfType(property, "Property")) return false;
+    if (getStaticPropertyKeyName(property, { allowComputedString: true }) !== "signal") {
+      return false;
+    }
+    const propertyValue = isNodeOfType(property.value, "AssignmentPattern")
+      ? property.value.left
+      : property.value;
+    return propertyValue === bindingIdentifier;
+  });
+};
+
+const resolveSignalAbortControllerSymbolId = (
+  signalNode: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds: Set<number> = new Set(),
+): number | null => {
+  const unwrappedSignal = stripParenExpression(signalNode);
+  const directControllerNode = readDirectMemberReceiver(unwrappedSignal, "signal");
+  if (directControllerNode) {
+    return resolveLocalAbortControllerSymbolId(directControllerNode, context);
+  }
+  if (!isNodeOfType(unwrappedSignal, "Identifier")) return null;
+  const signalSymbol = context.scopes.symbolFor(unwrappedSignal);
+  if (
+    !signalSymbol ||
+    signalSymbol.kind !== "const" ||
+    !signalSymbol.initializer ||
+    visitedSymbolIds.has(signalSymbol.id) ||
+    !hasOnlyReadReferences(signalSymbol)
+  ) {
+    return null;
+  }
+  visitedSymbolIds.add(signalSymbol.id);
+  const declarationNode = signalSymbol.declarationNode;
+  if (!isNodeOfType(declarationNode, "VariableDeclarator")) return null;
+  if (
+    isNodeOfType(declarationNode.id, "Identifier") &&
+    declarationNode.id === signalSymbol.bindingIdentifier
+  ) {
+    const initializer = stripParenExpression(signalSymbol.initializer);
+    if (isNodeOfType(initializer, "Identifier")) {
+      return resolveSignalAbortControllerSymbolId(initializer, context, visitedSymbolIds);
+    }
+    const controllerNode = readDirectMemberReceiver(initializer, "signal");
+    return controllerNode ? resolveLocalAbortControllerSymbolId(controllerNode, context) : null;
+  }
+  if (!isSignalObjectPatternBinding(declarationNode.id, signalSymbol.bindingIdentifier)) {
+    return null;
+  }
+  return resolveLocalAbortControllerSymbolId(signalSymbol.initializer, context);
+};
+
+const resolveRegistrationCancellation = (
+  optionsNode: EsTreeNode | null | undefined,
+  context: RuleContext,
+): RegistrationCancellation => {
+  const noCancellation: RegistrationCancellation = {
+    abortControllerSymbolId: null,
+    hasUnknownCancellation: false,
+  };
+  if (!optionsNode) return noCancellation;
+  const unwrappedOptions = stripParenExpression(optionsNode);
+  if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) return noCancellation;
+  let resolvedCancellation: RegistrationCancellation | null = null;
+  for (const property of unwrappedOptions.properties) {
+    if (!isNodeOfType(property, "Property")) return noCancellation;
+    if (getStaticPropertyKeyName(property, { allowComputedString: true }) !== "signal") continue;
+    if (resolvedCancellation) {
+      return { abortControllerSymbolId: null, hasUnknownCancellation: true };
+    }
+    const abortControllerSymbolId = resolveSignalAbortControllerSymbolId(property.value, context);
+    resolvedCancellation = {
+      abortControllerSymbolId,
+      hasUnknownCancellation: abortControllerSymbolId === null,
+    };
+  }
+  return resolvedCancellation ?? noCancellation;
+};
+
+const readListenerCandidate = (
+  node: EsTreeNodeOfType<"CallExpression">,
+  methodName: "addEventListener" | "removeEventListener",
+  context: RuleContext,
+): ListenerCandidate | null => {
+  const targetNode = readDirectMemberReceiver(node.callee, methodName);
+  if (!targetNode) return null;
+  const targetKey = resolveTargetKey(targetNode, context);
+  const eventName = resolveStaticEventName(node.arguments?.[0], context);
+  const callbackIdentity = resolveCallbackIdentity(node.arguments?.[1], context);
+  const capture = resolveCapture(node.arguments?.[2]);
+  if (targetKey === null || eventName === null) return null;
+  return { node, targetKey, eventName, callbackIdentity, capture };
+};
+
+const resolveReturnedCleanupBody = (
+  returnedValue: EsTreeNode | null | undefined,
+  context: RuleContext,
+): EsTreeNode | null => {
+  if (!returnedValue) return null;
+  const unwrappedValue = stripParenExpression(returnedValue);
+  if (isFunctionLike(unwrappedValue)) return unwrappedValue.body;
+  if (!isNodeOfType(unwrappedValue, "Identifier")) return null;
+  const symbol = resolveAliasedSymbol(unwrappedValue, context, new Set());
+  if (!symbol || !symbol.initializer) return null;
+  const initializer = stripParenExpression(symbol.initializer);
+  return isFunctionLike(initializer) ? initializer.body : null;
+};
+
+const collectEffectListenerInputs = (
+  effectBody: EsTreeNode,
+  context: RuleContext,
+): EffectListenerInputs => {
+  const registrations: ListenerRegistration[] = [];
+  const cleanupBodies: EsTreeNode[] = [];
+  let returnStatementCount = 0;
+  if (!isNodeOfType(effectBody, "BlockStatement")) {
+    return {
+      registrations,
+      cleanupBodies,
+      hasCanonicalCleanupReturn: false,
+      returnStatementCount,
+    };
+  }
+  const finalEffectStatement = effectBody.body[effectBody.body.length - 1];
+  const hasCanonicalCleanupReturn = isNodeOfType(finalEffectStatement, "ReturnStatement");
+  walkAst(effectBody, (child: EsTreeNode) => {
+    if (child !== effectBody && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "ClassDeclaration") || isNodeOfType(child, "ClassExpression")) {
+      return false;
+    }
+    if (isNodeOfType(child, "CallExpression")) {
+      if (isPathAmbiguousCall(child, effectBody)) return;
+      const candidate = readListenerCandidate(child, "addEventListener", context);
+      if (candidate?.callbackIdentity && candidate.capture !== null) {
+        const registrationCancellation = resolveRegistrationCancellation(
+          candidate.node.arguments?.[2],
+          context,
+        );
+        registrations.push({
+          node: candidate.node,
+          targetKey: candidate.targetKey,
+          eventName: candidate.eventName,
+          callbackIdentity: candidate.callbackIdentity,
+          capture: candidate.capture,
+          abortControllerSymbolId: registrationCancellation.abortControllerSymbolId,
+          hasUnknownCancellation: registrationCancellation.hasUnknownCancellation,
+        });
+      }
+      return;
+    }
+    if (isNodeOfType(child, "ReturnStatement")) {
+      returnStatementCount += 1;
+      const cleanupBody = resolveReturnedCleanupBody(child.argument, context);
+      if (cleanupBody) cleanupBodies.push(cleanupBody);
+    }
+  });
+  return {
+    registrations,
+    cleanupBodies,
+    hasCanonicalCleanupReturn,
+    returnStatementCount,
+  };
+};
+
+const analyzeCleanupBody = (
+  cleanupBody: EsTreeNode,
+  context: RuleContext,
+): CleanupAnalysis | null => {
+  const removals: ListenerCandidate[] = [];
+  const abortedControllerSymbolIds = new Set<number>();
+  let hasAmbiguousReachability = false;
+  let hasUnknownAbortCall = false;
+  let hasUnknownRemovalCall = false;
+  walkAst(cleanupBody, (child: EsTreeNode) => {
+    if (child !== cleanupBody && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "ClassDeclaration") || isNodeOfType(child, "ClassExpression")) {
+      return false;
+    }
+    if (isNodeOfType(child, "ReturnStatement") || isNodeOfType(child, "ThrowStatement")) {
+      hasAmbiguousReachability = true;
+      return false;
+    }
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (isPathAmbiguousCall(child, cleanupBody)) return;
+    const removalTarget = readDirectMemberReceiver(child.callee, "removeEventListener");
+    if (removalTarget) {
+      const removal = readListenerCandidate(child, "removeEventListener", context);
+      if (removal) {
+        removals.push(removal);
+      } else {
+        hasUnknownRemovalCall = true;
+      }
+    }
+    const controllerNode = readDirectMemberReceiver(child.callee, "abort");
+    if (!controllerNode) return;
+    const controllerSymbolId = resolveLocalAbortControllerSymbolId(controllerNode, context);
+    if (controllerSymbolId === null) {
+      hasUnknownAbortCall = true;
+    } else {
+      abortedControllerSymbolIds.add(controllerSymbolId);
+    }
+  });
+  if (hasAmbiguousReachability) return null;
+  return {
+    removals,
+    abortedControllerSymbolIds,
+    hasUnknownAbortCall,
+    hasUnknownRemovalCall,
+  };
+};
+
+const analyzeEffectListeners = (
+  effectBody: EsTreeNode,
+  context: RuleContext,
+): ListenerAnalysis | null => {
+  const effectInputs = collectEffectListenerInputs(effectBody, context);
+  if (
+    !effectInputs.hasCanonicalCleanupReturn ||
+    effectInputs.returnStatementCount !== 1 ||
+    effectInputs.cleanupBodies.length !== 1
+  ) {
+    return null;
+  }
+  const removals: ListenerCandidate[] = [];
+  const abortedControllerSymbolIds = new Set<number>();
+  let hasUnknownAbortCall = false;
+  let hasUnknownRemovalCall = false;
+  for (const cleanupBody of effectInputs.cleanupBodies) {
+    const cleanupAnalysis = analyzeCleanupBody(cleanupBody, context);
+    if (!cleanupAnalysis) return null;
+    removals.push(...cleanupAnalysis.removals);
+    hasUnknownAbortCall ||= cleanupAnalysis.hasUnknownAbortCall;
+    hasUnknownRemovalCall ||= cleanupAnalysis.hasUnknownRemovalCall;
+    for (const controllerSymbolId of cleanupAnalysis.abortedControllerSymbolIds) {
+      abortedControllerSymbolIds.add(controllerSymbolId);
+    }
+  }
+  return {
+    registrations: effectInputs.registrations,
+    removals,
+    abortedControllerSymbolIds,
+    hasUnknownAbortCall,
+    hasUnknownRemovalCall,
+  };
+};
+
+const buildMismatchMessage = (
+  registration: ListenerRegistration,
+  removalCapture: boolean,
+  callbackComparison: "different" | "same",
+): string => {
+  const hasCallbackMismatch = callbackComparison === "different";
+  const hasCaptureMismatch = registration.capture !== removalCapture;
+  if (hasCallbackMismatch && hasCaptureMismatch) {
+    return `The cleanup removes \`${registration.eventName}\` with a different callback binding and capture ${String(removalCapture)}, but it was registered with capture ${String(registration.capture)}. Pass the same callback binding and capture flag to both EventTarget calls.`;
+  }
+  if (hasCallbackMismatch) {
+    return `The cleanup removes \`${registration.eventName}\` with a different callback binding than the one registered, so \`removeEventListener\` cannot detach that listener. Pass the same callback binding to both calls.`;
+  }
+  return `The cleanup removes \`${registration.eventName}\` with capture ${String(removalCapture)}, but it was registered with capture ${String(registration.capture)}. \`removeEventListener\` must use the same capture flag as \`addEventListener\`.`;
+};
+
+export const effectListenerCleanupMismatch = defineRule({
+  id: "effect-listener-cleanup-mismatch",
+  title: "Effect cleanup does not match its event listener",
+  severity: "error",
+  recommendation:
+    "Pass the same callback binding and capture flag to `addEventListener` and `removeEventListener`, or abort the registration's local AbortController during cleanup.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isReactApiCall(node, LISTENER_EFFECT_HOOK_NAMES, context.scopes)) return;
+      const effectCallback = getEffectCallback(node);
+      if (!isFunctionLike(effectCallback)) return;
+      const listenerAnalysis = analyzeEffectListeners(effectCallback.body, context);
+      if (!listenerAnalysis) return;
+
+      for (const registration of listenerAnalysis.registrations) {
+        if (registration.hasUnknownCancellation || listenerAnalysis.hasUnknownRemovalCall) {
+          continue;
+        }
+        const sameEventRegistrations = listenerAnalysis.registrations.filter(
+          (candidateRegistration) =>
+            candidateRegistration.targetKey === registration.targetKey &&
+            candidateRegistration.eventName === registration.eventName,
+        );
+        if (sameEventRegistrations.length > 1) continue;
+        if (
+          registration.abortControllerSymbolId !== null &&
+          (listenerAnalysis.hasUnknownAbortCall ||
+            listenerAnalysis.abortedControllerSymbolIds.has(registration.abortControllerSymbolId))
+        ) {
+          continue;
+        }
+        const candidateRemovals = listenerAnalysis.removals.filter(
+          (removal) =>
+            removal.targetKey === registration.targetKey &&
+            removal.eventName === registration.eventName,
+        );
+        let firstProvableMismatch: ListenerMismatch | undefined;
+        let didFindNonMismatchCandidate = false;
+        for (const removal of candidateRemovals) {
+          if (!removal.callbackIdentity || removal.capture === null) {
+            didFindNonMismatchCandidate = true;
+            break;
+          }
+          const callbackComparison = compareCallbackIdentities(
+            registration.callbackIdentity,
+            removal.callbackIdentity,
+          );
+          if (callbackComparison === "unknown") {
+            didFindNonMismatchCandidate = true;
+            break;
+          }
+          if (callbackComparison === "same" && registration.capture === removal.capture) {
+            didFindNonMismatchCandidate = true;
+            break;
+          }
+          firstProvableMismatch ??= {
+            removalNode: removal.node,
+            removalCapture: removal.capture,
+            callbackComparison,
+          };
+        }
+        if (
+          candidateRemovals.length === 0 ||
+          didFindNonMismatchCandidate ||
+          !firstProvableMismatch
+        ) {
+          continue;
+        }
+        context.report({
+          node: firstProvableMismatch.removalNode,
+          message: buildMismatchMessage(
+            registration,
+            firstProvableMismatch.removalCapture,
+            firstProvableMismatch.callbackComparison,
+          ),
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch.ts
@@ -446,10 +446,16 @@ const analyzeCleanupBody = (
   let hasAmbiguousReachability = false;
   let hasUnknownAbortCall = false;
   let hasUnknownRemovalCall = false;
+  const finalCleanupStatement = isNodeOfType(cleanupBody, "BlockStatement")
+    ? cleanupBody.body[cleanupBody.body.length - 1]
+    : null;
   walkAst(cleanupBody, (child: EsTreeNode) => {
     if (child !== cleanupBody && isFunctionLike(child)) return false;
     if (isNodeOfType(child, "ClassDeclaration") || isNodeOfType(child, "ClassExpression")) {
       return false;
+    }
+    if (isNodeOfType(child, "ReturnStatement") && child === finalCleanupStatement) {
+      return;
     }
     if (isNodeOfType(child, "ReturnStatement") || isNodeOfType(child, "ThrowStatement")) {
       hasAmbiguousReachability = true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-listener-cleanup-mismatch.ts
@@ -4,10 +4,19 @@ import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { readStaticBoolean } from "../../utils/read-static-boolean.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import { buildListenerCleanupMismatchMessage } from "./utils/build-listener-cleanup-mismatch-message.js";
+import { callbackMayRegisterEventListener } from "./utils/callback-may-register-event-listener.js";
+import { compareListenerCallbackIdentities } from "./utils/compare-listener-callback-identities.js";
+import { doesListenerAnalysisAbortController } from "./utils/does-listener-analysis-abort-controller.js";
+import { doesListenerAnalysisCancelRegistration } from "./utils/does-listener-analysis-cancel-registration.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
+import { isListenerPathAmbiguous } from "./utils/is-listener-path-ambiguous.js";
+import { resolveEventListenerCapture } from "./utils/resolve-event-listener-capture.js";
+import { resolveStaticOnceOption } from "./utils/resolve-static-once-option.js";
 import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -32,16 +41,22 @@ interface ListenerRegistration {
   readonly eventName: string;
   readonly callbackIdentity: CallbackIdentity;
   readonly capture: boolean;
+  readonly once: boolean;
   readonly abortControllerSymbolId: number | null;
   readonly hasUnknownCancellation: boolean;
 }
 
-interface ListenerAnalysis {
-  readonly registrations: ListenerRegistration[];
+interface CancellationAnalysis {
   readonly removals: ListenerCandidate[];
   readonly abortedControllerSymbolIds: ReadonlySet<number>;
+  readonly exhaustiveBranches: ReadonlyArray<ExhaustiveCleanupBranches>;
   readonly hasUnknownAbortCall: boolean;
   readonly hasUnknownRemovalCall: boolean;
+}
+
+interface ListenerAnalysis extends CancellationAnalysis {
+  readonly registrations: ListenerRegistration[];
+  readonly setupAbortAnalysis: CancellationAnalysis | null;
 }
 
 interface ListenerMismatch {
@@ -50,11 +65,9 @@ interface ListenerMismatch {
   readonly callbackComparison: "different" | "same";
 }
 
-interface CleanupAnalysis {
-  readonly removals: ListenerCandidate[];
-  readonly abortedControllerSymbolIds: ReadonlySet<number>;
-  readonly hasUnknownAbortCall: boolean;
-  readonly hasUnknownRemovalCall: boolean;
+interface ExhaustiveCleanupBranches {
+  readonly alternate: CancellationAnalysis;
+  readonly consequent: CancellationAnalysis;
 }
 
 interface EffectListenerInputs {
@@ -69,32 +82,17 @@ interface RegistrationCancellation {
   readonly hasUnknownCancellation: boolean;
 }
 
+interface CalledCleanup {
+  readonly body: EsTreeNode;
+  readonly symbolId: number;
+}
+
+interface StaticEventDispatch {
+  readonly eventName: string;
+  readonly targetKey: string;
+}
+
 const LISTENER_EFFECT_HOOK_NAMES = new Set([...EFFECT_HOOK_NAMES, "useInsertionEffect"]);
-
-const PATH_AMBIGUOUS_ANCESTOR_TYPES: ReadonlySet<string> = new Set([
-  "CatchClause",
-  "ConditionalExpression",
-  "DoWhileStatement",
-  "ForInStatement",
-  "ForOfStatement",
-  "ForStatement",
-  "IfStatement",
-  "LogicalExpression",
-  "SwitchCase",
-  "SwitchStatement",
-  "TryStatement",
-  "WhileStatement",
-]);
-
-const isPathAmbiguousCall = (node: EsTreeNode, bodyNode: EsTreeNode): boolean => {
-  if (PATH_AMBIGUOUS_ANCESTOR_TYPES.has(bodyNode.type)) return true;
-  let currentNode: EsTreeNode | null | undefined = node;
-  while (currentNode?.parent && currentNode.parent !== bodyNode) {
-    currentNode = currentNode.parent;
-    if (PATH_AMBIGUOUS_ANCESTOR_TYPES.has(currentNode.type)) return true;
-  }
-  return false;
-};
 
 const hasOnlyReadReferences = (symbol: SymbolDescriptor): boolean =>
   symbol.references.every((reference) => reference.flag === "read");
@@ -148,22 +146,25 @@ const resolveCallbackIdentity = (
   return { node: symbol.bindingIdentifier, isConcreteFunction: false };
 };
 
-const compareCallbackIdentities = (
-  registrationIdentity: CallbackIdentity,
-  removalIdentity: CallbackIdentity,
-): "same" | "different" | "unknown" => {
-  if (registrationIdentity.node === removalIdentity.node) return "same";
-  if (registrationIdentity.isConcreteFunction && removalIdentity.isConcreteFunction) {
-    return "different";
-  }
-  return "unknown";
-};
-
 const resolveTargetKey = (targetNode: EsTreeNode, context: RuleContext): string | null => {
   const unwrappedTarget = stripParenExpression(targetNode);
   if (isNodeOfType(unwrappedTarget, "Identifier")) {
     const symbol = resolveAliasedSymbol(unwrappedTarget, context, new Set());
-    if (symbol) return `symbol:${symbol.id}`;
+    if (symbol) {
+      if (symbol.kind === "import" || symbol.kind === "parameter" || symbol.kind === "function") {
+        return null;
+      }
+      const initializer = symbol.initializer ? stripParenExpression(symbol.initializer) : null;
+      if (
+        isNodeOfType(initializer, "NewExpression") &&
+        isNodeOfType(initializer.callee, "Identifier") &&
+        !context.scopes.isGlobalReference(initializer.callee)
+      ) {
+        return null;
+      }
+      if (isNodeOfType(initializer, "NewExpression")) return `fresh:${symbol.id}`;
+      return `symbol:${symbol.id}`;
+    }
     if (context.scopes.isGlobalReference(unwrappedTarget)) {
       return `global:${unwrappedTarget.name}`;
     }
@@ -175,6 +176,18 @@ const resolveTargetKey = (targetNode: EsTreeNode, context: RuleContext): string 
     isNodeOfType(unwrappedTarget.property, "Identifier")
   ) {
     const objectKey = resolveTargetKey(unwrappedTarget.object, context);
+    if (
+      unwrappedTarget.property.name === "document" &&
+      (objectKey === "global:window" || objectKey === "global:globalThis")
+    ) {
+      return "global:document";
+    }
+    if (
+      unwrappedTarget.property.name === "window" &&
+      (objectKey === "global:window" || objectKey === "global:globalThis")
+    ) {
+      return "global:window";
+    }
     return objectKey === null ? null : `${objectKey}.${unwrappedTarget.property.name}`;
   }
   return null;
@@ -207,27 +220,40 @@ const resolveStaticEventName = (
   return resolveStaticEventName(symbol.initializer, context, visitedSymbolIds);
 };
 
-const resolveCapture = (optionsNode: EsTreeNode | null | undefined): boolean | null => {
-  if (!optionsNode) return false;
-  const unwrappedOptions = stripParenExpression(optionsNode);
-  if (isNodeOfType(unwrappedOptions, "Literal")) {
-    return typeof unwrappedOptions.value === "boolean" ? unwrappedOptions.value : null;
+const readStaticEventDispatch = (
+  node: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): StaticEventDispatch | null => {
+  const targetNode = readDirectMemberReceiver(node.callee, "dispatchEvent", context);
+  const eventArgument = node.arguments?.[0];
+  if (!eventArgument) return null;
+  const eventNode = stripParenExpression(eventArgument);
+  if (
+    !targetNode ||
+    !isNodeOfType(eventNode, "NewExpression") ||
+    !isNodeOfType(eventNode.callee, "Identifier") ||
+    eventNode.callee.name !== "Event" ||
+    !context.scopes.isGlobalReference(eventNode.callee)
+  ) {
+    return null;
   }
-  if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) return null;
-
-  let capture = false;
-  for (const property of unwrappedOptions.properties) {
-    if (!isNodeOfType(property, "Property")) return null;
-    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
-    if (propertyName === null) return null;
-    if (propertyName !== "capture") continue;
-    const propertyValue = stripParenExpression(property.value);
-    if (!isNodeOfType(propertyValue, "Literal") || typeof propertyValue.value !== "boolean") {
-      return null;
-    }
-    capture = propertyValue.value;
+  const target = stripParenExpression(targetNode);
+  if (!isNodeOfType(target, "Identifier")) return null;
+  const targetSymbol = resolveAliasedSymbol(target, context, new Set());
+  const targetInitializer = targetSymbol?.initializer
+    ? stripParenExpression(targetSymbol.initializer)
+    : null;
+  if (
+    !isNodeOfType(targetInitializer, "NewExpression") ||
+    !isNodeOfType(targetInitializer.callee, "Identifier") ||
+    targetInitializer.callee.name !== "EventTarget" ||
+    !context.scopes.isGlobalReference(targetInitializer.callee)
+  ) {
+    return null;
   }
-  return capture;
+  const targetKey = resolveTargetKey(targetNode, context);
+  const eventName = resolveStaticEventName(eventNode.arguments?.[0], context);
+  return targetKey !== null && eventName !== null ? { eventName, targetKey } : null;
 };
 
 const resolveLocalAbortControllerSymbolId = (
@@ -255,15 +281,17 @@ const resolveLocalAbortControllerSymbolId = (
 const readDirectMemberReceiver = (
   memberNode: EsTreeNode | null | undefined,
   memberName: string,
+  context?: RuleContext,
 ): EsTreeNode | null => {
   if (!memberNode) return null;
   const unwrappedMember = stripParenExpression(memberNode);
-  if (
-    !isNodeOfType(unwrappedMember, "MemberExpression") ||
-    getStaticMemberPropertyName(unwrappedMember) !== memberName
-  ) {
-    return null;
-  }
+  if (!isNodeOfType(unwrappedMember, "MemberExpression")) return null;
+  const staticPropertyName =
+    getStaticMemberPropertyName(unwrappedMember) ??
+    (context && unwrappedMember.computed
+      ? resolveStaticEventName(unwrappedMember.property, context)
+      : null);
+  if (staticPropertyName !== memberName) return null;
   return unwrappedMember.object;
 };
 
@@ -325,6 +353,117 @@ const resolveSignalAbortControllerSymbolId = (
   return resolveLocalAbortControllerSymbolId(signalSymbol.initializer, context);
 };
 
+const readControllerAbortedCondition = (
+  conditionNode: EsTreeNode,
+  controllerSymbolId: number,
+  context: RuleContext,
+): "aborted" | "not-aborted" | null => {
+  const unwrappedCondition = stripParenExpression(conditionNode);
+  if (isNodeOfType(unwrappedCondition, "UnaryExpression") && unwrappedCondition.operator === "!") {
+    const operandCondition = readControllerAbortedCondition(
+      unwrappedCondition.argument,
+      controllerSymbolId,
+      context,
+    );
+    if (operandCondition === "aborted") return "not-aborted";
+    if (operandCondition === "not-aborted") return "aborted";
+    return null;
+  }
+  if (isNodeOfType(unwrappedCondition, "BinaryExpression")) {
+    const leftBoolean = readStaticBoolean(unwrappedCondition.left);
+    const rightBoolean = readStaticBoolean(unwrappedCondition.right);
+    const memberNode =
+      leftBoolean === null
+        ? unwrappedCondition.left
+        : rightBoolean === null
+          ? unwrappedCondition.right
+          : null;
+    const comparedBoolean = leftBoolean ?? rightBoolean;
+    if (memberNode && comparedBoolean !== null) {
+      const memberCondition = readControllerAbortedCondition(
+        memberNode,
+        controllerSymbolId,
+        context,
+      );
+      if (memberCondition) {
+        const isEquality =
+          unwrappedCondition.operator === "==" || unwrappedCondition.operator === "===";
+        const isInequality =
+          unwrappedCondition.operator === "!=" || unwrappedCondition.operator === "!==";
+        const shouldInvert = (isEquality && !comparedBoolean) || (isInequality && comparedBoolean);
+        if (isEquality || isInequality) {
+          if (!shouldInvert) return memberCondition;
+          return memberCondition === "aborted" ? "not-aborted" : "aborted";
+        }
+      }
+    }
+    return null;
+  }
+  const signalNode = readDirectMemberReceiver(unwrappedCondition, "aborted");
+  if (!signalNode) return null;
+  return resolveSignalAbortControllerSymbolId(signalNode, context) === controllerSymbolId
+    ? "aborted"
+    : null;
+};
+
+const isAbortGuardForChild = (
+  parentNode: EsTreeNode,
+  childNode: EsTreeNode,
+  controllerSymbolId: number,
+  context: RuleContext,
+): boolean => {
+  if (
+    isNodeOfType(parentNode, "IfStatement") ||
+    isNodeOfType(parentNode, "ConditionalExpression")
+  ) {
+    const condition = readControllerAbortedCondition(parentNode.test, controllerSymbolId, context);
+    return (
+      (parentNode.consequent === childNode && condition === "not-aborted") ||
+      (parentNode.alternate === childNode && condition === "aborted")
+    );
+  }
+  if (!isNodeOfType(parentNode, "LogicalExpression") || parentNode.right !== childNode) {
+    return false;
+  }
+  const condition = readControllerAbortedCondition(parentNode.left, controllerSymbolId, context);
+  return (
+    (parentNode.operator === "&&" && condition === "not-aborted") ||
+    (parentNode.operator === "||" && condition === "aborted")
+  );
+};
+
+const isAbortGuaranteedByPath = (
+  node: EsTreeNode,
+  bodyNode: EsTreeNode,
+  controllerSymbolId: number,
+  context: RuleContext,
+): boolean =>
+  !isListenerPathAmbiguous(node, bodyNode, (parentNode, childNode) =>
+    isAbortGuardForChild(parentNode, childNode, controllerSymbolId, context),
+  );
+
+const resolveBoundAbortControllerSymbolId = (
+  callNode: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): number | null => {
+  const callee = stripParenExpression(callNode.callee);
+  if (!isNodeOfType(callee, "Identifier")) return null;
+  const boundAbortSymbol = resolveAliasedSymbol(callee, context, new Set());
+  if (!boundAbortSymbol?.initializer) return null;
+  const initializer = stripParenExpression(boundAbortSymbol.initializer);
+  if (!isNodeOfType(initializer, "CallExpression")) return null;
+  const abortMethodNode = readDirectMemberReceiver(initializer.callee, "bind");
+  if (!abortMethodNode) return null;
+  const controllerNode = readDirectMemberReceiver(abortMethodNode, "abort");
+  const boundThisNode = initializer.arguments?.[0];
+  if (!controllerNode || !boundThisNode) return null;
+  const controllerSymbolId = resolveLocalAbortControllerSymbolId(controllerNode, context);
+  const boundThisSymbolId = resolveLocalAbortControllerSymbolId(boundThisNode, context);
+  return controllerSymbolId !== null && controllerSymbolId === boundThisSymbolId
+    ? controllerSymbolId
+    : null;
+};
+
 const resolveRegistrationCancellation = (
   optionsNode: EsTreeNode | null | undefined,
   context: RuleContext,
@@ -357,14 +496,60 @@ const readListenerCandidate = (
   methodName: "addEventListener" | "removeEventListener",
   context: RuleContext,
 ): ListenerCandidate | null => {
-  const targetNode = readDirectMemberReceiver(node.callee, methodName);
+  const targetNode = readDirectMemberReceiver(node.callee, methodName, context);
   if (!targetNode) return null;
   const targetKey = resolveTargetKey(targetNode, context);
   const eventName = resolveStaticEventName(node.arguments?.[0], context);
   const callbackIdentity = resolveCallbackIdentity(node.arguments?.[1], context);
-  const capture = resolveCapture(node.arguments?.[2]);
+  const capture = resolveEventListenerCapture(node.arguments?.[2]);
   if (targetKey === null || eventName === null) return null;
   return { node, targetKey, eventName, callbackIdentity, capture };
+};
+
+const readDestructuredRemovalCandidate = (
+  node: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): ListenerCandidate | null => {
+  const methodNode = readDirectMemberReceiver(node.callee, "call");
+  if (!methodNode || !isNodeOfType(methodNode, "Identifier")) return null;
+  const methodSymbol = context.scopes.symbolFor(methodNode);
+  if (
+    !methodSymbol ||
+    methodSymbol.kind !== "const" ||
+    !hasOnlyReadReferences(methodSymbol) ||
+    !isNodeOfType(methodSymbol.declarationNode, "VariableDeclarator")
+  ) {
+    return null;
+  }
+  const declaration = methodSymbol.declarationNode;
+  if (!isNodeOfType(declaration.id, "ObjectPattern") || !declaration.init) return null;
+  const isRemovalBinding = declaration.id.properties.some((property) => {
+    if (!isNodeOfType(property, "Property")) return false;
+    const bindingNode = isNodeOfType(property.value, "AssignmentPattern")
+      ? property.value.left
+      : property.value;
+    return (
+      getStaticPropertyKeyName(property, { allowComputedString: true }) === "removeEventListener" &&
+      bindingNode === methodSymbol.bindingIdentifier
+    );
+  });
+  if (!isRemovalBinding) return null;
+  const targetNode = node.arguments?.[0];
+  if (!targetNode) return null;
+  const declarationTargetKey = resolveTargetKey(declaration.init, context);
+  const targetKey = resolveTargetKey(targetNode, context);
+  if (declarationTargetKey === null || targetKey === null || declarationTargetKey !== targetKey) {
+    return null;
+  }
+  const eventName = resolveStaticEventName(node.arguments?.[1], context);
+  if (eventName === null) return null;
+  return {
+    node,
+    targetKey,
+    eventName,
+    callbackIdentity: resolveCallbackIdentity(node.arguments?.[2], context),
+    capture: resolveEventListenerCapture(node.arguments?.[3]),
+  };
 };
 
 const resolveReturnedCleanupBody = (
@@ -387,6 +572,7 @@ const collectEffectListenerInputs = (
 ): EffectListenerInputs => {
   const registrations: ListenerRegistration[] = [];
   const cleanupBodies: EsTreeNode[] = [];
+  const listenerRegistrationCountsByTarget = new Map<string, number>();
   let returnStatementCount = 0;
   if (!isNodeOfType(effectBody, "BlockStatement")) {
     return {
@@ -404,7 +590,22 @@ const collectEffectListenerInputs = (
       return false;
     }
     if (isNodeOfType(child, "CallExpression")) {
-      if (isPathAmbiguousCall(child, effectBody)) return;
+      const hasAmbiguousPath = isListenerPathAmbiguous(child, effectBody);
+      if (hasAmbiguousPath) return;
+      const registrationTarget = readDirectMemberReceiver(
+        child.callee,
+        "addEventListener",
+        context,
+      );
+      const registrationTargetKey = registrationTarget
+        ? resolveTargetKey(registrationTarget, context)
+        : null;
+      if (registrationTargetKey !== null) {
+        listenerRegistrationCountsByTarget.set(
+          registrationTargetKey,
+          (listenerRegistrationCountsByTarget.get(registrationTargetKey) ?? 0) + 1,
+        );
+      }
       const candidate = readListenerCandidate(child, "addEventListener", context);
       if (candidate?.callbackIdentity && candidate.capture !== null) {
         const registrationCancellation = resolveRegistrationCancellation(
@@ -417,9 +618,28 @@ const collectEffectListenerInputs = (
           eventName: candidate.eventName,
           callbackIdentity: candidate.callbackIdentity,
           capture: candidate.capture,
+          once: resolveStaticOnceOption(candidate.node.arguments?.[2]) === true,
           abortControllerSymbolId: registrationCancellation.abortControllerSymbolId,
           hasUnknownCancellation: registrationCancellation.hasUnknownCancellation,
         });
+      }
+      const eventDispatch = readStaticEventDispatch(child, context);
+      if (eventDispatch) {
+        const dispatchedRegistrations = registrations.filter(
+          (registration) =>
+            registration.targetKey === eventDispatch.targetKey &&
+            registration.eventName === eventDispatch.eventName,
+        );
+        const dispatchedRegistration = dispatchedRegistrations[0];
+        if (
+          dispatchedRegistrations.length === 1 &&
+          dispatchedRegistration?.once &&
+          listenerRegistrationCountsByTarget.get(eventDispatch.targetKey) === 1 &&
+          dispatchedRegistration.callbackIdentity.isConcreteFunction &&
+          !callbackMayRegisterEventListener(dispatchedRegistration.callbackIdentity.node)
+        ) {
+          registrations.splice(registrations.indexOf(dispatchedRegistration), 1);
+        }
       }
       return;
     }
@@ -437,18 +657,90 @@ const collectEffectListenerInputs = (
   };
 };
 
+const resolveCalledCleanup = (
+  callNode: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): CalledCleanup | null => {
+  const callee = stripParenExpression(callNode.callee);
+  if (!isNodeOfType(callee, "Identifier")) return null;
+  const cleanupSymbol = resolveAliasedSymbol(callee, context, new Set());
+  if (
+    !cleanupSymbol?.initializer ||
+    (cleanupSymbol.kind !== "const" && cleanupSymbol.kind !== "function")
+  ) {
+    return null;
+  }
+  const initializer = stripParenExpression(cleanupSymbol.initializer);
+  if (!isFunctionLike(initializer) || initializer.async || initializer.generator) return null;
+  return { body: initializer.body, symbolId: cleanupSymbol.id };
+};
+
 const analyzeCleanupBody = (
   cleanupBody: EsTreeNode,
   context: RuleContext,
-): CleanupAnalysis | null => {
+  visitedCleanupSymbolIds: Set<number> = new Set(),
+  isLoopBody = false,
+): CancellationAnalysis | null => {
   const removals: ListenerCandidate[] = [];
   const abortedControllerSymbolIds = new Set<number>();
+  const exhaustiveBranches: ExhaustiveCleanupBranches[] = [];
   let hasAmbiguousReachability = false;
   let hasUnknownAbortCall = false;
   let hasUnknownRemovalCall = false;
   const finalCleanupStatement = isNodeOfType(cleanupBody, "BlockStatement")
     ? cleanupBody.body[cleanupBody.body.length - 1]
     : null;
+  const addCleanupAnalysis = (analysis: CancellationAnalysis): void => {
+    removals.push(...analysis.removals);
+    hasUnknownAbortCall ||= analysis.hasUnknownAbortCall;
+    hasUnknownRemovalCall ||= analysis.hasUnknownRemovalCall;
+    for (const controllerSymbolId of analysis.abortedControllerSymbolIds) {
+      abortedControllerSymbolIds.add(controllerSymbolId);
+    }
+    exhaustiveBranches.push(...analysis.exhaustiveBranches);
+  };
+  const addGuaranteedLoopPrefix = (loopBody: EsTreeNode): boolean => {
+    const loopStatements = isNodeOfType(loopBody, "BlockStatement") ? loopBody.body : [loopBody];
+    for (const loopStatement of loopStatements) {
+      if (
+        isNodeOfType(loopStatement, "BreakStatement") ||
+        isNodeOfType(loopStatement, "ContinueStatement")
+      ) {
+        return true;
+      }
+      if (isNodeOfType(loopStatement, "BlockStatement")) {
+        if (addGuaranteedLoopPrefix(loopStatement)) return true;
+        continue;
+      }
+      if (isNodeOfType(loopStatement, "IfStatement")) {
+        const staticTestValue = readStaticBoolean(loopStatement.test);
+        if (staticTestValue !== null) {
+          const testAnalysis = analyzeCleanupBody(
+            loopStatement.test,
+            context,
+            new Set(visitedCleanupSymbolIds),
+            true,
+          );
+          if (!testAnalysis) return true;
+          addCleanupAnalysis(testAnalysis);
+          const guaranteedBranch = staticTestValue
+            ? loopStatement.consequent
+            : loopStatement.alternate;
+          if (guaranteedBranch && addGuaranteedLoopPrefix(guaranteedBranch)) return true;
+          continue;
+        }
+      }
+      const loopStatementAnalysis = analyzeCleanupBody(
+        loopStatement,
+        context,
+        new Set(visitedCleanupSymbolIds),
+        true,
+      );
+      if (!loopStatementAnalysis) return true;
+      addCleanupAnalysis(loopStatementAnalysis);
+    }
+    return false;
+  };
   walkAst(cleanupBody, (child: EsTreeNode) => {
     if (child !== cleanupBody && isFunctionLike(child)) return false;
     if (isNodeOfType(child, "ClassDeclaration") || isNodeOfType(child, "ClassExpression")) {
@@ -457,34 +749,110 @@ const analyzeCleanupBody = (
     if (isNodeOfType(child, "ReturnStatement") && child === finalCleanupStatement) {
       return;
     }
-    if (isNodeOfType(child, "ReturnStatement") || isNodeOfType(child, "ThrowStatement")) {
+    if (
+      isNodeOfType(child, "ReturnStatement") ||
+      isNodeOfType(child, "ThrowStatement") ||
+      (isLoopBody &&
+        (isNodeOfType(child, "BreakStatement") || isNodeOfType(child, "ContinueStatement")))
+    ) {
       hasAmbiguousReachability = true;
       return false;
     }
+    if (isNodeOfType(child, "ForOfStatement")) {
+      const iterable = stripParenExpression(child.right);
+      const isGuaranteedNonEmpty =
+        isNodeOfType(iterable, "ArrayExpression") &&
+        iterable.elements.some((element) => element && !isNodeOfType(element, "SpreadElement"));
+      if (isGuaranteedNonEmpty && !isListenerPathAmbiguous(child, cleanupBody)) {
+        addGuaranteedLoopPrefix(child.body);
+      }
+      return false;
+    }
+    if (
+      (isNodeOfType(child, "IfStatement") || isNodeOfType(child, "ConditionalExpression")) &&
+      child.alternate &&
+      readStaticBoolean(child.test) === null &&
+      !isListenerPathAmbiguous(child, cleanupBody)
+    ) {
+      const consequentAnalysis = analyzeCleanupBody(
+        child.consequent,
+        context,
+        new Set(visitedCleanupSymbolIds),
+      );
+      const alternateAnalysis = analyzeCleanupBody(
+        child.alternate,
+        context,
+        new Set(visitedCleanupSymbolIds),
+      );
+      if (consequentAnalysis && alternateAnalysis) {
+        exhaustiveBranches.push({
+          alternate: alternateAnalysis,
+          consequent: consequentAnalysis,
+        });
+        hasUnknownAbortCall ||=
+          consequentAnalysis.hasUnknownAbortCall && alternateAnalysis.hasUnknownAbortCall;
+        hasUnknownRemovalCall ||=
+          consequentAnalysis.hasUnknownRemovalCall && alternateAnalysis.hasUnknownRemovalCall;
+      }
+      const testAnalysis = analyzeCleanupBody(
+        child.test,
+        context,
+        new Set(visitedCleanupSymbolIds),
+      );
+      if (testAnalysis) addCleanupAnalysis(testAnalysis);
+      return false;
+    }
     if (!isNodeOfType(child, "CallExpression")) return;
-    if (isPathAmbiguousCall(child, cleanupBody)) return;
-    const removalTarget = readDirectMemberReceiver(child.callee, "removeEventListener");
-    if (removalTarget) {
+    const hasAmbiguousPath = isListenerPathAmbiguous(child, cleanupBody);
+    const removalTarget = readDirectMemberReceiver(child.callee, "removeEventListener", context);
+    if (removalTarget && !hasAmbiguousPath) {
       const removal = readListenerCandidate(child, "removeEventListener", context);
       if (removal) {
         removals.push(removal);
+        hasUnknownRemovalCall ||= removal.callbackIdentity === null || removal.capture === null;
       } else {
         hasUnknownRemovalCall = true;
       }
     }
-    const controllerNode = readDirectMemberReceiver(child.callee, "abort");
-    if (!controllerNode) return;
-    const controllerSymbolId = resolveLocalAbortControllerSymbolId(controllerNode, context);
-    if (controllerSymbolId === null) {
-      hasUnknownAbortCall = true;
-    } else {
-      abortedControllerSymbolIds.add(controllerSymbolId);
+    if (!removalTarget && !hasAmbiguousPath) {
+      const destructuredRemoval = readDestructuredRemovalCandidate(child, context);
+      if (destructuredRemoval) removals.push(destructuredRemoval);
     }
+    const controllerNode = readDirectMemberReceiver(child.callee, "abort");
+    if (controllerNode) {
+      const controllerSymbolId = resolveLocalAbortControllerSymbolId(controllerNode, context);
+      if (controllerSymbolId === null) {
+        if (!hasAmbiguousPath) hasUnknownAbortCall = true;
+      } else if (
+        !hasAmbiguousPath ||
+        isAbortGuaranteedByPath(child, cleanupBody, controllerSymbolId, context)
+      ) {
+        abortedControllerSymbolIds.add(controllerSymbolId);
+      }
+      return;
+    }
+    if (hasAmbiguousPath) return;
+    const boundAbortControllerSymbolId = resolveBoundAbortControllerSymbolId(child, context);
+    if (boundAbortControllerSymbolId !== null) {
+      abortedControllerSymbolIds.add(boundAbortControllerSymbolId);
+      return;
+    }
+    const calledCleanup = resolveCalledCleanup(child, context);
+    if (!calledCleanup || visitedCleanupSymbolIds.has(calledCleanup.symbolId)) return;
+    visitedCleanupSymbolIds.add(calledCleanup.symbolId);
+    const calledCleanupAnalysis = analyzeCleanupBody(
+      calledCleanup.body,
+      context,
+      visitedCleanupSymbolIds,
+    );
+    if (!calledCleanupAnalysis) return;
+    addCleanupAnalysis(calledCleanupAnalysis);
   });
   if (hasAmbiguousReachability) return null;
   return {
     removals,
     abortedControllerSymbolIds,
+    exhaustiveBranches,
     hasUnknownAbortCall,
     hasUnknownRemovalCall,
   };
@@ -504,41 +872,33 @@ const analyzeEffectListeners = (
   }
   const removals: ListenerCandidate[] = [];
   const abortedControllerSymbolIds = new Set<number>();
+  const exhaustiveBranches: ExhaustiveCleanupBranches[] = [];
   let hasUnknownAbortCall = false;
   let hasUnknownRemovalCall = false;
+  const addAnalysis = (analysis: CancellationAnalysis): void => {
+    removals.push(...analysis.removals);
+    exhaustiveBranches.push(...analysis.exhaustiveBranches);
+    hasUnknownAbortCall ||= analysis.hasUnknownAbortCall;
+    hasUnknownRemovalCall ||= analysis.hasUnknownRemovalCall;
+    for (const controllerSymbolId of analysis.abortedControllerSymbolIds) {
+      abortedControllerSymbolIds.add(controllerSymbolId);
+    }
+  };
+  const setupAbortAnalysis = analyzeCleanupBody(effectBody, context);
   for (const cleanupBody of effectInputs.cleanupBodies) {
     const cleanupAnalysis = analyzeCleanupBody(cleanupBody, context);
     if (!cleanupAnalysis) return null;
-    removals.push(...cleanupAnalysis.removals);
-    hasUnknownAbortCall ||= cleanupAnalysis.hasUnknownAbortCall;
-    hasUnknownRemovalCall ||= cleanupAnalysis.hasUnknownRemovalCall;
-    for (const controllerSymbolId of cleanupAnalysis.abortedControllerSymbolIds) {
-      abortedControllerSymbolIds.add(controllerSymbolId);
-    }
+    addAnalysis(cleanupAnalysis);
   }
   return {
     registrations: effectInputs.registrations,
     removals,
     abortedControllerSymbolIds,
+    exhaustiveBranches,
     hasUnknownAbortCall,
     hasUnknownRemovalCall,
+    setupAbortAnalysis,
   };
-};
-
-const buildMismatchMessage = (
-  registration: ListenerRegistration,
-  removalCapture: boolean,
-  callbackComparison: "different" | "same",
-): string => {
-  const hasCallbackMismatch = callbackComparison === "different";
-  const hasCaptureMismatch = registration.capture !== removalCapture;
-  if (hasCallbackMismatch && hasCaptureMismatch) {
-    return `The cleanup removes \`${registration.eventName}\` with a different callback binding and capture ${String(removalCapture)}, but it was registered with capture ${String(registration.capture)}. Pass the same callback binding and capture flag to both EventTarget calls.`;
-  }
-  if (hasCallbackMismatch) {
-    return `The cleanup removes \`${registration.eventName}\` with a different callback binding than the one registered, so \`removeEventListener\` cannot detach that listener. Pass the same callback binding to both calls.`;
-  }
-  return `The cleanup removes \`${registration.eventName}\` with capture ${String(removalCapture)}, but it was registered with capture ${String(registration.capture)}. \`removeEventListener\` must use the same capture flag as \`addEventListener\`.`;
 };
 
 export const effectListenerCleanupMismatch = defineRule({
@@ -565,13 +925,20 @@ export const effectListenerCleanupMismatch = defineRule({
             candidateRegistration.eventName === registration.eventName,
         );
         if (sameEventRegistrations.length > 1) continue;
+        if (registration.abortControllerSymbolId !== null && listenerAnalysis.hasUnknownAbortCall) {
+          continue;
+        }
         if (
           registration.abortControllerSymbolId !== null &&
-          (listenerAnalysis.hasUnknownAbortCall ||
-            listenerAnalysis.abortedControllerSymbolIds.has(registration.abortControllerSymbolId))
+          listenerAnalysis.setupAbortAnalysis &&
+          doesListenerAnalysisAbortController(
+            listenerAnalysis.setupAbortAnalysis,
+            registration.abortControllerSymbolId,
+          )
         ) {
           continue;
         }
+        if (doesListenerAnalysisCancelRegistration(listenerAnalysis, registration)) continue;
         const candidateRemovals = listenerAnalysis.removals.filter(
           (removal) =>
             removal.targetKey === registration.targetKey &&
@@ -584,7 +951,7 @@ export const effectListenerCleanupMismatch = defineRule({
             didFindNonMismatchCandidate = true;
             break;
           }
-          const callbackComparison = compareCallbackIdentities(
+          const callbackComparison = compareListenerCallbackIdentities(
             registration.callbackIdentity,
             removal.callbackIdentity,
           );
@@ -611,8 +978,9 @@ export const effectListenerCleanupMismatch = defineRule({
         }
         context.report({
           node: firstProvableMismatch.removalNode,
-          message: buildMismatchMessage(
-            registration,
+          message: buildListenerCleanupMismatchMessage(
+            registration.eventName,
+            registration.capture,
             firstProvableMismatch.removalCapture,
             firstProvableMismatch.callbackComparison,
           ),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/build-listener-cleanup-mismatch-message.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/build-listener-cleanup-mismatch-message.ts
@@ -1,0 +1,16 @@
+export const buildListenerCleanupMismatchMessage = (
+  eventName: string,
+  registrationCapture: boolean,
+  removalCapture: boolean,
+  callbackComparison: "different" | "same",
+): string => {
+  const hasCallbackMismatch = callbackComparison === "different";
+  const hasCaptureMismatch = registrationCapture !== removalCapture;
+  if (hasCallbackMismatch && hasCaptureMismatch) {
+    return `The cleanup removes \`${eventName}\` with a different callback binding and capture ${String(removalCapture)}, but it was registered with capture ${String(registrationCapture)}. Pass the same callback binding and capture flag to both EventTarget calls.`;
+  }
+  if (hasCallbackMismatch) {
+    return `The cleanup removes \`${eventName}\` with a different callback binding than the one registered, so \`removeEventListener\` cannot detach that listener. Pass the same callback binding to both calls.`;
+  }
+  return `The cleanup removes \`${eventName}\` with capture ${String(removalCapture)}, but it was registered with capture ${String(registrationCapture)}. \`removeEventListener\` must use the same capture flag as \`addEventListener\`.`;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/callback-may-register-event-listener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/callback-may-register-event-listener.ts
@@ -1,0 +1,14 @@
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { walkAst } from "../../../utils/walk-ast.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+
+export const callbackMayRegisterEventListener = (callbackNode: EsTreeNode): boolean => {
+  let foundCall = false;
+  walkAst(callbackNode, (child) => {
+    if (isNodeOfType(child, "CallExpression")) {
+      foundCall = true;
+      return false;
+    }
+  });
+  return foundCall;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-function-like-local-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-function-like-local-names.ts
@@ -1,10 +1,8 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { getStaticPropertyKeyName } from "../../../utils/get-static-property-key-name.js";
 import { isInlineFunctionExpression } from "../../../utils/is-inline-function-expression.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
-import {
-  getStaticMemberReferenceName,
-  getStaticPropertyKeyName,
-} from "./event-handler-reference.js";
+import { getStaticMemberReferenceName } from "./event-handler-reference.js";
 import {
   addPatternBindings,
   createBlockBindingScope,
@@ -47,7 +45,9 @@ const addObjectPropertyFunctionNames = (
   if (!isNodeOfType(node, "ObjectExpression")) return;
   for (const property of node.properties ?? []) {
     if (!isNodeOfType(property, "Property")) continue;
-    const propertyName = getStaticPropertyKeyName(property);
+    const propertyName = getStaticPropertyKeyName(property, {
+      stringifyNonStringLiterals: true,
+    });
     if (!propertyName) continue;
     if (!isFunctionLikeReference(property.value, functionLikeLocalNames, scope)) continue;
     functionLikeLocalNames.add(`${objectBindingName}.${propertyName}`);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/compare-listener-callback-identities.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/compare-listener-callback-identities.ts
@@ -1,0 +1,17 @@
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+
+interface ComparableCallbackIdentity {
+  readonly node: EsTreeNode;
+  readonly isConcreteFunction: boolean;
+}
+
+export const compareListenerCallbackIdentities = (
+  registrationIdentity: ComparableCallbackIdentity,
+  removalIdentity: ComparableCallbackIdentity,
+): "same" | "different" | "unknown" => {
+  if (registrationIdentity.node === removalIdentity.node) return "same";
+  if (registrationIdentity.isConcreteFunction && removalIdentity.isConcreteFunction) {
+    return "different";
+  }
+  return "unknown";
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/compare-listener-target-keys.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/compare-listener-target-keys.ts
@@ -1,0 +1,13 @@
+export const compareListenerTargetKeys = (
+  firstTargetKey: string,
+  secondTargetKey: string,
+): "same" | "different" | "unknown" => {
+  if (firstTargetKey === secondTargetKey) return "same";
+  if (firstTargetKey.startsWith("global:") && secondTargetKey.startsWith("global:")) {
+    return "different";
+  }
+  if (firstTargetKey.startsWith("fresh:") || secondTargetKey.startsWith("fresh:")) {
+    return "different";
+  }
+  return "unknown";
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/does-listener-analysis-abort-controller.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/does-listener-analysis-abort-controller.ts
@@ -1,0 +1,20 @@
+interface ListenerCancellationAnalysis {
+  readonly abortedControllerSymbolIds: ReadonlySet<number>;
+  readonly exhaustiveBranches: ReadonlyArray<ListenerCancellationBranches>;
+}
+
+interface ListenerCancellationBranches {
+  readonly alternate: ListenerCancellationAnalysis;
+  readonly consequent: ListenerCancellationAnalysis;
+}
+
+export const doesListenerAnalysisAbortController = (
+  analysis: ListenerCancellationAnalysis,
+  controllerSymbolId: number,
+): boolean =>
+  analysis.abortedControllerSymbolIds.has(controllerSymbolId) ||
+  analysis.exhaustiveBranches.some(
+    ({ alternate, consequent }) =>
+      doesListenerAnalysisAbortController(alternate, controllerSymbolId) &&
+      doesListenerAnalysisAbortController(consequent, controllerSymbolId),
+  );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/does-listener-analysis-cancel-registration.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/does-listener-analysis-cancel-registration.ts
@@ -1,0 +1,84 @@
+import { compareListenerCallbackIdentities } from "./compare-listener-callback-identities.js";
+import { compareListenerTargetKeys } from "./compare-listener-target-keys.js";
+import { doesListenerAnalysisAbortController } from "./does-listener-analysis-abort-controller.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+
+interface CallbackIdentity {
+  readonly node: EsTreeNode;
+  readonly isConcreteFunction: boolean;
+}
+
+interface ListenerCandidate {
+  readonly targetKey: string;
+  readonly eventName: string;
+  readonly callbackIdentity: CallbackIdentity | null;
+  readonly capture: boolean | null;
+}
+
+interface CancellationAnalysis {
+  readonly removals: ReadonlyArray<ListenerCandidate>;
+  readonly abortedControllerSymbolIds: ReadonlySet<number>;
+  readonly exhaustiveBranches: ReadonlyArray<ExhaustiveCleanupBranches>;
+  readonly hasUnknownAbortCall: boolean;
+  readonly hasUnknownRemovalCall: boolean;
+}
+
+interface ExhaustiveCleanupBranches {
+  readonly alternate: CancellationAnalysis;
+  readonly consequent: CancellationAnalysis;
+}
+
+interface ListenerRegistration {
+  readonly targetKey: string;
+  readonly eventName: string;
+  readonly callbackIdentity: CallbackIdentity;
+  readonly capture: boolean;
+  readonly abortControllerSymbolId: number | null;
+}
+
+const cancellationResult = (
+  analysis: CancellationAnalysis,
+  registration: ListenerRegistration,
+): "cancelled" | "not-cancelled" | "unknown" => {
+  if (
+    registration.abortControllerSymbolId !== null &&
+    doesListenerAnalysisAbortController(analysis, registration.abortControllerSymbolId)
+  ) {
+    return "cancelled";
+  }
+  let result: "not-cancelled" | "unknown" =
+    analysis.hasUnknownRemovalCall ||
+    (registration.abortControllerSymbolId !== null && analysis.hasUnknownAbortCall)
+      ? "unknown"
+      : "not-cancelled";
+  for (const removal of analysis.removals) {
+    if (
+      removal.eventName !== registration.eventName ||
+      removal.capture !== registration.capture ||
+      removal.callbackIdentity === null ||
+      compareListenerCallbackIdentities(registration.callbackIdentity, removal.callbackIdentity) !==
+        "same"
+    ) {
+      continue;
+    }
+    const targetComparison = compareListenerTargetKeys(registration.targetKey, removal.targetKey);
+    if (targetComparison === "same") return "cancelled";
+    if (targetComparison === "unknown") result = "unknown";
+  }
+  for (const { alternate, consequent } of analysis.exhaustiveBranches) {
+    const alternateResult = cancellationResult(alternate, registration);
+    const consequentResult = cancellationResult(consequent, registration);
+    if (alternateResult === "cancelled" && consequentResult === "cancelled") {
+      return "cancelled";
+    }
+    if (alternateResult !== "not-cancelled" && consequentResult !== "not-cancelled") {
+      result = "unknown";
+    }
+  }
+  return result;
+};
+
+export const doesListenerAnalysisCancelRegistration = (
+  analysis: CancellationAnalysis,
+  registration: ListenerRegistration,
+): boolean => cancellationResult(analysis, registration) !== "not-cancelled";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/event-handler-reference.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/event-handler-reference.ts
@@ -15,14 +15,6 @@ export const getStaticMemberReferenceName = (
   return propertyName ? `${resolveName(node.object.name)}.${propertyName}` : null;
 };
 
-export const getStaticPropertyKeyName = (node: EsTreeNode): string | null => {
-  if (!isNodeOfType(node, "Property")) return null;
-  if (node.computed) return null;
-  if (isNodeOfType(node.key, "Identifier")) return node.key.name;
-  if (isNodeOfType(node.key, "Literal")) return String(node.key.value);
-  return null;
-};
-
 export const isEventHandlerValue = (
   node: EsTreeNode,
   eventHandlerReferenceNames: Set<string>,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-listener-path-ambiguous.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-listener-path-ambiguous.ts
@@ -1,0 +1,83 @@
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { readStaticBoolean } from "../../../utils/read-static-boolean.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+
+const PATH_AMBIGUOUS_ANCESTOR_TYPES: ReadonlySet<string> = new Set([
+  "CatchClause",
+  "ConditionalExpression",
+  "DoWhileStatement",
+  "ForInStatement",
+  "ForOfStatement",
+  "ForStatement",
+  "IfStatement",
+  "LogicalExpression",
+  "SwitchCase",
+  "SwitchStatement",
+  "TryStatement",
+  "WhileStatement",
+]);
+
+const isGuaranteedChild = (parentNode: EsTreeNode, childNode: EsTreeNode): boolean => {
+  if (isNodeOfType(parentNode, "IfStatement")) {
+    if (parentNode.test === childNode) return true;
+    const staticTestValue = readStaticBoolean(parentNode.test);
+    return (
+      (parentNode.consequent === childNode && staticTestValue === true) ||
+      (parentNode.alternate === childNode && staticTestValue === false)
+    );
+  }
+  if (isNodeOfType(parentNode, "ConditionalExpression")) {
+    if (parentNode.test === childNode) return true;
+    const staticTestValue = readStaticBoolean(parentNode.test);
+    return (
+      (parentNode.consequent === childNode && staticTestValue === true) ||
+      (parentNode.alternate === childNode && staticTestValue === false)
+    );
+  }
+  if (isNodeOfType(parentNode, "LogicalExpression")) {
+    if (parentNode.left === childNode) return true;
+    if (parentNode.right !== childNode) return false;
+    const staticLeftValue = readStaticBoolean(parentNode.left);
+    return (
+      (parentNode.operator === "&&" && staticLeftValue === true) ||
+      (parentNode.operator === "||" && staticLeftValue === false)
+    );
+  }
+  if (isNodeOfType(parentNode, "TryStatement")) {
+    return parentNode.finalizer === childNode;
+  }
+  if (isNodeOfType(parentNode, "SwitchStatement")) {
+    return parentNode.discriminant === childNode;
+  }
+  if (isNodeOfType(parentNode, "ForStatement")) {
+    return parentNode.init === childNode || parentNode.test === childNode;
+  }
+  if (isNodeOfType(parentNode, "ForInStatement") || isNodeOfType(parentNode, "ForOfStatement")) {
+    return parentNode.right === childNode;
+  }
+  if (isNodeOfType(parentNode, "WhileStatement")) {
+    return parentNode.test === childNode;
+  }
+  return false;
+};
+
+export const isListenerPathAmbiguous = (
+  node: EsTreeNode,
+  bodyNode: EsTreeNode,
+  allowAmbiguousChild?: (parentNode: EsTreeNode, childNode: EsTreeNode) => boolean,
+): boolean => {
+  let currentNode: EsTreeNode | null | undefined = node;
+  while (currentNode && currentNode !== bodyNode) {
+    const parentNode: EsTreeNode | null | undefined = currentNode.parent;
+    if (!parentNode) return true;
+    if (
+      PATH_AMBIGUOUS_ANCESTOR_TYPES.has(parentNode.type) &&
+      !isGuaranteedChild(parentNode, currentNode) &&
+      !allowAmbiguousChild?.(parentNode, currentNode)
+    ) {
+      return true;
+    }
+    currentNode = parentNode;
+  }
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/resolve-event-listener-capture.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/resolve-event-listener-capture.ts
@@ -1,0 +1,30 @@
+import { getStaticPropertyKeyName } from "../../../utils/get-static-property-key-name.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+
+export const resolveEventListenerCapture = (
+  optionsNode: EsTreeNode | null | undefined,
+): boolean | null => {
+  if (!optionsNode) return false;
+  const unwrappedOptions = stripParenExpression(optionsNode);
+  if (isNodeOfType(unwrappedOptions, "Literal")) {
+    return typeof unwrappedOptions.value === "boolean" ? unwrappedOptions.value : null;
+  }
+  if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) return null;
+
+  let capture = false;
+  for (const property of unwrappedOptions.properties) {
+    if (!isNodeOfType(property, "Property")) return null;
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (propertyName === null) return null;
+    if (!property.computed && propertyName === "__proto__") return null;
+    if (propertyName !== "capture") continue;
+    const propertyValue = stripParenExpression(property.value);
+    if (!isNodeOfType(propertyValue, "Literal") || typeof propertyValue.value !== "boolean") {
+      return null;
+    }
+    capture = propertyValue.value;
+  }
+  return capture;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/resolve-static-once-option.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/resolve-static-once-option.ts
@@ -1,0 +1,31 @@
+import { getStaticPropertyKeyName } from "../../../utils/get-static-property-key-name.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+
+export const resolveStaticOnceOption = (
+  optionsNode: EsTreeNode | null | undefined,
+): boolean | null => {
+  if (!optionsNode) return false;
+  const unwrappedOptions = stripParenExpression(optionsNode);
+  if (isNodeOfType(unwrappedOptions, "Literal")) {
+    return typeof unwrappedOptions.value === "boolean" ? false : null;
+  }
+  if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) return null;
+
+  let once = false;
+  for (const property of unwrappedOptions.properties) {
+    if (!isNodeOfType(property, "Property")) return null;
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (propertyName === null || (!property.computed && propertyName === "__proto__")) {
+      return null;
+    }
+    if (propertyName !== "once") continue;
+    const propertyValue = stripParenExpression(property.value);
+    if (!isNodeOfType(propertyValue, "Literal") || typeof propertyValue.value !== "boolean") {
+      return null;
+    }
+    once = propertyValue.value;
+  }
+  return once;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/scope-aware-reference-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/scope-aware-reference-names.ts
@@ -1,9 +1,9 @@
 import { collectPatternNames } from "../../../utils/collect-pattern-names.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { getStaticPropertyKeyName } from "../../../utils/get-static-property-key-name.js";
 import { isAstNode } from "../../../utils/is-ast-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import {
-  getStaticPropertyKeyName,
   isEventHandlerName,
   isEventHandlerValue,
   isIntrinsicJsxAttribute,
@@ -234,7 +234,9 @@ const collectPropertyReferenceNames = (
   eventHandlerReferenceNames: Set<string>,
 ): Set<string> => {
   if (!isNodeOfType(node, "Property")) return new Set();
-  const propertyName = getStaticPropertyKeyName(node);
+  const propertyName = getStaticPropertyKeyName(node, {
+    stringifyNonStringLiterals: true,
+  });
   if (
     propertyName &&
     isEventHandlerName(propertyName) &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.test.ts
@@ -14,6 +14,12 @@ interface FunctionFixture {
   program: EsTreeNode;
 }
 
+interface CreateElementRenderTestCase {
+  code: string;
+  expected: boolean;
+  name: string;
+}
+
 const parseFunctionFixture = (code: string, functionName: string): FunctionFixture => {
   const { program, errors } = parseFixture(code);
   expect(errors).toEqual([]);
@@ -46,6 +52,45 @@ describe("functionContainsReactRenderOutput", () => {
     expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(false);
     expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(false);
   });
+
+  const createElementCases: CreateElementRenderTestCase[] = [
+    {
+      name: "renamed named React imports",
+      code: `import { createElement as create } from "react";
+        function Card() { return create("div"); }`,
+      expected: true,
+    },
+    {
+      name: "namespace React imports",
+      code: `import * as ReactClient from "react";
+        function Card() { return ReactClient.createElement("div"); }`,
+      expected: true,
+    },
+    {
+      name: "same-named imports from another module",
+      code: `import { createElement } from "other";
+        function Card() { return createElement("div"); }`,
+      expected: false,
+    },
+    {
+      name: "unbound global React namespaces",
+      code: `function Card() { return React.createElement("div"); }`,
+      expected: false,
+    },
+    {
+      name: "shadowed default React imports",
+      code: `import ReactClient from "react";
+        function Card(ReactClient) { return ReactClient.createElement("div"); }`,
+      expected: false,
+    },
+  ];
+
+  for (const testCase of createElementCases) {
+    it(`handles ${testCase.name}`, () => {
+      const { functionNode, scopes } = parseFunctionFixture(testCase.code, "Card");
+      expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(testCase.expected);
+    });
+  }
 
   it("memoizes per (functionNode, scopes): a repeat query with the same inputs skips the re-walk", () => {
     const { functionNode, scopes, program } = parseFunctionFixture(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
@@ -1,8 +1,8 @@
 import type { EsTreeNode } from "./es-tree-node.js";
-import { getImportedName as getImportSpecifierName } from "./get-imported-name.js";
 import { isAstNode } from "./is-ast-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
-import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import { isReactApiCall, type ReactApiCallOptions } from "./is-react-api-call.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 
 const NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
   "FunctionDeclaration",
@@ -11,6 +11,11 @@ const NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
   "ClassDeclaration",
   "ClassExpression",
 ]);
+
+const REACT_CREATE_ELEMENT_OPTIONS: ReactApiCallOptions = {
+  allowGlobalReactNamespace: false,
+  allowUnboundBareCalls: false,
+};
 
 // A function expression passed directly as a call argument
 // (`items.map(item => <li/>)`, `useMemo(() => <div/>, deps)`) feeds the
@@ -29,54 +34,6 @@ const isCallArgumentFunctionExpression = (node: EsTreeNode): boolean => {
 const isNestedRenderEvidenceBoundary = (node: EsTreeNode): boolean =>
   NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES.has(node.type) && !isCallArgumentFunctionExpression(node);
 
-const isReactImport = (symbol: SymbolDescriptor): boolean => {
-  let importDeclaration: EsTreeNode | null | undefined = symbol.declarationNode?.parent;
-  while (importDeclaration && !isNodeOfType(importDeclaration, "ImportDeclaration")) {
-    importDeclaration = importDeclaration.parent ?? null;
-  }
-  if (!importDeclaration || !isNodeOfType(importDeclaration, "ImportDeclaration")) return false;
-  return importDeclaration.source.value === "react";
-};
-
-const getImportedName = (symbol: SymbolDescriptor): string | null => {
-  if (symbol.kind !== "import") return null;
-  if (!isReactImport(symbol)) return null;
-  return getImportSpecifierName(symbol.declarationNode) ?? null;
-};
-
-const isReactNamespaceImport = (symbol: SymbolDescriptor): boolean => {
-  if (symbol.kind !== "import") return false;
-  if (!isReactImport(symbol)) return false;
-  return (
-    isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||
-    isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier")
-  );
-};
-
-const isReactCreateElementIdentifierCall = (callee: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  if (!isNodeOfType(callee, "Identifier")) return false;
-  const symbol = scopes.symbolFor(callee);
-  return Boolean(symbol && getImportedName(symbol) === "createElement");
-};
-
-const isReactCreateElementMemberCall = (callee: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  if (!isNodeOfType(callee, "MemberExpression")) return false;
-  if (callee.computed) return false;
-  if (!isNodeOfType(callee.object, "Identifier")) return false;
-  if (!isNodeOfType(callee.property, "Identifier")) return false;
-  if (callee.property.name !== "createElement") return false;
-  const symbol = scopes.symbolFor(callee.object);
-  return Boolean(symbol && isReactNamespaceImport(symbol));
-};
-
-const isReactCreateElementCall = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  if (!isNodeOfType(node, "CallExpression")) return false;
-  return (
-    isReactCreateElementIdentifierCall(node.callee, scopes) ||
-    isReactCreateElementMemberCall(node.callee, scopes)
-  );
-};
-
 const containsRenderOutput = (
   node: EsTreeNode,
   rootNode: EsTreeNode,
@@ -88,7 +45,7 @@ const containsRenderOutput = (
   if (node.type === "JSXElement" || node.type === "JSXFragment") {
     return true;
   }
-  if (isReactCreateElementCall(node, scopes)) {
+  if (isReactApiCall(node, "createElement", scopes, REACT_CREATE_ELEMENT_OPTIONS)) {
     return true;
   }
   const nodeRecord = node as unknown as Record<string, unknown>;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-key-name.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-key-name.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseFixture } from "../../test-utils/parse-fixture.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import {
+  getStaticPropertyKeyName,
+  type StaticPropertyKeyOptions,
+} from "./get-static-property-key-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { walkAst } from "./walk-ast.js";
+
+interface StaticPropertyKeyTestCase {
+  expectedComputedString: string | null;
+  expectedNumericLiteral: string | null;
+  name: string;
+  options?: StaticPropertyKeyOptions;
+}
+
+const readFixtureProperties = (): Map<number, EsTreeNode> => {
+  const parsed = parseFixture(`
+    const options = {
+      plain: "plain",
+      "quoted": "quoted",
+      ["computed"]: "computed",
+      42: "numeric",
+      [43]: "computed-numeric",
+    };
+  `);
+  expect(parsed.errors).toEqual([]);
+  const propertiesByValue = new Map<number, EsTreeNode>();
+  let propertyIndex = 0;
+  walkAst(parsed.program, (node: EsTreeNode) => {
+    if (!isNodeOfType(node, "Property")) return;
+    propertiesByValue.set(propertyIndex, node);
+    propertyIndex += 1;
+  });
+  return propertiesByValue;
+};
+
+const requireProperty = (
+  properties: Map<number, EsTreeNode>,
+  propertyIndex: number,
+): EsTreeNode => {
+  const property = properties.get(propertyIndex);
+  if (!property) throw new Error(`fixture has no property at index ${String(propertyIndex)}`);
+  return property;
+};
+
+describe("getStaticPropertyKeyName", () => {
+  const testCases: StaticPropertyKeyTestCase[] = [
+    {
+      name: "default options",
+      expectedComputedString: null,
+      expectedNumericLiteral: null,
+    },
+    {
+      name: "computed strings enabled",
+      options: { allowComputedString: true },
+      expectedComputedString: "computed",
+      expectedNumericLiteral: null,
+    },
+    {
+      name: "non-string stringification enabled",
+      options: { stringifyNonStringLiterals: true },
+      expectedComputedString: null,
+      expectedNumericLiteral: "42",
+    },
+    {
+      name: "all options enabled",
+      options: {
+        allowComputedString: true,
+        stringifyNonStringLiterals: true,
+      },
+      expectedComputedString: "computed",
+      expectedNumericLiteral: "42",
+    },
+  ];
+
+  for (const testCase of testCases) {
+    it(`handles ${testCase.name}`, () => {
+      const properties = readFixtureProperties();
+      expect(getStaticPropertyKeyName(requireProperty(properties, 0), testCase.options)).toBe(
+        "plain",
+      );
+      expect(getStaticPropertyKeyName(requireProperty(properties, 1), testCase.options)).toBe(
+        "quoted",
+      );
+      expect(getStaticPropertyKeyName(requireProperty(properties, 2), testCase.options)).toBe(
+        testCase.expectedComputedString,
+      );
+      expect(getStaticPropertyKeyName(requireProperty(properties, 3), testCase.options)).toBe(
+        testCase.expectedNumericLiteral,
+      );
+      expect(getStaticPropertyKeyName(requireProperty(properties, 4), testCase.options)).toBe(null);
+    });
+  }
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-key-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-key-name.ts
@@ -1,0 +1,30 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export interface StaticPropertyKeyOptions {
+  allowComputedString?: boolean;
+  stringifyNonStringLiterals?: boolean;
+}
+
+export const getStaticPropertyKeyName = (
+  node: EsTreeNode,
+  options: StaticPropertyKeyOptions = {},
+): string | null => {
+  if (!isNodeOfType(node, "Property")) return null;
+  if (node.computed) {
+    if (
+      options.allowComputedString &&
+      isNodeOfType(node.key, "Literal") &&
+      typeof node.key.value === "string"
+    ) {
+      return node.key.value;
+    }
+    return null;
+  }
+  if (isNodeOfType(node.key, "Identifier")) return node.key.name;
+  if (isNodeOfType(node.key, "Literal")) {
+    if (typeof node.key.value === "string") return node.key.value;
+    if (options.stringifyNonStringLiterals) return String(node.key.value);
+  }
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vite-plus/test";
+import { analyzeScopes } from "../semantic/scope-analysis.js";
+import { attachParentReferences } from "../../test-utils/attach-parent-references.js";
+import { parseFixture } from "../../test-utils/parse-fixture.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { isReactApiCall, type ReactApiCallOptions } from "./is-react-api-call.js";
+import { walkAst } from "./walk-ast.js";
+
+interface ReactApiCallTestCase {
+  code: string;
+  expectedCount: number;
+  name: string;
+  options?: ReactApiCallOptions;
+}
+
+const EFFECT_API_NAMES = new Set(["useEffect", "useLayoutEffect"]);
+
+const countReactApiCalls = (code: string, options?: ReactApiCallOptions): number => {
+  const parsed = parseFixture(code);
+  expect(parsed.errors).toEqual([]);
+  attachParentReferences(parsed.program);
+  const scopes = analyzeScopes(parsed.program);
+  let matchingCallCount = 0;
+  walkAst(parsed.program, (node: EsTreeNode) => {
+    if (
+      isNodeOfType(node, "CallExpression") &&
+      isReactApiCall(node, EFFECT_API_NAMES, scopes, options)
+    ) {
+      matchingCallCount += 1;
+    }
+  });
+  return matchingCallCount;
+};
+
+describe("isReactApiCall", () => {
+  const testCases: ReactApiCallTestCase[] = [
+    {
+      name: "named React imports",
+      code: 'import { useEffect } from "react"; useEffect(() => {});',
+      expectedCount: 1,
+    },
+    {
+      name: "renamed React imports",
+      code: 'import { useLayoutEffect as useIsoEffect } from "react"; useIsoEffect(() => {});',
+      expectedCount: 1,
+    },
+    {
+      name: "default React receivers",
+      code: 'import ReactClient from "react"; ReactClient.useEffect(() => {});',
+      expectedCount: 1,
+    },
+    {
+      name: "namespace React receivers",
+      code: 'import * as ReactClient from "react"; ReactClient.useLayoutEffect(() => {});',
+      expectedCount: 1,
+    },
+    {
+      name: "same-named imports from another package",
+      code: 'import { useEffect } from "other"; useEffect(() => {});',
+      expectedCount: 0,
+    },
+    {
+      name: "shadowed named React imports",
+      code: `import { useEffect } from "react";
+        const run = () => {
+          const useEffect = (callback) => callback();
+          useEffect(() => {});
+        };`,
+      expectedCount: 0,
+    },
+    {
+      name: "shadowed React receivers",
+      code: `import ReactClient from "react";
+        const run = (ReactClient) => ReactClient.useEffect(() => {});`,
+      expectedCount: 0,
+    },
+    {
+      name: "unbound bare calls by default",
+      code: "useEffect(() => {});",
+      expectedCount: 0,
+    },
+    {
+      name: "allowed unbound bare calls",
+      code: "useEffect(() => {});",
+      options: { allowUnboundBareCalls: true },
+      expectedCount: 1,
+    },
+    {
+      name: "global React namespace by default",
+      code: "React.useEffect(() => {});",
+      expectedCount: 0,
+    },
+    {
+      name: "allowed global React namespace",
+      code: "React.useEffect(() => {});",
+      options: { allowGlobalReactNamespace: true },
+      expectedCount: 1,
+    },
+  ];
+
+  for (const testCase of testCases) {
+    it(testCase.name, () => {
+      expect(countReactApiCalls(testCase.code, testCase.options)).toBe(testCase.expectedCount);
+    });
+  }
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
@@ -1,0 +1,78 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getImportedName } from "./get-imported-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export interface ReactApiCallOptions {
+  allowGlobalReactNamespace?: boolean;
+  allowUnboundBareCalls?: boolean;
+}
+
+const includesApiName = (apiNames: string | ReadonlySet<string>, apiName: string): boolean =>
+  typeof apiNames === "string" ? apiNames === apiName : apiNames.has(apiName);
+
+const isImportedFromReact = (symbol: SymbolDescriptor): boolean => {
+  if (symbol.kind !== "import") return false;
+  const importDeclaration = symbol.declarationNode.parent;
+  return Boolean(
+    importDeclaration &&
+    isNodeOfType(importDeclaration, "ImportDeclaration") &&
+    importDeclaration.source.value === "react",
+  );
+};
+
+const isNamedReactApiImport = (
+  identifier: EsTreeNode,
+  apiNames: string | ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(identifier, "Identifier")) return false;
+  const symbol = scopes.symbolFor(identifier);
+  if (!symbol || !isImportedFromReact(symbol)) return false;
+  const importedName = getImportedName(symbol.declarationNode);
+  return Boolean(importedName && includesApiName(apiNames, importedName));
+};
+
+const isReactNamespaceImport = (identifier: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(identifier, "Identifier")) return false;
+  const symbol = scopes.symbolFor(identifier);
+  if (!symbol || !isImportedFromReact(symbol)) return false;
+  return (
+    isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||
+    isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier")
+  );
+};
+
+export const isReactApiCall = (
+  node: EsTreeNode,
+  apiNames: string | ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+  options: ReactApiCallOptions = {},
+): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  if (isNodeOfType(callee, "Identifier")) {
+    if (isNamedReactApiImport(callee, apiNames, scopes)) return true;
+    return Boolean(
+      options.allowUnboundBareCalls &&
+      includesApiName(apiNames, callee.name) &&
+      scopes.isGlobalReference(callee),
+    );
+  }
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    callee.computed ||
+    !isNodeOfType(callee.object, "Identifier") ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    !includesApiName(apiNames, callee.property.name)
+  ) {
+    return false;
+  }
+  if (isReactNamespaceImport(callee.object, scopes)) return true;
+  return Boolean(
+    options.allowGlobalReactNamespace &&
+    callee.object.name === "React" &&
+    scopes.isGlobalReference(callee.object),
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/read-static-boolean.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/read-static-boolean.ts
@@ -1,0 +1,12 @@
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+
+export const readStaticBoolean = (node: EsTreeNode | null | undefined): boolean | null => {
+  if (!node) return null;
+  const unwrappedNode = stripParenExpression(node);
+  if (!isNodeOfType(unwrappedNode, "Literal") || typeof unwrappedNode.value !== "boolean") {
+    return null;
+  }
+  return unwrappedNode.value;
+};


### PR DESCRIPTION
## Summary
- add `effect-listener-cleanup-mismatch` for cleanup callbacks or capture flags that cannot detach their EventTarget registration
- handle local AbortController cleanup, aliases, shadowing, and control-flow uncertainty conservatively
- add shared scope-aware React API and static property-key utilities with regression and verdict-robustness coverage

## Contract
Reports only canonical effects with one final top-level cleanup return and statically comparable target, event, callback, and capture identities. Unknown or path-ambiguous cleanup stays quiet.

## Examples
Reports a fresh callback and mismatched capture:

```tsx
useEffect(() => {
  const handleResize = () => resize();
  window.addEventListener("resize", handleResize, true);
  return () => window.removeEventListener("resize", () => resize());
}, []);
```

Stays quiet when callback identity and capture match:

```tsx
useEffect(() => {
  const handleResize = () => resize();
  window.addEventListener("resize", handleResize, true);
  return () => window.removeEventListener("resize", handleResize, { capture: true });
}, []);
```

A listener registered with a local `AbortController` also stays quiet when cleanup aborts that controller.

## Validation
- 74 focused listener tests
- 26 permanent verdict-robustness tests
- 11,335 plugin tests passed; 145 skipped
- strict fuzz: 500 iterations, 1/1 fire coverage, no findings
- workspace typecheck, lint, and format passed (three unrelated existing lint warnings)
- local RDE: 100 root directories across 12 repositories, 0 target diagnostics, 0 failures

## Test plan
- [x] CoreUI `ref.current` callback/capture witness reports
- [x] valid callback, capture, and AbortController cleanup stays quiet
- [x] shadowed React hooks and uncertain control flow stay quiet
- [x] concise/block-return metamorphic variants preserve the verdict

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new static-analysis rule with many edge cases; conservative gating limits blast radius, but mis-verdicts could annoy users or miss real listener leaks.
> 
> **Overview**
> Adds **`effect-listener-cleanup-mismatch`**, a new **Bugs** rule that flags React effects whose cleanup cannot detach `addEventListener` registrations—typically a **different callback binding** (e.g. fresh inline arrow in `removeEventListener`), **capture flag mismatch**, or a **signal-backed listener** not cancelled via matching removal or **local `AbortController.abort()`**.
> 
> The rule only runs on **canonical** effect shapes: one final top-level cleanup `return`, with statically comparable target, event name, callback identity, and capture. It stays quiet when cleanup is **path-ambiguous**, uses **unknown** dynamic values, or valid patterns apply (helpers, bound abort, exhaustive branches, alias targets, etc.).
> 
> **Shared infrastructure:** `isReactApiCall`, `getStaticPropertyKeyName`, and `readStaticBoolean` are extracted/refactored; `functionContainsReactRenderOutput` now uses `isReactApiCall` for `createElement` detection.
> 
> **Coverage:** rule registered in `rule-registry`, liveness fixture, verdict-robustness gate, 15 fuzz regression corpora, and large unit/false-positive/control-flow test suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e63bfd19cac39b594de8cbd8dec6f3c27e8b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->