### PR TITLE
feat(rules): detect ref mutations during render

### DIFF
--- a/.changeset/few-pandas-cross.md
+++ b/.changeset/few-pandas-cross.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Add no-ref-current-in-render to report React ref mutations during render while preserving event, effect, ref-callback, deferred, and predictable lazy-initialization writes.

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -32,6 +32,7 @@ const AUDITED_RULE_IDS = [
   "no-nested-component-definition",
   "no-pass-data-to-parent",
   "no-react19-deprecated-apis",
+  "no-ref-current-in-render",
   "no-render-in-render",
   "no-stale-timer-ref",
   "no-usememo-simple-expression",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -782,6 +782,14 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "no-prop-callback-in-effect": {
     code: "\n      const Image = ({ thing, property, onError, onSave, maxSize }: Props) => {\n        const values = useProperty({ thing, property, type: 'url' });\n        const { value, error: thingError } = values;\n        let valueError;\n        if (!value) {\n          valueError = new Error('No value found for property.');\n        }\n        const [error, setError] = useState(thingError ?? valueError);\n\n        useEffect(() => {\n          if (error) {\n            if (onError) {\n              onError(error);\n            }\n          }\n        }, [error, onError]);\n\n        const handleDelete = async () => {\n          try {\n            await deleteImage(value);\n          } catch (deleteError) {\n            setError(deleteError);\n          }\n        };\n\n        const handleChange = async (input) => {\n          const fileSelected = input.files && input.files[0];\n          try {\n            await saveImage(fileSelected);\n            if (onSave) {\n              onSave();\n            }\n          } catch (saveError) {\n            setError(saveError);\n          }\n        };\n\n        return (\n          <div>\n            <input onChange={(event) => handleChange(event.target)} />\n            <button onClick={handleDelete}>Delete</button>\n          </div>\n        );\n      };\n      ",
   },
+  "no-ref-current-in-render": {
+    code: `import { useRef } from "react";
+      const Panel = ({ value }) => {
+        const latestValueRef = useRef(value);
+        latestValueRef.current = value;
+        return null;
+      };`,
+  },
   "no-prop-types": {
     code: 'import PropTypes from "prop-types";\nconst Foo = () => null;\nFoo.propTypes = { name: PropTypes.string };',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -240,6 +240,7 @@ import { noReactDomDeprecatedApis } from "./rules/architecture/no-react-dom-depr
 import { noReact19DeprecatedApis } from "./rules/architecture/no-react19-deprecated-apis.js";
 import { noRedundantRoles } from "./rules/a11y/no-redundant-roles.js";
 import { noRedundantShouldComponentUpdate } from "./rules/react-builtins/no-redundant-should-component-update.js";
+import { noRefCurrentInRender } from "./rules/state-and-effects/no-ref-current-in-render.js";
 import { noRenderInRender } from "./rules/architecture/no-render-in-render.js";
 import { noRenderPropChildren } from "./rules/architecture/no-render-prop-children.js";
 import { noRenderReturnValue } from "./rules/react-builtins/no-render-return-value.js";
@@ -3148,6 +3149,18 @@ export const reactDoctorRules = [
       requires: [
         ...new Set<Capability>(["react", ...(noRedundantShouldComponentUpdate.requires ?? [])]),
       ],
+    },
+  },
+  {
+    key: "react-doctor/no-ref-current-in-render",
+    id: "no-ref-current-in-render",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noRefCurrentInRender,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set<Capability>(["react", ...(noRefCurrentInRender.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noRefCurrentInRender } from "./no-ref-current-in-render.js";
+
+const run = (code: string) => runRule(noRefCurrentInRender, code);
+
+describe("no-ref-current-in-render", () => {
+  it.each([
+    [
+      "a latest-value ref",
+      `import { useRef } from "react";
+       const Panel = ({ value }) => {
+         const latestValueRef = useRef(value);
+         latestValueRef.current = value;
+         return null;
+       };`,
+    ],
+    [
+      "a ref alias",
+      `import { useRef } from "react";
+       const Panel = ({ value }) => {
+         const valueRef = useRef(value);
+         const alias = valueRef;
+         alias.current = value;
+         return null;
+       };`,
+    ],
+    [
+      "a ref guard used to drive state",
+      `import { useRef, useState } from "react";
+       const Panel = ({ value }) => {
+         const previousValueRef = useRef(value);
+         const [selected, setSelected] = useState(value);
+         if (previousValueRef.current !== value) {
+           previousValueRef.current = value;
+           setSelected(value);
+         }
+         return <output>{selected}</output>;
+       };`,
+    ],
+    [
+      "an increment",
+      `import * as React from "react";
+       const Panel = () => {
+         const renderCountRef = React.useRef(0);
+         renderCountRef.current++;
+         return null;
+       };`,
+    ],
+    [
+      "an IIFE executed during render",
+      `import { useRef } from "react";
+       const Panel = ({ value }) => {
+         const valueRef = useRef(value);
+         (() => { valueRef.current = value; })();
+         return null;
+       };`,
+    ],
+    [
+      "a synchronous iteration callback",
+      `import { useRef } from "react";
+       const List = ({ items }) => {
+         const itemRef = useRef(null);
+         items.forEach((item) => { itemRef.current = item; });
+         return null;
+       };`,
+    ],
+    [
+      "a custom hook",
+      `import { useRef } from "react";
+       const useLatest = (value) => {
+         const latestValueRef = useRef(value);
+         latestValueRef.current = value;
+         return latestValueRef;
+       };`,
+    ],
+  ])("reports %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "the documented lazy initialization pattern",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef(null);
+         if (playerRef.current === null) {
+           playerRef.current = new VideoPlayer();
+         }
+         return <video />;
+       };`,
+    ],
+    [
+      "an event handler",
+      `import { useRef } from "react";
+       const Button = () => {
+         const clickedRef = useRef(false);
+         return <button onClick={() => { clickedRef.current = true; }}>Save</button>;
+       };`,
+    ],
+    [
+      "an effect",
+      `import { useEffect, useRef } from "react";
+       const Panel = ({ value }) => {
+         const latestValueRef = useRef(value);
+         useEffect(() => { latestValueRef.current = value; }, [value]);
+         return null;
+       };`,
+    ],
+    [
+      "a ref callback",
+      `import { useRef } from "react";
+       const Input = () => {
+         const inputRef = useRef(null);
+         return <input ref={(node) => { inputRef.current = node; }} />;
+       };`,
+    ],
+    [
+      "a deferred callback",
+      `import { useRef } from "react";
+       const Panel = ({ value }) => {
+         const latestValueRef = useRef(value);
+         queueMicrotask(() => { latestValueRef.current = value; });
+         return null;
+       };`,
+    ],
+    [
+      "a non-React current property",
+      `const Panel = ({ value }) => {
+         const cursor = { current: null };
+         cursor.current = value;
+         return null;
+       };`,
+    ],
+    [
+      "a userland useRef function",
+      `const useRef = (value) => ({ current: value });
+       const Panel = ({ value }) => {
+         const valueRef = useRef(value);
+         valueRef.current = value;
+         return null;
+       };`,
+    ],
+  ])("stays silent for %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
@@ -48,6 +48,19 @@ describe("no-ref-current-in-render", () => {
        };`,
     ],
     [
+      "a replacement in the null guard alternate",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef(null);
+         if (playerRef.current === null) {
+           preparePlayer();
+         } else {
+           playerRef.current = new VideoPlayer();
+         }
+         return <video />;
+       };`,
+    ],
+    [
       "an IIFE executed during render",
       `import { useRef } from "react";
        const Panel = ({ value }) => {
@@ -88,6 +101,19 @@ describe("no-ref-current-in-render", () => {
          const playerRef = useRef(null);
          if (playerRef.current === null) {
            playerRef.current = new VideoPlayer();
+         }
+         return <video />;
+       };`,
+    ],
+    [
+      "documented lazy initialization behind a nested wrapper",
+      `import { useRef } from "react";
+       const Video = ({ shouldInitialize }) => {
+         const playerRef = useRef(null);
+         if (playerRef.current === null) {
+           if (shouldInitialize) {
+             playerRef.current = new VideoPlayer();
+           }
          }
          return <video />;
        };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
@@ -44,6 +44,24 @@ describe("no-ref-current-in-render", () => {
        };`,
     ],
     [
+      "a write through a typed ref receiver",
+      `import { useRef } from "react";
+       const Panel = ({ value }: { value: string }) => {
+         const valueRef = useRef<string>(value);
+         (valueRef as React.MutableRefObject<string>).current = value;
+         return null;
+       };`,
+    ],
+    [
+      "a write through a non-null ref receiver",
+      `import { useRef } from "react";
+       const Panel = ({ value }: { value: string }) => {
+         const valueRef = useRef<string>(value);
+         valueRef!.current = value;
+         return null;
+       };`,
+    ],
+    [
       "a ref guard used to drive state",
       `import { useRef, useState } from "react";
        const Panel = ({ value }) => {
@@ -132,6 +150,17 @@ describe("no-ref-current-in-render", () => {
            if (shouldInitialize) {
              playerRef.current = new VideoPlayer();
            }
+         }
+         return <video />;
+       };`,
+    ],
+    [
+      "documented lazy initialization with wrapped receivers",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef<VideoPlayer | null>(null);
+         if ((playerRef as React.MutableRefObject<VideoPlayer | null>).current === null) {
+           playerRef!.current = new VideoPlayer();
          }
          return <video />;
        };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
@@ -26,6 +26,24 @@ describe("no-ref-current-in-render", () => {
        };`,
     ],
     [
+      "a generic ref behind a TypeScript cast",
+      `import { useRef } from "react";
+       const Panel = ({ value }: { value: string }) => {
+         const valueRef = useRef<string>(value) as React.MutableRefObject<string>;
+         valueRef.current = value;
+         return null;
+       };`,
+    ],
+    [
+      "a generic ref behind a non-null assertion",
+      `import { useRef } from "react";
+       const Panel = ({ value }: { value: string }) => {
+         const valueRef = useRef<string>(value)!;
+         valueRef.current = value;
+         return null;
+       };`,
+    ],
+    [
       "a ref guard used to drive state",
       `import { useRef, useState } from "react";
        const Panel = ({ value }) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -6,6 +6,7 @@ import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-co
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const resolveReactRefSymbol = (
   memberExpression: EsTreeNode,
@@ -21,8 +22,10 @@ const resolveReactRefSymbol = (
     return null;
   }
   const symbol = resolveConstIdentifierAlias(memberExpression.object, scopes);
-  if (!symbol?.initializer || !isNodeOfType(symbol.initializer, "CallExpression")) return null;
-  return isReactApiCall(symbol.initializer, "useRef", scopes, {
+  if (!symbol?.initializer) return null;
+  const initializer = stripParenExpression(symbol.initializer);
+  if (!isNodeOfType(initializer, "CallExpression")) return null;
+  return isReactApiCall(initializer, "useRef", scopes, {
     allowGlobalReactNamespace: true,
   })
     ? symbol

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -12,16 +12,19 @@ const resolveReactRefSymbol = (
   memberExpression: EsTreeNode,
   scopes: ScopeAnalysis,
 ): SymbolDescriptor | null => {
+  const receiver = isNodeOfType(memberExpression, "MemberExpression")
+    ? stripParenExpression(memberExpression.object)
+    : null;
   if (
     !isNodeOfType(memberExpression, "MemberExpression") ||
     memberExpression.computed ||
     !isNodeOfType(memberExpression.property, "Identifier") ||
     memberExpression.property.name !== "current" ||
-    !isNodeOfType(memberExpression.object, "Identifier")
+    !isNodeOfType(receiver, "Identifier")
   ) {
     return null;
   }
-  const symbol = resolveConstIdentifierAlias(memberExpression.object, scopes);
+  const symbol = resolveConstIdentifierAlias(receiver, scopes);
   if (!symbol?.initializer) return null;
   const initializer = stripParenExpression(symbol.initializer);
   if (!isNodeOfType(initializer, "CallExpression")) return null;
@@ -36,13 +39,21 @@ const isSameRefCurrentMember = (
   node: EsTreeNode,
   refSymbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
-): boolean =>
-  isNodeOfType(node, "MemberExpression") &&
-  !node.computed &&
-  isNodeOfType(node.property, "Identifier") &&
-  node.property.name === "current" &&
-  isNodeOfType(node.object, "Identifier") &&
-  resolveConstIdentifierAlias(node.object, scopes)?.id === refSymbol.id;
+): boolean => {
+  if (
+    !isNodeOfType(node, "MemberExpression") ||
+    node.computed ||
+    !isNodeOfType(node.property, "Identifier") ||
+    node.property.name !== "current"
+  ) {
+    return false;
+  }
+  const receiver = stripParenExpression(node.object);
+  return (
+    isNodeOfType(receiver, "Identifier") &&
+    resolveConstIdentifierAlias(receiver, scopes)?.id === refSymbol.id
+  );
+};
 
 const isDocumentedLazyInitialization = (
   assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -1,0 +1,107 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+
+const resolveReactRefSymbol = (
+  memberExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  if (
+    !isNodeOfType(memberExpression, "MemberExpression") ||
+    memberExpression.computed ||
+    !isNodeOfType(memberExpression.property, "Identifier") ||
+    memberExpression.property.name !== "current" ||
+    !isNodeOfType(memberExpression.object, "Identifier")
+  ) {
+    return null;
+  }
+  const symbol = resolveConstIdentifierAlias(memberExpression.object, scopes);
+  if (!symbol?.initializer || !isNodeOfType(symbol.initializer, "CallExpression")) return null;
+  return isReactApiCall(symbol.initializer, "useRef", scopes, {
+    allowGlobalReactNamespace: true,
+  })
+    ? symbol
+    : null;
+};
+
+const isSameRefCurrentMember = (
+  node: EsTreeNode,
+  refSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean =>
+  isNodeOfType(node, "MemberExpression") &&
+  !node.computed &&
+  isNodeOfType(node.property, "Identifier") &&
+  node.property.name === "current" &&
+  isNodeOfType(node.object, "Identifier") &&
+  resolveConstIdentifierAlias(node.object, scopes)?.id === refSymbol.id;
+
+const isDocumentedLazyInitialization = (
+  assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,
+  refSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (
+    assignmentExpression.operator !== "=" ||
+    !isNodeOfType(assignmentExpression.right, "NewExpression")
+  ) {
+    return false;
+  }
+  const parent = assignmentExpression.parent;
+  if (!isNodeOfType(parent, "ExpressionStatement")) return false;
+  const consequent = parent.parent;
+  const ifStatement = isNodeOfType(consequent, "BlockStatement") ? consequent.parent : consequent;
+  if (!isNodeOfType(ifStatement, "IfStatement")) return false;
+  const isDirectConsequent =
+    ifStatement.consequent === parent ||
+    (ifStatement.consequent === consequent &&
+      isNodeOfType(consequent, "BlockStatement") &&
+      consequent.body?.includes(parent));
+  if (!isDirectConsequent || !isNodeOfType(ifStatement.test, "BinaryExpression")) return false;
+  if (ifStatement.test.operator !== "===" && ifStatement.test.operator !== "==") return false;
+  const { left, right } = ifStatement.test;
+  return (
+    (isSameRefCurrentMember(left, refSymbol, scopes) &&
+      isNodeOfType(right, "Literal") &&
+      right.value === null) ||
+    (isSameRefCurrentMember(right, refSymbol, scopes) &&
+      isNodeOfType(left, "Literal") &&
+      left.value === null)
+  );
+};
+
+export const noRefCurrentInRender = defineRule({
+  id: "no-ref-current-in-render",
+  title: "Ref mutated during render",
+  severity: "error",
+  recommendation:
+    "Move ref writes into an event handler or effect. Render must stay pure because React can replay or discard it. The predictable null-guarded lazy initialization pattern remains supported.",
+  create: (context) => {
+    const report = (memberExpression: EsTreeNode) => {
+      if (!resolveReactRefSymbol(memberExpression, context.scopes)) return;
+      if (!findRenderPhaseComponentOrHook(memberExpression, context.scopes)) return;
+      context.report({
+        node: memberExpression,
+        message:
+          "This ref is mutated during render. React can replay or discard render work, so the mutation can leak from UI that never commits.",
+      });
+    };
+
+    return {
+      AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
+        const refSymbol = resolveReactRefSymbol(node.left, context.scopes);
+        if (!refSymbol) return;
+        if (isDocumentedLazyInitialization(node, refSymbol, context.scopes)) return;
+        report(node.left);
+      },
+      UpdateExpression(node: EsTreeNodeOfType<"UpdateExpression">) {
+        report(node.argument);
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -59,9 +59,7 @@ const isDocumentedLazyInitialization = (
   if (!isNodeOfType(ifStatement, "IfStatement")) return false;
   const isDirectConsequent =
     ifStatement.consequent === parent ||
-    (ifStatement.consequent === consequent &&
-      isNodeOfType(consequent, "BlockStatement") &&
-      consequent.body?.includes(parent));
+    (ifStatement.consequent === consequent && isNodeOfType(consequent, "BlockStatement"));
   if (!isDirectConsequent || !isNodeOfType(ifStatement.test, "BinaryExpression")) return false;
   if (ifStatement.test.operator !== "===" && ifStatement.test.operator !== "==") return false;
   const { left, right } = ifStatement.test;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -52,25 +52,31 @@ const isDocumentedLazyInitialization = (
   ) {
     return false;
   }
-  const parent = assignmentExpression.parent;
-  if (!isNodeOfType(parent, "ExpressionStatement")) return false;
-  const consequent = parent.parent;
-  const ifStatement = isNodeOfType(consequent, "BlockStatement") ? consequent.parent : consequent;
-  if (!isNodeOfType(ifStatement, "IfStatement")) return false;
-  const isDirectConsequent =
-    ifStatement.consequent === parent ||
-    (ifStatement.consequent === consequent && isNodeOfType(consequent, "BlockStatement"));
-  if (!isDirectConsequent || !isNodeOfType(ifStatement.test, "BinaryExpression")) return false;
-  if (ifStatement.test.operator !== "===" && ifStatement.test.operator !== "==") return false;
-  const { left, right } = ifStatement.test;
-  return (
-    (isSameRefCurrentMember(left, refSymbol, scopes) &&
-      isNodeOfType(right, "Literal") &&
-      right.value === null) ||
-    (isSameRefCurrentMember(right, refSymbol, scopes) &&
-      isNodeOfType(left, "Literal") &&
-      left.value === null)
-  );
+  let descendant: EsTreeNode = assignmentExpression;
+  let ancestor = descendant.parent;
+  while (ancestor) {
+    if (
+      isNodeOfType(ancestor, "IfStatement") &&
+      ancestor.consequent === descendant &&
+      isNodeOfType(ancestor.test, "BinaryExpression") &&
+      (ancestor.test.operator === "===" || ancestor.test.operator === "==")
+    ) {
+      const { left, right } = ancestor.test;
+      if (
+        (isSameRefCurrentMember(left, refSymbol, scopes) &&
+          isNodeOfType(right, "Literal") &&
+          right.value === null) ||
+        (isSameRefCurrentMember(right, refSymbol, scopes) &&
+          isNodeOfType(left, "Literal") &&
+          left.value === null)
+      ) {
+        return true;
+      }
+    }
+    descendant = ancestor;
+    ancestor = descendant.parent;
+  }
+  return false;
 };
 
 export const noRefCurrentInRender = defineRule({


### PR DESCRIPTION
## Summary

- add `no-ref-current-in-render` for `.current` assignments and updates to locally-created React refs on component and custom-hook render paths
- follow immutable ref aliases through IIFEs and synchronous iterator callbacks
- preserve event handlers, effects, ref callbacks, deferred callbacks, userland `useRef` lookalikes, ordinary `current` properties, and React's documented null-guarded `new` lazy initialization
- add liveness, verdict-robustness fuzz, and patch release coverage

## Validation

- `nr --filter oxlint-plugin-react-doctor test` (527 files; 11,706 passed; 145 skipped)
- `nr --filter @react-doctor/fuzz test` (34 passed; 398 skipped)
- strict targeted fuzz: 500 iterations, seed 42
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `nr build`
- `nr lint` (only the three existing warnings)
- `nr format:check`
- React Doctor changed-scope scan: 100/100
- fresh RDE across 500 OSS roots: zero reports

## Rule contract

Report assignment or update of `.current` when the receiver resolves through const aliases to a local `useRef` call imported from React and execution occurs during component/custom-hook render. Exempt the documented `if (ref.current === null) ref.current = new Thing()` initialization shape. Imported-helper and object-property ref indirection remain out of v1 scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new static analysis rule with explicit exemptions and test coverage; no runtime or security-sensitive behavior changes in application code.
> 
> **Overview**
> Adds **`no-ref-current-in-render`**, a new **Bugs** rule that flags assignments and updates to `.current` on React `useRef` values while component or custom-hook bodies are rendering.
> 
> Detection resolves const aliases and typed/non-null receivers, and only targets refs created from React’s `useRef`. It **does not** report writes in event handlers, effects, ref callbacks, or deferred callbacks (those paths are outside render-phase scope). It also allows React’s documented lazy init: `if (ref.current === null) ref.current = new Thing()`.
> 
> The rule is registered in the plugin, covered by unit tests and a liveness fixture, and included in the fuzz **verdict-robustness** audited rule list. A patch changeset documents the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19aa28a3f6e873f325010abf8cd9cb4385e4deda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->