### PR TITLE
fix(rules): detect render-phase derived state mirrors

### DIFF
--- a/.changeset/quick-toys-draw.md
+++ b/.changeset/quick-toys-draw.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Extend no-derived-state to report canonical render-phase prop and state mirrors while preserving semi-controlled and interaction state.

--- a/packages/fuzz/corpus/regressions/no-derived-state--render-ref-history.tsx
+++ b/packages/fuzz/corpus/regressions/no-derived-state--render-ref-history.tsx
@@ -1,0 +1,26 @@
+// rule: no-derived-state
+// weakness: library-idiom
+// source: react-bench Rad UI sticky-value and FloatingSheet latest-value adjudication
+
+import { useEffect, useRef } from "react";
+
+const useStickyValue = <Value,>(value: Value | null): Value | null => {
+  const lastNonEmptyValue = useRef(value);
+  if (value !== null) {
+    lastNonEmptyValue.current = value;
+  }
+  return lastNonEmptyValue.current;
+};
+
+export const LatestHeight = ({ height }: { height: number }) => {
+  const heightRef = useRef(height);
+  heightRef.current = height;
+
+  useEffect(() => {
+    readHeight(heightRef.current);
+  }, []);
+
+  return useStickyValue(height);
+};
+
+declare const readHeight: (height: number) => void;

