### PR TITLE
fix(rules): refine exhaustive dependency identities

### DIFF
--- a/.changeset/calm-refs-align.md
+++ b/.changeset/calm-refs-align.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Refine `exhaustive-deps` identity tracking for stable and React hook aliases, ref fallbacks, exact props members, and intentional reactive `useMemo` invalidation tokens.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--declared-props-members.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--declared-props-members.tsx
@@ -1,0 +1,21 @@
+// rule: exhaustive-deps
+// weakness: other
+// source: RD-FP-016 task-perfection addendum (Mailing, 2026-07-11)
+import { useMemo } from "react";
+
+interface ApiKey {
+  organizationId: string;
+}
+
+interface SettingsProps {
+  apiKeys: ApiKey[];
+  user: {
+    organizationId: string;
+  };
+}
+
+export const Settings = (props: SettingsProps) =>
+  useMemo(
+    () => props.apiKeys.filter((apiKey) => apiKey.organizationId === props.user.organizationId),
+    [props.apiKeys, props.user.organizationId],
+  );

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--imported-function-alias.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--imported-function-alias.tsx
@@ -1,0 +1,15 @@
+// rule: exhaustive-deps
+// weakness: alias-guard
+// source: RD-FP-016 task-perfection addendum (Psysonic, 2026-07-11)
+import { useEffect } from "react";
+import { setConnectionStatus } from "./connection-status";
+
+export const StatusPanel = ({ status }: { status: string }) => {
+  const setStatus = setConnectionStatus;
+
+  useEffect(() => {
+    setStatus(status);
+  }, [status]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--memo-invalidation-token.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--memo-invalidation-token.tsx
@@ -1,0 +1,15 @@
+// rule: exhaustive-deps
+// weakness: other
+// source: RD-FP-016 task-perfection addendum (Hightable, 2026-07-11)
+import { useMemo, useRef } from "react";
+
+export const Slice = ({ rows, cacheRevision }: { rows: string[]; cacheRevision: number }) => {
+  const cacheRef = useRef(new Map<string, string[]>());
+
+  return useMemo(() => {
+    const cachedRows = cacheRef.current.get("rows");
+    if (cachedRows) return cachedRows;
+    cacheRef.current.set("rows", rows);
+    return rows;
+  }, [rows, cacheRevision]);
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--object-ref-fallback.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--object-ref-fallback.tsx
@@ -1,0 +1,19 @@
+// rule: exhaustive-deps
+// weakness: alias-guard
+// source: Cursor Bugbot review on PR #1128 (2026-07-11)
+import { useLayoutEffect, useRef } from "react";
+
+export const EditorSurface = ({
+  pendingMappingOperationsRef,
+}: {
+  pendingMappingOperationsRef: React.RefObject<string[]> | null;
+}) => {
+  const fallbackRefs = { operations: useRef<string[]>([]) };
+  const pendingOperationsRef = pendingMappingOperationsRef ?? fallbackRefs.operations;
+
+  useLayoutEffect(() => {
+    pendingOperationsRef.current?.splice(0);
+  }, [pendingMappingOperationsRef]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--ref-alias-fallback.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--ref-alias-fallback.tsx
@@ -1,0 +1,21 @@
+// rule: exhaustive-deps
+// weakness: alias-guard
+// source: RD-FP-016 task-perfection addendum (Softmaple, 2026-07-11)
+import { useLayoutEffect, useRef } from "react";
+
+export const EditorSurface = ({
+  text,
+  pendingMappingOperationsRef,
+}: {
+  text: string;
+  pendingMappingOperationsRef: React.RefObject<string[]> | null;
+}) => {
+  const fallbackOperationsRef = useRef<string[]>([]);
+  const pendingOperationsRef = pendingMappingOperationsRef ?? fallbackOperationsRef;
+
+  useLayoutEffect(() => {
+    pendingOperationsRef.current?.splice(0);
+  }, [text, pendingMappingOperationsRef]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--stable-member-reactive-sibling.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--stable-member-reactive-sibling.tsx
@@ -1,0 +1,19 @@
+// rule: exhaustive-deps
+// weakness: alias-guard
+// source: Cursor Bugbot review on PR #1128 (2026-07-11)
+import { useLayoutEffect, useMemo } from "react";
+
+export const EditorSurface = ({
+  pendingMappingOperationsRef,
+}: {
+  pendingMappingOperationsRef: React.RefObject<string[]>;
+}) => {
+  const stableRefs = useMemo(() => ({ operations: null }), []);
+  const pendingOperationsRef = stableRefs.operations ?? pendingMappingOperationsRef;
+
+  useLayoutEffect(() => {
+    pendingOperationsRef.current?.splice(0);
+  }, [pendingMappingOperationsRef]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
@@ -16,6 +16,11 @@ export interface OxcDivergence {
 }
 
 export const DIVERGENCES: Record<string, OxcDivergence> = {
+  "exhaustive-deps": {
+    failSkips: [81],
+    reason:
+      "Intentional: exact props members suppress a synthetic whole-props dependency, and useMemo accepts extra reactive invalidation tokens.",
+  },
   "no-unknown-property": {
     // fp-review: 1110 unique false positives vs 28 true positives (1%
     // precision) drove three narrowings, each encoded by a fixture:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__upstream-fixtures__/divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__upstream-fixtures__/divergences.ts
@@ -20,6 +20,7 @@ export const RULES_OF_HOOKS_DIVERGENCES: UpstreamDivergence = {
 };
 
 export const EXHAUSTIVE_DEPS_DIVERGENCES: UpstreamDivergence = {
+  invalidSkips: [82, 187],
   reason:
-    "No known divergences. Flow `hook` / cast syntax is normalized by the parity harness before running the rule.",
+    "Intentional: exact props members suppress a synthetic whole-props dependency, and useMemo accepts extra reactive invalidation tokens while useCallback remains strict.",
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-low-level.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-low-level.ts
@@ -1,6 +1,8 @@
-import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 
 /**
  * Lowest-level helpers consumed by both the main `exhaustive-deps`
@@ -42,18 +44,30 @@ export const unwrapExpression = (node: EsTreeNode): EsTreeNode => {
 };
 
 /**
- * Get the hook name from a call expression's callee, regardless of
- * whether the hook is called as `useFoo()` (Identifier) or
- * `React.useFoo()` (MemberExpression).
+ * Get the hook name from a direct, wrapped, namespaced, or immutable
+ * React import alias call.
  */
-export const getHookName = (callee: EsTreeNode): string | null => {
-  if (isNodeOfType(callee, "Identifier")) return callee.name;
+export const getHookName = (callee: EsTreeNode, scopes?: ScopeAnalysis): string | null => {
+  const strippedCallee = unwrapExpression(callee);
+  if (isNodeOfType(strippedCallee, "Identifier")) {
+    const resolvedSymbol = scopes ? resolveConstIdentifierAlias(strippedCallee, scopes) : null;
+    const importDeclaration = resolvedSymbol?.declarationNode.parent;
+    if (
+      resolvedSymbol?.kind === "import" &&
+      importDeclaration &&
+      isNodeOfType(importDeclaration, "ImportDeclaration") &&
+      importDeclaration.source.value === "react"
+    ) {
+      return getImportedName(resolvedSymbol.declarationNode) ?? strippedCallee.name;
+    }
+    return strippedCallee.name;
+  }
   if (
-    isNodeOfType(callee, "MemberExpression") &&
-    !callee.computed &&
-    isNodeOfType(callee.property, "Identifier")
+    isNodeOfType(strippedCallee, "MemberExpression") &&
+    !strippedCallee.computed &&
+    isNodeOfType(strippedCallee.property, "Identifier")
   ) {
-    return callee.property.name;
+    return strippedCallee.property.name;
   }
   return null;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-symbol-stability.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-symbol-stability.ts
@@ -6,6 +6,7 @@ import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-l
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import {
   getHookName,
   isOutsideAllFunctions,
@@ -56,7 +57,10 @@ const STABLE_IDENTITY_WRAPPER_HOOK_NAMES: ReadonlySet<string> = new Set([
  *   - primitive-literal local consts (the value never changes
  *     between renders unless the literal does)
  */
-export const symbolHasStableHookOrigin = (symbol: SymbolDescriptor): boolean => {
+export const symbolHasStableHookOrigin = (
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
   if (symbol.references.some((reference) => reference.flag !== "read")) return false;
   // We need the binding's parent context. The symbol's
   // declarationNode is the VariableDeclarator (when destructured) or
@@ -93,7 +97,7 @@ export const symbolHasStableHookOrigin = (symbol: SymbolDescriptor): boolean => 
   }
 
   if (!isNodeOfType(initializer, "CallExpression")) return false;
-  const initializerHookName = getHookName(initializer.callee);
+  const initializerHookName = getHookName(initializer.callee, scopes);
   if (!initializerHookName) return false;
   // useRef returns a stable ref; the binding itself is the ref.
   if (initializerHookName === "useRef") return true;
@@ -166,7 +170,7 @@ const symbolHasStableMemoizedOrigin = (
   if (!declarator.init) return false;
   const initializer = unwrapExpression(declarator.init);
   if (!isNodeOfType(initializer, "CallExpression")) return false;
-  const initializerHookName = getHookName(initializer.callee);
+  const initializerHookName = getHookName(initializer.callee, scopes);
   if (!initializerHookName || !MEMOIZING_HOOK_NAMES.has(initializerHookName)) return false;
   const depsArgument = initializer.arguments[1];
   if (!depsArgument || !isAstNode(depsArgument)) return false;
@@ -215,7 +219,11 @@ const getObjectPropertyValue = (
 // `const refs = { slider: useRef(null) }` re-creates the container each
 // render, but each property holds the SAME ref object (hook-call order
 // guarantees it), so a captured `refs.slider` path can never be stale.
-export const isStableRefContainerCapture = (symbol: SymbolDescriptor, depKey: string): boolean => {
+export const isStableRefContainerCapture = (
+  symbol: SymbolDescriptor,
+  depKey: string,
+  scopes: ScopeAnalysis,
+): boolean => {
   if (symbol.kind !== "const") return false;
   if (!depKey.startsWith(`${symbol.name}.`)) return false;
   if (symbol.references.some((reference) => reference.flag !== "read")) return false;
@@ -230,7 +238,8 @@ export const isStableRefContainerCapture = (symbol: SymbolDescriptor, depKey: st
     currentValue = propertyValue;
   }
   return (
-    isNodeOfType(currentValue, "CallExpression") && getHookName(currentValue.callee) === "useRef"
+    isNodeOfType(currentValue, "CallExpression") &&
+    getHookName(currentValue.callee, scopes) === "useRef"
   );
 };
 
@@ -258,11 +267,19 @@ const symbolHasStableFunctionOrigin = (
   return true;
 };
 
+const symbolHasStableImportedAlias = (symbol: SymbolDescriptor, scopes: ScopeAnalysis): boolean => {
+  if (symbol.kind !== "const") return false;
+  if (symbol.references.some((reference) => reference.flag !== "read")) return false;
+  const resolvedSymbol = resolveConstIdentifierAlias(symbol.bindingIdentifier, scopes);
+  return resolvedSymbol !== null && resolvedSymbol !== symbol && resolvedSymbol.kind === "import";
+};
+
 export const symbolHasStableValue = (
   symbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
   visitedSymbolIds: Set<number> = new Set(),
 ): boolean =>
-  symbolHasStableHookOrigin(symbol) ||
+  symbolHasStableHookOrigin(symbol, scopes) ||
+  symbolHasStableImportedAlias(symbol, scopes) ||
   symbolHasStableFunctionOrigin(symbol, scopes, visitedSymbolIds) ||
   symbolHasStableMemoizedOrigin(symbol, scopes, visitedSymbolIds);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -946,17 +946,324 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("still flags a dep the callback truly never reads", () => {
+  it("still flags an extra reactive dependency in useCallback", () => {
     const code = `
       function MyComponent({ value, unrelated }) {
-        const doubled = useMemo(() => value * 2, [value, unrelated]);
-        return doubled;
+        const getValue = useCallback(() => value, [value, unrelated]);
+        return getValue;
       }
     `;
     const result = runRule(exhaustiveDeps, code);
     expect(result.parseErrors).toEqual([]);
     const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
     expect(messages).toContain("unrelated");
+  });
+
+  describe("bounded identity source resolution", () => {
+    it("treats an immutable local alias of an imported function as stable", () => {
+      const code = `
+        import { setConnectionStatus } from "./connection-status";
+        function StatusPanel({ status }) {
+          const setStatus = setConnectionStatus;
+          useEffect(() => {
+            setStatus(status);
+          }, [status]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("treats a transitive immutable alias of an imported function as stable", () => {
+      const code = `
+        import { setConnectionStatus } from "./connection-status";
+        function StatusPanel({ status }) {
+          const setStatus = setConnectionStatus;
+          const updateStatus = (nextStatus) => setStatus(nextStatus);
+          useEffect(() => {
+            updateStatus(status);
+          }, [status]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("resolves renamed and immutable aliases of React hooks", () => {
+      const code = `
+        import { useEffect as runEffect, useRef as createRef } from "react";
+        function StatusPanel({ status }) {
+          const invokeEffect = runEffect as typeof runEffect;
+          const statusRef = createRef(status);
+          (invokeEffect as typeof invokeEffect)(() => {
+            consumeStatus(status, statusRef.current);
+          }, []);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("status");
+      expect(messages).not.toContain("statusRef");
+    });
+
+    it("does not resolve a shadowed React hook import alias", () => {
+      const code = `
+        import { useMemo as memoize } from "react";
+        function StatusPanel({ status }) {
+          const run = (memoize) => memoize(() => status, []);
+          return run;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("accepts every reactive identity source of a ref alias with a stable fallback", () => {
+      const code = `
+        function EditorSurface({ text, pendingMappingOperationsRef }) {
+          const noopPendingMappingOperationsRef = useRef([]);
+          const pendingOpsRef =
+            pendingMappingOperationsRef ?? noopPendingMappingOperationsRef;
+          useLayoutEffect(() => {
+            consumeOperations(pendingOpsRef.current);
+          }, [text, pendingMappingOperationsRef]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("resolves wrapped optional member identity sources", () => {
+      const code = `
+        function EditorSurface(props) {
+          const fallbackOperationsRef = useRef([]);
+          const pendingOpsRef =
+            (props?.pendingMappingOperationsRef as React.RefObject<unknown[]>) ??
+            fallbackOperationsRef;
+          useLayoutEffect(() => {
+            consumeOperations(pendingOpsRef.current);
+          }, [props.pendingMappingOperationsRef]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("does not synthesize whole props when declared members cover every props capture", () => {
+      const code = `
+        function Settings(props) {
+          return useMemo(
+            () =>
+              props.apiKeys.filter(
+                (apiKey) => apiKey.organizationId === props.user.organizationId,
+              ),
+            [props.apiKeys, props.user.organizationId],
+          );
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("does not synthesize whole props from a shadowed callback parameter", () => {
+      const code = `
+        function Settings(props) {
+          return useMemo(
+            () => [
+              props.firstValue,
+              props.secondValue,
+              ...props.items.map((props) => props.format()),
+            ],
+            [props.firstValue, props.items],
+          );
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("props.secondValue");
+      expect(messages).not.toMatch(/dependencies?: `props`(?:,|\.|$)/);
+    });
+
+    it("allows an extra reactive useMemo dependency as an invalidation token", () => {
+      const code = `
+        function Slice({ rows, cacheRevision }) {
+          const cacheRef = useRef(new Map());
+          return useMemo(
+            () => readRows(cacheRef.current, rows),
+            [rows, cacheRevision],
+          );
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("allows reactive invalidation parameters on a generic useMemo call", () => {
+      const code = `
+        function usePosition(chart, chartWidth, chartHeight) {
+          return useMemo<Position>(
+            () => readPosition(chart),
+            [chart, chartWidth, chartHeight],
+          );
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags a fresh useMemo dependency that invalidates every render", () => {
+      const code = `
+        function Slice({ rows }) {
+          const freshInvalidationToken = {};
+          return useMemo(
+            () => readRows(rows),
+            [rows, freshInvalidationToken],
+          );
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("freshInvalidationToken");
+    });
+
+    it("still flags a stable useMemo dependency that cannot invalidate the memo", () => {
+      const code = `
+        function Slice({ rows }) {
+          const cacheRef = useRef(new Map());
+          return useMemo(
+            () => readRows(rows),
+            [rows, cacheRef],
+          );
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("cacheRef");
+    });
+
+    it("does not treat a mutable imported-function alias as stable", () => {
+      const code = `
+        import { setConnectionStatus } from "./connection-status";
+        function StatusPanel({ status, overrideStatus }) {
+          let setStatus = setConnectionStatus;
+          setStatus = overrideStatus ?? setStatus;
+          useEffect(() => {
+            setStatus(status);
+          }, [status]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("setStatus");
+    });
+
+    it("does not treat a render-local closure as an imported-function alias", () => {
+      const code = `
+        import { setConnectionStatus } from "./connection-status";
+        function StatusPanel({ status }) {
+          const setStatus = (nextStatus) => setConnectionStatus(nextStatus);
+          useEffect(() => {
+            setStatus(status);
+          }, [status, setStatus]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("setStatus");
+      expect(messages).toContain("rebuilt every render");
+    });
+
+    it("does not resolve an alias with a fresh fallback", () => {
+      const code = `
+        function EditorSurface({ pendingMappingOperationsRef }) {
+          const pendingOpsRef = pendingMappingOperationsRef ?? { current: [] };
+          useLayoutEffect(() => {
+            consumeOperations(pendingOpsRef.current);
+          }, [pendingMappingOperationsRef]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("pendingOpsRef");
+    });
+
+    it("reports every missing reactive identity source", () => {
+      const code = `
+        function EditorSurface({ primaryOperationsRef, secondaryOperationsRef }) {
+          const fallbackOperationsRef = useRef([]);
+          const pendingOpsRef =
+            primaryOperationsRef ?? secondaryOperationsRef ?? fallbackOperationsRef;
+          useLayoutEffect(() => {
+            consumeOperations(pendingOpsRef.current);
+          }, [primaryOperationsRef]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("secondaryOperationsRef");
+      expect(messages).not.toContain("`pendingOpsRef`");
+    });
+
+    it("does not resolve computed-member identity sources", () => {
+      const code = `
+        function EditorSurface({ operationRefs, operationKind }) {
+          const fallbackOperationsRef = useRef([]);
+          const pendingOpsRef =
+            operationRefs[operationKind] ?? fallbackOperationsRef;
+          useLayoutEffect(() => {
+            consumeOperations(pendingOpsRef.current);
+          }, [operationRefs, operationKind]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("pendingOpsRef");
+    });
+
+    it("does not let a narrower member dependency cover an identity source", () => {
+      const code = `
+        function EditorSurface(props) {
+          const fallbackOperationsRef = useRef([]);
+          const pendingOpsRef =
+            props.pendingMappingOperationsRef ?? fallbackOperationsRef;
+          useLayoutEffect(() => {
+            consumeOperations(pendingOpsRef.current);
+          }, [props.pendingMappingOperationsRef.current]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("props.pendingMappingOperationsRef");
+    });
   });
 });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1042,6 +1042,22 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("accepts a stable object ref member as a ref alias fallback", () => {
+      const code = `
+        function EditorSurface({ pendingMappingOperationsRef }) {
+          const fallbackRefs = { operations: useRef([]) };
+          const pendingOpsRef = pendingMappingOperationsRef ?? fallbackRefs.operations;
+          useLayoutEffect(() => {
+            consumeOperations(pendingOpsRef.current);
+          }, [pendingMappingOperationsRef]);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("resolves wrapped optional member identity sources", () => {
       const code = `
         function EditorSurface(props) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1058,6 +1058,24 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("keeps reactive identity sources beside a stable member fallback", () => {
+      const code = `
+        function EditorSurface({ pendingMappingOperationsRef }) {
+          const stableRefs = useMemo(() => ({ operations: null }), []);
+          const pendingOpsRef = stableRefs.operations ?? pendingMappingOperationsRef;
+          useLayoutEffect(() => {
+            consumeOperations(pendingOpsRef.current);
+          }, []);
+          return null;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("pendingMappingOperationsRef");
+      expect(result.diagnostics[0]?.message).not.toContain("pendingOpsRef");
+    });
+
     it("resolves wrapped optional member identity sources", () => {
       const code = `
         function EditorSurface(props) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -372,9 +372,17 @@ const collectCaptureDepKeys = (callback: EsTreeNode, scopes: ScopeAnalysis): Cap
     }
     const depKey = computeDepKey(reference);
     if (!depKey) continue;
-    if (isStableRefContainerCapture(symbol, depKey)) {
+    if (isStableRefContainerCapture(symbol, depKey, scopes)) {
       stableCapturedNames.add(depKey);
       continue;
+    }
+    if (depKey === symbol.name) {
+      const identitySourceKeys = resolveReactiveIdentitySourceKeys(symbol, scopes);
+      if (identitySourceKeys) {
+        if (identitySourceKeys.size === 0) stableCapturedNames.add(depKey);
+        for (const identitySourceKey of identitySourceKeys) keys.add(identitySourceKey);
+        continue;
+      }
     }
     keys.add(depKey);
   }
@@ -424,6 +432,106 @@ const hasComputedMemberExpression = (node: EsTreeNode): boolean => {
   return hasComputedMemberExpression(stripped.object);
 };
 
+const mergeIdentitySourceKeys = (
+  expressions: ReadonlyArray<EsTreeNode>,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): Set<string> | null => {
+  const identitySourceKeys = new Set<string>();
+  for (const expression of expressions) {
+    const expressionSourceKeys = resolveIdentitySourceKeysFromExpression(
+      expression,
+      scopes,
+      visitedSymbolIds,
+    );
+    if (!expressionSourceKeys) return null;
+    for (const expressionSourceKey of expressionSourceKeys) {
+      identitySourceKeys.add(expressionSourceKey);
+    }
+  }
+  return identitySourceKeys;
+};
+
+const resolveIdentitySourceKeysFromExpression = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): Set<string> | null => {
+  const stripped = unwrapExpression(expression);
+  if (
+    (isNodeOfType(stripped, "Literal") &&
+      (stripped.value === null ||
+        typeof stripped.value === "string" ||
+        typeof stripped.value === "number" ||
+        typeof stripped.value === "boolean")) ||
+    (isNodeOfType(stripped, "TemplateLiteral") && getStaticTemplateLiteralValue(stripped) !== null)
+  ) {
+    return new Set();
+  }
+  if (isNodeOfType(stripped, "Identifier")) {
+    const sourceSymbol = scopes.symbolFor(stripped);
+    if (!sourceSymbol) return null;
+    if (isOutsideAllFunctions(sourceSymbol) || symbolHasStableValue(sourceSymbol, scopes)) {
+      return new Set();
+    }
+    if (
+      sourceSymbol.kind === "const" &&
+      sourceSymbol.initializer &&
+      isNodeOfType(sourceSymbol.declarationNode, "VariableDeclarator") &&
+      sourceSymbol.declarationNode.id === sourceSymbol.bindingIdentifier &&
+      sourceSymbol.references.every((reference) => reference.flag === "read")
+    ) {
+      if (visitedSymbolIds.has(sourceSymbol.id)) return null;
+      visitedSymbolIds.add(sourceSymbol.id);
+      const sourceKeys = resolveIdentitySourceKeysFromExpression(
+        sourceSymbol.initializer,
+        scopes,
+        visitedSymbolIds,
+      );
+      visitedSymbolIds.delete(sourceSymbol.id);
+      if (sourceKeys) return sourceKeys;
+    }
+    return new Set([sourceSymbol.name]);
+  }
+  if (isNodeOfType(stripped, "MemberExpression")) {
+    if (hasComputedMemberExpression(stripped)) return null;
+    const sourceKey = stringifyMemberChain(stripped);
+    const rootIdentifier = getMemberRootIdentifier(stripped);
+    const rootSymbol = rootIdentifier ? scopes.symbolFor(rootIdentifier) : null;
+    if (!sourceKey || !rootSymbol) return null;
+    if (isOutsideAllFunctions(rootSymbol)) return new Set();
+    if (symbolHasStableValue(rootSymbol, scopes)) return null;
+    return new Set([sourceKey]);
+  }
+  if (isNodeOfType(stripped, "LogicalExpression")) {
+    return mergeIdentitySourceKeys([stripped.left, stripped.right], scopes, visitedSymbolIds);
+  }
+  if (isNodeOfType(stripped, "ConditionalExpression")) {
+    return mergeIdentitySourceKeys(
+      [stripped.test, stripped.consequent, stripped.alternate],
+      scopes,
+      visitedSymbolIds,
+    );
+  }
+  return null;
+};
+
+const resolveReactiveIdentitySourceKeys = (
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): Set<string> | null => {
+  if (
+    symbol.kind !== "const" ||
+    !symbol.initializer ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    symbol.declarationNode.id !== symbol.bindingIdentifier ||
+    symbol.references.some((reference) => reference.flag !== "read")
+  ) {
+    return null;
+  }
+  return resolveIdentitySourceKeysFromExpression(symbol.initializer, scopes, new Set([symbol.id]));
+};
+
 // Extra (unused) deps in effect hooks are allowed as intentional
 // re-run triggers (upstream blesses `useEffect(() => scrollTo(0, 0),
 // [activeTab])`). A `useCallback(...)` binding is the one shape that
@@ -437,11 +545,11 @@ const isUseCallbackResultDep = (node: EsTreeNode, scopes: ScopeAnalysis): boolea
   return Boolean(
     initializer &&
     isNodeOfType(initializer, "CallExpression") &&
-    getHookName(initializer.callee) === "useCallback",
+    getHookName(initializer.callee, scopes) === "useCallback",
   );
 };
 
-const isExtraEffectDepAllowed = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+const isExtraReactiveDepAllowed = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const rootIdentifier = getMemberRootIdentifier(node);
   if (!rootIdentifier) return false;
   const symbol = scopes.symbolFor(rootIdentifier);
@@ -493,6 +601,22 @@ const isUnstableInitializer = (node: EsTreeNode | null): boolean => {
   );
 };
 
+const isExtraDepAllowedForHook = (
+  hookName: string,
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isExtraReactiveDepAllowed(node, scopes)) return false;
+  if (EFFECT_HOOKS_ALLOWING_EXTRA_REACTIVE_DEPS.has(hookName)) return true;
+  if (hookName !== "useMemo") return false;
+  const rootSymbol = getRootSymbol(node, scopes);
+  return Boolean(
+    rootSymbol &&
+    !symbolHasStableValue(rootSymbol, scopes) &&
+    !isUnstableInitializer(rootSymbol.initializer),
+  );
+};
+
 const hasDirectIdentifierDeclarator = (symbol: SymbolDescriptor): boolean =>
   (isNodeOfType(symbol.declarationNode, "VariableDeclarator") &&
     isNodeOfType(symbol.declarationNode.id, "Identifier")) ||
@@ -501,8 +625,8 @@ const hasDirectIdentifierDeclarator = (symbol: SymbolDescriptor): boolean =>
 const isFunctionValueSymbol = (symbol: SymbolDescriptor): boolean =>
   getFunctionValueNode(symbol) !== null;
 
-const isStableSetterLikeSymbol = (symbol: SymbolDescriptor): boolean => {
-  if (!symbolHasStableHookOrigin(symbol)) return false;
+const isStableSetterLikeSymbol = (symbol: SymbolDescriptor, scopes: ScopeAnalysis): boolean => {
+  if (!symbolHasStableHookOrigin(symbol, scopes)) return false;
   return (
     symbol.name.startsWith("set") ||
     symbol.name.startsWith("dispatch") ||
@@ -525,7 +649,7 @@ const findStableSetterReference = (node: EsTreeNode, scopes: ScopeAnalysis): str
     if (isNodeOfType(current, "Identifier")) {
       const reference = scopes.referenceFor(current);
       const symbol = reference?.resolvedSymbol;
-      if (symbol && isStableSetterLikeSymbol(symbol)) {
+      if (symbol && isStableSetterLikeSymbol(symbol, scopes)) {
         setterName = symbol.name;
         return;
       }
@@ -693,11 +817,14 @@ const hasRefCurrentAssignmentInComponent = (refSymbol: SymbolDescriptor | null):
 // React-rendered DOM node — the "cleanup may read the wrong node"
 // warning doesn't apply. `useRef()` / `useRef(null)` stay eligible:
 // that's the DOM-ref idiom the warning exists for.
-const isSeededDataRefSymbol = (refSymbol: SymbolDescriptor | null): boolean => {
+const isSeededDataRefSymbol = (
+  refSymbol: SymbolDescriptor | null,
+  scopes: ScopeAnalysis,
+): boolean => {
   if (!refSymbol) return false;
   const initializer = refSymbol.initializer ? unwrapExpression(refSymbol.initializer) : null;
   if (!initializer || !isNodeOfType(initializer, "CallExpression")) return false;
-  if (getHookName(initializer.callee) !== "useRef") return false;
+  if (getHookName(initializer.callee, scopes) !== "useRef") return false;
   const firstArgument = initializer.arguments[0];
   if (!firstArgument || !isAstNode(firstArgument)) return false;
   const strippedArgument = unwrapExpression(firstArgument);
@@ -756,7 +883,15 @@ const isOuterFunctionScopeDep = (
   return Boolean(componentOrHookScope && !isDescendantScope(symbol.scope, componentOrHookScope));
 };
 
-const hasMemberCallForRoot = (node: EsTreeNode, rootName: string): boolean => {
+const hasMemberCallForRoot = (
+  node: EsTreeNode,
+  rootName: string,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const rootSymbol =
+    closureCaptures(node, scopes).find((reference) => reference.resolvedSymbol?.name === rootName)
+      ?.resolvedSymbol ?? null;
+  if (!rootSymbol) return false;
   let didFindMemberCall = false;
   const visit = (current: EsTreeNode): void => {
     if (didFindMemberCall) return;
@@ -779,7 +914,8 @@ const hasMemberCallForRoot = (node: EsTreeNode, rootName: string): boolean => {
           !doesChainPassThroughCurrent &&
           chainObject &&
           isNodeOfType(chainObject, "Identifier") &&
-          chainObject.name === rootName
+          chainObject.name === rootName &&
+          scopes.symbolFor(chainObject) === rootSymbol
         ) {
           didFindMemberCall = true;
           return;
@@ -805,12 +941,16 @@ const addAggregatePropsDependency = (
   captureKeys: Set<string>,
   declaredKeys: ReadonlySet<string>,
   callback: EsTreeNode,
+  scopes: ScopeAnalysis,
 ): void => {
-  const propsCaptureCount = [...captureKeys].filter((captureKey) =>
-    captureKey.startsWith("props."),
-  ).length;
+  const propsCaptureKeys = [...captureKeys].filter((captureKey) => captureKey.startsWith("props."));
+  const propsCaptureCount = propsCaptureKeys.length;
   if (propsCaptureCount < 2 || declaredKeys.has("props")) return;
-  if (hasMemberCallForRoot(callback, "props")) captureKeys.add("props");
+  const areAllPropsCapturesCovered = propsCaptureKeys.every((captureKey) =>
+    [...declaredKeys].some((declaredKey) => isMatchingDepOrPrefix(declaredKey, captureKey)),
+  );
+  if (areAllPropsCapturesCovered) return;
+  if (hasMemberCallForRoot(callback, "props", scopes)) captureKeys.add("props");
 };
 
 export const exhaustiveDeps = defineRule({
@@ -877,7 +1017,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
 
     return {
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        const hookName = getHookName(node.callee);
+        const hookName = getHookName(node.callee, context.scopes);
         if (!hookName || !isHookOfInterest(hookName, node.callee)) return;
 
         const callbackArgumentIndex = getCallbackArgumentIndex(hookName);
@@ -964,7 +1104,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
             shouldCheckRefCleanup &&
             !hasRefCurrentAssignment(callbackToAnalyze, refCurrentInCleanup.refCurrentName) &&
             !hasRefCurrentAssignmentInComponent(refCurrentInCleanup.refSymbol) &&
-            !isSeededDataRefSymbol(refCurrentInCleanup.refSymbol)
+            !isSeededDataRefSymbol(refCurrentInCleanup.refSymbol, context.scopes)
           ) {
             context.report({
               node: callbackToAnalyze,
@@ -1116,7 +1256,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
             isNodeOfType(stripped.object, "Identifier")
           ) {
             const refSymbol = context.scopes.symbolFor(stripped.object);
-            if (refSymbol && symbolHasStableHookOrigin(refSymbol)) {
+            if (refSymbol && symbolHasStableHookOrigin(refSymbol, context.scopes)) {
               if (!didReportRefCurrentDep) {
                 context.report({
                   node: elementNode,
@@ -1153,6 +1293,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
           captureKeys,
           declaredKeys,
           callbackToAnalyze ?? callbackArgument,
+          context.scopes,
         );
 
         const missingCaptureKeys: string[] = [];
@@ -1287,10 +1428,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
           if (stableCapturedNames.has(rootName) || stableCapturedNames.has(declaredKey)) continue;
           if (outerFunctionCapturedNames.has(rootName)) continue;
           const reportNode = declaredKeyToReportNode.get(declaredKey) ?? depsArgument;
-          if (
-            EFFECT_HOOKS_ALLOWING_EXTRA_REACTIVE_DEPS.has(hookName) &&
-            isExtraEffectDepAllowed(reportNode, context.scopes)
-          ) {
+          if (isExtraDepAllowedForHook(hookName, reportNode, context.scopes)) {
             continue;
           }
           if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -500,6 +500,7 @@ const resolveIdentitySourceKeysFromExpression = (
     const rootSymbol = rootIdentifier ? scopes.symbolFor(rootIdentifier) : null;
     if (!sourceKey || !rootSymbol) return null;
     if (isOutsideAllFunctions(rootSymbol)) return new Set();
+    if (isStableRefContainerCapture(rootSymbol, sourceKey, scopes)) return new Set();
     if (symbolHasStableValue(rootSymbol, scopes)) return null;
     return new Set([sourceKey]);
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -501,7 +501,7 @@ const resolveIdentitySourceKeysFromExpression = (
     if (!sourceKey || !rootSymbol) return null;
     if (isOutsideAllFunctions(rootSymbol)) return new Set();
     if (isStableRefContainerCapture(rootSymbol, sourceKey, scopes)) return new Set();
-    if (symbolHasStableValue(rootSymbol, scopes)) return null;
+    if (symbolHasStableValue(rootSymbol, scopes)) return new Set();
     return new Set([sourceKey]);
   }
   if (isNodeOfType(stripped, "LogicalExpression")) {


### PR DESCRIPTION
## Why

`exhaustive-deps` reported valid dependency arrays when a stable identity was routed through a local alias, a ref selected a stable fallback, exact props members already covered every capture, or a `useMemo` intentionally used a reactive invalidation token.

Before (incorrect warning):

```tsx
import { setConnectionStatus } from "./connection-status";

const StatusPanel = ({ status }) => {
  const setStatus = setConnectionStatus;

  useEffect(() => {
    setStatus(status);
  }, [status]);
};
```

After (accepted):

```tsx
import { setConnectionStatus } from "./connection-status";

const StatusPanel = ({ status }) => {
  const setStatus = setConnectionStatus;

  useEffect(() => {
    setStatus(status);
  }, [status]);
};
```

The imported function identity is stable, so adding the render-local alias to the dependency array does not make the effect safer.

## What changed

- Resolves immutable aliases of imported functions and renamed React hooks.
- Traces every reactive identity source of nullish and conditional ref aliases while treating stable ref fallbacks as stable.
- Avoids synthesizing a whole-`props` dependency when exact declared members cover every props capture.
- Allows reactive extra dependencies as intentional `useMemo` invalidation tokens while keeping `useCallback` strict.
- Continues reporting mutable aliases, fresh fallbacks, computed members, missing identity sources, narrower member dependencies, fresh invalidation tokens, and stable non-invalidating extras.
- Adds focused regressions, upstream divergence records, four permanent fuzz corpus seeds, and a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| Distinct repositories | 64 |
| Root scans | 500 successful / 0 failed on each side |
| Target rule | `exhaustive-deps` |
| Target diagnostics | 3,883 on branch / 3,883 on `origin/main` |
| Rule-filtered delta | 0 added / 0 removed |
| False positives found | 0 |

The built-in parity renderer exceeded Node's 4 GB heap on the two full artifacts, so the target-rule comparison was streamed from both JSONL files by stable diagnostic identity. Counts and identities matched exactly.

## Test plan

- Full plugin suite: 526 files passed; 11,706 tests passed; 148 skipped.
- Focused exhaustive-deps suites: 683 passed; 3 skipped.
- Fuzz package: 33 passed; 397 skipped.
- `FUZZ_RULE=exhaustive-deps FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed.
- Plugin and fuzz typechecks passed.
- Full monorepo build passed.
- Format check passed.
- Lint passed with three existing repository warnings and three expected upstream `exhaustive-deps` warnings in the new divergence corpus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change expands static analysis in a heavily used lint rule with deliberate upstream divergences; risk is mitigated by broad regressions and a zero diagnostic delta on large-repo eval, but subtle alias edge cases could still slip through.
> 
> **Overview**
> Reduces **false positives** in `exhaustive-deps` by tracing how captured values relate to their **reactive identity sources**, instead of treating every local alias as a missing dependency.
> 
> **Identity aliases:** When a read-only `const` (e.g. `pendingOpsRef = propRef ?? fallbackRef`) is used in a hook, the rule now walks `??`, `?:`, and transitive `const` chains to require the underlying reactive bindings (props/refs), while stable fallbacks (`useRef`, imported functions, stable object members) stay exempt. Mutable aliases, render-local wrappers, computed members, and fresh object fallbacks are still flagged.
> 
> **Stability:** Immutable aliases of **imported functions** and **renamed React hook imports** count as stable; `getHookName` unwraps those aliases for hook-origin checks across the rule.
> 
> **Props aggregation:** Synthetic whole-`props` dependencies are skipped when declared `props.*` members already cover every `props` capture (unless `props` is invoked as a method).
> 
> **Extra deps:** Unused reactive entries remain allowed as re-run triggers on effects; **`useMemo`** additionally allows intentional invalidation tokens (e.g. `cacheRevision`), while **`useCallback`** still reports unused reactive extras.
> 
> Coverage adds a large regression block, four fuzz corpus seeds, and documented OXC/upstream fixture skips for these intentional behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2d96f118b35fd1456919a5f94b28728b48a5d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->