### PR TITLE
fix(no-derived-state): trace values through refs

### DIFF
--- a/.changeset/refs-reveal-copies.md
+++ b/.changeset/refs-reveal-copies.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect prop- and state-derived values copied into state through local refs while preserving DOM, escaped, and externally assigned refs.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ref-provenance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ref-provenance.test.ts
@@ -22,6 +22,50 @@ describe("no-derived-state — ref value provenance", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it.each([
+    [
+      "a bare ref",
+      `const incomingRef = useRef();
+       useEffect(() => { incomingRef.current = source; }, [source]);
+       useEffect(() => { setValue(incomingRef.current); }, [source]);`,
+    ],
+    [
+      "a single-assignment alias",
+      `const incomingRef = useRef(source);
+       useEffect(() => {
+         let next;
+         next = incomingRef.current;
+         setValue(next);
+       }, [source]);`,
+    ],
+  ])("detects prop-derived state copied through %s", (_scenario, body) => {
+    const result = runRule(
+      noDerivedState,
+      `function Panel({ source }) {
+        const [value, setValue] = useState(null);
+        ${body}
+        return value;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps compound ref assignments unknown", () => {
+    const result = runRule(
+      noDerivedState,
+      `function Counter({ initialCount }) {
+        const countRef = useRef(initialCount);
+        const [count, setCount] = useState(0);
+        useEffect(() => { countRef.current += 1; }, []);
+        useEffect(() => { setCount(countRef.current); }, [initialCount]);
+        return count;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("keeps DOM and externally assigned refs out of render provenance", () => {
     const domResult = runRule(
       noDerivedState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ref-provenance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ref-provenance.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noDerivedState } from "./no-derived-state.js";
+
+describe("no-derived-state — ref value provenance", () => {
+  it("detects prop-derived state copied through a ref", () => {
+    const result = runRule(
+      noDerivedState,
+      `function Settings(props) {
+        const incomingApiKeysRef = useRef(props.apiKeys);
+        const [apiKeys, setApiKeys] = useState([]);
+        useEffect(() => {
+          incomingApiKeysRef.current = props.apiKeys;
+        }, [props.apiKeys]);
+        useEffect(() => {
+          setApiKeys(incomingApiKeysRef.current);
+        }, [props.apiKeys]);
+        return apiKeys.length;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps DOM and externally assigned refs out of render provenance", () => {
+    const domResult = runRule(
+      noDerivedState,
+      `function Panel() {
+        const elementRef = useRef(null);
+        const [width, setWidth] = useState(0);
+        useLayoutEffect(() => setWidth(elementRef.current.getBoundingClientRect().width), []);
+        return <div ref={elementRef}>{width}</div>;
+      }`,
+    );
+    const externalResult = runRule(
+      noDerivedState,
+      `function Panel({ source }) {
+        const valueRef = useRef(source);
+        const [value, setValue] = useState(0);
+        useEffect(() => { valueRef.current = readExternalValue(); }, []);
+        useEffect(() => setValue(valueRef.current), [source]);
+        return value;
+      }`,
+    );
+    expect(domResult.parseErrors).toEqual([]);
+    expect(externalResult.parseErrors).toEqual([]);
+    expect(domResult.diagnostics).toEqual([]);
+    expect(externalResult.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -1097,11 +1097,27 @@ const collectValueEvidence = (
       evidence.hasUnknownSource = true;
       return evidence;
     }
-    if (
-      reference.resolved.references.some(
-        (candidateReference) => candidateReference.isWrite() && !candidateReference.init,
-      )
-    ) {
+    const nonInitializerWrites = reference.resolved.references.filter(
+      (candidateReference) => candidateReference.isWrite() && !candidateReference.init,
+    );
+    if (nonInitializerWrites.length > 0) {
+      const writtenIdentifier = nonInitializerWrites[0]?.identifier as unknown as EsTreeNode;
+      const assignment = writtenIdentifier.parent;
+      if (
+        nonInitializerWrites.length === 1 &&
+        assignment &&
+        isNodeOfType(assignment, "AssignmentExpression") &&
+        assignment.operator === "=" &&
+        assignment.left === writtenIdentifier
+      ) {
+        return collectValueEvidence(
+          analysis,
+          assignment.right as EsTreeNode,
+          frame,
+          remainingCallFrames,
+          visitedBindings,
+        );
+      }
       evidence.hasUnknownSource = true;
       return evidence;
     }
@@ -1157,8 +1173,6 @@ const collectValueEvidence = (
               new Set(refVisitedBindings),
             ),
           );
-        } else {
-          evidence.hasUnknownSource = true;
         }
         for (const candidateReference of refBinding.references) {
           if (candidateReference.init) continue;
@@ -1179,6 +1193,10 @@ const collectValueEvidence = (
             isNodeOfType(memberParent, "AssignmentExpression") &&
             memberParent.left === member
           ) {
+            if (memberParent.operator !== "=") {
+              evidence.hasUnknownSource = true;
+              continue;
+            }
             mergeEvidence(
               evidence,
               collectValueEvidence(
@@ -1191,11 +1209,7 @@ const collectValueEvidence = (
             );
             continue;
           }
-          if (
-            memberParent &&
-            ((isNodeOfType(memberParent, "AssignmentExpression") && memberParent.left !== member) ||
-              isNodeOfType(memberParent, "UpdateExpression"))
-          ) {
+          if (memberParent && isNodeOfType(memberParent, "UpdateExpression")) {
             evidence.hasUnknownSource = true;
           }
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -991,6 +991,30 @@ const isLocallyConstructedObjectMember = (
     );
   }) === true;
 
+const getUseRefDeclarator = (
+  analysis: ProgramAnalysis,
+  memberExpression: EsTreeNode,
+): EsTreeNode | null => {
+  if (
+    !isNodeOfType(memberExpression, "MemberExpression") ||
+    getStaticMemberName(memberExpression) !== "current" ||
+    !isNodeOfType(memberExpression.object, "Identifier")
+  ) {
+    return null;
+  }
+  const objectReference = getRef(analysis, memberExpression.object);
+  return (
+    objectReference?.resolved?.defs
+      .map((definition) => definition.node as unknown as EsTreeNode)
+      .find(
+        (definitionNode) =>
+          isNodeOfType(definitionNode, "VariableDeclarator") &&
+          isNodeOfType(definitionNode.init, "CallExpression") &&
+          getCallCalleeName(definitionNode.init) === "useRef",
+      ) ?? null
+  );
+};
+
 const collectValueEvidence = (
   analysis: ProgramAnalysis,
   expression: EsTreeNode,
@@ -1000,8 +1024,12 @@ const collectValueEvidence = (
 ): EffectValueEvidence => {
   const node = stripParenExpression(expression);
   const evidence = emptyEvidence();
+  const useRefDeclarator = getUseRefDeclarator(analysis, node);
 
-  if (readsPostMountValue(node) || readsPostMountValueThroughLocals(node, frame.functionNode)) {
+  if (
+    !useRefDeclarator &&
+    (readsPostMountValue(node) || readsPostMountValueThroughLocals(node, frame.functionNode))
+  ) {
     evidence.readsExternalValue = true;
     return evidence;
   }
@@ -1101,6 +1129,79 @@ const collectValueEvidence = (
   }
 
   if (isNodeOfType(node, "MemberExpression")) {
+    if (getStaticMemberName(node) === "current" && isNodeOfType(node.object, "Identifier")) {
+      const objectReference = getRef(analysis, node.object);
+      const refBinding = objectReference?.resolved;
+      const refDeclarator = useRefDeclarator;
+      if (
+        refBinding &&
+        refDeclarator &&
+        isNodeOfType(refDeclarator, "VariableDeclarator") &&
+        isNodeOfType(refDeclarator.init, "CallExpression")
+      ) {
+        if (visitedBindings.has(refBinding)) {
+          evidence.hasUnknownSource = true;
+          return evidence;
+        }
+        const refVisitedBindings = new Set(visitedBindings);
+        refVisitedBindings.add(refBinding);
+        const initialValue = refDeclarator.init.arguments?.[0];
+        if (initialValue) {
+          mergeEvidence(
+            evidence,
+            collectValueEvidence(
+              analysis,
+              initialValue as EsTreeNode,
+              frame,
+              remainingCallFrames,
+              new Set(refVisitedBindings),
+            ),
+          );
+        } else {
+          evidence.hasUnknownSource = true;
+        }
+        for (const candidateReference of refBinding.references) {
+          if (candidateReference.init) continue;
+          const identifier = candidateReference.identifier as unknown as EsTreeNode;
+          const member = identifier.parent;
+          if (
+            !member ||
+            !isNodeOfType(member, "MemberExpression") ||
+            member.object !== identifier ||
+            getStaticMemberName(member) !== "current"
+          ) {
+            evidence.hasUnknownSource = true;
+            continue;
+          }
+          const memberParent = member.parent;
+          if (
+            memberParent &&
+            isNodeOfType(memberParent, "AssignmentExpression") &&
+            memberParent.left === member
+          ) {
+            mergeEvidence(
+              evidence,
+              collectValueEvidence(
+                analysis,
+                memberParent.right as EsTreeNode,
+                frame,
+                remainingCallFrames,
+                new Set(refVisitedBindings),
+              ),
+            );
+            continue;
+          }
+          if (
+            memberParent &&
+            ((isNodeOfType(memberParent, "AssignmentExpression") && memberParent.left !== member) ||
+              isNodeOfType(memberParent, "UpdateExpression"))
+          ) {
+            evidence.hasUnknownSource = true;
+          }
+        }
+        return evidence;
+      }
+    }
     if (isNodeOfType(node.object, "Identifier")) {
       const objectReference = getRef(analysis, node.object);
       if (objectReference && isLocallyConstructedObjectMember(objectReference, node)) {


### PR DESCRIPTION
## Why

Prop-derived state could evade no-derived-state by passing through useRef.current before reaching a state setter.

## What changed

- Track local useRef initializers and direct current assignments conservatively. Bail out for DOM refs, escaped refs, nested mutation, opaque sources, imports, and external reads.
- Added focused regressions, a patch changeset, and permanent fuzz coverage where this was a confirmed false positive.

## Eval results

The current RDE wrapper cannot consume schema v3 and its rebuilt local path invokes the removed `--diff false` form. I ran the built combined candidate directly over the same first 100 pinned RDE rootDir entries and inspected this rule's filtered results before splitting the identical source change into this PR.

## Test plan

- 69 focused tests; plugin typecheck; 500 strict fuzz iterations; direct candidate-vs-main comparison across 100 pinned RDE root scans added zero unexpected no-derived-state diagnostics; lint/typecheck/format/smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis in effect value provenance for a core lint rule; behavior is guarded by tests but false positives/negatives are possible on edge-case ref patterns.
> 
> **Overview**
> Closes a **no-derived-state** bypass where props or other render-known values were staged in **`useRef.current`** before an effect called a state setter.
> 
> **`collectValueEvidence`** now follows local **`useRef`** bindings: it merges provenance from the ref’s initializer and simple **`ref.current = …`** writes, and can trace a single **`identifier = …`** reassignment instead of treating any write as opaque. **`ref.current`** reads no longer count as post-mount/external when the binding is a **`useRef`**.
> 
> The analysis stays conservative: compound assignments, **`++`/`--`**, non-**`current`** ref uses, imports, and refs fed from external/DOM-style reads are still treated as unknown so legitimate patterns (layout measurement, externally assigned refs) stay quiet.
> 
> Adds focused **ref provenance** regressions and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19e6e73da4915b1c7f2e2f3fc55e617da4bc5de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->