### PR TITLE
fix(rules): correlate effect request cancellation

### DIFF
--- a/.changeset/wild-maps-create.md
+++ b/.changeset/wild-maps-create.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Require `no-fetch-in-effect` cancellation cleanups to guard the matching request and its completion state updates.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
@@ -29,6 +29,21 @@ describe("state-and-effects/no-fetch-in-effect — regressions", () => {
     `);
   });
 
+  it("does not flag an aliased signal passed through a const options object", () => {
+    expectPass(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          const controller = new AbortController();
+          const signal = controller.signal;
+          const options = { signal };
+          fetch(url, options).then((response) => response.json()).then(setProfile);
+          return () => controller.abort();
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
   it("does not flag a fetch guarded by a cancelled flag set in the cleanup", () => {
     expectPass(`
       const GithubSection = ({ isOpen }) => {
@@ -45,6 +60,102 @@ describe("state-and-effects/no-fetch-in-effect — regressions", () => {
             isCancelled = true;
           };
         }, [isOpen]);
+        return null;
+      };
+    `);
+  });
+
+  it("does not flag a promise completion gated by an ignore flag", () => {
+    expectPass(`
+      const SearchResults = ({ query }) => {
+        useEffect(() => {
+          let ignore = false;
+          fetch("/api/search?q=" + query)
+            .then((response) => response.json())
+            .then((results) => {
+              if (!ignore) setResults(results);
+            });
+          setLoading(true);
+          return () => {
+            ignore = true;
+          };
+        }, [query]);
+        return null;
+      };
+    `);
+  });
+
+  it("flags cleanup that aborts a controller not passed to the request", () => {
+    expectFail(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          const controller = new AbortController();
+          fetch(url).then((response) => response.json()).then(setProfile);
+          return () => controller.abort();
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("flags cleanup that aborts a different request controller", () => {
+    expectFail(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          const requestController = new AbortController();
+          const cleanupController = new AbortController();
+          fetch(url, { signal: requestController.signal })
+            .then((response) => response.json())
+            .then(setProfile);
+          return () => cleanupController.abort();
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("flags a cancellation flag that never guards the completion sink", () => {
+    expectFail(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          let isCancelled = false;
+          fetch(url).then((response) => response.json()).then(setProfile);
+          return () => {
+            isCancelled = true;
+          };
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("flags a cancellation flag checked with the stale-result polarity", () => {
+    expectFail(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          let isCancelled = false;
+          fetch(url).then(async (response) => {
+            const profile = await response.json();
+            if (isCancelled) setProfile(profile);
+          });
+          return () => {
+            isCancelled = true;
+          };
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("flags effects when only one of multiple requests uses the aborted signal", () => {
+    expectFail(`
+      const Dashboard = ({ profileUrl, activityUrl }) => {
+        useEffect(() => {
+          const controller = new AbortController();
+          fetch(profileUrl, { signal: controller.signal }).then(setProfile);
+          fetch(activityUrl).then(setActivity);
+          return () => controller.abort();
+        }, [profileUrl, activityUrl]);
         return null;
       };
     `);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
@@ -260,4 +260,108 @@ describe("state-and-effects/no-fetch-in-effect — regressions", () => {
       };
     `);
   });
