### PR TITLE
feat(rules): detect impure state updaters

### DIFF
--- a/.changeset/every-rocks-roll.md
+++ b/.changeset/every-rocks-roll.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Add no-impure-state-updater to report replay-unsafe side effects inside React state updater callbacks while preserving pure calculations and local accumulators.

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -65,6 +65,7 @@ export const STATE_SNIPPET_POOL = [
   `const deferredValue = useDeferredValue(state);`,
   `const [isPending, startTransition] = useTransition();`,
   `const [counterState, dispatchCounter] = useReducer((state, action) => { state.count += 1; return state; }, { count: 0 });`,
+  `const [persistedCount, setPersistedCount] = useState(0); const incrementPersistedCount = () => setPersistedCount((previousCount) => { localStorage.setItem("count", String(previousCount + 1)); return previousCount + 1; });`,
   `const [parsedItems, setParsedItems] = useState(parseItems(value));`,
   `const indexRef = useRef(buildIndex(items));`,
   `const doubled = useMemo(() => state * 2, [state]);`,

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -25,6 +25,7 @@ const AUDITED_RULE_IDS = [
   "no-aria-hidden-on-focusable",
   "no-cascading-set-state",
   "no-derived-state-effect",
+  "no-impure-state-updater",
   "no-jsx-element-type",
   "no-locale-format-in-render",
   "no-mutating-reducer-state",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -685,6 +685,17 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "no-json-parse-stringify-clone": {
     code: "const copy = JSON.parse(JSON.stringify(state));",
   },
+  "no-impure-state-updater": {
+    code: `import { useState } from "react";
+      const Counter = () => {
+        const [count, setCount] = useState(0);
+        const increment = () => setCount((previousCount) => {
+          localStorage.setItem("count", String(previousCount + 1));
+          return previousCount + 1;
+        });
+        return <button onClick={increment}>{count}</button>;
+      };`,
+  },
   "no-jsx-element-type": {
     code: "\n      function App(): JSX.Element {\n        return <div />;\n      }\n    ",
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -195,6 +195,7 @@ import { noGradientText } from "./rules/design/no-gradient-text.js";
 import { noGrayOnColoredBackground } from "./rules/design/no-gray-on-colored-background.js";
 import { noHydrationBranchOnBrowserGlobal } from "./rules/performance/no-hydration-branch-on-browser-global.js";
 import { noImgLazyWithHighFetchpriority } from "./rules/performance/no-img-lazy-with-high-fetchpriority.js";
+import { noImpureStateUpdater } from "./rules/state-and-effects/no-impure-state-updater.js";
 import { noIndeterminateAttribute } from "./rules/correctness/no-indeterminate-attribute.js";
 import { noInitializeState } from "./rules/state-and-effects/no-initialize-state.js";
 import { noInlineBounceEasing } from "./rules/design/no-inline-bounce-easing.js";
@@ -2610,6 +2611,18 @@ export const reactDoctorRules = [
       requires: [
         ...new Set<Capability>(["react", ...(noImgLazyWithHighFetchpriority.requires ?? [])]),
       ],
+    },
+  },
+  {
+    key: "react-doctor/no-impure-state-updater",
+    id: "no-impure-state-updater",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noImpureStateUpdater,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set<Capability>(["react", ...(noImpureStateUpdater.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noImpureStateUpdater } from "./no-impure-state-updater.js";
+
+const run = (code: string) => runRule(noImpureStateUpdater, code);
+
+describe("no-impure-state-updater", () => {
+  it.each([
+    [
+      "browser storage mutation",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         const increment = () => setCount((previousCount) => {
+           localStorage.setItem("count", String(previousCount + 1));
+           return previousCount + 1;
+         });
+         return <button onClick={increment}>{count}</button>;
+       };`,
+    ],
+    [
+      "a notification",
+      `import { useState } from "react";
+       import { toast } from "sonner";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         const increment = () => setCount((previousCount) => {
+           toast.error("Try again");
+           return previousCount + 1;
+         });
+         return <button onClick={increment}>{count}</button>;
+       };`,
+    ],
+    [
+      "a DOM measurement",
+      `import { useRef, useState } from "react";
+       const Gallery = () => {
+         const containerRef = useRef(null);
+         const [width, setWidth] = useState(0);
+         const measure = () => setWidth(() => containerRef.current.getBoundingClientRect().width);
+         return <div ref={containerRef} onClick={measure}>{width}</div>;
+       };`,
+    ],
+    [
+      "a nested state update",
+      `import { useState } from "react";
+       const Form = () => {
+         const [value, setValue] = useState(0);
+         const [error, setError] = useState(null);
+         const update = () => setValue((previousValue) => {
+           setError(null);
+           return previousValue + 1;
+         });
+         return <button onClick={update}>{value}{error}</button>;
+       };`,
+    ],
+    [
+      "a captured ref mutation",
+      `import { useRef, useState } from "react";
+       const Counter = () => {
+         const countRef = useRef(0);
+         const [count, setCount] = useState(0);
+         const increment = () => setCount((previousCount) => {
+           countRef.current = previousCount + 1;
+           return previousCount + 1;
+         });
+         return <button onClick={increment}>{count}</button>;
+       };`,
+    ],
+    [
+      "a timer inside a synchronous callback",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         const increment = () => setCount((previousCount) => {
+           [previousCount].forEach(() => setTimeout(save, 0));
+           return previousCount + 1;
+         });
+         return <button onClick={increment}>{count}</button>;
+       };`,
+    ],
+  ])("reports %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "a pure arithmetic updater",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         return <button onClick={() => setCount((previousCount) => previousCount + 1)}>{count}</button>;
+       };`,
+    ],
+    [
+      "local mutation used to build the next value",
+      `import { useState } from "react";
+       const List = () => {
+         const [items, setItems] = useState([]);
+         const add = () => setItems((previousItems) => {
+           const nextItems = [...previousItems];
+           nextItems.push("new");
+           return nextItems;
+         });
+         return <button onClick={add}>{items.length}</button>;
+       };`,
+    ],
+    [
+      "a locally created Map accumulator",
+      `import { useState } from "react";
+       const Index = () => {
+         const [index, setIndex] = useState(new Map());
+         const rebuild = () => setIndex((previousIndex) => {
+           const nextIndex = new Map(previousIndex);
+           nextIndex.set("updated", true);
+           return nextIndex;
+         });
+         return <button onClick={rebuild}>{index.size}</button>;
+       };`,
+    ],
+    [
+      "a side effect in a nested event callback",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [state, setState] = useState({ onSave: null });
+         const prepare = () => setState((previousState) => ({
+           ...previousState,
+           onSave: () => localStorage.setItem("saved", "true"),
+         }));
+         return <button onClick={prepare}>{Boolean(state.onSave)}</button>;
+       };`,
+    ],
+    [
+      "a userland setter-shaped function",
+      `const useState = () => [0, (updater) => updater(0)];
+       const Counter = () => {
+         const [count, setCount] = useState();
+         setCount((previousCount) => {
+           localStorage.setItem("count", String(previousCount));
+           return previousCount;
+         });
+         return count;
+       };`,
+    ],
+    [
+      "a value update outside the updater",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         const increment = () => {
+           localStorage.setItem("count", String(count + 1));
+           setCount((previousCount) => previousCount + 1);
+         };
+         return <button onClick={increment}>{count}</button>;
+       };`,
+    ],
+  ])("stays silent for %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.ts
@@ -1,0 +1,194 @@
+import { isDescendantScope } from "../../semantic/scope-analysis.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { executesDuringRender } from "../../utils/executes-during-render.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { getRef } from "./utils/effect/ast.js";
+import { getProgramAnalysis } from "./utils/effect/get-program-analysis.js";
+import { getUseStateDecl, isStateSetterCall } from "./utils/effect/react.js";
+
+interface MemberCall {
+  methodName: string;
+  receiver: EsTreeNode;
+}
+
+const TIMER_FUNCTION_NAMES = new Set([
+  "cancelAnimationFrame",
+  "clearInterval",
+  "clearTimeout",
+  "queueMicrotask",
+  "requestAnimationFrame",
+  "setInterval",
+  "setTimeout",
+]);
+
+const STORAGE_MUTATION_METHOD_NAMES = new Set(["clear", "removeItem", "setItem"]);
+const STORAGE_RECEIVER_NAMES = new Set(["localStorage", "sessionStorage"]);
+const EXTERNAL_READ_METHOD_NAMES = new Set(["getBoundingClientRect", "getClientRects"]);
+const NOTIFICATION_RECEIVER_NAMES = new Set(["message", "notification", "toast"]);
+const NOTIFICATION_METHOD_NAMES = new Set([
+  "error",
+  "info",
+  "loading",
+  "open",
+  "show",
+  "success",
+  "warning",
+]);
+
+const getMemberCall = (node: EsTreeNode): MemberCall | null => {
+  if (!isNodeOfType(node, "CallExpression")) return null;
+  if (!isNodeOfType(node.callee, "MemberExpression") || node.callee.computed) return null;
+  if (!isNodeOfType(node.callee.property, "Identifier")) return null;
+  return {
+    methodName: node.callee.property.name,
+    receiver: stripParenExpression(node.callee.object),
+  };
+};
+
+const isNotificationReceiver = (receiver: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  if (!NOTIFICATION_RECEIVER_NAMES.has(receiver.name)) return false;
+  const symbol = scopes.symbolFor(receiver);
+  if (symbol?.kind === "import") return true;
+  if (!isNodeOfType(symbol?.initializer, "CallExpression")) return false;
+  const callee = symbol.initializer.callee;
+  return (
+    isNodeOfType(callee, "Identifier") && /^use(?:Message|Notification|Toast)$/.test(callee.name)
+  );
+};
+
+const getKnownImpureCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): string | null => {
+  if (
+    isNodeOfType(callExpression.callee, "Identifier") &&
+    TIMER_FUNCTION_NAMES.has(callExpression.callee.name) &&
+    scopes.isGlobalReference(callExpression.callee)
+  ) {
+    return `${callExpression.callee.name}()`;
+  }
+
+  const memberCall = getMemberCall(callExpression);
+  if (!memberCall) return null;
+  const { methodName, receiver } = memberCall;
+  if (
+    STORAGE_MUTATION_METHOD_NAMES.has(methodName) &&
+    isNodeOfType(receiver, "Identifier") &&
+    STORAGE_RECEIVER_NAMES.has(receiver.name) &&
+    scopes.isGlobalReference(receiver)
+  ) {
+    return `${receiver.name}.${methodName}()`;
+  }
+  if (EXTERNAL_READ_METHOD_NAMES.has(methodName)) return `.${methodName}()`;
+  if (
+    NOTIFICATION_METHOD_NAMES.has(methodName) &&
+    isNodeOfType(receiver, "Identifier") &&
+    isNotificationReceiver(receiver, scopes)
+  ) {
+    return `${receiver.name}.${methodName}()`;
+  }
+  return null;
+};
+
+const getExternalAssignmentDescription = (
+  assignmentTarget: EsTreeNode,
+  updater: EsTreeNode,
+  scopes: ScopeAnalysis,
+): string | null => {
+  let rootIdentifier: EsTreeNodeOfType<"Identifier"> | null = null;
+  if (isNodeOfType(assignmentTarget, "Identifier")) {
+    rootIdentifier = assignmentTarget;
+  } else if (
+    isNodeOfType(assignmentTarget, "MemberExpression") &&
+    isNodeOfType(assignmentTarget.object, "Identifier")
+  ) {
+    rootIdentifier = assignmentTarget.object;
+  }
+  if (!rootIdentifier) return null;
+  const updaterScope = scopes.ownScopeFor(updater);
+  if (!updaterScope) return null;
+  const symbol = scopes.symbolFor(rootIdentifier);
+  if (!symbol) return `the external value "${rootIdentifier.name}"`;
+  if (symbol.kind === "parameter" && symbol.scope === updaterScope) {
+    return `the updater argument "${rootIdentifier.name}"`;
+  }
+  return isDescendantScope(symbol.scope, updaterScope)
+    ? null
+    : `the captured value "${rootIdentifier.name}"`;
+};
+
+const findImpureUpdaterOperation = (updater: EsTreeNode, scopes: ScopeAnalysis): string | null => {
+  const analysis = getProgramAnalysis(updater);
+  let operation: string | null = null;
+  walkAst(updater, (child: EsTreeNode): boolean | void => {
+    if (operation) return false;
+    if (child !== updater && isFunctionLike(child) && !executesDuringRender(child, scopes)) {
+      return false;
+    }
+    if (isNodeOfType(child, "CallExpression")) {
+      if (isNodeOfType(child.callee, "Identifier") && analysis) {
+        const calleeReference = getRef(analysis, child.callee);
+        if (calleeReference && isStateSetterCall(analysis, calleeReference)) {
+          operation = `the nested state update "${child.callee.name}()"`;
+          return false;
+        }
+      }
+      const impureCall = getKnownImpureCall(child, scopes);
+      if (impureCall) {
+        operation = impureCall;
+        return false;
+      }
+    }
+    if (isNodeOfType(child, "AssignmentExpression")) {
+      operation = getExternalAssignmentDescription(child.left, updater, scopes);
+      if (operation) return false;
+    }
+    if (isNodeOfType(child, "UpdateExpression")) {
+      operation = getExternalAssignmentDescription(child.argument, updater, scopes);
+      if (operation) return false;
+    }
+  });
+  return operation;
+};
+
+export const noImpureStateUpdater = defineRule({
+  id: "no-impure-state-updater",
+  title: "State updater has side effects",
+  severity: "error",
+  recommendation:
+    "Keep state updater callbacks pure and return only the next state. Move notifications, storage, timers, ref writes, and other external work into the event or effect that queues the update.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const updater = node.arguments?.[0];
+      if (!updater || !isFunctionLike(updater)) return;
+      const analysis = getProgramAnalysis(node);
+      if (!analysis || !isNodeOfType(node.callee, "Identifier")) return;
+      const calleeReference = getRef(analysis, node.callee);
+      if (!calleeReference || !isStateSetterCall(analysis, calleeReference)) return;
+      const stateDeclarator = getUseStateDecl(analysis, calleeReference);
+      if (
+        !isNodeOfType(stateDeclarator, "VariableDeclarator") ||
+        !isNodeOfType(stateDeclarator.init, "CallExpression") ||
+        !isReactApiCall(stateDeclarator.init, "useState", context.scopes, {
+          allowGlobalReactNamespace: true,
+        })
+      ) {
+        return;
+      }
+      const operation = findImpureUpdaterOperation(updater, context.scopes);
+      if (!operation) return;
+      context.report({
+        node: updater,
+        message: `This state updater performs ${operation}. React may run updater functions more than once, so side effects here can repeat or observe inconsistent external state.`,
+      });
+    },
+  }),
+});


### PR DESCRIPTION
## Summary

- add `no-impure-state-updater` for replay-unsafe operations inside inline React `useState` updater callbacks
- detect nested state updates, captured/ref/updater-argument mutation, browser storage mutation, timers, notifications, and DOM layout reads
- follow synchronous IIFEs and iterator callbacks while pruning stored/deferred nested functions
- preserve pure calculations, local array/Map accumulators, userland `useState` lookalikes, and side effects moved before the updater
- add liveness, fuzz, and patch release coverage

React explicitly requires updater functions to be pure and may invoke them twice in Strict Mode: https://react.dev/reference/react/useState

## Validation

- `nr --filter oxlint-plugin-react-doctor test` (527 files; 11,704 passed; 145 skipped)
- `nr --filter @react-doctor/fuzz test` (34 passed; 398 skipped)
- strict targeted fuzz: 500 iterations, seed 42
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `nr build`
- `nr lint` (only the three existing warnings)
- `nr format:check`
- React Doctor changed-scope scan: 100/100
- fresh RDE across 500 OSS roots: zero reports

## Rule contract

Report an objectively replay-unsafe operation reached synchronously from an inline updater passed to a setter that resolves to React-imported `useState`. Do not infer impurity from arbitrary helper calls. Imported-helper and custom-hook setter provenance remain out of v1 scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New heuristic static rule may miss custom-hook setters or mis-flag edge cases, but scope is limited to known impure patterns on React `useState` setters rather than runtime/security paths.
> 
> **Overview**
> Adds **`no-impure-state-updater`**, a **Bugs**-category error that flags **side effects inside inline `useState` updater functions** (React may run updaters more than once).
> 
> The rule only applies when the callee is a setter tied to **React-imported `useState`**. It walks the updater synchronously (following IIFEs/iterators, skipping nested functions that don’t run during render) and reports **nested `setState` calls**, **timer APIs**, **`localStorage` / `sessionStorage` writes**, **layout reads** like `getBoundingClientRect`, **toast/notification calls**, and **assignments to captured values or refs** outside the updater’s own locals. **Pure math**, **local array/Map copies**, **effects deferred to nested callbacks**, and **I/O before the updater** stay clean.
> 
> Wiring includes **registry + liveness fixture**, **unit tests**, **fuzz state snippet**, **verdict-robustness audit entry**, and a **patch changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d903ca1c7e4b8edd37d25e38a0e2858c3d3d0938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->