### PR TITLE
fix(performance): allow bounded map-filter pipelines

### DIFF
--- a/.changeset/bounded-pipelines-stay-clear.md
+++ b/.changeset/bounded-pipelines-stay-clear.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid recommending flatMap for bounded slice and string-tokenization pipelines where a second pass is negligible.

--- a/packages/fuzz/corpus/regressions/js-flatmap-filter--bounded-ui-pipelines.tsx
+++ b/packages/fuzz/corpus/regressions/js-flatmap-filter--bounded-ui-pipelines.tsx
@@ -1,0 +1,14 @@
+interface Level {
+  selected?: string;
+}
+
+export const collectSelections = (levels: Level[], index: number, search: string) => ({
+  ancestors: levels
+    .slice(0, index)
+    .map((level) => level.selected)
+    .filter(Boolean),
+  tokens: search
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean),
+});

--- a/packages/fuzz/corpus/regressions/js-flatmap-filter--bounded-ui-pipelines.tsx
+++ b/packages/fuzz/corpus/regressions/js-flatmap-filter--bounded-ui-pipelines.tsx
@@ -1,3 +1,6 @@
+// rule: js-flatmap-filter
+// weakness: cost-model
+// source: ISSUES_TO_FIX_ASAP.md (bounded ancestry and URL-token pipelines)
 interface Level {
   selected?: string;
 }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.bounded.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.bounded.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jsFlatmapFilter } from "./js-flatmap-filter.js";
+
+describe("js-flatmap-filter — bounded UI pipelines", () => {
+  it.each([
+    `levels.slice(0, index).map((level) => level.selected).filter(Boolean);`,
+    `search.split(",").map((token) => token.trim()).filter(Boolean);`,
+  ])("accepts a bounded map/filter pipeline", (code) => {
+    const result = runRule(jsFlatmapFilter, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports generic collection pipelines", () => {
+    const result = runRule(jsFlatmapFilter, `items.map((item) => item.value).filter(Boolean);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
@@ -6,6 +6,18 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
+const BOUNDED_PIPELINE_SOURCE_METHOD_NAMES = new Set(["slice", "split"]);
+
+const isBoundedPipelineSource = (node: EsTreeNode): boolean => {
+  const receiver = stripParenExpression(node);
+  return (
+    isNodeOfType(receiver, "CallExpression") &&
+    isNodeOfType(receiver.callee, "MemberExpression") &&
+    isNodeOfType(receiver.callee.property, "Identifier") &&
+    BOUNDED_PIPELINE_SOURCE_METHOD_NAMES.has(receiver.callee.property.name)
+  );
+};
+
 export const jsFlatmapFilter = defineRule({
   id: "js-flatmap-filter",
   title: ".map().filter(Boolean) loops twice",
@@ -55,6 +67,7 @@ export const jsFlatmapFilter = defineRule({
       // literal twice is trivial cost; the flatMap rewrite is pure
       // ceremony at this scale.
       const receiver: EsTreeNode | null | undefined = stripParenExpression(innerCall.callee.object);
+      if (receiver && isBoundedPipelineSource(receiver)) return;
       if (receiver && isNodeOfType(receiver, "ArrayExpression")) {
         const elements = receiver.elements ?? [];
         if (


### PR DESCRIPTION
## Why

js-flatmap-filter recommended a readability-changing flatMap rewrite for small ancestry slices and URL tokenization pipelines without evidence that the second pass is material.

## What changed

- Treat slice- and split-produced pipelines as bounded while retaining the diagnostic for generic collections.
- Added focused regressions, a patch changeset, and permanent fuzz coverage where this was a confirmed false positive.

## Eval results

The current RDE wrapper cannot consume schema v3 and its rebuilt local path invokes the removed `--diff false` form. I ran the built combined candidate directly over the same first 100 pinned RDE rootDir entries and inspected this rule's filtered results before splitting the identical source change into this PR.

## Test plan

- 4 focused tests; plugin typecheck; 500 strict fuzz iterations; direct 100-root candidate corpus scan inspected; lint/typecheck/format/build/smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint rule cost-model tweak with targeted tests; no runtime or security impact.
> 
> **Overview**
> **`js-flatmap-filter`** no longer suggests a **`.flatMap()`** rewrite when **`.map().filter(Boolean)`** is chained off a **`.slice()`** or **`.split()`** receiver, treating those UI-style ancestry and tokenization paths as bounded where a second pass is negligible.
> 
> Generic collection pipelines (e.g. **`items.map(...).filter(Boolean)`**) still get the same diagnostic. Coverage adds focused rule tests, a fuzz regression corpus case, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d87076486b22474890e9a41163f15501d455d912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->