### PR TITLE
fix(core): TypeScript CJS interop in project discovery + surface discovery failures

### DIFF
--- a/.changeset/ts-cjs-interop-project-discovery.md
+++ b/.changeset/ts-cjs-interop-project-discovery.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Fix project discovery failing with "No React project found" when the resolved `typescript` package loads as CJS without named ESM exports (e.g. typescript@5.3 under pnpm's isolated layout): import the TypeScript compiler API via its default export, and surface unexpected discovery exceptions as a new `ProjectDiscoveryFailed` error instead of masking them as `ProjectNotFound`. (#1115)

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -122,6 +122,18 @@ export class AmbiguousProject extends Schema.TaggedErrorClass<AmbiguousProject>(
   }
 }
 
+export class ProjectDiscoveryFailed extends Schema.TaggedErrorClass<ProjectDiscoveryFailed>()(
+  "ProjectDiscoveryFailed",
+  {
+    directory: Schema.String,
+    cause: Schema.Unknown,
+  },
+) {
+  get message() {
+    return `Project discovery failed for ${this.directory}: ${Cause.pretty(Cause.fail(this.cause))}`;
+  }
+}
+
 export class DeadCodeAnalysisFailed extends Schema.TaggedErrorClass<DeadCodeAnalysisFailed>()(
   "DeadCodeAnalysisFailed",
   {
@@ -178,6 +190,7 @@ export const ReactDoctorErrorReason = Schema.Union([
   ProjectNotFound,
   NoReactDependency,
   AmbiguousProject,
+  ProjectDiscoveryFailed,
   DeadCodeAnalysisFailed,
   GitInvocationFailed,
   GitBaseBranchMissing,

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
-import * as ts from "typescript";
+import ts from "typescript";
 import { ES2023_YEAR, ES_TARGET_YEAR_BY_NAME, TSCONFIG_EXTENDS_MAX_DEPTH } from "../constants.js";
 import type { Framework, PackageJson } from "../types/index.js";
 import { isProjectBoundary } from "../utils/is-project-boundary.js";

--- a/packages/core/src/runners/oxlint/resolve-use-call-binding.ts
+++ b/packages/core/src/runners/oxlint/resolve-use-call-binding.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 interface ReactImportBindings {
   namespaceNames: Set<string>;

--- a/packages/core/src/runners/oxlint/should-suppress-compiler-finding-in-worklet.ts
+++ b/packages/core/src/runners/oxlint/should-suppress-compiler-finding-in-worklet.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as ts from "typescript";
+import ts from "typescript";
 import type { ProjectInfo } from "../../types/index.js";
 
 // React Compiler diagnostics fire on `sharedValue.value` reads/writes even

--- a/packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts
+++ b/packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import * as ts from "typescript";
+import ts from "typescript";
 import type { Diagnostic } from "../../types/index.js";
 
 const MANUAL_MEMOIZATION_PLUGIN = "react-doctor";

--- a/packages/core/src/services/project.ts
+++ b/packages/core/src/services/project.ts
@@ -12,6 +12,7 @@ import type { ProjectInfo } from "../types/index.js";
 import {
   AmbiguousProject,
   NoReactDependency,
+  ProjectDiscoveryFailed,
   ProjectNotFound,
   ReactDoctorError,
 } from "../errors.js";
@@ -34,7 +35,7 @@ const translateProjectInfoError = (cause: unknown, directory: string): ReactDoct
       }),
     });
   }
-  return new ReactDoctorError({ reason: new ProjectNotFound({ directory }) });
+  return new ReactDoctorError({ reason: new ProjectDiscoveryFailed({ directory, cause }) });
 };
 
 export class Project extends Context.Service<

--- a/packages/core/tests/errors.test.ts
+++ b/packages/core/tests/errors.test.ts
@@ -11,6 +11,7 @@ import {
   OxlintOutputUnparseable,
   OxlintSpawnFailed,
   OxlintUnavailable,
+  ProjectDiscoveryFailed,
   ProjectNotFound,
   ReactDoctorError,
   ScanDeadlineExceeded,
@@ -119,6 +120,21 @@ describe("ReactDoctorError leaves", () => {
     );
   });
 
