### PR TITLE
fix(rules): tighten React 19 and JSX precision

### DIFF
--- a/.changeset/tight-rules-rest.md
+++ b/.changeset/tight-rules-rest.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Tighten React 19 deprecation, JSX slot, and React import-origin diagnostics to avoid stale false positives.

--- a/packages/core/tests/fixtures/basic-react/src/legacy-react.tsx
+++ b/packages/core/tests/fixtures/basic-react/src/legacy-react.tsx
@@ -1,13 +1,6 @@
-import { createContext, forwardRef, useContext } from "react";
+import React, { createContext, useContext } from "react";
 
-export const ForwardedInput = forwardRef<HTMLInputElement, { label: string }>(({ label }, ref) => (
-  <label>
-    {label}
-    <input ref={ref} />
-  </label>
-));
-
-ForwardedInput.displayName = "ForwardedInput";
+export const createLegacyInput = React.createFactory("input");
 
 const ThemeContext = createContext<"light" | "dark">("light");
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -784,7 +784,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: 'import { render } from "react-dom";\nrender(null, document.getElementById("root"));',
   },
   "no-react19-deprecated-apis": {
-    code: 'import * as React from "react";\nimport * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";\n\nconst AlertDialogOverlay = React.forwardRef((props, ref) => (\n  <AlertDialogPrimitive.Overlay {...props} ref={ref} />\n));\nconst AlertDialogContent = React.forwardRef((props, ref) => (\n  <AlertDialogPrimitive.Content {...props} ref={ref} />\n));\nconst AlertDialogTitle = React.forwardRef((props, ref) => (\n  <AlertDialogPrimitive.Title {...props} ref={ref} />\n));\n',
+    code: 'import * as React from "react";\nconst Button = React.createFactory("button");\nvoid Button;',
   },
   "no-redundant-roles": {
     code: 'const Nav = () => <nav role="navigation" />;',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.regressions.test.ts
@@ -50,6 +50,32 @@ describe("architecture/no-react19-deprecated-apis — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("reports createFactory through immutable React namespace aliases", () => {
+    const result = run(`
+      import * as React from "react";
+      const ReactAlias = React;
+      const WrappedReactAlias = ReactAlias as typeof ReactAlias;
+      const createButton = WrappedReactAlias.createFactory("button");
+      void createButton;
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain("createFactory");
+  });
+
+  it("does not trust mutable React namespace aliases", () => {
+    const result = run(`
+      import * as React from "react";
+      const Compat = { createFactory: (tag) => tag };
+      let ReactAlias = React;
+      ReactAlias = Compat;
+      const createButton = ReactAlias.createFactory("button");
+      void createButton;
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not report a shadowed React namespace binding", () => {
     const result = run(`
       import * as React from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.regressions.test.ts
@@ -2,177 +2,98 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noReact19DeprecatedApis } from "./no-react19-deprecated-apis.js";
 
-const run = (code: string, filename = "src/features/profile/ProfileCard.tsx") =>
-  runRule(noReact19DeprecatedApis, code, { filename });
-
-const SHADCN_STYLE_SOURCE = `import * as React from "react";
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
-
-const AlertDialogOverlay = React.forwardRef((props, ref) => (
-  <AlertDialogPrimitive.Overlay {...props} ref={ref} />
-));
-const AlertDialogContent = React.forwardRef((props, ref) => (
-  <AlertDialogPrimitive.Content {...props} ref={ref} />
-));
-const AlertDialogTitle = React.forwardRef((props, ref) => (
-  <AlertDialogPrimitive.Title {...props} ref={ref} />
-));
-`;
+const run = (code: string) =>
+  runRule(noReact19DeprecatedApis, code, {
+    filename: "src/features/profile/profile-card.tsx",
+  });
 
 describe("architecture/no-react19-deprecated-apis — regressions", () => {
-  // prod-fp review: 10 of 40 corpus samples were vendored shadcn/ui files
-  // (walterlow__freecut src/components/ui/{accordion,alert-dialog}.tsx,
-  // pedropalau__react-bnb-gallery components/ui/sidebar.tsx) — generated
-  // code the user should regenerate, not hand-edit.
-  it("does not flag vendored shadcn files under components/ui/", () => {
-    const result = run(SHADCN_STYLE_SOURCE, "src/components/ui/alert-dialog.tsx");
+  it("does not report forwardRef, which remains supported in React 19", () => {
+    const result = run(`
+      import React, { forwardRef as createInput } from "react";
+      const Input = createInput((props, ref) => <input ref={ref} {...props} />);
+      const Button = React.forwardRef((props, ref) => <button ref={ref} {...props} />);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("does not flag components/ui/ at the project root", () => {
-    const result = run(SHADCN_STYLE_SOURCE, "components/ui/sidebar.tsx");
-    expect(result.diagnostics).toEqual([]);
-  });
+  it("reports the removed createFactory named import", () => {
+    const result = run(`
+      import { createFactory } from "react";
+      const createButton = createFactory("button");
+    `);
 
-  // prod-fp review: the corpus sampler drew 5 diagnostics from ONE file
-  // (alert-dialog.tsx) — per-occurrence reporting of the same API in the
-  // same file is density, not signal.
-  it("reports each deprecated API at most once per file", () => {
-    const result = run(SHADCN_STYLE_SOURCE);
     expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0]?.message).toContain("forwardRef");
+    expect(result.diagnostics[0]?.message).toContain("createFactory");
   });
 
-  // useContext is NOT deprecated in React 19 — `use()` is additive. Flagging
-  // it was reward-deciding misinformation (RD-FP-010).
-  it("does not flag useContext (not deprecated; use() is additive)", () => {
-    const result = run(
-      `import { forwardRef, useContext } from "react";
-const Ctx = {};
-const A = forwardRef((props, ref) => <div ref={ref} />);
-const B = forwardRef((props, ref) => <span ref={ref} />);
-const useTheme = () => useContext(Ctx);
-const useLocale = () => useContext(Ctx);
-`,
-    );
+  it("reports a renamed createFactory import by its canonical imported name", () => {
+    const result = run(`
+      import { createFactory as makeLegacyElement } from "react";
+      const createButton = makeLegacyElement("button");
+    `);
+
     expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0]?.message).toContain("forwardRef");
+    expect(result.diagnostics[0]?.message).toContain("createFactory");
   });
 
-  it("still flags a named forwardRef import outside components/ui/", () => {
-    const result = run(
-      `import { forwardRef } from "react";
-const Input = forwardRef((props, ref) => <input ref={ref} {...props} />);
-`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0]?.message).toContain("forwardRef");
-  });
+  it("reports createFactory on namespace and default React imports once", () => {
+    const result = run(`
+      import React from "react";
+      import * as ReactNamespace from "react";
+      const createButton = React.createFactory("button");
+      const createInput = ReactNamespace.createFactory("input");
+    `);
 
-  it("does not flag React.useContext on a namespace import", () => {
-    const result = run(
-      `import * as React from "react";
-const Ctx = {};
-const useTheme = () => React.useContext(Ctx);
-`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("still flags directories that merely resemble components/ui/", () => {
-    const result = run(
-      `import { forwardRef } from "react";
-const Input = forwardRef((props, ref) => <input ref={ref} {...props} />);
-`,
-      "src/components/uikit/input.tsx",
-    );
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  // fuzz edge-case wave: the lookup keys on the IMPORTED (canonical) name,
-  // so a rename can't hide the deprecated API.
-  it("still flags a renamed forwardRef import (forwardRef as fr)", () => {
-    const result = run(
-      `import { forwardRef as fr } from "react";
-const Input = fr((props, ref) => <input ref={ref} {...props} />);
-`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0]?.message).toContain("forwardRef");
-  });
+  it("does not report a shadowed React namespace binding", () => {
+    const result = run(`
+      import * as React from "react";
+      const build = (React) => React.createFactory("button");
+      void build;
+    `);
 
-  // Type-only imports emit no runtime code — nothing to migrate at runtime.
-  it("does not flag a type-only forwardRef import", () => {
-    const result = run(
-      `import type { forwardRef } from "react";
-type ForwardRefFn = typeof forwardRef;
-`,
-    );
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("does not flag an inline type specifier (import { type forwardRef })", () => {
-    const result = run(
-      `import { type forwardRef } from "react";
-type ForwardRefFn = typeof forwardRef;
-`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
+  it("still reports the imported namespace outside a shadowed scope", () => {
+    const result = run(`
+      import * as React from "react";
+      const build = (React) => React.createFactory("button");
+      const createInput = React.createFactory("input");
+      void build;
+      void createInput;
+    `);
 
-  it("does not flag forwardRef imported from preact/compat", () => {
-    const result = run(
-      `import { forwardRef } from "preact/compat";
-const Input = forwardRef((props, ref) => <input ref={ref} {...props} />);
-`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag P.forwardRef on a preact/compat namespace import", () => {
-    const result = run(
-      `import * as P from "preact/compat";
-const Input = P.forwardRef((props, ref) => <input ref={ref} {...props} />);
-`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  // Computed member access is intentionally out of scope for the
-  // name-based member check — staying silent beats guessing.
-  it('does not flag computed member access React["forwardRef"]', () => {
-    const result = run(
-      `import * as React from "react";
-const Input = React["forwardRef"]((props, ref) => <input ref={ref} {...props} />);
-`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not flag React.forwardRef on a local object with no react import", () => {
-    const result = run(
-      `const React = { forwardRef: (render) => render };
-const Input = React.forwardRef((props, ref) => <input ref={ref} {...props} />);
-`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("flags (React as any).forwardRef — the cast wrapper does not change the call", () => {
-    const result = run(
-      `import * as React from "react";
-const Input = (React as any).forwardRef((props, ref) => <input ref={ref} {...props} />);
-`,
-    );
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("flags (React!).forwardRef through a non-null assertion", () => {
-    const result = run(
-      `import * as React from "react";
-const Input = (React!).forwardRef((props, ref) => <input ref={ref} {...props} />);
-`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
+  it("does not report same-named APIs from non-React modules or local objects", () => {
+    const result = run(`
+      import { createFactory } from "preact/compat";
+      import * as Compat from "preact/compat";
+      const React = { createFactory: (tag) => tag };
+      void createFactory;
+      void Compat.createFactory;
+      void React.createFactory;
+    `);
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not report type-only imports or computed member access", () => {
+    const result = run(`
+      import type { createFactory } from "react";
+      import * as React from "react";
+      type Factory = typeof createFactory;
+      const createButton = React["createFactory"];
+      void createButton;
+    `);
+
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-react19-deprecated-apis.ts
@@ -4,40 +4,14 @@ import type { ReportDescriptor } from "../../utils/report-descriptor.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 
-// HACK: React 19+ deprecated `forwardRef` (refs are now regular props on
-// function components). Catches both named imports
-// (`import { forwardRef } from "react"`) AND member access on
-// namespace/default imports (`React.forwardRef` after
-// `import React from "react"` or `import * as React from "react"`).
-//
-// `useContext` is deliberately NOT in this map: React 19's `use()` is an
-// additive alternative, and `useContext` remains a fully supported,
-// non-deprecated API — calling it deprecated was reward-deciding
-// misinformation in downstream audits.
-//
 // Stored as a Map (not a plain object) because plain-object lookups inherit
 // from `Object.prototype` — `messages["constructor"]` returns the native
 // `Object` function, which is truthy and would silently false-positive on
 // `import { constructor } from "react"` or `React.toString()`. Maps return
 // `undefined` for missing keys with no prototype fall-through.
 const REACT_19_DEPRECATED_MESSAGES = new Map<string, string>([
-  [
-    "forwardRef",
-    "forwardRef is dead weight in React 19, since ref is a normal prop now, so drop it & pass ref straight through.",
-  ],
+  ["createFactory", "React 19 removed createFactory. Use JSX or createElement instead."],
 ]);
-
-// shadcn/ui vendors generated components under `components/ui/` — code the
-// user copied in, not authored. Those files use `forwardRef` heavily (5-8×
-// per file across dozens of files), and the actionable fix is regenerating
-// from shadcn's React-19 registry, not hand-editing each callsite — so the
-// per-callsite migration hint is pure noise there.
-const isVendoredShadcnUiFilename = (rawFilename: string | undefined): boolean => {
-  if (!rawFilename) return false;
-  const filename = rawFilename.replaceAll("\\", "/");
-  const rootedFilename = filename.startsWith("/") ? filename : `/${filename}`;
-  return rootedFilename.includes("/components/ui/");
-};
 
 const deprecatedReactImportRule = createDeprecatedReactImportRule({
   source: "react",
@@ -81,9 +55,7 @@ export const noReact19DeprecatedApis = defineRule({
   tags: ["test-noise", "migration-hint"],
   severity: "warn",
   recommendation:
-    "Pass `ref` as a normal prop on function components, since `forwardRef` isn't needed in React 19. Only runs on React 19+ projects.",
-  create: (context: RuleContext): RuleVisitors => {
-    if (isVendoredShadcnUiFilename(context.filename)) return {};
-    return deprecatedReactImportRule.create(buildOncePerApiContext(context));
-  },
+    "Replace removed React APIs with their supported React 19 alternatives. Only runs on React 19+ projects.",
+  create: (context: RuleContext): RuleVisitors =>
+    deprecatedReactImportRule.create(buildOncePerApiContext(context)),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { getImportedName } from "../../../utils/get-imported-name.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import { isTypeOnlyImport } from "../../../utils/is-type-only-import.js";
+import { resolveConstIdentifierAlias } from "../../../utils/resolve-const-identifier-alias.js";
 import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../../utils/rule-context.js";
 import type { Rule } from "../../../utils/rule.js";
@@ -36,25 +37,8 @@ export const createDeprecatedReactImportRule = ({
   create: (context: RuleContext) => {
     const namespaceImportSpecifiers = new Set<EsTreeNode>();
     const resolvesToNamespaceImport = (identifier: EsTreeNode): boolean => {
-      const visitedSymbolIds = new Set<number>();
-      let symbol = context.scopes.symbolFor(identifier);
-      while (symbol) {
-        if (namespaceImportSpecifiers.has(symbol.declarationNode)) return true;
-        if (
-          symbol.kind !== "const" ||
-          visitedSymbolIds.has(symbol.id) ||
-          !symbol.initializer ||
-          !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
-          symbol.declarationNode.id !== symbol.bindingIdentifier
-        ) {
-          return false;
-        }
-        visitedSymbolIds.add(symbol.id);
-        const initializer = stripParenExpression(symbol.initializer);
-        if (!isNodeOfType(initializer, "Identifier")) return false;
-        symbol = context.scopes.symbolFor(initializer);
-      }
-      return false;
+      const symbol = resolveConstIdentifierAlias(identifier, context.scopes);
+      return Boolean(symbol && namespaceImportSpecifiers.has(symbol.declarationNode));
     };
 
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
@@ -35,6 +35,27 @@ export const createDeprecatedReactImportRule = ({
 }: DeprecatedReactImportRuleOptions): Pick<Rule, "create"> => ({
   create: (context: RuleContext) => {
     const namespaceImportSpecifiers = new Set<EsTreeNode>();
+    const resolvesToNamespaceImport = (identifier: EsTreeNode): boolean => {
+      const visitedSymbolIds = new Set<number>();
+      let symbol = context.scopes.symbolFor(identifier);
+      while (symbol) {
+        if (namespaceImportSpecifiers.has(symbol.declarationNode)) return true;
+        if (
+          symbol.kind !== "const" ||
+          visitedSymbolIds.has(symbol.id) ||
+          !symbol.initializer ||
+          !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+          symbol.declarationNode.id !== symbol.bindingIdentifier
+        ) {
+          return false;
+        }
+        visitedSymbolIds.add(symbol.id);
+        const initializer = stripParenExpression(symbol.initializer);
+        if (!isNodeOfType(initializer, "Identifier")) return false;
+        symbol = context.scopes.symbolFor(initializer);
+      }
+      return false;
+    };
 
     return {
       ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
@@ -70,9 +91,7 @@ export const createDeprecatedReactImportRule = ({
         // strip transparent wrappers before matching the namespace binding.
         const receiver = stripParenExpression(node.object);
         if (!isNodeOfType(receiver, "Identifier")) return;
-        const receiverSymbol = context.scopes.symbolFor(receiver);
-        if (!receiverSymbol || !namespaceImportSpecifiers.has(receiverSymbol.declarationNode))
-          return;
+        if (!resolvesToNamespaceImport(receiver)) return;
         if (!isNodeOfType(node.property, "Identifier")) return;
         const message = messages.get(node.property.name);
         if (message) context.report({ node, message });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/utils/create-deprecated-react-import-rule.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { getImportedName } from "../../../utils/get-imported-name.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import { isTypeOnlyImport } from "../../../utils/is-type-only-import.js";
@@ -33,7 +34,7 @@ export const createDeprecatedReactImportRule = ({
   handleExtraSource,
 }: DeprecatedReactImportRuleOptions): Pick<Rule, "create"> => ({
   create: (context: RuleContext) => {
-    const namespaceBindings = new Set<string>();
+    const namespaceImportSpecifiers = new Set<EsTreeNode>();
 
     return {
       ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
@@ -58,19 +59,20 @@ export const createDeprecatedReactImportRule = ({
             isNodeOfType(specifier, "ImportDefaultSpecifier") ||
             isNodeOfType(specifier, "ImportNamespaceSpecifier")
           ) {
-            const localName = specifier.local?.name;
-            if (localName) namespaceBindings.add(localName);
+            namespaceImportSpecifiers.add(specifier);
           }
         }
       },
       MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
-        if (namespaceBindings.size === 0) return;
+        if (namespaceImportSpecifiers.size === 0) return;
         if (node.computed) return;
-        // `(React as any).forwardRef` still calls the deprecated API —
+        // `(React as any).createFactory` still calls the deprecated API —
         // strip transparent wrappers before matching the namespace binding.
         const receiver = stripParenExpression(node.object);
         if (!isNodeOfType(receiver, "Identifier")) return;
-        if (!namespaceBindings.has(receiver.name)) return;
+        const receiverSymbol = context.scopes.symbolFor(receiver);
+        if (!receiverSymbol || !namespaceImportSpecifiers.has(receiverSymbol.declarationNode))
+          return;
         if (!isNodeOfType(node.property, "Identifier")) return;
         const message = messages.get(node.property.name);
         if (message) context.report({ node, message });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1108,6 +1108,22 @@ describe("react-builtins/exhaustive-deps — upstream disable-comment suppressio
       const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
       expect(messages).toContain("useEffectEvent");
     });
+
+    it("still flags useEffectEvent through an immutable React default-import alias", () => {
+      const code = `
+        import React, { useEffect } from "react";
+        const ReactAlias = React;
+        export const TickPanel = ({ value }) => {
+          const onTick = ReactAlias.useEffectEvent(() => value);
+          useEffect(() => { onTick(); }, [onTick]);
+          return null;
+        };
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("useEffectEvent");
+    });
   });
 
   it("does not suppress a report on a different line than the disable comment", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1093,6 +1093,21 @@ describe("react-builtins/exhaustive-deps — upstream disable-comment suppressio
       const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
       expect(messages).toContain("useEffectEvent");
     });
+
+    it("still flags useEffectEvent from a wrapped React namespace listed in deps", () => {
+      const code = `
+        import React, { useEffect } from "react";
+        export const TickPanel = ({ value }) => {
+          const onTick = (React as typeof React).useEffectEvent(() => value);
+          useEffect(() => { onTick(); }, [onTick]);
+          return null;
+        };
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("useEffectEvent");
+    });
   });
 
   it("does not suppress a report on a different line than the disable comment", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1078,6 +1078,21 @@ describe("react-builtins/exhaustive-deps — upstream disable-comment suppressio
       const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
       expect(messages).toContain("useEffectEvent");
     });
+
+    it("still flags a renamed React useEffectEvent import listed in deps", () => {
+      const code = `
+        import { useEffect, useEffectEvent as useStableEvent } from "react";
+        export const TickPanel = ({ value }) => {
+          const onTick = useStableEvent(() => value);
+          useEffect(() => { onTick(); }, [onTick]);
+          return null;
+        };
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("useEffectEvent");
+    });
   });
 
   it("does not suppress a report on a different line than the disable comment", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.regressions.test.ts
@@ -319,6 +319,64 @@ ${INK_STATUS_BAR_USAGE}
     expect(result.diagnostics[0]?.message).toContain("brand new JSX");
   });
 
+  it("resolves memo references to same-file component implementations", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      import { memo, type ReactNode } from "react";
+      interface ChildProps {
+        payload: ReactNode;
+      }
+      const ChildImplementation = ({ payload }: ChildProps) => <>{payload}</>;
+      const MemoChild = memo(ChildImplementation);
+      const Parent = () => <MemoChild payload={<Heavy />} />;
+      `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("uses the JSX component binding when applying same-file slot contracts", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      import { memo, type ReactNode } from "react";
+      const MemoChild = memo(({ payload }: { payload: ReactNode }) => <>{payload}</>);
+      const Parent = () => {
+        const MemoChild = memo(
+          ({ payload }: { payload: unknown }) => <span>{String(payload)}</span>,
+        );
+        return <MemoChild payload={<Heavy />} />;
+      };
+      `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain("brand new JSX");
+  });
+
+  it("does not treat arbitrary wrappers as transparent component contracts", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      import { memo, type ReactNode } from "react";
+      interface ChildProps {
+        payload: ReactNode;
+      }
+      const adapt = (render: (props: ChildProps) => JSX.Element) =>
+        ({ payload }: { payload: unknown }) => render({ payload: String(payload) });
+      const MemoChild = memo(adapt(({ payload }: ChildProps) => <>{payload}</>));
+      const Parent = () => <MemoChild payload={<Heavy />} />;
+      `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain("brand new JSX");
+  });
+
   it("resolves renamed React slot type imports and same-file type aliases", () => {
     const result = runRule(
       jsxNoJsxAsProp,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.regressions.test.ts
@@ -53,6 +53,19 @@ describe("react-builtins/jsx-no-jsx-as-prop regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag the corpus MUI ListItemText primary slot", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      import ListItemText from "@mui/material/ListItemText";
+      import { FormattedMessage } from "react-intl";
+      const Row = () => <ListItemText primary={<FormattedMessage id="row.title" />} />;
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // Mined ant-design FP (.dumi/pages/index/index.tsx:92):
   // `<Group decoration={<img .../>}>` — a background-decoration slot.
   it("does not flag a `decoration` slot receiving inline JSX", () => {
@@ -272,5 +285,101 @@ ${INK_STATUS_BAR_USAGE}
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("exempts same-file memoized props typed as React JSX slots while reporting a non-slot prop", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      import React, { memo, type ReactNode } from "react";
+      interface ChildProps {
+        payload: ReactNode;
+        visual: React.ReactElement;
+        artifact: JSX.Element | null;
+        strictValue: string;
+      }
+      const MemoChild = memo(
+        ({ payload, visual, artifact, strictValue }: ChildProps) => (
+          <section>{payload}{visual}{artifact}{strictValue}</section>
+        ),
+      );
+      const Parent = () => (
+        <MemoChild
+          payload={<Heavy />}
+          visual={<Chart />}
+          artifact={<Badge />}
+          strictValue={<Incorrect />}
+        />
+      );
+      `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain("brand new JSX");
+  });
+
+  it("resolves renamed React slot type imports and same-file type aliases", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      import { memo, type ReactElement as ElementSlot, type ReactNode as NodeSlot } from "react";
+      type OptionalSlot = NodeSlot | undefined;
+      type ChildProps = {
+        payload: ElementSlot;
+        artifact: OptionalSlot;
+      };
+      const MemoChild = memo(({ payload, artifact }: ChildProps) => <>{payload}{artifact}</>);
+      const Parent = () => <MemoChild payload={<Heavy />} artifact={<Badge />} />;
+      `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not trust imported props or a same-file JSX namespace", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      import { memo } from "react";
+      import type { ChildProps } from "./child-props";
+      namespace JSX {
+        export interface Element {}
+      }
+      interface LocalJsxChildProps {
+        payload: JSX.Element;
+      }
+      const ImportedTypedChild = memo(({ payload }: ChildProps) => <>{payload}</>);
+      const LocalJsxTypedChild = memo(({ payload }: LocalJsxChildProps) => <>{payload}</>);
+      const Parent = () => (
+        <>
+          <ImportedTypedChild payload={<Heavy />} />
+          <LocalJsxTypedChild payload={<Heavy />} />
+        </>
+      );
+      `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not mistake a same-file ReactNode namesake for React's slot type", () => {
+    const result = runRule(
+      jsxNoJsxAsProp,
+      `
+      import { memo } from "react";
+      type ReactNode = string;
+      interface ChildProps {
+        payload: ReactNode;
+      }
+      const MemoChild = memo(({ payload }: ChildProps) => <>{payload}</>);
+      const Parent = () => <MemoChild payload={<Heavy />} />;
+      `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.ts
@@ -349,11 +349,11 @@ export const jsxNoJsxAsProp = defineRule({
   create: (context) => {
     const isTestlikeFile = isTestlikeFilename(context.filename);
     let memoRegistry: Map<string, MemoStatus> | null = null;
-    let jsxSlotPropRegistry: Map<string, ReadonlySet<string>> | null = null;
+    let jsxSlotPropRegistry: Map<number, ReadonlySet<string>> | null = null;
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
         memoRegistry = buildSameFileMemoRegistry(node as EsTreeNode);
-        jsxSlotPropRegistry = buildSameFileJsxSlotPropRegistry(node, memoRegistry);
+        jsxSlotPropRegistry = buildSameFileJsxSlotPropRegistry(node, memoRegistry, context.scopes);
       },
       JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
         if (isTestlikeFile) return;
@@ -371,11 +371,14 @@ export const jsxNoJsxAsProp = defineRule({
             : null;
         const memoStatus = memoStatusForJsxOpeningName(memoRegistry, openingName);
         if (memoStatus !== "memoised") return;
+        const openingSymbol =
+          openingName && isNodeOfType(openingName, "JSXIdentifier")
+            ? context.scopes.symbolFor(openingName)
+            : null;
         if (
-          openingName &&
-          isNodeOfType(openingName, "JSXIdentifier") &&
+          openingSymbol &&
           isNodeOfType(node.name, "JSXIdentifier") &&
-          jsxSlotPropRegistry?.get(openingName.name)?.has(node.name.name)
+          jsxSlotPropRegistry?.get(openingSymbol.id)?.has(node.name.name)
         ) {
           return;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-jsx-as-prop.ts
@@ -3,6 +3,7 @@ import {
   memoStatusForJsxOpeningName,
   type MemoStatus,
 } from "../../utils/build-same-file-memo-registry.js";
+import { buildSameFileJsxSlotPropRegistry } from "../../utils/build-same-file-jsx-slot-prop-registry.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -348,9 +349,11 @@ export const jsxNoJsxAsProp = defineRule({
   create: (context) => {
     const isTestlikeFile = isTestlikeFilename(context.filename);
     let memoRegistry: Map<string, MemoStatus> | null = null;
+    let jsxSlotPropRegistry: Map<string, ReadonlySet<string>> | null = null;
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
         memoRegistry = buildSameFileMemoRegistry(node as EsTreeNode);
+        jsxSlotPropRegistry = buildSameFileJsxSlotPropRegistry(node, memoRegistry);
       },
       JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
         if (isTestlikeFile) return;
@@ -368,6 +371,14 @@ export const jsxNoJsxAsProp = defineRule({
             : null;
         const memoStatus = memoStatusForJsxOpeningName(memoRegistry, openingName);
         if (memoStatus !== "memoised") return;
+        if (
+          openingName &&
+          isNodeOfType(openingName, "JSXIdentifier") &&
+          isNodeOfType(node.name, "JSXIdentifier") &&
+          jsxSlotPropRegistry?.get(openingName.name)?.has(node.name.name)
+        ) {
+          return;
+        }
         // Known slot prop names (icon, tooltip, fallback, header, etc.)
         // and slot suffixes (*Button, *Icon, *Component, *Element, ...)
         // are designed to receive JSX. Flagging them is unactionable.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
@@ -404,6 +404,19 @@ describe("react-builtins/rules-of-hooks — regressions: same-named non-React us
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
+  it("still flags useEffectEvent through an immutable React namespace alias", () => {
+    const result = runTsx(`
+      import * as React from "react";
+      const ReactAlias = React;
+      const MyComponent = ({ onDone }) => {
+        const handleChange = ReactAlias.useEffectEvent(() => onDone());
+        return <Child onChange={handleChange} />;
+      };
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
   it("still flags a bare/unimported useEffectEvent when passed around (parity)", () => {
     const result = runTsx(`
       const MyComponent = ({ onDone }) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
@@ -381,6 +381,17 @@ describe("react-builtins/rules-of-hooks — regressions: same-named non-React us
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
+  it("still flags a renamed React useEffectEvent import when passed around", () => {
+    const result = runTsx(`
+      import { useEffectEvent as useStableEvent } from "react";
+      const MyComponent = ({ onDone }) => {
+        const handleChange = useStableEvent(() => onDone());
+        return <Child onChange={handleChange} />;
+      };
+    `);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
   it("still flags a bare/unimported useEffectEvent when passed around (parity)", () => {
     const result = runTsx(`
       const MyComponent = ({ onDone }) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
@@ -392,6 +392,18 @@ describe("react-builtins/rules-of-hooks — regressions: same-named non-React us
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
+  it("still flags useEffectEvent from a wrapped React namespace when passed around", () => {
+    const result = runTsx(`
+      import * as React from "react";
+      const MyComponent = ({ onDone }) => {
+        const handleChange = (React as typeof React).useEffectEvent(() => onDone());
+        return <Child onChange={handleChange} />;
+      };
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
   it("still flags a bare/unimported useEffectEvent when passed around (parity)", () => {
     const result = runTsx(`
       const MyComponent = ({ onDone }) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/build-same-file-jsx-slot-prop-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/build-same-file-jsx-slot-prop-registry.ts
@@ -1,0 +1,290 @@
+import type { MemoStatus } from "./build-same-file-memo-registry.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getImportedName } from "./get-imported-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+interface ReactSlotTypeEnvironment {
+  reactSlotTypeBindings: ReadonlySet<string>;
+  reactNamespaceBindings: ReadonlySet<string>;
+  reactJsxNamespaceBindings: ReadonlySet<string>;
+  nonReactJsxNamespaceBindings: ReadonlySet<string>;
+  sameFileTypeDeclarations: ReadonlyMap<string, EsTreeNode>;
+  hasLocalJsxNamespace: boolean;
+}
+
+const REACT_SLOT_TYPE_NAMES: ReadonlySet<string> = new Set(["ReactNode", "ReactElement"]);
+
+const unwrapTopLevelDeclaration = (statement: EsTreeNode): EsTreeNode | null => {
+  if (isNodeOfType(statement, "ExportNamedDeclaration")) return statement.declaration;
+  if (isNodeOfType(statement, "ExportDefaultDeclaration")) return statement.declaration;
+  return statement;
+};
+
+const buildReactSlotTypeEnvironment = (program: EsTreeNode): ReactSlotTypeEnvironment => {
+  const reactSlotTypeBindings = new Set<string>();
+  const reactNamespaceBindings = new Set<string>();
+  const reactJsxNamespaceBindings = new Set<string>();
+  const nonReactJsxNamespaceBindings = new Set<string>();
+  const sameFileTypeDeclarations = new Map<string, EsTreeNode>();
+  let hasLocalJsxNamespace = false;
+
+  if (!isNodeOfType(program, "Program")) {
+    return {
+      reactSlotTypeBindings,
+      reactNamespaceBindings,
+      reactJsxNamespaceBindings,
+      nonReactJsxNamespaceBindings,
+      sameFileTypeDeclarations,
+      hasLocalJsxNamespace,
+    };
+  }
+
+  for (const statement of program.body) {
+    if (isNodeOfType(statement, "ImportDeclaration")) {
+      const isReactImport = statement.source.value === "react";
+      for (const specifier of statement.specifiers) {
+        if (
+          isReactImport &&
+          (isNodeOfType(specifier, "ImportDefaultSpecifier") ||
+            isNodeOfType(specifier, "ImportNamespaceSpecifier"))
+        ) {
+          reactNamespaceBindings.add(specifier.local.name);
+          continue;
+        }
+        if (!isNodeOfType(specifier, "ImportSpecifier")) continue;
+        const importedName = getImportedName(specifier);
+        if (!importedName) continue;
+        if (isReactImport && REACT_SLOT_TYPE_NAMES.has(importedName)) {
+          reactSlotTypeBindings.add(specifier.local.name);
+        }
+        if (importedName === "JSX") {
+          if (isReactImport) reactJsxNamespaceBindings.add(specifier.local.name);
+          else nonReactJsxNamespaceBindings.add(specifier.local.name);
+        }
+      }
+      continue;
+    }
+
+    const declaration = unwrapTopLevelDeclaration(statement);
+    if (!declaration) continue;
+    if (
+      (isNodeOfType(declaration, "TSInterfaceDeclaration") ||
+        isNodeOfType(declaration, "TSTypeAliasDeclaration")) &&
+      isNodeOfType(declaration.id, "Identifier")
+    ) {
+      sameFileTypeDeclarations.set(declaration.id.name, declaration);
+    }
+    if (
+      isNodeOfType(declaration, "TSModuleDeclaration") &&
+      isNodeOfType(declaration.id, "Identifier") &&
+      declaration.id.name === "JSX"
+    ) {
+      hasLocalJsxNamespace = true;
+    }
+  }
+
+  return {
+    reactSlotTypeBindings,
+    reactNamespaceBindings,
+    reactJsxNamespaceBindings,
+    nonReactJsxNamespaceBindings,
+    sameFileTypeDeclarations,
+    hasLocalJsxNamespace,
+  };
+};
+
+const isJsxElementTypeName = (
+  typeName: EsTreeNode,
+  environment: ReactSlotTypeEnvironment,
+): boolean => {
+  if (!isNodeOfType(typeName, "TSQualifiedName")) return false;
+  if (!isNodeOfType(typeName.right, "Identifier") || typeName.right.name !== "Element") {
+    return false;
+  }
+  if (isNodeOfType(typeName.left, "Identifier")) {
+    const namespaceName = typeName.left.name;
+    if (environment.reactNamespaceBindings.has(namespaceName)) return true;
+    if (environment.reactJsxNamespaceBindings.has(namespaceName)) return true;
+    if (environment.nonReactJsxNamespaceBindings.has(namespaceName)) return false;
+    return namespaceName === "JSX" && !environment.hasLocalJsxNamespace;
+  }
+  return (
+    isNodeOfType(typeName.left, "TSQualifiedName") &&
+    isNodeOfType(typeName.left.left, "Identifier") &&
+    environment.reactNamespaceBindings.has(typeName.left.left.name) &&
+    isNodeOfType(typeName.left.right, "Identifier") &&
+    typeName.left.right.name === "JSX"
+  );
+};
+
+const isReactSlotType = (
+  typeNode: EsTreeNode,
+  environment: ReactSlotTypeEnvironment,
+  activeDeclarations: Set<EsTreeNode>,
+): boolean => {
+  if (isNodeOfType(typeNode, "TSUnionType")) {
+    return typeNode.types.some((unionMember) =>
+      isReactSlotType(unionMember, environment, activeDeclarations),
+    );
+  }
+  if (!isNodeOfType(typeNode, "TSTypeReference")) return false;
+  if (isJsxElementTypeName(typeNode.typeName, environment)) return true;
+  if (
+    isNodeOfType(typeNode.typeName, "TSQualifiedName") &&
+    isNodeOfType(typeNode.typeName.left, "Identifier") &&
+    environment.reactNamespaceBindings.has(typeNode.typeName.left.name) &&
+    isNodeOfType(typeNode.typeName.right, "Identifier") &&
+    REACT_SLOT_TYPE_NAMES.has(typeNode.typeName.right.name)
+  ) {
+    return true;
+  }
+  if (!isNodeOfType(typeNode.typeName, "Identifier")) return false;
+  const typeName = typeNode.typeName.name;
+  const sameFileDeclaration = environment.sameFileTypeDeclarations.get(typeName);
+  if (sameFileDeclaration) {
+    if (
+      !isNodeOfType(sameFileDeclaration, "TSTypeAliasDeclaration") ||
+      activeDeclarations.has(sameFileDeclaration)
+    ) {
+      return false;
+    }
+    activeDeclarations.add(sameFileDeclaration);
+    const isSlot = isReactSlotType(
+      sameFileDeclaration.typeAnnotation,
+      environment,
+      activeDeclarations,
+    );
+    activeDeclarations.delete(sameFileDeclaration);
+    return isSlot;
+  }
+  return environment.reactSlotTypeBindings.has(typeName);
+};
+
+const getPropertyName = (property: EsTreeNode): string | null => {
+  if (!isNodeOfType(property, "TSPropertySignature") || property.computed) return null;
+  if (isNodeOfType(property.key, "Identifier")) return property.key.name;
+  if (isNodeOfType(property.key, "Literal") && typeof property.key.value === "string") {
+    return property.key.value;
+  }
+  return null;
+};
+
+const collectSlotPropertyNames = (
+  propsType: EsTreeNode,
+  environment: ReactSlotTypeEnvironment,
+  slotPropertyNames: Set<string>,
+  activeDeclarations: Set<EsTreeNode>,
+): void => {
+  let members: ReadonlyArray<EsTreeNode> | null = null;
+  if (isNodeOfType(propsType, "TSTypeLiteral")) members = propsType.members;
+  if (isNodeOfType(propsType, "TSInterfaceDeclaration")) members = propsType.body.body;
+  if (members) {
+    for (const member of members) {
+      const propertyName = getPropertyName(member);
+      if (!propertyName || !isNodeOfType(member, "TSPropertySignature")) continue;
+      const annotation = member.typeAnnotation;
+      if (
+        annotation &&
+        isNodeOfType(annotation, "TSTypeAnnotation") &&
+        isReactSlotType(annotation.typeAnnotation, environment, new Set())
+      ) {
+        slotPropertyNames.add(propertyName);
+      }
+    }
+    return;
+  }
+  if (isNodeOfType(propsType, "TSIntersectionType")) {
+    for (const intersectionMember of propsType.types) {
+      collectSlotPropertyNames(
+        intersectionMember,
+        environment,
+        slotPropertyNames,
+        activeDeclarations,
+      );
+    }
+    return;
+  }
+  if (isNodeOfType(propsType, "TSTypeAliasDeclaration")) {
+    collectSlotPropertyNames(
+      propsType.typeAnnotation,
+      environment,
+      slotPropertyNames,
+      activeDeclarations,
+    );
+    return;
+  }
+  if (
+    !isNodeOfType(propsType, "TSTypeReference") ||
+    !isNodeOfType(propsType.typeName, "Identifier")
+  ) {
+    return;
+  }
+  const declaration = environment.sameFileTypeDeclarations.get(propsType.typeName.name);
+  if (!declaration || activeDeclarations.has(declaration)) return;
+  activeDeclarations.add(declaration);
+  collectSlotPropertyNames(declaration, environment, slotPropertyNames, activeDeclarations);
+  activeDeclarations.delete(declaration);
+};
+
+const findWrappedComponentFunction = (node: EsTreeNode): EsTreeNode | null => {
+  const candidate = stripParenExpression(node);
+  if (
+    isNodeOfType(candidate, "ArrowFunctionExpression") ||
+    isNodeOfType(candidate, "FunctionExpression")
+  ) {
+    return candidate;
+  }
+  if (!isNodeOfType(candidate, "CallExpression")) return null;
+  const firstArgument = candidate.arguments[0];
+  if (!firstArgument || isNodeOfType(firstArgument, "SpreadElement")) return null;
+  return findWrappedComponentFunction(firstArgument);
+};
+
+const getMemoizedComponentPropsType = (initializer: EsTreeNode): EsTreeNode | null => {
+  const componentFunction = findWrappedComponentFunction(initializer);
+  if (
+    componentFunction &&
+    (isNodeOfType(componentFunction, "ArrowFunctionExpression") ||
+      isNodeOfType(componentFunction, "FunctionExpression"))
+  ) {
+    const firstParameter = componentFunction.params[0];
+    const annotation =
+      firstParameter && "typeAnnotation" in firstParameter ? firstParameter.typeAnnotation : null;
+    if (annotation && isNodeOfType(annotation, "TSTypeAnnotation")) {
+      return annotation.typeAnnotation;
+    }
+  }
+  if (!isNodeOfType(initializer, "CallExpression")) return null;
+  return initializer.typeArguments?.params[0] ?? null;
+};
+
+export const buildSameFileJsxSlotPropRegistry = (
+  program: EsTreeNode,
+  memoRegistry: Map<string, MemoStatus>,
+): Map<string, ReadonlySet<string>> => {
+  const registry = new Map<string, ReadonlySet<string>>();
+  if (!isNodeOfType(program, "Program")) return registry;
+  const environment = buildReactSlotTypeEnvironment(program);
+  for (const statement of program.body) {
+    const declaration = unwrapTopLevelDeclaration(statement);
+    if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) continue;
+    for (const declarator of declaration.declarations) {
+      if (
+        !isNodeOfType(declarator.id, "Identifier") ||
+        memoRegistry.get(declarator.id.name) !== "memoised" ||
+        !declarator.init
+      ) {
+        continue;
+      }
+      const propsType = getMemoizedComponentPropsType(declarator.init);
+      if (!propsType) continue;
+      const slotPropertyNames = new Set<string>();
+      collectSlotPropertyNames(propsType, environment, slotPropertyNames, new Set());
+      if (slotPropertyNames.size > 0) {
+        registry.set(declarator.id.name, slotPropertyNames);
+      }
+    }
+  }
+  return registry;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/build-same-file-jsx-slot-prop-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/build-same-file-jsx-slot-prop-registry.ts
@@ -1,8 +1,9 @@
 import type { MemoStatus } from "./build-same-file-memo-registry.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { getImportedName } from "./get-imported-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
-import { stripParenExpression } from "./strip-paren-expression.js";
+import { unwrapReactHocFunction } from "./unwrap-react-hoc-function.js";
 
 interface ReactSlotTypeEnvironment {
   reactSlotTypeBindings: ReadonlySet<string>;
@@ -227,27 +228,12 @@ const collectSlotPropertyNames = (
   activeDeclarations.delete(declaration);
 };
 
-const findWrappedComponentFunction = (node: EsTreeNode): EsTreeNode | null => {
-  const candidate = stripParenExpression(node);
-  if (
-    isNodeOfType(candidate, "ArrowFunctionExpression") ||
-    isNodeOfType(candidate, "FunctionExpression")
-  ) {
-    return candidate;
-  }
-  if (!isNodeOfType(candidate, "CallExpression")) return null;
-  const firstArgument = candidate.arguments[0];
-  if (!firstArgument || isNodeOfType(firstArgument, "SpreadElement")) return null;
-  return findWrappedComponentFunction(firstArgument);
-};
-
-const getMemoizedComponentPropsType = (initializer: EsTreeNode): EsTreeNode | null => {
-  const componentFunction = findWrappedComponentFunction(initializer);
-  if (
-    componentFunction &&
-    (isNodeOfType(componentFunction, "ArrowFunctionExpression") ||
-      isNodeOfType(componentFunction, "FunctionExpression"))
-  ) {
+const getMemoizedComponentPropsType = (
+  initializer: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  const componentFunction = unwrapReactHocFunction(initializer, scopes);
+  if (componentFunction) {
     const firstParameter = componentFunction.params[0];
     const annotation =
       firstParameter && "typeAnnotation" in firstParameter ? firstParameter.typeAnnotation : null;
@@ -262,8 +248,9 @@ const getMemoizedComponentPropsType = (initializer: EsTreeNode): EsTreeNode | nu
 export const buildSameFileJsxSlotPropRegistry = (
   program: EsTreeNode,
   memoRegistry: Map<string, MemoStatus>,
-): Map<string, ReadonlySet<string>> => {
-  const registry = new Map<string, ReadonlySet<string>>();
+  scopes: ScopeAnalysis,
+): Map<number, ReadonlySet<string>> => {
+  const registry = new Map<number, ReadonlySet<string>>();
   if (!isNodeOfType(program, "Program")) return registry;
   const environment = buildReactSlotTypeEnvironment(program);
   for (const statement of program.body) {
@@ -277,12 +264,14 @@ export const buildSameFileJsxSlotPropRegistry = (
       ) {
         continue;
       }
-      const propsType = getMemoizedComponentPropsType(declarator.init);
+      const componentSymbol = scopes.symbolFor(declarator.id);
+      if (!componentSymbol) continue;
+      const propsType = getMemoizedComponentPropsType(declarator.init, scopes);
       if (!propsType) continue;
       const slotPropertyNames = new Set<string>();
       collectSlotPropertyNames(propsType, environment, slotPropertyNames, new Set());
       if (slotPropertyNames.size > 0) {
-        registry.set(declarator.id.name, slotPropertyNames);
+        registry.set(componentSymbol.id, slotPropertyNames);
       }
     }
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-enclosing-jsx-opening-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-enclosing-jsx-opening-element.ts
@@ -1,0 +1,12 @@
+import { isNodeOfType } from "./is-node-of-type.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+
+export const findEnclosingJsxOpeningElement = (node: EsTreeNode): EsTreeNode | null => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor) {
+    if (isNodeOfType(cursor, "JSXElement")) return cursor.openingElement;
+    if (isNodeOfType(cursor, "JSXFragment")) return null;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
@@ -56,6 +56,11 @@ describe("isReactApiCall", () => {
       expectedCount: 1,
     },
     {
+      name: "wrapped namespace React receivers",
+      code: 'import * as ReactClient from "react"; (ReactClient as any).useEffect(() => {});',
+      expectedCount: 1,
+    },
+    {
       name: "same-named imports from another package",
       code: 'import { useEffect } from "other"; useEffect(() => {});',
       expectedCount: 0,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
@@ -56,6 +56,33 @@ describe("isReactApiCall", () => {
       expectedCount: 1,
     },
     {
+      name: "immutable default and namespace React aliases",
+      code: `import ReactDefault from "react";
+        import * as ReactNamespace from "react";
+        const ReactAlias = ReactDefault;
+        const ChainedReactAlias = ReactAlias;
+        const WrappedReactAlias = ReactNamespace as typeof ReactNamespace;
+        ChainedReactAlias.useEffect(() => {});
+        WrappedReactAlias.useLayoutEffect(() => {});`,
+      expectedCount: 2,
+    },
+    {
+      name: "mutable React aliases",
+      code: `import * as ReactNamespace from "react";
+        let ReactAlias = ReactNamespace;
+        ReactAlias = { useEffect: (callback) => callback() };
+        ReactAlias.useEffect(() => {});`,
+      expectedCount: 0,
+    },
+    {
+      name: "shadowed immutable React aliases",
+      code: `import * as ReactNamespace from "react";
+        const ReactAlias = ReactNamespace;
+        const run = (ReactAlias) => ReactAlias.useEffect(() => {});
+        run({ useEffect: (callback) => callback() });`,
+      expectedCount: 0,
+    },
+    {
       name: "wrapped namespace React receivers",
       code: 'import * as ReactClient from "react"; (ReactClient as any).useEffect(() => {});',
       expectedCount: 1,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
@@ -63,16 +63,17 @@ export const isReactApiCall = (
   if (
     !isNodeOfType(callee, "MemberExpression") ||
     callee.computed ||
-    !isNodeOfType(callee.object, "Identifier") ||
     !isNodeOfType(callee.property, "Identifier") ||
     !includesApiName(apiNames, callee.property.name)
   ) {
     return false;
   }
-  if (isReactNamespaceImport(callee.object, scopes)) return true;
+  const receiver = stripParenExpression(callee.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  if (isReactNamespaceImport(receiver, scopes)) return true;
   return Boolean(
     options.allowGlobalReactNamespace &&
-    callee.object.name === "React" &&
-    scopes.isGlobalReference(callee.object),
+    receiver.name === "React" &&
+    scopes.isGlobalReference(receiver),
   );
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
@@ -2,6 +2,7 @@ import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis
 import type { EsTreeNode } from "./es-tree-node.js";
 import { getImportedName } from "./get-imported-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
 
 export interface ReactApiCallOptions {
@@ -35,8 +36,7 @@ const isNamedReactApiImport = (
 };
 
 const isReactNamespaceImport = (identifier: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  if (!isNodeOfType(identifier, "Identifier")) return false;
-  const symbol = scopes.symbolFor(identifier);
+  const symbol = resolveConstIdentifierAlias(identifier, scopes);
   if (!symbol || !isImportedFromReact(symbol)) return false;
   return (
     isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-const-identifier-alias.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-const-identifier-alias.ts
@@ -1,0 +1,28 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export const resolveConstIdentifierAlias = (
+  identifier: EsTreeNode,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  if (!isNodeOfType(identifier, "Identifier")) return null;
+  const visitedSymbolIds = new Set<number>();
+  let symbol = scopes.symbolFor(identifier);
+  while (symbol?.kind === "const") {
+    if (
+      visitedSymbolIds.has(symbol.id) ||
+      !symbol.initializer ||
+      !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+      symbol.declarationNode.id !== symbol.bindingIdentifier
+    ) {
+      return null;
+    }
+    visitedSymbolIds.add(symbol.id);
+    const initializer = stripParenExpression(symbol.initializer);
+    if (!isNodeOfType(initializer, "Identifier")) return symbol;
+    symbol = scopes.symbolFor(initializer);
+  }
+  return symbol;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/symbol-has-react-use-effect-event-origin.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/symbol-has-react-use-effect-event-origin.ts
@@ -1,20 +1,7 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
-import type { EsTreeNode } from "./es-tree-node.js";
+import { isReactApiCall } from "./is-react-api-call.js";
 import { isNodeOfType } from "./is-node-of-type.js";
-import { isNonReactEffectEventCallee } from "./is-non-react-effect-event-callee.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
-
-const getUseEffectEventCalleeName = (callee: EsTreeNode): string | null => {
-  if (isNodeOfType(callee, "Identifier")) return callee.name;
-  if (
-    isNodeOfType(callee, "MemberExpression") &&
-    !callee.computed &&
-    isNodeOfType(callee.property, "Identifier")
-  ) {
-    return callee.property.name;
-  }
-  return null;
-};
 
 // The ONE symbol-level answer to "is this binding the product of React's own
 // `useEffectEvent`?" — the initializer is a `useEffectEvent(...)` /
@@ -29,6 +16,8 @@ export const symbolHasReactUseEffectEventOrigin = (
 ): boolean => {
   const initializer = symbol.initializer ? stripParenExpression(symbol.initializer) : null;
   if (!initializer || !isNodeOfType(initializer, "CallExpression")) return false;
-  if (getUseEffectEventCalleeName(initializer.callee) !== "useEffectEvent") return false;
-  return !isNonReactEffectEventCallee(initializer.callee, initializer, scopes);
+  return isReactApiCall(initializer, "useEffectEvent", scopes, {
+    allowGlobalReactNamespace: true,
+    allowUnboundBareCalls: true,
+  });
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-react-hoc-function.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-react-hoc-function.ts
@@ -1,4 +1,5 @@
 import { REACT_HOC_NAMES } from "../constants/react.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { flattenCalleeName } from "./flatten-callee-name.js";
@@ -14,23 +15,52 @@ import { stripParenExpression } from "./strip-paren-expression.js";
  *   `() => {}`                          → the arrow
  *   `memo(function Foo() {})`           → the named function expression
  *   `React.memo(forwardRef(() => {}))`  → the inner arrow
- *   `memo(SomeIdentifier)`              → `null` (no inline function)
+ *   `memo(SomeIdentifier)`              → the identifier's same-file function when scopes are provided
  *
  * Component-shaped rules that previously gated on a direct function init
  * (via `isComponentAssignment`) use this so memo-wrapped components are
  * not silently skipped.
  */
-export const unwrapReactHocFunction = (
+const resolveReactHocFunction = (
   node: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis | undefined,
+  visitedSymbolIds: Set<number>,
 ): EsTreeNodeOfType<"ArrowFunctionExpression"> | EsTreeNodeOfType<"FunctionExpression"> | null => {
   if (!node) return null;
-  let current = stripParenExpression(node);
-  while (isNodeOfType(current, "CallExpression")) {
+  const current = stripParenExpression(node);
+  if (isInlineFunctionExpression(current)) return current;
+  if (isNodeOfType(current, "Identifier") && scopes) {
+    const symbol = scopes.symbolFor(current);
+    if (
+      !symbol ||
+      visitedSymbolIds.has(symbol.id) ||
+      !symbol.initializer ||
+      (symbol.kind !== "const" && symbol.kind !== "function")
+    ) {
+      return null;
+    }
+    if (
+      symbol.kind === "const" &&
+      (!isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+        symbol.declarationNode.id !== symbol.bindingIdentifier)
+    ) {
+      return null;
+    }
+    visitedSymbolIds.add(symbol.id);
+    return resolveReactHocFunction(symbol.initializer, scopes, visitedSymbolIds);
+  }
+  if (isNodeOfType(current, "CallExpression")) {
     const calleeName = flattenCalleeName(current.callee);
     if (!calleeName || !REACT_HOC_NAMES.has(calleeName)) return null;
     const firstArgument = current.arguments[0] as EsTreeNode | undefined;
-    if (!firstArgument) return null;
-    current = stripParenExpression(firstArgument);
+    if (!firstArgument || isNodeOfType(firstArgument, "SpreadElement")) return null;
+    return resolveReactHocFunction(firstArgument, scopes, visitedSymbolIds);
   }
-  return isInlineFunctionExpression(current) ? current : null;
+  return null;
 };
+
+export const unwrapReactHocFunction = (
+  node: EsTreeNode | null | undefined,
+  scopes?: ScopeAnalysis,
+): EsTreeNodeOfType<"ArrowFunctionExpression"> | EsTreeNodeOfType<"FunctionExpression"> | null =>
+  resolveReactHocFunction(node, scopes, new Set());

--- a/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
@@ -498,15 +498,13 @@ export { config };
 });
 
 describe("version gating", () => {
-  it("does NOT flag forwardRef on React 18 projects (migration-hint, suppressed below minMajor)", async () => {
-    const projectDir = setupReactProject(tempRoot, "gating-r18-forwardRef", {
+  it("does NOT flag createFactory on React 18 projects (migration-hint, suppressed below minMajor)", async () => {
+    const projectDir = setupReactProject(tempRoot, "gating-r18-createFactory", {
       reactVersion: "^18.3.1",
       files: {
-        "src/Button.tsx": `import { forwardRef } from "react";
+        "src/legacy.tsx": `import React from "react";
 
-export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
-  <button ref={ref} />
-));
+export const createLegacyButton = React.createFactory("button");
 `,
       },
     });
@@ -517,15 +515,13 @@ export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
     expect(hits).toHaveLength(0);
   });
 
-  it("does NOT flag forwardRef on React 17 projects", async () => {
-    const projectDir = setupReactProject(tempRoot, "gating-r17-forwardRef", {
+  it("does NOT flag createFactory on React 17 projects", async () => {
+    const projectDir = setupReactProject(tempRoot, "gating-r17-createFactory", {
       reactVersion: "^17.0.2",
       files: {
-        "src/Button.tsx": `import { forwardRef } from "react";
+        "src/legacy.tsx": `import React from "react";
 
-export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
-  <button ref={ref} />
-));
+export const createLegacyButton = React.createFactory("button");
 `,
       },
     });
@@ -536,14 +532,16 @@ export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
     expect(hits).toHaveLength(0);
   });
 
-  it("DOES flag forwardRef on React 19 projects", async () => {
-    const projectDir = setupReactProject(tempRoot, "gating-r19-forwardRef", {
+  it("accepts forwardRef and flags createFactory on React 19 projects", async () => {
+    const projectDir = setupReactProject(tempRoot, "gating-r19-react-apis", {
       files: {
-        "src/Button.tsx": `import { forwardRef } from "react";
+        "src/Button.tsx": `import React, { forwardRef } from "react";
 
 export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
   <button ref={ref} />
 ));
+
+export const createLegacyButton = React.createFactory("button");
 `,
       },
     });
@@ -551,18 +549,18 @@ export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
     const hits = await collectRuleHits(projectDir, "no-react19-deprecated-apis", {
       reactMajorVersion: 19,
     });
-    expect(hits.length).toBeGreaterThanOrEqual(1);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.message).toContain("createFactory");
+    expect(hits[0]?.message).not.toContain("forwardRef");
   });
 
-  it("does NOT flag forwardRef when the React version is unknown", async () => {
-    const projectDir = setupReactProject(tempRoot, "gating-null-forwardRef", {
+  it("does NOT flag createFactory when the React version is unknown", async () => {
+    const projectDir = setupReactProject(tempRoot, "gating-null-createFactory", {
       reactVersion: "*",
       files: {
-        "src/Button.tsx": `import { forwardRef } from "react";
+        "src/legacy.tsx": `import React from "react";
 
-export const Button = forwardRef<HTMLButtonElement>((_props, ref) => (
-  <button ref={ref} />
-));
+export const createLegacyButton = React.createFactory("button");
 `,
       },
     });


### PR DESCRIPTION
## Why
Three high-confidence precision issues remained from the React Bench ledger: React 19 guidance was stale, typed JSX slots were treated like arbitrary props, and renamed React imports could evade origin checks.

## What changed
- stop reporting `forwardRef`, which remains supported in React 19
- report `createFactory`, which React 19 removed
- preserve JSX passed to explicitly typed `ReactNode`, `ReactElement`, or `JSX.Element` slots
- resolve renamed `useEffectEvent` imports by canonical React API origin
- keep namespace checks scope-aware so shadowed `React` bindings stay quiet

## Examples
React 19 API status:

```tsx
const Input = React.forwardRef((props, ref) => <input ref={ref} {...props} />); // no warning
const LegacyButton = React.createFactory("button"); // reported
```

Typed JSX slots:

```tsx
interface CardProps {
  icon: React.ReactNode;
}

const Card = memo(({ icon }: CardProps) => <>{icon}</>);
const Page = () => <Card icon={<Avatar />} />; // no warning
```

Renamed React imports still retain their origin:

```tsx
import { useEffectEvent as useStableEvent } from "react";
```

## Stack
This PR targets `main`. #1122 is stacked on this branch and uses the shared render/JSX utilities introduced here.

## Verification
- [x] full oxlint plugin suite
- [x] focused React 19, JSX-slot, and rules-of-hooks regressions
- [x] `nr typecheck`
- [x] `nr lint`
- [x] `nr format:check`
- [x] strict targeted fuzzing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect many lint rules’ AST/symbol heuristics (aliases, slot typing, React 19 API set); regressions could mean missed real issues or new false positives, but scope is limited to static analysis in the oxlint plugin.
> 
> **Overview**
> **React 19 migration rule** no longer warns on `forwardRef` and instead reports removed **`createFactory`** (named, namespace, and immutable alias access). The vendored **`components/ui/`** shadcn skip is removed.
> 
> **`jsx-no-jsx-as-prop`** skips inline JSX on same-file **`memo`** children when props are explicitly typed as **`ReactNode`**, **`ReactElement`**, or **`JSX.Element`** (including aliases and `memo(ChildImpl)`), while still flagging non-slot props and untrusted imported/local `JSX` types.
> 
> Shared **`resolveConstIdentifierAlias`** plus **`isReactApiCall`** updates make React API origin checks follow immutable default/namespace aliases and **`(React as …)`** receivers, so **`useEffectEvent`** in **`exhaustive-deps`** / **`rules-of-hooks`** still fires for renamed React imports and stays quiet for polyfills, mutable aliases, and shadowed bindings. Deprecated-import **`MemberExpression`** checks use the same resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68ddf7f49dfe48be4f12a22d4fdedaa721f431aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->