### PR TITLE
fix: track effect callback provenance

### DIFF
--- a/.changeset/brown-trains-rush.md
+++ b/.changeset/brown-trains-rush.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix no-prop-callback-in-effect dependency provenance and callback-ref parity.

--- a/packages/fuzz/corpus/regressions/no-prop-callback-in-effect--prop-derived-dependency-alias.tsx
+++ b/packages/fuzz/corpus/regressions/no-prop-callback-in-effect--prop-derived-dependency-alias.tsx
@@ -1,0 +1,20 @@
+// rule: no-prop-callback-in-effect
+// weakness: alias-guard
+// source: react-bench fix-react-rdh-embeddable-hq-remarkable-ui-multiselectfield
+
+import { useEffect } from "react";
+
+interface MultiSelectFieldProps {
+  values: ReadonlyArray<string>;
+  onPendingChange: (values: ReadonlyArray<string>) => void;
+}
+
+export const MultiSelectField = ({ values, onPendingChange }: MultiSelectFieldProps) => {
+  const valuesKey = JSON.stringify(values);
+
+  useEffect(() => {
+    onPendingChange(values);
+  }, [valuesKey]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.regressions.test.ts
@@ -99,6 +99,82 @@ describe("no-prop-callback-in-effect — must-detect regressions", () => {
 });
 
 describe("no-prop-callback-in-effect — regressions", () => {
+  it("treats inline and named prop-derived dependencies identically", () => {
+    const inlineResult = runRule(
+      noPropCallbackInEffect,
+      `function MultiSelectField({ values, onPendingChange }) {
+        useEffect(() => {
+          onPendingChange(values);
+        }, [JSON.stringify(values)]);
+        return null;
+      }`,
+    );
+    const namedResult = runRule(
+      noPropCallbackInEffect,
+      `function MultiSelectField({ values, onPendingChange }) {
+        const valuesKey = JSON.stringify(values);
+        useEffect(() => {
+          onPendingChange(values);
+        }, [valuesKey]);
+        return null;
+      }`,
+    );
+
+    expect(inlineResult.parseErrors).toEqual([]);
+    expect(namedResult.parseErrors).toEqual([]);
+    expect(inlineResult.diagnostics).toEqual([]);
+    expect(namedResult.diagnostics).toEqual([]);
+  });
+
+  it("flags a genuine local-state mirror through direct and callback-ref calls", () => {
+    const directResult = runRule(
+      noPropCallbackInEffect,
+      `function MultiSelectField({ onPendingChange }) {
+        const [draft, setDraft] = useState([]);
+        const draftKey = JSON.stringify(draft);
+        useEffect(() => {
+          onPendingChange(draft);
+        }, [draftKey]);
+        return null;
+      }`,
+    );
+    const refResult = runRule(
+      noPropCallbackInEffect,
+      `function MultiSelectField({ onPendingChange }) {
+        const [draft, setDraft] = useState([]);
+        const draftKey = JSON.stringify(draft);
+        const onPendingChangeRef = useRef(onPendingChange);
+        useEffect(() => {
+          onPendingChangeRef.current?.(draft);
+        }, [draftKey]);
+        return null;
+      }`,
+    );
+
+    expect(directResult.parseErrors).toEqual([]);
+    expect(refResult.parseErrors).toEqual([]);
+    expect(directResult.diagnostics).toHaveLength(1);
+    expect(refResult.diagnostics).toHaveLength(1);
+  });
+
+  it("flags callback-ref mirrors through transparent receiver wrappers", () => {
+    const result = runRule(
+      noPropCallbackInEffect,
+      `function MultiSelectField({ onPendingChange }) {
+        const [draft, setDraft] = useState([]);
+        const onPendingChangeRef = useRef(onPendingChange);
+        useEffect(() => {
+          (onPendingChangeRef as any).current(draft);
+          (onPendingChangeRef!).current(draft);
+        }, [draft]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
   it("stays silent when the prop is a pure transform consumed locally", () => {
     const result = runRule(
       noPropCallbackInEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
@@ -6,15 +6,17 @@ import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isResultDiscardedCall } from "../../utils/is-result-discarded-call.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { Reference } from "eslint-scope";
 import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blocks.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { getRef } from "./utils/effect/ast.js";
+import { getRef, getUpstreamRefs } from "./utils/effect/ast.js";
 import { isExternallyDrivenState } from "./utils/effect/external-state.js";
-import { getProgramAnalysis } from "./utils/effect/get-program-analysis.js";
+import { getProgramAnalysis, type ProgramAnalysis } from "./utils/effect/get-program-analysis.js";
+import { isProp, isState } from "./utils/effect/react.js";
 
 // The ref-latch shape: the effect reads a `<ref>.current` in an
 // if-guard AND writes that same `<ref>.current`. That is the one-shot
@@ -79,6 +81,44 @@ const hasPreviousValueDep = (
   return false;
 };
 
+const isStateLikeDependency = (
+  analysis: ProgramAnalysis | null,
+  element: EsTreeNode,
+  isPropName: (name: string) => boolean,
+): boolean => {
+  if (!isNodeOfType(element, "Identifier") || isPropName(element.name)) return false;
+  if (!analysis) return true;
+  const reference = getRef(analysis, element);
+  if (!reference) return true;
+  const upstreamReferences = getUpstreamRefs(analysis, reference);
+  if (upstreamReferences.some((upstreamReference) => isState(analysis, upstreamReference))) {
+    return true;
+  }
+  return !upstreamReferences.some((upstreamReference) => isProp(analysis, upstreamReference));
+};
+
+const getRefHeldPropCallbackName = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  isPropName: (name: string) => boolean,
+): string | null => {
+  const callee = stripParenExpression(callExpression.callee as EsTreeNode);
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    callee.property.name !== "current"
+  ) {
+    return null;
+  }
+  const receiver = stripParenExpression(callee.object as EsTreeNode);
+  if (!isNodeOfType(receiver, "Identifier")) return null;
+  const binding = findVariableInitializer(callExpression, receiver.name);
+  if (!binding?.initializer || !isNodeOfType(binding.initializer, "CallExpression")) return null;
+  if (getCalleeName(binding.initializer) !== "useRef") return null;
+  const callbackArgument = binding.initializer.arguments?.[0];
+  if (!callbackArgument || !isNodeOfType(callbackArgument, "Identifier")) return null;
+  return isPropName(callbackArgument.name) ? callbackArgument.name : null;
+};
+
 // HACK: `useEffect(() => parentCallback(state.x), [state.x])` is the
 // "lift state up via callback" anti-pattern: the child owns state, then
 // fires a parent callback every time the state changes to keep the
@@ -109,13 +149,15 @@ export const noPropCallbackInEffect = defineRule({
           return;
         const depsNode = node.arguments[1];
         if (!isNodeOfType(depsNode, "ArrayExpression") || !depsNode.elements?.length) return;
+        const analysis = getProgramAnalysis(node);
 
         // Only flag if at least one dep is a non-prop (state-shape)
         // identifier — otherwise the effect is just adapting to prop
         // changes (legit pattern).
         const stateLikeDeps = (depsNode.elements ?? []).filter(
           (element) =>
-            isNodeOfType(element, "Identifier") && !propStackTracker.isPropName(element.name),
+            element &&
+            isStateLikeDependency(analysis, element as EsTreeNode, propStackTracker.isPropName),
         );
         if (stateLikeDeps.length === 0) return;
 
@@ -126,7 +168,6 @@ export const noPropCallbackInEffect = defineRule({
         // observer / subscription, the parent callback bridges an imperative
         // browser event, not a local state mirror — moving it into a Provider
         // wouldn't remove the effect.
-        const analysis = getProgramAnalysis(node);
         if (analysis) {
           const stateLikeDepRefs: Reference[] = [];
           for (const element of stateLikeDeps) {
@@ -150,9 +191,13 @@ export const noPropCallbackInEffect = defineRule({
         const reportedNodes = new Set<EsTreeNode>();
         walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
           if (!isNodeOfType(child, "CallExpression")) return;
-          if (!isNodeOfType(child.callee, "Identifier")) return;
-          const calleeName = child.callee.name;
-          if (!propStackTracker.isPropName(calleeName)) return;
+          const directCallee = stripParenExpression(child.callee as EsTreeNode);
+          const calleeName =
+            (isNodeOfType(directCallee, "Identifier") &&
+              propStackTracker.isPropName(directCallee.name) &&
+              directCallee.name) ||
+            getRefHeldPropCallbackName(child, propStackTracker.isPropName);
+          if (!calleeName) return;
           // Only the "lift state up" hand-back fires: a discarded
           // `onChange(state)`. When the prop call's result flows somewhere
           // (`setError(validate(value))`) the prop is a pure transform consumed


### PR DESCRIPTION
## Why

Make `no-prop-callback-in-effect` invariant to harmless aliasing.

A dependency derived only from props was treated as local state when named, even though the inline expression stayed silent. Conversely, wrapping a genuine prop callback in `useRef` hid the same local-state mirror from the rule.

Before:

```tsx
const valuesKey = JSON.stringify(values)
useEffect(() => onPendingChange(values), [valuesKey])
```

This falsely fired, while `onPendingChangeRef.current?.(draft)` evaded a genuine local-state mirror.

After: dependency provenance follows existing scope references, and a one-hop `useRef(propCallback)` call receives the same verdict as the direct callback. Transparent `as any` and non-null receiver wrappers are handled too.

## What changed

- Classify named effect dependencies by upstream prop/state provenance instead of identifier shape.
- Follow one-hop callback refs initialized from prop callbacks.
- Preserve direct/ref parity through transparent TypeScript wrappers.
- Add metamorphic regressions and a permanent false-positive fuzz seed.
- Add a patch changeset for `oxlint-plugin-react-doctor`.

## Eval results

| Check | Result |
| --- | --- |
| Repos scanned | 9 distinct repositories |
| RootDir scans | 50 |
| Target rule | `no-prop-callback-in-effect` |
| Diagnostics | 17; identical to `main` |
| False positives found | 0 new hits |
| Output artifact | local RDE JSONL in disposable validation worktree |

## Test plan

- `nr test -- tests/no-prop-callback-in-effect.regressions.test.ts` (full plugin suite: 538 files, 11,901 passed)
- `nr test` in `packages/fuzz` (37 passed)
- `FUZZ_RULE=no-prop-callback-in-effect FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr build`
- `nr typecheck`
- `nr lint`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to one lint rule’s analysis heuristics with broad regression/fuzz coverage; no runtime app or auth/data paths.
> 
> **Overview**
> **`no-prop-callback-in-effect`** now judges effect dependencies and prop callback calls from **data-flow provenance**, not from whether a dep is a bare prop identifier or the callback is invoked directly.
> 
> Named deps that only trace back to props (e.g. `valuesKey = JSON.stringify(values)` in the deps array) are treated like inline prop-derived expressions, so prop-only sync effects stop false positives. Genuine local-state mirrors are still reported when the same prop callback is invoked through a **one-hop `useRef(propCallback).current`** call, including callees wrapped in parentheses or transparent TypeScript casts/non-null assertions.
> 
> Regression tests cover inline vs named deps, direct vs ref calls, and wrapper spellings; a fuzz corpus seed locks the prop-derived alias case. Ships as a **patch** changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57c49f669c77aee96402bcdef88327c16a89baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->