+
+  it("flags a fetch inside an effect-registered event listener", () => {
+    expectFail(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          const onFocus = () => {
+            fetch(url).then((response) => response.json()).then(setProfile);
+          };
+          window.addEventListener("focus", onFocus);
+          return () => window.removeEventListener("focus", onFocus);
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("flags a fetch inside an effect-scheduled timer callback", () => {
+    expectFail(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          const timer = setTimeout(() => {
+            fetch(url).then((response) => response.json()).then(setProfile);
+          }, 100);
+          return () => clearTimeout(timer);
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("ignores a fetch inside an unreferenced nested declaration", () => {
+    expectPass(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          const neverCalled = () => {
+            fetch(url).then((response) => response.json()).then(setProfile);
+          };
+          console.log("mounted");
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("does not flag an event-listener fetch cancelled by its matching controller", () => {
+    expectPass(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          const controller = new AbortController();
+          const onFocus = () => {
+            fetch(url, { signal: controller.signal })
+              .then((response) => response.json())
+              .then(setProfile);
+          };
+          window.addEventListener("focus", onFocus);
+          return () => {
+            window.removeEventListener("focus", onFocus);
+            controller.abort();
+          };
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("does not flag a timer fetch whose completion uses the matching ignore flag", () => {
+    expectPass(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          let ignore = false;
+          const timer = setTimeout(async () => {
+            const response = await fetch(url);
+            if (ignore) return;
+            setProfile(await response.json());
+          }, 100);
+          return () => {
+            ignore = true;
+            clearTimeout(timer);
+          };
+        }, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("flags a listener fetch when cleanup aborts an unrelated controller", () => {
+    expectFail(`
+      const Profile = ({ url }) => {
+        useEffect(() => {
+          const requestController = new AbortController();
+          const cleanupController = new AbortController();
+          const onFocus = () => {
+            fetch(url, { signal: requestController.signal }).then(setProfile);
+          };
+          window.addEventListener("focus", onFocus);
+          return () => {
+            window.removeEventListener("focus", onFocus);
+            cleanupController.abort();
+          };
+        }, [url]);
+        return null;
+      };
+    `);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -2,7 +2,6 @@ import { FETCH_CALLEE_NAMES, FETCH_MEMBER_OBJECTS } from "../../constants/librar
 import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { collectEffectInvokedFunctions } from "../../utils/collect-effect-invoked-functions.js";
-import { executesDuringRender } from "../../utils/executes-during-render.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
@@ -62,45 +61,51 @@ const isXmlHttpRequestConstruction = (node: EsTreeNode): boolean =>
 const isNetworkRequest = (node: EsTreeNode): boolean =>
   isRealFetchCall(node) || isXmlHttpRequestConstruction(node);
 
-const collectComponentScopeFunctionBindings = (
-  componentScope: EsTreeNode,
-  effectCallback: EsTreeNode,
-): Map<string, EsTreeNode> => {
-  const bindings = new Map<string, EsTreeNode>();
-  walkAst(componentScope, (child) => {
-    if (child === effectCallback) return false;
-    if (isNodeOfType(child, "VariableDeclarator") && isNodeOfType(child.id, "Identifier")) {
-      const initializer = child.init ? stripParenExpression(child.init) : null;
-      if (isFunctionLike(initializer)) bindings.set(child.id.name, initializer);
-      return;
-    }
-    if (isNodeOfType(child, "FunctionDeclaration") && isNodeOfType(child.id, "Identifier")) {
-      bindings.set(child.id.name, child);
-    }
-  });
-  return bindings;
+const resolveLocalFunction = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+): EsTreeNode | null => {
+  if (!expression) return null;
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isFunctionLike(unwrappedExpression)) return unwrappedExpression;
+  if (!isNodeOfType(unwrappedExpression, "Identifier")) return null;
+  const initializer = context.scopes.symbolFor(unwrappedExpression)?.initializer;
+  if (!initializer) return null;
+  const unwrappedInitializer = stripParenExpression(initializer);
+  return isFunctionLike(unwrappedInitializer) ? unwrappedInitializer : null;
 };
 
-const collectEffectAnalysisFunctions = (effectCallback: EsTreeNode): Set<EsTreeNode> => {
-  const invokedFunctions = collectEffectInvokedFunctions(effectCallback);
-  const enclosingComponent = findEnclosingFunction(effectCallback);
-  if (!enclosingComponent) return invokedFunctions;
+const collectEffectAnalysisFunctions = (
+  effectCallback: EsTreeNode,
+  context: RuleContext,
+): Set<EsTreeNode> => {
+  const analysisFunctions = new Set<EsTreeNode>();
+  const pendingFunctions: EsTreeNode[] = [];
+  const enqueueFunction = (functionNode: EsTreeNode): void => {
+    for (const invokedFunction of collectEffectInvokedFunctions(functionNode)) {
+      if (analysisFunctions.has(invokedFunction)) continue;
+      analysisFunctions.add(invokedFunction);
+      pendingFunctions.push(invokedFunction);
+    }
+  };
 
-  const scopeFunctions = collectComponentScopeFunctionBindings(enclosingComponent, effectCallback);
-  walkAst(effectCallback, (child) => {
-    if (child !== effectCallback && isFunctionLike(child) && invokedFunctions.has(child)) {
-      return false;
-    }
-    if (isNodeOfType(child, "CallExpression") && isNodeOfType(child.callee, "Identifier")) {
-      const scopeFunction = scopeFunctions.get(child.callee.name);
-      if (scopeFunction) {
-        for (const invokedFunction of collectEffectInvokedFunctions(scopeFunction)) {
-          invokedFunctions.add(invokedFunction);
-        }
+  enqueueFunction(effectCallback);
+  while (pendingFunctions.length > 0) {
+    const currentFunction = pendingFunctions.pop();
+    if (!currentFunction) break;
+    walkAst(currentFunction, (child) => {
+      if (child !== currentFunction && isFunctionLike(child)) return false;
+      if (!isNodeOfType(child, "CallExpression")) return;
+
+      const calledFunction = resolveLocalFunction(child.callee, context);
+      if (calledFunction) enqueueFunction(calledFunction);
+      for (const callArgument of child.arguments ?? []) {
+        const callbackFunction = resolveLocalFunction(callArgument, context);
+        if (callbackFunction) enqueueFunction(callbackFunction);
       }
-    }
-  });
-  return invokedFunctions;
+    });
+  }
+  return analysisFunctions;
 };
 
 const collectNodesFromAnalysisFunctions = (
@@ -111,9 +116,7 @@ const collectNodesFromAnalysisFunctions = (
   const seenNodes = new Set<EsTreeNode>();
   for (const analysisFunction of analysisFunctions) {
     walkAst(analysisFunction, (child) => {
-      if (child !== analysisFunction && isFunctionLike(child) && !executesDuringRender(child)) {
-        return false;
-      }
+      if (child !== analysisFunction && isFunctionLike(child)) return false;
       if (!seenNodes.has(child) && predicate(child)) {
         seenNodes.add(child);
         nodes.push(child);
@@ -511,7 +514,7 @@ export const noFetchInEffect = defineRule({
       const callback = getEffectCallback(node);
       if (!callback) return;
 
-      const analysisFunctions = collectEffectAnalysisFunctions(callback);
+      const analysisFunctions = collectEffectAnalysisFunctions(callback, context);
       const requests = collectNodesFromAnalysisFunctions(analysisFunctions, isNetworkRequest);
       if (requests.length === 0) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -2,11 +2,17 @@ import { FETCH_CALLEE_NAMES, FETCH_MEMBER_OBJECTS } from "../../constants/librar
 import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { collectEffectInvokedFunctions } from "../../utils/collect-effect-invoked-functions.js";
+import { executesDuringRender } from "../../utils/executes-during-render.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { isSetterCall } from "../../utils/is-setter-call.js";
+import { resolveExpressionKey } from "../../utils/resolve-expression-key.js";
+import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -20,7 +26,8 @@ const IMPORT_INITIALIZER_TYPES = new Set([
   "ImportNamespaceSpecifier",
 ]);
 
-const CANCELLATION_FLAG_NAME_PATTERN = /cancel/i;
+const CANCELLATION_FLAG_NAME_PATTERN = /cancel|ignore/i;
+const PROMISE_CONTINUATION_METHOD_NAMES = new Set(["then", "catch", "finally"]);
 
 // `const fetch = useCallback(...)` (demo mocks, wrappers) shadows the global;
 // the call is not a network fetch by the library the rule targets. A binding
@@ -55,18 +62,6 @@ const isXmlHttpRequestConstruction = (node: EsTreeNode): boolean =>
 const isNetworkRequest = (node: EsTreeNode): boolean =>
   isRealFetchCall(node) || isXmlHttpRequestConstruction(node);
 
-const containsNetworkRequest = (root: EsTreeNode): boolean => {
-  let found = false;
-  walkAst(root, (child) => {
-    if (found) return false;
-    if (isNetworkRequest(child)) {
-      found = true;
-      return false;
-    }
-  });
-  return found;
-};
-
 const collectComponentScopeFunctionBindings = (
   componentScope: EsTreeNode,
   effectCallback: EsTreeNode,
@@ -86,31 +81,46 @@ const collectComponentScopeFunctionBindings = (
   return bindings;
 };
 
-const containsNetworkRequestInEffect = (effectCallback: EsTreeNode): boolean => {
+const collectEffectAnalysisFunctions = (effectCallback: EsTreeNode): Set<EsTreeNode> => {
   const invokedFunctions = collectEffectInvokedFunctions(effectCallback);
-  for (const invokedFunction of invokedFunctions) {
-    if (containsNetworkRequest(invokedFunction)) return true;
-  }
-
   const enclosingComponent = findEnclosingFunction(effectCallback);
-  if (!enclosingComponent) return false;
+  if (!enclosingComponent) return invokedFunctions;
 
   const scopeFunctions = collectComponentScopeFunctionBindings(enclosingComponent, effectCallback);
-  let found = false;
   walkAst(effectCallback, (child) => {
-    if (found) return false;
     if (child !== effectCallback && isFunctionLike(child) && invokedFunctions.has(child)) {
       return false;
     }
     if (isNodeOfType(child, "CallExpression") && isNodeOfType(child.callee, "Identifier")) {
       const scopeFunction = scopeFunctions.get(child.callee.name);
-      if (scopeFunction && containsNetworkRequest(scopeFunction)) {
-        found = true;
-        return false;
+      if (scopeFunction) {
+        for (const invokedFunction of collectEffectInvokedFunctions(scopeFunction)) {
+          invokedFunctions.add(invokedFunction);
+        }
       }
     }
   });
-  return found;
+  return invokedFunctions;
+};
+
+const collectNodesFromAnalysisFunctions = (
+  analysisFunctions: ReadonlySet<EsTreeNode>,
+  predicate: (node: EsTreeNode) => boolean,
+): EsTreeNode[] => {
+  const nodes: EsTreeNode[] = [];
+  const seenNodes = new Set<EsTreeNode>();
+  for (const analysisFunction of analysisFunctions) {
+    walkAst(analysisFunction, (child) => {
+      if (child !== analysisFunction && isFunctionLike(child) && !executesDuringRender(child)) {
+        return false;
+      }
+      if (!seenNodes.has(child) && predicate(child)) {
+        seenNodes.add(child);
+        nodes.push(child);
+      }
+    });
+  }
+  return nodes;
 };
 
 const findEffectCleanupFunction = (callback: EsTreeNode): EsTreeNode | null => {
@@ -131,11 +141,14 @@ const findEffectCleanupFunction = (callback: EsTreeNode): EsTreeNode | null => {
   return cleanup;
 };
 
-const collectEffectCancellationFlagNames = (effectCallback: EsTreeNode): Set<string> => {
-  const flagNames = new Set<string>();
-  if (!isFunctionLike(effectCallback)) return flagNames;
+const collectEffectCancellationFlagKeys = (
+  effectCallback: EsTreeNode,
+  context: RuleContext,
+): Set<string> => {
+  const flagKeys = new Set<string>();
+  if (!isFunctionLike(effectCallback)) return flagKeys;
   const body = effectCallback.body;
-  if (!isNodeOfType(body, "BlockStatement")) return flagNames;
+  if (!isNodeOfType(body, "BlockStatement")) return flagKeys;
   for (const statement of body.body ?? []) {
     if (!isNodeOfType(statement, "VariableDeclaration") || statement.kind !== "let") continue;
     for (const declarator of statement.declarations ?? []) {
@@ -151,42 +164,339 @@ const collectEffectCancellationFlagNames = (effectCallback: EsTreeNode): Set<str
         initializer.value === false &&
         CANCELLATION_FLAG_NAME_PATTERN.test(declarator.id.name)
       ) {
-        flagNames.add(declarator.id.name);
+        const flagKey = resolveExpressionKey(declarator.id, context);
+        if (flagKey) flagKeys.add(flagKey);
       }
     }
   }
-  return flagNames;
+  return flagKeys;
 };
 
-// The doc's explicit false-positive carve-out: a one-shot fetch with proper
-// cancellation cleanup — `controller.abort()` on unmount, or the react.dev
-// boolean-flag equivalent (`cancelled = true` checked before setState).
-const isCancellationCleanup = (cleanup: EsTreeNode, effectCallback: EsTreeNode): boolean => {
-  const cancellationFlagNames = collectEffectCancellationFlagNames(effectCallback);
-  let found = false;
+const resolveConstValue = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+  visitedSymbolIds: Set<number> = new Set(),
+): EsTreeNode | null => {
+  if (!expression) return null;
+  const unwrappedExpression = stripParenExpression(expression);
+  if (!isNodeOfType(unwrappedExpression, "Identifier")) return unwrappedExpression;
+  const symbol = context.scopes.symbolFor(unwrappedExpression);
+  if (
+    !symbol ||
+    symbol.kind !== "const" ||
+    !symbol.initializer ||
+    visitedSymbolIds.has(symbol.id)
+  ) {
+    return unwrappedExpression;
+  }
+  visitedSymbolIds.add(symbol.id);
+  return resolveConstValue(symbol.initializer, context, visitedSymbolIds);
+};
+
+const resolveRequestAbortControllerKey = (
+  request: EsTreeNode,
+  context: RuleContext,
+): string | null => {
+  if (isNodeOfType(request, "NewExpression")) {
+    const declarator = request.parent;
+    return isNodeOfType(declarator, "VariableDeclarator") && declarator.init === request
+      ? resolveExpressionKey(declarator.id, context)
+      : null;
+  }
+  if (!isNodeOfType(request, "CallExpression")) return null;
+  for (const requestArgument of request.arguments ?? []) {
+    const options = resolveConstValue(requestArgument, context);
+    if (!isNodeOfType(options, "ObjectExpression")) continue;
+    for (const property of options.properties ?? []) {
+      if (
+        !isNodeOfType(property, "Property") ||
+        getStaticPropertyKeyName(property, { allowComputedString: true }) !== "signal"
+      ) {
+        continue;
+      }
+      const signalKey = resolveExpressionKey(property.value, context);
+      return signalKey?.endsWith(".signal") ? signalKey.slice(0, -".signal".length) : null;
+    }
+  }
+  return null;
+};
+
+const collectCleanupAbortedControllerKeys = (
+  cleanup: EsTreeNode,
+  context: RuleContext,
+): Set<string> => {
+  const controllerKeys = new Set<string>();
   walkAst(cleanup, (child) => {
-    if (found) return false;
     if (
       isNodeOfType(child, "CallExpression") &&
       isNodeOfType(child.callee, "MemberExpression") &&
+      !child.callee.computed &&
       isNodeOfType(child.callee.property, "Identifier") &&
       child.callee.property.name === "abort"
     ) {
-      found = true;
-      return false;
+      const controllerKey = resolveExpressionKey(child.callee.object, context);
+      if (controllerKey) controllerKeys.add(controllerKey);
     }
+  });
+  return controllerKeys;
+};
+
+const collectCleanupAssignedCancellationFlagKeys = (
+  cleanup: EsTreeNode,
+  cancellationFlagKeys: ReadonlySet<string>,
+  context: RuleContext,
+): Set<string> => {
+  const assignedFlagKeys = new Set<string>();
+  walkAst(cleanup, (child) => {
     if (
       isNodeOfType(child, "AssignmentExpression") &&
-      isNodeOfType(child.left, "Identifier") &&
-      cancellationFlagNames.has(child.left.name) &&
       isNodeOfType(child.right, "Literal") &&
       child.right.value === true
     ) {
-      found = true;
-      return false;
+      const assignedKey = resolveExpressionKey(child.left, context);
+      if (assignedKey && cancellationFlagKeys.has(assignedKey)) {
+        assignedFlagKeys.add(assignedKey);
+      }
     }
   });
-  return found;
+  return assignedFlagKeys;
+};
+
+const readCancellationCondition = (
+  expression: EsTreeNode,
+  cancellationFlagKey: string,
+  context: RuleContext,
+): boolean | null => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (resolveExpressionKey(unwrappedExpression, context) === cancellationFlagKey) return true;
+  if (
+    isNodeOfType(unwrappedExpression, "UnaryExpression") &&
+    unwrappedExpression.operator === "!"
+  ) {
+    const argumentResult = readCancellationCondition(
+      unwrappedExpression.argument,
+      cancellationFlagKey,
+      context,
+    );
+    return argumentResult === null ? null : !argumentResult;
+  }
+  if (!isNodeOfType(unwrappedExpression, "BinaryExpression")) return null;
+  const leftResult = readCancellationCondition(
+    unwrappedExpression.left,
+    cancellationFlagKey,
+    context,
+  );
+  const rightResult = readCancellationCondition(
+    unwrappedExpression.right,
+    cancellationFlagKey,
+    context,
+  );
+  const leftBoolean =
+    isNodeOfType(unwrappedExpression.left, "Literal") &&
+    typeof unwrappedExpression.left.value === "boolean"
+      ? unwrappedExpression.left.value
+      : null;
+  const rightBoolean =
+    isNodeOfType(unwrappedExpression.right, "Literal") &&
+    typeof unwrappedExpression.right.value === "boolean"
+      ? unwrappedExpression.right.value
+      : null;
+  const comparedCancellationValue =
+    leftResult !== null && rightBoolean !== null
+      ? rightBoolean
+      : rightResult !== null && leftBoolean !== null
+        ? leftBoolean
+        : null;
+  if (comparedCancellationValue === null) return null;
+  if (unwrappedExpression.operator === "===" || unwrappedExpression.operator === "==") {
+    return comparedCancellationValue;
+  }
+  if (unwrappedExpression.operator === "!==" || unwrappedExpression.operator === "!=") {
+    return !comparedCancellationValue;
+  }
+  return null;
+};
+
+const isCompletionSinkInsideCancellationGuard = (
+  completionSink: EsTreeNode,
+  cancellationFlagKey: string,
+  context: RuleContext,
+): boolean => {
+  let currentNode = completionSink;
+  let parentNode = currentNode.parent;
+  while (parentNode) {
+    if (isFunctionLike(parentNode)) return false;
+    if (isNodeOfType(parentNode, "IfStatement")) {
+      const cancellationResult = readCancellationCondition(
+        parentNode.test,
+        cancellationFlagKey,
+        context,
+      );
+      if (currentNode === parentNode.consequent && cancellationResult === false) return true;
+      if (currentNode === parentNode.alternate && cancellationResult === true) return true;
+    }
+    if (isNodeOfType(parentNode, "ConditionalExpression")) {
+      const cancellationResult = readCancellationCondition(
+        parentNode.test,
+        cancellationFlagKey,
+        context,
+      );
+      if (currentNode === parentNode.consequent && cancellationResult === false) return true;
+      if (currentNode === parentNode.alternate && cancellationResult === true) return true;
+    }
+    if (isNodeOfType(parentNode, "LogicalExpression") && currentNode === parentNode.right) {
+      const cancellationResult = readCancellationCondition(
+        parentNode.left,
+        cancellationFlagKey,
+        context,
+      );
+      if (parentNode.operator === "&&" && cancellationResult === false) return true;
+      if (parentNode.operator === "||" && cancellationResult === true) return true;
+    }
+    currentNode = parentNode;
+    parentNode = currentNode.parent;
+  }
+  return false;
+};
+
+const isCompletionSinkAfterCancellationEarlyExit = (
+  completionSink: EsTreeNode,
+  cancellationFlagKey: string,
+  context: RuleContext,
+): boolean => {
+  let currentNode = completionSink;
+  let parentNode = currentNode.parent;
+  while (parentNode) {
+    if (isFunctionLike(parentNode)) return false;
+    if (isNodeOfType(parentNode, "BlockStatement")) {
+      const statementIndex = parentNode.body.findIndex((statement) => statement === currentNode);
+      if (statementIndex >= 0) {
+        for (const statement of parentNode.body.slice(0, statementIndex)) {
+          if (!isNodeOfType(statement, "IfStatement")) continue;
+          const cancellationResult = readCancellationCondition(
+            statement.test,
+            cancellationFlagKey,
+            context,
+          );
+          if (
+            (cancellationResult === true && statementAlwaysExits(statement.consequent)) ||
+            (cancellationResult === false &&
+              statement.alternate &&
+              statementAlwaysExits(statement.alternate))
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+    currentNode = parentNode;
+    parentNode = currentNode.parent;
+  }
+  return false;
+};
+
+const isCompletionSinkGuardedByCancellationFlag = (
+  completionSink: EsTreeNode,
+  cancellationFlagKey: string,
+  context: RuleContext,
+): boolean =>
+  isCompletionSinkInsideCancellationGuard(completionSink, cancellationFlagKey, context) ||
+  isCompletionSinkAfterCancellationEarlyExit(completionSink, cancellationFlagKey, context);
+
+const isDescendantOf = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
+  let currentNode: EsTreeNode | null | undefined = node;
+  while (currentNode) {
+    if (currentNode === ancestor) return true;
+    currentNode = currentNode.parent ?? null;
+  }
+  return false;
+};
+
+const isPromiseContinuationForRequest = (
+  functionNode: EsTreeNode,
+  request: EsTreeNode,
+): boolean => {
+  const callNode = functionNode.parent;
+  if (
+    !isNodeOfType(callNode, "CallExpression") ||
+    !callNode.arguments?.some((callArgument) => callArgument === functionNode) ||
+    !isNodeOfType(callNode.callee, "MemberExpression") ||
+    callNode.callee.computed ||
+    !isNodeOfType(callNode.callee.property, "Identifier") ||
+    !PROMISE_CONTINUATION_METHOD_NAMES.has(callNode.callee.property.name)
+  ) {
+    return false;
+  }
+  return isDescendantOf(request, callNode.callee.object);
+};
+
+const isAwaitedInFunction = (request: EsTreeNode, functionNode: EsTreeNode): boolean => {
+  let currentNode = request.parent;
+  while (currentNode && currentNode !== functionNode) {
+    if (isNodeOfType(currentNode, "AwaitExpression")) return true;
+    currentNode = currentNode.parent ?? null;
+  }
+  return false;
+};
+
+const isCompletionSinkForRequest = (completionSink: EsTreeNode, request: EsTreeNode): boolean => {
+  const requestFunction = findEnclosingFunction(request);
+  const completionSinkFunction = findEnclosingFunction(completionSink);
+  if (!requestFunction || !completionSinkFunction) return false;
+  if (requestFunction === completionSinkFunction) {
+    if (!isAwaitedInFunction(request, requestFunction)) return false;
+    const requestStart = getRangeStart(request);
+    const completionSinkStart = getRangeStart(completionSink);
+    return (
+      requestStart === null || completionSinkStart === null || completionSinkStart > requestStart
+    );
+  }
+  return isPromiseContinuationForRequest(completionSinkFunction, request);
+};
+
+const requestHasGuardedCompletionSinks = (
+  request: EsTreeNode,
+  completionSinks: ReadonlyArray<EsTreeNode>,
+  assignedCancellationFlagKeys: ReadonlySet<string>,
+  context: RuleContext,
+): boolean => {
+  const followingCompletionSinks = completionSinks.filter((completionSink) =>
+    isCompletionSinkForRequest(completionSink, request),
+  );
+  return (
+    followingCompletionSinks.length > 0 &&
+    followingCompletionSinks.every((completionSink) =>
+      [...assignedCancellationFlagKeys].some((cancellationFlagKey) =>
+        isCompletionSinkGuardedByCancellationFlag(completionSink, cancellationFlagKey, context),
+      ),
+    )
+  );
+};
+
+const allRequestsHaveCorrelatedCancellation = (
+  requests: ReadonlyArray<EsTreeNode>,
+  completionSinks: ReadonlyArray<EsTreeNode>,
+  cleanup: EsTreeNode,
+  effectCallback: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const abortedControllerKeys = collectCleanupAbortedControllerKeys(cleanup, context);
+  const cancellationFlagKeys = collectEffectCancellationFlagKeys(effectCallback, context);
+  const assignedCancellationFlagKeys = collectCleanupAssignedCancellationFlagKeys(
+    cleanup,
+    cancellationFlagKeys,
+    context,
+  );
+  return requests.every((request) => {
+    const requestControllerKey = resolveRequestAbortControllerKey(request, context);
+    if (requestControllerKey && abortedControllerKeys.has(requestControllerKey)) return true;
+    return requestHasGuardedCompletionSinks(
+      request,
+      completionSinks,
+      assignedCancellationFlagKeys,
+      context,
+    );
+  });
 };
 
 export const noFetchInEffect = defineRule({
@@ -201,10 +511,25 @@ export const noFetchInEffect = defineRule({
       const callback = getEffectCallback(node);
       if (!callback) return;
 
-      if (!containsNetworkRequestInEffect(callback)) return;
+      const analysisFunctions = collectEffectAnalysisFunctions(callback);
+      const requests = collectNodesFromAnalysisFunctions(analysisFunctions, isNetworkRequest);
+      if (requests.length === 0) return;
 
       const cleanup = findEffectCleanupFunction(callback);
-      if (cleanup && isCancellationCleanup(cleanup, callback)) return;
+      if (cleanup) {
+        const completionSinks = collectNodesFromAnalysisFunctions(analysisFunctions, isSetterCall);
+        if (
+          allRequestsHaveCorrelatedCancellation(
+            requests,
+            completionSinks,
+            cleanup,
+            callback,
+            context,
+          )
+        ) {
+          return;
+        }
+      }
 
       context.report({
         node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-expression-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-expression-key.ts
@@ -1,0 +1,67 @@
+import { getRangeStart } from "./get-range-start.js";
+import { getStaticPropertyKeyName } from "./get-static-property-key-name.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { RuleContext } from "./rule-context.js";
+
+export const resolveExpressionKey = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+  visitedSymbolIds: Set<number> = new Set(),
+): string | null => {
+  if (!expression) return null;
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isNodeOfType(unwrappedExpression, "Identifier")) {
+    const symbol = context.scopes.symbolFor(unwrappedExpression);
+    if (!symbol) {
+      return context.scopes.isGlobalReference(unwrappedExpression)
+        ? `global:${unwrappedExpression.name}`
+        : null;
+    }
+    if (visitedSymbolIds.has(symbol.id)) return `symbol:${symbol.id}`;
+    visitedSymbolIds.add(symbol.id);
+    const bindingProperty = symbol.bindingIdentifier.parent;
+    const bindingPattern = bindingProperty?.parent;
+    const variableDeclarator = bindingPattern?.parent;
+    const bindingPropertyName = isNodeOfType(bindingProperty, "Property")
+      ? getStaticPropertyKeyName(bindingProperty)
+      : null;
+    if (
+      bindingPropertyName &&
+      isNodeOfType(bindingPattern, "ObjectPattern") &&
+      isNodeOfType(variableDeclarator, "VariableDeclarator") &&
+      variableDeclarator.id === bindingPattern
+    ) {
+      const objectKey = resolveExpressionKey(variableDeclarator.init, context, visitedSymbolIds);
+      return objectKey ? `${objectKey}.${bindingPropertyName}` : `symbol:${symbol.id}`;
+    }
+    const initializer = symbol.initializer ? stripParenExpression(symbol.initializer) : null;
+    if (
+      symbol.kind === "const" &&
+      initializer &&
+      (isNodeOfType(initializer, "Identifier") || isNodeOfType(initializer, "MemberExpression"))
+    ) {
+      return resolveExpressionKey(initializer, context, visitedSymbolIds) ?? `symbol:${symbol.id}`;
+    }
+    return `symbol:${symbol.id}`;
+  }
+  if (isNodeOfType(unwrappedExpression, "MemberExpression") && !unwrappedExpression.computed) {
+    if (!isNodeOfType(unwrappedExpression.property, "Identifier")) return null;
+    const objectKey = resolveExpressionKey(unwrappedExpression.object, context, visitedSymbolIds);
+    return objectKey ? `${objectKey}.${unwrappedExpression.property.name}` : null;
+  }
+  if (isNodeOfType(unwrappedExpression, "ThisExpression")) return "this";
+  if (
+    isNodeOfType(unwrappedExpression, "Literal") &&
+    (typeof unwrappedExpression.value === "string" || typeof unwrappedExpression.value === "number")
+  ) {
+    return `literal:${String(unwrappedExpression.value)}`;
+  }
+  if (isFunctionLike(unwrappedExpression)) {
+    const rangeStart = getRangeStart(unwrappedExpression);
+    return rangeStart === null ? null : `function:${rangeStart}`;
+  }
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/statement-always-exits.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/statement-always-exits.ts
@@ -1,0 +1,17 @@
+import { isNodeOfType } from "./is-node-of-type.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+
+export const statementAlwaysExits = (statement: EsTreeNode): boolean => {
+  if (isNodeOfType(statement, "ReturnStatement") || isNodeOfType(statement, "ThrowStatement")) {
+    return true;
+  }
+  if (isNodeOfType(statement, "IfStatement")) {
+    return Boolean(
+      statement.alternate &&
+      statementAlwaysExits(statement.consequent) &&
+      statementAlwaysExits(statement.alternate),
+    );
+  }
+  if (!isNodeOfType(statement, "BlockStatement")) return false;
+  return statement.body.some((childStatement) => statementAlwaysExits(childStatement));
+};


### PR DESCRIPTION
## Why

Catches effect requests whose cleanup looks cancellable but does not protect the request that can commit stale state.

Previously, any `.abort()` call or cancellation-looking flag assignment suppressed `no-fetch-in-effect`, even when the controller was never passed to the request, a different controller was aborted, or the flag never guarded the async completion.

Before:

```tsx
useEffect(() => {
  const controller = new AbortController()
  fetch(url).then(response => response.json()).then(setProfile)
  return () => controller.abort()
}, [url])
```

After:

```tsx
useEffect(() => {
  const controller = new AbortController()
  fetch(url, { signal: controller.signal })
    .then(response => response.json())
    .then(setProfile)
  return () => controller.abort()
}, [url])
```

The React-documented ignore-flag pattern remains valid when the same cleanup-assigned flag gates the request's completion state update.

## What changed

- Correlates request signals, const aliases, cleanup abort receivers, and XHR handles by binding identity.
- Requires every request in a multi-request effect to have matching cancellation.
- Proves ignore/cancel flags are assigned in cleanup and guard async state-setter sinks with the correct polarity.
- Keeps unrelated synchronous state updates outside promise completions from invalidating a valid guard.
- Adds adversarial regressions and a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| Distinct repos scanned | 12 |
| RootDir scans | 100 |
| Target rule | `no-fetch-in-effect` |
| Diagnostics | 3 unchanged from baseline |
| New diagnostics | 0 |
| False positives found | 0 |
| Manually inspected hits | 3/3 |
| Output artifact | `react-doctor-evals/.evals/-Users-aidenybai-Developer-react-doctor-pr-fetch-cancellation.jsonl` |

## Test plan

- `nr test -- src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts`
- `nr typecheck`
- `nr lint`
- `FUZZ_RULE=no-fetch-in-effect FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- Local RDE scan across 100 roots / 12 distinct repositories

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Linter behavior change may surface new warnings on effects with superficial cleanup; logic is complex but scoped to one rule with heavy regression coverage.
> 
> **Overview**
> Tightens **`no-fetch-in-effect`** so cleanup only suppresses the warning when cancellation actually protects each network request and its async state updates—not when cleanup merely *looks* cancellable.
> 
> The rule now walks a broader set of effect-reachable functions (including listeners and timers), matches **`AbortController`** instances to **`fetch`** signals (including const aliases and `{ signal }` options objects) via a new **`resolveExpressionKey`** helper, and requires **every** request in a multi-fetch effect to be covered. For ignore/cancel flags (now including **`ignore`**), cleanup must assign the flag and completion **setters** must be guarded with the correct polarity (`if (!ignore)` / early return), with **`statementAlwaysExits`** supporting early-exit patterns.
> 
> Effects that only remove listeners or clear timers without correlating abort/guards still flag; dead nested declarations are ignored. Adds extensive regression tests and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9ead4c89c654aead989da3cf4a3f7c66bdde08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->