### PR TITLE
fix(security): allow product API-key records

### DIFF
--- a/.changeset/product-records-are-not-secrets.md
+++ b/.changeset/product-records-are-not-secrets.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid treating qualified product API-key record collections as authentication credentials in browser storage.

--- a/packages/fuzz/corpus/regressions/auth-token-storage--product-api-key-records.tsx
+++ b/packages/fuzz/corpus/regressions/auth-token-storage--product-api-key-records.tsx
@@ -1,3 +1,6 @@
+// rule: auth-token-in-web-storage
+// weakness: domain-semantics
+// source: ISSUES_TO_FIX_ASAP.md (product API-key records are not auth credentials)
 interface ApiKeyRecord {
   id: string;
   status: string;

--- a/packages/fuzz/corpus/regressions/auth-token-storage--product-api-key-records.tsx
+++ b/packages/fuzz/corpus/regressions/auth-token-storage--product-api-key-records.tsx
@@ -1,0 +1,8 @@
+interface ApiKeyRecord {
+  id: string;
+  status: string;
+}
+
+export const persistCreatedApiKeys = (records: ApiKeyRecord[]) => {
+  sessionStorage.setItem("mailing.createdApiKeys", JSON.stringify(records));
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.product-records.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.product-records.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { authTokenInWebStorage } from "./auth-token-in-web-storage.js";
+
+describe("auth-token-in-web-storage — product API-key records", () => {
+  it("accepts qualified product API-key record collections", () => {
+    const result = runRule(
+      authTokenInWebStorage,
+      `sessionStorage.setItem("mailing.createdApiKeys", JSON.stringify(records));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still rejects actual API-key credential storage", () => {
+    const result = runRule(authTokenInWebStorage, `localStorage.setItem("auth.apiKey", apiKey);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.ts
@@ -29,9 +29,11 @@ const NON_AUTH_TOKEN_PATTERN =
   /csrf|xsrf|device|fcm|apns|push|design|tokeniz|syntax|css|theme|color/i;
 const STRONG_AUTH_KEY_PATTERN =
   /jwt|secret|password|passwd|credential|private[-_]?key|api[-_]?key|bearer|access[-_]?token|refresh[-_]?token|auth[-_]?token|id[-_]?token|session/i;
+const PRODUCT_API_KEY_COLLECTION_PATTERN = /[._:-](?:created|generated|saved)[-_]?api[-_]?keys$/i;
 
 const isAuthCredentialKey = (key: string): boolean => {
   if (!SENSITIVE_KEY_PATTERN.test(key)) return false;
+  if (PRODUCT_API_KEY_COLLECTION_PATTERN.test(key)) return false;
   if (NON_AUTH_TOKEN_PATTERN.test(key) && !STRONG_AUTH_KEY_PATTERN.test(key)) return false;
   return true;
 };


### PR DESCRIPTION
## Why

auth-token-in-web-storage treated a qualified collection of product API-key records as an authentication credential solely because the key ended in apiKeys.

## What changed

- Exempt product-scoped created/generated/saved API-key collection names while preserving actual apiKey, auth.apiKey, JWT, access-token, refresh-token, and secret diagnostics.
- Added focused regressions, a patch changeset, and permanent fuzz coverage where this was a confirmed false positive.

## Eval results

The current RDE wrapper cannot consume schema v3 and its rebuilt local path invokes the removed `--diff false` form. I ran the built combined candidate directly over the same first 100 pinned RDE rootDir entries and inspected this rule's filtered results before splitting the identical source change into this PR.

## Test plan

- 29 focused tests; plugin typecheck; 500 strict fuzz iterations; direct 100-root candidate corpus scan inspected; lint/typecheck/format/build/smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lint heuristic tweak with regression tests; slightly relaxes one rule for specific key shapes but retains strong-auth patterns.
> 
> **Overview**
> Fixes a **false positive** in `auth-token-in-web-storage` where storage keys ending in `apiKeys` (e.g. `mailing.createdApiKeys`) were flagged as auth credentials even when they hold product API-key **record metadata**, not secrets.
> 
> `isAuthCredentialKey` now skips keys matching a new **product collection** pattern: qualified names ending in `created` / `generated` / `saved` + `apiKeys` (with common separators). Real credential keys such as `auth.apiKey` still diagnose.
> 
> Adds focused unit tests, a fuzz regression corpus entry, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a172a8fa17b1525d37ffc5ad9ceda0c4dfc79b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->