+  it("ProjectDiscoveryFailed names the directory and wraps the cause", () => {
+    const error = new ReactDoctorError({
+      reason: new ProjectDiscoveryFailed({
+        directory: "/repo/apps/mobile",
+        cause: new TypeError("ts.parseConfigFileTextToJson is not a function"),
+      }),
+    });
+    expect(formatReactDoctorError(error)).toContain(
+      "Project discovery failed for /repo/apps/mobile",
+    );
+    expect(formatReactDoctorError(error)).toContain(
+      "ts.parseConfigFileTextToJson is not a function",
+    );
+  });
+
   it("DeadCodeAnalysisFailed wraps the cause", () => {
     const error = new ReactDoctorError({
       reason: new DeadCodeAnalysisFailed({ cause: "SIGABRT from native binding" }),
@@ -175,6 +191,7 @@ describe("isSplittableReactDoctorError", () => {
       new ProjectNotFound({ directory: "x" }),
       new NoReactDependency({ directory: "x" }),
       new AmbiguousProject({ directory: "x", candidates: [] }),
+      new ProjectDiscoveryFailed({ directory: "x", cause: new Error("boom") }),
       new DeadCodeAnalysisFailed({ cause: "x" }),
     ] as const;
     for (const reason of cases) {


### PR DESCRIPTION
## Summary

Fixes #1115 — `react-doctor` reported `No React project found` for a valid Expo app because `detectPreES2023FromConfig` crashed with `TypeError: ts.parseConfigFileTextToJson is not a function` when the resolved `typescript` (5.3.x under pnpm's isolated layout) loads as CJS-without-named-ESM-exports, and `Project.discover` masked that crash as `ProjectNotFound`.

Two fixes:

1. **Interop**: `import * as ts from "typescript"` → `import ts from "typescript"` in the four `packages/core` files that use the compiler API (deslop-js already used the default import). The default import always resolves to `module.exports` regardless of whether cjs-module-lexer can synthesize named exports, so `ts.parseConfigFileTextToJson` is defined for both typescript 5.x and 6.x. Verified the built `dist/cli.js` / `dist/index.js` now emit `import ts from "typescript"`.

2. **No more masking**: `translateProjectInfoError`'s catch-all no longer coerces unexpected discovery exceptions into `ProjectNotFound`. New tagged reason:

```ts
class ProjectDiscoveryFailed extends Schema.TaggedErrorClass<ProjectDiscoveryFailed>()(
  "ProjectDiscoveryFailed",
  { directory: Schema.String, cause: Schema.Unknown },
) // message: `Project discovery failed for ${directory}: ${Cause.pretty(...)}`
```

The known discovery errors (`NoReactDependencyError`, `ProjectNotFoundError`, `PackageJsonNotFoundError`, `AmbiguousProjectError`) still map to their existing reasons; only genuinely unexpected throws hit the new reason. `ProjectDiscoveryFailed` is intentionally NOT in `isExpectedUserError`'s expected set, so it goes through the crash-reporting path (Sentry + prefilled issue) with the real underlying error in the message instead of a misleading "No React project found".


Link to Devin session: https://app.devin.ai/sessions/be41126e02e748838d2f2b6879dcd04c
Requested by: @aidenybai

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the universal project-discovery path and changes how some failures surface to users/telemetry, though behavior for known discovery errors is unchanged.
> 
> **Overview**
> Fixes valid React/Expo projects being rejected as **“No React project found”** when discovery crashes loading the TypeScript compiler API under pnpm’s isolated layout (e.g. `typescript@5.3` as CJS without named ESM exports).
> 
> **Interop:** Core now uses `import ts from "typescript"` instead of `import * as ts` in project detection and oxlint helpers so `ts.parseConfigFileTextToJson` and related APIs resolve reliably.
> 
> **Errors:** Unexpected discovery throws are no longer mapped to `ProjectNotFound`. A new **`ProjectDiscoveryFailed`** reason carries the directory and underlying cause in the message, so failures like the missing `parseConfigFileTextToJson` show up explicitly instead of a misleading “could not find a React project” message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34a0570c347510e37d2f3a0ca3dfafe3ac1b1dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->