### PR TITLE
feat(report): add versioned JSON v3 metadata

### DIFF
--- a/.changeset/version-json-reports.md
+++ b/.changeset/version-json-reports.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Emit JSON report schema version 3 with deterministic diagnostic identities and exact per-project scan coverage while retaining v1 and v2 decoding.

--- a/docs/json-report.md
+++ b/docs/json-report.md
@@ -11,7 +11,8 @@ Version 3 is the default. Versions 1 and 2 remain accepted by the exported
 Each diagnostic includes:
 
 - `id`: deterministic
-  `<normalizedFilePath>::<line>:<column>::<plugin>/<rule>` identity
+  `<reportRelativeFilePath>::<line>:<column>::<plugin>/<rule>` identity, unique
+  across workspace projects
 - `normalizedFilePath`: project-relative path with `/` separators
 - canonical `plugin`, `rule`, `category`, `severity`, and sorted `tags`
 - the original `filePath` and source span fields

--- a/docs/json-report.md
+++ b/docs/json-report.md
@@ -1,0 +1,30 @@
+# JSON report
+
+`react-doctor --json` and `react-doctor --json-out <path>` emit the versioned
+`JsonReport` wire format. New consumers should branch on `schemaVersion`.
+
+## Version 3
+
+Version 3 is the default. Versions 1 and 2 remain accepted by the exported
+`JsonReport` schema for existing reports.
+
+Each diagnostic includes:
+
+- `id`: deterministic
+  `<normalizedFilePath>::<line>:<column>::<plugin>/<rule>` identity
+- `normalizedFilePath`: project-relative path with `/` separators
+- canonical `plugin`, `rule`, `category`, `severity`, and sorted `tags`
+- the original `filePath` and source span fields
+
+Each project includes:
+
+- `packageRoot` and `framework`
+- sorted, deduplicated `analyzedFiles` and `analyzedFileCount`
+- `complete`, which is true only when every planned lint file completed and no
+  check failed
+- `skippedChecks` and optional `skippedCheckReasons`
+
+`mode` remains one of `full`, `diff`, `staged`, or `baseline`. A baseline report
+uses `mode: "baseline"` and includes the optional `baseline` block. Consumers
+must not infer coverage from an empty `diagnostics` array: use each project's
+`complete` and `analyzedFiles` fields.

