### PR TITLE
fix(jsx-key): inspect named iterator callbacks

### DIFF
--- a/.changeset/fuzzy-keys-render.md
+++ b/.changeset/fuzzy-keys-render.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect missing JSX keys when list iterators use named local callbacks.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
@@ -75,6 +75,76 @@ describe("react-builtins/jsx-key — regressions", () => {
     expectFail(`items.map(item => <Item name={item.name} />);`);
   });
 
+  it("flags a keyless element returned by a named function callback", () => {
+    expectFail(`
+      function renderRow(item) {
+        return <Item name={item.name} />;
+      }
+      items.map(renderRow);
+    `);
+  });
+
+  it("flags a keyless element returned by a named arrow callback", () => {
+    expectFail(`
+      const renderRow = (item) => <Item name={item.name} />;
+      items.flatMap(renderRow);
+    `);
+  });
+
+  it("flags a keyless element returned by a named Array.from callback", () => {
+    expectFail(`
+      const renderRow = (item) => <Item name={item.name} />;
+      Array.from(items, renderRow);
+    `);
+  });
+
+  it("does not flag a keyed element returned by a named callback", () => {
+    expectPass(`
+      const renderRow = (item) => <Item key={item.id} name={item.name} />;
+      items.map(renderRow);
+    `);
+  });
+
+  it("does not flag a named callback whose mapped output is a non-children prop", () => {
+    expectPass(`
+      const renderRow = (item) => <Item name={item.name} />;
+      <Menu items={items.map(renderRow)} />;
+    `);
+  });
+
+  it("does not flag a named JSX-returning callback that is not an iterator", () => {
+    expectPass(`
+      const renderRow = (item) => <Item name={item.name} />;
+      consume(renderRow);
+    `);
+  });
+
+  it("keeps same-named callbacks in different scopes separate", () => {
+    expectPass(`
+      const renderRow = (item) => <Item name={item.name} />;
+      const Panel = () => {
+        const renderRow = (item) => <Item key={item.id} name={item.name} />;
+        return items.map(renderRow);
+      };
+      consume(renderRow);
+    `);
+  });
+
+  it("flags each keyless return branch in a named callback", () => {
+    const result = runRule(
+      jsxKey,
+      `
+        const renderRow = (item) => {
+          if (item.featured) return <FeaturedItem name={item.name} />;
+          return <Item name={item.name} />;
+        };
+        items.map(renderRow);
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
   it("still flags when spreading something other than the iteration item", () => {
     expectFail(`items.map(item => <Item {...other} />);`);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.regressions.test.ts
@@ -105,6 +105,13 @@ describe("react-builtins/jsx-key — regressions", () => {
     `);
   });
 