--- a/packages/fuzz/corpus/regressions/no-derived-state--render-tracker-divergent-state.tsx
+++ b/packages/fuzz/corpus/regressions/no-derived-state--render-tracker-divergent-state.tsx
@@ -1,0 +1,64 @@
+// rule: no-derived-state
+// weakness: control-flow
+// source: react-bench RD-FN-010 Divz, FloatingSheet, and Brainly adjudication
+
+import { useRef, useState } from "react";
+
+export const Divz = ({ isExpanded, autoPlay }: { isExpanded: boolean; autoPlay: boolean }) => {
+  const previousIsExpanded = useRef(isExpanded);
+  const previousAutoPlay = useRef(autoPlay);
+  const [expanded, setExpanded] = useState(isExpanded);
+  const [playing, setPlaying] = useState(autoPlay);
+
+  if (previousIsExpanded.current !== isExpanded) {
+    previousIsExpanded.current = isExpanded;
+    setExpanded(isExpanded);
+  }
+  if (previousAutoPlay.current !== autoPlay) {
+    previousAutoPlay.current = autoPlay;
+    setPlaying(autoPlay);
+  }
+
+  return (
+    <button
+      onClick={() => setExpanded((current) => !current)}
+      onDoubleClick={() => setPlaying((current) => !current)}
+    >
+      {expanded && playing ? "playing" : "paused"}
+    </button>
+  );
+};
+
+export const RadioGroup = ({ value }: { value: string }) => {
+  const previousValue = useRef(value);
+  const [selectedValue, setSelectedValue] = useState(value);
+
+  if (value !== previousValue.current) {
+    previousValue.current = value;
+    setSelectedValue(value);
+  }
+
+  return <button onClick={() => setSelectedValue("other")}>{selectedValue}</button>;
+};
+
+export const FloatingSheet = ({
+  isOpen,
+  restingHeight,
+}: {
+  isOpen: boolean;
+  restingHeight: number;
+}) => {
+  const previousOpen = useRef(isOpen);
+  const [height, setHeight] = useState(restingHeight);
+
+  if (isOpen !== previousOpen.current) {
+    previousOpen.current = isOpen;
+    if (isOpen) {
+      setHeight(restingHeight);
+    } else {
+      setHeight(0);
+    }
+  }
+
+  return <div onPointerMove={(event) => setHeight(event.clientY)}>{height}</div>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state-render-phase.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state-render-phase.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noDerivedState } from "./no-derived-state.js";
+
+const run = (code: string): ReturnType<typeof runRule> =>
+  runRule(noDerivedState, code, { filename: "fixture.tsx", forceJsx: true });
+
+describe("no-derived-state — render-phase compare-and-set", () => {
+  it("flags the Rad UI state-tracker prop mirror", () => {
+    const result = run(`
+      function Theme({ accentColor }) {
+        const [previousAccentColor, setPreviousAccentColor] = useState(accentColor);
+        const [themeAccentColor, setThemeAccentColor] = useState(accentColor);
+
+        if (accentColor !== previousAccentColor) {
+          setPreviousAccentColor(accentColor);
+          setThemeAccentColor(accentColor);
+        }
+
+        return <ThemeContext.Provider value={themeAccentColor} />;
+      }
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("themeAccentColor");
+  });
+
+  it("flags a pure transform through an immutable alias and module helper", () => {
+    const result = run(`
+      const normalizeTheme = (value) => value.trim().toLowerCase();
+
+      function Theme({ appearance }) {
+        const nextAppearance = appearance;
+        const previousAppearance = useRef(nextAppearance);
+        const [theme, setTheme] = useState(normalizeTheme(nextAppearance));
+
+        if (previousAppearance.current !== nextAppearance) {
+          previousAppearance.current = nextAppearance;
+          setTheme(normalizeTheme(nextAppearance));
+        }
+
+        return <output>{theme}</output>;
+      }
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags state derived exclusively from another state value", () => {
+    const result = run(`
+      function Picker() {
+        const [selection, setSelection] = useState("first");
+        const previousSelection = useRef(selection);
+        const [label, setLabel] = useState(selection.toUpperCase());
+
+        if (selection !== previousSelection.current) {
+          previousSelection.current = selection;
+          setLabel(selection.toUpperCase());
+        }
+
+        return <button onClick={() => setSelection("second")}>{label}</button>;
+      }
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("resolves aliased and namespace React hooks", () => {
+    const aliasedResult = run(`
+      import { useRef as usePrevious, useState as useValue } from "react";
+      function Theme({ appearance }) {
+        const previousAppearance = usePrevious(appearance);
+        const [theme, setTheme] = useValue(appearance);
+        if (appearance !== previousAppearance.current) {
+          previousAppearance.current = appearance;
+          setTheme(appearance);
+        }
+        return theme;
+      }
+    `);
+    const namespaceResult = run(`
+      import * as React from "react";
+      function Theme({ appearance }) {
+        const [previousAppearance, setPreviousAppearance] = React.useState(appearance);
+        const [theme, setTheme] = React.useState(appearance);
+        if (previousAppearance !== appearance) {
+          setPreviousAppearance(appearance);
+          setTheme(appearance);
+        }
+        return theme;
+      }
+    `);
+
+    expect(aliasedResult.parseErrors).toEqual([]);
+    expect(namespaceResult.parseErrors).toEqual([]);
+    expect(aliasedResult.diagnostics).toHaveLength(1);
+    expect(namespaceResult.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves existing effect-derived-state detection", () => {
+    const result = run(`
+      function Name({ firstName, lastName }) {
+        const [fullName, setFullName] = useState("");
+        useEffect(() => {
+          setFullName(firstName + " " + lastName);
+        }, [firstName, lastName]);
+        return fullName;
+      }
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: "previous-value tracking without a destination state write",
+      source: `
+        function Counter({ count }) {
+          const previousCount = useRef(count);
+          if (count !== previousCount.current) {
+            previousCount.current = count;
+          }
+          return previousCount.current;
+        }
+      `,
+    },
+    {
+      name: "guarded ref initialization",
+      source: `
+        function Cache({ value }) {
+          const cacheRef = useRef(null);
+          if (cacheRef.current === null) {
+            cacheRef.current = createCache(value);
+          }
+          return cacheRef.current;
+        }
+      `,
+    },
+    {
+      name: "ref-only sticky value tracking",
+      source: `
+        function useStickyValue(value) {
+          const lastNonEmptyRef = useRef(value);
+          if (value) {
+            lastNonEmptyRef.current = value;
+          }
+          return lastNonEmptyRef.current;
+        }
+      `,
+    },
+    {
+      name: "latest-value ref writes",
+      source: `
+        function FloatingSheet({ height }) {
+          const heightRef = useRef(height);
+          heightRef.current = height;
+          useEffect(() => readHeight(heightRef.current), []);
+          return null;
+        }
+      `,
+    },
+    {
+      name: "Divz semi-controlled state",
+      source: `
+        function Divz({ isExpanded, autoPlay }) {
+          const previousIsExpanded = useRef(isExpanded);
+          const previousAutoPlay = useRef(autoPlay);
+          const [expanded, setExpanded] = useState(isExpanded);
+          const [playing, setPlaying] = useState(autoPlay);
+
+          if (previousIsExpanded.current !== isExpanded) {
+            previousIsExpanded.current = isExpanded;
+            setExpanded(isExpanded);
+          }
+          if (previousAutoPlay.current !== autoPlay) {
+            previousAutoPlay.current = autoPlay;
+            setPlaying(autoPlay);
+          }
+
+          return (
+            <button
+              onClick={() => setExpanded((current) => !current)}
+              onDoubleClick={() => setPlaying((current) => !current)}
+            >
+              {expanded && playing ? "playing" : "paused"}
+            </button>
+          );
+        }
+      `,
+    },
+    {
+      name: "FloatingSheet transition and gesture state",
+      source: `
+        function FloatingSheet({ isOpen, restingHeight, isDragging }) {
+          const previousOpenRef = useRef(isOpen);
+          const previousRestingHeightRef = useRef(restingHeight);
+          const [height, setHeight] = useState(restingHeight);
+          const [isAnimating, setIsAnimating] = useState(false);
+          const [isClosing, setIsClosing] = useState(false);
+
+          if (isOpen !== previousOpenRef.current) {
+            previousOpenRef.current = isOpen;
+            previousRestingHeightRef.current = restingHeight;
+            setIsAnimating(true);
+            if (isOpen) {
+              setIsClosing(false);
+              setHeight(restingHeight);
+            } else {
+              setIsClosing(true);
+              setHeight(0);
+            }
+          } else if (restingHeight !== previousRestingHeightRef.current) {
+            previousRestingHeightRef.current = restingHeight;
+            if (isOpen && !isDragging) setHeight(restingHeight);
+          }
+
+          return <div onPointerMove={(event) => setHeight(event.clientY)}>{height}</div>;
+        }
+      `,
+    },
+    {
+      name: "Brainly-style semi-controlled selection",
+      source: `
+        function RadioGroup({ value }) {
+          const previousValue = useRef(value);
+          const [selectedValue, setSelectedValue] = useState(value);
+
+          if (value !== previousValue.current) {
+            previousValue.current = value;
+            setSelectedValue(value);
+          }
+
+          return <Radio value={selectedValue} onChange={setSelectedValue} />;
+        }
+      `,
+    },
+    {
+      name: "Cosmos-style keyboard state reset",
+      source: `
+        function FixtureSearch({ searchText }) {
+          const previousSearchText = useRef(searchText);
+          const [activePath, setActivePath] = useState(null);
+
+          if (searchText !== previousSearchText.current) {
+            previousSearchText.current = searchText;
+            setActivePath(null);
+          }
+
+          return <div onKeyDown={() => setActivePath("next")}>{activePath}</div>;
+        }
+      `,
+    },
+    {
+      name: "transition state seeded from sibling state",
+      source: `
+        function Autocomplete({ open }) {
+          const [selectedIndex] = useState(0);
+          const [activeIndex, setActiveIndex] = useState(null);
+          const previousOpen = useRef(open);
+
+          if (open !== previousOpen.current) {
+            previousOpen.current = open;
+            if (open) setActiveIndex(selectedIndex);
+          }
+
+          return <div onKeyDown={() => setActiveIndex(1)}>{activeIndex}</div>;
+        }
+      `,
+    },
+    {
+      name: "Prisma-style independently toggled expansion state",
+      source: `
+        function ModelSection({ expanded }) {
+          const previousExpanded = useRef(expanded);
+          const [isExpanded, setIsExpanded] = useState(expanded);
+
+          if (expanded !== previousExpanded.current) {
+            previousExpanded.current = expanded;
+            setIsExpanded(expanded);
+          }
+
+          return <button onClick={() => setIsExpanded((current) => !current)}>{String(isExpanded)}</button>;
+        }
+      `,
+    },
+    {
+      name: "DateRangePicker controlled and uncontrolled state",
+      source: `
+        function DateRangePicker({ isOpen: isOpenProp }) {
+          const previousIsOpen = useRef(isOpenProp);
+          const [isOpen, setIsOpen] = useState(isOpenProp);
+
+          if (isOpenProp !== previousIsOpen.current) {
+            previousIsOpen.current = isOpenProp;
+            setIsOpen(isOpenProp);
+          }
+
+          return <button onClick={() => setIsOpen((current) => !current)}>{String(isOpen)}</button>;
+        }
+      `,
+    },
+    {
+      name: "gallery index reset with an independent writer",
+      source: `
+        function Gallery({ current }) {
+          const previousCurrent = useRef(current);
+          const [selectedIndex, setSelectedIndex] = useState(current);
+
+          if (current !== previousCurrent.current) {
+            previousCurrent.current = current;
+            setSelectedIndex(current);
+          }
+
+          return <button onClick={() => setSelectedIndex((index) => index + 1)}>{selectedIndex}</button>;
+        }
+      `,
+    },
+    {
+      name: "external-store snapshots",
+      source: `
+        function StoreStatus({ store }) {
+          const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot);
+          const previousSnapshot = useRef(snapshot);
+          const [status, setStatus] = useState(snapshot);
+
+          if (snapshot !== previousSnapshot.current) {
+            previousSnapshot.current = snapshot;
+            setStatus(snapshot);
+          }
+
+          return status;
+        }
+      `,
+    },
+    {
+      name: "unknown helper results",
+      source: `
+        import { deriveTheme } from "theme-library";
+        function Theme({ appearance }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(deriveTheme(appearance));
+          if (appearance !== previousAppearance.current) {
+            previousAppearance.current = appearance;
+            setTheme(deriveTheme(appearance));
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "mutable source aliases",
+      source: `
+        function Theme({ appearance }) {
+          let nextAppearance = appearance;
+          const previousAppearance = useRef(nextAppearance);
+          const [theme, setTheme] = useState(nextAppearance);
+          nextAppearance = normalizeTheme(nextAppearance);
+          if (nextAppearance !== previousAppearance.current) {
+            previousAppearance.current = nextAppearance;
+            setTheme(nextAppearance);
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "functional destination updaters",
+      source: `
+        function Theme({ appearance }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(appearance);
+          if (appearance !== previousAppearance.current) {
+            previousAppearance.current = appearance;
+            setTheme(() => appearance);
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "compound guards",
+      source: `
+        function Theme({ appearance, enabled }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(appearance);
+          if (enabled && appearance !== previousAppearance.current) {
+            previousAppearance.current = appearance;
+            setTheme(appearance);
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "nested destination setters",
+      source: `
+        function Theme({ appearance, enabled }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(appearance);
+          if (appearance !== previousAppearance.current) {
+            previousAppearance.current = appearance;
+            if (enabled) setTheme(appearance);
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "member-path mismatches",
+      source: `
+        function Theme({ settings }) {
+          const appearance = settings.appearance;
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(settings.theme);
+          if (appearance !== previousAppearance.current) {
+            previousAppearance.current = appearance;
+            setTheme(settings.theme);
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "destination initializers from a different source",
+      source: `
+        function Theme({ appearance, defaultTheme }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(defaultTheme);
+          if (appearance !== previousAppearance.current) {
+            previousAppearance.current = appearance;
+            setTheme(appearance);
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "setters passed to child components",
+      source: `
+        function Theme({ appearance }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(appearance);
+          if (appearance !== previousAppearance.current) {
+            previousAppearance.current = appearance;
+            setTheme(appearance);
+          }
+          return <ThemeEditor value={theme} onChange={setTheme} />;
+        }
+      `,
+    },
+    {
+      name: "locally shadowed React hooks",
+      source: `
+        const useRef = (value) => ({ current: value });
+        const useState = (value) => [value, () => {}];
+        function Theme({ appearance }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(appearance);
+          if (appearance !== previousAppearance.current) {
+            previousAppearance.current = appearance;
+            setTheme(appearance);
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "trackers not synchronized in the branch",
+      source: `
+        function Theme({ appearance }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(appearance);
+          if (appearance !== previousAppearance.current) {
+            setTheme(appearance);
+          }
+          return theme;
+        }
+      `,
+    },
+    {
+      name: "tracker writes from a different source",
+      source: `
+        function Theme({ appearance, fallback }) {
+          const previousAppearance = useRef(appearance);
+          const [theme, setTheme] = useState(appearance);
+          if (appearance !== previousAppearance.current) {
+            previousAppearance.current = fallback;
+            setTheme(appearance);
+          }
+          return theme;
+        }
+      `,
+    },
+  ])("stays quiet for $name", ({ source }) => {
+    const result = run(source);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.cross-file.test.ts
@@ -38,6 +38,24 @@ const runConsumer = (
 };
 
 describe("no-derived-state — cross-file helper return summaries", () => {
+  it("flags a render-phase mirror through an imported pure helper", () => {
+    writeFile("src/derive-label.ts", `export const deriveLabel = (value) => value.trim();\n`);
+    const result = runConsumer(`
+import { deriveLabel } from "./derive-label";
+function Field({ value }) {
+  const previousValue = useRef(value);
+  const [label, setLabel] = useState(deriveLabel(value));
+  if (value !== previousValue.current) {
+    previousValue.current = value;
+    setLabel(deriveLabel(value));
+  }
+  return label;
+}
+`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags a named helper imported under an alias", () => {
     writeFile(
       "src/select-visible.ts",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ts
@@ -1,9 +1,11 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { createComponentPropStackTracker } from "../../utils/create-component-prop-stack-tracker.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectEffectStateWriteFacts } from "./utils/collect-effect-state-write-facts.js";
+import { collectRenderStateWriteFacts } from "./utils/collect-render-state-write-facts.js";
 import { getProgramAnalysis } from "./utils/effect/get-program-analysis.js";
 import { isUseEffect } from "./utils/effect/react.js";
 
@@ -26,20 +28,40 @@ export const noDerivedState = defineRule({
   severity: "warn",
   tags: ["test-noise"],
   recommendation:
-    "Work out the value while rendering (or with useMemo if it's expensive) instead of copying it into useState through a useEffect. See https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isUseEffect(node)) return;
-      const analysis = getProgramAnalysis(node);
-      if (!analysis) return;
-      for (const fact of collectEffectStateWriteFacts(analysis, node, context.filename)) {
-        if (!fact.isRenderKnownCopy || fact.resetsSourceState) continue;
-        const stateName = getStateName(fact.stateDeclarator);
-        context.report({
-          node: fact.callExpression,
-          message: `Storing "${stateName}" in state when you can derive it from other values costs an extra render.`,
-        });
-      }
-    },
-  }),
+    "Work out the value while rendering (or with useMemo if it's expensive) instead of copying it into state and synchronizing it during render or through an effect. See https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state",
+  create: (context: RuleContext) => {
+    const reportStateWrite = (callExpression: EsTreeNode, stateDeclarator: EsTreeNode): void => {
+      const stateName = getStateName(stateDeclarator);
+      context.report({
+        node: callExpression,
+        message: `Storing "${stateName}" in state when you can derive it from other values costs an extra render.`,
+      });
+    };
+    const componentTracker = createComponentPropStackTracker({
+      onComponentEnter: (componentBody) => {
+        if (!componentBody) return;
+        const analysis = getProgramAnalysis(componentBody);
+        if (!analysis) return;
+        for (const fact of collectRenderStateWriteFacts(
+          analysis,
+          componentBody,
+          context.filename,
+        )) {
+          reportStateWrite(fact.callExpression, fact.stateDeclarator);
+        }
+      },
+    });
+    return {
+      ...componentTracker.visitors,
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!isUseEffect(node)) return;
+        const analysis = getProgramAnalysis(node);
+        if (!analysis) return;
+        for (const fact of collectEffectStateWriteFacts(analysis, node, context.filename)) {
+          if (!fact.isRenderKnownCopy || fact.resetsSourceState) continue;
+          reportStateWrite(fact.callExpression, fact.stateDeclarator);
+        }
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -45,6 +45,11 @@ interface EffectValueEvidence {
   readsExternalValue: boolean;
 }
 
+export interface RenderValueEvidence {
+  sourceReferences: ReadonlySet<Reference>;
+  isExclusivelyRenderKnown: boolean;
+}
+
 interface HelperReturnSummary {
   usedParameterIndices: ReadonlySet<number>;
 }
@@ -1281,6 +1286,35 @@ const collectValueEvidence = (
     }
   }
   return evidence;
+};
+
+export const collectRenderValueEvidence = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+  componentFunction: EsTreeNode,
+  currentFilename?: string,
+): RenderValueEvidence => {
+  const evidence = collectValueEvidence(
+    analysis,
+    expression,
+    {
+      functionNode: componentFunction,
+      invocation: null,
+      isDeferred: false,
+      introducedBindings: new Set(),
+      substitutions: new Map(),
+      currentFilename,
+    },
+    1,
+  );
+  return {
+    sourceReferences: evidence.sourceReferences,
+    isExclusivelyRenderKnown:
+      evidence.sourceReferences.size > 0 &&
+      !evidence.hasUnknownSource &&
+      !evidence.hasDeferredIntroducedValue &&
+      !evidence.readsExternalValue,
+  };
 };
 
 const findStateSetterReference = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-render-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-render-state-write-facts.ts
@@ -1,0 +1,366 @@
+import type { Reference } from "eslint-scope";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isFunctionLike } from "../../../utils/is-function-like.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
+import {
+  collectRenderValueEvidence,
+  type RenderValueEvidence,
+} from "./collect-effect-state-write-facts.js";
+import { getRef } from "./effect/ast.js";
+import { isExternallyDrivenState } from "./effect/external-state.js";
+import type { ProgramAnalysis } from "./effect/get-program-analysis.js";
+import {
+  getUseStateDecl,
+  isGenuineReactHookDeclarator,
+  isProp,
+  isState,
+  isStateSetter,
+  isWholePropsObjectReference,
+} from "./effect/react.js";
+
+export interface RenderStateWriteFact {
+  callExpression: EsTreeNode;
+  stateDeclarator: EsTreeNode;
+}
+
+interface RenderSource {
+  bindingIdentity: unknown;
+}
+
+interface StateRenderTracker {
+  kind: "state";
+  declarator: EsTreeNode;
+}
+
+interface RefRenderTracker {
+  kind: "ref";
+  reference: Reference;
+}
+
+interface RenderTrackerGuard {
+  source: RenderSource;
+  tracker: StateRenderTracker | RefRenderTracker;
+  statements: ReadonlyArray<EsTreeNode>;
+}
+
+const findReferenceDeclarator = (reference: Reference): EsTreeNode | null => {
+  for (const definition of reference.resolved?.defs ?? []) {
+    const definitionNode = definition.node as unknown as EsTreeNode;
+    if (isNodeOfType(definitionNode, "VariableDeclarator")) return definitionNode;
+  }
+  return null;
+};
+
+const resolveSimpleRenderSource = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+  visitedBindings: ReadonlySet<unknown> = new Set(),
+): RenderSource | null => {
+  const node = stripParenExpression(expression);
+  if (!isNodeOfType(node, "Identifier")) return null;
+  const reference = getRef(analysis, node);
+  if (!reference?.resolved || visitedBindings.has(reference.resolved)) return null;
+  if (isProp(analysis, reference)) {
+    if (isWholePropsObjectReference(analysis, reference)) return null;
+    return { bindingIdentity: reference.resolved };
+  }
+  if (isState(analysis, reference)) {
+    const stateDeclarator = getUseStateDecl(analysis, reference);
+    if (
+      !stateDeclarator ||
+      !isGenuineReactHookDeclarator(analysis, stateDeclarator, "useState") ||
+      isExternallyDrivenState(analysis, reference)
+    ) {
+      return null;
+    }
+    return { bindingIdentity: reference.resolved };
+  }
+  if (
+    reference.resolved.references.some(
+      (candidateReference) => candidateReference.isWrite() && !candidateReference.init,
+    )
+  ) {
+    return null;
+  }
+  const declarator = findReferenceDeclarator(reference);
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator") || !declarator.init) {
+    return null;
+  }
+  const nextVisitedBindings = new Set(visitedBindings);
+  nextVisitedBindings.add(reference.resolved);
+  return resolveSimpleRenderSource(analysis, declarator.init as EsTreeNode, nextVisitedBindings);
+};
+
+const doesEvidenceMatchSource = (evidence: RenderValueEvidence, source: RenderSource): boolean =>
+  evidence.isExclusivelyRenderKnown &&
+  evidence.sourceReferences.size > 0 &&
+  [...evidence.sourceReferences].every(
+    (sourceReference) => sourceReference.resolved === source.bindingIdentity,
+  );
+
+const getDirectBranchStatements = (branch: EsTreeNode): ReadonlyArray<EsTreeNode> => {
+  if (isNodeOfType(branch, "BlockStatement")) {
+    return (branch.body ?? []) as ReadonlyArray<EsTreeNode>;
+  }
+  return [branch];
+};
+
+const getDirectCallExpression = (statement: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(statement, "ExpressionStatement")) return null;
+  const expression = stripParenExpression(statement.expression);
+  return isNodeOfType(expression, "CallExpression") ? expression : null;
+};
+
+const getDirectAssignmentExpression = (statement: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(statement, "ExpressionStatement")) return null;
+  const expression = stripParenExpression(statement.expression);
+  return isNodeOfType(expression, "AssignmentExpression") && expression.operator === "="
+    ? expression
+    : null;
+};
+
+const findDirectStateSetterReference = (
+  analysis: ProgramAnalysis,
+  callExpression: EsTreeNode,
+): Reference | null => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return null;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "Identifier")) return null;
+  const reference = getRef(analysis, callee);
+  return reference && isStateSetter(analysis, reference) ? reference : null;
+};
+
+const getStaticRefCurrentReference = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+): Reference | null => {
+  const node = stripParenExpression(expression);
+  if (
+    !isNodeOfType(node, "MemberExpression") ||
+    node.computed ||
+    !isNodeOfType(node.object, "Identifier") ||
+    !isNodeOfType(node.property, "Identifier") ||
+    node.property.name !== "current"
+  ) {
+    return null;
+  }
+  const reference = getRef(analysis, node.object);
+  if (!reference) return null;
+  const declarator = findReferenceDeclarator(reference);
+  return declarator && isGenuineReactHookDeclarator(analysis, declarator, "useRef")
+    ? reference
+    : null;
+};
+
+const getStateTracker = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+): StateRenderTracker | null => {
+  const node = stripParenExpression(expression);
+  if (!isNodeOfType(node, "Identifier")) return null;
+  const reference = getRef(analysis, node);
+  if (!reference || !isState(analysis, reference)) return null;
+  const declarator = getUseStateDecl(analysis, reference);
+  if (!declarator || !isGenuineReactHookDeclarator(analysis, declarator, "useState")) return null;
+  return { kind: "state", declarator };
+};
+
+const getRefTracker = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+): RefRenderTracker | null => {
+  const reference = getStaticRefCurrentReference(analysis, expression);
+  return reference ? { kind: "ref", reference } : null;
+};
+
+const getTrackerInitializer = (
+  tracker: StateRenderTracker | RefRenderTracker,
+): EsTreeNode | null => {
+  const declarator =
+    tracker.kind === "state" ? tracker.declarator : findReferenceDeclarator(tracker.reference);
+  if (
+    !declarator ||
+    !isNodeOfType(declarator, "VariableDeclarator") ||
+    !isNodeOfType(declarator.init, "CallExpression")
+  ) {
+    return null;
+  }
+  const initializer = declarator.init.arguments?.[0];
+  return initializer ? (initializer as EsTreeNode) : null;
+};
+
+const isTrackerSynchronized = (analysis: ProgramAnalysis, guard: RenderTrackerGuard): boolean => {
+  for (const statement of guard.statements) {
+    if (guard.tracker.kind === "state") {
+      const callExpression = getDirectCallExpression(statement);
+      if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) continue;
+      const setterReference = findDirectStateSetterReference(analysis, callExpression);
+      if (
+        !setterReference ||
+        getUseStateDecl(analysis, setterReference) !== guard.tracker.declarator ||
+        (callExpression.arguments ?? []).length !== 1
+      ) {
+        continue;
+      }
+      const writtenValue = callExpression.arguments?.[0];
+      if (
+        writtenValue &&
+        resolveSimpleRenderSource(analysis, writtenValue as EsTreeNode)?.bindingIdentity ===
+          guard.source.bindingIdentity
+      ) {
+        return true;
+      }
+      continue;
+    }
+
+    const assignmentExpression = getDirectAssignmentExpression(statement);
+    if (!assignmentExpression || !isNodeOfType(assignmentExpression, "AssignmentExpression")) {
+      continue;
+    }
+    const trackerReference = getStaticRefCurrentReference(
+      analysis,
+      assignmentExpression.left as EsTreeNode,
+    );
+    if (trackerReference?.resolved !== guard.tracker.reference.resolved) continue;
+    if (
+      resolveSimpleRenderSource(analysis, assignmentExpression.right as EsTreeNode)
+        ?.bindingIdentity === guard.source.bindingIdentity
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const parseRenderTrackerGuard = (
+  analysis: ProgramAnalysis,
+  statement: EsTreeNode,
+): RenderTrackerGuard | null => {
+  if (
+    !isNodeOfType(statement, "IfStatement") ||
+    statement.alternate ||
+    !isNodeOfType(statement.test, "BinaryExpression") ||
+    statement.test.operator !== "!==" ||
+    !isNodeOfType(statement.consequent, "BlockStatement")
+  ) {
+    return null;
+  }
+  const left = statement.test.left as EsTreeNode;
+  const right = statement.test.right as EsTreeNode;
+  const candidates: ReadonlyArray<{
+    sourceExpression: EsTreeNode;
+    trackerExpression: EsTreeNode;
+  }> = [
+    { sourceExpression: left, trackerExpression: right },
+    { sourceExpression: right, trackerExpression: left },
+  ];
+  for (const candidate of candidates) {
+    const source = resolveSimpleRenderSource(analysis, candidate.sourceExpression);
+    if (!source) continue;
+    const tracker =
+      getStateTracker(analysis, candidate.trackerExpression) ??
+      getRefTracker(analysis, candidate.trackerExpression);
+    if (!tracker) continue;
+    const trackerInitializer = getTrackerInitializer(tracker);
+    if (
+      !trackerInitializer ||
+      resolveSimpleRenderSource(analysis, trackerInitializer)?.bindingIdentity !==
+        source.bindingIdentity
+    ) {
+      continue;
+    }
+    const guard: RenderTrackerGuard = {
+      source,
+      tracker,
+      statements: getDirectBranchStatements(statement.consequent as EsTreeNode),
+    };
+    return isTrackerSynchronized(analysis, guard) ? guard : null;
+  }
+  return null;
+};
+
+const isExclusiveDestinationSetterReference = (
+  setterReference: Reference,
+  callExpression: EsTreeNode,
+): boolean => {
+  if (!setterReference.resolved || !isNodeOfType(callExpression, "CallExpression")) return false;
+  const references = setterReference.resolved.references.filter((reference) => !reference.init);
+  if (references.length !== 1) return false;
+  return references[0].identifier === callExpression.callee;
+};
+
+const getStateInitializer = (stateDeclarator: EsTreeNode): EsTreeNode | null => {
+  if (
+    !isNodeOfType(stateDeclarator, "VariableDeclarator") ||
+    !isNodeOfType(stateDeclarator.init, "CallExpression")
+  ) {
+    return null;
+  }
+  const initializer = stateDeclarator.init.arguments?.[0];
+  return initializer ? (initializer as EsTreeNode) : null;
+};
+
+export const collectRenderStateWriteFacts = (
+  analysis: ProgramAnalysis,
+  componentBody: EsTreeNode,
+  currentFilename?: string,
+): ReadonlyArray<RenderStateWriteFact> => {
+  if (
+    !isNodeOfType(componentBody, "BlockStatement") ||
+    !componentBody.parent ||
+    !isFunctionLike(componentBody.parent)
+  ) {
+    return [];
+  }
+  const componentFunction = componentBody.parent;
+  const facts: RenderStateWriteFact[] = [];
+  for (const statement of componentBody.body ?? []) {
+    const guard = parseRenderTrackerGuard(analysis, statement as EsTreeNode);
+    if (!guard) continue;
+    for (const branchStatement of guard.statements) {
+      const callExpression = getDirectCallExpression(branchStatement);
+      if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) continue;
+      const setterReference = findDirectStateSetterReference(analysis, callExpression);
+      if (
+        !setterReference ||
+        (callExpression.arguments ?? []).length !== 1 ||
+        !isExclusiveDestinationSetterReference(setterReference, callExpression)
+      ) {
+        continue;
+      }
+      const stateDeclarator = getUseStateDecl(analysis, setterReference);
+      if (
+        !stateDeclarator ||
+        !isGenuineReactHookDeclarator(analysis, stateDeclarator, "useState") ||
+        (guard.tracker.kind === "state" && stateDeclarator === guard.tracker.declarator)
+      ) {
+        continue;
+      }
+      const writtenValue = callExpression.arguments?.[0];
+      const initializer = getStateInitializer(stateDeclarator);
+      if (
+        !writtenValue ||
+        !initializer ||
+        isFunctionLike(writtenValue as EsTreeNode) ||
+        !doesEvidenceMatchSource(
+          collectRenderValueEvidence(
+            analysis,
+            writtenValue as EsTreeNode,
+            componentFunction,
+            currentFilename,
+          ),
+          guard.source,
+        ) ||
+        !doesEvidenceMatchSource(
+          collectRenderValueEvidence(analysis, initializer, componentFunction, currentFilename),
+          guard.source,
+        )
+      ) {
+        continue;
+      }
+      facts.push({ callExpression, stateDeclarator });
+    }
+  }
+  return facts;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
@@ -155,6 +155,58 @@ const isReactNamedImportReference = (ref: Reference | null, importedName: string
     }),
   );
 
+const isReactNamespaceImportReference = (ref: Reference | null): boolean =>
+  Boolean(
+    ref?.resolved?.defs.some((def) => {
+      if (def.type !== "ImportBinding") return false;
+      const declarationNode = def.node as unknown as EsTreeNode;
+      if (
+        !isNodeOfType(declarationNode, "ImportNamespaceSpecifier") &&
+        !isNodeOfType(declarationNode, "ImportDefaultSpecifier")
+      ) {
+        return false;
+      }
+      const importDeclaration = declarationNode.parent;
+      return Boolean(
+        importDeclaration &&
+        isNodeOfType(importDeclaration, "ImportDeclaration") &&
+        isNodeOfType(importDeclaration.source as EsTreeNode, "Literal") &&
+        importDeclaration.source.value === "react",
+      );
+    }),
+  );
+
+export const isGenuineReactHookDeclarator = (
+  analysis: ProgramAnalysis,
+  declarator: EsTreeNode,
+  hookName: string,
+): boolean => {
+  if (
+    !isNodeOfType(declarator, "VariableDeclarator") ||
+    !isNodeOfType(declarator.init, "CallExpression")
+  ) {
+    return false;
+  }
+  const callee = stripParenExpression(declarator.init.callee);
+  if (isNodeOfType(callee, "Identifier")) {
+    const reference = getRef(analysis, callee);
+    if (!reference?.resolved) return callee.name === hookName;
+    return isReactNamedImportReference(reference, hookName);
+  }
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    callee.computed ||
+    !isNodeOfType(callee.object, "Identifier") ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    callee.property.name !== hookName
+  ) {
+    return false;
+  }
+  const namespaceReference = getRef(analysis, callee.object);
+  if (!namespaceReference?.resolved) return callee.object.name === "React";
+  return isReactNamespaceImportReference(namespaceReference);
+};
+
 const isHookCallee = (
   analysis: ProgramAnalysis,
   node: EsTreeNode | null | undefined,


### PR DESCRIPTION
## Why

`no-derived-state` detected copies synchronized in effects, but canonical render-phase mirrors could launder the same derived value through a previous-value state or ref guard.

```tsx
const Component = ({ value }) => {
  const [previousValue, setPreviousValue] = useState(value);
  const [derivedValue, setDerivedValue] = useState(transform(value));

  if (value !== previousValue) {
    setPreviousValue(value);
    setDerivedValue(transform(value));
  }

  return derivedValue;
};
```

The destination remains fully derivable from `value`; storing and synchronizing it costs an extra render.

## What changed

- Detects direct render-phase prop and state mirrors guarded by an exact previous-value comparison.
- Requires a genuine React state/ref tracker initialized from and synchronized to the same source.
- Requires the destination initializer and render write to derive exclusively from that source.
- Rejects functional updaters, independent writers, compound or nested control flow, mutable aliases, external snapshots, unknown helpers, mismatched sources, and unsynchronized trackers.
- Preserves semi-controlled, sticky, interaction, and history state, including the CoreUI `CAlert` pattern.
- Adds focused positive and adversarial regressions, cross-file helper coverage, two permanent fuzz corpus seeds, and a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| Root scans | 500 successful / 0 failed on each side |
| Baseline | `fix/helper-value-provenance` |
| Target rule | `no-derived-state` |
| Target diagnostics | 357 on branch / 357 on baseline |
| Rule-filtered delta | 0 added / 0 removed |
| False positives found | 0 |

The built-in parity reducer exceeded an 8 GB Node heap on the two full artifacts, so the target-rule comparison was streamed from both JSONL files by stable diagnostic identity. Counts and identities matched exactly.

## Test plan

- Full plugin suite: 528 files passed; 11,772 tests passed; 145 skipped.
- Focused render/effect/cross-file suites: 87 passed.
- Existing CoreUI `CAlert` regression control passed.
- Fuzz package: 33 passed; 397 skipped.
- `FUZZ_RULE=no-derived-state FUZZ_ITERATIONS=500 FUZZ_SEED=42 FUZZ_INVARIANTS=1 nr fuzz` passed.
- Root and plugin typechecks passed.
- Plugin build and format check passed.
- Changeset status validation passed.
- Lint passed with the same three unrelated repository warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds ~400 lines of render-phase static analysis with many carve-outs; misclassification could annoy users, but behavior is heavily tested and eval reported zero diagnostic delta vs baseline.
> 
> **Overview**
> **`no-derived-state`** now flags **render-time** prop/state mirrors that used to slip past because only **`useEffect`** syncs were checked. On each component body entry it looks for the canonical **`if (source !== previousTracker) { update tracker; setDestination(...) }`** pattern when the destination state is initialized and updated from the **same** derivable source.
> 
> Detection is intentionally narrow: genuine **`useState`/`useRef`** trackers (including aliased and **`React.*`** imports), synchronized tracker writes in the guard branch, exclusive destination setters, and **render-known** value provenance via shared **`collectRenderValueEvidence`**. Semi-controlled components, sticky refs, interaction-only state, resets to constants, and unknown cross-file helpers stay silent.
> 
> Adds **`collect-render-state-write-facts`**, **`isGenuineReactHookDeclarator`**, a large render-phase test matrix, cross-file render mirror coverage, and two fuzz regression seeds; recommendation text mentions render sync as well as effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc88b516e0dc13132cb648dd5ef1d0bf8bd14bf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->