### PR TITLE
fix(rules): correlate useSyncExternalStore cleanup

### DIFF
--- a/.changeset/lucky-lions-jog.md
+++ b/.changeset/lucky-lions-jog.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix effect-needs-cleanup correlation for useSyncExternalStore subscribe callbacks that return matching disposers.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--external-store-returned-disposer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--external-store-returned-disposer.tsx
@@ -1,0 +1,20 @@
+// rule: effect-needs-cleanup
+// weakness: library-idiom
+// source: react-bench TaskTrove LanguageProvider false positive
+import { useCallback, useSyncExternalStore } from "react";
+import i18next from "i18next";
+
+export const LanguageProvider = () => {
+  const subscribeToLanguage = useCallback((onStoreChange: () => void) => {
+    i18next.on("languageChanged", onStoreChange);
+    return () => {
+      i18next.off("languageChanged", onStoreChange);
+    };
+  }, []);
+
+  return useSyncExternalStore(
+    subscribeToLanguage,
+    () => i18next.resolvedLanguage,
+    () => "en",
+  );
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -142,6 +142,7 @@ export const GUARD_SNIPPET_POOL = [
 
 // Library idioms — tanstack, mobx, styled-components, next/dynamic, redux.
 export const LIBRARY_SNIPPET_POOL = [
+  `const subscribeStore = useCallback((onStoreChange) => { store.on("change", onStoreChange); return () => store.off("change", onStoreChange); }, [store]); const snapshot = useSyncExternalStore(subscribeStore, getSnapshot);`,
   `const { data: queryData, isPending } = useQuery({ queryKey: ["items", value], queryFn: () => fetch(url).then((response) => response.json()) });`,
   `const mutation = useMutation({ mutationFn: (payload) => api.post(url, payload) });`,
   `const { mutate, mutateAsync } = useMutation({ mutationFn: (payload) => api.post(url, payload) });`,
@@ -319,7 +320,7 @@ export const EDGE_CASE_STATEMENT_POOL = [
 export const IMPORT_LINE_POOL = [
   `import React from "react";`,
   `import * as React from "react";`,
-  `import { useState, useEffect, useMemo, useCallback, useRef, useContext, useReducer, useTransition, useDeferredValue, useId, useLayoutEffect } from "react";`,
+  `import { useState, useEffect, useMemo, useCallback, useRef, useContext, useReducer, useTransition, useDeferredValue, useId, useLayoutEffect, useSyncExternalStore } from "react";`,
   `import { useState as useLocalState } from "react";`,
   `import { createPortal } from "react-dom";`,
   `import Link from "next/link";`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -2050,3 +2050,120 @@ export const Feed = ({ url }) => (
     expect(result.diagnostics).toHaveLength(0);
   });
 });
+
+describe("effect-needs-cleanup useSyncExternalStore subscription cleanup", () => {
+  it("accepts the TaskTrove i18next subscription with its matching returned disposer", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useSyncExternalStore } from "react";
+import i18next from "i18next";
+export const LanguageProvider = () => {
+  const subscribeToLanguage = useCallback((onStoreChange: () => void) => {
+    i18next.on("languageChanged", onStoreChange);
+    return () => {
+      i18next.off("languageChanged", onStoreChange);
+    };
+  }, []);
+  const language = useSyncExternalStore(
+    subscribeToLanguage,
+    () => i18next.resolvedLanguage,
+    () => "en",
+  );
+  return language;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      name: "receiver",
+      cleanup: `otherI18next.off("languageChanged", onStoreChange);`,
+    },
+    {
+      name: "event",
+      cleanup: `i18next.off("loaded", onStoreChange);`,
+    },
+    {
+      name: "handler",
+      cleanup: `i18next.off("languageChanged", otherHandler);`,
+    },
+  ])("rejects a returned disposer with the wrong $name", ({ cleanup }) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useSyncExternalStore } from "react";
+export const LanguageProvider = ({ i18next, otherI18next, otherHandler }) => {
+  const subscribeToLanguage = useCallback((onStoreChange) => {
+    i18next.on("languageChanged", onStoreChange);
+    return () => {
+      ${cleanup}
+    };
+  }, [i18next, otherI18next, otherHandler]);
+  useSyncExternalStore(subscribeToLanguage, getSnapshot);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects cleanup returned on only one path after subscribing", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useSyncExternalStore } from "react";
+export const LanguageProvider = ({ i18next, shouldCleanup }) => {
+  const subscribeToLanguage = useCallback((onStoreChange) => {
+    i18next.on("languageChanged", onStoreChange);
+    if (shouldCleanup) {
+      return () => i18next.off("languageChanged", onStoreChange);
+    }
+    return undefined;
+  }, [i18next, shouldCleanup]);
+  useSyncExternalStore(subscribeToLanguage, getSnapshot);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts matching receiver, event, and handler aliases", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useSyncExternalStore as useStore } from "react";
+export const LanguageProvider = ({ i18next }) => {
+  const subscribeToLanguage = useCallback((onStoreChange) => {
+    const emitter = i18next;
+    const eventName = "languageChanged";
+    const handler = onStoreChange;
+    emitter.on(eventName, handler);
+    return () => emitter.off(eventName, handler);
+  }, [i18next]);
+  const subscribe = subscribeToLanguage;
+  useStore(subscribe, getSnapshot);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat a shadowed useSyncExternalStore call as a cleanup contract", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback } from "react";
+export const LanguageProvider = ({ i18next }) => {
+  const useSyncExternalStore = (subscribe) => subscribe;
+  const subscribeToLanguage = useCallback((onStoreChange) => {
+    i18next.on("languageChanged", onStoreChange);
+    return () => i18next.off("languageChanged", onStoreChange);
+  }, [i18next]);
+  useSyncExternalStore(subscribeToLanguage);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -22,6 +22,7 @@ import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blocks.js";
@@ -1218,6 +1219,40 @@ const fileContainsReleaseForUsage = (usage: SubscribeLikeUsage, context: RuleCon
   return didFindRelease;
 };
 
+const isUseSyncExternalStoreSubscribeFunction = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) return false;
+  const visitedSymbolIds = new Set<number>();
+  const isSubscribeBinding = (candidateBinding: EsTreeNode): boolean => {
+    const symbol = context.scopes.symbolFor(candidateBinding);
+    if (!symbol || visitedSymbolIds.has(symbol.id) || symbol.references.length === 0) return false;
+    visitedSymbolIds.add(symbol.id);
+    return symbol.references.every((reference) => {
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const referenceParent = referenceRoot.parent;
+      if (
+        isNodeOfType(referenceParent, "CallExpression") &&
+        referenceParent.arguments?.[0] === referenceRoot
+      ) {
+        return isReactApiCall(referenceParent, "useSyncExternalStore", context.scopes);
+      }
+      const aliasDeclaration = referenceParent?.parent;
+      return Boolean(
+        isNodeOfType(referenceParent, "VariableDeclarator") &&
+        referenceParent.init === referenceRoot &&
+        isNodeOfType(referenceParent.id, "Identifier") &&
+        isNodeOfType(aliasDeclaration, "VariableDeclaration") &&
+        aliasDeclaration.kind === "const" &&
+        isSubscribeBinding(referenceParent.id),
+      );
+    });
+  };
+  return isSubscribeBinding(bindingIdentifier);
+};
+
 const doesResourceResultEscape = (
   resourceNode: EsTreeNode,
   allowConciseReturnEscape: boolean,
@@ -1261,6 +1296,14 @@ const findRetainedFunctionLeak = (
   // caller, which owns the handle.
   let leak: SubscribeLikeUsage | null = null;
   const allowConciseReturnEscape = !isInlineRetainedHandlerFunction(retainedFunction, context);
+  const isExternalStoreSubscribeFunction = isUseSyncExternalStoreSubscribeFunction(
+    retainedFunction,
+    context,
+  );
+  const hasReleaseForUsage = (usage: SubscribeLikeUsage): boolean =>
+    isExternalStoreSubscribeFunction
+      ? effectHasCleanupForUsage(retainedFunction, usage, context)
+      : fileContainsReleaseForUsage(usage, context);
   walkAst(body, (child: EsTreeNode) => {
     if (leak !== null) return false;
     if (isFunctionLike(child)) return false;
@@ -1276,7 +1319,7 @@ const findRetainedFunctionLeak = (
         eventKey: null,
         handlerKey: null,
       };
-      if (!fileContainsReleaseForUsage(socketUsage, context)) {
+      if (!hasReleaseForUsage(socketUsage)) {
         leak = socketUsage;
         return false;
       }
@@ -1299,7 +1342,7 @@ const findRetainedFunctionLeak = (
         eventKey: null,
         handlerKey: null,
       };
-      if (!fileContainsReleaseForUsage(timerUsage, context)) {
+      if (!hasReleaseForUsage(timerUsage)) {
         leak = timerUsage;
         return false;
       }
@@ -1320,7 +1363,7 @@ const findRetainedFunctionLeak = (
       };
       if (
         !hasSelfReleasingListenerOptions(child, context) &&
-        !fileContainsReleaseForUsage(subscriptionUsage, context)
+        !hasReleaseForUsage(subscriptionUsage)
       ) {
         leak = subscriptionUsage;
       }


### PR DESCRIPTION
## Why

Stops `effect-needs-cleanup` from reporting a leak when a React `useSyncExternalStore` subscribe callback returns a disposer for the exact registration.

React invokes the function returned by its subscribe callback when the subscription is replaced or unmounted. Retained-function analysis previously rejected that returned function as unreachable because it only recognized returned Effect cleanup functions.

Before (incorrect diagnostic):

```tsx
const subscribeToLanguage = useCallback((onStoreChange) => {
  i18next.on("languageChanged", onStoreChange);
  return () => i18next.off("languageChanged", onStoreChange);
}, []);

useSyncExternalStore(subscribeToLanguage, getSnapshot);
```

After: the same valid subscription is accepted because the returned disposer is correlated by receiver, event, handler, and control-flow path.

## What changed

- Recognizes bindings used exclusively as React's `useSyncExternalStore` subscribe argument, including immutable aliases and aliased React imports.
- Reuses the existing path-aware cleanup matcher for the returned disposer.
- Keeps reporting wrong receivers, events, handlers, conditional-only cleanup, shadowed `useSyncExternalStore`, and callbacks with non-subscribe consumers.
- Adds the confirmed TaskTrove false positive to the fuzz regression corpus and generator library-idiom pool.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

## Eval results

| Check | Result |
| --- | --- |
| Initial RDE pass | 12 distinct repos / 100 rootDir scans |
| Expanded RDE pass | 86 distinct repos / 600 rootDir scans (the harness appended 500) |
| Target rule | `effect-needs-cleanup` |
| Existing target diagnostics | 593 across 55 repos |
| Scan failures | 0 |
| New diagnostic noise | 0; this change only removes a diagnostic after an exact cleanup proof |
| Exact TaskTrove oracle | target diagnostic removed with the local build |

## Test plan

- `cd packages/oxlint-plugin-react-doctor && nr test` — 526 files / 11,691 tests passed
- `cd packages/fuzz && nr test` — corpus and generator tests passed
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_SILENT=1 nr fuzz --disableConsoleIntercept` — passed, fire coverage 1/1
- `bun scripts/hunt-false-positives.ts` — 89 seeds, 0 named-rule regressions
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- Full `nr test`: all touched/plugin suites passed; eight unrelated CLI/dead-code integration tests exceeded default timeouts on the shared machine. Re-running those five files serially with `--maxWorkers=1 --testTimeout=120000` passed 28/28.

## Non-goals

- No i18next-specific receiver or method allowlist.
- No suppression for ordinary retained event handlers whose return values React ignores.
- No inference for dynamic or mutable callback aliases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow rule refinement that only suppresses diagnostics when an exact cleanup proof exists; no auth or runtime behavior changes.
> 
> **Overview**
> Fixes a **false positive** in `effect-needs-cleanup` when a `useSyncExternalStore` subscribe callback registers a listener and **returns a matching disposer** (e.g. i18next `on` / `off`).
> 
> Retained-function analysis now treats functions whose binding is used **only** as React’s `useSyncExternalStore` subscribe argument (including `const` aliases and aliased imports) as owning cleanup via the **returned function**, reusing the existing path-aware `effectHasCleanupForUsage` matcher instead of requiring a separate file-wide release. Ordinary retained handlers still need explicit cleanup; mismatched receiver/event/handler, conditional-only returns, and shadowed `useSyncExternalStore` stay flagged.
> 
> Adds regression tests, a fuzz corpus case, and generator snippets for this library idiom; patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9539e00dee16e895c873b3274e73f9fd93fb7902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->