### PR TITLE
fix(architecture): stabilize giant component identity

### DIFF
--- a/.changeset/giant-messages-stay-stable.md
+++ b/.changeset/giant-messages-stay-stable.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Keep no-giant-component diagnostic identity stable by excluding volatile measured line counts from its message.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.identity.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.identity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noGiantComponent } from "./no-giant-component.js";
+
+const buildComponent = (statementCount: number): string => `function ReactPhotoEditor() {
+${Array.from(
+  { length: statementCount },
+  (_, statementIndex) => `const value${statementIndex} = ${statementIndex};`,
+).join("\n")}
+return <main />;
+}`;
+
+describe("no-giant-component — diagnostic identity", () => {
+  it("keeps the message stable when only measured line count changes", () => {
+    const before = runRule(noGiantComponent, buildComponent(468));
+    const after = runRule(noGiantComponent, buildComponent(467));
+    expect(before.parseErrors).toEqual([]);
+    expect(after.parseErrors).toEqual([]);
+    expect(before.diagnostics).toHaveLength(1);
+    expect(after.diagnostics).toHaveLength(1);
+    expect(after.diagnostics[0]?.message).toBe(before.diagnostics[0]?.message);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-giant-component.ts
@@ -22,14 +22,10 @@ export const noGiantComponent = defineRule({
       return lineCount > GIANT_COMPONENT_LINE_THRESHOLD ? lineCount : null;
     };
 
-    const reportOversizedComponent = (
-      nameNode: EsTreeNode,
-      componentName: string,
-      lineCount: number,
-    ): void => {
+    const reportOversizedComponent = (nameNode: EsTreeNode, componentName: string): void => {
       context.report({
         node: nameNode,
-        message: `Component "${componentName}" is ${lineCount} lines long, which is hard to read & change. Split it into a few smaller components.`,
+        message: `Component "${componentName}" is over ${GIANT_COMPONENT_LINE_THRESHOLD} lines long, which is hard to read & change. Split it into a few smaller components.`,
       });
     };
 
@@ -39,7 +35,7 @@ export const noGiantComponent = defineRule({
         const lineCount = getOversizedComponentLineCount(node);
         if (lineCount === null) return;
         if (!functionContainsReactRenderOutput(node, context.scopes)) return;
-        reportOversizedComponent(node.id, node.id.name, lineCount);
+        reportOversizedComponent(node.id, node.id.name);
       },
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!isNodeOfType(node.id, "Identifier") || !isUppercaseName(node.id.name)) return;
@@ -48,7 +44,7 @@ export const noGiantComponent = defineRule({
         const lineCount = getOversizedComponentLineCount(functionNode);
         if (lineCount === null) return;
         if (!functionContainsReactRenderOutput(functionNode, context.scopes)) return;
-        reportOversizedComponent(node.id, node.id.name, lineCount);
+        reportOversizedComponent(node.id, node.id.name);
       },
     };
   },


### PR DESCRIPTION
## Why

no-giant-component embedded the measured line count in its message, so behavior-neutral one-line edits changed diagnostic identity and destabilized differential gates.

## What changed

- Report the stable configured threshold in the message while retaining measured line count for detection only.
- Added focused regressions, a patch changeset, and permanent fuzz coverage where this was a confirmed false positive.

## Eval results

The current RDE wrapper cannot consume schema v3 and its rebuilt local path invokes the removed `--diff false` form. I ran the built combined candidate directly over the same first 100 pinned RDE rootDir entries and inspected this rule's filtered results before splitting the identical source change into this PR.

## Test plan

- 20 focused tests; plugin typecheck; 500 strict invariant fuzz iterations; direct 100-root candidate corpus scan inspected; lint/typecheck/format/build/smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint message wording only; detection logic unchanged aside from dropping line count from the reported string.
> 
> **Overview**
> **`no-giant-component`** no longer puts the measured line count in the diagnostic message. It now says the component is **over the configured threshold** (`GIANT_COMPONENT_LINE_THRESHOLD`), while oversize detection still uses the actual line count.
> 
> That keeps diagnostic identity stable when a one-line edit only changes the measured size (e.g. differential gates).
> 
> Adds an identity regression test and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db324a2eeeca4d55b02ae854d25f07fb4421e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->