### PR TITLE
fix(rerender-state): trace render-time map merges

### DIFF
--- a/.changeset/maps-carry-render-state.md
+++ b/.changeset/maps-carry-render-state.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize state consumed through synchronous render-time collection merges in rerender-state-only-in-handlers.

--- a/packages/fuzz/corpus/regressions/rerender-state--render-time-map-merge.tsx
+++ b/packages/fuzz/corpus/regressions/rerender-state--render-time-map-merge.tsx
@@ -1,3 +1,6 @@
+// rule: rerender-state-only-in-handlers
+// weakness: render-dataflow
+// source: ISSUES_TO_FIX_ASAP.md (state merged into a rendered Map)
 import { useState } from "react";
 
 interface ApiKeyRecord {

--- a/packages/fuzz/corpus/regressions/rerender-state--render-time-map-merge.tsx
+++ b/packages/fuzz/corpus/regressions/rerender-state--render-time-map-merge.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+
+interface ApiKeyRecord {
+  id: string;
+}
+
+interface ApiKeysProps {
+  apiKeys: ApiKeyRecord[];
+}
+
+export const ApiKeys = ({ apiKeys }: ApiKeysProps) => {
+  const [localApiKeys, setLocalApiKeys] = useState<ApiKeyRecord[]>([]);
+  const mergedApiKeys = new Map(apiKeys.map((apiKey) => [apiKey.id, apiKey]));
+  localApiKeys.forEach((apiKey) => mergedApiKeys.set(apiKey.id, apiKey));
+  return (
+    <button onClick={() => setLocalApiKeys([])}>
+      {[...mergedApiKeys.values()].map((apiKey) => apiKey.id).join(",")}
+    </button>
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.map-merge.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.map-merge.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rerenderStateOnlyInHandlers } from "./rerender-state-only-in-handlers.js";
+
+describe("rerender-state-only-in-handlers — render-time collection merges", () => {
+  it("accepts state merged into a rendered Map", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `function Settings({ apiKeys }) {
+        const [localApiKeys, setLocalApiKeys] = useState([]);
+        const mergedById = new Map(apiKeys.map((apiKey) => [apiKey.id, apiKey]));
+        localApiKeys.forEach((apiKey) => mergedById.set(apiKey.id, apiKey));
+        return <button onClick={() => setLocalApiKeys([])}>
+          {[...mergedById.values()].map((apiKey) => <span>{apiKey.id}</span>)}
+        </button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports handler-only state", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `function Tracker() {
+        const [lastEvent, setLastEvent] = useState(null);
+        return <button onClick={(event) => setLastEvent(event)}>Track</button>;
+      }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/build-local-dependency-graph.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/build-local-dependency-graph.ts
@@ -1,5 +1,7 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { isFunctionLike } from "../../../utils/is-function-like.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { walkAst } from "../../../utils/walk-ast.js";
 import {
   addPatternBindings,
   collectPatternAssignmentNames,
@@ -14,6 +16,18 @@ import {
 import { getStaticMemberPropertyName } from "./static-member-property-name.js";
 
 const MUTATING_COLLECTION_METHOD_NAMES = new Set(["push", "unshift", "splice", "set", "add"]);
+const SYNCHRONOUS_ITERATOR_METHOD_NAMES = new Set([
+  "every",
+  "filter",
+  "find",
+  "findIndex",
+  "flatMap",
+  "forEach",
+  "map",
+  "reduce",
+  "reduceRight",
+  "some",
+]);
 
 const getMemberRootBindingName = (node: EsTreeNode, scope: BindingScope): string | null => {
   let currentNode = node;
@@ -130,6 +144,42 @@ const addMutatingCollectionCallDependencies = (
   addDependencies(graph, receiverRootName, dependencyNames);
 };
 
+const addIteratorMutationDependencies = (
+  graph: Map<string, Set<string>>,
+  expression: EsTreeNode,
+  scope: BindingScope,
+  eventHandlerReferenceNames: Set<string>,
+  controlDependencyNames: Set<string>,
+): void => {
+  if (!isNodeOfType(expression, "CallExpression")) return;
+  if (!isNodeOfType(expression.callee, "MemberExpression")) return;
+  const methodName = getStaticMemberPropertyName(expression.callee);
+  if (!methodName || !SYNCHRONOUS_ITERATOR_METHOD_NAMES.has(methodName)) return;
+  const iteratorDependencyNames = collectScopedReferenceNames(
+    expression.callee.object,
+    scope,
+    eventHandlerReferenceNames,
+  );
+  addDependencyNames(iteratorDependencyNames, controlDependencyNames);
+  for (const argument of expression.arguments ?? []) {
+    if (
+      !isNodeOfType(argument, "ArrowFunctionExpression") &&
+      !isNodeOfType(argument, "FunctionExpression")
+    ) {
+      continue;
+    }
+    walkAst(argument.body as EsTreeNode, (node: EsTreeNode): boolean | void => {
+      if (node !== argument.body && isFunctionLike(node)) return false;
+      if (!isNodeOfType(node, "CallExpression")) return;
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      const nestedMethodName = getStaticMemberPropertyName(node.callee);
+      if (!nestedMethodName || !MUTATING_COLLECTION_METHOD_NAMES.has(nestedMethodName)) return;
+      const receiverRootName = getMemberRootBindingName(node.callee.object, scope);
+      if (receiverRootName) addDependencies(graph, receiverRootName, iteratorDependencyNames);
+    });
+  }
+};
+
 const collectExpressionDependencies = (
   graph: Map<string, Set<string>>,
   expression: EsTreeNode,
@@ -150,6 +200,13 @@ const collectExpressionDependencies = (
 
   if (isNodeOfType(expression, "CallExpression")) {
     addMutatingCollectionCallDependencies(
+      graph,
+      expression,
+      scope,
+      eventHandlerReferenceNames,
+      controlDependencyNames,
+    );
+    addIteratorMutationDependencies(
       graph,
       expression,
       scope,


### PR DESCRIPTION
## Why

rerender-state-only-in-handlers reported state that visibly contributes to rendered output through a render-time Map merge.

## What changed

- Carry synchronous iterator receiver dependencies into local collection mutations while pruning nested deferred functions.
- Added focused regressions, a patch changeset, and permanent fuzz coverage where this was a confirmed false positive.

## Eval results

The current RDE wrapper cannot consume schema v3 and its rebuilt local path invokes the removed `--diff false` form. I ran the built combined candidate directly over the same first 100 pinned RDE rootDir entries and inspected this rule's filtered results before splitting the identical source change into this PR.

## Test plan

- 41 focused tests; plugin typecheck; 500 strict fuzz iterations; direct 100-root candidate corpus scan inspected; lint/typecheck/format/smoke.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static analysis-only change in a lint rule’s dependency graph with targeted tests; no runtime or security impact.
> 
> **Overview**
> Fixes a **false positive** in `rerender-state-only-in-handlers` when local state is merged into a `Map` during render (e.g. `localApiKeys.forEach((k) => mergedById.set(k.id, k))`) and that map is used in JSX.
> 
> `build-local-dependency-graph` now links **synchronous iterator receivers** (`forEach`, `map`, etc.) to **mutating collection calls** inside the iterator callback (`.set`, `.push`, …), while **skipping nested function-like nodes** so deferred work is not treated as render-time dataflow.
> 
> Adds focused rule tests, a fuzz regression corpus case, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526305c499d764624c5c12b0333c8b6abafe2d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->