+  it("does not flag a named callback that spreads the iteration item", () => {
+    expectPass(`
+      const renderRow = (item) => <Item {...item} />;
+      items.map(renderRow);
+    `);
+  });
+
   it("does not flag a named callback whose mapped output is a non-children prop", () => {
     expectPass(`
       const renderRow = (item) => <Item name={item.name} />;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
@@ -5,6 +5,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getFunctionBindingIdentifier } from "../../utils/get-function-binding-name.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { hasJsxKeyAttribute } from "../../utils/has-jsx-key-attribute.js";
 import { isConstDeclaredBinding } from "../../utils/is-const-declared-binding.js";
@@ -177,6 +178,54 @@ interface IteratorContextIterator {
 }
 type IteratorContext = IteratorContextArray | IteratorContextIterator;
 
+const namedCallbackIteratorCallCache = new WeakMap<EsTreeNode, EsTreeNode | null>();
+
+const findNamedCallbackIteratorCall = (functionNode: EsTreeNode): EsTreeNode | null => {
+  const cached = namedCallbackIteratorCallCache.get(functionNode);
+  if (cached !== undefined) return cached;
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) {
+    namedCallbackIteratorCallCache.set(functionNode, null);
+    return null;
+  }
+  const programRoot = findProgramRoot(functionNode);
+  if (!programRoot) {
+    namedCallbackIteratorCallCache.set(functionNode, null);
+    return null;
+  }
+  let iteratorCall: EsTreeNode | null = null;
+  walkAst(programRoot, (node) => {
+    if (iteratorCall) return false;
+    if (
+      !isNodeOfType(node, "Identifier") ||
+      node === bindingIdentifier ||
+      node.name !== bindingIdentifier.name
+    ) {
+      return;
+    }
+    const binding = findVariableInitializer(node, node.name);
+    if (!binding || binding.bindingIdentifier !== bindingIdentifier) return;
+    const callbackExpression = findTransparentExpressionRoot(node);
+    const callExpression = callbackExpression.parent;
+    if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) return;
+    const callee = callExpression.callee;
+    if (
+      !isNodeOfType(callee, "MemberExpression") ||
+      !isNodeOfType(callee.property, "Identifier") ||
+      !ITERATOR_METHOD_NAMES.has(callee.property.name)
+    ) {
+      return;
+    }
+    const callbackIndex = callee.property.name === "from" ? 1 : 0;
+    if (callExpression.arguments[callbackIndex] !== callbackExpression) return;
+    if (isNonChildrenJsxAttributeValue(callExpression)) return;
+    iteratorCall = callExpression;
+    return false;
+  });
+  namedCallbackIteratorCallCache.set(functionNode, iteratorCall);
+  return iteratorCall;
+};
+
 const findEnclosingIteratorContext = (jsxNode: EsTreeNode): IteratorContext | null => {
   let current: EsTreeNode | null | undefined = jsxNode;
   let isOutsideContainingFunction = false;
@@ -200,6 +249,10 @@ const findEnclosingIteratorContext = (jsxNode: EsTreeNode): IteratorContext | nu
       const grandparent = parent.parent;
       if (grandparent && isNodeOfType(grandparent, "Property")) return null;
       if (isOutsideContainingFunction) return null;
+      const namedCallbackIteratorCall = findNamedCallbackIteratorCall(parent);
+      if (namedCallbackIteratorCall) {
+        return { kind: "iterator", callExpression: namedCallbackIteratorCall };
+      }
       isOutsideContainingFunction = true;
     } else if (isNodeOfType(parent, "ArrayExpression")) {
       if (isOutsideContainingFunction) return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-key.ts
@@ -321,7 +321,12 @@ const resolveIterationItemName = (callExpression: EsTreeNode): string | null => 
   if (!isNodeOfType(callee, "MemberExpression")) return null;
   if (!isNodeOfType(callee.property, "Identifier")) return null;
   const targetArgIndex = callee.property.name === "from" ? 1 : 0;
-  const callback = callExpression.arguments[targetArgIndex];
+  const callbackArgument = callExpression.arguments[targetArgIndex];
+  if (!callbackArgument) return null;
+  const unwrappedCallback = stripParenExpression(callbackArgument);
+  const callback = isNodeOfType(unwrappedCallback, "Identifier")
+    ? findVariableInitializer(unwrappedCallback, unwrappedCallback.name)?.initializer
+    : unwrappedCallback;
   if (
     !callback ||
     (!isNodeOfType(callback, "ArrowFunctionExpression") &&


### PR DESCRIPTION
## Why

Catches missing React keys when a list iterator delegates rendering to a named local callback.

Before:

```tsx
const renderRow = (item) => <Row value={item} />;
items.map(renderRow);
```

After:

```tsx
const renderRow = (item) => <Row key={item.id} value={item} />;
items.map(renderRow);
```

The inline callback form was already checked, but crossing a local function binding lost the iterator context and left the equivalent named form silent.

## What changed

- Resolves named function and arrow callback bindings used by `map`, `flatMap`, and `Array.from`.
- Reuses the existing scope-aware binding resolver so same-named callbacks in different scopes stay separate.
- Preserves the existing exemptions for keyed output, non-children props, and non-iterator callback uses.
- Caches callback-to-iterator lookups per function node.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

## Eval results

The official RDE wrapper is currently incompatible with the v3 CLI, so I ran the equivalent baseline/candidate scans directly against its pinned checkout cache.

| Check | Result |
| --- | --- |
| Distinct repos scanned | 12 |
| RootDir scans | 100 complete |
| Target rule | `jsx-key` |
| Diagnostics | 13 baseline → 13 candidate |
| False positives found | 0 |
| Output artifacts | `/tmp/rde-jsx-key-base`, `/tmp/rde-jsx-key-candidate` |

## Test plan

- `nr test src/plugin/rules/react-builtins/jsx-key.regressions.test.ts` (63 tests)
- Full `oxlint-plugin-react-doctor` suite (538 files, 11,897 passed / 148 skipped)
- `FUZZ_RULE=jsx-key FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr build`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands jsx-key diagnostics on real list code; behavior is well-tested but may surface new lint errors in codebases using named render callbacks.
> 
> **Overview**
> The **jsx-key** rule now treats JSX returned from **named** `map` / `flatMap` / `Array.from` callbacks the same as inline iterators, so patterns like `const renderRow = (item) => <Row … />; items.map(renderRow)` report missing keys.
> 
> Implementation walks the program for scope-correct references to the callback binding, links them to the iterator call (skipping non-`children` prop uses), and caches that lookup per function node. **`resolveIterationItemName`** also follows an identifier callback to its function so item-spread exemptions still apply for named callbacks.
> 
> Regression tests cover keyed output, item spreads, non-iterator uses, shadowed names, and multi-branch returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2f2bd6a6eb4140a341236990aea09e11c04a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->