### PR TITLE
fix(exhaustive-deps): allow converging every-commit updates

### DIFF
--- a/.changeset/quiet-effects-converge.md
+++ b/.changeset/quiet-effects-converge.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Allow equality-guarded functional state updates in intentional every-commit effects while retaining infinite-loop diagnostics for fresh and non-converging values.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--guarded-every-commit-setter.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--guarded-every-commit-setter.tsx
@@ -1,3 +1,6 @@
+// rule: exhaustive-deps
+// weakness: effect-semantics
+// source: ISSUES_TO_FIX_ASAP.md (intentional every-commit DOM synchronization)
 import { useLayoutEffect, useState } from "react";
 
 export const VisualContext = () => {

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--guarded-every-commit-setter.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--guarded-every-commit-setter.tsx
@@ -1,0 +1,12 @@
+import { useLayoutEffect, useState } from "react";
+
+export const VisualContext = () => {
+  const [visualContext, setVisualContext] = useState("");
+  useLayoutEffect(() => {
+    const nextVisualContext = document.body.className;
+    setVisualContext((previousVisualContext) =>
+      previousVisualContext === nextVisualContext ? previousVisualContext : nextVisualContext,
+    );
+  });
+  return <output>{visualContext}</output>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.asap.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.asap.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { exhaustiveDeps } from "./exhaustive-deps.js";
+
+describe("exhaustive-deps — every-commit converging setters", () => {
+  it("accepts an intentional every-commit layout effect", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function VisualContext() {
+        const [visualContext, setVisualContext] = useState("");
+        useLayoutEffect(() => {
+          const next = readAncestorClass();
+          setVisualContext((previous) => previous === next ? previous : next);
+        });
+        return visualContext;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still rejects a non-converging every-commit state update", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Counter({ enabled }) {
+        const [count, setCount] = useState(0);
+        useEffect(() => setCount((previous) => enabled ? previous : previous + 1));
+        return count;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each(["{}", "[]", "new Map()"])(
+    "still rejects an equality guard against a fresh %s value",
+    (freshValue) => {
+      const result = runRule(
+        exhaustiveDeps,
+        `function Snapshot() {
+          const [snapshot, setSnapshot] = useState(null);
+          useEffect(() => {
+            const next = ${freshValue};
+            setSnapshot((previous) => previous === next ? previous : next);
+          });
+          return snapshot;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.asap.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.asap.test.ts
@@ -50,4 +50,39 @@ describe("exhaustive-deps — every-commit converging setters", () => {
       expect(result.diagnostics).toHaveLength(1);
     },
   );
+
+  it("still rejects fresh values hidden behind const aliases and fallbacks", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Snapshot({ value }) {
+        const [snapshot, setSnapshot] = useState(null);
+        useEffect(() => {
+          const empty = {};
+          const fallback = empty;
+          const next = value ?? fallback;
+          setSnapshot((previous) => previous === next ? previous : next);
+        });
+        return snapshot;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still rejects reassigned compared bindings", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Snapshot() {
+        const [snapshot, setSnapshot] = useState(null);
+        useEffect(() => {
+          let next = readSnapshot();
+          next = {};
+          setSnapshot((previous) => previous === next ? previous : next);
+        });
+        return snapshot;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -602,6 +602,34 @@ const isUnstableInitializer = (node: EsTreeNode | null): boolean => {
   );
 };
 
+const isPotentiallyFreshComparedValue = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const candidate = unwrapExpression(node);
+  if (isUnstableInitializer(candidate)) return true;
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return (
+      isPotentiallyFreshComparedValue(candidate.consequent, scopes, visitedSymbolIds) ||
+      isPotentiallyFreshComparedValue(candidate.alternate, scopes, visitedSymbolIds)
+    );
+  }
+  if (isNodeOfType(candidate, "LogicalExpression")) {
+    return (
+      isPotentiallyFreshComparedValue(candidate.left, scopes, visitedSymbolIds) ||
+      isPotentiallyFreshComparedValue(candidate.right, scopes, visitedSymbolIds)
+    );
+  }
+  if (!isNodeOfType(candidate, "Identifier")) return false;
+  const symbol = scopes.symbolFor(candidate);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+  if (symbol.kind === "let" || symbol.kind === "var") return true;
+  if (symbol.kind !== "const" || !symbol.initializer) return false;
+  visitedSymbolIds.add(symbol.id);
+  return isPotentiallyFreshComparedValue(symbol.initializer, scopes, visitedSymbolIds);
+};
+
 const isExtraDepAllowedForHook = (
   hookName: string,
   node: EsTreeNode,
@@ -672,13 +700,7 @@ const isConvergingFunctionalUpdater = (node: EsTreeNode, scopes: ScopeAnalysis):
   if (isPreviousValue(test.left)) comparedValue = test.right;
   else if (isPreviousValue(test.right)) comparedValue = test.left;
   if (!comparedValue) return false;
-  const comparedValueSymbol = getRootSymbol(comparedValue, scopes);
-  if (
-    isUnstableInitializer(comparedValue) ||
-    isUnstableInitializer(comparedValueSymbol?.initializer ?? null)
-  ) {
-    return false;
-  }
+  if (isPotentiallyFreshComparedValue(comparedValue, scopes)) return false;
   const isSameComparedValue = (expression: EsTreeNode): boolean => {
     const candidate = unwrapExpression(expression);
     const compared = unwrapExpression(comparedValue);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -635,6 +635,85 @@ const isStableSetterLikeSymbol = (symbol: SymbolDescriptor, scopes: ScopeAnalysi
   );
 };
 
+const isConvergingFunctionalUpdater = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const updater = unwrapExpression(node);
+  if (
+    !isNodeOfType(updater, "ArrowFunctionExpression") &&
+    !isNodeOfType(updater, "FunctionExpression")
+  ) {
+    return false;
+  }
+  const previousValueParameter = updater.params?.[0];
+  if (!previousValueParameter || !isNodeOfType(previousValueParameter, "Identifier")) return false;
+  let returnedExpression: EsTreeNode | null | undefined = updater.body;
+  if (isNodeOfType(updater.body, "BlockStatement")) {
+    returnedExpression = null;
+    for (const statement of updater.body.body ?? []) {
+      if (isNodeOfType(statement, "ReturnStatement") && statement.argument) {
+        returnedExpression = statement.argument;
+        break;
+      }
+    }
+  }
+  const conditional = returnedExpression ? unwrapExpression(returnedExpression) : null;
+  if (!conditional || !isNodeOfType(conditional, "ConditionalExpression")) return false;
+  const test = unwrapExpression(conditional.test);
+  if (
+    !isNodeOfType(test, "BinaryExpression") ||
+    !["===", "!==", "==", "!="].includes(test.operator)
+  ) {
+    return false;
+  }
+  const isPreviousValue = (expression: EsTreeNode): boolean => {
+    const candidate = unwrapExpression(expression);
+    return isNodeOfType(candidate, "Identifier") && candidate.name === previousValueParameter.name;
+  };
+  let comparedValue: EsTreeNode | null = null;
+  if (isPreviousValue(test.left)) comparedValue = test.right;
+  else if (isPreviousValue(test.right)) comparedValue = test.left;
+  if (!comparedValue) return false;
+  const comparedValueSymbol = getRootSymbol(comparedValue, scopes);
+  if (
+    isUnstableInitializer(comparedValue) ||
+    isUnstableInitializer(comparedValueSymbol?.initializer ?? null)
+  ) {
+    return false;
+  }
+  const isSameComparedValue = (expression: EsTreeNode): boolean => {
+    const candidate = unwrapExpression(expression);
+    const compared = unwrapExpression(comparedValue);
+    if (isNodeOfType(candidate, "Identifier") && isNodeOfType(compared, "Identifier")) {
+      return candidate.name === compared.name;
+    }
+    if (isNodeOfType(candidate, "Literal") && isNodeOfType(compared, "Literal")) {
+      return candidate.value === compared.value;
+    }
+    return false;
+  };
+  const equalityTest = test.operator === "===" || test.operator === "==";
+  return equalityTest
+    ? isPreviousValue(conditional.consequent) && isSameComparedValue(conditional.alternate)
+    : isSameComparedValue(conditional.consequent) && isPreviousValue(conditional.alternate);
+};
+
+const isGuardedStableSetterCall = (
+  identifier: EsTreeNode,
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const parent = identifier.parent;
+  if (
+    !parent ||
+    !isNodeOfType(parent, "CallExpression") ||
+    parent.callee !== identifier ||
+    !isStableSetterLikeSymbol(symbol, scopes)
+  ) {
+    return false;
+  }
+  const writtenValue = parent.arguments?.[0];
+  return Boolean(writtenValue && isConvergingFunctionalUpdater(writtenValue, scopes));
+};
+
 const findStableSetterReference = (node: EsTreeNode, scopes: ScopeAnalysis): string | null => {
   let setterName: string | null = null;
   const visit = (current: EsTreeNode): void => {
@@ -650,7 +729,11 @@ const findStableSetterReference = (node: EsTreeNode, scopes: ScopeAnalysis): str
     if (isNodeOfType(current, "Identifier")) {
       const reference = scopes.referenceFor(current);
       const symbol = reference?.resolvedSymbol;
-      if (symbol && isStableSetterLikeSymbol(symbol, scopes)) {
+      if (
+        symbol &&
+        isStableSetterLikeSymbol(symbol, scopes) &&
+        !isGuardedStableSetterCall(current, symbol, scopes)
+      ) {
         setterName = symbol.name;
         return;
       }


### PR DESCRIPTION
## Why

Intentional every-commit layout effects can safely synchronize state when a functional updater returns the previous value after equality convergence. The rule reported these as infinite loops.

## What changed

- Recognize equality-guarded converging updater shapes while retaining diagnostics for non-converging updates and definitely fresh object, array, class, JSX, assignment, and new-expression values.
- Added focused regressions, a patch changeset, and permanent fuzz coverage where this was a confirmed false positive.

## Eval results

The current RDE wrapper cannot consume schema v3 and its rebuilt local path invokes the removed `--diff false` form. I ran the built combined candidate directly over the same first 100 pinned RDE rootDir entries and inspected this rule's filtered results before splitting the identical source change into this PR.

## Test plan

- 84 focused tests; plugin typecheck; 500 strict fuzz iterations; lint/typecheck/format/smoke. The combined full suite passed before this fix was split; a parallel three-worktree full-suite rerun hit unrelated timing/OOM-rescue timeouts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes infinite-loop heuristics in a widely used lint rule; false negatives are possible if the AST pattern matcher is too permissive, though fresh-value and reassignment cases remain guarded by tests.
> 
> **Overview**
> **`exhaustive-deps`** no longer flags intentional every-commit effects that call a stable setter with an **equality-guarded functional updater** (e.g. `setState(prev => prev === next ? prev : next`) as an infinite loop.
> 
> The rule now recognizes that updater shape via `isConvergingFunctionalUpdater` and skips those calls in `findStableSetterReference`. Compared values that are **potentially fresh each render**—literal `{}`/`[]`, `new` expressions, `let`/`var`, or `const` aliases to those—still trigger the loop diagnostic. Non-converging updaters (e.g. always incrementing) are unchanged.
> 
> Adds **focused ASAP tests**, a **fuzz regression** for DOM class sync, and a **patch changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9d09fab4170379bd1a594cd37440ea861e70d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->