### PR TITLE
fix(client): exclude session storage versioning

### DIFF
--- a/.changeset/session-storage-expires.md
+++ b/.changeset/session-storage-expires.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Limit client-localstorage-no-version to persistent localStorage data instead of flagging session-scoped JSON.

--- a/packages/fuzz/corpus/regressions/localstorage-version--session-storage-records.tsx
+++ b/packages/fuzz/corpus/regressions/localstorage-version--session-storage-records.tsx
@@ -1,0 +1,7 @@
+interface DraftRecord {
+  id: string;
+}
+
+export const persistDraftRecords = (records: DraftRecord[]) => {
+  sessionStorage.setItem("draft.records", JSON.stringify(records));
+};

--- a/packages/fuzz/corpus/regressions/localstorage-version--session-storage-records.tsx
+++ b/packages/fuzz/corpus/regressions/localstorage-version--session-storage-records.tsx
@@ -1,3 +1,6 @@
+// rule: client-localstorage-no-version
+// weakness: storage-lifetime
+// source: ISSUES_TO_FIX_ASAP.md (defensively decoded session-scoped records)
 interface DraftRecord {
   id: string;
 }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.session.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.session.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { clientLocalstorageNoVersion } from "./client-localstorage-no-version.js";
+
+describe("client-localstorage-no-version — session storage", () => {
+  it("accepts unversioned session-scoped JSON", () => {
+    const result = runRule(
+      clientLocalstorageNoVersion,
+      `sessionStorage.setItem("mailing.createdApiKeys", JSON.stringify(records));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports unversioned persistent localStorage JSON", () => {
+    const result = runRule(
+      clientLocalstorageNoVersion,
+      `localStorage.setItem("mailing.createdApiKeys", JSON.stringify(records));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
@@ -15,13 +15,11 @@ const VERSIONED_KEY_PATTERN = /(?:[._:-]v\d+|@\d+|\bv\d+\b)/i;
 // camelCase version tag.
 const CAMEL_CASE_VERSIONED_KEY_PATTERN = /[a-z]V\d+/;
 
-const STORAGE_OBJECTS = new Set(["localStorage", "sessionStorage"]);
-
 const isVersionedKey = (key: string): boolean =>
   VERSIONED_KEY_PATTERN.test(key) || CAMEL_CASE_VERSIONED_KEY_PATTERN.test(key);
 
-// HACK: keys that store JSON-serialized objects in localStorage /
-// sessionStorage live forever and often outlast the JavaScript that
+// HACK: keys that store JSON-serialized objects in localStorage
+// live forever and often outlast the JavaScript that
 // wrote them. When you change the stored shape (rename a field, switch
 // encoding, etc.), old code in existing browsers reads the new format
 // and either crashes or silently loses data. Versioning the key
@@ -63,7 +61,7 @@ export const clientLocalstorageNoVersion = defineRule({
       if (!isNodeOfType(node.callee, "MemberExpression")) return;
       const receiver = stripParenExpression(node.callee.object);
       if (!isNodeOfType(receiver, "Identifier")) return;
-      if (!STORAGE_OBJECTS.has(receiver.name)) return;
+      if (receiver.name !== "localStorage") return;
       if (!isNodeOfType(node.callee.property, "Identifier")) return;
       if (node.callee.property.name !== "setItem") return;
 


### PR DESCRIPTION
## Why

client-localstorage-no-version warned on defensively decoded, tab-scoped sessionStorage records even though its persistence rationale and title are specific to localStorage.

## What changed

- Limit the rule to persistent localStorage JSON while keeping unversioned localStorage diagnostics unchanged.
- Added focused regressions, a patch changeset, and permanent fuzz coverage where this was a confirmed false positive.

## Eval results

The current RDE wrapper cannot consume schema v3 and its rebuilt local path invokes the removed `--diff false` form. I ran the built combined candidate directly over the same first 100 pinned RDE rootDir entries and inspected this rule's filtered results before splitting the identical source change into this PR.

## Test plan

- 9 focused tests; plugin typecheck; 500 strict fuzz iterations; direct 100-root candidate corpus scan inspected; lint/typecheck/format/build/smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint rule scope tightening with tests; no runtime app behavior or security path changes.
> 
> **Overview**
> **`client-localstorage-no-version`** no longer warns on unversioned `sessionStorage.setItem(..., JSON.stringify(...))`; it only applies to persistent **`localStorage`** writes with the same heuristic (unversioned key + JSON value).
> 
> The rule’s rationale comment was updated to match (persistence across deploys), and coverage was added: focused session vs local tests, a fuzz regression for tab-scoped draft records, and a patch changeset for the plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1167cd673b549f4dda23fb7ced796510798edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->