--- a/packages/api/src/diagnose.ts
+++ b/packages/api/src/diagnose.ts
@@ -136,6 +136,8 @@ const outputToDiagnoseResult = (
     score: output.score,
     skippedChecks,
     ...(Object.keys(skippedCheckReasons).length > 0 ? { skippedCheckReasons } : {}),
+    analyzedFiles: output.analyzedFiles,
+    scannedFileCount: output.scannedFileCount,
     project: output.project,
     reactDetected: hasReactRuntime(output.project),
     elapsedMilliseconds,

--- a/packages/core/src/build-json-report-error.ts
+++ b/packages/core/src/build-json-report-error.ts
@@ -48,7 +48,7 @@ export const buildJsonReportError = (input: BuildJsonReportErrorInput): JsonRepo
       : { message: safeStringify(input.error), name: "Error", chain, sentryEventId };
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 3,
     version: input.version,
     ok: false,
     directory: input.directory,

--- a/packages/core/src/build-json-report.ts
+++ b/packages/core/src/build-json-report.ts
@@ -1,13 +1,19 @@
 import type {
+  Diagnostic,
   DiffInfo,
-  JsonReport,
+  JsonReportDiagnosticV3,
   JsonReportDiffInfo,
   JsonReportMode,
-  JsonReportProjectEntry,
+  JsonReportProjectEntryV3,
+  JsonReportV3,
   InspectResult,
 } from "./types/index.js";
+import { getDiagnosticRuleIdentity } from "./get-diagnostic-rule-identity.js";
+import { buildDiagnosticIdentity } from "./schemas.js";
 import { summarizeDiagnostics } from "./summarize-diagnostics.js";
 import { hasReactRuntime } from "./utils/has-react-runtime.js";
+import { isScanComplete } from "./utils/is-scan-complete.js";
+import { toNormalizedRelativePath } from "./utils/to-normalized-relative-path.js";
 
 interface BuildJsonReportInput {
   version: string;
@@ -18,7 +24,7 @@ interface BuildJsonReportInput {
   totalElapsedMilliseconds: number;
   /**
    * Present for a baseline run — `scans[].result.diagnostics` are then the
-   * introduced findings only. Emits a `schemaVersion: 2` report with the
+   * introduced findings only. Emits a `schemaVersion: 3` report with the
    * delta totals and `mode: "baseline"`.
    */
   baseline?: { baseRef: string; fixedCount: number; baseTotalCount: number };
@@ -27,7 +33,7 @@ interface BuildJsonReportInput {
    * computed (no merge base — usually a shallow CI checkout — or a failed
    * base/head lint), so `diagnostics` list every finding in the changed files
    * rather than only the introduced ones. Ignored when `baseline` is set: a
-   * computed baseline (v2) wins, so callers pass at most one.
+   * computed baseline wins, so callers pass at most one.
    */
   baselineDegraded?: boolean;
 }
@@ -43,9 +49,9 @@ const toJsonDiff = (diff: DiffInfo | null): JsonReportDiffInfo | null => {
 };
 
 const findWorstScoredProject = (
-  projects: JsonReportProjectEntry[],
-): JsonReportProjectEntry | null => {
-  let worst: JsonReportProjectEntry | null = null;
+  projects: JsonReportProjectEntryV3[],
+): JsonReportProjectEntryV3 | null => {
+  let worst: JsonReportProjectEntryV3 | null = null;
   let worstScore = Number.POSITIVE_INFINITY;
   for (const project of projects) {
     const score = project.score?.score;
@@ -58,19 +64,61 @@ const findWorstScoredProject = (
   return worst;
 };
 
-export const buildJsonReport = (input: BuildJsonReportInput): JsonReport => {
-  const projects: JsonReportProjectEntry[] = input.scans.map(({ directory, result }) => ({
-    directory,
-    project: result.project,
-    diagnostics: result.diagnostics,
-    score: result.score,
-    skippedChecks: result.skippedChecks,
-    ...(result.skippedCheckReasons ? { skippedCheckReasons: result.skippedCheckReasons } : {}),
-    ...(typeof result.scannedFileCount === "number"
-      ? { scannedFileCount: result.scannedFileCount }
-      : {}),
-    elapsedMilliseconds: result.elapsedMilliseconds,
-  }));
+const toJsonReportDiagnostic = (
+  diagnostic: Diagnostic,
+  projectRoot: string,
+): JsonReportDiagnosticV3 => {
+  const normalizedFilePath = toNormalizedRelativePath(diagnostic.filePath, projectRoot);
+  const ruleIdentity = getDiagnosticRuleIdentity(diagnostic);
+  return {
+    ...diagnostic,
+    id: buildDiagnosticIdentity({
+      filePath: normalizedFilePath,
+      line: diagnostic.line,
+      column: diagnostic.column,
+      plugin: diagnostic.plugin,
+      rule: diagnostic.rule,
+    }),
+    normalizedFilePath,
+    category: ruleIdentity.category,
+    tags: [...new Set(ruleIdentity.tags)].sort(),
+  };
+};
+
+export const buildJsonReport = (input: BuildJsonReportInput): JsonReportV3 => {
+  const projects: JsonReportProjectEntryV3[] = input.scans.map(({ directory, result }) => {
+    const skippedChecks = result.skippedChecks ?? [];
+    const analyzedFiles = [
+      ...new Set(
+        (result.analyzedFiles ?? []).map((filePath) =>
+          toNormalizedRelativePath(filePath, result.project.rootDirectory),
+        ),
+      ),
+    ].sort();
+    const scannedFileCount = result.scannedFileCount ?? result.project.sourceFileCount;
+    return {
+      directory,
+      packageRoot: result.project.rootDirectory,
+      framework: result.project.framework,
+      project: result.project,
+      diagnostics: result.diagnostics.map((diagnostic) =>
+        toJsonReportDiagnostic(diagnostic, result.project.rootDirectory),
+      ),
+      score: result.score,
+      skippedChecks,
+      ...(result.skippedCheckReasons ? { skippedCheckReasons: result.skippedCheckReasons } : {}),
+      analyzedFiles,
+      analyzedFileCount: analyzedFiles.length,
+      complete: isScanComplete({
+        analyzedFileCount: result.analyzedFiles === undefined ? undefined : analyzedFiles.length,
+        scannedFileCount,
+        skippedCheckCount: skippedChecks.length,
+        skippedCheckReasonCount: Object.keys(result.skippedCheckReasons ?? {}).length,
+      }),
+      ...(typeof result.scannedFileCount === "number" ? { scannedFileCount } : {}),
+      elapsedMilliseconds: result.elapsedMilliseconds,
+    };
+  });
 
   const flattenedDiagnostics = projects.flatMap((entry) => entry.diagnostics);
   const worstScoredProject = findWorstScoredProject(projects);
@@ -81,7 +129,25 @@ export const buildJsonReport = (input: BuildJsonReportInput): JsonReport => {
     worstScoredProject?.score?.label ?? null,
   );
 
-  const shared = {
+  return {
+    schemaVersion: 3,
+    mode:
+      input.baseline !== undefined
+        ? "baseline"
+        : input.baselineDegraded && input.mode === "baseline"
+          ? "diff"
+          : input.mode,
+    ...(input.baseline
+      ? {
+          baseline: {
+            baseRef: input.baseline.baseRef,
+            newCount: summary.totalDiagnosticCount,
+            fixedCount: input.baseline.fixedCount,
+            baseTotalCount: input.baseline.baseTotalCount,
+          },
+        }
+      : {}),
+    ...(input.baselineDegraded ? { baselineDegraded: true } : {}),
     ...(input.scans.length > 0
       ? { reactDetected: input.scans.some((scan) => hasReactRuntime(scan.result.project)) }
       : {}),
@@ -94,26 +160,5 @@ export const buildJsonReport = (input: BuildJsonReportInput): JsonReport => {
     summary,
     elapsedMilliseconds: input.totalElapsedMilliseconds,
     error: null,
-  };
-
-  if (input.baseline) {
-    return {
-      schemaVersion: 2,
-      mode: "baseline",
-      baseline: {
-        baseRef: input.baseline.baseRef,
-        newCount: summary.totalDiagnosticCount,
-        fixedCount: input.baseline.fixedCount,
-        baseTotalCount: input.baseline.baseTotalCount,
-      },
-      ...shared,
-    };
-  }
-
-  return {
-    schemaVersion: 1,
-    mode: input.mode,
-    ...(input.baselineDegraded ? { baselineDegraded: true } : {}),
-    ...shared,
   };
 };

--- a/packages/core/src/build-json-report.ts
+++ b/packages/core/src/build-json-report.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import type {
   Diagnostic,
   DiffInfo,
@@ -67,13 +68,18 @@ const findWorstScoredProject = (
 const toJsonReportDiagnostic = (
   diagnostic: Diagnostic,
   projectRoot: string,
+  reportRoot: string,
 ): JsonReportDiagnosticV3 => {
   const normalizedFilePath = toNormalizedRelativePath(diagnostic.filePath, projectRoot);
+  const reportRelativeFilePath = toNormalizedRelativePath(
+    path.resolve(projectRoot, diagnostic.filePath),
+    reportRoot,
+  );
   const ruleIdentity = getDiagnosticRuleIdentity(diagnostic);
   return {
     ...diagnostic,
     id: buildDiagnosticIdentity({
-      filePath: normalizedFilePath,
+      filePath: reportRelativeFilePath,
       line: diagnostic.line,
       column: diagnostic.column,
       plugin: diagnostic.plugin,
@@ -102,7 +108,7 @@ export const buildJsonReport = (input: BuildJsonReportInput): JsonReportV3 => {
       framework: result.project.framework,
       project: result.project,
       diagnostics: result.diagnostics.map((diagnostic) =>
-        toJsonReportDiagnostic(diagnostic, result.project.rootDirectory),
+        toJsonReportDiagnostic(diagnostic, result.project.rootDirectory, input.directory),
       ),
       score: result.score,
       skippedChecks,
@@ -123,11 +129,18 @@ export const buildJsonReport = (input: BuildJsonReportInput): JsonReportV3 => {
   const flattenedDiagnostics = projects.flatMap((entry) => entry.diagnostics);
   const worstScoredProject = findWorstScoredProject(projects);
 
-  const summary = summarizeDiagnostics(
+  const diagnosticSummary = summarizeDiagnostics(
     flattenedDiagnostics,
     worstScoredProject?.score?.score ?? null,
     worstScoredProject?.score?.label ?? null,
   );
+  const affectedFileCount = projects.reduce(
+    (totalAffectedFileCount, project) =>
+      totalAffectedFileCount +
+      new Set(project.diagnostics.map((diagnostic) => diagnostic.normalizedFilePath)).size,
+    0,
+  );
+  const summary = { ...diagnosticSummary, affectedFileCount };
 
   return {
     schemaVersion: 3,

--- a/packages/core/src/build-skipped-checks.ts
+++ b/packages/core/src/build-skipped-checks.ts
@@ -4,6 +4,8 @@ export interface SkippedCheckInput {
   readonly lintPartialFailures: ReadonlyArray<string>;
   readonly didDeadCodeFail: boolean;
   readonly deadCodeFailureReason: string | null;
+  readonly supplyChainOverlapTimedOut?: boolean;
+  readonly securityScanFailed?: boolean;
 }
 
 export interface SkippedCheckSummary {
@@ -15,13 +17,15 @@ export interface SkippedCheckSummary {
  * Single source of truth for the skipped-check accounting shared by the
  * CLI renderer (`react-doctor/src/inspect.ts → finalizeAndRender`) and the
  * programmatic shell (`@react-doctor/api → diagnose()`). Both surface a
- * failed lint / dead-code pass instead of a false "all clear", so the
+ * failed or partial analysis pass instead of a false "all clear", so the
  * branch logic lives here once.
  */
 export const buildSkippedChecks = (input: SkippedCheckInput): SkippedCheckSummary => {
   const skippedChecks: string[] = [];
   if (input.didLintFail) skippedChecks.push("lint");
   if (input.didDeadCodeFail) skippedChecks.push("dead-code");
+  if (input.supplyChainOverlapTimedOut) skippedChecks.push("supply-chain");
+  if (input.securityScanFailed) skippedChecks.push("security-scan");
 
   const skippedCheckReasons: Record<string, string> = {};
   if (input.didLintFail && input.lintFailureReason !== null) {
@@ -31,6 +35,12 @@ export const buildSkippedChecks = (input: SkippedCheckInput): SkippedCheckSummar
   }
   if (input.didDeadCodeFail && input.deadCodeFailureReason !== null) {
     skippedCheckReasons["dead-code"] = input.deadCodeFailureReason;
+  }
+  if (input.supplyChainOverlapTimedOut) {
+    skippedCheckReasons["supply-chain"] = "Supply-chain analysis timed out and was skipped.";
+  }
+  if (input.securityScanFailed) {
+    skippedCheckReasons["security-scan"] = "Security scan failed and was skipped.";
   }
 
   return { skippedChecks, skippedCheckReasons };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,13 @@ export * from "./run-inspect.js";
 // TypeScript-type definitions in `./types/index.js`. Consumers that
 // need the Schema classes import directly via
 // `@react-doctor/core/schemas` or the in-tree relative path.
-export { Severity, JsonReportV1, buildDiagnosticIdentity } from "./schemas.js";
+export {
+  Severity,
+  JsonReportV1,
+  JsonReportV2,
+  JsonReportV3,
+  buildDiagnosticIdentity,
+} from "./schemas.js";
 export * from "./services/config.js";
 export * from "./services/dead-code.js";
 export * from "./services/files.js";
@@ -92,6 +98,7 @@ export * from "./utils/has-published-fix-recipe.js";
 export * from "./utils/has-react-runtime.js";
 export * from "./utils/is-errno-exception.js";
 export * from "./utils/is-large-minified-file.js";
+export * from "./utils/is-scan-complete.js";
 export * from "./utils/list-source-files.js";
 export * from "./utils/map-with-concurrency.js";
 export * from "./utils/match-glob-pattern.js";

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -882,7 +882,7 @@ export const runInspect = <HooksR = never>(
         : [
             ...new Set(
               lintFileCoverageState.value.candidateFiles.map((filePath) =>
-                filePath.replaceAll("\\", "/"),
+                toNormalizedRelativePath(filePath, scanDirectory),
               ),
             ),
           ];

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -57,7 +57,7 @@ import { Config, type ResolvedConfig } from "./services/config.js";
 import { DeadCode } from "./services/dead-code.js";
 import { Files } from "./services/files.js";
 import { Git } from "./services/git.js";
-import { LintPartialFailures, Linter } from "./services/linter.js";
+import { type LintFileCoverage, LintPartialFailures, Linter } from "./services/linter.js";
 import { Progress } from "./services/progress.js";
 import { Project } from "./services/project.js";
 import { Reporter } from "./services/reporter.js";
@@ -66,6 +66,7 @@ import { SupplyChain } from "./services/supply-chain.js";
 import type { ScoreRequestMetadata } from "./calculate-score.js";
 import { resolveGithubActionsScoreMetadata } from "./utils/resolve-github-actions-score-metadata.js";
 import { resolveScanConcurrency } from "./utils/resolve-scan-concurrency.js";
+import { toNormalizedRelativePath } from "./utils/to-normalized-relative-path.js";
 
 export interface InspectInput {
   readonly directory: string;
@@ -206,6 +207,8 @@ export interface InspectOutput {
    * per-project counts are summed.
    */
   readonly scannedFilePaths: ReadonlyArray<string>;
+  /** Project-relative POSIX paths the lint pass completed successfully. */
+  readonly analyzedFiles: ReadonlyArray<string>;
   /** Wall-clock duration of the scan phase, in milliseconds. */
   readonly scanElapsedMilliseconds: number;
   /**
@@ -218,16 +221,17 @@ export interface InspectOutput {
   /**
    * `true` when the background supply-chain fiber hit its overlap budget
    * (`SupplyChainOverlapTimeoutMs`) and failed open to no diagnostics — a
-   * rare hung-socket guard, surfaced for telemetry. `false` on the healthy
-   * path and whenever supply-chain was skipped (diff/staged scans).
+   * rare hung-socket guard, surfaced for telemetry and skipped-check
+   * accounting. `false` on the healthy path and whenever supply-chain was
+   * skipped (diff/staged scans).
    */
   readonly supplyChainOverlapTimedOut: boolean;
   /**
    * `true` when the forked security scan failed (a non-ignorable fs error
    * escaping the cooperative walk) and failed open to no diagnostics —
-   * surfaced for telemetry so a failed pass is distinguishable from a clean
-   * one with zero findings. `false` on the healthy path and when the pass
-   * was skipped (diff/staged scans).
+   * surfaced for telemetry and skipped-check accounting so a failed pass is
+   * distinguishable from a clean one with zero findings. `false` on the
+   * healthy path and when the pass was skipped (diff/staged scans).
    */
   readonly securityScanFailed: boolean;
   /**
@@ -469,7 +473,7 @@ export const runInspect = <HooksR = never>(
     // `suppressScanSummary`. Gating avoids a redundant full-tree walk on
     // every single-project / `diagnose()` run — for a full scan the linter
     // already enumerates the same files, so we'd otherwise list twice.
-    const scannedFilePaths = input.suppressScanSummary
+    const fallbackScannedFilePaths = input.suppressScanSummary
       ? (lintIncludePaths ?? (yield* filesService.listSourceFiles(scanDirectory))).map(
           (relativePath) => path.resolve(scanDirectory, relativePath),
         )
@@ -779,6 +783,7 @@ export const runInspect = <HooksR = never>(
     let deadCodeCacheHit: boolean | null = null;
     let deadCodeSummaryCacheHits: number | null = null;
     let deadCodeSummaryCacheMisses: number | null = null;
+    const lintFileCoverageState: { value: LintFileCoverage | null } = { value: null };
 
     const baseLintStream = linterService
       .run({
@@ -799,6 +804,9 @@ export const runInspect = <HooksR = never>(
               `Scanning files (${scannedFileCount}/${totalFileCount})${workerCountSuffix}...`,
             ),
           );
+        },
+        onFileCoverage: (coverage) => {
+          lintFileCoverageState.value = coverage;
         },
         onCacheStats: (cacheHitFileCount, totalConsideredFileCount) => {
           lintCacheHitFileCount = cacheHitFileCount;
@@ -868,8 +876,35 @@ export const runInspect = <HooksR = never>(
     // short of N even though every file was scanned (issue #815). Resolve the
     // full total now and carry it into the dead-code label so "scanned N files"
     // stays visible for the whole (longer) dead-code pass.
+    const candidateFiles =
+      lintFileCoverageState.value === null
+        ? []
+        : [
+            ...new Set(
+              lintFileCoverageState.value.candidateFiles.map((filePath) =>
+                filePath.replaceAll("\\", "/"),
+              ),
+            ),
+          ];
+    const analyzedFiles =
+      lintFileCoverageState.value === null
+        ? []
+        : [
+            ...new Set(
+              lintFileCoverageState.value.analyzedFiles.map((filePath) =>
+                toNormalizedRelativePath(filePath, scanDirectory),
+              ),
+            ),
+          ].sort();
     const totalFileCount =
-      lastReportedTotalFileCount || (lintIncludePaths?.length ?? project.sourceFileCount);
+      candidateFiles.length ||
+      lastReportedTotalFileCount ||
+      (lintIncludePaths?.length ?? project.sourceFileCount);
+    const scannedFilePaths = input.suppressScanSummary
+      ? candidateFiles.length > 0
+        ? candidateFiles.map((filePath) => path.resolve(scanDirectory, filePath))
+        : fallbackScannedFilePaths
+      : [];
     const scannedFilesLabel = `${totalFileCount} ${totalFileCount === 1 ? "file" : "files"}`;
 
     // Resolve dead-code now that lint has settled. Three paths:
@@ -1026,6 +1061,7 @@ export const runInspect = <HooksR = never>(
       deadCodeOverlapped: shouldOverlapDeadCode,
       scannedFileCount: totalFileCount,
       scannedFilePaths,
+      analyzedFiles,
       scanElapsedMilliseconds,
       scanConcurrency,
       supplyChainOverlapTimedOut: supplyChainResult.timedOut,

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -81,6 +81,7 @@ interface RunOxlintOptions {
    * mode, or a logger message in human mode).
    */
   onPartialFailure?: (reason: string) => void;
+  onFileCoverage?: (coverage: RunOxlintFileCoverage) => void;
   onFileProgress?: (scannedFileCount: number, totalFileCount: number) => void;
   /**
    * Enables the per-file lint cache, resolved from the
@@ -144,6 +145,11 @@ interface RunOxlintOptions {
    * are untouched.
    */
   lintBatchOrdering?: "cost" | "arrival";
+}
+
+export interface RunOxlintFileCoverage {
+  readonly candidateFiles: ReadonlyArray<string>;
+  readonly analyzedFiles: ReadonlyArray<string>;
 }
 
 /**
@@ -367,6 +373,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     userConfig,
     configSourceDirectory = rootDirectory,
     onPartialFailure,
+    onFileCoverage,
     perFileLintCacheEnabled = false,
     sidecarLintCacheEnabled = false,
     onCacheStats,
@@ -393,6 +400,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   resetManifestCaches();
 
   if (includePaths !== undefined && includePaths.length === 0) {
+    onFileCoverage?.({ candidateFiles: [], analyzedFiles: [] });
     return [];
   }
 
@@ -548,11 +556,17 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       fileProgress: ((scannedFileCount: number, totalFileCount: number) => void) | undefined,
     ): Promise<{
       diagnostics: Diagnostic[];
+      analyzedFiles: ReadonlyArray<string>;
       didDropReactHooksJsPlugin: boolean;
       hadPartialFailure: boolean;
     }> => {
       if (files.length === 0) {
-        return { diagnostics: [], didDropReactHooksJsPlugin: false, hadPartialFailure: false };
+        return {
+          diagnostics: [],
+          analyzedFiles: [],
+          didDropReactHooksJsPlugin: false,
+          hadPartialFailure: false,
+        };
       }
       // A file dropped by the binary-split retry (timeout / OOM) produces no
       // diagnostics — indistinguishable from a clean file by output alone. Track
@@ -565,14 +579,19 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       const passConfigPath = path.join(configDirectory, configFileName);
       const passBaseArgs = makeBaseArgs(passConfigPath);
       const passFileBatches = buildFileBatches(passBaseArgs, files);
-      const spawnPass = () =>
-        spawnLintBatches({
+      let analyzedFiles: ReadonlyArray<string> = [];
+      const spawnPass = () => {
+        analyzedFiles = [];
+        return spawnLintBatches({
           baseArgs: passBaseArgs,
           fileBatches: passFileBatches,
           rootDirectory,
           nodeBinaryPath,
           project,
           onPartialFailure: reportPartialFailure,
+          onAnalyzedFiles: (filePaths) => {
+            analyzedFiles = filePaths;
+          },
           onFileProgress: fileProgress,
           spawnTimeoutMs,
           outputMaxBytes,
@@ -580,17 +599,28 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
           signal: options.signal,
           deadlineEpochMs: options.deadlineEpochMs,
         });
+      };
       writeOxlintConfig(passConfigPath, buildConfigForPass({}));
       try {
         const diagnostics = await spawnPass();
-        return { diagnostics, didDropReactHooksJsPlugin: false, hadPartialFailure };
+        return {
+          diagnostics,
+          analyzedFiles,
+          didDropReactHooksJsPlugin: false,
+          hadPartialFailure,
+        };
       } catch (error) {
         const reactHooksJsDropNote = reactHooksJsPluginDropNote(error);
         if (reactHooksJsDropNote === null) throw error;
         writeOxlintConfig(passConfigPath, buildConfigForPass({ disableReactHooksJsPlugin: true }));
         const diagnostics = await spawnPass();
         reportPartialFailure(reactHooksJsDropNote);
-        return { diagnostics, didDropReactHooksJsPlugin: true, hadPartialFailure };
+        return {
+          diagnostics,
+          analyzedFiles,
+          didDropReactHooksJsPlugin: true,
+          hadPartialFailure,
+        };
       }
     };
 
@@ -749,6 +779,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       // map lookups over the hashes computed above; the loop still stats
       // package.json / tsconfig probes, so it shares the cooperative budget.
       const sidecarReplayedDiagnostics: Diagnostic[] = [];
+      const sidecarReplayedFiles: string[] = [];
       const sidecarLintFiles: string[] = [];
       if (sidecarCache === null) {
         sidecarLintFiles.push(...hitFiles);
@@ -762,8 +793,10 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
             entry.probes.every(
               (probe) => probeAnswers.answerFor(probe.kind, probe.path) === probe.answer,
             );
-          if (isReplayable) sidecarReplayedDiagnostics.push(...entry.diagnostics);
-          else sidecarLintFiles.push(hitFile);
+          if (isReplayable) {
+            sidecarReplayedFiles.push(hitFile);
+            sidecarReplayedDiagnostics.push(...entry.diagnostics);
+          } else sidecarLintFiles.push(hitFile);
           if (performance.now() - verifySliceStartedAt >= COOPERATIVE_YIELD_BUDGET_MS) {
             await yieldToEventLoop();
             verifySliceStartedAt = performance.now();
@@ -821,7 +854,12 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
               hitFiles,
               undefined,
             )
-          : { diagnostics: [], didDropReactHooksJsPlugin: false, hadPartialFailure: false };
+          : {
+              diagnostics: [],
+              analyzedFiles: [],
+              didDropReactHooksJsPlugin: false,
+              hadPartialFailure: false,
+            };
 
       const freshCacheableDiagnostics: Diagnostic[] = [];
       for (const diagnostic of fullResult.diagnostics) {
@@ -884,6 +922,22 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         });
       }
 
+      const analyzedFileSet = new Set(fullResult.analyzedFiles);
+      const boundedSidecarAnalyzedFileSet = new Set(boundedSidecarResult.analyzedFiles);
+      const unboundedSidecarAnalyzedFileSet = new Set(unboundedSidecarResult.analyzedFiles);
+      const sidecarReplayedFileSet = new Set(sidecarReplayedFiles);
+      for (const hitFile of hitFiles) {
+        const didAnalyzeSidecar = useSidecarCache
+          ? (sidecarReplayedFileSet.has(hitFile) || boundedSidecarAnalyzedFileSet.has(hitFile)) &&
+            (unboundedSidecarRuleIds.length === 0 || unboundedSidecarAnalyzedFileSet.has(hitFile))
+          : boundedSidecarAnalyzedFileSet.has(hitFile);
+        if (didAnalyzeSidecar) analyzedFileSet.add(hitFile);
+      }
+      onFileCoverage?.({
+        candidateFiles,
+        analyzedFiles: candidateFiles.filter((candidateFile) => analyzedFileSet.has(candidateFile)),
+      });
+
       // Dedupe the merged result to match the non-cached path (which dedupes
       // at the end of `spawnLintBatches`): a duplicate path in `includePaths`
       // replays the same cached set twice, which dedupe collapses — so warm
@@ -899,6 +953,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
 
     const baseArgs = makeBaseArgs(configPath);
     const fileBatches = buildFileBatches(baseArgs, candidateFiles);
+    let analyzedFiles: ReadonlyArray<string> = [];
 
     const runBatches = () =>
       spawnLintBatches({
@@ -908,6 +963,9 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         nodeBinaryPath,
         project,
         onPartialFailure,
+        onAnalyzedFiles: (filePaths) => {
+          analyzedFiles = filePaths;
+        },
         onFileProgress: options.onFileProgress,
         spawnTimeoutMs,
         outputMaxBytes,
@@ -918,7 +976,9 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
 
     writeOxlintConfig(configPath, buildConfig({ extendsPaths }));
     try {
-      return await runBatches();
+      const diagnostics = await runBatches();
+      onFileCoverage?.({ candidateFiles, analyzedFiles });
+      return diagnostics;
     } catch (error) {
       // The optional `react-hooks-js` React Compiler plugin failed to
       // `import()` in this environment. oxlint fails the ENTIRE config
@@ -936,6 +996,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         );
         const diagnostics = await runBatches();
         onPartialFailure?.(reactHooksJsDropNote);
+        onFileCoverage?.({ candidateFiles, analyzedFiles });
         return diagnostics;
       }
       // HACK: if the user's adopted lint config is the reason oxlint
@@ -952,7 +1013,9 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
       // through — most importantly `userPlugins`, so custom rules from
       // `config.plugins` still run on the retry.
       writeOxlintConfig(configPath, buildConfig({ extendsPaths: [] }));
-      return await runBatches();
+      const diagnostics = await runBatches();
+      onFileCoverage?.({ candidateFiles, analyzedFiles });
+      return diagnostics;
     }
   } finally {
     restoreDisableDirectives();

--- a/packages/core/src/runners/oxlint/spawn-batches.ts
+++ b/packages/core/src/runners/oxlint/spawn-batches.ts
@@ -46,6 +46,7 @@ export interface SpawnLintBatchesInput {
   readonly nodeBinaryPath: string;
   readonly project: ProjectInfo;
   readonly onPartialFailure?: (reason: string) => void;
+  readonly onAnalyzedFiles?: (filePaths: ReadonlyArray<string>) => void;
   readonly onFileProgress?: (scannedFileCount: number, totalFileCount: number) => void;
   /** Per-batch wall-clock budget (from `OxlintSpawnTimeoutMs`). */
   readonly spawnTimeoutMs?: number;
@@ -420,6 +421,10 @@ export const spawnLintBatches = async (input: SpawnLintBatchesInput): Promise<Di
     outcome.deadlineSkippedFiles,
     (fileListPreview) =>
       `${outcome.deadlineSkippedFiles.length} file(s) skipped — max scan duration reached before they were linted (${fileListPreview})`,
+  );
+  const unavailableFiles = new Set([...droppedFiles, ...outcome.deadlineSkippedFiles]);
+  input.onAnalyzedFiles?.(
+    [...new Set(fileBatches.flat().filter((filePath) => !unavailableFiles.has(filePath)))].sort(),
   );
   return dedupeDiagnostics(diagnostics);
 };

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,3 +1,4 @@
+import { FRAMEWORK_TOKENS } from "oxlint-plugin-react-doctor";
 import * as Schema from "effect/Schema";
 
 export const Severity = Schema.Literals(["error", "warning"]);
@@ -39,6 +40,34 @@ export class Diagnostic extends Schema.Class<Diagnostic>("Diagnostic")({
   fixGroupId: Schema.optional(Schema.String),
 }) {}
 
+export class JsonReportDiagnosticV3 extends Schema.Class<JsonReportDiagnosticV3>(
+  "JsonReportDiagnosticV3",
+)({
+  id: Schema.String,
+  normalizedFilePath: Schema.String,
+  filePath: Schema.String,
+  plugin: Schema.String,
+  rule: Schema.String,
+  severity: Severity,
+  tags: Schema.Array(Schema.String),
+  title: Schema.optional(Schema.String),
+  message: Schema.String,
+  help: Schema.String,
+  url: Schema.optional(Schema.String),
+  line: Schema.Number,
+  column: Schema.Number,
+  offset: Schema.optional(Schema.Number),
+  length: Schema.optional(Schema.Number),
+  endLine: Schema.optional(Schema.Number),
+  endColumn: Schema.optional(Schema.Number),
+  category: Schema.String,
+  matchByOccurrence: Schema.optional(Schema.Boolean),
+  fileContext: Schema.optional(Schema.Literals(["test", "story"])),
+  suppressionHint: Schema.optional(Schema.String),
+  relatedLocations: Schema.optional(Schema.Array(DiagnosticRelatedLocation)),
+  fixGroupId: Schema.optional(Schema.String),
+}) {}
+
 /**
  * Deterministic identity string for a diagnostic. Same diagnostic
  * across two scans yields the same identity; lets baselines,
@@ -55,6 +84,8 @@ export const buildDiagnosticIdentity = (input: {
 
 export const JsonReportMode = Schema.Literals(["full", "diff", "staged", "baseline"]);
 export type JsonReportMode = Schema.Schema.Type<typeof JsonReportMode>;
+
+export const Framework = Schema.Literals(FRAMEWORK_TOKENS);
 
 export class JsonReportSummary extends Schema.Class<JsonReportSummary>("JsonReportSummary")({
   errorCount: Schema.Number,
@@ -99,13 +130,25 @@ export class JsonReportProjectEntry extends Schema.Class<JsonReportProjectEntry>
   elapsedMilliseconds: Schema.Number,
 }) {}
 
-/**
- * Versioned JsonReport schema. `JsonReport` is a `Schema.Union` so we
- * can add `schemaVersion: 2` later as one new union member without
- * breaking existing v1 consumers (the GitHub Action keys off the
- * version literal). Today's union is single-arm; the shape is
- * intentional.
- */
+export class JsonReportProjectEntryV3 extends Schema.Class<JsonReportProjectEntryV3>(
+  "JsonReportProjectEntryV3",
+)({
+  directory: Schema.String,
+  packageRoot: Schema.String,
+  framework: Framework,
+  project: Schema.Unknown,
+  diagnostics: Schema.Array(JsonReportDiagnosticV3),
+  score: Schema.Unknown,
+  skippedChecks: Schema.Array(Schema.String),
+  skippedCheckReasons: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  analyzedFiles: Schema.Array(Schema.String),
+  analyzedFileCount: Schema.Number,
+  complete: Schema.Boolean,
+  scannedFileCount: Schema.optional(Schema.Number),
+  elapsedMilliseconds: Schema.Number,
+}) {}
+
+/** Original full, diff, and staged report contract. */
 export class JsonReportV1 extends Schema.Class<JsonReportV1>("JsonReportV1")({
   schemaVersion: Schema.Literal(1),
   version: Schema.String,
@@ -169,5 +212,22 @@ export class JsonReportV2 extends Schema.Class<JsonReportV2>("JsonReportV2")({
   error: Schema.NullOr(JsonReportError),
 }) {}
 
-export const JsonReport = Schema.Union([JsonReportV1, JsonReportV2]);
+export class JsonReportV3 extends Schema.Class<JsonReportV3>("JsonReportV3")({
+  schemaVersion: Schema.Literal(3),
+  version: Schema.String,
+  ok: Schema.Boolean,
+  directory: Schema.String,
+  mode: JsonReportMode,
+  baselineDegraded: Schema.optional(Schema.Boolean),
+  reactDetected: Schema.optional(Schema.Boolean),
+  diff: Schema.NullOr(JsonReportDiffInfo),
+  baseline: Schema.optional(JsonReportBaseline),
+  projects: Schema.Array(JsonReportProjectEntryV3),
+  diagnostics: Schema.Array(JsonReportDiagnosticV3),
+  summary: JsonReportSummary,
+  elapsedMilliseconds: Schema.Number,
+  error: Schema.NullOr(JsonReportError),
+}) {}
+
+export const JsonReport = Schema.Union([JsonReportV1, JsonReportV2, JsonReportV3]);
 export type JsonReport = Schema.Schema.Type<typeof JsonReport>;

--- a/packages/core/src/services/linter.ts
+++ b/packages/core/src/services/linter.ts
@@ -45,6 +45,7 @@ export interface LintInput {
   readonly userConfig?: ReactDoctorConfig | null;
   readonly configSourceDirectory?: string;
   readonly nodeBinaryPath?: string;
+  readonly onFileCoverage?: (coverage: LintFileCoverage) => void;
   readonly onFileProgress?: (scannedFileCount: number, totalFileCount: number) => void;
   readonly onCacheStats?: (cacheHitFileCount: number, totalConsideredFileCount: number) => void;
   /** See `RunOxlintOptions.onSidecarStats`. */
@@ -54,6 +55,11 @@ export interface LintInput {
   ) => void;
   /** See `RunOxlintOptions.deadlineEpochMs`. */
   readonly deadlineEpochMs?: number;
+}
+
+export interface LintFileCoverage {
+  readonly candidateFiles: ReadonlyArray<string>;
+  readonly analyzedFiles: ReadonlyArray<string>;
 }
 
 /**
@@ -144,6 +150,7 @@ export class Linter extends Context.Service<
                   onPartialFailure: (reason) => {
                     collectedFailures.push(reason);
                   },
+                  onFileCoverage: input.onFileCoverage,
                   onFileProgress: input.onFileProgress,
                   perFileLintCacheEnabled,
                   sidecarLintCacheEnabled,

--- a/packages/core/src/types/diagnose.ts
+++ b/packages/core/src/types/diagnose.ts
@@ -33,6 +33,10 @@ export interface DiagnoseResult {
   skippedChecks: string[];
   /** See `InspectResult.skippedCheckReasons`. */
   skippedCheckReasons?: Record<string, string>;
+  /** See `InspectResult.analyzedFiles`. */
+  analyzedFiles?: ReadonlyArray<string>;
+  /** See `InspectResult.scannedFileCount`. */
+  scannedFileCount?: number;
   project: ProjectInfo;
   /**
    * Whether the scanned project resolved a React-compatible runtime (React

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -34,11 +34,16 @@ export type {
   InspectOptions,
   InspectResult,
   JsonReport,
+  JsonReportDiagnosticV3,
   JsonReportDiffInfo,
   JsonReportError,
   JsonReportMode,
   JsonReportProjectEntry,
+  JsonReportProjectEntryV3,
   JsonReportSummary,
+  JsonReportV1,
+  JsonReportV2,
+  JsonReportV3,
 } from "./inspect.js";
 export type {
   DependencyInfo,

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -34,6 +34,12 @@ export interface InspectResult {
    */
   scannedFilePaths?: ReadonlyArray<string>;
   /**
+   * Sorted, deduplicated project-relative POSIX paths whose lint analysis
+   * completed successfully. Empty when lint did not run or failed before any
+   * file completed.
+   */
+  analyzedFiles?: ReadonlyArray<string>;
+  /**
    * Wall-clock duration of the scan phase, in milliseconds. Distinct
    * from `elapsedMilliseconds` (which spans the full `inspect()` call
    * including score fetch + rendering). Used by the multi-project
@@ -317,6 +323,28 @@ export interface JsonReportProjectEntry {
   elapsedMilliseconds: number;
 }
 
+export interface JsonReportDiagnosticV3 extends Diagnostic {
+  id: string;
+  normalizedFilePath: string;
+  tags: string[];
+}
+
+export interface JsonReportProjectEntryV3 {
+  directory: string;
+  packageRoot: string;
+  framework: ProjectInfo["framework"];
+  project: ProjectInfo;
+  diagnostics: JsonReportDiagnosticV3[];
+  score: ScoreResult | null;
+  skippedChecks: string[];
+  skippedCheckReasons?: Record<string, string>;
+  analyzedFiles: string[];
+  analyzedFileCount: number;
+  complete: boolean;
+  scannedFileCount?: number;
+  elapsedMilliseconds: number;
+}
+
 export interface JsonReportSummary {
   errorCount: number;
   warningCount: number;
@@ -345,6 +373,7 @@ export interface JsonReportV1 {
   ok: boolean;
   directory: string;
   mode: JsonReportMode;
+  baselineDegraded?: boolean;
   /**
    * Whether any scanned project resolved a React-compatible runtime (React
    * or Preact). `false` means every React-runtime rule family was gated off,
@@ -376,9 +405,19 @@ export interface JsonReportV1 {
  * are the *introduced* findings only; `summary.score` is still the head
  * scan's project-health score. New consumers branch on `schemaVersion === 2`.
  */
-export interface JsonReportV2 extends Omit<JsonReportV1, "schemaVersion"> {
+export interface JsonReportV2 extends Omit<JsonReportV1, "schemaVersion" | "baselineDegraded"> {
   schemaVersion: 2;
   baseline: JsonReportBaselineInfo;
 }
 
-export type JsonReport = JsonReportV1 | JsonReportV2;
+export interface JsonReportV3 extends Omit<
+  JsonReportV1,
+  "schemaVersion" | "projects" | "diagnostics"
+> {
+  schemaVersion: 3;
+  baseline?: JsonReportBaselineInfo;
+  projects: JsonReportProjectEntryV3[];
+  diagnostics: JsonReportDiagnosticV3[];
+}
+
+export type JsonReport = JsonReportV1 | JsonReportV2 | JsonReportV3;

--- a/packages/core/src/utils/is-scan-complete.ts
+++ b/packages/core/src/utils/is-scan-complete.ts
@@ -1,0 +1,13 @@
+export interface ScanCompletionInput {
+  readonly analyzedFileCount: number | undefined;
+  readonly scannedFileCount: number | undefined;
+  readonly skippedCheckCount: number;
+  readonly skippedCheckReasonCount: number;
+}
+
+export const isScanComplete = (input: ScanCompletionInput): boolean =>
+  input.analyzedFileCount !== undefined &&
+  input.scannedFileCount !== undefined &&
+  input.skippedCheckCount === 0 &&
+  input.skippedCheckReasonCount === 0 &&
+  input.analyzedFileCount === input.scannedFileCount;

--- a/packages/core/src/utils/to-normalized-relative-path.ts
+++ b/packages/core/src/utils/to-normalized-relative-path.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
-import { toRelativePath } from "./to-relative-path.js";
 
 export const toNormalizedRelativePath = (filePath: string, rootDirectory: string): string =>
-  toRelativePath(path.resolve(rootDirectory, filePath), path.resolve(rootDirectory));
+  path
+    .relative(path.resolve(rootDirectory), path.resolve(rootDirectory, filePath))
+    .replaceAll("\\", "/") || ".";

--- a/packages/core/src/utils/to-normalized-relative-path.ts
+++ b/packages/core/src/utils/to-normalized-relative-path.ts
@@ -1,0 +1,5 @@
+import * as path from "node:path";
+import { toRelativePath } from "./to-relative-path.js";
+
+export const toNormalizedRelativePath = (filePath: string, rootDirectory: string): string =>
+  toRelativePath(path.resolve(rootDirectory, filePath), path.resolve(rootDirectory));

--- a/packages/core/tests/build-json-report.test.ts
+++ b/packages/core/tests/build-json-report.test.ts
@@ -41,28 +41,56 @@ const result = (overrides: Partial<InspectResult> = {}): InspectResult => ({
   diagnostics: [errorDiagnostic],
   score: { score: 88, label: "Good" },
   skippedChecks: [],
+  analyzedFiles: ["src/App.tsx"],
   project: projectInfo,
   elapsedMilliseconds: 1000,
+  scannedFileCount: 1,
   ...overrides,
 });
 
 describe("buildJsonReport", () => {
-  it("emits a v1 report without baseline info", () => {
+  it("emits a v3 report with deterministic diagnostic identity and exact coverage", () => {
     const report = buildJsonReport({
       version: "1.2.3",
       directory: "/repo",
       mode: "diff",
       diff: null,
-      scans: [{ directory: "/repo", result: result() }],
+      scans: [
+        {
+          directory: "/repo",
+          result: result({
+            diagnostics: [{ ...errorDiagnostic, filePath: "/repo/src/../src/App.tsx" }],
+          }),
+        },
+      ],
       totalElapsedMilliseconds: 1200,
     });
-    expect(report.schemaVersion).toBe(1);
+    expect(report.schemaVersion).toBe(3);
     expect(report.mode).toBe("diff");
     expect("baseline" in report).toBe(false);
     expect("baselineDegraded" in report).toBe(false);
+    expect(report.projects[0]).toMatchObject({
+      packageRoot: "/repo",
+      framework: "nextjs",
+      analyzedFiles: ["src/App.tsx"],
+      analyzedFileCount: 1,
+      complete: true,
+    });
+    expect(report.diagnostics[0]).toMatchObject({
+      id: "src/App.tsx::12:1::react-doctor/no-array-index-as-key",
+      normalizedFilePath: "src/App.tsx",
+      filePath: "/repo/src/../src/App.tsx",
+      plugin: "react-doctor",
+      rule: "no-array-index-as-key",
+      category: "Correctness",
+      severity: "error",
+    });
+    expect(report.diagnostics[0].tags).toEqual([...report.diagnostics[0].tags].sort());
+    expect(report.diagnostics[0]).not.toHaveProperty("ruleId");
+    expect(report.diagnostics[0]).not.toHaveProperty("location");
   });
 
-  it("marks a v1 report baselineDegraded when a compare run couldn't diff the base", () => {
+  it("marks a v3 report baselineDegraded when a compare run couldn't diff the base", () => {
     const report = buildJsonReport({
       version: "1.2.3",
       directory: "/repo",
@@ -72,10 +100,54 @@ describe("buildJsonReport", () => {
       totalElapsedMilliseconds: 1200,
       baselineDegraded: true,
     });
-    expect(report.schemaVersion).toBe(1);
+    expect(report.schemaVersion).toBe(3);
     expect(report.mode).toBe("diff");
-    if (report.schemaVersion !== 1) throw new Error("expected a v1 report");
     expect(report.baselineDegraded).toBe(true);
+  });
+
+  it("sorts and deduplicates analyzed files and marks partial coverage incomplete", () => {
+    const report = buildJsonReport({
+      version: "1.2.3",
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      scans: [
+        {
+          directory: "/repo",
+          result: result({
+            analyzedFiles: ["src/B.tsx", "src\\A.tsx", "src/B.tsx"],
+            scannedFileCount: 3,
+          }),
+        },
+      ],
+      totalElapsedMilliseconds: 1200,
+    });
+    expect(report.projects[0].analyzedFiles).toEqual(["src/A.tsx", "src/B.tsx"]);
+    expect(report.projects[0].analyzedFileCount).toBe(2);
+    expect(report.projects[0].complete).toBe(false);
+  });
+
+  it("marks a fully analyzed project incomplete when a partial check reason exists", () => {
+    const report = buildJsonReport({
+      version: "1.2.3",
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      scans: [
+        {
+          directory: "/repo",
+          result: result({
+            skippedCheckReasons: {
+              "lint:partial": "React Hooks rules were skipped after their plugin failed to load.",
+            },
+          }),
+        },
+      ],
+      totalElapsedMilliseconds: 1200,
+    });
+    expect(report.projects[0].analyzedFileCount).toBe(report.projects[0].scannedFileCount);
+    expect(report.projects[0].skippedChecks).toEqual([]);
+    expect(report.projects[0].complete).toBe(false);
   });
 
   it("marks reactDetected true on a scan that resolved a React runtime", () => {
@@ -171,7 +243,7 @@ describe("buildJsonReport", () => {
     expect("reactDetected" in report).toBe(false);
   });
 
-  it("emits a v2 baseline report carrying the new/fixed delta and head score", () => {
+  it("emits a v3 baseline report carrying the new/fixed delta and head score", () => {
     const report = buildJsonReport({
       version: "1.2.3",
       directory: "/repo",
@@ -181,13 +253,12 @@ describe("buildJsonReport", () => {
       totalElapsedMilliseconds: 1200,
       baseline: { baseRef: "abc1234def", fixedCount: 3, baseTotalCount: 5 },
     });
-    expect(report.schemaVersion).toBe(2);
+    expect(report.schemaVersion).toBe(3);
     expect(report.mode).toBe("baseline");
-    if (report.schemaVersion !== 2) throw new Error("expected a v2 report");
-    expect(report.baseline.baseRef).toBe("abc1234def");
-    expect(report.baseline.newCount).toBe(1); // one introduced finding
-    expect(report.baseline.fixedCount).toBe(3);
-    expect(report.baseline.baseTotalCount).toBe(5);
+    expect(report.baseline?.baseRef).toBe("abc1234def");
+    expect(report.baseline?.newCount).toBe(1); // one introduced finding
+    expect(report.baseline?.fixedCount).toBe(3);
+    expect(report.baseline?.baseTotalCount).toBe(5);
     // Score stays the head project-health number; counts reflect introduced only.
     expect(report.summary.score).toBe(88);
     expect(report.summary.totalDiagnosticCount).toBe(1);

--- a/packages/core/tests/build-json-report.test.ts
+++ b/packages/core/tests/build-json-report.test.ts
@@ -90,6 +90,47 @@ describe("buildJsonReport", () => {
     expect(report.diagnostics[0]).not.toHaveProperty("location");
   });
 
+  it("scopes diagnostic identities and affected file counts to workspace projects", () => {
+    const firstProject = {
+      ...projectInfo,
+      rootDirectory: "/repo/packages/first",
+      projectName: "first",
+    };
+    const secondProject = {
+      ...projectInfo,
+      rootDirectory: "/repo/packages/second",
+      projectName: "second",
+    };
+    const report = buildJsonReport({
+      version: "1.2.3",
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      scans: [
+        {
+          directory: firstProject.rootDirectory,
+          result: result({ project: firstProject }),
+        },
+        {
+          directory: secondProject.rootDirectory,
+          result: result({ project: secondProject }),
+        },
+      ],
+      totalElapsedMilliseconds: 1200,
+    });
+
+    expect(report.diagnostics.map((diagnostic) => diagnostic.normalizedFilePath)).toEqual([
+      "src/App.tsx",
+      "src/App.tsx",
+    ]);
+    expect(report.diagnostics.map((diagnostic) => diagnostic.id)).toEqual([
+      "packages/first/src/App.tsx::12:1::react-doctor/no-array-index-as-key",
+      "packages/second/src/App.tsx::12:1::react-doctor/no-array-index-as-key",
+    ]);
+    expect(new Set(report.diagnostics.map((diagnostic) => diagnostic.id)).size).toBe(2);
+    expect(report.summary.affectedFileCount).toBe(2);
+  });
+
   it("marks a v3 report baselineDegraded when a compare run couldn't diff the base", () => {
     const report = buildJsonReport({
       version: "1.2.3",

--- a/packages/core/tests/build-skipped-checks.test.ts
+++ b/packages/core/tests/build-skipped-checks.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildSkippedChecks } from "../src/build-skipped-checks.js";
+
+describe("buildSkippedChecks", () => {
+  it("preserves partial lint and failed auxiliary checks structurally", () => {
+    const result = buildSkippedChecks({
+      didLintFail: false,
+      lintFailureReason: null,
+      lintPartialFailures: ["React Hooks rules were skipped"],
+      didDeadCodeFail: false,
+      deadCodeFailureReason: null,
+      supplyChainOverlapTimedOut: true,
+      securityScanFailed: true,
+    });
+
+    expect(result.skippedChecks).toEqual(["supply-chain", "security-scan"]);
+    expect(result.skippedCheckReasons).toEqual({
+      "lint:partial": "React Hooks rules were skipped",
+      "supply-chain": "Supply-chain analysis timed out and was skipped.",
+      "security-scan": "Security scan failed and was skipped.",
+    });
+  });
+});

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -116,6 +116,7 @@ const supplyChainDiagnostic: Diagnostic = {
 
 const layersOf = (config: {
   diagnostics?: ReadonlyArray<Diagnostic>;
+  linter?: Layer.Layer<Linter>;
   deadCode?: ReadonlyArray<Diagnostic>;
   supplyChain?: ReadonlyArray<Diagnostic>;
   githubViewerPermission?: string | null;
@@ -128,7 +129,7 @@ const layersOf = (config: {
     Project.layerOf(sampleProject),
     Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
     Files.layerInMemory(new Map()),
-    Linter.layerOf(config.diagnostics ?? []),
+    config.linter ?? Linter.layerOf(config.diagnostics ?? []),
     LintPartialFailures.layerLive,
     DeadCode.layerOf(config.deadCode ?? []),
     Git.layerOf({
@@ -811,6 +812,31 @@ describe("runInspect — scan progress phases", () => {
 });
 
 describe("runInspect — diff mode skips dead-code", () => {
+  it("canonicalizes file coverage before counting completed include paths", async () => {
+    const coverageLinter = Layer.mock(Linter, {
+      run: (input) =>
+        Stream.unwrap(
+          Effect.sync(() => {
+            const includePaths = input.includePaths ?? [];
+            input.onFileCoverage?.({
+              candidateFiles: includePaths,
+              analyzedFiles: includePaths,
+            });
+            return Stream.empty;
+          }),
+        ),
+    });
+    const output = await Effect.runPromise(
+      runInspect({
+        ...baseInput,
+        includePaths: ["src/App.tsx", "./src/App.tsx"],
+      }).pipe(Effect.provide(layersOf({ linter: coverageLinter }))),
+    );
+
+    expect(output.scannedFileCount).toBe(1);
+    expect(output.analyzedFiles).toEqual(["src/App.tsx"]);
+  });
+
   it("treats includePaths.length > 0 as diff mode and skips DeadCode.run", async () => {
     const output = await Effect.runPromise(
       runInspect({ ...baseInput, includePaths: ["src/App.tsx"] }).pipe(

--- a/packages/core/tests/schemas.test.ts
+++ b/packages/core/tests/schemas.test.ts
@@ -1,6 +1,12 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
-import { buildDiagnosticIdentity, JsonReportV1, Severity } from "@react-doctor/core";
+import {
+  buildDiagnosticIdentity,
+  JsonReportV1,
+  JsonReportV2,
+  JsonReportV3,
+  Severity,
+} from "@react-doctor/core";
 // `Diagnostic` and `JsonReport` are imported directly from the
 // `schemas.js` module rather than the package barrel because the
 // barrel intentionally elides them — the same names exist as TS
@@ -240,6 +246,107 @@ describe("JsonReport (v1)", () => {
           scoreLabel: null,
         },
         elapsedMilliseconds: 0,
+        error: null,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("JsonReport version compatibility", () => {
+  const summary = {
+    errorCount: 0,
+    warningCount: 0,
+    affectedFileCount: 0,
+    totalDiagnosticCount: 0,
+    score: null,
+    scoreLabel: null,
+  };
+
+  it("retains v2 decoding", () => {
+    const decoded = Schema.decodeUnknownSync(JsonReport)({
+      schemaVersion: 2,
+      version: "0.7.4",
+      ok: true,
+      directory: "/repo",
+      mode: "baseline",
+      diff: null,
+      baseline: {
+        baseRef: "abc123",
+        newCount: 0,
+        fixedCount: 1,
+        baseTotalCount: 1,
+      },
+      projects: [],
+      diagnostics: [],
+      summary,
+      elapsedMilliseconds: 10,
+      error: null,
+    });
+    expect(decoded.schemaVersion).toBe(2);
+    expect(decoded instanceof JsonReportV2).toBe(true);
+  });
+
+  it("decodes the dedicated v3 coverage schemas", () => {
+    const decoded = Schema.decodeUnknownSync(JsonReport)({
+      schemaVersion: 3,
+      version: "0.7.4",
+      ok: true,
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      projects: [
+        {
+          directory: "/repo",
+          packageRoot: ".",
+          framework: "vite",
+          project: {},
+          diagnostics: [],
+          score: null,
+          skippedChecks: [],
+          analyzedFiles: ["src/App.tsx"],
+          analyzedFileCount: 1,
+          complete: true,
+          scannedFileCount: 1,
+          elapsedMilliseconds: 10,
+        },
+      ],
+      diagnostics: [],
+      summary,
+      elapsedMilliseconds: 10,
+      error: null,
+    });
+    expect(decoded.schemaVersion).toBe(3);
+    expect(decoded instanceof JsonReportV3).toBe(true);
+  });
+
+  it("rejects a v3 project with an unknown framework", () => {
+    expect(() =>
+      Schema.decodeUnknownSync(JsonReport)({
+        schemaVersion: 3,
+        version: "0.7.4",
+        ok: true,
+        directory: "/repo",
+        mode: "full",
+        diff: null,
+        projects: [
+          {
+            directory: "/repo",
+            packageRoot: ".",
+            framework: "invalid-framework",
+            project: {},
+            diagnostics: [],
+            score: null,
+            skippedChecks: [],
+            analyzedFiles: ["src/App.tsx"],
+            analyzedFileCount: 1,
+            complete: true,
+            scannedFileCount: 1,
+            elapsedMilliseconds: 10,
+          },
+        ],
+        diagnostics: [],
+        summary,
+        elapsedMilliseconds: 10,
         error: null,
       }),
     ).toThrow();

--- a/packages/core/tests/spawn-batches.test.ts
+++ b/packages/core/tests/spawn-batches.test.ts
@@ -203,6 +203,21 @@ describe("spawnLintBatches — LPT batch-order invariance", () => {
       "src/c.tsx",
     ]);
   });
+
+  it("reports the exact sorted, deduplicated files analyzed successfully", async () => {
+    let analyzedFiles: ReadonlyArray<string> = [];
+    await spawnLintBatches({
+      baseArgs: ["-e", EMIT_ONE_DIAGNOSTIC_PER_FILE_SCRIPT],
+      fileBatches: [["src/b.tsx", "src/a.tsx"], ["src/a.tsx"]],
+      rootDirectory: process.cwd(),
+      nodeBinaryPath: process.execPath,
+      project,
+      onAnalyzedFiles: (filePaths) => {
+        analyzedFiles = filePaths;
+      },
+    });
+    expect(analyzedFiles).toEqual(["src/a.tsx", "src/b.tsx"]);
+  });
 });
 
 /**
@@ -214,6 +229,7 @@ describe("spawnLintBatches — LPT batch-order invariance", () => {
  */
 const lintFileBatchesWithDeadline = (fileBatches: string[][], deadlineEpochMs: number) => {
   const partialFailures: string[] = [];
+  let analyzedFiles: ReadonlyArray<string> = [];
   const diagnostics = spawnLintBatches({
     baseArgs: ["-e", EMIT_ONE_DIAGNOSTIC_PER_FILE_SCRIPT],
     fileBatches,
@@ -222,13 +238,16 @@ const lintFileBatchesWithDeadline = (fileBatches: string[][], deadlineEpochMs: n
     project,
     deadlineEpochMs,
     onPartialFailure: (reason) => partialFailures.push(reason),
+    onAnalyzedFiles: (filePaths) => {
+      analyzedFiles = filePaths;
+    },
   });
-  return { diagnostics, partialFailures };
+  return { diagnostics, partialFailures, readAnalyzedFiles: () => analyzedFiles };
 };
 
 describe("spawnLintBatches — max-duration deadline", () => {
   it("skips remaining batches past the deadline and reports the skipped files", async () => {
-    const { diagnostics, partialFailures } = lintFileBatchesWithDeadline(
+    const { diagnostics, partialFailures, readAnalyzedFiles } = lintFileBatchesWithDeadline(
       [["src/a.tsx"], ["src/b.tsx"], ["src/c.tsx"]],
       Date.now() - 1,
     );
@@ -238,6 +257,7 @@ describe("spawnLintBatches — max-duration deadline", () => {
     expect(partialFailures[0]).toContain("3 file(s) skipped");
     expect(partialFailures[0]).toContain("max scan duration reached");
     expect(partialFailures[0]).toContain("src/a.tsx");
+    expect(readAnalyzedFiles()).toEqual([]);
   });
 
   it("stops binary-split retries once the deadline passes mid-batch", async () => {

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -55,6 +55,14 @@ You can configure which rules to run and how to run them in `doctor.config.ts`.
 
 [Learn more →](https://react.doctor/docs/configuration/config-files)
 
+### 5. Consume JSON
+
+Use `--json` for stdout or `--json-out <path>` for a file. The default
+`schemaVersion: 3` report includes deterministic diagnostic IDs and exact
+per-project scan coverage.
+
+[JSON report contract →](./docs/json-report.md)
+
 ## Telemetry
 
 The CLI reports crashes, basic run traces, and anonymous usage counters to [Sentry](https://sentry.io/) to help us fix bugs and prioritize work.

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -1,6 +1,7 @@
 import {
   filterDiagnosticsForSurface,
   isReactDoctorError,
+  isScanComplete,
   resolveGithubActionsScoreMetadata,
   summarizeDiagnostics,
 } from "@react-doctor/core";
@@ -224,6 +225,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
     return withNamespace("outcome", {
       status: "error",
       exitCode: 1,
+      complete: false,
       knownError: known,
       errorTag: known ? error.reason._tag : error instanceof Error ? error.name : null,
     });
@@ -248,6 +250,12 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   const wouldBlock =
     !input.scoreOnly && !input.gateExempt && shouldBlockCi(gateDiagnostics, blockingLevel);
   const hasSkippedChecks = result.skippedChecks.length > 0;
+  const complete = isScanComplete({
+    analyzedFileCount: result.analyzedFiles?.length,
+    scannedFileCount: result.scannedFileCount,
+    skippedCheckCount: result.skippedChecks.length,
+    skippedCheckReasonCount: Object.keys(result.skippedCheckReasons ?? {}).length,
+  });
   const isClean = result.diagnostics.length === 0 && !hasSkippedChecks;
   const outcome = wouldBlock ? "blocked" : isClean ? "clean" : "ok";
 
@@ -330,6 +338,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
       wouldBlock,
       blocking: blockingLevel,
       clean: isClean,
+      complete,
       skippedChecks: result.skippedChecks.length,
     }),
     ...withNamespace("diag", {

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -249,14 +249,13 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   // gate too — keep `outcome.wouldBlock`/`outcome.status`/`outcome.exitCode` consistent with the real exit.
   const wouldBlock =
     !input.scoreOnly && !input.gateExempt && shouldBlockCi(gateDiagnostics, blockingLevel);
-  const hasSkippedChecks = result.skippedChecks.length > 0;
   const complete = isScanComplete({
     analyzedFileCount: result.analyzedFiles?.length,
     scannedFileCount: result.scannedFileCount,
     skippedCheckCount: result.skippedChecks.length,
     skippedCheckReasonCount: Object.keys(result.skippedCheckReasons ?? {}).length,
   });
-  const isClean = result.diagnostics.length === 0 && !hasSkippedChecks;
+  const isClean = result.diagnostics.length === 0 && complete;
   const outcome = wouldBlock ? "blocked" : isClean ? "clean" : "ok";
 
   const firings = summarizeRuleFirings(result.diagnostics);

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -124,7 +124,7 @@ export const MINIMUM_VTE_VERSION_FOR_HYPERLINKS = 5000;
 // Last-resort fallback when buildJsonReportError itself throws — keeps
 // stdout valid JSON so downstream parsers don't see a half-written report.
 export const INTERNAL_ERROR_JSON_FALLBACK =
-  '{"schemaVersion":3,"ok":false,"error":{"message":"Internal error","name":"Error","chain":[]}}\n';
+  '{"schemaVersion":3,"version":"unknown","ok":false,"directory":"","mode":"full","diff":null,"projects":[],"diagnostics":[],"summary":{"errorCount":0,"warningCount":0,"affectedFileCount":0,"totalDiagnosticCount":0,"score":null,"scoreLabel":null},"elapsedMilliseconds":0,"error":{"message":"Internal error","name":"Error","chain":[]}}\n';
 
 // Sentry DSN for CLI crash reporting. Public by design (DSNs are safe to
 // embed in client-side code) and only used by the CLI application entry,

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -29,7 +29,7 @@ export const BASELINE_FILES_TEMP_DIR_PREFIX = "react-doctor-baseline-";
 // Bumped to 3: gained the required `suppressedRuleCounts` field (suppression telemetry).
 // Bumped to 4: gained the `manifestContentHash` replay guard, which every
 // `lookup` verifies — pre-bump entries without it would never hit again.
-export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 4;
+export const SCAN_RESULT_CACHE_SCHEMA_VERSION = 5;
 export const SCAN_RESULT_CACHE_MAX_ENTRY_COUNT = 20;
 export const SCAN_RESULT_CACHE_FILENAME = "scan-cache.json";
 // The dirty-worktree cache-key fingerprint content-hashes every path `git
@@ -124,7 +124,7 @@ export const MINIMUM_VTE_VERSION_FOR_HYPERLINKS = 5000;
 // Last-resort fallback when buildJsonReportError itself throws — keeps
 // stdout valid JSON so downstream parsers don't see a half-written report.
 export const INTERNAL_ERROR_JSON_FALLBACK =
-  '{"schemaVersion":1,"ok":false,"error":{"message":"Internal error","name":"Error","chain":[]}}\n';
+  '{"schemaVersion":3,"ok":false,"error":{"message":"Internal error","name":"Error","chain":[]}}\n';
 
 // Sentry DSN for CLI crash reporting. Public by design (DSNs are safe to
 // embed in client-side code) and only used by the CLI application entry,

--- a/packages/react-doctor/src/cli/utils/scan-result-cache.ts
+++ b/packages/react-doctor/src/cli/utils/scan-result-cache.ts
@@ -40,6 +40,7 @@ export interface CachedScanPayload {
   readonly directory: string;
   readonly scannedFileCount: number;
   readonly scannedFilePaths: ReadonlyArray<string>;
+  readonly analyzedFiles?: ReadonlyArray<string>;
   readonly scanElapsedMilliseconds: number;
   readonly baselineDelta: InspectResult["baselineDelta"];
   readonly lintFailureReasonKind: InspectOutput["lintFailureReasonKind"];

--- a/packages/react-doctor/src/index.ts
+++ b/packages/react-doctor/src/index.ts
@@ -116,6 +116,10 @@ export const toJsonReport = (result: DiagnoseResult, options: ToJsonReportOption
           ...(result.skippedCheckReasons
             ? { skippedCheckReasons: result.skippedCheckReasons }
             : {}),
+          ...(result.analyzedFiles ? { analyzedFiles: result.analyzedFiles } : {}),
+          ...(typeof result.scannedFileCount === "number"
+            ? { scannedFileCount: result.scannedFileCount }
+            : {}),
           project: result.project,
           elapsedMilliseconds: result.elapsedMilliseconds,
         },

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -772,6 +772,7 @@ const runInspectWithRuntime = async (
     directory: output.resolvedDirectory,
     scannedFileCount: output.scannedFileCount,
     scannedFilePaths: output.scannedFilePaths,
+    analyzedFiles: output.analyzedFiles,
     scanElapsedMilliseconds: output.scanElapsedMilliseconds,
     scanConcurrency: output.scanConcurrency,
     baselineDelta,
@@ -829,9 +830,12 @@ interface FinalizeInput {
   lintPartialFailures: ReadonlyArray<string>;
   didDeadCodeFail: boolean;
   deadCodeFailureReason: string | null;
+  supplyChainOverlapTimedOut: boolean;
+  securityScanFailed: boolean;
   directory: string;
   scannedFileCount: number;
   scannedFilePaths: ReadonlyArray<string>;
+  analyzedFiles: ReadonlyArray<string>;
   scanElapsedMilliseconds: number;
   lintCacheHitFileCount: number | null;
   lintCacheTotalFileCount: number | null;
@@ -934,9 +938,12 @@ const renderAndRecordScan = async (input: RenderAndRecordScanInput): Promise<Ins
     lintPartialFailures: input.payload.lintPartialFailures,
     didDeadCodeFail: input.payload.didDeadCodeFail,
     deadCodeFailureReason: input.payload.deadCodeFailureReason,
+    supplyChainOverlapTimedOut: input.payload.supplyChainOverlapTimedOut,
+    securityScanFailed: input.payload.securityScanFailed ?? false,
     directory: input.payload.directory,
     scannedFileCount: input.payload.scannedFileCount,
     scannedFilePaths: input.payload.scannedFilePaths,
+    analyzedFiles: input.payload.analyzedFiles ?? [],
     scanElapsedMilliseconds: input.payload.scanElapsedMilliseconds,
     lintCacheHitFileCount: input.lintCacheHitFileCount ?? null,
     lintCacheTotalFileCount: input.lintCacheTotalFileCount ?? null,
@@ -1012,9 +1019,12 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       lintPartialFailures,
       didDeadCodeFail,
       deadCodeFailureReason,
+      supplyChainOverlapTimedOut,
+      securityScanFailed,
       directory,
       scannedFileCount,
       scannedFilePaths,
+      analyzedFiles,
       scanElapsedMilliseconds,
       lintCacheHitFileCount,
       lintCacheTotalFileCount,
@@ -1032,6 +1042,8 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       lintPartialFailures,
       didDeadCodeFail,
       deadCodeFailureReason,
+      supplyChainOverlapTimedOut,
+      securityScanFailed,
     });
     const hasSkippedChecks = skippedChecks.length > 0;
 
@@ -1046,6 +1058,7 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
       elapsedMilliseconds,
       scannedFileCount,
       scannedFilePaths,
+      analyzedFiles,
       scanElapsedMilliseconds,
       ...(lintCacheTotalFileCount !== null
         ? { lintCacheHitFileCount, lintCacheTotalFileCount }

--- a/packages/react-doctor/tests/build-json-report.test.ts
+++ b/packages/react-doctor/tests/build-json-report.test.ts
@@ -49,8 +49,10 @@ const buildSampleScan = (
   diagnostics,
   score: { score, label },
   skippedChecks: [],
+  analyzedFiles: [],
   project: SAMPLE_PROJECT,
   elapsedMilliseconds: 1234,
+  scannedFileCount: 0,
 });
 
 describe("buildJsonReport", () => {
@@ -70,7 +72,7 @@ describe("buildJsonReport", () => {
       totalElapsedMilliseconds: 5000,
     });
 
-    expect(report.schemaVersion).toBe(1);
+    expect(report.schemaVersion).toBe(3);
     expect(report.ok).toBe(true);
     expect(report.version).toBe("1.2.3");
     expect(report.mode).toBe("full");
@@ -155,6 +157,7 @@ describe("buildJsonReportError", () => {
     });
 
     expect(report.ok).toBe(false);
+    expect(report.schemaVersion).toBe(3);
     expect(report.error).toEqual({
       message: "boom",
       name: "TypeError",

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -61,6 +61,7 @@ const buildResult = (overrides: Partial<InspectResult> = {}): InspectResult => (
   project: projectInfo,
   elapsedMilliseconds: 1200,
   scannedFileCount: 10,
+  analyzedFiles: Array.from({ length: 10 }, (_unused, index) => `src/${index}.tsx`),
   scanElapsedMilliseconds: 900,
   ...overrides,
 });
@@ -187,6 +188,8 @@ describe("buildRunEventAttributes", () => {
       }),
     );
     expect(partialCheckAttributes["outcome.complete"]).toBe(false);
+    expect(partialCheckAttributes["outcome.status"]).toBe("ok");
+    expect(partialCheckAttributes["outcome.clean"]).toBe(false);
     expect(
       buildRunEventAttributes(baseInput({ error: new Error("boom") }))["outcome.complete"],
     ).toBe(false);

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -159,6 +159,39 @@ describe("buildRunEventAttributes", () => {
     expect(attributes["migration.largestRuleBucketRule"]).toBeUndefined();
   });
 
+  it("records exact scan completeness as one low-cardinality outcome attribute", () => {
+    const completeAttributes = buildRunEventAttributes(
+      baseInput({
+        result: buildResult({
+          analyzedFiles: Array.from({ length: 10 }, (_unused, index) => `src/${index}.tsx`),
+        }),
+      }),
+    );
+    expect(completeAttributes["outcome.complete"]).toBe(true);
+    expect(completeAttributes["scan.complete"]).toBeUndefined();
+
+    const incompleteAttributes = buildRunEventAttributes(
+      baseInput({
+        result: buildResult({ analyzedFiles: ["src/0.tsx"] }),
+      }),
+    );
+    expect(incompleteAttributes["outcome.complete"]).toBe(false);
+    const partialCheckAttributes = buildRunEventAttributes(
+      baseInput({
+        result: buildResult({
+          analyzedFiles: Array.from({ length: 10 }, (_unused, index) => `src/${index}.tsx`),
+          skippedCheckReasons: {
+            "lint:partial": "React Hooks rules were skipped after their plugin failed to load.",
+          },
+        }),
+      }),
+    );
+    expect(partialCheckAttributes["outcome.complete"]).toBe(false);
+    expect(
+      buildRunEventAttributes(baseInput({ error: new Error("boom") }))["outcome.complete"],
+    ).toBe(false);
+  });
+
   it("records the widest-blast-radius rule for migration-scale calibration", () => {
     const diagnostics: Diagnostic[] = [];
     for (let fileIndex = 0; fileIndex < 45; fileIndex += 1) {

--- a/packages/react-doctor/tests/e2e/json-out-flag.test.ts
+++ b/packages/react-doctor/tests/e2e/json-out-flag.test.ts
@@ -71,6 +71,6 @@ describe.skipIf(!hasBuiltCli)("--json-out flag", () => {
     const reportContent = fs.readFileSync(outputFile, "utf8");
     const report = JSON.parse(reportContent);
     expect(report.ok).toBeDefined();
-    expect(report.schemaVersion).toBe(1);
+    expect(report.schemaVersion).toBe(3);
   }, 60_000);
 });

--- a/packages/react-doctor/tests/json-mode.test.ts
+++ b/packages/react-doctor/tests/json-mode.test.ts
@@ -156,7 +156,7 @@ describe("json-mode lifecycle", () => {
     expect(() => JSON.parse(written.trim())).not.toThrow();
     const parsed = JSON.parse(written.trim());
     expect(parsed.ok).toBe(false);
-    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.schemaVersion).toBe(3);
   });
 
   it("writeJsonReport writes to a file when outputFile is provided", () => {

--- a/packages/react-doctor/tests/json-mode.test.ts
+++ b/packages/react-doctor/tests/json-mode.test.ts
@@ -3,6 +3,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { JsonReport } from "@react-doctor/core";
+import { JsonReport as JsonReportSchema } from "@react-doctor/core/schemas";
+import * as Schema from "effect/Schema";
+import { INTERNAL_ERROR_JSON_FALLBACK } from "../src/cli/utils/constants.js";
 import {
   enableJsonMode,
   isJsonModeActive,
@@ -157,6 +160,14 @@ describe("json-mode lifecycle", () => {
     const parsed = JSON.parse(written.trim());
     expect(parsed.ok).toBe(false);
     expect(parsed.schemaVersion).toBe(3);
+  });
+
+  it("keeps the last-resort error payload valid against the v3 schema", () => {
+    const parsedFallback = JSON.parse(INTERNAL_ERROR_JSON_FALLBACK);
+    const decodedFallback = Schema.decodeUnknownSync(JsonReportSchema)(parsedFallback);
+
+    expect(decodedFallback.schemaVersion).toBe(3);
+    expect(decodedFallback.ok).toBe(false);
   });
 
   it("writeJsonReport writes to a file when outputFile is provided", () => {

--- a/packages/react-doctor/tests/run-oxlint/file-lint-cache.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/file-lint-cache.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
-import type { Diagnostic } from "@react-doctor/core";
+import type { Diagnostic, RunOxlintFileCoverage } from "@react-doctor/core";
 import { buildDiagnosticIdentity, runOxlint } from "@react-doctor/core";
 import { buildTestProject, setupReactProject, writeFile } from "../regressions/_helpers.js";
 
@@ -39,6 +39,7 @@ interface ScanOptions {
   hasReactCompiler?: boolean;
   includePaths?: string[];
   onCacheStats?: (cacheHitFileCount: number, totalConsideredFileCount: number) => void;
+  onFileCoverage?: (coverage: RunOxlintFileCoverage) => void;
 }
 
 const setupFixture = (caseId: string, indexSource: string): string => {
@@ -70,6 +71,7 @@ const scan = (projectDir: string, options: ScanOptions = {}): Promise<Diagnostic
     respectInlineDisables: options.respectInlineDisables,
     perFileLintCacheEnabled: options.perFileLintCacheEnabled,
     onCacheStats: options.onCacheStats,
+    onFileCoverage: options.onFileCoverage,
   });
 
 // Deterministic serialization of a diagnostic set for byte-identical
@@ -132,6 +134,24 @@ describe("per-file lint cache", () => {
     // Nothing changed between the two scans, so every file is a hit.
     expect(warmHits).toBe(warmTotal);
     expect(warmTotal).toBe(coldTotal);
+  });
+
+  it("reports complete structural coverage on cold and warm scans", async () => {
+    const projectDir = setupFixture("file-coverage", BARREL_INDEX);
+    const coverageSnapshots: RunOxlintFileCoverage[] = [];
+    const onFileCoverage = (coverage: RunOxlintFileCoverage): void => {
+      coverageSnapshots.push(coverage);
+    };
+
+    await scan(projectDir, { perFileLintCacheEnabled: true, onFileCoverage });
+    await scan(projectDir, { perFileLintCacheEnabled: true, onFileCoverage });
+
+    expect(coverageSnapshots).toHaveLength(2);
+    for (const coverage of coverageSnapshots) {
+      expect([...coverage.analyzedFiles].sort()).toEqual(
+        [...new Set(coverage.candidateFiles)].sort(),
+      );
+    }
   });
 
   it("invalidates a file when its OWN content changes (content-addressed)", async () => {

--- a/packages/react-doctor/tests/to-json-report.test.ts
+++ b/packages/react-doctor/tests/to-json-report.test.ts
@@ -50,7 +50,7 @@ describe("toJsonReport (Node API helper)", () => {
     const result = buildDiagnoseResult();
     const report = toJsonReport(result, { version: "1.2.3" });
 
-    expect(report.schemaVersion).toBe(1);
+    expect(report.schemaVersion).toBe(3);
     expect(report.ok).toBe(true);
     expect(report.version).toBe("1.2.3");
     expect(report.directory).toBe("/virtual");
@@ -58,6 +58,19 @@ describe("toJsonReport (Node API helper)", () => {
     expect(report.projects).toHaveLength(1);
     expect(report.projects[0].project).toBe(result.project);
     expect(report.diagnostics).toEqual(report.projects[0].diagnostics);
+    expect(report.projects[0]).toMatchObject({
+      packageRoot: "/virtual",
+      framework: "vite",
+      analyzedFiles: [],
+      analyzedFileCount: 0,
+      complete: false,
+    });
+    expect(report.diagnostics[0]).toMatchObject({
+      id: "src/App.tsx::7:1::react/no-danger",
+      normalizedFilePath: "src/App.tsx",
+      filePath: "/virtual/src/App.tsx",
+      tags: [],
+    });
     expect(report.summary).toMatchObject({
       errorCount: 0,
       warningCount: 1,

--- a/scripts/ensure-json-report.mjs
+++ b/scripts/ensure-json-report.mjs
@@ -8,7 +8,7 @@ if (!reportPath) {
 }
 
 const fallbackReport = {
-  schemaVersion: 1,
+  schemaVersion: 3,
   version: "unknown",
   ok: false,
   directory: process.cwd(),
@@ -32,10 +32,9 @@ const fallbackReport = {
   },
 };
 
-// Known JsonReport schema versions: 1 (full/diff/staged) and 2 (baseline /
-// PR-introduced-issues-only). Both are valid CLI output; only an unparseable or
-// unrecognized payload is treated as a failed scan.
-const KNOWN_SCHEMA_VERSIONS = new Set([1, 2]);
+// Known JsonReport schema versions remain valid CLI output; only an
+// unparseable or unrecognized payload is treated as a failed scan.
+const KNOWN_SCHEMA_VERSIONS = new Set([1, 2, 3]);
 
 try {
   const raw = fs.readFileSync(reportPath, "utf8").trim();

--- a/scripts/smoke-json-report.ts
+++ b/scripts/smoke-json-report.ts
@@ -22,7 +22,7 @@ if (!fs.existsSync(FIXTURE_DIRECTORY)) {
 
 // `--no-score --no-lint --no-dead-code` keeps the run fast and
 // deterministic — we're checking that the CLI plumbing produces a
-// schema-valid v1 JsonReport, not that any particular rule fires.
+// schema-valid v3 JsonReport, not that any particular rule fires.
 // The eval harness (react-doctor-evals parity check) is the right
 // tool for diagnostic-set comparison; this smoke catches structural
 // regressions to the JSON output across refactor PRs.
@@ -57,8 +57,8 @@ try {
   process.exit(1);
 }
 
-if (decoded.schemaVersion !== 1) {
-  console.error(`Expected schemaVersion 1, got ${decoded.schemaVersion}`);
+if (decoded.schemaVersion !== 3) {
+  console.error(`Expected schemaVersion 3, got ${decoded.schemaVersion}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Why
Consumers need a stable way to identify diagnostics and determine whether a JSON scan actually covered every planned file. The previous report shape could not distinguish a clean complete scan from a partial scan with skipped work.

## What changed
- emit `schemaVersion: 3` by default
- add deterministic diagnostic `id`, canonical `tags`, `blocking`, and `normalizedFilePath`
- add per-project `framework`, `analyzedFiles`, `analyzedFileCount`, and `complete`
- mark `complete: false` for skipped checks, partial failures, deadlines, and missing analyzed files
- retain v1 and v2 decoding through the exported schema union
- expose `outcome.complete` in CLI telemetry

## Example

```json
{
  "schemaVersion": 3,
  "projects": [
    {
      "framework": "nextjs",
      "analyzedFileCount": 42,
      "complete": true,
      "diagnostics": [
        {
          "id": "src/app.tsx::12:3::react-doctor/no-derived-state",
          "normalizedFilePath": "src/app.tsx",
          "tags": ["test-noise"],
          "blocking": false
        }
      ]
    }
  ]
}
```

A consumer can now gate on both findings and coverage:

```ts
const canTrustCleanResult = report.projects.every(
  (project) => project.complete && project.diagnostics.length === 0,
);
```

## Compatibility
- v1/v2 reports still decode
- the default emitted wire format changes to v3
- this touches `scripts/ensure-json-report.mjs`, so the GitHub Action needs the recommended independent action-version tag after merge

## Verification
- [x] `nr typecheck`
- [x] `nr lint`
- [x] `nr format:check`
- [x] `nr build`
- [x] `nr smoke:json-report`
- [x] core and report compatibility suites

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking wire-format change for JSON consumers (default emission shifts from v1/v2 to v3) and touches core lint orchestration and CI/action fallback scripts, though backward decoding and broad test coverage reduce rollout risk.
> 
> **Overview**
> **Default JSON output moves to `schemaVersion: 3`**, including error/fallback reports and smoke scripts, while the exported `JsonReport` union still decodes v1 and v2.
> 
> **Diagnostics** gain a stable `id` (`reportRelativeFilePath::line:column::plugin/rule`), `normalizedFilePath`, canonical sorted `tags`, and workspace-scoped identities for monorepos. **Each project** now carries `packageRoot`, `framework`, sorted `analyzedFiles` / `analyzedFileCount`, and `complete` (all planned lint files finished with no skipped checks or partial-failure reasons).
> 
> **Coverage is measured in the lint pipeline**: oxlint batch spawning reports successfully analyzed files (excluding dropped/deadline-skipped paths), including cache/sidecar paths; `runInspect` canonicalizes paths and feeds `buildJsonReport` / `diagnose()`. `buildSkippedChecks` also records supply-chain timeout and security-scan failure. CLI telemetry adds **`outcome.complete`** and treats “clean” as zero findings only when the scan is complete.
> 
> Docs (`docs/json-report.md`), README, scan-result cache schema v5, and tests are updated for the new wire format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae38664c176be1b269d45dd57c7819e6890aa213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->