### PR TITLE
fix: use default TypeScript import for ESM/CJS interop

### DIFF
--- a/.changeset/typescript-import-interop.md
+++ b/.changeset/typescript-import-interop.md
@@ -1,0 +1,7 @@
+---
+"@react-doctor/core": patch
+---
+
+Fix project discovery failures in pnpm workspaces by using default TypeScript import for ESM/CJS interop.
+
+Replace `import * as ts from 'typescript'` with `import ts from 'typescript'` in 4 files to fix "No React project found" errors in environments where TypeScript 5.3.3 is resolved. The namespace import created a structure where the TypeScript API was under `ts.default`, causing calls like `ts.parseConfigFileTextToJson` to fail with "not a function". The default import pattern works consistently across all TypeScript versions and module resolution strategies.

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
-import * as ts from "typescript";
+import ts from "typescript";
 import { ES2023_YEAR, ES_TARGET_YEAR_BY_NAME, TSCONFIG_EXTENDS_MAX_DEPTH } from "../constants.js";
 import type { Framework, PackageJson } from "../types/index.js";
 import { isProjectBoundary } from "../utils/is-project-boundary.js";

--- a/packages/core/src/runners/oxlint/resolve-use-call-binding.ts
+++ b/packages/core/src/runners/oxlint/resolve-use-call-binding.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 interface ReactImportBindings {
   namespaceNames: Set<string>;

--- a/packages/core/src/runners/oxlint/should-suppress-compiler-finding-in-worklet.ts
+++ b/packages/core/src/runners/oxlint/should-suppress-compiler-finding-in-worklet.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as ts from "typescript";
+import ts from "typescript";
 import type { ProjectInfo } from "../../types/index.js";
 
 // React Compiler diagnostics fire on `sharedValue.value` reads/writes even

--- a/packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts
+++ b/packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as ts from "typescript";
+import ts from "typescript";
 import type { Diagnostic } from "../../types/index.js";
 
 const MANUAL_MEMOIZATION_PLUGIN = "react-doctor";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1115 - react-doctor fails to discover React projects in pnpm workspaces due to TypeScript module interop error.

## Root Cause

Four files used `import * as ts from "typescript"` which creates a namespace import. In environments where TypeScript 5.3.3 is resolved (common with pnpm's isolated dependency resolution), the TypeScript compiler API is available under `ts.default`, causing direct calls like `ts.parseConfigFileTextToJson` to fail with "not a function".

This prevented project discovery from working, resulting in "No React project found" errors even for valid React projects.

## Changes

Changed TypeScript imports from namespace to default import in 4 files:
- `packages/core/src/project-info/detectors.ts`
- `packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts`
- `packages/core/src/runners/oxlint/should-suppress-compiler-finding-in-worklet.ts`
- `packages/core/src/runners/oxlint/resolve-use-call-binding.ts`

The default import pattern (`import ts from "typescript"`) works consistently across all TypeScript versions and module resolution strategies, and matches the pattern already used elsewhere in the codebase (deslop-js package).

## Validation

- ✅ All existing tests pass (including `detectPreES2023Target` tests that exercise the fixed code)
- ✅ Typecheck passes
- ✅ No diagnostic logic changed - pure module interop fix
- ✅ Changeset added (patch)

## Scope

This is the narrowest correct fix:
- **What's fixed**: Project discovery now works in all module resolution environments
- **What's unchanged**: No detection logic, rules, or diagnostic behavior modified
- **Why narrow**: Only changes the import pattern to be ESM/CJS compatible; the rest of the codebase already uses this pattern
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b01d2d0e-6628-410f-ad5b-85f209bed0e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b01d2d0e-6628-410f-ad5b-85f209bed0e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

